### PR TITLE
Support for data structure that can not be used in the property list.

### DIFF
--- a/bugsnag/BugsnagEvent.m
+++ b/bugsnag/BugsnagEvent.m
@@ -197,7 +197,7 @@
 
 - (NSDictionary *) toDictionary {
     @synchronized(self) {
-        [self.dictionary setObject:[self.metaData toDictionary] forKey:@"metaData"];
+        [self.dictionary setObject:[self.metaData toDescriptionDictionary] forKey:@"metaData"];
         return [NSDictionary dictionaryWithDictionary:self.dictionary];
     }
 }

--- a/bugsnag/BugsnagMetaData.h
+++ b/bugsnag/BugsnagMetaData.h
@@ -15,6 +15,7 @@
 - (void) clearTab:(NSString*)tabName;
 - (void) mergeWith:(NSDictionary*)data;
 - (NSDictionary*) toDictionary;
+- (NSDictionary *) toDescriptionDictionary;
 - (void) addAttribute:(NSString*)attributeName withValue:(id)value toTabWithName:(NSString*)tabName;
 
 @end


### PR DESCRIPTION
I want to use this as.
```
[Bugsnag notify: [NSException exceptionWithName:@"net.dealforest.exception" reason:@"sample" userInfo:nil]
       withData: @{ @"error": [NSError errorWithDomain:@"net.dealforest.demo" code:200 userInfo:nil] }
];
```
but this method call is failed.
and the developer will not be able to notice that it has failed.

The reason for this is using a data structure that is not supported in the property list.
(https://github.com/dealforest/bugsnag-cocoa/blob/master/bugsnag/BugsnagNotifier.m#L160)

I think the unsported object is call `-[NSObejct description]`.

Regards best.