### PR TITLE
added method for starting BugSnag with out exception handler

### DIFF
--- a/bugsnag/Bugsnag.h
+++ b/bugsnag/Bugsnag.h
@@ -14,6 +14,7 @@
 @interface Bugsnag : NSObject
 
 + (void)startBugsnagWithApiKey:(NSString*)apiKey;
++ (void)startBugsnagWithApiKey:(NSString*)apiKey andStartExceptionHandler:(BOOL)shouldStartExceptionHandler;
 + (BugsnagConfiguration*)configuration;
 + (BugsnagConfiguration*)instance; // For backwards compatability
 + (BugsnagNotifier*)notifier;

--- a/bugsnag/Bugsnag.m
+++ b/bugsnag/Bugsnag.m
@@ -88,8 +88,13 @@ void handle_exception(NSException *exception) {
 @implementation Bugsnag
 
 + (void)startBugsnagWithApiKey:(NSString*)apiKey {
+    [self startBugsnagWithApiKey:apiKey andStartExceptionHandler:YES];
+}
+
++ (void)startBugsnagWithApiKey:(NSString*)apiKey andStartExceptionHandler:(BOOL)shouldStartExceptionHandler{
     BugsnagConfiguration *configuration = [[BugsnagConfiguration alloc] init];
     configuration.apiKey = apiKey;
+    configuration.shouldRegisterExceptionHandler = shouldStartExceptionHandler;
     
     [self startBugsnagWithConfiguration:configuration];
 }
@@ -97,6 +102,10 @@ void handle_exception(NSException *exception) {
 + (void)startBugsnagWithConfiguration:(BugsnagConfiguration*) configuration {
 
     notifier = [[NSClassFromString(notiferClass) alloc] initWithConfiguration:configuration];
+    
+    if (!configuration.shouldRegisterExceptionHandler)
+        return;
+    
     // Register the notifier to receive exceptions and signals
     NSSetUncaughtExceptionHandler(&handle_exception);
     

--- a/bugsnag/BugsnagConfiguration.h
+++ b/bugsnag/BugsnagConfiguration.h
@@ -34,6 +34,7 @@
 
 @property (atomic) BOOL enableSSL;
 @property (atomic) BOOL autoNotify;
+@property (atomic) BOOL shouldRegisterExceptionHandler;
 @property (atomic) BOOL collectMAU;
 @property (atomic, copy) NSArray *notifyReleaseStages;
 


### PR DESCRIPTION
Aniways is an SDK for mobile apps which have chat. If a client application is already using a bug reporting framework we do not wish to de-register their's exception handler (`NSSetUncaughtExceptionHandler`)