### PR TITLE
Fixes a bug when crash occurs in didFinishLaunchingWithOptions

### DIFF
--- a/bugsnag/Bugsnag.m
+++ b/bugsnag/Bugsnag.m
@@ -90,7 +90,7 @@ void handle_exception(NSException *exception) {
 + (void)startBugsnagWithApiKey:(NSString*)apiKey {
     BugsnagConfiguration *configuration = [[BugsnagConfiguration alloc] init];
     configuration.apiKey = apiKey;
-    
+    configuration.context = @"Undetermined";
     [self startBugsnagWithConfiguration:configuration];
 }
 

--- a/bugsnag/Bugsnag.m
+++ b/bugsnag/Bugsnag.m
@@ -90,7 +90,7 @@ void handle_exception(NSException *exception) {
 + (void)startBugsnagWithApiKey:(NSString*)apiKey {
     BugsnagConfiguration *configuration = [[BugsnagConfiguration alloc] init];
     configuration.apiKey = apiKey;
-    configuration.context = @"Undetermined";
+    configuration.context = @"Indetermined";
     [self startBugsnagWithConfiguration:configuration];
 }
 


### PR DESCRIPTION
When context is not set or guessed from topmost view controller ((e.g. didFinishLaunhcingWithOptions) bugsnag itself crashes and no crash report is sent