### PR TITLE
NSNotificationCenter dealloc

### DIFF
--- a/Source/Bugsnag/BugsnagIosNotifier.m
+++ b/Source/Bugsnag/BugsnagIosNotifier.m
@@ -94,6 +94,10 @@
     [[self state] addAttribute: @"lowMemoryWarning" withValue: [RFC3339DateTool stringFromDate:[NSDate date]] toTabWithName:@"deviceState"];
 }
 
+- (void)dealloc {
+    [[NSNotificationCenter defaultCenter] removeObserver:self];
+}
+
 @end
 
 #endif


### PR DESCRIPTION
This is a possible fix for bugsnag/bugsnag-unity#6

I think it can happen if people call start multiple times in a single app run. This is safer regardless and could possibly fix. I will try and reproduce tomorrow.