### PR TITLE
Initial pass of breadcrumbs for iOS

### DIFF
--- a/Bugsnag.xcodeproj/project.pbxproj
+++ b/Bugsnag.xcodeproj/project.pbxproj
@@ -96,6 +96,12 @@
 		79FD0E301A0C1AAB0050DBC5 /* Bugsnag.h in Headers */ = {isa = PBXBuildFile; fileRef = 79FD0D541A0C168B0050DBC5 /* Bugsnag.h */; settings = {ATTRIBUTES = (Public, ); }; };
 		79FD0E311A0C1AAF0050DBC5 /* BugsnagMetaData.h in Headers */ = {isa = PBXBuildFile; fileRef = 79FD0D5A1A0C168B0050DBC5 /* BugsnagMetaData.h */; settings = {ATTRIBUTES = (Public, ); }; };
 		79FD0E321A0C1AB30050DBC5 /* BugsnagConfiguration.h in Headers */ = {isa = PBXBuildFile; fileRef = 79FD0D561A0C168B0050DBC5 /* BugsnagConfiguration.h */; settings = {ATTRIBUTES = (Public, ); }; };
+		8A4C96F11BAA2DEA007B2BFC /* BugsnagBreadcrumbsTest.m in Sources */ = {isa = PBXBuildFile; fileRef = 8A4C96F01BAA2DEA007B2BFC /* BugsnagBreadcrumbsTest.m */; settings = {ASSET_TAGS = (); }; };
+		8A4C96F41BAA2EC9007B2BFC /* BugsnagBreadcrumb.h in Headers */ = {isa = PBXBuildFile; fileRef = 8A4C96F21BAA2EC9007B2BFC /* BugsnagBreadcrumb.h */; settings = {ASSET_TAGS = (); }; };
+		8A4C96F51BAA2EC9007B2BFC /* BugsnagBreadcrumb.m in Sources */ = {isa = PBXBuildFile; fileRef = 8A4C96F31BAA2EC9007B2BFC /* BugsnagBreadcrumb.m */; settings = {ASSET_TAGS = (); }; };
+		8A4C96F61BAA2EC9007B2BFC /* BugsnagBreadcrumb.m in Sources */ = {isa = PBXBuildFile; fileRef = 8A4C96F31BAA2EC9007B2BFC /* BugsnagBreadcrumb.m */; settings = {ASSET_TAGS = (); }; };
+		8A4C96F81BAA2EDA007B2BFC /* BugsnagBreadcrumb.h in Headers */ = {isa = PBXBuildFile; fileRef = 8A4C96F21BAA2EC9007B2BFC /* BugsnagBreadcrumb.h */; settings = {ASSET_TAGS = (); }; };
+		8A4C96F91BAA2EDD007B2BFC /* BugsnagBreadcrumb.m in Sources */ = {isa = PBXBuildFile; fileRef = 8A4C96F31BAA2EC9007B2BFC /* BugsnagBreadcrumb.m */; settings = {ASSET_TAGS = (); }; };
 		932642E41AB249650006C447 /* KSCrashC.c in Sources */ = {isa = PBXBuildFile; fileRef = 79FD0D731A0C16C70050DBC5 /* KSCrashC.c */; };
 		932642E51AB249650006C447 /* KSCrashReport.c in Sources */ = {isa = PBXBuildFile; fileRef = 79FD0D781A0C16C70050DBC5 /* KSCrashReport.c */; };
 		932642E61AB249650006C447 /* KSCrashState.c in Sources */ = {isa = PBXBuildFile; fileRef = 79FD0D7E1A0C16C70050DBC5 /* KSCrashState.c */; };
@@ -302,6 +308,9 @@
 		79FD0E211A0C18F30050DBC5 /* BugsnagTests.xctest */ = {isa = PBXFileReference; explicitFileType = wrapper.cfbundle; includeInIndex = 0; path = BugsnagTests.xctest; sourceTree = BUILT_PRODUCTS_DIR; };
 		79FD0E271A0C18F30050DBC5 /* Info.plist */ = {isa = PBXFileReference; lastKnownFileType = text.plist.xml; path = Info.plist; sourceTree = "<group>"; };
 		79FD0E281A0C18F30050DBC5 /* BugsnagTests.m */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.objc; path = BugsnagTests.m; sourceTree = "<group>"; };
+		8A4C96F01BAA2DEA007B2BFC /* BugsnagBreadcrumbsTest.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; path = BugsnagBreadcrumbsTest.m; sourceTree = "<group>"; };
+		8A4C96F21BAA2EC9007B2BFC /* BugsnagBreadcrumb.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; name = BugsnagBreadcrumb.h; path = Source/Bugsnag/BugsnagBreadcrumb.h; sourceTree = "<group>"; };
+		8A4C96F31BAA2EC9007B2BFC /* BugsnagBreadcrumb.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; name = BugsnagBreadcrumb.m; path = Source/Bugsnag/BugsnagBreadcrumb.m; sourceTree = "<group>"; };
 		932642CB1AB2494F0006C447 /* BugsnagOSX.framework */ = {isa = PBXFileReference; explicitFileType = wrapper.framework; includeInIndex = 0; path = BugsnagOSX.framework; sourceTree = BUILT_PRODUCTS_DIR; };
 		9326431D1AB24D820006C447 /* BugsnagOSXNotifier.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; name = BugsnagOSXNotifier.h; path = Source/Bugsnag/BugsnagOSXNotifier.h; sourceTree = "<group>"; };
 		9326431E1AB24D820006C447 /* BugsnagOSXNotifier.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; name = BugsnagOSXNotifier.m; path = Source/Bugsnag/BugsnagOSXNotifier.m; sourceTree = "<group>"; };
@@ -398,6 +407,8 @@
 				79FD0D5F1A0C168B0050DBC5 /* BugsnagSink.m */,
 				938594C31A2686DD0082E445 /* BugsnagCrashReport.h */,
 				938594C41A2686DD0082E445 /* BugsnagCrashReport.m */,
+				8A4C96F21BAA2EC9007B2BFC /* BugsnagBreadcrumb.h */,
+				8A4C96F31BAA2EC9007B2BFC /* BugsnagBreadcrumb.m */,
 			);
 			name = Bugsnag;
 			sourceTree = "<group>";
@@ -538,9 +549,10 @@
 		79FD0E251A0C18F30050DBC5 /* BugsnagTests */ = {
 			isa = PBXGroup;
 			children = (
-				79FD0E281A0C18F30050DBC5 /* BugsnagTests.m */,
+				8A4C96F01BAA2DEA007B2BFC /* BugsnagBreadcrumbsTest.m */,
 				938595BC1A2D52400082E445 /* BugsnagCrashReportTests.m */,
 				938595BA1A2D51FE0082E445 /* BugsnagSinkTests.m */,
+				79FD0E281A0C18F30050DBC5 /* BugsnagTests.m */,
 				79FD0E261A0C18F30050DBC5 /* Supporting Files */,
 			);
 			path = BugsnagTests;
@@ -574,6 +586,7 @@
 				79FD0E321A0C1AB30050DBC5 /* BugsnagConfiguration.h in Headers */,
 				79FD0E311A0C1AAF0050DBC5 /* BugsnagMetaData.h in Headers */,
 				79FD0E301A0C1AAB0050DBC5 /* Bugsnag.h in Headers */,
+				8A4C96F41BAA2EC9007B2BFC /* BugsnagBreadcrumb.h in Headers */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};
@@ -584,6 +597,7 @@
 				932643121AB24AAE0006C447 /* Bugsnag.h in Headers */,
 				932643131AB24AAE0006C447 /* BugsnagConfiguration.h in Headers */,
 				932643141AB24AAE0006C447 /* BugsnagMetaData.h in Headers */,
+				8A4C96F81BAA2EDA007B2BFC /* BugsnagBreadcrumb.h in Headers */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};
@@ -800,6 +814,7 @@
 				79FD0DE61A0C16C70050DBC5 /* KSCrashCallCompletion.m in Sources */,
 				79FD0D641A0C168B0050DBC5 /* BugsnagIosNotifier.m in Sources */,
 				79FD0DE21A0C16C70050DBC5 /* Demangle.cpp in Sources */,
+				8A4C96F51BAA2EC9007B2BFC /* BugsnagBreadcrumb.m in Sources */,
 				79FD0DC41A0C16C70050DBC5 /* KSCrash.m in Sources */,
 				79FD0D681A0C168B0050DBC5 /* BugsnagNotifier.m in Sources */,
 				79FD0DDE1A0C16C70050DBC5 /* KSCrashSentry_Signal.c in Sources */,
@@ -851,6 +866,7 @@
 				79FD0DE71A0C16C70050DBC5 /* KSCrashCallCompletion.m in Sources */,
 				79FD0D651A0C168B0050DBC5 /* BugsnagIosNotifier.m in Sources */,
 				79FD0DE31A0C16C70050DBC5 /* Demangle.cpp in Sources */,
+				8A4C96F61BAA2EC9007B2BFC /* BugsnagBreadcrumb.m in Sources */,
 				79FD0DC51A0C16C70050DBC5 /* KSCrash.m in Sources */,
 				79FD0D691A0C168B0050DBC5 /* BugsnagNotifier.m in Sources */,
 				79FD0DDF1A0C16C70050DBC5 /* KSCrashSentry_Signal.c in Sources */,
@@ -886,6 +902,7 @@
 			isa = PBXSourcesBuildPhase;
 			buildActionMask = 2147483647;
 			files = (
+				8A4C96F11BAA2DEA007B2BFC /* BugsnagBreadcrumbsTest.m in Sources */,
 				938596831A2EB6730082E445 /* BugsnagTests.m in Sources */,
 				938596841A2EB6730082E445 /* BugsnagCrashReportTests.m in Sources */,
 				938596851A2EB6730082E445 /* BugsnagSinkTests.m in Sources */,
@@ -919,6 +936,7 @@
 				9326430E1AB249800006C447 /* BugsnagCrashReport.m in Sources */,
 				932642F91AB249700006C447 /* Demangle.cpp in Sources */,
 				932642E41AB249650006C447 /* KSCrashC.c in Sources */,
+				8A4C96F91BAA2EDD007B2BFC /* BugsnagBreadcrumb.m in Sources */,
 				932642E51AB249650006C447 /* KSCrashReport.c in Sources */,
 				932643201AB24D820006C447 /* BugsnagOSXNotifier.m in Sources */,
 				932642E61AB249650006C447 /* KSCrashState.c in Sources */,

--- a/BugsnagTests/BugsnagBreadcrumbsTest.m
+++ b/BugsnagTests/BugsnagBreadcrumbsTest.m
@@ -1,0 +1,86 @@
+//
+//  BugsnagBreadcrumbsTest.m
+//  Bugsnag
+//
+//  Created by Delisa Mason on 9/16/15.
+//
+//
+
+#import <XCTest/XCTest.h>
+#import "BugsnagBreadcrumb.h"
+#import "RFC3339DateTool.h"
+
+@interface BugsnagBreadcrumbsTest : XCTestCase
+@property (nonatomic,strong) BugsnagBreadcrumbs* crumbs;
+@end
+
+@implementation BugsnagBreadcrumbsTest
+
+- (void)setUp {
+    [super setUp];
+    BugsnagBreadcrumbs* crumbs = [BugsnagBreadcrumbs new];
+    [crumbs addBreadcrumb:@"Launch app"];
+    [crumbs addBreadcrumb:@"Tap button"];
+    [crumbs addBreadcrumb:@"Close tutorial"];
+    self.crumbs = crumbs;
+}
+
+- (void)testDefaultCapacity {
+    XCTAssertTrue([BugsnagBreadcrumbs new].capacity == 20);
+}
+
+- (void)testDefaultCount {
+    XCTAssertTrue([BugsnagBreadcrumbs new].count == 0);
+}
+
+- (void)testMaxBreadcrumbs {
+    self.crumbs.capacity = 3;
+    [self.crumbs addBreadcrumb:@"Clear notifications"];
+    XCTAssertTrue(self.crumbs.count == 3);
+    XCTAssertEqualObjects(self.crumbs[0].message, @"Tap button");
+    XCTAssertEqualObjects(self.crumbs[1].message, @"Close tutorial");
+    XCTAssertEqualObjects(self.crumbs[2].message, @"Clear notifications");
+    XCTAssertNil(self.crumbs[3]);
+}
+
+- (void)testClearBreadcrumbs {
+    [self.crumbs clearBreadcrumbs];
+    XCTAssertTrue(self.crumbs.count == 0);
+    XCTAssertNil(self.crumbs[0]);
+}
+
+- (void)testEmptyCapacity {
+    self.crumbs.capacity = 0;
+    [self.crumbs addBreadcrumb:@"Clear notifications"];
+    XCTAssertTrue(self.crumbs.count == 0);
+    XCTAssertNil(self.crumbs[0]);
+}
+
+- (void)testResizeBreadcrumbs {
+    self.crumbs.capacity = 2;
+    XCTAssertTrue(self.crumbs.count == 2);
+    XCTAssertEqualObjects(self.crumbs[0].message, @"Tap button");
+    XCTAssertEqualObjects(self.crumbs[1].message, @"Close tutorial");
+    XCTAssertNil(self.crumbs[2]);
+}
+
+- (void)testArrayValue {
+    NSArray* value = [self.crumbs arrayValue];
+    XCTAssertNotNil(value);
+    XCTAssertTrue(value.count == 3);
+    for (NSArray* item in value) {
+        XCTAssertTrue([item isKindOfClass:[NSArray class]]);
+        XCTAssertTrue(item.count == 2);
+        XCTAssertTrue([[RFC3339DateTool dateFromString:item[0]] isKindOfClass:[NSDate class]]);
+    }
+    XCTAssertEqualObjects(value[0][1], @"Launch app");
+    XCTAssertEqualObjects(value[1][1], @"Tap button");
+    XCTAssertEqualObjects(value[2][1], @"Close tutorial");
+}
+
+- (void)testDiscardInvalidCrumbs {
+    [self.crumbs addBreadcrumb:nil];
+    XCTAssertTrue(self.crumbs.count == 3);
+}
+
+@end

--- a/BugsnagTests/BugsnagCrashReportTests.m
+++ b/BugsnagTests/BugsnagCrashReportTests.m
@@ -87,6 +87,11 @@
     XCTAssertEqualObjects(self.report.severity, @"warning");
 }
 
+- (void)testBreadcrumbs {
+    NSArray* breadcrumbs = @[@[@"1442466386", @"App launched"], @[@"1442466386", @"Tapped button"]];
+    XCTAssertEqualObjects(self.report.breadcrumbs, breadcrumbs);
+}
+
 - (void)testDSYMUUID {
     XCTAssertEqualObjects(self.report.dsymUUID, @"D0A41830-4FD2-3B02-A23B-0741AD4C7F52");
 }

--- a/BugsnagTests/BugsnagSinkTests.m
+++ b/BugsnagTests/BugsnagSinkTests.m
@@ -55,18 +55,21 @@
     XCTAssertEqualObjects([[dict objectForKey:@"notifier"] valueForKey:@"name"], @"iOS Bugsnag Notifier");
     XCTAssertEqualObjects([[dict objectForKey:@"notifier"] valueForKey:@"url"], @"https://github.com/bugsnag/bugsnag-cocoa");
     XCTAssertNotEqualObjects([[dict objectForKey:@"notifier"] valueForKey:@"version"], nil);
-    XCTAssert([[[dict objectForKey:@"notifier"] valueForKey:@"version"] isKindOfClass:[NSString class]]);
+    XCTAssertTrue([[[dict objectForKey:@"notifier"] valueForKey:@"version"] isKindOfClass:[NSString class]]);
     
     // Check events array
     XCTAssert(((NSArray*)[dict objectForKey:@"events"]).count == 1);
     
     // Check event
     NSDictionary *event = [((NSArray*)[dict objectForKey:@"events"]) objectAtIndex:0];
-    [self check:[event allKeys] ContainsOnly:@[@"exceptions", @"metaData", @"context", @"payloadVersion", @"severity", @"device", @"deviceState", @"app", @"appState", @"dsymUUID", @"threads"]];
-    
+    NSArray* eventKeys = @[@"app", @"appState", @"breadcrumbs", @"context", @"device",
+                           @"deviceState", @"dsymUUID", @"exceptions", @"metaData",
+                           @"payloadVersion", @"severity", @"threads"];
+    XCTAssertEqualObjects([[event allKeys] sortedArrayUsingSelector:@selector(compare:)], eventKeys);
     XCTAssertEqualObjects([event objectForKey:@"dsymUUID"], self.report.dsymUUID);
     XCTAssertEqualObjects([event objectForKey:@"payloadVersion"], @"2");
     XCTAssertEqualObjects([event objectForKey:@"severity"], self.report.severity);
+    XCTAssertEqualObjects([event objectForKey:@"breadcrumbs"], self.report.breadcrumbs);
     XCTAssertEqualObjects([event objectForKey:@"context"], self.report.context);
     XCTAssertEqualObjects([event objectForKey:@"metaData"], (@{
                                                                @"error": @{

--- a/BugsnagTests/report.json
+++ b/BugsnagTests/report.json
@@ -2093,7 +2093,8 @@
             },
             "crash": {
                 "depth": 4,
-                "severity": "warning"
+                "severity": "warning",
+                "breadcrumbs": [["1442466386","App launched"],["1442466386","Tapped button"]]
             }
         }
     }

--- a/README.md
+++ b/README.md
@@ -140,6 +140,15 @@ Severity is displayed in the dashboard and can be used to filter the error list.
 By default all crashes (or unhandled exceptions) are set to `error` and all
 `[Bugsnag notify]` calls default to `warning`.
 
+Logging Breadcrumbs
+-------------------
+
+You can add custom log messages called "breadcrumbs" to document what user interactions occurred in your application prior to a crash. Each breadcrumb also records the time at which it was left. To record a breadcrumb:
+
+```objective-c
+[Bugsnag leaveBreadcrumbWithMessage:@"Button tapped"];
+```
+
 Adding Tabs to Bugsnag Error Reports
 ------------------------------------
 

--- a/Source/Bugsnag/Bugsnag.h
+++ b/Source/Bugsnag/Bugsnag.h
@@ -117,4 +117,27 @@ static NSString* BugsnagSeverityInfo    = @"info";
  */
 + (void) clearTabWithName:(NSString*) tabName;
 
+/**
+ * Leave a "breadcrumb" log message, representing an action that occurred
+ * in your app, to aid with debugging. Must be called from the main thread.
+ *
+ * @param message  the log message to leave (max 140 chars)
+ */
++ (void) leaveBreadcrumbWithMessage:(NSString*)message;
+
+/**
+ * Set the maximum number of breadcrumbs to keep and sent to Bugsnag.
+ * By default, we'll keep and send the 20 most recent breadcrumb log
+ * messages. Must be called from the main thread.
+ *
+ * @param max  number of breadcrumb log messages to send
+ */
++ (void) setBreadcrumbCapacity:(NSUInteger)capacity;
+
+/**
+ * Clear any breadcrumbs that have been left so far. Must be called from
+ * the main thread.
+ */
++ (void) clearBreadcrumbs;
+
 @end

--- a/Source/Bugsnag/Bugsnag.m
+++ b/Source/Bugsnag/Bugsnag.m
@@ -25,6 +25,7 @@
 //
 
 #import "Bugsnag.h"
+#import "BugsnagBreadcrumb.h"
 #import "BugsnagConfiguration.h"
 #import "BugsnagNotifier.h"
 #import "BugsnagSink.h"
@@ -113,6 +114,18 @@ static BugsnagNotifier* g_bugsnag_notifier = NULL;
         return false;
     }
     return true;
+}
+
++ (void) leaveBreadcrumbWithMessage:(NSString *)message {
+    [self.notifier.configuration.breadcrumbs addBreadcrumb:message];
+}
+
++ (void) setBreadcrumbCapacity:(NSUInteger)capacity {
+    self.notifier.configuration.breadcrumbs.capacity = capacity;
+}
+
++ (void) clearBreadcrumbs {
+    [self.notifier.configuration.breadcrumbs clearBreadcrumbs];
 }
 
 @end

--- a/Source/Bugsnag/BugsnagBreadcrumb.h
+++ b/Source/Bugsnag/BugsnagBreadcrumb.h
@@ -1,0 +1,77 @@
+//
+//  BugsnagBreadcrumb.h
+//
+//  Created by Delisa Mason on 9/16/15.
+//
+//  Copyright (c) 2015 Bugsnag, Inc. All rights reserved.
+//
+// Permission is hereby granted, free of charge, to any person obtaining a copy
+// of this software and associated documentation files (the "Software"), to deal
+// in the Software without restriction, including without limitation the rights
+// to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+// copies of the Software, and to permit persons to whom the Software is
+// furnished to do so, subject to the following conditions:
+//
+// The above copyright notice and this permission notice shall remain in place
+// in this source code.
+//
+// THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+// IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+// FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+// AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+// LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+// OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+// THE SOFTWARE.
+//
+#import <Foundation/Foundation.h>
+
+#ifndef NS_DESIGNATED_INITIALIZER
+#if __has_attribute(objc_designated_initializer)
+#define NS_DESIGNATED_INITIALIZER __attribute__((objc_designated_initializer))
+#else
+#define NS_DESIGNATED_INITIALIZER
+#endif
+#endif
+
+@interface BugsnagBreadcrumb : NSObject
+
+@property (readonly) NSDate* timestamp;
+@property (readonly,copy) NSString* message;
+
+- (instancetype) initWithMessage:(NSString*)message
+                       timestamp:(NSDate*)date NS_DESIGNATED_INITIALIZER;
+@end
+
+@interface BugsnagBreadcrumbs : NSObject
+
+/** 
+ * The maximum number of breadcrumbs. Resizable. Must be called from the 
+ * main thread.
+ */
+@property (assign,nonatomic,readwrite) NSUInteger capacity;
+
+/** Number of breadcrumbs accumulated */
+@property (assign,readonly) NSUInteger count;
+
+/**
+ * Store a new breadcrumb with a provided message. Must be called from the
+ * main thread.
+ */
+- (void) addBreadcrumb:(NSString*)breadcrumbMessage;
+
+/**
+ * Clear all stored breadcrumbs. Must be called from the main thread.
+ */
+- (void) clearBreadcrumbs;
+
+/** Breadcrumb object for a particular index or nil */
+- (BugsnagBreadcrumb*) objectAtIndexedSubscript:(NSUInteger)index;
+
+/** 
+ * Serializable array representation of breadcrumbs, represented as nested
+ * strings in the format:
+ * [[timestamp,message]...]
+ */
+- (NSArray*) arrayValue;
+
+@end

--- a/Source/Bugsnag/BugsnagBreadcrumb.m
+++ b/Source/Bugsnag/BugsnagBreadcrumb.m
@@ -1,0 +1,129 @@
+//
+//  BugsnagBreadcrumb.m
+//
+//  Created by Delisa Mason on 9/16/15.
+//
+//  Copyright (c) 2015 Bugsnag, Inc. All rights reserved.
+//
+// Permission is hereby granted, free of charge, to any person obtaining a copy
+// of this software and associated documentation files (the "Software"), to deal
+// in the Software without restriction, including without limitation the rights
+// to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+// copies of the Software, and to permit persons to whom the Software is
+// furnished to do so, subject to the following conditions:
+//
+// The above copyright notice and this permission notice shall remain in place
+// in this source code.
+//
+// THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+// IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+// FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+// AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+// LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+// OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+// THE SOFTWARE.
+//
+#import "BugsnagBreadcrumb.h"
+#import "RFC3339DateTool.h"
+
+@interface BugsnagBreadcrumbs()
+
+@property (nonatomic,readwrite,strong) NSMutableArray* breadcrumbs;
+@end
+
+@implementation BugsnagBreadcrumb
+
+- (instancetype)init {
+    self = [self initWithMessage:nil timestamp:nil];
+    return self;
+}
+
+- (instancetype)initWithMessage:(NSString *)message timestamp:(NSDate *)date {
+    if (message.length == 0)
+        return nil;
+
+    if (self = [super init]) {
+        _message = [message copy];
+        _timestamp = date;
+    }
+    return self;
+}
+
+@end
+
+@implementation BugsnagBreadcrumbs
+
+NSUInteger BreadcrumbsDefaultCapacity = 20;
+
+- (instancetype)init {
+    if (self = [super init]) {
+        _breadcrumbs = [NSMutableArray new];
+        _capacity = BreadcrumbsDefaultCapacity;
+    }
+    return self;
+}
+
+- (void)addBreadcrumb:(NSString *)breadcrumbMessage {
+    NSAssert([[NSThread currentThread] isMainThread], @"Breadcrumbs must be mutated on the main thread.");
+    if (self.capacity == 0) {
+        return;
+    }
+    BugsnagBreadcrumb* crumb = [[BugsnagBreadcrumb alloc] initWithMessage:breadcrumbMessage timestamp:[NSDate date]];
+    if (crumb) {
+        [self resizeToFitCapacity:self.capacity - 1];
+        [self.breadcrumbs addObject:crumb];
+    }
+}
+
+- (void)setCapacity:(NSUInteger)capacity {
+    NSAssert([[NSThread currentThread] isMainThread], @"Breadcrumbs must be mutated on the main thread.");
+    if (capacity == _capacity) {
+        return;
+    }
+    [self resizeToFitCapacity:capacity];
+    [self willChangeValueForKey:NSStringFromSelector(@selector(capacity))];
+    _capacity = capacity;
+    [self didChangeValueForKey:NSStringFromSelector(@selector(capacity))];
+}
+
+- (void)clearBreadcrumbs {
+    NSAssert([[NSThread currentThread] isMainThread], @"Breadcrumbs must be mutated on the main thread.");
+    [self.breadcrumbs removeAllObjects];
+}
+
+- (NSUInteger)count {
+    return self.breadcrumbs.count;
+}
+
+- (BugsnagBreadcrumb *)objectAtIndexedSubscript:(NSUInteger)index {
+    if (index < [self count]) {
+        return self.breadcrumbs[index];
+    }
+    return nil;
+}
+
+- (NSArray *)arrayValue {
+    if ([self count] == 0) {
+        return nil;
+    }
+    NSMutableArray* contents = [[NSMutableArray alloc] initWithCapacity:[self count]];
+    for (BugsnagBreadcrumb* crumb in self.breadcrumbs) {
+        NSString* timestamp = [RFC3339DateTool stringFromDate:crumb.timestamp];
+        if (timestamp && crumb.message.length > 0) {
+            [contents addObject:@[timestamp,crumb.message]];
+        }
+    }
+    return contents;
+}
+
+- (void)resizeToFitCapacity:(NSUInteger)capacity {
+    if (capacity == 0) {
+        [self clearBreadcrumbs];
+        return;
+    }
+    while ([self count] > capacity) {
+        [self.breadcrumbs removeObjectAtIndex:0];
+    }
+}
+
+@end

--- a/Source/Bugsnag/BugsnagConfiguration.h
+++ b/Source/Bugsnag/BugsnagConfiguration.h
@@ -28,6 +28,8 @@
 
 #import "BugsnagMetaData.h"
 
+@class BugsnagBreadcrumbs;
+
 @interface BugsnagConfiguration : NSObject
 
 @property(nonatomic,readwrite,retain) NSString* apiKey;
@@ -38,6 +40,7 @@
 @property(nonatomic,readwrite,retain) NSString* appVersion;
 @property(nonatomic,readwrite,retain) BugsnagMetaData* metaData;
 @property(nonatomic,readwrite,retain) BugsnagMetaData* config;
+@property(nonatomic,readonly,strong) BugsnagBreadcrumbs* breadcrumbs;
 
 @property(nonatomic) BOOL autoNotify;
 

--- a/Source/Bugsnag/BugsnagConfiguration.m
+++ b/Source/Bugsnag/BugsnagConfiguration.m
@@ -25,6 +25,7 @@
 //
 
 #import "BugsnagConfiguration.h"
+#import "BugsnagBreadcrumb.h"
 
 @implementation BugsnagConfiguration
 
@@ -37,6 +38,7 @@
         self.notifyURL = [NSURL URLWithString:@"https://notify.bugsnag.com/"];
 
         self.notifyReleaseStages = nil;
+        _breadcrumbs = [BugsnagBreadcrumbs new];
 #if DEBUG
         self.releaseStage = @"development";
 #else

--- a/Source/Bugsnag/BugsnagCrashReport.h
+++ b/Source/Bugsnag/BugsnagCrashReport.h
@@ -21,6 +21,7 @@
 
 @property (readonly) NSArray *binaryImages;
 @property (readonly) NSArray *threads;
+@property (readonly) NSArray *breadcrumbs;
 @property (readonly) NSDictionary *error;
 @property (readonly) NSString *errorType;
 @property (readonly) NSString *errorClass;

--- a/Source/Bugsnag/BugsnagCrashReport.m
+++ b/Source/Bugsnag/BugsnagCrashReport.m
@@ -80,6 +80,10 @@
     return [self.error objectForKey:@"reason"];
 }
 
+- (NSArray*) breadcrumbs {
+    return [[self.state objectForKey:@"crash"] objectForKey:@"breadcrumbs"];
+}
+
 -(NSString*) severity {
     return [[self.state objectForKey:@"crash"] objectForKey:@"severity"];
 }

--- a/Source/Bugsnag/BugsnagSink.m
+++ b/Source/Bugsnag/BugsnagSink.m
@@ -120,6 +120,7 @@
     [event safeSetObject: @[exception] forKey: @"exceptions"];
     [event setObjectIfNotNil: report.dsymUUID forKey: @"dsymUUID"];
     [event safeSetObject: report.severity forKey:@"severity"];
+    [event safeSetObject: report.breadcrumbs forKey:@"breadcrumbs"];
     [event safeSetObject: @"2" forKey:@"payloadVersion"];
     [event safeSetObject: metaData forKey: @"metaData"];
     [event safeSetObject: [self deviceStateFromReport: report] forKey:@"deviceState"];


### PR DESCRIPTION

Breadcrumbs are [supported](https://bugsnag.com/blog/introducing-mobile-breadcrumbs) on Android, as noted in #43. These changes add breadcrumb support to the iOS library, and updates the `README` with the basic usage. 

![Aww yiss](http://i.giphy.com/S4P8Z5fiLRpOU.gif)

## Implementation notes

* The breadcrumb interface mirrors the [android implementation](https://github.com/bugsnag/bugsnag-android/blob/97eca13c7aa604a6578a231abb83cdfa5e14bf49/src/main/java/com/bugsnag/android/Bugsnag.java#L365-L391), adjusting the selector naming slightly for platform conventions.
* `breadcrumbs` is added to the `crash` tab if any are recorded.
* I assumed breadcrumbs are intended for recording user interactions and/or view loading. As such, the `BugsnagBreadcrumbs` container enforces use of the main thread for modification.
* Breadcrumbs are stored in `BugsnagConfiguration` alongside `metaData`. I'm not sure if there is a better place for this.

## Usage questions

* Should breadcrumbs be cleared after recording an exception? What about multiple exceptions occuring without crashing the app, such as on OS X?