### PR TITLE
Nil name

### DIFF
--- a/BugsnagTests/BugsnagTests.m
+++ b/BugsnagTests/BugsnagTests.m
@@ -29,6 +29,8 @@
     XCTAssert(YES, @"Pass");
 }
 
+// Ensure that Bugsnag deals with nil exception names appropriately
+// KSCrash can crash itself if a nil name is passed through
 - (void)testNotifyWithNilName {
     NSString *nilName = nil;
     NSException *exception = [NSException exceptionWithName:nilName reason:nil userInfo:nil];

--- a/BugsnagTests/BugsnagTests.m
+++ b/BugsnagTests/BugsnagTests.m
@@ -8,6 +8,7 @@
 
 #import <UIKit/UIKit.h>
 #import <XCTest/XCTest.h>
+#import "Bugsnag.h"
 
 @interface BugsnagTests : XCTestCase
 
@@ -17,6 +18,7 @@
 
 - (void)setUp {
     [super setUp];
+    [Bugsnag startBugsnagWithApiKey:@"123456789012345678901234"];
 }
 
 - (void)tearDown {
@@ -24,6 +26,13 @@
 }
 
 - (void)testExample {
+    XCTAssert(YES, @"Pass");
+}
+
+- (void)testNotifyWithNilName {
+    NSString *nilName = nil;
+    NSException *exception = [NSException exceptionWithName:nilName reason:nil userInfo:nil];
+    [Bugsnag notify:exception];
     XCTAssert(YES, @"Pass");
 }
 

--- a/Source/Bugsnag/BugsnagNotifier.m
+++ b/Source/Bugsnag/BugsnagNotifier.m
@@ -118,7 +118,8 @@ void serialize_bugsnag_data(const KSCrashReportWriter *writer) {
     [self.state addAttribute:@"severity" withValue: severity toTabWithName: @"crash"];
     [self.state addAttribute:@"depth" withValue: [NSNumber numberWithUnsignedInteger:depth + 3] toTabWithName: @"crash"];
 
-    [[KSCrash sharedInstance] reportUserException:[exception name] reason:[exception reason] lineOfCode:@"" stackTrace:@[] terminateProgram:NO];
+    NSString *exceptionName = [exception name] != nil ? [exception name] : @"NSException";
+    [[KSCrash sharedInstance] reportUserException:exceptionName reason:[exception reason] lineOfCode:@"" stackTrace:@[] terminateProgram:NO];
 
     // Restore metaData to pre-crash state.
     [self.metaDataLock unlock];


### PR DESCRIPTION
This deals appropriately with a nil name. It is hard but possible to get a nil name into NSException, and KSCrash enforces that it should not be nil.