### PR TITLE
Add Clang Pragma to ignore the deprecated `Cache` warning

### DIFF
--- a/KSCrash/Source/KSCrash/Recording/Tools/KSObjCApple.h
+++ b/KSCrash/Source/KSCrash/Recording/Tools/KSObjCApple.h
@@ -119,7 +119,10 @@ typedef struct class_rw_t {
 typedef struct class_t {
     struct class_t *isa;
     struct class_t *superclass;
+#pragma clang diagnostic push
+#pragma clang diagnostic ignored "-Wdeprecated-declarations"
     Cache cache;
+#pragma clang diagnostic pop
     IMP *vtable;
     uintptr_t data_NEVER_USE;  // class_rw_t * plus custom rr/alloc flags
 } class_t;


### PR DESCRIPTION
Sorta fixes #50 