### PR TITLE
Update to the crash handler to send breadcrumbs and severity when uncaught errors occur

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,7 +1,7 @@
 Bugsnag Notifier for Cocoa
 ==========================
 
-The Bugsnag Notifier for Cocoa gives you instant notification of exceptions thrown from your *iOS* 4.3+ or *OSX* applications.
+The Bugsnag Notifier for Cocoa gives you instant notification of exceptions thrown from your *iOS* 5.0+ or *OSX* applications.
 The notifier hooks into `NSSetUncaughtExceptionHandler`, which means any uncaught exceptions will trigger a notification to be sent to your Bugsnag dashboard. Bugsnag will also monitor for fatal signals sent to your application, for example, Segmentation Faults.
 
 [Bugsnag](https://bugsnag.com) captures errors in real-time from your web, mobile and desktop applications, helping you to understand and resolve them as fast as possible. [Create a free account](https://bugsnag.com) to start capturing exceptions from your applications.

--- a/Source/Bugsnag/Bugsnag.h
+++ b/Source/Bugsnag/Bugsnag.h
@@ -105,7 +105,7 @@ static NSString* BugsnagSeverityInfo    = @"info";
  *
  * @param attributeName  The name of the data.
  *
- * @param value          It's value.
+ * @param value          Its value.
  *
  * @param tabName        The tab to show it on on the Bugsnag dashboard.
  */

--- a/Source/Bugsnag/BugsnagMetaData.m
+++ b/Source/Bugsnag/BugsnagMetaData.m
@@ -58,7 +58,7 @@ void mergeDictionaries(NSMutableDictionary *destination, NSDictionary *source) {
 - (id) mutableCopyWithZone:(NSZone *)zone {
     @synchronized(self) {
         NSMutableDictionary *dict = [self.dictionary mutableCopy];
-        return [[BugsnagMetaData alloc] initWithDictionary:dict];
+        return [[BugsnagMetaData allocWithZone:zone] initWithDictionary:dict];
     }
 }
 

--- a/examples/objective-c-ios/Bugsnag Test App.xcodeproj/project.pbxproj
+++ b/examples/objective-c-ios/Bugsnag Test App.xcodeproj/project.pbxproj
@@ -1,917 +1,429 @@
-<?xml version="1.0" encoding="UTF-8"?>
-<!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
-<plist version="1.0">
-<dict>
-	<key>archiveVersion</key>
-	<string>1</string>
-	<key>classes</key>
-	<dict/>
-	<key>objectVersion</key>
-	<string>46</string>
-	<key>objects</key>
-	<dict>
-		<key>0E579FC164E842FBB5C923B7</key>
-		<dict>
-			<key>buildActionMask</key>
-			<string>2147483647</string>
-			<key>files</key>
-			<array/>
-			<key>inputPaths</key>
-			<array/>
-			<key>isa</key>
-			<string>PBXShellScriptBuildPhase</string>
-			<key>name</key>
-			<string>Check Pods Manifest.lock</string>
-			<key>outputPaths</key>
-			<array/>
-			<key>runOnlyForDeploymentPostprocessing</key>
-			<string>0</string>
-			<key>shellPath</key>
-			<string>/bin/sh</string>
-			<key>shellScript</key>
-			<string>diff "${PODS_ROOT}/../Podfile.lock" "${PODS_ROOT}/Manifest.lock" &gt; /dev/null
-if [[ $? != 0 ]] ; then
-    cat &lt;&lt; EOM
-error: The sandbox is not in sync with the Podfile.lock. Run 'pod install' or update your CocoaPods installation.
-EOM
-    exit 1
-fi
-</string>
-			<key>showEnvVarsInLog</key>
-			<string>0</string>
-		</dict>
-		<key>100749203726440EA4E45D3E</key>
-		<dict>
-			<key>fileRef</key>
-			<string>BBE4E4C4FB284B448E57166E</string>
-			<key>isa</key>
-			<string>PBXBuildFile</string>
-		</dict>
-		<key>1D860917AA32015D2A67696B</key>
-		<dict>
-			<key>includeInIndex</key>
-			<string>1</string>
-			<key>isa</key>
-			<string>PBXFileReference</string>
-			<key>lastKnownFileType</key>
-			<string>text.xcconfig</string>
-			<key>name</key>
-			<string>Pods.debug.xcconfig</string>
-			<key>path</key>
-			<string>Pods/Target Support Files/Pods/Pods.debug.xcconfig</string>
-			<key>sourceTree</key>
-			<string>&lt;group&gt;</string>
-		</dict>
-		<key>2CA6385EE8EA5F91543DE7E0</key>
-		<dict>
-			<key>includeInIndex</key>
-			<string>1</string>
-			<key>isa</key>
-			<string>PBXFileReference</string>
-			<key>lastKnownFileType</key>
-			<string>text.xcconfig</string>
-			<key>name</key>
-			<string>Pods.release.xcconfig</string>
-			<key>path</key>
-			<string>Pods/Target Support Files/Pods/Pods.release.xcconfig</string>
-			<key>sourceTree</key>
-			<string>&lt;group&gt;</string>
-		</dict>
-		<key>5142A2F8286744A694BDB5BA</key>
-		<dict>
-			<key>buildActionMask</key>
-			<string>2147483647</string>
-			<key>files</key>
-			<array/>
-			<key>inputPaths</key>
-			<array/>
-			<key>isa</key>
-			<string>PBXShellScriptBuildPhase</string>
-			<key>name</key>
-			<string>Upload Bugsnag dSYM</string>
-			<key>outputPaths</key>
-			<array/>
-			<key>runOnlyForDeploymentPostprocessing</key>
-			<string>0</string>
-			<key>shellPath</key>
-			<string>/usr/bin/env ruby</string>
-			<key>shellScript</key>
-			<string>fork do
-  Process.setsid
-  STDIN.reopen("/dev/null")
-  STDOUT.reopen("/dev/null", "a")
-  STDERR.reopen("/dev/null", "a")
+// !$*UTF8*$!
+{
+	archiveVersion = 1;
+	classes = {
+	};
+	objectVersion = 46;
+	objects = {
 
-  require 'shellwords'
+/* Begin PBXBuildFile section */
+		100749203726440EA4E45D3E /* libPods.a in Frameworks */ = {isa = PBXBuildFile; fileRef = BBE4E4C4FB284B448E57166E /* libPods.a */; };
+		F40B874B16AA233500676BB2 /* UIKit.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = F40B874A16AA233500676BB2 /* UIKit.framework */; };
+		F40B874D16AA233500676BB2 /* Foundation.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = F40B874C16AA233500676BB2 /* Foundation.framework */; };
+		F40B874F16AA233500676BB2 /* CoreGraphics.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = F40B874E16AA233500676BB2 /* CoreGraphics.framework */; };
+		F40B875516AA233500676BB2 /* InfoPlist.strings in Resources */ = {isa = PBXBuildFile; fileRef = F40B875316AA233500676BB2 /* InfoPlist.strings */; };
+		F40B875716AA233500676BB2 /* main.m in Sources */ = {isa = PBXBuildFile; fileRef = F40B875616AA233500676BB2 /* main.m */; };
+		F40B875B16AA233500676BB2 /* AppDelegate.m in Sources */ = {isa = PBXBuildFile; fileRef = F40B875A16AA233500676BB2 /* AppDelegate.m */; };
+		F40B875D16AA233500676BB2 /* Default.png in Resources */ = {isa = PBXBuildFile; fileRef = F40B875C16AA233500676BB2 /* Default.png */; };
+		F40B875F16AA233500676BB2 /* Default@2x.png in Resources */ = {isa = PBXBuildFile; fileRef = F40B875E16AA233500676BB2 /* Default@2x.png */; };
+		F40B876116AA233500676BB2 /* Default-568h@2x.png in Resources */ = {isa = PBXBuildFile; fileRef = F40B876016AA233500676BB2 /* Default-568h@2x.png */; };
+		F40B876416AA233500676BB2 /* MainStoryboard_iPhone.storyboard in Resources */ = {isa = PBXBuildFile; fileRef = F40B876216AA233500676BB2 /* MainStoryboard_iPhone.storyboard */; };
+		F40B876716AA233500676BB2 /* MainStoryboard_iPad.storyboard in Resources */ = {isa = PBXBuildFile; fileRef = F40B876516AA233500676BB2 /* MainStoryboard_iPad.storyboard */; };
+		F40B876A16AA233500676BB2 /* ViewController.m in Sources */ = {isa = PBXBuildFile; fileRef = F40B876916AA233500676BB2 /* ViewController.m */; };
+/* End PBXBuildFile section */
 
-  Dir["#{ENV["DWARF_DSYM_FOLDER_PATH"]}/*/Contents/Resources/DWARF/*"].each do |dsym|
-    system("curl -F dsym=@#{Shellwords.escape(dsym)} -F projectRoot=#{Shellwords.escape(ENV["PROJECT_DIR"])} https://upload.bugsnag.com/")
-  end
-end
-</string>
-			<key>showEnvVarsInLog</key>
-			<string>0</string>
-		</dict>
-		<key>7F7F36E5290F6E12E446687F</key>
-		<dict>
-			<key>children</key>
-			<array>
-				<string>1D860917AA32015D2A67696B</string>
-				<string>2CA6385EE8EA5F91543DE7E0</string>
-			</array>
-			<key>isa</key>
-			<string>PBXGroup</string>
-			<key>name</key>
-			<string>Pods</string>
-			<key>sourceTree</key>
-			<string>&lt;group&gt;</string>
-		</dict>
-		<key>BBE4E4C4FB284B448E57166E</key>
-		<dict>
-			<key>explicitFileType</key>
-			<string>archive.ar</string>
-			<key>includeInIndex</key>
-			<string>0</string>
-			<key>isa</key>
-			<string>PBXFileReference</string>
-			<key>path</key>
-			<string>libPods.a</string>
-			<key>sourceTree</key>
-			<string>BUILT_PRODUCTS_DIR</string>
-		</dict>
-		<key>EC9C64C5098541749BAC1444</key>
-		<dict>
-			<key>buildActionMask</key>
-			<string>2147483647</string>
-			<key>files</key>
-			<array/>
-			<key>inputPaths</key>
-			<array/>
-			<key>isa</key>
-			<string>PBXShellScriptBuildPhase</string>
-			<key>name</key>
-			<string>Copy Pods Resources</string>
-			<key>outputPaths</key>
-			<array/>
-			<key>runOnlyForDeploymentPostprocessing</key>
-			<string>0</string>
-			<key>shellPath</key>
-			<string>/bin/sh</string>
-			<key>shellScript</key>
-			<string>"${SRCROOT}/Pods/Target Support Files/Pods/Pods-resources.sh"
-</string>
-			<key>showEnvVarsInLog</key>
-			<string>0</string>
-		</dict>
-		<key>F40B873B16AA233500676BB2</key>
-		<dict>
-			<key>children</key>
-			<array>
-				<string>F40B875016AA233500676BB2</string>
-				<string>F40B874916AA233500676BB2</string>
-				<string>F40B874716AA233500676BB2</string>
-				<string>7F7F36E5290F6E12E446687F</string>
-			</array>
-			<key>isa</key>
-			<string>PBXGroup</string>
-			<key>sourceTree</key>
-			<string>&lt;group&gt;</string>
-		</dict>
-		<key>F40B873D16AA233500676BB2</key>
-		<dict>
-			<key>attributes</key>
-			<dict>
-				<key>LastUpgradeCheck</key>
-				<string>0450</string>
-				<key>ORGANIZATIONNAME</key>
-				<string>Simon Maynard</string>
-				<key>TargetAttributes</key>
-				<dict>
-					<key>F40B874516AA233500676BB2</key>
-					<dict>
-						<key>DevelopmentTeam</key>
-						<string>372ZUL2ZB7</string>
-					</dict>
-				</dict>
-			</dict>
-			<key>buildConfigurationList</key>
-			<string>F40B874016AA233500676BB2</string>
-			<key>compatibilityVersion</key>
-			<string>Xcode 3.2</string>
-			<key>developmentRegion</key>
-			<string>English</string>
-			<key>hasScannedForEncodings</key>
-			<string>0</string>
-			<key>isa</key>
-			<string>PBXProject</string>
-			<key>knownRegions</key>
-			<array>
-				<string>en</string>
-			</array>
-			<key>mainGroup</key>
-			<string>F40B873B16AA233500676BB2</string>
-			<key>productRefGroup</key>
-			<string>F40B874716AA233500676BB2</string>
-			<key>projectDirPath</key>
-			<string></string>
-			<key>projectReferences</key>
-			<array/>
-			<key>projectRoot</key>
-			<string></string>
-			<key>targets</key>
-			<array>
-				<string>F40B874516AA233500676BB2</string>
-			</array>
-		</dict>
-		<key>F40B874016AA233500676BB2</key>
-		<dict>
-			<key>buildConfigurations</key>
-			<array>
-				<string>F40B876B16AA233500676BB2</string>
-				<string>F40B876C16AA233500676BB2</string>
-			</array>
-			<key>defaultConfigurationIsVisible</key>
-			<string>0</string>
-			<key>defaultConfigurationName</key>
-			<string>Release</string>
-			<key>isa</key>
-			<string>XCConfigurationList</string>
-		</dict>
-		<key>F40B874216AA233500676BB2</key>
-		<dict>
-			<key>buildActionMask</key>
-			<string>2147483647</string>
-			<key>files</key>
-			<array>
-				<string>F40B875716AA233500676BB2</string>
-				<string>F40B875B16AA233500676BB2</string>
-				<string>F40B876A16AA233500676BB2</string>
-			</array>
-			<key>isa</key>
-			<string>PBXSourcesBuildPhase</string>
-			<key>runOnlyForDeploymentPostprocessing</key>
-			<string>0</string>
-		</dict>
-		<key>F40B874316AA233500676BB2</key>
-		<dict>
-			<key>buildActionMask</key>
-			<string>2147483647</string>
-			<key>files</key>
-			<array>
-				<string>F40B874B16AA233500676BB2</string>
-				<string>F40B874D16AA233500676BB2</string>
-				<string>F40B874F16AA233500676BB2</string>
-				<string>100749203726440EA4E45D3E</string>
-			</array>
-			<key>isa</key>
-			<string>PBXFrameworksBuildPhase</string>
-			<key>runOnlyForDeploymentPostprocessing</key>
-			<string>0</string>
-		</dict>
-		<key>F40B874416AA233500676BB2</key>
-		<dict>
-			<key>buildActionMask</key>
-			<string>2147483647</string>
-			<key>files</key>
-			<array>
-				<string>F40B875516AA233500676BB2</string>
-				<string>F40B875D16AA233500676BB2</string>
-				<string>F40B875F16AA233500676BB2</string>
-				<string>F40B876116AA233500676BB2</string>
-				<string>F40B876416AA233500676BB2</string>
-				<string>F40B876716AA233500676BB2</string>
-			</array>
-			<key>isa</key>
-			<string>PBXResourcesBuildPhase</string>
-			<key>runOnlyForDeploymentPostprocessing</key>
-			<string>0</string>
-		</dict>
-		<key>F40B874516AA233500676BB2</key>
-		<dict>
-			<key>buildConfigurationList</key>
-			<string>F40B876D16AA233500676BB2</string>
-			<key>buildPhases</key>
-			<array>
-				<string>0E579FC164E842FBB5C923B7</string>
-				<string>F40B874216AA233500676BB2</string>
-				<string>F40B874316AA233500676BB2</string>
-				<string>F40B874416AA233500676BB2</string>
-				<string>EC9C64C5098541749BAC1444</string>
-				<string>5142A2F8286744A694BDB5BA</string>
-			</array>
-			<key>buildRules</key>
-			<array/>
-			<key>dependencies</key>
-			<array/>
-			<key>isa</key>
-			<string>PBXNativeTarget</string>
-			<key>name</key>
-			<string>Bugsnag Test App</string>
-			<key>productName</key>
-			<string>Bugsnag Test App</string>
-			<key>productReference</key>
-			<string>F40B874616AA233500676BB2</string>
-			<key>productType</key>
-			<string>com.apple.product-type.application</string>
-		</dict>
-		<key>F40B874616AA233500676BB2</key>
-		<dict>
-			<key>explicitFileType</key>
-			<string>wrapper.application</string>
-			<key>includeInIndex</key>
-			<string>0</string>
-			<key>isa</key>
-			<string>PBXFileReference</string>
-			<key>path</key>
-			<string>Bugsnag Test App.app</string>
-			<key>sourceTree</key>
-			<string>BUILT_PRODUCTS_DIR</string>
-		</dict>
-		<key>F40B874716AA233500676BB2</key>
-		<dict>
-			<key>children</key>
-			<array>
-				<string>F40B874616AA233500676BB2</string>
-			</array>
-			<key>isa</key>
-			<string>PBXGroup</string>
-			<key>name</key>
-			<string>Products</string>
-			<key>sourceTree</key>
-			<string>&lt;group&gt;</string>
-		</dict>
-		<key>F40B874916AA233500676BB2</key>
-		<dict>
-			<key>children</key>
-			<array>
-				<string>F40B874A16AA233500676BB2</string>
-				<string>F40B874C16AA233500676BB2</string>
-				<string>F40B874E16AA233500676BB2</string>
-				<string>BBE4E4C4FB284B448E57166E</string>
-			</array>
-			<key>isa</key>
-			<string>PBXGroup</string>
-			<key>name</key>
-			<string>Frameworks</string>
-			<key>sourceTree</key>
-			<string>&lt;group&gt;</string>
-		</dict>
-		<key>F40B874A16AA233500676BB2</key>
-		<dict>
-			<key>isa</key>
-			<string>PBXFileReference</string>
-			<key>lastKnownFileType</key>
-			<string>wrapper.framework</string>
-			<key>name</key>
-			<string>UIKit.framework</string>
-			<key>path</key>
-			<string>System/Library/Frameworks/UIKit.framework</string>
-			<key>sourceTree</key>
-			<string>SDKROOT</string>
-		</dict>
-		<key>F40B874B16AA233500676BB2</key>
-		<dict>
-			<key>fileRef</key>
-			<string>F40B874A16AA233500676BB2</string>
-			<key>isa</key>
-			<string>PBXBuildFile</string>
-		</dict>
-		<key>F40B874C16AA233500676BB2</key>
-		<dict>
-			<key>isa</key>
-			<string>PBXFileReference</string>
-			<key>lastKnownFileType</key>
-			<string>wrapper.framework</string>
-			<key>name</key>
-			<string>Foundation.framework</string>
-			<key>path</key>
-			<string>System/Library/Frameworks/Foundation.framework</string>
-			<key>sourceTree</key>
-			<string>SDKROOT</string>
-		</dict>
-		<key>F40B874D16AA233500676BB2</key>
-		<dict>
-			<key>fileRef</key>
-			<string>F40B874C16AA233500676BB2</string>
-			<key>isa</key>
-			<string>PBXBuildFile</string>
-		</dict>
-		<key>F40B874E16AA233500676BB2</key>
-		<dict>
-			<key>isa</key>
-			<string>PBXFileReference</string>
-			<key>lastKnownFileType</key>
-			<string>wrapper.framework</string>
-			<key>name</key>
-			<string>CoreGraphics.framework</string>
-			<key>path</key>
-			<string>System/Library/Frameworks/CoreGraphics.framework</string>
-			<key>sourceTree</key>
-			<string>SDKROOT</string>
-		</dict>
-		<key>F40B874F16AA233500676BB2</key>
-		<dict>
-			<key>fileRef</key>
-			<string>F40B874E16AA233500676BB2</string>
-			<key>isa</key>
-			<string>PBXBuildFile</string>
-		</dict>
-		<key>F40B875016AA233500676BB2</key>
-		<dict>
-			<key>children</key>
-			<array>
-				<string>F40B875916AA233500676BB2</string>
-				<string>F40B875A16AA233500676BB2</string>
-				<string>F40B876216AA233500676BB2</string>
-				<string>F40B876516AA233500676BB2</string>
-				<string>F40B876816AA233500676BB2</string>
-				<string>F40B876916AA233500676BB2</string>
-				<string>F40B875116AA233500676BB2</string>
-			</array>
-			<key>isa</key>
-			<string>PBXGroup</string>
-			<key>path</key>
-			<string>Bugsnag Test App</string>
-			<key>sourceTree</key>
-			<string>&lt;group&gt;</string>
-		</dict>
-		<key>F40B875116AA233500676BB2</key>
-		<dict>
-			<key>children</key>
-			<array>
-				<string>F40B875216AA233500676BB2</string>
-				<string>F40B875316AA233500676BB2</string>
-				<string>F40B875616AA233500676BB2</string>
-				<string>F40B875816AA233500676BB2</string>
-				<string>F40B875C16AA233500676BB2</string>
-				<string>F40B875E16AA233500676BB2</string>
-				<string>F40B876016AA233500676BB2</string>
-			</array>
-			<key>isa</key>
-			<string>PBXGroup</string>
-			<key>name</key>
-			<string>Supporting Files</string>
-			<key>sourceTree</key>
-			<string>&lt;group&gt;</string>
-		</dict>
-		<key>F40B875216AA233500676BB2</key>
-		<dict>
-			<key>isa</key>
-			<string>PBXFileReference</string>
-			<key>lastKnownFileType</key>
-			<string>text.plist.xml</string>
-			<key>path</key>
-			<string>Bugsnag Test App-Info.plist</string>
-			<key>sourceTree</key>
-			<string>&lt;group&gt;</string>
-		</dict>
-		<key>F40B875316AA233500676BB2</key>
-		<dict>
-			<key>children</key>
-			<array>
-				<string>F40B875416AA233500676BB2</string>
-			</array>
-			<key>isa</key>
-			<string>PBXVariantGroup</string>
-			<key>name</key>
-			<string>InfoPlist.strings</string>
-			<key>sourceTree</key>
-			<string>&lt;group&gt;</string>
-		</dict>
-		<key>F40B875416AA233500676BB2</key>
-		<dict>
-			<key>isa</key>
-			<string>PBXFileReference</string>
-			<key>lastKnownFileType</key>
-			<string>text.plist.strings</string>
-			<key>name</key>
-			<string>en</string>
-			<key>path</key>
-			<string>en.lproj/InfoPlist.strings</string>
-			<key>sourceTree</key>
-			<string>&lt;group&gt;</string>
-		</dict>
-		<key>F40B875516AA233500676BB2</key>
-		<dict>
-			<key>fileRef</key>
-			<string>F40B875316AA233500676BB2</string>
-			<key>isa</key>
-			<string>PBXBuildFile</string>
-		</dict>
-		<key>F40B875616AA233500676BB2</key>
-		<dict>
-			<key>isa</key>
-			<string>PBXFileReference</string>
-			<key>lastKnownFileType</key>
-			<string>sourcecode.c.objc</string>
-			<key>path</key>
-			<string>main.m</string>
-			<key>sourceTree</key>
-			<string>&lt;group&gt;</string>
-		</dict>
-		<key>F40B875716AA233500676BB2</key>
-		<dict>
-			<key>fileRef</key>
-			<string>F40B875616AA233500676BB2</string>
-			<key>isa</key>
-			<string>PBXBuildFile</string>
-		</dict>
-		<key>F40B875816AA233500676BB2</key>
-		<dict>
-			<key>isa</key>
-			<string>PBXFileReference</string>
-			<key>lastKnownFileType</key>
-			<string>sourcecode.c.h</string>
-			<key>path</key>
-			<string>Bugsnag Test App-Prefix.pch</string>
-			<key>sourceTree</key>
-			<string>&lt;group&gt;</string>
-		</dict>
-		<key>F40B875916AA233500676BB2</key>
-		<dict>
-			<key>isa</key>
-			<string>PBXFileReference</string>
-			<key>lastKnownFileType</key>
-			<string>sourcecode.c.h</string>
-			<key>path</key>
-			<string>AppDelegate.h</string>
-			<key>sourceTree</key>
-			<string>&lt;group&gt;</string>
-		</dict>
-		<key>F40B875A16AA233500676BB2</key>
-		<dict>
-			<key>isa</key>
-			<string>PBXFileReference</string>
-			<key>lastKnownFileType</key>
-			<string>sourcecode.c.objc</string>
-			<key>path</key>
-			<string>AppDelegate.m</string>
-			<key>sourceTree</key>
-			<string>&lt;group&gt;</string>
-		</dict>
-		<key>F40B875B16AA233500676BB2</key>
-		<dict>
-			<key>fileRef</key>
-			<string>F40B875A16AA233500676BB2</string>
-			<key>isa</key>
-			<string>PBXBuildFile</string>
-		</dict>
-		<key>F40B875C16AA233500676BB2</key>
-		<dict>
-			<key>isa</key>
-			<string>PBXFileReference</string>
-			<key>lastKnownFileType</key>
-			<string>image.png</string>
-			<key>path</key>
-			<string>Default.png</string>
-			<key>sourceTree</key>
-			<string>&lt;group&gt;</string>
-		</dict>
-		<key>F40B875D16AA233500676BB2</key>
-		<dict>
-			<key>fileRef</key>
-			<string>F40B875C16AA233500676BB2</string>
-			<key>isa</key>
-			<string>PBXBuildFile</string>
-		</dict>
-		<key>F40B875E16AA233500676BB2</key>
-		<dict>
-			<key>isa</key>
-			<string>PBXFileReference</string>
-			<key>lastKnownFileType</key>
-			<string>image.png</string>
-			<key>path</key>
-			<string>Default@2x.png</string>
-			<key>sourceTree</key>
-			<string>&lt;group&gt;</string>
-		</dict>
-		<key>F40B875F16AA233500676BB2</key>
-		<dict>
-			<key>fileRef</key>
-			<string>F40B875E16AA233500676BB2</string>
-			<key>isa</key>
-			<string>PBXBuildFile</string>
-		</dict>
-		<key>F40B876016AA233500676BB2</key>
-		<dict>
-			<key>isa</key>
-			<string>PBXFileReference</string>
-			<key>lastKnownFileType</key>
-			<string>image.png</string>
-			<key>path</key>
-			<string>Default-568h@2x.png</string>
-			<key>sourceTree</key>
-			<string>&lt;group&gt;</string>
-		</dict>
-		<key>F40B876116AA233500676BB2</key>
-		<dict>
-			<key>fileRef</key>
-			<string>F40B876016AA233500676BB2</string>
-			<key>isa</key>
-			<string>PBXBuildFile</string>
-		</dict>
-		<key>F40B876216AA233500676BB2</key>
-		<dict>
-			<key>children</key>
-			<array>
-				<string>F40B876316AA233500676BB2</string>
-			</array>
-			<key>isa</key>
-			<string>PBXVariantGroup</string>
-			<key>name</key>
-			<string>MainStoryboard_iPhone.storyboard</string>
-			<key>sourceTree</key>
-			<string>&lt;group&gt;</string>
-		</dict>
-		<key>F40B876316AA233500676BB2</key>
-		<dict>
-			<key>isa</key>
-			<string>PBXFileReference</string>
-			<key>lastKnownFileType</key>
-			<string>file.storyboard</string>
-			<key>name</key>
-			<string>en</string>
-			<key>path</key>
-			<string>en.lproj/MainStoryboard_iPhone.storyboard</string>
-			<key>sourceTree</key>
-			<string>&lt;group&gt;</string>
-		</dict>
-		<key>F40B876416AA233500676BB2</key>
-		<dict>
-			<key>fileRef</key>
-			<string>F40B876216AA233500676BB2</string>
-			<key>isa</key>
-			<string>PBXBuildFile</string>
-		</dict>
-		<key>F40B876516AA233500676BB2</key>
-		<dict>
-			<key>children</key>
-			<array>
-				<string>F40B876616AA233500676BB2</string>
-			</array>
-			<key>isa</key>
-			<string>PBXVariantGroup</string>
-			<key>name</key>
-			<string>MainStoryboard_iPad.storyboard</string>
-			<key>sourceTree</key>
-			<string>&lt;group&gt;</string>
-		</dict>
-		<key>F40B876616AA233500676BB2</key>
-		<dict>
-			<key>isa</key>
-			<string>PBXFileReference</string>
-			<key>lastKnownFileType</key>
-			<string>file.storyboard</string>
-			<key>name</key>
-			<string>en</string>
-			<key>path</key>
-			<string>en.lproj/MainStoryboard_iPad.storyboard</string>
-			<key>sourceTree</key>
-			<string>&lt;group&gt;</string>
-		</dict>
-		<key>F40B876716AA233500676BB2</key>
-		<dict>
-			<key>fileRef</key>
-			<string>F40B876516AA233500676BB2</string>
-			<key>isa</key>
-			<string>PBXBuildFile</string>
-		</dict>
-		<key>F40B876816AA233500676BB2</key>
-		<dict>
-			<key>isa</key>
-			<string>PBXFileReference</string>
-			<key>lastKnownFileType</key>
-			<string>sourcecode.c.h</string>
-			<key>path</key>
-			<string>ViewController.h</string>
-			<key>sourceTree</key>
-			<string>&lt;group&gt;</string>
-		</dict>
-		<key>F40B876916AA233500676BB2</key>
-		<dict>
-			<key>isa</key>
-			<string>PBXFileReference</string>
-			<key>lastKnownFileType</key>
-			<string>sourcecode.c.objc</string>
-			<key>path</key>
-			<string>ViewController.m</string>
-			<key>sourceTree</key>
-			<string>&lt;group&gt;</string>
-		</dict>
-		<key>F40B876A16AA233500676BB2</key>
-		<dict>
-			<key>fileRef</key>
-			<string>F40B876916AA233500676BB2</string>
-			<key>isa</key>
-			<string>PBXBuildFile</string>
-		</dict>
-		<key>F40B876B16AA233500676BB2</key>
-		<dict>
-			<key>buildSettings</key>
-			<dict>
-				<key>ALWAYS_SEARCH_USER_PATHS</key>
-				<string>NO</string>
-				<key>CLANG_CXX_LANGUAGE_STANDARD</key>
-				<string>gnu++0x</string>
-				<key>CLANG_CXX_LIBRARY</key>
-				<string>libc++</string>
-				<key>CLANG_ENABLE_OBJC_ARC</key>
-				<string>YES</string>
-				<key>CLANG_WARN_EMPTY_BODY</key>
-				<string>YES</string>
-				<key>CLANG_WARN__DUPLICATE_METHOD_MATCH</key>
-				<string>YES</string>
-				<key>CODE_SIGN_IDENTITY[sdk=iphoneos*]</key>
-				<string>iPhone Developer</string>
-				<key>COPY_PHASE_STRIP</key>
-				<string>YES</string>
-				<key>DEPLOYMENT_POSTPROCESSING</key>
-				<string>YES</string>
-				<key>GCC_C_LANGUAGE_STANDARD</key>
-				<string>gnu99</string>
-				<key>GCC_DYNAMIC_NO_PIC</key>
-				<string>NO</string>
-				<key>GCC_GENERATE_DEBUGGING_SYMBOLS</key>
-				<string>YES</string>
-				<key>GCC_OPTIMIZATION_LEVEL</key>
-				<string>0</string>
-				<key>GCC_PREPROCESSOR_DEFINITIONS</key>
-				<array>
-					<string>DEBUG=1</string>
-					<string>$(inherited)</string>
-				</array>
-				<key>GCC_SYMBOLS_PRIVATE_EXTERN</key>
-				<string>YES</string>
-				<key>GCC_WARN_ABOUT_RETURN_TYPE</key>
-				<string>YES</string>
-				<key>GCC_WARN_UNINITIALIZED_AUTOS</key>
-				<string>YES</string>
-				<key>GCC_WARN_UNUSED_VARIABLE</key>
-				<string>YES</string>
-				<key>IPHONEOS_DEPLOYMENT_TARGET</key>
-				<string>5.0</string>
-				<key>ONLY_ACTIVE_ARCH</key>
-				<string>YES</string>
-				<key>SDKROOT</key>
-				<string>iphoneos</string>
-				<key>TARGETED_DEVICE_FAMILY</key>
-				<string>1,2</string>
-			</dict>
-			<key>isa</key>
-			<string>XCBuildConfiguration</string>
-			<key>name</key>
-			<string>Debug</string>
-		</dict>
-		<key>F40B876C16AA233500676BB2</key>
-		<dict>
-			<key>buildSettings</key>
-			<dict>
-				<key>ALWAYS_SEARCH_USER_PATHS</key>
-				<string>NO</string>
-				<key>CLANG_CXX_LANGUAGE_STANDARD</key>
-				<string>gnu++0x</string>
-				<key>CLANG_CXX_LIBRARY</key>
-				<string>libc++</string>
-				<key>CLANG_ENABLE_OBJC_ARC</key>
-				<string>YES</string>
-				<key>CLANG_WARN_EMPTY_BODY</key>
-				<string>YES</string>
-				<key>CLANG_WARN__DUPLICATE_METHOD_MATCH</key>
-				<string>YES</string>
-				<key>CODE_SIGN_IDENTITY[sdk=iphoneos*]</key>
-				<string>iPhone Developer</string>
-				<key>COPY_PHASE_STRIP</key>
-				<string>YES</string>
-				<key>DEPLOYMENT_POSTPROCESSING</key>
-				<string>YES</string>
-				<key>GCC_C_LANGUAGE_STANDARD</key>
-				<string>gnu99</string>
-				<key>GCC_GENERATE_DEBUGGING_SYMBOLS</key>
-				<string>YES</string>
-				<key>GCC_SYMBOLS_PRIVATE_EXTERN</key>
-				<string>YES</string>
-				<key>GCC_WARN_ABOUT_RETURN_TYPE</key>
-				<string>YES</string>
-				<key>GCC_WARN_UNINITIALIZED_AUTOS</key>
-				<string>YES</string>
-				<key>GCC_WARN_UNUSED_VARIABLE</key>
-				<string>YES</string>
-				<key>IPHONEOS_DEPLOYMENT_TARGET</key>
-				<string>5.0</string>
-				<key>OTHER_CFLAGS</key>
-				<string>-DNS_BLOCK_ASSERTIONS=1</string>
-				<key>SDKROOT</key>
-				<string>iphoneos</string>
-				<key>TARGETED_DEVICE_FAMILY</key>
-				<string>1,2</string>
-				<key>VALIDATE_PRODUCT</key>
-				<string>YES</string>
-			</dict>
-			<key>isa</key>
-			<string>XCBuildConfiguration</string>
-			<key>name</key>
-			<string>Release</string>
-		</dict>
-		<key>F40B876D16AA233500676BB2</key>
-		<dict>
-			<key>buildConfigurations</key>
-			<array>
-				<string>F40B876E16AA233500676BB2</string>
-				<string>F40B876F16AA233500676BB2</string>
-			</array>
-			<key>defaultConfigurationIsVisible</key>
-			<string>0</string>
-			<key>defaultConfigurationName</key>
-			<string>Release</string>
-			<key>isa</key>
-			<string>XCConfigurationList</string>
-		</dict>
-		<key>F40B876E16AA233500676BB2</key>
-		<dict>
-			<key>baseConfigurationReference</key>
-			<string>1D860917AA32015D2A67696B</string>
-			<key>buildSettings</key>
-			<dict>
-				<key>ARCHS</key>
-				<string>$(ARCHS_STANDARD_INCLUDING_64_BIT)</string>
-				<key>CODE_SIGN_IDENTITY</key>
-				<string>iPhone Developer</string>
-				<key>CODE_SIGN_IDENTITY[sdk=iphoneos*]</key>
-				<string>iPhone Developer</string>
-				<key>COPY_PHASE_STRIP</key>
-				<string>YES</string>
-				<key>DEPLOYMENT_POSTPROCESSING</key>
-				<string>YES</string>
-				<key>GCC_GENERATE_DEBUGGING_SYMBOLS</key>
-				<string>YES</string>
-				<key>GCC_PRECOMPILE_PREFIX_HEADER</key>
-				<string>YES</string>
-				<key>GCC_PREFIX_HEADER</key>
-				<string>Bugsnag Test App/Bugsnag Test App-Prefix.pch</string>
-				<key>GCC_SYMBOLS_PRIVATE_EXTERN</key>
-				<string>YES</string>
-				<key>INFOPLIST_FILE</key>
-				<string>Bugsnag Test App/Bugsnag Test App-Info.plist</string>
-				<key>IPHONEOS_DEPLOYMENT_TARGET</key>
-				<string>6.0</string>
-				<key>PRODUCT_NAME</key>
-				<string>$(TARGET_NAME)</string>
-				<key>PROVISIONING_PROFILE</key>
-				<string></string>
-				<key>SEPARATE_STRIP</key>
-				<string>YES</string>
-				<key>STRIP_INSTALLED_PRODUCT</key>
-				<string>YES</string>
-				<key>WRAPPER_EXTENSION</key>
-				<string>app</string>
-			</dict>
-			<key>isa</key>
-			<string>XCBuildConfiguration</string>
-			<key>name</key>
-			<string>Debug</string>
-		</dict>
-		<key>F40B876F16AA233500676BB2</key>
-		<dict>
-			<key>baseConfigurationReference</key>
-			<string>2CA6385EE8EA5F91543DE7E0</string>
-			<key>buildSettings</key>
-			<dict>
-				<key>ARCHS</key>
-				<string>$(ARCHS_STANDARD_INCLUDING_64_BIT)</string>
-				<key>CODE_SIGN_IDENTITY</key>
-				<string>iPhone Developer</string>
-				<key>CODE_SIGN_IDENTITY[sdk=iphoneos*]</key>
-				<string>iPhone Developer</string>
-				<key>DEPLOYMENT_POSTPROCESSING</key>
-				<string>YES</string>
-				<key>GCC_GENERATE_DEBUGGING_SYMBOLS</key>
-				<string>YES</string>
-				<key>GCC_PRECOMPILE_PREFIX_HEADER</key>
-				<string>YES</string>
-				<key>GCC_PREFIX_HEADER</key>
-				<string>Bugsnag Test App/Bugsnag Test App-Prefix.pch</string>
-				<key>INFOPLIST_FILE</key>
-				<string>Bugsnag Test App/Bugsnag Test App-Info.plist</string>
-				<key>IPHONEOS_DEPLOYMENT_TARGET</key>
-				<string>6.0</string>
-				<key>PRODUCT_NAME</key>
-				<string>$(TARGET_NAME)</string>
-				<key>PROVISIONING_PROFILE</key>
-				<string></string>
-				<key>SEPARATE_STRIP</key>
-				<string>YES</string>
-				<key>STRIP_INSTALLED_PRODUCT</key>
-				<string>YES</string>
-				<key>WRAPPER_EXTENSION</key>
-				<string>app</string>
-			</dict>
-			<key>isa</key>
-			<string>XCBuildConfiguration</string>
-			<key>name</key>
-			<string>Release</string>
-		</dict>
-	</dict>
-	<key>rootObject</key>
-	<string>F40B873D16AA233500676BB2</string>
-</dict>
-</plist>
+/* Begin PBXFileReference section */
+		1D860917AA32015D2A67696B /* Pods.debug.xcconfig */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.xcconfig; name = Pods.debug.xcconfig; path = "Pods/Target Support Files/Pods/Pods.debug.xcconfig"; sourceTree = "<group>"; };
+		2CA6385EE8EA5F91543DE7E0 /* Pods.release.xcconfig */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.xcconfig; name = Pods.release.xcconfig; path = "Pods/Target Support Files/Pods/Pods.release.xcconfig"; sourceTree = "<group>"; };
+		BBE4E4C4FB284B448E57166E /* libPods.a */ = {isa = PBXFileReference; explicitFileType = archive.ar; includeInIndex = 0; path = libPods.a; sourceTree = BUILT_PRODUCTS_DIR; };
+		F40B874616AA233500676BB2 /* Bugsnag Test App.app */ = {isa = PBXFileReference; explicitFileType = wrapper.application; includeInIndex = 0; path = "Bugsnag Test App.app"; sourceTree = BUILT_PRODUCTS_DIR; };
+		F40B874A16AA233500676BB2 /* UIKit.framework */ = {isa = PBXFileReference; lastKnownFileType = wrapper.framework; name = UIKit.framework; path = System/Library/Frameworks/UIKit.framework; sourceTree = SDKROOT; };
+		F40B874C16AA233500676BB2 /* Foundation.framework */ = {isa = PBXFileReference; lastKnownFileType = wrapper.framework; name = Foundation.framework; path = System/Library/Frameworks/Foundation.framework; sourceTree = SDKROOT; };
+		F40B874E16AA233500676BB2 /* CoreGraphics.framework */ = {isa = PBXFileReference; lastKnownFileType = wrapper.framework; name = CoreGraphics.framework; path = System/Library/Frameworks/CoreGraphics.framework; sourceTree = SDKROOT; };
+		F40B875216AA233500676BB2 /* Bugsnag Test App-Info.plist */ = {isa = PBXFileReference; lastKnownFileType = text.plist.xml; path = "Bugsnag Test App-Info.plist"; sourceTree = "<group>"; };
+		F40B875416AA233500676BB2 /* en */ = {isa = PBXFileReference; lastKnownFileType = text.plist.strings; name = en; path = en.lproj/InfoPlist.strings; sourceTree = "<group>"; };
+		F40B875616AA233500676BB2 /* main.m */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.objc; path = main.m; sourceTree = "<group>"; };
+		F40B875816AA233500676BB2 /* Bugsnag Test App-Prefix.pch */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; path = "Bugsnag Test App-Prefix.pch"; sourceTree = "<group>"; };
+		F40B875916AA233500676BB2 /* AppDelegate.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; path = AppDelegate.h; sourceTree = "<group>"; };
+		F40B875A16AA233500676BB2 /* AppDelegate.m */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.objc; path = AppDelegate.m; sourceTree = "<group>"; };
+		F40B875C16AA233500676BB2 /* Default.png */ = {isa = PBXFileReference; lastKnownFileType = image.png; path = Default.png; sourceTree = "<group>"; };
+		F40B875E16AA233500676BB2 /* Default@2x.png */ = {isa = PBXFileReference; lastKnownFileType = image.png; path = "Default@2x.png"; sourceTree = "<group>"; };
+		F40B876016AA233500676BB2 /* Default-568h@2x.png */ = {isa = PBXFileReference; lastKnownFileType = image.png; path = "Default-568h@2x.png"; sourceTree = "<group>"; };
+		F40B876316AA233500676BB2 /* en */ = {isa = PBXFileReference; lastKnownFileType = file.storyboard; name = en; path = en.lproj/MainStoryboard_iPhone.storyboard; sourceTree = "<group>"; };
+		F40B876616AA233500676BB2 /* en */ = {isa = PBXFileReference; lastKnownFileType = file.storyboard; name = en; path = en.lproj/MainStoryboard_iPad.storyboard; sourceTree = "<group>"; };
+		F40B876816AA233500676BB2 /* ViewController.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; path = ViewController.h; sourceTree = "<group>"; };
+		F40B876916AA233500676BB2 /* ViewController.m */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.objc; path = ViewController.m; sourceTree = "<group>"; };
+/* End PBXFileReference section */
+
+/* Begin PBXFrameworksBuildPhase section */
+		F40B874316AA233500676BB2 /* Frameworks */ = {
+			isa = PBXFrameworksBuildPhase;
+			buildActionMask = 2147483647;
+			files = (
+				F40B874B16AA233500676BB2 /* UIKit.framework in Frameworks */,
+				F40B874D16AA233500676BB2 /* Foundation.framework in Frameworks */,
+				F40B874F16AA233500676BB2 /* CoreGraphics.framework in Frameworks */,
+				100749203726440EA4E45D3E /* libPods.a in Frameworks */,
+			);
+			runOnlyForDeploymentPostprocessing = 0;
+		};
+/* End PBXFrameworksBuildPhase section */
+
+/* Begin PBXGroup section */
+		7F7F36E5290F6E12E446687F /* Pods */ = {
+			isa = PBXGroup;
+			children = (
+				1D860917AA32015D2A67696B /* Pods.debug.xcconfig */,
+				2CA6385EE8EA5F91543DE7E0 /* Pods.release.xcconfig */,
+			);
+			name = Pods;
+			sourceTree = "<group>";
+		};
+		F40B873B16AA233500676BB2 = {
+			isa = PBXGroup;
+			children = (
+				F40B875016AA233500676BB2 /* Bugsnag Test App */,
+				F40B874916AA233500676BB2 /* Frameworks */,
+				F40B874716AA233500676BB2 /* Products */,
+				7F7F36E5290F6E12E446687F /* Pods */,
+			);
+			sourceTree = "<group>";
+		};
+		F40B874716AA233500676BB2 /* Products */ = {
+			isa = PBXGroup;
+			children = (
+				F40B874616AA233500676BB2 /* Bugsnag Test App.app */,
+			);
+			name = Products;
+			sourceTree = "<group>";
+		};
+		F40B874916AA233500676BB2 /* Frameworks */ = {
+			isa = PBXGroup;
+			children = (
+				F40B874A16AA233500676BB2 /* UIKit.framework */,
+				F40B874C16AA233500676BB2 /* Foundation.framework */,
+				F40B874E16AA233500676BB2 /* CoreGraphics.framework */,
+				BBE4E4C4FB284B448E57166E /* libPods.a */,
+			);
+			name = Frameworks;
+			sourceTree = "<group>";
+		};
+		F40B875016AA233500676BB2 /* Bugsnag Test App */ = {
+			isa = PBXGroup;
+			children = (
+				F40B875916AA233500676BB2 /* AppDelegate.h */,
+				F40B875A16AA233500676BB2 /* AppDelegate.m */,
+				F40B876216AA233500676BB2 /* MainStoryboard_iPhone.storyboard */,
+				F40B876516AA233500676BB2 /* MainStoryboard_iPad.storyboard */,
+				F40B876816AA233500676BB2 /* ViewController.h */,
+				F40B876916AA233500676BB2 /* ViewController.m */,
+				F40B875116AA233500676BB2 /* Supporting Files */,
+			);
+			path = "Bugsnag Test App";
+			sourceTree = "<group>";
+		};
+		F40B875116AA233500676BB2 /* Supporting Files */ = {
+			isa = PBXGroup;
+			children = (
+				F40B875216AA233500676BB2 /* Bugsnag Test App-Info.plist */,
+				F40B875316AA233500676BB2 /* InfoPlist.strings */,
+				F40B875616AA233500676BB2 /* main.m */,
+				F40B875816AA233500676BB2 /* Bugsnag Test App-Prefix.pch */,
+				F40B875C16AA233500676BB2 /* Default.png */,
+				F40B875E16AA233500676BB2 /* Default@2x.png */,
+				F40B876016AA233500676BB2 /* Default-568h@2x.png */,
+			);
+			name = "Supporting Files";
+			sourceTree = "<group>";
+		};
+/* End PBXGroup section */
+
+/* Begin PBXNativeTarget section */
+		F40B874516AA233500676BB2 /* Bugsnag Test App */ = {
+			isa = PBXNativeTarget;
+			buildConfigurationList = F40B876D16AA233500676BB2 /* Build configuration list for PBXNativeTarget "Bugsnag Test App" */;
+			buildPhases = (
+				0E579FC164E842FBB5C923B7 /* Check Pods Manifest.lock */,
+				F40B874216AA233500676BB2 /* Sources */,
+				F40B874316AA233500676BB2 /* Frameworks */,
+				F40B874416AA233500676BB2 /* Resources */,
+				EC9C64C5098541749BAC1444 /* Copy Pods Resources */,
+				5142A2F8286744A694BDB5BA /* Upload Bugsnag dSYM */,
+				4C4EF4DB138A9BB5E2D23D4A /* Embed Pods Frameworks */,
+			);
+			buildRules = (
+			);
+			dependencies = (
+			);
+			name = "Bugsnag Test App";
+			productName = "Bugsnag Test App";
+			productReference = F40B874616AA233500676BB2 /* Bugsnag Test App.app */;
+			productType = "com.apple.product-type.application";
+		};
+/* End PBXNativeTarget section */
+
+/* Begin PBXProject section */
+		F40B873D16AA233500676BB2 /* Project object */ = {
+			isa = PBXProject;
+			attributes = {
+				LastUpgradeCheck = 0450;
+				ORGANIZATIONNAME = "Simon Maynard";
+				TargetAttributes = {
+					F40B874516AA233500676BB2 = {
+						DevelopmentTeam = 372ZUL2ZB7;
+					};
+				};
+			};
+			buildConfigurationList = F40B874016AA233500676BB2 /* Build configuration list for PBXProject "Bugsnag Test App" */;
+			compatibilityVersion = "Xcode 3.2";
+			developmentRegion = English;
+			hasScannedForEncodings = 0;
+			knownRegions = (
+				en,
+			);
+			mainGroup = F40B873B16AA233500676BB2;
+			productRefGroup = F40B874716AA233500676BB2 /* Products */;
+			projectDirPath = "";
+			projectRoot = "";
+			targets = (
+				F40B874516AA233500676BB2 /* Bugsnag Test App */,
+			);
+		};
+/* End PBXProject section */
+
+/* Begin PBXResourcesBuildPhase section */
+		F40B874416AA233500676BB2 /* Resources */ = {
+			isa = PBXResourcesBuildPhase;
+			buildActionMask = 2147483647;
+			files = (
+				F40B875516AA233500676BB2 /* InfoPlist.strings in Resources */,
+				F40B875D16AA233500676BB2 /* Default.png in Resources */,
+				F40B875F16AA233500676BB2 /* Default@2x.png in Resources */,
+				F40B876116AA233500676BB2 /* Default-568h@2x.png in Resources */,
+				F40B876416AA233500676BB2 /* MainStoryboard_iPhone.storyboard in Resources */,
+				F40B876716AA233500676BB2 /* MainStoryboard_iPad.storyboard in Resources */,
+			);
+			runOnlyForDeploymentPostprocessing = 0;
+		};
+/* End PBXResourcesBuildPhase section */
+
+/* Begin PBXShellScriptBuildPhase section */
+		0E579FC164E842FBB5C923B7 /* Check Pods Manifest.lock */ = {
+			isa = PBXShellScriptBuildPhase;
+			buildActionMask = 2147483647;
+			files = (
+			);
+			inputPaths = (
+			);
+			name = "Check Pods Manifest.lock";
+			outputPaths = (
+			);
+			runOnlyForDeploymentPostprocessing = 0;
+			shellPath = /bin/sh;
+			shellScript = "diff \"${PODS_ROOT}/../Podfile.lock\" \"${PODS_ROOT}/Manifest.lock\" > /dev/null\nif [[ $? != 0 ]] ; then\n    cat << EOM\nerror: The sandbox is not in sync with the Podfile.lock. Run 'pod install' or update your CocoaPods installation.\nEOM\n    exit 1\nfi\n";
+			showEnvVarsInLog = 0;
+		};
+		4C4EF4DB138A9BB5E2D23D4A /* Embed Pods Frameworks */ = {
+			isa = PBXShellScriptBuildPhase;
+			buildActionMask = 2147483647;
+			files = (
+			);
+			inputPaths = (
+			);
+			name = "Embed Pods Frameworks";
+			outputPaths = (
+			);
+			runOnlyForDeploymentPostprocessing = 0;
+			shellPath = /bin/sh;
+			shellScript = "\"${SRCROOT}/Pods/Target Support Files/Pods/Pods-frameworks.sh\"\n";
+			showEnvVarsInLog = 0;
+		};
+		5142A2F8286744A694BDB5BA /* Upload Bugsnag dSYM */ = {
+			isa = PBXShellScriptBuildPhase;
+			buildActionMask = 2147483647;
+			files = (
+			);
+			inputPaths = (
+			);
+			name = "Upload Bugsnag dSYM";
+			outputPaths = (
+			);
+			runOnlyForDeploymentPostprocessing = 0;
+			shellPath = "/usr/bin/env ruby";
+			shellScript = "fork do\n  Process.setsid\n  STDIN.reopen(\"/dev/null\")\n  STDOUT.reopen(\"/dev/null\", \"a\")\n  STDERR.reopen(\"/dev/null\", \"a\")\n\n  require 'shellwords'\n\n  Dir[\"#{ENV[\"DWARF_DSYM_FOLDER_PATH\"]}/*/Contents/Resources/DWARF/*\"].each do |dsym|\n    system(\"curl -F dsym=@#{Shellwords.escape(dsym)} -F projectRoot=#{Shellwords.escape(ENV[\"PROJECT_DIR\"])} https://upload.bugsnag.com/\")\n  end\nend\n";
+			showEnvVarsInLog = 0;
+		};
+		EC9C64C5098541749BAC1444 /* Copy Pods Resources */ = {
+			isa = PBXShellScriptBuildPhase;
+			buildActionMask = 2147483647;
+			files = (
+			);
+			inputPaths = (
+			);
+			name = "Copy Pods Resources";
+			outputPaths = (
+			);
+			runOnlyForDeploymentPostprocessing = 0;
+			shellPath = /bin/sh;
+			shellScript = "\"${SRCROOT}/Pods/Target Support Files/Pods/Pods-resources.sh\"\n";
+			showEnvVarsInLog = 0;
+		};
+/* End PBXShellScriptBuildPhase section */
+
+/* Begin PBXSourcesBuildPhase section */
+		F40B874216AA233500676BB2 /* Sources */ = {
+			isa = PBXSourcesBuildPhase;
+			buildActionMask = 2147483647;
+			files = (
+				F40B875716AA233500676BB2 /* main.m in Sources */,
+				F40B875B16AA233500676BB2 /* AppDelegate.m in Sources */,
+				F40B876A16AA233500676BB2 /* ViewController.m in Sources */,
+			);
+			runOnlyForDeploymentPostprocessing = 0;
+		};
+/* End PBXSourcesBuildPhase section */
+
+/* Begin PBXVariantGroup section */
+		F40B875316AA233500676BB2 /* InfoPlist.strings */ = {
+			isa = PBXVariantGroup;
+			children = (
+				F40B875416AA233500676BB2 /* en */,
+			);
+			name = InfoPlist.strings;
+			sourceTree = "<group>";
+		};
+		F40B876216AA233500676BB2 /* MainStoryboard_iPhone.storyboard */ = {
+			isa = PBXVariantGroup;
+			children = (
+				F40B876316AA233500676BB2 /* en */,
+			);
+			name = MainStoryboard_iPhone.storyboard;
+			sourceTree = "<group>";
+		};
+		F40B876516AA233500676BB2 /* MainStoryboard_iPad.storyboard */ = {
+			isa = PBXVariantGroup;
+			children = (
+				F40B876616AA233500676BB2 /* en */,
+			);
+			name = MainStoryboard_iPad.storyboard;
+			sourceTree = "<group>";
+		};
+/* End PBXVariantGroup section */
+
+/* Begin XCBuildConfiguration section */
+		F40B876B16AA233500676BB2 /* Debug */ = {
+			isa = XCBuildConfiguration;
+			buildSettings = {
+				ALWAYS_SEARCH_USER_PATHS = NO;
+				CLANG_CXX_LANGUAGE_STANDARD = "gnu++0x";
+				CLANG_CXX_LIBRARY = "libc++";
+				CLANG_ENABLE_OBJC_ARC = YES;
+				CLANG_WARN_EMPTY_BODY = YES;
+				CLANG_WARN__DUPLICATE_METHOD_MATCH = YES;
+				"CODE_SIGN_IDENTITY[sdk=iphoneos*]" = "iPhone Developer";
+				COPY_PHASE_STRIP = YES;
+				DEPLOYMENT_POSTPROCESSING = YES;
+				GCC_C_LANGUAGE_STANDARD = gnu99;
+				GCC_DYNAMIC_NO_PIC = NO;
+				GCC_GENERATE_DEBUGGING_SYMBOLS = YES;
+				GCC_OPTIMIZATION_LEVEL = 0;
+				GCC_PREPROCESSOR_DEFINITIONS = (
+					"DEBUG=1",
+					"$(inherited)",
+				);
+				GCC_SYMBOLS_PRIVATE_EXTERN = YES;
+				GCC_WARN_ABOUT_RETURN_TYPE = YES;
+				GCC_WARN_UNINITIALIZED_AUTOS = YES;
+				GCC_WARN_UNUSED_VARIABLE = YES;
+				IPHONEOS_DEPLOYMENT_TARGET = 5.0;
+				ONLY_ACTIVE_ARCH = YES;
+				SDKROOT = iphoneos;
+				TARGETED_DEVICE_FAMILY = "1,2";
+			};
+			name = Debug;
+		};
+		F40B876C16AA233500676BB2 /* Release */ = {
+			isa = XCBuildConfiguration;
+			buildSettings = {
+				ALWAYS_SEARCH_USER_PATHS = NO;
+				CLANG_CXX_LANGUAGE_STANDARD = "gnu++0x";
+				CLANG_CXX_LIBRARY = "libc++";
+				CLANG_ENABLE_OBJC_ARC = YES;
+				CLANG_WARN_EMPTY_BODY = YES;
+				CLANG_WARN__DUPLICATE_METHOD_MATCH = YES;
+				"CODE_SIGN_IDENTITY[sdk=iphoneos*]" = "iPhone Developer";
+				COPY_PHASE_STRIP = YES;
+				DEPLOYMENT_POSTPROCESSING = YES;
+				GCC_C_LANGUAGE_STANDARD = gnu99;
+				GCC_GENERATE_DEBUGGING_SYMBOLS = YES;
+				GCC_SYMBOLS_PRIVATE_EXTERN = YES;
+				GCC_WARN_ABOUT_RETURN_TYPE = YES;
+				GCC_WARN_UNINITIALIZED_AUTOS = YES;
+				GCC_WARN_UNUSED_VARIABLE = YES;
+				IPHONEOS_DEPLOYMENT_TARGET = 5.0;
+				OTHER_CFLAGS = "-DNS_BLOCK_ASSERTIONS=1";
+				SDKROOT = iphoneos;
+				TARGETED_DEVICE_FAMILY = "1,2";
+				VALIDATE_PRODUCT = YES;
+			};
+			name = Release;
+		};
+		F40B876E16AA233500676BB2 /* Debug */ = {
+			isa = XCBuildConfiguration;
+			baseConfigurationReference = 1D860917AA32015D2A67696B /* Pods.debug.xcconfig */;
+			buildSettings = {
+				ARCHS = "$(ARCHS_STANDARD_INCLUDING_64_BIT)";
+				CODE_SIGN_IDENTITY = "iPhone Developer";
+				"CODE_SIGN_IDENTITY[sdk=iphoneos*]" = "iPhone Developer";
+				COPY_PHASE_STRIP = YES;
+				DEPLOYMENT_POSTPROCESSING = YES;
+				GCC_GENERATE_DEBUGGING_SYMBOLS = YES;
+				GCC_PRECOMPILE_PREFIX_HEADER = YES;
+				GCC_PREFIX_HEADER = "Bugsnag Test App/Bugsnag Test App-Prefix.pch";
+				GCC_SYMBOLS_PRIVATE_EXTERN = YES;
+				INFOPLIST_FILE = "Bugsnag Test App/Bugsnag Test App-Info.plist";
+				IPHONEOS_DEPLOYMENT_TARGET = 6.0;
+				PRODUCT_NAME = "$(TARGET_NAME)";
+				PROVISIONING_PROFILE = "";
+				SEPARATE_STRIP = YES;
+				STRIP_INSTALLED_PRODUCT = YES;
+				WRAPPER_EXTENSION = app;
+			};
+			name = Debug;
+		};
+		F40B876F16AA233500676BB2 /* Release */ = {
+			isa = XCBuildConfiguration;
+			baseConfigurationReference = 2CA6385EE8EA5F91543DE7E0 /* Pods.release.xcconfig */;
+			buildSettings = {
+				ARCHS = "$(ARCHS_STANDARD_INCLUDING_64_BIT)";
+				CODE_SIGN_IDENTITY = "iPhone Developer";
+				"CODE_SIGN_IDENTITY[sdk=iphoneos*]" = "iPhone Developer";
+				DEPLOYMENT_POSTPROCESSING = YES;
+				GCC_GENERATE_DEBUGGING_SYMBOLS = YES;
+				GCC_PRECOMPILE_PREFIX_HEADER = YES;
+				GCC_PREFIX_HEADER = "Bugsnag Test App/Bugsnag Test App-Prefix.pch";
+				INFOPLIST_FILE = "Bugsnag Test App/Bugsnag Test App-Info.plist";
+				IPHONEOS_DEPLOYMENT_TARGET = 6.0;
+				PRODUCT_NAME = "$(TARGET_NAME)";
+				PROVISIONING_PROFILE = "";
+				SEPARATE_STRIP = YES;
+				STRIP_INSTALLED_PRODUCT = YES;
+				WRAPPER_EXTENSION = app;
+			};
+			name = Release;
+		};
+/* End XCBuildConfiguration section */
+
+/* Begin XCConfigurationList section */
+		F40B874016AA233500676BB2 /* Build configuration list for PBXProject "Bugsnag Test App" */ = {
+			isa = XCConfigurationList;
+			buildConfigurations = (
+				F40B876B16AA233500676BB2 /* Debug */,
+				F40B876C16AA233500676BB2 /* Release */,
+			);
+			defaultConfigurationIsVisible = 0;
+			defaultConfigurationName = Release;
+		};
+		F40B876D16AA233500676BB2 /* Build configuration list for PBXNativeTarget "Bugsnag Test App" */ = {
+			isa = XCConfigurationList;
+			buildConfigurations = (
+				F40B876E16AA233500676BB2 /* Debug */,
+				F40B876F16AA233500676BB2 /* Release */,
+			);
+			defaultConfigurationIsVisible = 0;
+			defaultConfigurationName = Release;
+		};
+/* End XCConfigurationList section */
+	};
+	rootObject = F40B873D16AA233500676BB2 /* Project object */;
+}

--- a/examples/objective-c-ios/Bugsnag Test App/ViewController.m
+++ b/examples/objective-c-ios/Bugsnag Test App/ViewController.m
@@ -16,19 +16,18 @@
 
 @implementation ViewController
 
-- (void)viewDidLoad
-{
+- (void)viewDidLoad {
     [super viewDidLoad];
-	// Do any additional setup after loading the view, typically from a nib.
+    [Bugsnag leaveBreadcrumbWithMessage:@"Loaded iOS Objective-C test app"];
 }
 
-- (void)didReceiveMemoryWarning
-{
+- (void)didReceiveMemoryWarning {
     [super didReceiveMemoryWarning];
-    // Dispose of any resources that can be recreated.
+    [Bugsnag leaveBreadcrumbWithMessage:@"Received memory warning"];
 }
 
 - (IBAction)generateException:(id)sender {
+    [Bugsnag leaveBreadcrumbWithMessage:@"Generating exception by non-existent selector"];
     [self performSelectorOnMainThread:@selector(someRandomMethod) withObject:nil waitUntilDone:NO];
 }
 
@@ -45,10 +44,12 @@
 }
 
 - (IBAction)delayedException:(id)sender {
+    [Bugsnag leaveBreadcrumbWithMessage:@"Queuing a non-fatal exception in 5 seconds"];
     [self performSelector:@selector(nonFatalException:) withObject:sender afterDelay:5];
 }
 
 - (IBAction)nonFatalException:(id)sender {
+    [Bugsnag leaveBreadcrumbWithMessage:@"generate non-fatal exception"];
     NSMutableDictionary *data = [[NSMutableDictionary alloc] init];
     [data setObject: data forKey: @"data"];
     

--- a/examples/objective-c-ios/Podfile
+++ b/examples/objective-c-ios/Podfile
@@ -1,3 +1,3 @@
 platform :ios, "5.0"
-pod 'Bugsnag', :git => "https://github.com/bugsnag/bugsnag-cocoa.git"
+pod 'Bugsnag', :path => "../.."
 

--- a/examples/objective-c-ios/Podfile.lock
+++ b/examples/objective-c-ios/Podfile.lock
@@ -1,21 +1,16 @@
 PODS:
-  - Bugsnag (4.0.5):
-    - Bugsnag/no-arc (= 4.0.5)
-  - Bugsnag/no-arc (4.0.5)
+  - Bugsnag (4.0.9):
+    - Bugsnag/no-arc (= 4.0.9)
+  - Bugsnag/no-arc (4.0.9)
 
 DEPENDENCIES:
-  - Bugsnag (from `https://github.com/bugsnag/bugsnag-cocoa.git`)
+  - Bugsnag (from `../..`)
 
 EXTERNAL SOURCES:
   Bugsnag:
-    :git: https://github.com/bugsnag/bugsnag-cocoa.git
-
-CHECKOUT OPTIONS:
-  Bugsnag:
-    :commit: dbb4affbc19efb831ed4bc34d7db83c86269a380
-    :git: https://github.com/bugsnag/bugsnag-cocoa.git
+    :path: ../..
 
 SPEC CHECKSUMS:
-  Bugsnag: 55a90bc87b467fe72bbedaba430753b5822420ce
+  Bugsnag: a4bdbf356f318cef00d12eb1601f16d8d0c71ba4
 
-COCOAPODS: 0.36.4
+COCOAPODS: 0.39.0


### PR DESCRIPTION
## Changes

* Refactor `serializedDictionary:toJSON:` into a function, `BSSerializeJSONDictionary`, for reuse
* Move #defines into string constants
* Rename onCrash handler to indicate purpose
* Add notifier state metadata to crash report