### PR TITLE
Adding proper support for notifyReleaseStages

### DIFF
--- a/Source/Bugsnag/BugsnagConfiguration.m
+++ b/Source/Bugsnag/BugsnagConfiguration.m
@@ -70,6 +70,14 @@
     [self.config addAttribute:@"releaseStage" withValue:newReleaseStage toTabWithName:@"config"];
 }
 
+
+- (void)setNotifyReleaseStages:(NSArray *)newNotifyReleaseStages;
+{
+    NSArray *notifyReleaseStagesCopy = [newNotifyReleaseStages copy];
+    self->notifyReleaseStages = notifyReleaseStagesCopy;
+    [self.config addAttribute:@"notifyReleaseStages" withValue:notifyReleaseStagesCopy toTabWithName:@"config"];
+}
+
 -(void) setContext:(NSString *)newContext
 {
     self->context = newContext;


### PR DESCRIPTION
Notify release stages don't actually work in the current version.

Before this fix, in `[BugsnagSink filterReports:completion:]`, `bugsnagReport.notifyReleaseStages` would return nil because it was never encoded in the JSON.