### PR TITLE
Ignore deprecation warning for selector in BugsnagSink

### DIFF
--- a/Source/Bugsnag/BugsnagSink.m
+++ b/Source/Bugsnag/BugsnagSink.m
@@ -91,10 +91,13 @@
                                                        timeoutInterval: 15];
     request.HTTPMethod = @"POST";
     request.HTTPBody = jsonData;
-    
+
+#pragma clang diagnostic push
+#pragma clang diaginostic ignored "-Wdeprecated-declarations"
     [NSURLConnection sendSynchronousRequest:request
                           returningResponse:NULL
                                       error:&error];
+#pragma clang diagnostic pop
     
     if (onCompletion) {
         onCompletion(reports, error == nil, error);


### PR DESCRIPTION
In order to avoid causing deprecation warnings in projects that include
this library, this commit adds some compiler instructions to ignore the
deprecated selector used on NSURLConnection
(sendSynchronousRequest:returningResponse:error:).