### PR TITLE
Send severity and breadcrumbs with uncaught exceptions

### DIFF
--- a/Source/Bugsnag/Bugsnag.m
+++ b/Source/Bugsnag/Bugsnag.m
@@ -118,6 +118,7 @@ static BugsnagNotifier* g_bugsnag_notifier = NULL;
 
 + (void) leaveBreadcrumbWithMessage:(NSString *)message {
     [self.notifier.configuration.breadcrumbs addBreadcrumb:message];
+    [self.notifier serializeBreadcrumbs];
 }
 
 + (void) setBreadcrumbCapacity:(NSUInteger)capacity {
@@ -126,6 +127,7 @@ static BugsnagNotifier* g_bugsnag_notifier = NULL;
 
 + (void) clearBreadcrumbs {
     [self.notifier.configuration.breadcrumbs clearBreadcrumbs];
+    [self.notifier serializeBreadcrumbs];
 }
 
 @end

--- a/Source/Bugsnag/BugsnagNotifier.h
+++ b/Source/Bugsnag/BugsnagNotifier.h
@@ -52,4 +52,9 @@
  */
 - (void) notify:(NSException *)exception withData:(NSDictionary*)metaData atSeverity:(NSString*)severity atDepth:(NSUInteger) depth;
 
+/**
+ *  Write breadcrumbs to the cached metadata for error reports
+ */
+- (void) serializeBreadcrumbs;
+
 @end

--- a/Source/Bugsnag/BugsnagNotifier.m
+++ b/Source/Bugsnag/BugsnagNotifier.m
@@ -39,6 +39,11 @@
 
 NSString *const NOTIFIER_VERSION = @"4.1.0";
 NSString *const NOTIFIER_URL = @"https://github.com/bugsnag/bugsnag-cocoa";
+NSString *const BSTabCrash = @"crash";
+NSString *const BSTabConfig = @"config";
+NSString *const BSAttributeSeverity = @"severity";
+NSString *const BSAttributeDepth = @"depth";
+NSString *const BSAttributeBreadcrumbs = @"breadcrumbs";
 
 struct bugsnag_data_t {
     // Contains the user-specified metaData, including the user tab from config.
@@ -60,6 +65,28 @@ void serialize_bugsnag_data(const KSCrashReportWriter *writer) {
     }
     if (g_bugsnag_data.stateJSON) {
         writer->addJSONElement(writer, "state", g_bugsnag_data.stateJSON);
+    }
+}
+
+/**
+ *  Writes a dictionary to a destination using the KSCrash JSON encoding
+ *
+ *  @param dictionary  data to encode
+ *  @param destination target location of the data
+ */
+void BSSerializeJSONDictionary(NSDictionary *dictionary, char **destination) {
+    NSError *error;
+    NSData *json = [KSJSONCodec encode: dictionary options:0 error:&error];
+
+    if (!json) {
+        NSLog(@"Bugsnag could not serialize metaData: %@", error);
+        return;
+    }
+
+    *destination = reallocf(*destination, [json length] + 1);
+    if (*destination) {
+        memcpy(*destination, [json bytes], [json length]);
+        (*destination)[[json length]] = '\0';
     }
 }
 
@@ -114,17 +141,17 @@ void serialize_bugsnag_data(const KSCrashReportWriter *writer) {
     }
 
     [self.metaDataLock lock];
-    [self serializeDictionary: metaData toJSON: &g_bugsnag_data.metaDataJSON];
-    [self.state addAttribute:@"severity" withValue: severity toTabWithName: @"crash"];
-    [self.state addAttribute:@"depth" withValue: [NSNumber numberWithUnsignedInteger:depth + 3] toTabWithName: @"crash"];
+    BSSerializeJSONDictionary(metaData, &g_bugsnag_data.metaDataJSON);
+    [self.state addAttribute:BSAttributeSeverity withValue:severity toTabWithName:BSTabCrash];
+    [self.state addAttribute:BSAttributeDepth withValue:@(depth + 3) toTabWithName:BSTabCrash];
     [self serializeBreadcrumbs];
-    NSString *exceptionName = [exception name] != nil ? [exception name] : @"NSException";
+    NSString *exceptionName = [exception name] ?: NSStringFromClass([NSException class]);
     [[KSCrash sharedInstance] reportUserException:exceptionName reason:[exception reason] lineOfCode:@"" stackTrace:@[] terminateProgram:NO];
 
     // Restore metaData to pre-crash state.
     [self.metaDataLock unlock];
     [self metaDataChanged: self.configuration.metaData];
-    [[self state] clearTab:@"crash"];
+    [[self state] clearTab:BSTabCrash];
 
     [self performSelectorInBackground:@selector(sendPendingReports) withObject:nil];
 }
@@ -134,7 +161,7 @@ void serialize_bugsnag_data(const KSCrashReportWriter *writer) {
     if (crumbs.count == 0) {
         return;
     }
-    [self.state addAttribute:@"breadcrumbs" withValue:[crumbs arrayValue] toTabWithName:@"crash"];
+    [self.state addAttribute:BSAttributeBreadcrumbs withValue:[crumbs arrayValue] toTabWithName:BSTabCrash];
 }
 
 - (void) sendPendingReports {
@@ -154,31 +181,16 @@ void serialize_bugsnag_data(const KSCrashReportWriter *writer) {
 
     if (metaData == self.configuration.metaData) {
         if ([self.metaDataLock tryLock]) {
-            [self serializeDictionary: [metaData toDictionary] toJSON: &g_bugsnag_data.metaDataJSON];
+            BSSerializeJSONDictionary([metaData toDictionary], &g_bugsnag_data.metaDataJSON);
             [self.metaDataLock unlock];
         }
     } else if (metaData == self.configuration.config) {
-        [self serializeDictionary: [metaData getTab:@"config"] toJSON: &g_bugsnag_data.configJSON];
+        BSSerializeJSONDictionary([metaData getTab:BSTabConfig], &g_bugsnag_data.configJSON);
     } else if (metaData == self.state) {
-        [self serializeDictionary: [metaData toDictionary] toJSON: &g_bugsnag_data.stateJSON];
+        BSSerializeJSONDictionary([metaData toDictionary], &g_bugsnag_data.stateJSON);
     } else {
-        NSLog(@"Unknown meta-Data dictionary changed");
+        NSLog(@"Unknown metadata dictionary changed");
     }
 }
 
-- (void) serializeDictionary: (NSDictionary*) dictionary toJSON: (char **) destination {
-    NSError *error;
-    NSData *json = [KSJSONCodec encode: dictionary options:0 error:&error];
-
-    if (!json) {
-        NSLog(@"Bugsnag could not serialize metaData: %@", error);
-        return;
-    }
-
-    *destination = reallocf(*destination, [json length] + 1);
-    if (*destination) {
-        memcpy(*destination, [json bytes], [json length]);
-        (*destination)[[json length]] = '\0';
-    }
-}
 @end

--- a/Source/Bugsnag/BugsnagNotifier.m
+++ b/Source/Bugsnag/BugsnagNotifier.m
@@ -56,7 +56,13 @@ struct bugsnag_data_t {
 
 static struct bugsnag_data_t g_bugsnag_data;
 
-void serialize_bugsnag_data(const KSCrashReportWriter *writer) {
+/**
+ *  Handler executed when the application crashes. Writes information about the
+ *  current application state using the crash report writer.
+ *
+ *  @param writer report writer which will receive updated metadata
+ */
+void BSSerializeDataCrashHandler(const KSCrashReportWriter *writer) {
     if (g_bugsnag_data.configJSON) {
         writer->addJSONElement(writer, "config", g_bugsnag_data.configJSON);
     }
@@ -121,7 +127,7 @@ void BSSerializeJSONDictionary(NSDictionary *dictionary, char **destination) {
     // We don't use this feature yet, so we turn it off
     [KSCrash sharedInstance].introspectMemory = NO;
 
-    [KSCrash sharedInstance].onCrash = &serialize_bugsnag_data;
+    [KSCrash sharedInstance].onCrash = &BSSerializeDataCrashHandler;
 
     if (configuration.autoNotify) {
         [[KSCrash sharedInstance] install];

--- a/Source/Bugsnag/BugsnagNotifier.m
+++ b/Source/Bugsnag/BugsnagNotifier.m
@@ -150,7 +150,6 @@ void BSSerializeJSONDictionary(NSDictionary *dictionary, char **destination) {
     BSSerializeJSONDictionary(metaData, &g_bugsnag_data.metaDataJSON);
     [self.state addAttribute:BSAttributeSeverity withValue:severity toTabWithName:BSTabCrash];
     [self.state addAttribute:BSAttributeDepth withValue:@(depth + 3) toTabWithName:BSTabCrash];
-    [self serializeBreadcrumbs];
     NSString *exceptionName = [exception name] ?: NSStringFromClass([NSException class]);
     [[KSCrash sharedInstance] reportUserException:exceptionName reason:[exception reason] lineOfCode:@"" stackTrace:@[] terminateProgram:NO];
 
@@ -164,10 +163,8 @@ void BSSerializeJSONDictionary(NSDictionary *dictionary, char **destination) {
 
 - (void) serializeBreadcrumbs {
     BugsnagBreadcrumbs* crumbs = self.configuration.breadcrumbs;
-    if (crumbs.count == 0) {
-        return;
-    }
-    [self.state addAttribute:BSAttributeBreadcrumbs withValue:[crumbs arrayValue] toTabWithName:BSTabCrash];
+    NSArray* arrayValue = crumbs.count == 0 ? nil : [crumbs arrayValue];
+    [self.state addAttribute:BSAttributeBreadcrumbs withValue:arrayValue toTabWithName:BSTabCrash];
 }
 
 - (void) sendPendingReports {

--- a/Source/Bugsnag/BugsnagSink.m
+++ b/Source/Bugsnag/BugsnagSink.m
@@ -128,12 +128,13 @@
     NSMutableDictionary* exception = [NSMutableDictionary dictionary];
     NSMutableArray *bugsnagThreads = [NSMutableArray array];
     NSMutableDictionary *metaData = [report.metaData mutableCopy];
-    
+    NSString *severity = report.severity.length > 0 ? report.severity : BugsnagSeverityError;
+
     // Build Event
     [event safeSetObject: bugsnagThreads forKey: @"threads"];
     [event safeSetObject: @[exception] forKey: @"exceptions"];
     [event setObjectIfNotNil: report.dsymUUID forKey: @"dsymUUID"];
-    [event safeSetObject: report.severity forKey:@"severity"];
+    [event safeSetObject: severity forKey:@"severity"];
     [event safeSetObject: report.breadcrumbs forKey:@"breadcrumbs"];
     [event safeSetObject: @"2" forKey:@"payloadVersion"];
     [event safeSetObject: metaData forKey: @"metaData"];


### PR DESCRIPTION
## Changes

* Set and serialize default severity as `error` in case of an uncaught exception. It is still overridden in the case of a handled exception.
* Serialize breadcrumbs after each change
* Refactor `serializedDictionary:toJSON:` into a function, `BSSerializeJSONDictionary`
* Rename onCrash handler to indicate purpose

Fixes #58