### PR TITLE
Correct the spelling of CocoaPods in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -44,12 +44,12 @@ Getting Started
 
 #### Using CocoaPods (Recommended)
 
-[Cocoapods](http://cocoapods.org/) is a library management system for iOS/OSX
+[CocoaPods](http://cocoapods.org/) is a library management system for iOS/OSX
 which allows you to manage your libraries, detail your dependencies and handle
 updates nicely. It is the recommended way of installing the Bugsnag Cocoa
 library.
 
-0.  Install Cocoapods and the [Bugsnag Cocoapods Plugin](https://github.com/bugsnag/cocoapods-bugsnag).
+0.  Install CocoaPods and the [Bugsnag CocoaPods Plugin](https://github.com/bugsnag/cocoapods-bugsnag).
     The plugin is not required, but it adds a build phase to your projects for
     uploading dSYM files to Bugsnag for symbolicating crash reports.
 
@@ -78,7 +78,7 @@ library.
     pod install
     ```
 
-#### Without Cocoapods
+#### Without CocoaPods
 
 1.  Download Bugsnag.zip from the [latest release](https://github.com/bugsnag/bugsnag-cocoa/releases/latest)
 


### PR DESCRIPTION

This pull requests corrects the spelling of **CocoaPods** 🤓
https://github.com/CocoaPods/shared_resources/tree/master/media

<blockquote class="twitter-tweet" data-lang="en"><p lang="en" dir="ltr">One day I’ll make a bot that looks through the READMEs of all Pods, looks to see if it uses “Cocoapods” and PRs “CocoaPods” :D</p>&mdash; Ørta (@orta) <a href="https://twitter.com/orta/status/697374357975388160">February 10, 2016</a></blockquote>
<script async src="//platform.twitter.com/widgets.js" charset="utf-8"></script>
