### PR TITLE
Make a few BugsnagCrashReport properties public

### DIFF
--- a/Source/BugsnagCrashReport.h
+++ b/Source/BugsnagCrashReport.h
@@ -132,4 +132,24 @@ NSString *_Nonnull BSGFormatSeverity(BSGSeverity severity);
  *  Number of frames to discard at the top of the stacktrace
  */
 @property(nonatomic, readwrite) NSUInteger depth;
+/**
+ *  Raw error data
+ */
+@property (nonatomic, readwrite, copy, nullable) NSDictionary *error;
+/**
+ *  Device information such as OS name and version
+ */
+@property (nonatomic, readwrite, copy, nullable) NSDictionary *device;
+/**
+ *  Device state such as memory allocation at crash time
+ */
+@property (nonatomic, readwrite, copy, nullable) NSDictionary *deviceState;
+/**
+ *  App information such as the name, version, and bundle ID
+ */
+@property (nonatomic, readwrite, copy, nullable) NSDictionary *app;
+/**
+ *  Device state such as oreground status and run duration
+ */
+@property (nonatomic, readwrite, copy, nullable) NSDictionary *appState;
 @end

--- a/Source/BugsnagCrashReport.m
+++ b/Source/BugsnagCrashReport.m
@@ -223,10 +223,6 @@ static NSString *const DEFAULT_EXCEPTION_TYPE = @"cocoa";
  */
 @property (nonatomic, readwrite, copy, nullable) NSString *errorType;
 /**
- *  Raw error data
- */
-@property (nonatomic, readwrite, copy, nullable) NSDictionary *error;
-/**
  *  The UUID of the dSYM file
  */
 @property (nonatomic, readonly, copy, nullable) NSString *dsymUUID;
@@ -242,22 +238,6 @@ static NSString *const DEFAULT_EXCEPTION_TYPE = @"cocoa";
  *  Thread information captured at the time of the error
  */
 @property (nonatomic, readonly, copy, nullable) NSArray *threads;
-/**
- *  Device information such as OS name and version
- */
-@property (nonatomic, readwrite, copy, nullable) NSDictionary *device;
-/**
- *  Device state such as memory allocation at crash time
- */
-@property (nonatomic, readwrite, copy, nullable) NSDictionary *deviceState;
-/**
- *  App information such as the name, version, and bundle ID
- */
-@property (nonatomic, readwrite, copy, nullable) NSDictionary *app;
-/**
- *  Device state such as oreground status and run duration
- */
-@property (nonatomic, readwrite, copy, nullable) NSDictionary *appState;
 /**
  *  User-provided exception metadata
  */


### PR DESCRIPTION
Move a few `BugsnagCrashReport` property definitions to the header file
to make them public:

* `error`
* `device`
* `deviceState`
* `app`
* `appState`

Perhaps some more of the properties should be made public as well?

We need this in order to access this data in a `addBeforeSendBlock`
block. While upgrading from 5.3.0 to 5.6.3, we changed our code to
use `addBeforeSendBlock` instead of `addBeforeNotifyBlock`, which has
been deprecated. However, `addBeforeSendBlock` provides
`BugsnagCrashReport` as an argument, rather than a raw `NSDictionary`
containing the `error`, `device`, `deviceState`, `appState`, etc.
fields. We're consuming this information in order to log analytics data
to our own servers. By exposing these properties on
`BugsnagCrashReport`, it allows us to keep logging this information in
the `addBeforeSendBlock` block.

to: @kattrali 
cc: @lelandrichardson