### PR TITLE
Fix accidental rename of beforeSendBlocks

### DIFF
--- a/Source/BugsnagConfiguration.m
+++ b/Source/BugsnagConfiguration.m
@@ -51,7 +51,7 @@
     _autoNotify = YES;
     _notifyURL = [NSURL URLWithString:@"https://notify.bugsnag.com/"];
     _beforeNotifyHooks = [NSMutableArray new];
-    _BugsnagBeforeSendBlock = [NSMutableArray new];
+    _beforeSendBlocks = [NSMutableArray new];
     _notifyReleaseStages = nil;
     _breadcrumbs = [BugsnagBreadcrumbs new];
     _automaticallyCollectBreadcrumbs = YES;


### PR DESCRIPTION
It looks like in this commit:
https://github.com/bugsnag/bugsnag-cocoa/commit/3bf80c9551e9c9bc93d475eca2b91878c8844550#diff-31f3ba7de1042a9da5dca47128578247R48

which was meant to clean up naming of the blocks, there was an accidental mis-renaming of the `_beforeSendBlocks` variable, which causes `addBeforeSendBlock` to silently fail 😢 .

to: @kattrali 