### PR TITLE
Filter reports should perform onCompletion on the filtered reports

### DIFF
--- a/Source/BugsnagSink.m
+++ b/Source/BugsnagSink.m
@@ -78,7 +78,7 @@
     
     if (bugsnagReports.count == 0) {
         if (onCompletion) {
-            onCompletion(reports, YES, nil);
+            onCompletion(bugsnagReports, YES, nil);
         }
         return;
     }


### PR DESCRIPTION
It seems that ```BugsnagSink``` ```filterReports``` should be passing in the ```bugsnagReports``` instead of the ```reports``` to the ```KSCrashReportFilterCompletion``` in line 81.

This way returning false from the ```BugsnagBeforeSendBlock``` will actually not send the Bugsnag report as expected.