### PR TITLE
Add URL session as configuration property

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,14 @@
 Changelog
 =========
 
+## TBD
+
+### Enhancements
+
+* Add support for customizing the `NSURLSession` used when sending error reports
+  to Bugsnag
+  [#127](https://github.com/bugsnag/bugsnag-cocoa/pull/127)
+
 ## 5.6.5 (7 Nov 2016)
 
 ### Bug fixes

--- a/OSX/Bugsnag.xcodeproj/project.pbxproj
+++ b/OSX/Bugsnag.xcodeproj/project.pbxproj
@@ -34,6 +34,8 @@
 		8A7630E21D2523AE000D6737 /* Kiwi.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = 8A7630E11D2523AE000D6737 /* Kiwi.framework */; };
 		8A7630E51D2524DB000D6737 /* BugsnagSpec.m in Sources */ = {isa = PBXBuildFile; fileRef = 8A7630DF1D252309000D6737 /* BugsnagSpec.m */; };
 		8A87352C1C6D3B1600EDBD5B /* BSGKSCrashReportWriter.h in Headers */ = {isa = PBXBuildFile; fileRef = 8A87352B1C6D3B1600EDBD5B /* BSGKSCrashReportWriter.h */; settings = {ATTRIBUTES = (Public, ); }; };
+		8AD9FA881E08633F002859A7 /* BugsnagConfigurationSpec.m in Sources */ = {isa = PBXBuildFile; fileRef = 8AD9FA841E0862DC002859A7 /* BugsnagConfigurationSpec.m */; };
+		8AD9FA891E086351002859A7 /* BugsnagConfigurationTests.m in Sources */ = {isa = PBXBuildFile; fileRef = 8AD9FA851E0862DC002859A7 /* BugsnagConfigurationTests.m */; };
 /* End PBXBuildFile section */
 
 /* Begin PBXContainerItemProxy section */
@@ -81,6 +83,8 @@
 		8A7630DF1D252309000D6737 /* BugsnagSpec.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; name = BugsnagSpec.m; path = ../Tests/BugsnagSpec.m; sourceTree = SOURCE_ROOT; };
 		8A7630E11D2523AE000D6737 /* Kiwi.framework */ = {isa = PBXFileReference; lastKnownFileType = wrapper.framework; name = Kiwi.framework; path = "../../../../../Library/Developer/Xcode/DerivedData/OSX-fywomumlxcstijawyihsvjfwghcm/Build/Products/Debug/Kiwi.framework"; sourceTree = "<group>"; };
 		8A87352B1C6D3B1600EDBD5B /* BSGKSCrashReportWriter.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; name = BSGKSCrashReportWriter.h; path = ../Source/BSGKSCrashReportWriter.h; sourceTree = SOURCE_ROOT; };
+		8AD9FA841E0862DC002859A7 /* BugsnagConfigurationSpec.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; name = BugsnagConfigurationSpec.m; path = ../Tests/BugsnagConfigurationSpec.m; sourceTree = SOURCE_ROOT; };
+		8AD9FA851E0862DC002859A7 /* BugsnagConfigurationTests.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; name = BugsnagConfigurationTests.m; path = ../Tests/BugsnagConfigurationTests.m; sourceTree = SOURCE_ROOT; };
 /* End PBXFileReference section */
 
 /* Begin PBXFrameworksBuildPhase section */
@@ -154,6 +158,8 @@
 		8A2C8FAF1C6BC1F700846019 /* Tests */ = {
 			isa = PBXGroup;
 			children = (
+				8AD9FA841E0862DC002859A7 /* BugsnagConfigurationSpec.m */,
+				8AD9FA851E0862DC002859A7 /* BugsnagConfigurationTests.m */,
 				8A2C8FE01C6BC38200846019 /* BugsnagBreadcrumbsTest.m */,
 				8A2C8FE11C6BC38200846019 /* BugsnagCrashReportTests.m */,
 				8A7630DF1D252309000D6737 /* BugsnagSpec.m */,
@@ -310,9 +316,11 @@
 			isa = PBXSourcesBuildPhase;
 			buildActionMask = 2147483647;
 			files = (
+				8AD9FA881E08633F002859A7 /* BugsnagConfigurationSpec.m in Sources */,
 				8A2C8FEA1C6BC38900846019 /* BugsnagBreadcrumbsTest.m in Sources */,
 				8A2C8FEC1C6BC38900846019 /* BugsnagSinkTests.m in Sources */,
 				8A7630E51D2524DB000D6737 /* BugsnagSpec.m in Sources */,
+				8AD9FA891E086351002859A7 /* BugsnagConfigurationTests.m in Sources */,
 				8A2C8FEB1C6BC38900846019 /* BugsnagCrashReportTests.m in Sources */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;

--- a/Source/BugsnagConfiguration.h
+++ b/Source/BugsnagConfiguration.h
@@ -92,6 +92,11 @@ typedef NSDictionary *_Nullable (^BugsnagBeforeNotifyHook)(
 @property(nonatomic, readwrite, retain, nullable) NSString *appVersion;
 
 /**
+ *  The URL session used to send requests to Bugsnag.
+ */
+@property(nonatomic, readwrite, strong, nonnull) NSURLSession *session;
+
+/**
  *  Additional information about the state of the app or environment at the 
  *  time the report was generated
  */

--- a/Source/BugsnagConfiguration.m
+++ b/Source/BugsnagConfiguration.m
@@ -55,6 +55,9 @@
     _notifyReleaseStages = nil;
     _breadcrumbs = [BugsnagBreadcrumbs new];
     _automaticallyCollectBreadcrumbs = YES;
+    if ([NSURLSession class]) {
+      _session = [NSURLSession sessionWithConfiguration:[NSURLSessionConfiguration defaultSessionConfiguration]];
+    }
 #if DEBUG
     _releaseStage = @"development";
 #else

--- a/Source/BugsnagSink.m
+++ b/Source/BugsnagSink.m
@@ -37,18 +37,8 @@
 + (BugsnagNotifier*)notifier;
 @end
 
-@interface BugsnagSink ()
-@property (nonatomic, strong) NSURLSession *session;
-@end
 
 @implementation BugsnagSink
-
-- (instancetype)init {
-    if (self = [super init])
-        _session = [NSURLSession sessionWithConfiguration:[NSURLSessionConfiguration defaultSessionConfiguration]];
-    
-    return self;
-}
 
 // Entry point called by KSCrash when a report needs to be sent. Handles report filtering based on the configuration
 // options for `notifyReleaseStages`.
@@ -132,7 +122,11 @@
 
 
         if ([NSURLSession class]) {
-            NSURLSessionTask *task = [self.session uploadTaskWithRequest:request fromData:jsonData completionHandler:^(NSData * _Nullable data, NSURLResponse * _Nullable response, NSError * _Nullable error) {
+            NSURLSession *session = [Bugsnag configuration].session;
+            if (!session) {
+                session = [NSURLSession sessionWithConfiguration:[NSURLSessionConfiguration defaultSessionConfiguration]];
+            }
+            NSURLSessionTask *task = [session uploadTaskWithRequest:request fromData:jsonData completionHandler:^(NSData * _Nullable data, NSURLResponse * _Nullable response, NSError * _Nullable error) {
                 if (onCompletion)
                     onCompletion(reports, error == nil, error);
             }];

--- a/Tests/BugsnagConfigurationSpec.m
+++ b/Tests/BugsnagConfigurationSpec.m
@@ -1,0 +1,43 @@
+//
+//  BugsnagConfigurationSpec.m
+//  Bugsnag
+//
+//  Created by Delisa Mason on 11/30/16.
+//  Copyright 2016 Bugsnag. All rights reserved.
+//
+
+#import <Kiwi/Kiwi.h>
+#import "BugsnagConfiguration.h"
+#import "Bugsnag.h"
+
+@interface SomeDelegate : NSObject<NSURLSessionTaskDelegate>
+@property (nonatomic) BOOL didInvoke;
+@end
+
+@implementation SomeDelegate
+
+- (void)URLSession:(NSURLSession *)session task:(NSURLSessionTask *)task didReceiveChallenge:(nonnull NSURLAuthenticationChallenge *)challenge completionHandler:(nonnull void (^)(NSURLSessionAuthChallengeDisposition, NSURLCredential * _Nullable))completionHandler {
+    self.didInvoke = YES;
+    completionHandler(NSURLSessionAuthChallengeCancelAuthenticationChallenge, nil);
+}
+
+@end
+
+
+SPEC_BEGIN(BugsnagConfigurationSpec)
+
+describe(@"BugsnagConfiguration", ^{
+
+    it(@"sets the request session", ^{
+        SomeDelegate *delegate = [SomeDelegate new];
+        BugsnagConfiguration *config = [BugsnagConfiguration new];
+        config.session = [NSURLSession sessionWithConfiguration:[NSURLSessionConfiguration defaultSessionConfiguration]
+                                                       delegate:delegate
+                                                  delegateQueue:[NSOperationQueue mainQueue]];
+        [Bugsnag startBugsnagWithConfiguration:config];
+        [Bugsnag notify:[NSException exceptionWithName:@"oh no" reason:nil userInfo:nil]];
+        [[expectFutureValue(@(delegate.didInvoke)) shouldEventually] beYes];
+    });
+});
+
+SPEC_END

--- a/Tests/BugsnagConfigurationTests.m
+++ b/Tests/BugsnagConfigurationTests.m
@@ -1,11 +1,17 @@
 #import <XCTest/XCTest.h>
 #import "BugsnagConfiguration.h"
+#import "Bugsnag.h"
 
 
 @interface BugsnagConfigurationTests : XCTestCase
 @end
 
 @implementation BugsnagConfigurationTests
+
+- (void)testDefaultSessionNotNil {
+    BugsnagConfiguration *config = [BugsnagConfiguration new];
+    XCTAssertNotNil(config.session);
+}
 
 - (void)testNotifyReleaseStagesDefaultSends {
     BugsnagConfiguration *config = [BugsnagConfiguration new];

--- a/Tests/BugsnagSpec.m
+++ b/Tests/BugsnagSpec.m
@@ -43,8 +43,7 @@ describe(@"Bugsnag", ^{
 
     beforeEach(^{
         request = nil;
-        BugsnagSink *sink = [[KSCrash sharedInstance] valueForKeyPath:@"sink"];
-        NSURLSession *session = [sink valueForKeyPath:@"session"];
+        NSURLSession *session = [Bugsnag configuration].session;
         [session stub:@selector(uploadTaskWithRequest:fromData:completionHandler:) withBlock:^id(NSArray *params) {
             request = [params firstObject];
             httpBody = params[1];

--- a/iOS/Bugsnag.xcodeproj/project.pbxproj
+++ b/iOS/Bugsnag.xcodeproj/project.pbxproj
@@ -36,6 +36,7 @@
 		8A87351E1C6D2ADE00EDBD5B /* BSGKSCrashReportWriter.h in Headers */ = {isa = PBXBuildFile; fileRef = 8A87351D1C6D2ADE00EDBD5B /* BSGKSCrashReportWriter.h */; settings = {ATTRIBUTES = (Public, ); }; };
 		8AAA64011D2407CE00A9A123 /* Kiwi.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = 8AAA64001D2407CE00A9A123 /* Kiwi.framework */; };
 		8AAA64081D24088600A9A123 /* BugsnagSpec.m in Sources */ = {isa = PBXBuildFile; fileRef = 8AAA64071D24088600A9A123 /* BugsnagSpec.m */; };
+		8AE1BC951DEFCE8B00D16CEF /* BugsnagConfigurationSpec.m in Sources */ = {isa = PBXBuildFile; fileRef = 8AE1BC941DEFCE8B00D16CEF /* BugsnagConfigurationSpec.m */; };
 /* End PBXBuildFile section */
 
 /* Begin PBXContainerItemProxy section */
@@ -85,6 +86,7 @@
 		8AAA63FE1D2404BB00A9A123 /* Nocilla.framework */ = {isa = PBXFileReference; lastKnownFileType = wrapper.framework; name = Nocilla.framework; path = "../development/Nocilla/build/Debug-iphoneos/Nocilla.framework"; sourceTree = "<group>"; };
 		8AAA64001D2407CE00A9A123 /* Kiwi.framework */ = {isa = PBXFileReference; lastKnownFileType = wrapper.framework; name = Kiwi.framework; path = "../development/Kiwi/build/Debug-iphoneos/Kiwi.framework"; sourceTree = "<group>"; };
 		8AAA64071D24088600A9A123 /* BugsnagSpec.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; name = BugsnagSpec.m; path = ../Tests/BugsnagSpec.m; sourceTree = SOURCE_ROOT; };
+		8AE1BC941DEFCE8B00D16CEF /* BugsnagConfigurationSpec.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; name = BugsnagConfigurationSpec.m; path = ../Tests/BugsnagConfigurationSpec.m; sourceTree = SOURCE_ROOT; };
 /* End PBXFileReference section */
 
 /* Begin PBXFrameworksBuildPhase section */
@@ -161,6 +163,7 @@
 			children = (
 				8A2C8F8B1C6BBFDD00846019 /* BugsnagBreadcrumbsTest.m */,
 				8A2C8F8C1C6BBFDD00846019 /* BugsnagCrashReportTests.m */,
+				8AE1BC941DEFCE8B00D16CEF /* BugsnagConfigurationSpec.m */,
 				8A4E733E1DC13281001F7CC8 /* BugsnagConfigurationTests.m */,
 				8AAA64071D24088600A9A123 /* BugsnagSpec.m */,
 				8A2C8F8D1C6BBFDD00846019 /* BugsnagSinkTests.m */,
@@ -318,6 +321,7 @@
 			buildActionMask = 2147483647;
 			files = (
 				8A2C8F8F1C6BBFDD00846019 /* BugsnagBreadcrumbsTest.m in Sources */,
+				8AE1BC951DEFCE8B00D16CEF /* BugsnagConfigurationSpec.m in Sources */,
 				8A2C8F911C6BBFDD00846019 /* BugsnagSinkTests.m in Sources */,
 				8AAA64081D24088600A9A123 /* BugsnagSpec.m in Sources */,
 				8A2C8F901C6BBFDD00846019 /* BugsnagCrashReportTests.m in Sources */,

--- a/tvOS/Bugsnag.xcodeproj/project.pbxproj
+++ b/tvOS/Bugsnag.xcodeproj/project.pbxproj
@@ -30,6 +30,7 @@
 		8AD9A5031D42EEB0004E1CC5 /* BugsnagNotifier.m in Sources */ = {isa = PBXBuildFile; fileRef = 8AB151331D41366400C9B218 /* BugsnagNotifier.m */; };
 		8AD9A5041D42EEB0004E1CC5 /* BugsnagSink.m in Sources */ = {isa = PBXBuildFile; fileRef = 8AB151351D41366400C9B218 /* BugsnagSink.m */; };
 		8AD9A5051D42EEE9004E1CC5 /* BSGKSCrashReportWriter.h in Headers */ = {isa = PBXBuildFile; fileRef = 8AB151251D41366400C9B218 /* BSGKSCrashReportWriter.h */; settings = {ATTRIBUTES = (Public, ); }; };
+		8AD9FA8D1E0863A1002859A7 /* BugsnagConfigurationTests.m in Sources */ = {isa = PBXBuildFile; fileRef = 8AD9FA8B1E0863A1002859A7 /* BugsnagConfigurationTests.m */; };
 /* End PBXBuildFile section */
 
 /* Begin PBXContainerItemProxy section */
@@ -69,6 +70,8 @@
 		8AB151341D41366400C9B218 /* BugsnagSink.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; name = BugsnagSink.h; path = ../Source/BugsnagSink.h; sourceTree = "<group>"; };
 		8AB151351D41366400C9B218 /* BugsnagSink.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; name = BugsnagSink.m; path = ../Source/BugsnagSink.m; sourceTree = "<group>"; };
 		8AB1513E1D4136F100C9B218 /* KSCrash.framework */ = {isa = PBXFileReference; lastKnownFileType = wrapper.framework; name = KSCrash.framework; path = "../../../../Library/Developer/Xcode/DerivedData/tvOS-ebsbvpxsfrmszpejtqlahdcmtszc/Build/Products/Debug-appletvsimulator/KSCrash.framework"; sourceTree = "<group>"; };
+		8AD9FA8A1E0863A1002859A7 /* BugsnagConfigurationSpec.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; name = BugsnagConfigurationSpec.m; path = ../Tests/BugsnagConfigurationSpec.m; sourceTree = SOURCE_ROOT; };
+		8AD9FA8B1E0863A1002859A7 /* BugsnagConfigurationTests.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; name = BugsnagConfigurationTests.m; path = ../Tests/BugsnagConfigurationTests.m; sourceTree = SOURCE_ROOT; };
 /* End PBXFileReference section */
 
 /* Begin PBXFrameworksBuildPhase section */
@@ -138,6 +141,8 @@
 		8AB151131D41356800C9B218 /* Tests */ = {
 			isa = PBXGroup;
 			children = (
+				8AD9FA8A1E0863A1002859A7 /* BugsnagConfigurationSpec.m */,
+				8AD9FA8B1E0863A1002859A7 /* BugsnagConfigurationTests.m */,
 				8AB1511D1D41361700C9B218 /* BugsnagBreadcrumbsTest.m */,
 				8AB1511E1D41361700C9B218 /* BugsnagCrashReportTests.m */,
 				8AB1511F1D41361700C9B218 /* BugsnagSinkTests.m */,
@@ -289,6 +294,7 @@
 				8AB151231D41361700C9B218 /* BugsnagSinkTests.m in Sources */,
 				8AB151211D41361700C9B218 /* BugsnagBreadcrumbsTest.m in Sources */,
 				8AB151221D41361700C9B218 /* BugsnagCrashReportTests.m in Sources */,
+				8AD9FA8D1E0863A1002859A7 /* BugsnagConfigurationTests.m in Sources */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};


### PR DESCRIPTION
## Changes

* Exposes the `NSURLSession` used to send error reports to Bugsnag, which allows for user customization. This could potentially be used for pinning custom certificates (fixing #118).