### PR TITLE
[Doc] Fixed @param names

### DIFF
--- a/Source/Bugsnag.h
+++ b/Source/Bugsnag.h
@@ -182,7 +182,7 @@ static NSString *_Nonnull const BugsnagSeverityInfo = @"info";
  * By default, we'll keep and send the 20 most recent breadcrumb log
  * messages.
  *
- * @param max  number of breadcrumb log messages to send
+ * @param capacity max number of breadcrumb log messages to send
  */
 + (void)setBreadcrumbCapacity:(NSUInteger)capacity;
 

--- a/Source/BugsnagConfiguration.h
+++ b/Source/BugsnagConfiguration.h
@@ -44,7 +44,7 @@ typedef void (^BugsnagNotifyBlock)(BugsnagCrashReport *_Nonnull report);
  *
  *  @param rawEventData The raw event data written at crash time. This
  *                      includes data added in onCrashHandler.
- *  @param report       The report generated from the rawEventData
+ *  @param reports      The report generated from the rawEventData
  *
  *  @return YES if the report should be sent
  */


### PR DESCRIPTION
Fixed two @param names. Xcode was generating warnings in a project of mine that uses Bugsnag.