### PR TITLE
Add BugsnagCrashReport methods to append metadata

### DIFF
--- a/Source/BugsnagCrashReport.h
+++ b/Source/BugsnagCrashReport.h
@@ -86,6 +86,29 @@ NSString *_Nonnull BSGFormatSeverity(BSGSeverity severity);
 - (void)attachCustomStacktrace:(NSArray *_Nonnull)frames
                       withType:(NSString *_Nonnull)type;
 
+
+/**
+ * Add metadata to a report to a tab. If the tab does not exist, it will be added.
+ *
+ * @param metadata The key/value pairs to add
+ * @param tabName  The name of the report section
+ */
+- (void)addMetadata:(NSDictionary *_Nonnull)metadata
+      toTabWithName:(NSString *_Nonnull)tabName;
+
+
+/**
+ * Add or remove a value from report metadata. If value is nil, the existing value
+ * will be removed.
+
+ @param attributeName The key name
+ @param value The value to set
+ @param tabName The name of the report section
+ */
+- (void)addAttribute:(NSString*_Nonnull)attributeName
+           withValue:(id _Nullable)value
+       toTabWithName:(NSString*_Nonnull)tabName;
+
 /**
  *  The release stages used to notify at the time this report is captured
  */

--- a/Source/BugsnagCrashReport.m
+++ b/Source/BugsnagCrashReport.m
@@ -216,6 +216,10 @@ NSDictionary *BSGParseCustomException(NSDictionary *report, NSString *errorClass
 
 static NSString *const DEFAULT_EXCEPTION_TYPE = @"cocoa";
 
+@interface NSDictionary (BSGKSMerge)
+- (NSDictionary*)BSG_mergedInto:(NSDictionary *)dest;
+@end
+
 @interface BugsnagCrashReport ()
 
 /**
@@ -291,6 +295,27 @@ static NSString *const DEFAULT_EXCEPTION_TYPE = @"cocoa";
         _overrides = [NSDictionary new];
     }
     return self;
+}
+
+- (void)addMetadata:(NSDictionary *)tabData toTabWithName:(NSString *)tabName {
+    NSMutableDictionary *allMetadata = [self.metaData mutableCopy];
+    NSMutableDictionary *allTabData = allMetadata[tabName] ?: [NSMutableDictionary new];
+    allMetadata[tabName] = [tabData BSG_mergedInto:allTabData];
+    self.metaData = allMetadata;
+}
+
+- (void)addAttribute:(NSString*)attributeName
+           withValue:(id)value
+       toTabWithName:(NSString*)tabName {
+    NSMutableDictionary *allMetadata = [self.metaData mutableCopy];
+    NSMutableDictionary *allTabData = allMetadata[tabName] ?: [NSMutableDictionary new];
+    if (value) {
+        allTabData[attributeName] = value;
+    } else {
+        [allTabData removeObjectForKey:attributeName];
+    }
+    allMetadata[tabName] = allTabData;
+    self.metaData = allMetadata;
 }
 
 - (BOOL)shouldBeSent {

--- a/Tests/BugsnagCrashReportTests.m
+++ b/Tests/BugsnagCrashReportTests.m
@@ -49,6 +49,47 @@
     XCTAssertTrue([self.report shouldBeSent]);
 }
 
+- (void)testAddMetadataAddsNewTab {
+    NSDictionary *metadata = @{ @"color": @"blue", @"beverage": @"tea" };
+    [self.report addMetadata:metadata toTabWithName:@"user prefs"];
+    NSDictionary *prefs = self.report.metaData[@"user prefs"];
+    XCTAssertEqual(@"blue", prefs[@"color"]);
+    XCTAssertEqual(@"tea", prefs[@"beverage"]);
+    XCTAssert([prefs count] == 2);
+}
+
+- (void)testAddMetadataMergesExistingTab {
+    NSDictionary *oldMetadata = @{ @"color": @"red", @"food": @"carrots" };
+    [self.report addMetadata:oldMetadata toTabWithName:@"user prefs"];
+    NSDictionary *metadata = @{ @"color": @"blue", @"beverage": @"tea" };
+    [self.report addMetadata:metadata toTabWithName:@"user prefs"];
+    NSDictionary *prefs = self.report.metaData[@"user prefs"];
+    XCTAssertEqual(@"blue", prefs[@"color"]);
+    XCTAssertEqual(@"tea", prefs[@"beverage"]);
+    XCTAssertEqual(@"carrots", prefs[@"food"]);
+    XCTAssert([prefs count] == 3);
+}
+
+- (void)testAddAttributeAddsNewTab {
+    [self.report addAttribute:@"color" withValue:@"blue" toTabWithName:@"prefs"];
+    NSDictionary *prefs = self.report.metaData[@"prefs"];
+    XCTAssertEqual(@"blue", prefs[@"color"]);
+}
+
+- (void)testAddAttributeOverridesExistingValue {
+    [self.report addAttribute:@"color" withValue:@"red" toTabWithName:@"prefs"];
+    [self.report addAttribute:@"color" withValue:@"blue" toTabWithName:@"prefs"];
+    NSDictionary *prefs = self.report.metaData[@"prefs"];
+    XCTAssertEqual(@"blue", prefs[@"color"]);
+}
+
+- (void)testAddAttributeRemovesValue {
+    [self.report addAttribute:@"color" withValue:@"red" toTabWithName:@"prefs"];
+    [self.report addAttribute:@"color" withValue:nil toTabWithName:@"prefs"];
+    NSDictionary *prefs = self.report.metaData[@"prefs"];
+    XCTAssertNil(prefs[@"color"]);
+}
+
 - (void)testNotifyReleaseStagesSendsFromConfig {
     BugsnagConfiguration *config = [BugsnagConfiguration new];
     config.notifyReleaseStages = @[@"foo"];


### PR DESCRIPTION
Simplify the most common cases for metadata manipulation by allowing users to append data without accessing/overriding the `metaData` property directly.