### PR TITLE
Add sanitization pass during metadata editing and serialization

### DIFF
--- a/OSX/Bugsnag.xcodeproj/project.pbxproj
+++ b/OSX/Bugsnag.xcodeproj/project.pbxproj
@@ -32,6 +32,8 @@
 		8A2C90031C6BC3FA00846019 /* libKSCrashLib.a in Frameworks */ = {isa = PBXBuildFile; fileRef = 8A2C90021C6BC3FA00846019 /* libKSCrashLib.a */; };
 		8A2C90441C6C040700846019 /* Cocoa.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = 8A2C90401C6C03F000846019 /* Cocoa.framework */; };
 		8A48EF271EAA805D00B70024 /* BugsnagLogger.h in Headers */ = {isa = PBXBuildFile; fileRef = 8A48EF261EAA805D00B70024 /* BugsnagLogger.h */; };
+		8A627CD91EC3B75200F7C04E /* BSGSerialization.h in Headers */ = {isa = PBXBuildFile; fileRef = 8A627CD71EC3B75200F7C04E /* BSGSerialization.h */; };
+		8A627CDA1EC3B75200F7C04E /* BSGSerialization.m in Sources */ = {isa = PBXBuildFile; fileRef = 8A627CD81EC3B75200F7C04E /* BSGSerialization.m */; };
 		8A7630E21D2523AE000D6737 /* Kiwi.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = 8A7630E11D2523AE000D6737 /* Kiwi.framework */; };
 		8A87352C1C6D3B1600EDBD5B /* BSGKSCrashReportWriter.h in Headers */ = {isa = PBXBuildFile; fileRef = 8A87352B1C6D3B1600EDBD5B /* BSGKSCrashReportWriter.h */; settings = {ATTRIBUTES = (Public, ); }; };
 		8AD9FA881E08633F002859A7 /* BugsnagConfigurationSpec.m in Sources */ = {isa = PBXBuildFile; fileRef = 8AD9FA841E0862DC002859A7 /* BugsnagConfigurationSpec.m */; };
@@ -81,6 +83,8 @@
 		8A2C90401C6C03F000846019 /* Cocoa.framework */ = {isa = PBXFileReference; lastKnownFileType = wrapper.framework; name = Cocoa.framework; path = System/Library/Frameworks/Cocoa.framework; sourceTree = SDKROOT; };
 		8A2C90421C6C03FF00846019 /* Foundation.framework */ = {isa = PBXFileReference; lastKnownFileType = wrapper.framework; name = Foundation.framework; path = System/Library/Frameworks/Foundation.framework; sourceTree = SDKROOT; };
 		8A48EF261EAA805D00B70024 /* BugsnagLogger.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; name = BugsnagLogger.h; path = ../Source/BugsnagLogger.h; sourceTree = SOURCE_ROOT; };
+		8A627CD71EC3B75200F7C04E /* BSGSerialization.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; name = BSGSerialization.h; path = ../Source/BSGSerialization.h; sourceTree = SOURCE_ROOT; };
+		8A627CD81EC3B75200F7C04E /* BSGSerialization.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; name = BSGSerialization.m; path = ../Source/BSGSerialization.m; sourceTree = SOURCE_ROOT; };
 		8A7630E11D2523AE000D6737 /* Kiwi.framework */ = {isa = PBXFileReference; lastKnownFileType = wrapper.framework; name = Kiwi.framework; path = "../../../../../Library/Developer/Xcode/DerivedData/OSX-fywomumlxcstijawyihsvjfwghcm/Build/Products/Debug/Kiwi.framework"; sourceTree = "<group>"; };
 		8A87352B1C6D3B1600EDBD5B /* BSGKSCrashReportWriter.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; name = BSGKSCrashReportWriter.h; path = ../Source/BSGKSCrashReportWriter.h; sourceTree = SOURCE_ROOT; };
 		8AD9FA841E0862DC002859A7 /* BugsnagConfigurationSpec.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; name = BugsnagConfigurationSpec.m; path = ../Tests/BugsnagConfigurationSpec.m; sourceTree = SOURCE_ROOT; };
@@ -141,6 +145,8 @@
 				8A2C8FBF1C6BC2C800846019 /* BugsnagCollections.h */,
 				8A2C8FC01C6BC2C800846019 /* BugsnagCollections.m */,
 				8A2C8FC11C6BC2C800846019 /* BugsnagConfiguration.h */,
+				8A627CD71EC3B75200F7C04E /* BSGSerialization.h */,
+				8A627CD81EC3B75200F7C04E /* BSGSerialization.m */,
 				8A2C8FC21C6BC2C800846019 /* BugsnagConfiguration.m */,
 				8A2C8FC31C6BC2C800846019 /* BugsnagCrashReport.h */,
 				8A2C8FC41C6BC2C800846019 /* BugsnagCrashReport.m */,
@@ -193,6 +199,7 @@
 			buildActionMask = 2147483647;
 			files = (
 				8A2C8FD11C6BC2C800846019 /* BugsnagCollections.h in Headers */,
+				8A627CD91EC3B75200F7C04E /* BSGSerialization.h in Headers */,
 				8A2C8FD71C6BC2C800846019 /* BugsnagMetaData.h in Headers */,
 				8A48EF271EAA805D00B70024 /* BugsnagLogger.h in Headers */,
 				8A2C8FCD1C6BC2C800846019 /* Bugsnag.h in Headers */,
@@ -303,6 +310,7 @@
 			buildActionMask = 2147483647;
 			files = (
 				8A2C8FD41C6BC2C800846019 /* BugsnagConfiguration.m in Sources */,
+				8A627CDA1EC3B75200F7C04E /* BSGSerialization.m in Sources */,
 				8A2C8FDE1C6BC2C800846019 /* BugsnagSink.m in Sources */,
 				8A2C8FDA1C6BC2C800846019 /* BugsnagNotifier.m in Sources */,
 				8A2C8FD01C6BC2C800846019 /* BugsnagBreadcrumb.m in Sources */,

--- a/Source/BSGSerialization.h
+++ b/Source/BSGSerialization.h
@@ -1,0 +1,43 @@
+#ifndef BugsnagJSONSerializable_h
+#define BugsnagJSONSerializable_h
+
+#import <Foundation/Foundation.h>
+
+
+/**
+ Removes any values which would be rejected by NSJSONSerialization for
+ documented reasons
+
+ @param input an array
+ @return a new array
+ */
+NSArray *_Nonnull BSGSanitizeArray(NSArray *_Nonnull input);
+
+/**
+ Removes any values which would be rejected by NSJSONSerialization for
+ documented reasons
+
+ @param input a dictionary
+ @return a new dictionary
+ */
+NSDictionary *_Nonnull BSGSanitizeDict(NSDictionary *_Nonnull input);
+
+
+/**
+ Checks whether the base type would be accepted by the serialization process
+
+ @param obj any object or nil
+ @return YES if the object is an Array, Dictionary, String, Number, or NSNull
+ */
+BOOL BSGIsSanitizedType(id _Nullable obj);
+
+
+/**
+ Cleans the object, including nested dictionary and array values
+
+ @param obj any object or nil
+ @return a new object for serialization or nil if the obj was incompatible
+ */
+id _Nullable BSGSanitizeObject(id _Nullable obj);
+
+#endif

--- a/Source/BSGSerialization.m
+++ b/Source/BSGSerialization.m
@@ -1,0 +1,54 @@
+#import <Foundation/Foundation.h>
+#import <math.h>
+#import "BSGSerialization.h"
+
+BOOL BSGIsSanitizedType(id obj) {
+    static dispatch_once_t onceToken;
+    static NSArray *allowedTypes = nil;
+    dispatch_once(&onceToken, ^{
+        allowedTypes = @[[NSArray class], [NSDictionary class], [NSNull class], [NSNumber class], [NSString class]];
+    });
+
+    for (Class klass in allowedTypes) {
+        if ([obj isKindOfClass:klass])
+            return YES;
+    }
+    return NO;
+}
+
+id BSGSanitizeObject(id obj) {
+    if ([obj isKindOfClass:[NSNumber class]]) {
+        NSNumber *number = obj;
+        if (![number isEqualToNumber:[NSDecimalNumber notANumber]] && !isinf([number doubleValue]))
+            return obj;
+    } else if ([obj isKindOfClass:[NSArray class]]) {
+        return BSGSanitizeArray(obj);
+    } else if ([obj isKindOfClass:[NSDictionary class]]) {
+        return BSGSanitizeDict(obj);
+    } else if (BSGIsSanitizedType(obj)) {
+        return obj;
+    }
+    return nil;
+}
+
+NSDictionary *_Nonnull BSGSanitizeDict(NSDictionary *input) {
+    __block NSMutableDictionary *output = [NSMutableDictionary dictionaryWithCapacity:[input count]];
+    [input enumerateKeysAndObjectsUsingBlock:^(id _Nonnull key, id _Nonnull obj, BOOL *_Nonnull stop) {
+        if ([key isKindOfClass:[NSString class]]) {
+            id cleanedObject = BSGSanitizeObject(obj);
+            if (cleanedObject)
+                [output setObject:cleanedObject forKey:key];
+        }
+    }];
+    return output;
+}
+
+NSArray *BSGSanitizeArray(NSArray *input) {
+    NSMutableArray *output = [NSMutableArray arrayWithCapacity:[input count]];
+    for (id obj in input) {
+        id cleanedObject = BSGSanitizeObject(obj);
+        if (cleanedObject)
+            [output addObject:cleanedObject];
+    }
+    return output;
+}

--- a/Source/BugsnagBreadcrumb.h
+++ b/Source/BugsnagBreadcrumb.h
@@ -100,8 +100,7 @@ typedef void(^BSGBreadcrumbConfiguration)(BugsnagBreadcrumb *_Nonnull);
 - (void)addBreadcrumb:(NSString *_Nonnull)breadcrumbMessage;
 
 /**
- *  Store a new breadcrumb configured via block. Must be called from the main
- *  thread
+ *  Store a new breadcrumb configured via block.
  *
  *  @param block configuration block
  */

--- a/Source/BugsnagBreadcrumb.m
+++ b/Source/BugsnagBreadcrumb.m
@@ -54,7 +54,7 @@ NSString *BSGBreadcrumbTypeValue(BSGBreadcrumbType type) {
 @interface BugsnagBreadcrumbs()
 
 @property (nonatomic,readwrite,strong) NSMutableArray* breadcrumbs;
-@property (nonatomic,readonly,strong) NSLock* lock;
+@property (nonatomic,readonly,strong) dispatch_queue_t readWriteQueue;
 @end
 
 @interface BugsnagBreadcrumb ()
@@ -113,7 +113,7 @@ NSUInteger BreadcrumbsDefaultCapacity = 20;
     if (self = [super init]) {
         _breadcrumbs = [NSMutableArray new];
         _capacity = BreadcrumbsDefaultCapacity;
-        _lock = [NSLock new];
+        _readWriteQueue = dispatch_queue_create("com.bugsnag.BreadcrumbRead", DISPATCH_QUEUE_CONCURRENT);
     }
     return self;
 }
@@ -131,9 +131,9 @@ NSUInteger BreadcrumbsDefaultCapacity = 20;
     BugsnagBreadcrumb* crumb = [BugsnagBreadcrumb breadcrumbWithBlock:block];
     if (crumb) {
         [self resizeToFitCapacity:self.capacity - 1];
-        [self.lock lock];
-        [self.breadcrumbs addObject:crumb];
-        [self.lock unlock];
+        dispatch_barrier_sync(self.readWriteQueue, ^{
+            [self.breadcrumbs addObject:crumb];
+        });
     }
 }
 
@@ -148,9 +148,9 @@ NSUInteger BreadcrumbsDefaultCapacity = 20;
 }
 
 - (void)clearBreadcrumbs {
-    [self.lock lock];
-    [self.breadcrumbs removeAllObjects];
-    [self.lock unlock];
+    dispatch_barrier_sync(self.readWriteQueue, ^{
+        [self.breadcrumbs removeAllObjects];
+    });
 }
 
 - (NSUInteger)count {
@@ -159,9 +159,10 @@ NSUInteger BreadcrumbsDefaultCapacity = 20;
 
 - (BugsnagBreadcrumb *)objectAtIndexedSubscript:(NSUInteger)index {
     if (index < [self count]) {
-        [self.lock lock];
-        BugsnagBreadcrumb *crumb = self.breadcrumbs[index];
-        [self.lock unlock];
+        __block BugsnagBreadcrumb *crumb = nil;
+        dispatch_sync(self.readWriteQueue, ^{
+            crumb = self.breadcrumbs[index];
+        });
         return crumb;
     }
     return nil;
@@ -171,35 +172,37 @@ NSUInteger BreadcrumbsDefaultCapacity = 20;
     if ([self count] == 0) {
         return nil;
     }
-    NSMutableArray* contents = [[NSMutableArray alloc] initWithCapacity:[self count]];
-    [self.lock lock];
-    for (BugsnagBreadcrumb* crumb in self.breadcrumbs) {
-        NSDictionary *objectValue = [crumb objectValue];
-        NSError *error = nil;
-        @try {
-            NSData* data = [NSJSONSerialization dataWithJSONObject:objectValue options:0 error:&error];
-            if (data.length <= BSGBreadcrumbMaxByteSize)
-                [contents addObject:objectValue];
-            else
-                bsg_log_warn(@"Dropping breadcrumb (%@) exceeding %lu byte size limit", crumb.name, (unsigned long)BSGBreadcrumbMaxByteSize);
-        } @catch (NSException *exception) {
-            bsg_log_err(@"Unable to serialize breadcrumb: %@", error);
+    __block NSMutableArray* contents = [[NSMutableArray alloc] initWithCapacity:[self count]];
+    dispatch_sync(self.readWriteQueue, ^{
+        for (BugsnagBreadcrumb* crumb in self.breadcrumbs) {
+            NSDictionary *objectValue = [crumb objectValue];
+            NSError *error = nil;
+            @try {
+                if (![NSJSONSerialization isValidJSONObject:objectValue]) {
+                    bsg_log_err(@"Unable to serialize breadcrumb: Not a valid JSON object");
+                    continue;
+                }
+                NSData* data = [NSJSONSerialization dataWithJSONObject:objectValue options:0 error:&error];
+                if (data.length <= BSGBreadcrumbMaxByteSize)
+                    [contents addObject:objectValue];
+                else
+                    bsg_log_warn(@"Dropping breadcrumb (%@) exceeding %lu byte size limit", crumb.name, (unsigned long)BSGBreadcrumbMaxByteSize);
+            } @catch (NSException *exception) {
+                bsg_log_err(@"Unable to serialize breadcrumb: %@", error);
+            }
         }
-    }
-    [self.lock unlock];
+    });
     return contents;
 }
 
 - (void)resizeToFitCapacity:(NSUInteger)capacity {
     if (capacity == 0) {
         [self clearBreadcrumbs];
-        return;
+    } else if ([self count] > capacity) {
+        dispatch_barrier_sync(self.readWriteQueue, ^{
+            [self.breadcrumbs removeObjectsInRange:NSMakeRange(0, self.count - capacity)];
+        });
     }
-    [self.lock lock];
-    while ([self count] > capacity) {
-        [self.breadcrumbs removeObjectAtIndex:0];
-    }
-    [self.lock unlock];
 }
 
 @end

--- a/Source/BugsnagNotifier.m
+++ b/Source/BugsnagNotifier.m
@@ -103,6 +103,10 @@ NSString *BSGBreadcrumbNameForNotificationName(NSString *name) {
  *  @param destination target location of the data
  */
 void BSSerializeJSONDictionary(NSDictionary *dictionary, char **destination) {
+    if (![NSJSONSerialization isValidJSONObject:dictionary]) {
+        bsg_log_err(@"could not serialize metadata: is not valid JSON object");
+        return;
+    }
     @try {
         NSError *error;
         NSData *json = [NSJSONSerialization dataWithJSONObject:dictionary options:0 error:&error];

--- a/iOS/Bugsnag.xcodeproj/project.pbxproj
+++ b/iOS/Bugsnag.xcodeproj/project.pbxproj
@@ -34,6 +34,8 @@
 		8A2C8F961C6BC08600846019 /* report.json in Resources */ = {isa = PBXBuildFile; fileRef = 8A2C8F951C6BC08600846019 /* report.json */; };
 		8A381D4B1EAA49A700AF8429 /* BugsnagLogger.h in Headers */ = {isa = PBXBuildFile; fileRef = 8A381D491EAA49A700AF8429 /* BugsnagLogger.h */; };
 		8A4E733F1DC13281001F7CC8 /* BugsnagConfigurationTests.m in Sources */ = {isa = PBXBuildFile; fileRef = 8A4E733E1DC13281001F7CC8 /* BugsnagConfigurationTests.m */; };
+		8A627CD01EC2A5FD00F7C04E /* BSGSerialization.h in Headers */ = {isa = PBXBuildFile; fileRef = 8A627CCF1EC2A5FD00F7C04E /* BSGSerialization.h */; };
+		8A627CD21EC2A62900F7C04E /* BSGSerialization.m in Sources */ = {isa = PBXBuildFile; fileRef = 8A627CD11EC2A62900F7C04E /* BSGSerialization.m */; };
 		8A87351E1C6D2ADE00EDBD5B /* BSGKSCrashReportWriter.h in Headers */ = {isa = PBXBuildFile; fileRef = 8A87351D1C6D2ADE00EDBD5B /* BSGKSCrashReportWriter.h */; settings = {ATTRIBUTES = (Public, ); }; };
 		8AAA64011D2407CE00A9A123 /* Kiwi.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = 8AAA64001D2407CE00A9A123 /* Kiwi.framework */; };
 		8AE1BC951DEFCE8B00D16CEF /* BugsnagConfigurationSpec.m in Sources */ = {isa = PBXBuildFile; fileRef = 8AE1BC941DEFCE8B00D16CEF /* BugsnagConfigurationSpec.m */; };
@@ -83,6 +85,8 @@
 		8A2C8F951C6BC08600846019 /* report.json */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = text.json; name = report.json; path = ../Tests/report.json; sourceTree = SOURCE_ROOT; };
 		8A381D491EAA49A700AF8429 /* BugsnagLogger.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; name = BugsnagLogger.h; path = ../Source/BugsnagLogger.h; sourceTree = SOURCE_ROOT; };
 		8A4E733E1DC13281001F7CC8 /* BugsnagConfigurationTests.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; name = BugsnagConfigurationTests.m; path = ../Tests/BugsnagConfigurationTests.m; sourceTree = SOURCE_ROOT; };
+		8A627CCF1EC2A5FD00F7C04E /* BSGSerialization.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; name = BSGSerialization.h; path = ../Source/BSGSerialization.h; sourceTree = SOURCE_ROOT; };
+		8A627CD11EC2A62900F7C04E /* BSGSerialization.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; name = BSGSerialization.m; path = ../Source/BSGSerialization.m; sourceTree = SOURCE_ROOT; };
 		8A87351D1C6D2ADE00EDBD5B /* BSGKSCrashReportWriter.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; name = BSGKSCrashReportWriter.h; path = ../Source/BSGKSCrashReportWriter.h; sourceTree = SOURCE_ROOT; };
 		8AAA63FE1D2404BB00A9A123 /* Nocilla.framework */ = {isa = PBXFileReference; lastKnownFileType = wrapper.framework; name = Nocilla.framework; path = "../development/Nocilla/build/Debug-iphoneos/Nocilla.framework"; sourceTree = "<group>"; };
 		8AAA64001D2407CE00A9A123 /* Kiwi.framework */ = {isa = PBXFileReference; lastKnownFileType = wrapper.framework; name = Kiwi.framework; path = "../development/Kiwi/build/Debug-iphoneos/Kiwi.framework"; sourceTree = "<group>"; };
@@ -135,6 +139,8 @@
 		8A2C8F1A1C6BBD2300846019 /* Bugsnag */ = {
 			isa = PBXGroup;
 			children = (
+				8A627CCF1EC2A5FD00F7C04E /* BSGSerialization.h */,
+				8A627CD11EC2A62900F7C04E /* BSGSerialization.m */,
 				8A381D491EAA49A700AF8429 /* BugsnagLogger.h */,
 				8A2C8F3D1C6BBE3C00846019 /* Bugsnag.h */,
 				8A87351D1C6D2ADE00EDBD5B /* BSGKSCrashReportWriter.h */,
@@ -197,6 +203,7 @@
 			buildActionMask = 2147483647;
 			files = (
 				8A2C8F4F1C6BBE3C00846019 /* Bugsnag.h in Headers */,
+				8A627CD01EC2A5FD00F7C04E /* BSGSerialization.h in Headers */,
 				8A2C8F5B1C6BBE3C00846019 /* BugsnagMetaData.h in Headers */,
 				8A381D4B1EAA49A700AF8429 /* BugsnagLogger.h in Headers */,
 				8A2C8F551C6BBE3C00846019 /* BugsnagConfiguration.h in Headers */,
@@ -307,6 +314,7 @@
 			buildActionMask = 2147483647;
 			files = (
 				8A2C8F561C6BBE3C00846019 /* BugsnagConfiguration.m in Sources */,
+				8A627CD21EC2A62900F7C04E /* BSGSerialization.m in Sources */,
 				8A2C8F501C6BBE3C00846019 /* Bugsnag.m in Sources */,
 				8A2C8F5E1C6BBE3C00846019 /* BugsnagNotifier.m in Sources */,
 				8A2C8F601C6BBE3C00846019 /* BugsnagSink.m in Sources */,

--- a/tvOS/Bugsnag.xcodeproj/project.pbxproj
+++ b/tvOS/Bugsnag.xcodeproj/project.pbxproj
@@ -8,6 +8,8 @@
 
 /* Begin PBXBuildFile section */
 		8A48EF291EAA824100B70024 /* BugsnagLogger.h in Headers */ = {isa = PBXBuildFile; fileRef = 8A48EF281EAA824100B70024 /* BugsnagLogger.h */; };
+		8A627CD51EC3B69300F7C04E /* BSGSerialization.h in Headers */ = {isa = PBXBuildFile; fileRef = 8A627CD31EC3B69300F7C04E /* BSGSerialization.h */; };
+		8A627CD61EC3B69300F7C04E /* BSGSerialization.m in Sources */ = {isa = PBXBuildFile; fileRef = 8A627CD41EC3B69300F7C04E /* BSGSerialization.m */; };
 		8AB151171D41356800C9B218 /* Bugsnag.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = 8A8D51241D41343500D33797 /* Bugsnag.framework */; };
 		8AB151211D41361700C9B218 /* BugsnagBreadcrumbsTest.m in Sources */ = {isa = PBXBuildFile; fileRef = 8AB1511D1D41361700C9B218 /* BugsnagBreadcrumbsTest.m */; };
 		8AB151221D41361700C9B218 /* BugsnagCrashReportTests.m in Sources */ = {isa = PBXBuildFile; fileRef = 8AB1511E1D41361700C9B218 /* BugsnagCrashReportTests.m */; };
@@ -46,6 +48,8 @@
 
 /* Begin PBXFileReference section */
 		8A48EF281EAA824100B70024 /* BugsnagLogger.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; name = BugsnagLogger.h; path = ../Source/BugsnagLogger.h; sourceTree = "<group>"; };
+		8A627CD31EC3B69300F7C04E /* BSGSerialization.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; name = BSGSerialization.h; path = ../Source/BSGSerialization.h; sourceTree = "<group>"; };
+		8A627CD41EC3B69300F7C04E /* BSGSerialization.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; name = BSGSerialization.m; path = ../Source/BSGSerialization.m; sourceTree = "<group>"; };
 		8A8D51241D41343500D33797 /* Bugsnag.framework */ = {isa = PBXFileReference; explicitFileType = wrapper.framework; includeInIndex = 0; path = Bugsnag.framework; sourceTree = BUILT_PRODUCTS_DIR; };
 		8A8D51291D41343500D33797 /* Info.plist */ = {isa = PBXFileReference; lastKnownFileType = text.plist.xml; path = Info.plist; sourceTree = "<group>"; };
 		8AB151121D41356800C9B218 /* Tests.xctest */ = {isa = PBXFileReference; explicitFileType = wrapper.cfbundle; includeInIndex = 0; path = Tests.xctest; sourceTree = BUILT_PRODUCTS_DIR; };
@@ -123,6 +127,8 @@
 				8AB151271D41366400C9B218 /* Bugsnag.m */,
 				8AB151281D41366400C9B218 /* BugsnagBreadcrumb.h */,
 				8AB151291D41366400C9B218 /* BugsnagBreadcrumb.m */,
+				8A627CD31EC3B69300F7C04E /* BSGSerialization.h */,
+				8A627CD41EC3B69300F7C04E /* BSGSerialization.m */,
 				8AB1512A1D41366400C9B218 /* BugsnagCollections.h */,
 				8AB1512B1D41366400C9B218 /* BugsnagCollections.m */,
 				8A48EF281EAA824100B70024 /* BugsnagLogger.h */,
@@ -171,6 +177,7 @@
 			buildActionMask = 2147483647;
 			files = (
 				8AD9A4F51D42EE87004E1CC5 /* Bugsnag.h in Headers */,
+				8A627CD51EC3B69300F7C04E /* BSGSerialization.h in Headers */,
 				8AD9A4FA1D42EE96004E1CC5 /* BugsnagMetaData.h in Headers */,
 				8A48EF291EAA824100B70024 /* BugsnagLogger.h in Headers */,
 				8AD9A4F81D42EE96004E1CC5 /* BugsnagConfiguration.h in Headers */,
@@ -281,6 +288,7 @@
 			buildActionMask = 2147483647;
 			files = (
 				8AD9A5001D42EEA9004E1CC5 /* BugsnagConfiguration.m in Sources */,
+				8A627CD61EC3B69300F7C04E /* BSGSerialization.m in Sources */,
 				8AD9A5031D42EEB0004E1CC5 /* BugsnagNotifier.m in Sources */,
 				8AD9A4FE1D42EE9D004E1CC5 /* BugsnagBreadcrumb.m in Sources */,
 				8AD9A4FF1D42EEA0004E1CC5 /* BugsnagCollections.m in Sources */,


### PR DESCRIPTION
* Make breadcrumb interface available for more than UI/user action/main thread
* Sanitize metadata values
  * invalid values are dropped when added, logging an error
  * values are rechecked before serialization