### PR TITLE
Fix comparison warning

### DIFF
--- a/Source/BugsnagNotifier.m
+++ b/Source/BugsnagNotifier.m
@@ -404,7 +404,7 @@ void BSSerializeJSONDictionary(NSDictionary *dictionary, char **destination) {
              UIWindowDidResignKeyNotification,
              UIScreenBrightnessDidChangeNotification];
 #elif TARGET_IPHONE_SIMULATOR || TARGET_OS_IPHONE
-    NSMutableArray *notifications = @[UIWindowDidBecomeHiddenNotification,
+    return @[UIWindowDidBecomeHiddenNotification,
              UIWindowDidBecomeVisibleNotification,
              UIApplicationWillTerminateNotification,
              UIApplicationWillEnterForegroundNotification,
@@ -414,10 +414,11 @@ void BSSerializeJSONDictionary(NSDictionary *dictionary, char **destination) {
              UIMenuControllerDidShowMenuNotification,
              UIMenuControllerDidHideMenuNotification,
              NSUndoManagerDidUndoChangeNotification,
-             NSUndoManagerDidRedoChangeNotification].mutableCopy;
-    if (&UIApplicationUserDidTakeScreenshotNotification)
-        [notifications addObject:UIApplicationUserDidTakeScreenshotNotification];
-    return notifications;
+             NSUndoManagerDidRedoChangeNotification,
+#if __IPHONE_OS_VERSION_MIN_REQUIRED >= __IPHONE_7_0
+             UIApplicationUserDidTakeScreenshotNotification
+#endif
+            ];
 #elif TARGET_OS_MAC
     return @[NSApplicationDidBecomeActiveNotification,
              NSApplicationDidResignActiveNotification,


### PR DESCRIPTION
After changing the deployment target for the library to 6.0,
`UIApplicationUserDidTakeScreenshotNotification` was not guaranteed to
be available anymore. However, our project's deployment target is set to
8.0 which _does_ guarantee the presence of the symbol and leads to a
warning in Xcode.