### PR TITLE
Update example apps

### DIFF
--- a/examples/objective-c-ios/Bugsnag Test App.xcodeproj/project.pbxproj
+++ b/examples/objective-c-ios/Bugsnag Test App.xcodeproj/project.pbxproj
@@ -241,9 +241,11 @@
 					8ACFFA081D895D4D00357B5E = {
 						CreatedOnToolsVersion = 7.3.1;
 						DevelopmentTeam = 372ZUL2ZB7;
+						LastSwiftMigration = 0830;
 					};
 					F40B874516AA233500676BB2 = {
 						DevelopmentTeam = 372ZUL2ZB7;
+						LastSwiftMigration = 0830;
 					};
 				};
 			};
@@ -316,7 +318,7 @@
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 			shellPath = /bin/sh;
-			shellScript = "diff \"${PODS_ROOT}/../Podfile.lock\" \"${PODS_ROOT}/Manifest.lock\" > /dev/null\nif [ $? != 0 ] ; then\n    # print error to STDERR\n    echo \"error: The sandbox is not in sync with the Podfile.lock. Run 'pod install' or update your CocoaPods installation.\" >&2\n    exit 1\nfi\n";
+			shellScript = "diff \"${PODS_PODFILE_DIR_PATH}/Podfile.lock\" \"${PODS_ROOT}/Manifest.lock\" > /dev/null\nif [ $? != 0 ] ; then\n    # print error to STDERR\n    echo \"error: The sandbox is not in sync with the Podfile.lock. Run 'pod install' or update your CocoaPods installation.\" >&2\n    exit 1\nfi\n";
 			showEnvVarsInLog = 0;
 		};
 		765F7485E02A01DA5E42AC27 /* [CP] Embed Pods Frameworks */ = {
@@ -346,7 +348,7 @@
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 			shellPath = /bin/sh;
-			shellScript = "diff \"${PODS_ROOT}/../Podfile.lock\" \"${PODS_ROOT}/Manifest.lock\" > /dev/null\nif [ $? != 0 ] ; then\n    # print error to STDERR\n    echo \"error: The sandbox is not in sync with the Podfile.lock. Run 'pod install' or update your CocoaPods installation.\" >&2\n    exit 1\nfi\n";
+			shellScript = "diff \"${PODS_PODFILE_DIR_PATH}/Podfile.lock\" \"${PODS_ROOT}/Manifest.lock\" > /dev/null\nif [ $? != 0 ] ; then\n    # print error to STDERR\n    echo \"error: The sandbox is not in sync with the Podfile.lock. Run 'pod install' or update your CocoaPods installation.\" >&2\n    exit 1\nfi\n";
 			showEnvVarsInLog = 0;
 		};
 		E142138E1656CA8499F1E0A3 /* [CP] Copy Pods Resources */ = {
@@ -473,6 +475,7 @@
 				SKIP_INSTALL = YES;
 				SWIFT_OBJC_BRIDGING_HEADER = "custom-keyboard/BridgingHeader.h";
 				SWIFT_OPTIMIZATION_LEVEL = "-Onone";
+				SWIFT_VERSION = 3.0;
 			};
 			name = Debug;
 		};
@@ -510,6 +513,7 @@
 				PRODUCT_NAME = "$(TARGET_NAME)";
 				SKIP_INSTALL = YES;
 				SWIFT_OBJC_BRIDGING_HEADER = "custom-keyboard/BridgingHeader.h";
+				SWIFT_VERSION = 3.0;
 			};
 			name = Release;
 		};
@@ -590,6 +594,7 @@
 				PROVISIONING_PROFILE = "";
 				SEPARATE_STRIP = YES;
 				STRIP_INSTALLED_PRODUCT = YES;
+				SWIFT_VERSION = 3.0;
 				WRAPPER_EXTENSION = app;
 			};
 			name = Debug;
@@ -612,6 +617,7 @@
 				PROVISIONING_PROFILE = "";
 				SEPARATE_STRIP = YES;
 				STRIP_INSTALLED_PRODUCT = YES;
+				SWIFT_VERSION = 3.0;
 				WRAPPER_EXTENSION = app;
 			};
 			name = Release;

--- a/examples/objective-c-ios/Podfile.lock
+++ b/examples/objective-c-ios/Podfile.lock
@@ -1,21 +1,21 @@
 PODS:
-  - Bugsnag (5.7.0):
-    - KSCrash/Recording (= 1.15.3)
-  - KSCrash/Recording (1.15.3):
-    - KSCrash/Recording/Tools (= 1.15.3)
-  - KSCrash/Recording/Tools (1.15.3)
+  - Bugsnag (5.10.1):
+    - KSCrash/RecordingAdvanced (= 1.8.13)
+  - KSCrash/Recording (1.8.13)
+  - KSCrash/RecordingAdvanced (1.8.13):
+    - KSCrash/Recording
 
 DEPENDENCIES:
   - Bugsnag (from `../..`)
 
 EXTERNAL SOURCES:
   Bugsnag:
-    :path: "../.."
+    :path: ../..
 
 SPEC CHECKSUMS:
-  Bugsnag: c3959ada534c7ddf67d9ee1bf0beeb12f2fef8ce
-  KSCrash: f344875321256d5906569a0853d73c6354a9f6f4
+  Bugsnag: 9c2d242eac7f215c40ff0f5813d378e9fcccf6e4
+  KSCrash: 4c3a83f133b60f4bd57e05235ebf8d46e36d378d
 
 PODFILE CHECKSUM: 1412e9880d9b870b64c3191b0fcb110903c8c7c2
 
-COCOAPODS: 1.1.1
+COCOAPODS: 1.2.1

--- a/examples/objective-c-ios/custom-keyboard/KeyboardViewController.swift
+++ b/examples/objective-c-ios/custom-keyboard/KeyboardViewController.swift
@@ -7,44 +7,44 @@ class KeyboardViewController: UIInputViewController {
 
     required init?(coder aDecoder: NSCoder) {
         super.init(coder: aDecoder)
-        Bugsnag.startBugsnagWithApiKey("YOUR-API-KEY")
+        Bugsnag.start(withApiKey: "YOUR-API-KEY")
     }
 
-    required override init(nibName nibNameOrNil: String?, bundle nibBundleOrNil: NSBundle?) {
+    required override init(nibName nibNameOrNil: String?, bundle nibBundleOrNil: Bundle?) {
         super.init(nibName: nibNameOrNil, bundle: nibBundleOrNil)
-        Bugsnag.startBugsnagWithApiKey("YOUR-API-KEY")
+        Bugsnag.start(withApiKey: "YOUR-API-KEY")
     }
 
     override func viewDidLoad() {
         super.viewDidLoad()
     
         // Perform custom UI setup here
-        self.nextKeyboardButton = UIButton(type: .System)
+        self.nextKeyboardButton = UIButton(type: .system)
     
-        self.nextKeyboardButton.setTitle(NSLocalizedString("Next Keyboard", comment: "Title for 'Next Keyboard' button"), forState: .Normal)
+        self.nextKeyboardButton.setTitle(NSLocalizedString("Next Keyboard", comment: "Title for 'Next Keyboard' button"), for: UIControlState())
         self.nextKeyboardButton.sizeToFit()
         self.nextKeyboardButton.translatesAutoresizingMaskIntoConstraints = false
     
-        self.nextKeyboardButton.addTarget(self, action: #selector(advanceToNextInputMode), forControlEvents: .TouchUpInside)
+        self.nextKeyboardButton.addTarget(self, action: #selector(advanceToNextInputMode), for: .touchUpInside)
         
         self.view.addSubview(self.nextKeyboardButton)
     
-        self.nextKeyboardButton.leftAnchor.constraintEqualToAnchor(self.view.leftAnchor).active = true
-        self.nextKeyboardButton.bottomAnchor.constraintEqualToAnchor(self.view.bottomAnchor).active = true
+        self.nextKeyboardButton.leftAnchor.constraint(equalTo: self.view.leftAnchor).isActive = true
+        self.nextKeyboardButton.bottomAnchor.constraint(equalTo: self.view.bottomAnchor).isActive = true
 
         // Perform custom UI setup here
-        self.crashButton = UIButton(type: .System)
+        self.crashButton = UIButton(type: .system)
 
-        self.crashButton.setTitle(NSLocalizedString("Cause crash", comment: "Title for 'Crash' button"), forState: .Normal)
+        self.crashButton.setTitle(NSLocalizedString("Cause crash", comment: "Title for 'Crash' button"), for: UIControlState())
         self.crashButton.sizeToFit()
         self.crashButton.translatesAutoresizingMaskIntoConstraints = false
 
-        self.crashButton.addTarget(self, action: #selector(crashStuff), forControlEvents: .TouchUpInside)
+        self.crashButton.addTarget(self, action: #selector(crashStuff), for: .touchUpInside)
 
         self.view.addSubview(self.crashButton)
 
-        self.crashButton.leftAnchor.constraintEqualToAnchor(self.nextKeyboardButton.rightAnchor).active = true
-        self.crashButton.bottomAnchor.constraintEqualToAnchor(self.view.bottomAnchor).active = true
+        self.crashButton.leftAnchor.constraint(equalTo: self.nextKeyboardButton.rightAnchor).isActive = true
+        self.crashButton.bottomAnchor.constraint(equalTo: self.view.bottomAnchor).isActive = true
     }
 
     override func didReceiveMemoryWarning() {
@@ -52,21 +52,21 @@ class KeyboardViewController: UIInputViewController {
         // Dispose of any resources that can be recreated
     }
 
-    override func textWillChange(textInput: UITextInput?) {
+    override func textWillChange(_ textInput: UITextInput?) {
         // The app is about to change the document's contents. Perform any preparation here.
     }
 
-    override func textDidChange(textInput: UITextInput?) {
+    override func textDidChange(_ textInput: UITextInput?) {
         // The app has just changed the document's contents, the document context has been updated.
     
         var textColor: UIColor
         let proxy = self.textDocumentProxy
-        if proxy.keyboardAppearance == UIKeyboardAppearance.Dark {
-            textColor = UIColor.whiteColor()
+        if proxy.keyboardAppearance == UIKeyboardAppearance.dark {
+            textColor = UIColor.white
         } else {
-            textColor = UIColor.blackColor()
+            textColor = UIColor.black
         }
-        self.nextKeyboardButton.setTitleColor(textColor, forState: .Normal)
+        self.nextKeyboardButton.setTitleColor(textColor, for: UIControlState())
     }
 
     func crashStuff() {

--- a/examples/objective-c-osx/Podfile
+++ b/examples/objective-c-osx/Podfile
@@ -1,3 +1,5 @@
-platform :osx, "10.8"
-pod 'Bugsnag', :path => "../.."
+target 'objective-c-osx' do
+    platform :osx, "10.8"
+    pod 'Bugsnag', :path => "../.."
+end
 

--- a/examples/objective-c-osx/Podfile.lock
+++ b/examples/objective-c-osx/Podfile.lock
@@ -1,56 +1,8 @@
 PODS:
-  - Bugsnag (4.1.0):
-    - KSCrash/Recording (~> 1.0.0)
-    - KSCrash/Reporting (~> 1.0.0)
-  - KSCrash/no-arc (1.0.0)
-  - KSCrash/Recording (1.0.0):
-    - KSCrash/no-arc
-  - KSCrash/Reporting (1.0.0):
-    - KSCrash/Recording
-    - KSCrash/Reporting/Filters (= 1.0.0)
-    - KSCrash/Reporting/MessageUI (= 1.0.0)
-    - KSCrash/Reporting/Sinks (= 1.0.0)
-    - KSCrash/Reporting/Tools (= 1.0.0)
-  - KSCrash/Reporting/Filters (1.0.0):
-    - KSCrash/Recording
-    - KSCrash/Reporting/Filters/Alert (= 1.0.0)
-    - KSCrash/Reporting/Filters/AppleFmt (= 1.0.0)
-    - KSCrash/Reporting/Filters/Base (= 1.0.0)
-    - KSCrash/Reporting/Filters/Basic (= 1.0.0)
-    - KSCrash/Reporting/Filters/GZip (= 1.0.0)
-    - KSCrash/Reporting/Filters/JSON (= 1.0.0)
-    - KSCrash/Reporting/Filters/Sets (= 1.0.0)
-  - KSCrash/Reporting/Filters/Alert (1.0.0):
-    - KSCrash/Recording
-    - KSCrash/Reporting/Filters/Base
-  - KSCrash/Reporting/Filters/AppleFmt (1.0.0):
-    - KSCrash/Recording
-    - KSCrash/Reporting/Filters/Base
-  - KSCrash/Reporting/Filters/Base (1.0.0):
-    - KSCrash/Recording
-  - KSCrash/Reporting/Filters/Basic (1.0.0):
-    - KSCrash/Recording
-    - KSCrash/Reporting/Filters/Base
-  - KSCrash/Reporting/Filters/GZip (1.0.0):
-    - KSCrash/Recording
-    - KSCrash/Reporting/Filters/Base
-  - KSCrash/Reporting/Filters/JSON (1.0.0):
-    - KSCrash/Recording
-    - KSCrash/Reporting/Filters/Base
-  - KSCrash/Reporting/Filters/Sets (1.0.0):
-    - KSCrash/Recording
-    - KSCrash/Reporting/Filters/AppleFmt
-    - KSCrash/Reporting/Filters/Base
-    - KSCrash/Reporting/Filters/Basic
-    - KSCrash/Reporting/Filters/GZip
-    - KSCrash/Reporting/Filters/JSON
-  - KSCrash/Reporting/MessageUI (1.0.0):
-    - KSCrash/Recording
-  - KSCrash/Reporting/Sinks (1.0.0):
-    - KSCrash/Recording
-    - KSCrash/Reporting/Filters
-    - KSCrash/Reporting/Tools
-  - KSCrash/Reporting/Tools (1.0.0):
+  - Bugsnag (5.10.1):
+    - KSCrash/RecordingAdvanced (= 1.8.13)
+  - KSCrash/Recording (1.8.13)
+  - KSCrash/RecordingAdvanced (1.8.13):
     - KSCrash/Recording
 
 DEPENDENCIES:
@@ -58,10 +10,12 @@ DEPENDENCIES:
 
 EXTERNAL SOURCES:
   Bugsnag:
-    :path: "../.."
+    :path: ../..
 
 SPEC CHECKSUMS:
-  Bugsnag: 3f6f32511a1488f3f91adb329234827b11398192
-  KSCrash: 248e7d1d5b3c375b3cbcc9654f570eb756ebbbb5
+  Bugsnag: 9c2d242eac7f215c40ff0f5813d378e9fcccf6e4
+  KSCrash: 4c3a83f133b60f4bd57e05235ebf8d46e36d378d
 
-COCOAPODS: 0.39.0
+PODFILE CHECKSUM: df3de31179198c85e1d68a7930eb894bbeb22744
+
+COCOAPODS: 1.2.1

--- a/examples/objective-c-osx/objective-c-osx.xcodeproj/project.pbxproj
+++ b/examples/objective-c-osx/objective-c-osx.xcodeproj/project.pbxproj
@@ -7,7 +7,6 @@
 	objects = {
 
 /* Begin PBXBuildFile section */
-		918A346DCC1B2C974D948308 /* libPods.a in Frameworks */ = {isa = PBXBuildFile; fileRef = C3DC5294BAB504E58D210978 /* libPods.a */; };
 		93BE1CD61B62CC360016380C /* AppDelegate.m in Sources */ = {isa = PBXBuildFile; fileRef = 93BE1CD51B62CC360016380C /* AppDelegate.m */; };
 		93BE1CD81B62CC360016380C /* main.m in Sources */ = {isa = PBXBuildFile; fileRef = 93BE1CD71B62CC360016380C /* main.m */; };
 		93BE1CDB1B62CC360016380C /* ViewController.m in Sources */ = {isa = PBXBuildFile; fileRef = 93BE1CDA1B62CC360016380C /* ViewController.m */; };
@@ -28,8 +27,6 @@
 /* End PBXContainerItemProxy section */
 
 /* Begin PBXFileReference section */
-		78A2A64FC09C3AE04F0B5AB6 /* Pods.release.xcconfig */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.xcconfig; name = Pods.release.xcconfig; path = "Pods/Target Support Files/Pods/Pods.release.xcconfig"; sourceTree = "<group>"; };
-		8D28FD0A0F3E7F63C4EA7338 /* Pods.debug.xcconfig */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.xcconfig; name = Pods.debug.xcconfig; path = "Pods/Target Support Files/Pods/Pods.debug.xcconfig"; sourceTree = "<group>"; };
 		93BE1CCF1B62CC360016380C /* objective-c-osx.app */ = {isa = PBXFileReference; explicitFileType = wrapper.application; includeInIndex = 0; path = "objective-c-osx.app"; sourceTree = BUILT_PRODUCTS_DIR; };
 		93BE1CD31B62CC360016380C /* Info.plist */ = {isa = PBXFileReference; lastKnownFileType = text.plist.xml; path = Info.plist; sourceTree = "<group>"; };
 		93BE1CD41B62CC360016380C /* AppDelegate.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; path = AppDelegate.h; sourceTree = "<group>"; };
@@ -44,7 +41,6 @@
 		93BE1CEB1B62CC360016380C /* objective_c_osxTests.m */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.objc; path = objective_c_osxTests.m; sourceTree = "<group>"; };
 		93CF94F61B66B09300D1558C /* CustomApplication.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = CustomApplication.h; sourceTree = "<group>"; };
 		93CF94F71B66B09300D1558C /* CustomApplication.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; path = CustomApplication.m; sourceTree = "<group>"; };
-		C3DC5294BAB504E58D210978 /* libPods.a */ = {isa = PBXFileReference; explicitFileType = archive.ar; includeInIndex = 0; path = libPods.a; sourceTree = BUILT_PRODUCTS_DIR; };
 /* End PBXFileReference section */
 
 /* Begin PBXFrameworksBuildPhase section */
@@ -52,7 +48,6 @@
 			isa = PBXFrameworksBuildPhase;
 			buildActionMask = 2147483647;
 			files = (
-				918A346DCC1B2C974D948308 /* libPods.a in Frameworks */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};
@@ -66,31 +61,12 @@
 /* End PBXFrameworksBuildPhase section */
 
 /* Begin PBXGroup section */
-		65CC3202D52DEBE202B9F747 /* Frameworks */ = {
-			isa = PBXGroup;
-			children = (
-				C3DC5294BAB504E58D210978 /* libPods.a */,
-			);
-			name = Frameworks;
-			sourceTree = "<group>";
-		};
-		7BC0639ADD01C623F5FF10DD /* Pods */ = {
-			isa = PBXGroup;
-			children = (
-				8D28FD0A0F3E7F63C4EA7338 /* Pods.debug.xcconfig */,
-				78A2A64FC09C3AE04F0B5AB6 /* Pods.release.xcconfig */,
-			);
-			name = Pods;
-			sourceTree = "<group>";
-		};
 		93BE1CC61B62CC360016380C = {
 			isa = PBXGroup;
 			children = (
 				93BE1CD11B62CC360016380C /* objective-c-osx */,
 				93BE1CE81B62CC360016380C /* objective-c-osxTests */,
 				93BE1CD01B62CC360016380C /* Products */,
-				7BC0639ADD01C623F5FF10DD /* Pods */,
-				65CC3202D52DEBE202B9F747 /* Frameworks */,
 			);
 			sourceTree = "<group>";
 		};
@@ -152,13 +128,10 @@
 			isa = PBXNativeTarget;
 			buildConfigurationList = 93BE1CEF1B62CC360016380C /* Build configuration list for PBXNativeTarget "objective-c-osx" */;
 			buildPhases = (
-				D552769B62EC0CD18DC1916F /* Check Pods Manifest.lock */,
 				93BE1CCB1B62CC360016380C /* Sources */,
 				93BE1CCC1B62CC360016380C /* Frameworks */,
 				93BE1CCD1B62CC360016380C /* Resources */,
-				40A5C5D356170963159E944D /* Copy Pods Resources */,
 				D24AA2BFC04EE1A1916426C8 /* Upload Bugsnag dSYM */,
-				09E7C9406C6A00A6A35079BC /* Embed Pods Frameworks */,
 			);
 			buildRules = (
 			);
@@ -244,36 +217,6 @@
 /* End PBXResourcesBuildPhase section */
 
 /* Begin PBXShellScriptBuildPhase section */
-		09E7C9406C6A00A6A35079BC /* Embed Pods Frameworks */ = {
-			isa = PBXShellScriptBuildPhase;
-			buildActionMask = 2147483647;
-			files = (
-			);
-			inputPaths = (
-			);
-			name = "Embed Pods Frameworks";
-			outputPaths = (
-			);
-			runOnlyForDeploymentPostprocessing = 0;
-			shellPath = /bin/sh;
-			shellScript = "\"${SRCROOT}/Pods/Target Support Files/Pods/Pods-frameworks.sh\"\n";
-			showEnvVarsInLog = 0;
-		};
-		40A5C5D356170963159E944D /* Copy Pods Resources */ = {
-			isa = PBXShellScriptBuildPhase;
-			buildActionMask = 2147483647;
-			files = (
-			);
-			inputPaths = (
-			);
-			name = "Copy Pods Resources";
-			outputPaths = (
-			);
-			runOnlyForDeploymentPostprocessing = 0;
-			shellPath = /bin/sh;
-			shellScript = "\"${SRCROOT}/Pods/Target Support Files/Pods/Pods-resources.sh\"\n";
-			showEnvVarsInLog = 0;
-		};
 		D24AA2BFC04EE1A1916426C8 /* Upload Bugsnag dSYM */ = {
 			isa = PBXShellScriptBuildPhase;
 			buildActionMask = 2147483647;
@@ -287,21 +230,6 @@
 			runOnlyForDeploymentPostprocessing = 0;
 			shellPath = "/usr/bin/env ruby";
 			shellScript = "fork do\n  Process.setsid\n  STDIN.reopen(\"/dev/null\")\n  STDOUT.reopen(\"/dev/null\", \"a\")\n  STDERR.reopen(\"/dev/null\", \"a\")\n\n  require 'shellwords'\n\n  Dir[\"#{ENV[\"DWARF_DSYM_FOLDER_PATH\"]}/*/Contents/Resources/DWARF/*\"].each do |dsym|\n    system(\"curl -F dsym=@#{Shellwords.escape(dsym)} -F projectRoot=#{Shellwords.escape(ENV[\"PROJECT_DIR\"])} https://upload.bugsnag.com/\")\n  end\nend\n";
-			showEnvVarsInLog = 0;
-		};
-		D552769B62EC0CD18DC1916F /* Check Pods Manifest.lock */ = {
-			isa = PBXShellScriptBuildPhase;
-			buildActionMask = 2147483647;
-			files = (
-			);
-			inputPaths = (
-			);
-			name = "Check Pods Manifest.lock";
-			outputPaths = (
-			);
-			runOnlyForDeploymentPostprocessing = 0;
-			shellPath = /bin/sh;
-			shellScript = "diff \"${PODS_ROOT}/../Podfile.lock\" \"${PODS_ROOT}/Manifest.lock\" > /dev/null\nif [[ $? != 0 ]] ; then\n    cat << EOM\nerror: The sandbox is not in sync with the Podfile.lock. Run 'pod install' or update your CocoaPods installation.\nEOM\n    exit 1\nfi\n";
 			showEnvVarsInLog = 0;
 		};
 /* End PBXShellScriptBuildPhase section */
@@ -429,7 +357,6 @@
 		};
 		93BE1CF01B62CC360016380C /* Debug */ = {
 			isa = XCBuildConfiguration;
-			baseConfigurationReference = 8D28FD0A0F3E7F63C4EA7338 /* Pods.debug.xcconfig */;
 			buildSettings = {
 				ASSETCATALOG_COMPILER_APPICON_NAME = AppIcon;
 				COMBINE_HIDPI_IMAGES = YES;
@@ -442,7 +369,6 @@
 		};
 		93BE1CF11B62CC360016380C /* Release */ = {
 			isa = XCBuildConfiguration;
-			baseConfigurationReference = 78A2A64FC09C3AE04F0B5AB6 /* Pods.release.xcconfig */;
 			buildSettings = {
 				ASSETCATALOG_COMPILER_APPICON_NAME = AppIcon;
 				COMBINE_HIDPI_IMAGES = YES;

--- a/examples/objective-c-osx/objective-c-osx.xcodeproj/project.pbxproj
+++ b/examples/objective-c-osx/objective-c-osx.xcodeproj/project.pbxproj
@@ -14,6 +14,7 @@
 		93BE1CE01B62CC360016380C /* Main.storyboard in Resources */ = {isa = PBXBuildFile; fileRef = 93BE1CDE1B62CC360016380C /* Main.storyboard */; };
 		93BE1CEC1B62CC360016380C /* objective_c_osxTests.m in Sources */ = {isa = PBXBuildFile; fileRef = 93BE1CEB1B62CC360016380C /* objective_c_osxTests.m */; };
 		93CF94F81B66B09300D1558C /* CustomApplication.m in Sources */ = {isa = PBXBuildFile; fileRef = 93CF94F71B66B09300D1558C /* CustomApplication.m */; };
+		D237D8A707A739A4034FF767 /* libPods-objective-c-osx.a in Frameworks */ = {isa = PBXBuildFile; fileRef = 54B9582E2984563C0F07C26D /* libPods-objective-c-osx.a */; };
 /* End PBXBuildFile section */
 
 /* Begin PBXContainerItemProxy section */
@@ -27,6 +28,8 @@
 /* End PBXContainerItemProxy section */
 
 /* Begin PBXFileReference section */
+		42399E10422D1D0AC8097A88 /* Pods-objective-c-osx.release.xcconfig */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.xcconfig; name = "Pods-objective-c-osx.release.xcconfig"; path = "Pods/Target Support Files/Pods-objective-c-osx/Pods-objective-c-osx.release.xcconfig"; sourceTree = "<group>"; };
+		54B9582E2984563C0F07C26D /* libPods-objective-c-osx.a */ = {isa = PBXFileReference; explicitFileType = archive.ar; includeInIndex = 0; path = "libPods-objective-c-osx.a"; sourceTree = BUILT_PRODUCTS_DIR; };
 		93BE1CCF1B62CC360016380C /* objective-c-osx.app */ = {isa = PBXFileReference; explicitFileType = wrapper.application; includeInIndex = 0; path = "objective-c-osx.app"; sourceTree = BUILT_PRODUCTS_DIR; };
 		93BE1CD31B62CC360016380C /* Info.plist */ = {isa = PBXFileReference; lastKnownFileType = text.plist.xml; path = Info.plist; sourceTree = "<group>"; };
 		93BE1CD41B62CC360016380C /* AppDelegate.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; path = AppDelegate.h; sourceTree = "<group>"; };
@@ -41,6 +44,7 @@
 		93BE1CEB1B62CC360016380C /* objective_c_osxTests.m */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.objc; path = objective_c_osxTests.m; sourceTree = "<group>"; };
 		93CF94F61B66B09300D1558C /* CustomApplication.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = CustomApplication.h; sourceTree = "<group>"; };
 		93CF94F71B66B09300D1558C /* CustomApplication.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; path = CustomApplication.m; sourceTree = "<group>"; };
+		F830779A7F2A813CA88B426B /* Pods-objective-c-osx.debug.xcconfig */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.xcconfig; name = "Pods-objective-c-osx.debug.xcconfig"; path = "Pods/Target Support Files/Pods-objective-c-osx/Pods-objective-c-osx.debug.xcconfig"; sourceTree = "<group>"; };
 /* End PBXFileReference section */
 
 /* Begin PBXFrameworksBuildPhase section */
@@ -48,6 +52,7 @@
 			isa = PBXFrameworksBuildPhase;
 			buildActionMask = 2147483647;
 			files = (
+				D237D8A707A739A4034FF767 /* libPods-objective-c-osx.a in Frameworks */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};
@@ -61,12 +66,22 @@
 /* End PBXFrameworksBuildPhase section */
 
 /* Begin PBXGroup section */
+		237A9755E6B64C219CB26705 /* Frameworks */ = {
+			isa = PBXGroup;
+			children = (
+				54B9582E2984563C0F07C26D /* libPods-objective-c-osx.a */,
+			);
+			name = Frameworks;
+			sourceTree = "<group>";
+		};
 		93BE1CC61B62CC360016380C = {
 			isa = PBXGroup;
 			children = (
 				93BE1CD11B62CC360016380C /* objective-c-osx */,
 				93BE1CE81B62CC360016380C /* objective-c-osxTests */,
 				93BE1CD01B62CC360016380C /* Products */,
+				FEC429E808D94D8B6E6E14D5 /* Pods */,
+				237A9755E6B64C219CB26705 /* Frameworks */,
 			);
 			sourceTree = "<group>";
 		};
@@ -121,6 +136,15 @@
 			name = "Supporting Files";
 			sourceTree = "<group>";
 		};
+		FEC429E808D94D8B6E6E14D5 /* Pods */ = {
+			isa = PBXGroup;
+			children = (
+				F830779A7F2A813CA88B426B /* Pods-objective-c-osx.debug.xcconfig */,
+				42399E10422D1D0AC8097A88 /* Pods-objective-c-osx.release.xcconfig */,
+			);
+			name = Pods;
+			sourceTree = "<group>";
+		};
 /* End PBXGroup section */
 
 /* Begin PBXNativeTarget section */
@@ -128,10 +152,13 @@
 			isa = PBXNativeTarget;
 			buildConfigurationList = 93BE1CEF1B62CC360016380C /* Build configuration list for PBXNativeTarget "objective-c-osx" */;
 			buildPhases = (
+				AF12CC88EC2DA5EF6D40C883 /* [CP] Check Pods Manifest.lock */,
 				93BE1CCB1B62CC360016380C /* Sources */,
 				93BE1CCC1B62CC360016380C /* Frameworks */,
 				93BE1CCD1B62CC360016380C /* Resources */,
 				D24AA2BFC04EE1A1916426C8 /* Upload Bugsnag dSYM */,
+				3B550964C9496E4003E11717 /* [CP] Embed Pods Frameworks */,
+				2DB50B6F565C5C917EEF01B4 /* [CP] Copy Pods Resources */,
 			);
 			buildRules = (
 			);
@@ -217,6 +244,51 @@
 /* End PBXResourcesBuildPhase section */
 
 /* Begin PBXShellScriptBuildPhase section */
+		2DB50B6F565C5C917EEF01B4 /* [CP] Copy Pods Resources */ = {
+			isa = PBXShellScriptBuildPhase;
+			buildActionMask = 2147483647;
+			files = (
+			);
+			inputPaths = (
+			);
+			name = "[CP] Copy Pods Resources";
+			outputPaths = (
+			);
+			runOnlyForDeploymentPostprocessing = 0;
+			shellPath = /bin/sh;
+			shellScript = "\"${SRCROOT}/Pods/Target Support Files/Pods-objective-c-osx/Pods-objective-c-osx-resources.sh\"\n";
+			showEnvVarsInLog = 0;
+		};
+		3B550964C9496E4003E11717 /* [CP] Embed Pods Frameworks */ = {
+			isa = PBXShellScriptBuildPhase;
+			buildActionMask = 2147483647;
+			files = (
+			);
+			inputPaths = (
+			);
+			name = "[CP] Embed Pods Frameworks";
+			outputPaths = (
+			);
+			runOnlyForDeploymentPostprocessing = 0;
+			shellPath = /bin/sh;
+			shellScript = "\"${SRCROOT}/Pods/Target Support Files/Pods-objective-c-osx/Pods-objective-c-osx-frameworks.sh\"\n";
+			showEnvVarsInLog = 0;
+		};
+		AF12CC88EC2DA5EF6D40C883 /* [CP] Check Pods Manifest.lock */ = {
+			isa = PBXShellScriptBuildPhase;
+			buildActionMask = 2147483647;
+			files = (
+			);
+			inputPaths = (
+			);
+			name = "[CP] Check Pods Manifest.lock";
+			outputPaths = (
+			);
+			runOnlyForDeploymentPostprocessing = 0;
+			shellPath = /bin/sh;
+			shellScript = "diff \"${PODS_PODFILE_DIR_PATH}/Podfile.lock\" \"${PODS_ROOT}/Manifest.lock\" > /dev/null\nif [ $? != 0 ] ; then\n    # print error to STDERR\n    echo \"error: The sandbox is not in sync with the Podfile.lock. Run 'pod install' or update your CocoaPods installation.\" >&2\n    exit 1\nfi\n";
+			showEnvVarsInLog = 0;
+		};
 		D24AA2BFC04EE1A1916426C8 /* Upload Bugsnag dSYM */ = {
 			isa = PBXShellScriptBuildPhase;
 			buildActionMask = 2147483647;
@@ -357,6 +429,7 @@
 		};
 		93BE1CF01B62CC360016380C /* Debug */ = {
 			isa = XCBuildConfiguration;
+			baseConfigurationReference = F830779A7F2A813CA88B426B /* Pods-objective-c-osx.debug.xcconfig */;
 			buildSettings = {
 				ASSETCATALOG_COMPILER_APPICON_NAME = AppIcon;
 				COMBINE_HIDPI_IMAGES = YES;
@@ -369,6 +442,7 @@
 		};
 		93BE1CF11B62CC360016380C /* Release */ = {
 			isa = XCBuildConfiguration;
+			baseConfigurationReference = 42399E10422D1D0AC8097A88 /* Pods-objective-c-osx.release.xcconfig */;
 			buildSettings = {
 				ASSETCATALOG_COMPILER_APPICON_NAME = AppIcon;
 				COMBINE_HIDPI_IMAGES = YES;

--- a/examples/swift-ios/Podfile.lock
+++ b/examples/swift-ios/Podfile.lock
@@ -1,8 +1,8 @@
 PODS:
-  - Bugsnag (5.7.0):
-    - KSCrash/RecordingAdvanced (= 1.11.2)
-  - KSCrash/Recording (1.11.2)
-  - KSCrash/RecordingAdvanced (1.11.2):
+  - Bugsnag (5.10.1):
+    - KSCrash/RecordingAdvanced (= 1.8.13)
+  - KSCrash/Recording (1.8.13)
+  - KSCrash/RecordingAdvanced (1.8.13):
     - KSCrash/Recording
 
 DEPENDENCIES:
@@ -10,12 +10,12 @@ DEPENDENCIES:
 
 EXTERNAL SOURCES:
   Bugsnag:
-    :path: "../.."
+    :path: ../..
 
 SPEC CHECKSUMS:
-  Bugsnag: d86488d670f91acbce0186e6570e500039676ef0
-  KSCrash: 8acc46aca72b2772d5d1e3cba1da9173db4d705e
+  Bugsnag: 9c2d242eac7f215c40ff0f5813d378e9fcccf6e4
+  KSCrash: 4c3a83f133b60f4bd57e05235ebf8d46e36d378d
 
 PODFILE CHECKSUM: 2107babfbfdb18f0288407b9d9ebd48cbee8661c
 
-COCOAPODS: 1.2.0.beta.1
+COCOAPODS: 1.2.1

--- a/examples/swift-ios/bugsnag-example.xcodeproj/project.pbxproj
+++ b/examples/swift-ios/bugsnag-example.xcodeproj/project.pbxproj
@@ -262,7 +262,7 @@
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 			shellPath = /bin/sh;
-			shellScript = "diff \"${PODS_ROOT}/../Podfile.lock\" \"${PODS_ROOT}/Manifest.lock\" > /dev/null\nif [ $? != 0 ] ; then\n    # print error to STDERR\n    echo \"error: The sandbox is not in sync with the Podfile.lock. Run 'pod install' or update your CocoaPods installation.\" >&2\n    exit 1\nfi\n";
+			shellScript = "diff \"${PODS_PODFILE_DIR_PATH}/Podfile.lock\" \"${PODS_ROOT}/Manifest.lock\" > /dev/null\nif [ $? != 0 ] ; then\n    # print error to STDERR\n    echo \"error: The sandbox is not in sync with the Podfile.lock. Run 'pod install' or update your CocoaPods installation.\" >&2\n    exit 1\nfi\n";
 			showEnvVarsInLog = 0;
 		};
 		9AFEEED933DC82BFDDB374F6 /* Upload Bugsnag dSYM */ = {


### PR DESCRIPTION
This fixes the build for:

- The *objective-c-ios* example app, which has been updated to use Swift 3 syntax
- The *objective-c-osx* example app, whose Podfile has been updated to a later syntax

It looks like we may need to update the Swift syntax in the API docs also - I'll raise that in a separate ticket.