### PR TITLE
Refine iOS Automatic Breadcrumbs

### DIFF
--- a/Source/BugsnagBreadcrumb.m
+++ b/Source/BugsnagBreadcrumb.m
@@ -95,8 +95,9 @@ NSString *BSGBreadcrumbTypeValue(BSGBreadcrumbType type) {
 
 + (instancetype)breadcrumbWithBlock:(BSGBreadcrumbConfiguration)block {
     BugsnagBreadcrumb *crumb = [self new];
-    if (block)
+    if (block) {
         block(crumb);
+    }
     if ([crumb isValid]) {
         return crumb;
     }

--- a/Source/BugsnagNotifier.m
+++ b/Source/BugsnagNotifier.m
@@ -316,7 +316,9 @@ void BSSerializeJSONDictionary(NSDictionary *dictionary, char **destination) {
 
 - (void)orientationChanged:(NSNotification *)notif {
   NSString *orientation;
-  switch ([UIDevice currentDevice].orientation) {
+  UIDeviceOrientation deviceOrientation = [UIDevice currentDevice].orientation;
+    
+  switch (deviceOrientation) {
   case UIDeviceOrientationPortraitUpsideDown:
     orientation = @"portraitupsidedown";
     break;
@@ -335,9 +337,8 @@ void BSSerializeJSONDictionary(NSDictionary *dictionary, char **destination) {
   case UIDeviceOrientationFaceDown:
     orientation = @"facedown";
     break;
-  case UIDeviceOrientationUnknown:
   default:
-    orientation = @"unknown";
+    return; // always ignore unknown breadcrumbs
   }
   [[self state] addAttribute:@"orientation"
                    withValue:orientation

--- a/Source/BugsnagNotifier.m
+++ b/Source/BugsnagNotifier.m
@@ -340,6 +340,13 @@ void BSSerializeJSONDictionary(NSDictionary *dictionary, char **destination) {
   default:
     return; // always ignore unknown breadcrumbs
   }
+  
+  NSDictionary *lastBreadcrumb = [[self.configuration.breadcrumbs arrayValue] lastObject];
+    
+  if (lastBreadcrumb && [orientation isEqualToString:lastBreadcrumb[@"name"]]) {
+    return; // ignore duplicate orientation event
+  }
+    
   [[self state] addAttribute:@"orientation"
                    withValue:orientation
                toTabWithName:@"deviceState"];

--- a/Source/BugsnagNotifier.m
+++ b/Source/BugsnagNotifier.m
@@ -176,14 +176,7 @@ NSString *const kTableViewSelectionChange = @"TableView Select Change";
 NSString *const kAppWillTerminate = @"App Will Terminate";
 
 - (void)initializeNotificationNameMap {
-    
-    
     notificationNameMap = @{
-                                UIDeviceBatteryStateDidChangeNotification: @"Battery State Changed",
-                                UIDeviceBatteryLevelDidChangeNotification: @"Battery Level Changed",
-                                UIDeviceOrientationDidChangeNotification: @"Orientation Changed",
-                                UIApplicationDidReceiveMemoryWarningNotification: @"Memory Warning",
-                            
 #if TARGET_OS_TV
                                 NSUndoManagerDidUndoChangeNotification: kUndoOperation,
                                 NSUndoManagerDidRedoChangeNotification: kRedoOperation,
@@ -212,6 +205,10 @@ NSString *const kAppWillTerminate = @"App Will Terminate";
                                 UITextFieldTextDidEndEditingNotification: kStoppedTextEdit,
                                 UITextViewTextDidEndEditingNotification: kStoppedTextEdit,
                                 UITableViewSelectionDidChangeNotification: kTableViewSelectionChange,
+                                UIDeviceBatteryStateDidChangeNotification: @"Battery State Changed",
+                                UIDeviceBatteryLevelDidChangeNotification: @"Battery Level Changed",
+                                UIDeviceOrientationDidChangeNotification: @"Orientation Changed",
+                                UIApplicationDidReceiveMemoryWarningNotification: @"Memory Warning",
 
 #elif TARGET_OS_MAC
                                 NSApplicationDidBecomeActiveNotification: @"App Became Active",

--- a/Source/BugsnagNotifier.m
+++ b/Source/BugsnagNotifier.m
@@ -50,6 +50,7 @@ NSString *const BSAttributeSeverity = @"severity";
 NSString *const BSAttributeDepth = @"depth";
 NSString *const BSAttributeBreadcrumbs = @"breadcrumbs";
 NSString *const BSEventLowMemoryWarning = @"lowMemoryWarning";
+
 NSUInteger const BSG_MAX_STORED_REPORTS = 12;
 
 struct bugsnag_data_t {
@@ -165,7 +166,18 @@ void BSSerializeJSONDictionary(NSDictionary *dictionary, char **destination) {
     return self;
 }
 
+NSString *const kWindowVisible = @"Window Became Visible";
+NSString *const kWindowHidden = @"Window Became Hidden";
+NSString *const kBeganTextEdit = @"Began Editing Text";
+NSString *const kStoppedTextEdit = @"Stopped Editing Text";
+NSString *const kUndoOperation = @"Undo Operation";
+NSString *const kRedoOperation = @"Redo Operation";
+NSString *const kTableViewSelectionChange = @"TableView Select Change";
+NSString *const kAppWillTerminate = @"App Will Terminate";
+
 - (void)initializeNotificationNameMap {
+    
+    
     notificationNameMap = @{
                                 UIDeviceBatteryStateDidChangeNotification: @"Battery State Changed",
                                 UIDeviceBatteryLevelDidChangeNotification: @"Battery Level Changed",
@@ -173,53 +185,54 @@ void BSSerializeJSONDictionary(NSDictionary *dictionary, char **destination) {
                                 UIApplicationDidReceiveMemoryWarningNotification: @"Memory Warning",
                             
 #if TARGET_OS_TV
-                                NSUndoManagerDidUndoChangeNotification: @"Undo Operation",
-                                NSUndoManagerDidRedoChangeNotification: @"Redo Operation",
-                                UIWindowDidBecomeVisibleNotification: @"",
-                                UIWindowDidBecomeHiddenNotification: @"",
-                                UIWindowDidBecomeKeyNotification: @"",
-                                UIWindowDidResignKeyNotification: @"",
-                                UIScreenBrightnessDidChangeNotification: @"",
-                                UITableViewSelectionDidChangeNotification: @"",
+                                NSUndoManagerDidUndoChangeNotification: kUndoOperation,
+                                NSUndoManagerDidRedoChangeNotification: kRedoOperation,
+                                UIWindowDidBecomeVisibleNotification: kWindowVisible,
+                                UIWindowDidBecomeHiddenNotification: kWindowHidden,
+                                UIWindowDidBecomeKeyNotification: @"Window Became Key",
+                                UIWindowDidResignKeyNotification: @"Window Resigned Key",
+                                UIScreenBrightnessDidChangeNotification: @"Screen Brightness Changed",
+                                UITableViewSelectionDidChangeNotification: kTableViewSelectionChange,
                             
 #elif TARGET_IPHONE_SIMULATOR || TARGET_OS_IPHONE
-                                UIWindowDidBecomeHiddenNotification: @"",
-                                UIWindowDidBecomeVisibleNotification: @"",
-                                UIApplicationWillTerminateNotification: @"",
-                                UIApplicationWillEnterForegroundNotification: @"",
-                                UIApplicationDidEnterBackgroundNotification: @"",
-                                UIKeyboardDidShowNotification: @"",
-                                UIKeyboardDidHideNotification: @"",
-                                UIMenuControllerDidShowMenuNotification: @"",
-                                UIMenuControllerDidHideMenuNotification: @"",
-                                NSUndoManagerDidUndoChangeNotification: @"",
-                                NSUndoManagerDidRedoChangeNotification: @"",
-                                UIApplicationUserDidTakeScreenshotNotification: @"",
-                                UITextFieldTextDidBeginEditingNotification: @"",
-                                UITextViewTextDidBeginEditingNotification: @"",
-                                UITextFieldTextDidEndEditingNotification: @"",
-                                UITextViewTextDidEndEditingNotification: @"",
-                                UITableViewSelectionDidChangeNotification: @"",
+                                UIWindowDidBecomeVisibleNotification: kWindowVisible,
+                                UIWindowDidBecomeHiddenNotification: kWindowHidden,
+                                UIApplicationWillTerminateNotification: kAppWillTerminate,
+                                UIApplicationWillEnterForegroundNotification: @"App Will Enter Foreground",
+                                UIApplicationDidEnterBackgroundNotification: @"App Did Enter Background",
+                                UIKeyboardDidShowNotification: @"Keyboard Became Visible",
+                                UIKeyboardDidHideNotification: @"Keyboard Became Hidden",
+                                UIMenuControllerDidShowMenuNotification: @"Did Show Menu",
+                                UIMenuControllerDidHideMenuNotification: @"Did Hide Menu",
+                                NSUndoManagerDidUndoChangeNotification: kUndoOperation,
+                                NSUndoManagerDidRedoChangeNotification: kRedoOperation,
+                                UIApplicationUserDidTakeScreenshotNotification: @"Took Screenshot",
+                                UITextFieldTextDidBeginEditingNotification: kBeganTextEdit,
+                                UITextViewTextDidBeginEditingNotification: kBeganTextEdit,
+                                UITextFieldTextDidEndEditingNotification: kStoppedTextEdit,
+                                UITextViewTextDidEndEditingNotification: kStoppedTextEdit,
+                                UITableViewSelectionDidChangeNotification: kTableViewSelectionChange,
 
 #elif TARGET_OS_MAC
-                                NSApplicationDidBecomeActiveNotification: @"",
-                                NSApplicationDidResignActiveNotification: @"",
-                                NSApplicationDidHideNotification: @"",
-                                NSApplicationDidUnhideNotification: @"",
-                                NSApplicationWillTerminateNotification: @"",
-                                NSWorkspaceScreensDidSleepNotification: @"",
-                                NSWorkspaceScreensDidWakeNotification: @"",
-                                NSWindowWillCloseNotification: @"",
-                                NSWindowDidBecomeKeyNotification: @"",
-                                NSWindowWillMiniaturizeNotification: @"",
-                                NSWindowDidEnterFullScreenNotification: @"",
-                                NSWindowDidExitFullScreenNotification: @"",
-                                NSControlTextDidBeginEditingNotification: @"",
-                                NSControlTextDidEndEditingNotification: @"",
-                                NSMenuWillSendActionNotification: @"",
-                                NSTableViewSelectionDidChangeNotification: @"",
+                                NSApplicationDidBecomeActiveNotification: @"App Became Active",
+                                NSApplicationDidResignActiveNotification: @"App Resigned Active",
+                                NSApplicationDidHideNotification: @"App Did Hide",
+                                NSApplicationDidUnhideNotification: @"App Did Unhide",
+                                NSApplicationWillTerminateNotification: kAppWillTerminate,
+                                NSWorkspaceScreensDidSleepNotification: @"Workspace Screen Slept",
+                                NSWorkspaceScreensDidWakeNotification: @"Workspace Screen Awoke",
+                                NSWindowWillCloseNotification: @"Window Will Close",
+                                NSWindowDidBecomeKeyNotification: @"Window Became Key",
+                                NSWindowWillMiniaturizeNotification: @"Window Will Miniaturize",
+                                NSWindowDidEnterFullScreenNotification: @"Window Entered Full Screen",
+                                NSWindowDidExitFullScreenNotification: @"Window Exited Full Screen",
+                                NSControlTextDidBeginEditingNotification: @"Control Text Began Edit",
+                                NSControlTextDidEndEditingNotification: @"Control Text Ended Edit",
+                                NSMenuWillSendActionNotification: @"Menu Will Send Action",
+                                NSTableViewSelectionDidChangeNotification: kTableViewSelectionChange,
 #endif
                             };
+    
 }
 
 - (void) start {

--- a/Source/BugsnagNotifier.m
+++ b/Source/BugsnagNotifier.m
@@ -159,15 +159,67 @@ void BSSerializeJSONDictionary(NSDictionary *dictionary, char **destination) {
         
         static dispatch_once_t once_t;
         dispatch_once(&once_t, ^{
-            notificationNameMap = @{
-                                    UIDeviceBatteryStateDidChangeNotification: @"Battery State Changed",
-                                    UIDeviceBatteryLevelDidChangeNotification: @"Battery Level Changed",
-                                    UIDeviceOrientationDidChangeNotification: @"Orientation Changed",
-                                    UIApplicationDidReceiveMemoryWarningNotification: @"Memory Warning"
-                                    };
+            [self initializeNotificationNameMap];
         });
     }
     return self;
+}
+
+- (void)initializeNotificationNameMap {
+    notificationNameMap = @{
+                                UIDeviceBatteryStateDidChangeNotification: @"Battery State Changed",
+                                UIDeviceBatteryLevelDidChangeNotification: @"Battery Level Changed",
+                                UIDeviceOrientationDidChangeNotification: @"Orientation Changed",
+                                UIApplicationDidReceiveMemoryWarningNotification: @"Memory Warning",
+                            
+#if TARGET_OS_TV
+                                NSUndoManagerDidUndoChangeNotification: @"Undo Operation",
+                                NSUndoManagerDidRedoChangeNotification: @"Redo Operation",
+                                UIWindowDidBecomeVisibleNotification: @"",
+                                UIWindowDidBecomeHiddenNotification: @"",
+                                UIWindowDidBecomeKeyNotification: @"",
+                                UIWindowDidResignKeyNotification: @"",
+                                UIScreenBrightnessDidChangeNotification: @"",
+                                UITableViewSelectionDidChangeNotification: @"",
+                            
+#elif TARGET_IPHONE_SIMULATOR || TARGET_OS_IPHONE
+                                UIWindowDidBecomeHiddenNotification: @"",
+                                UIWindowDidBecomeVisibleNotification: @"",
+                                UIApplicationWillTerminateNotification: @"",
+                                UIApplicationWillEnterForegroundNotification: @"",
+                                UIApplicationDidEnterBackgroundNotification: @"",
+                                UIKeyboardDidShowNotification: @"",
+                                UIKeyboardDidHideNotification: @"",
+                                UIMenuControllerDidShowMenuNotification: @"",
+                                UIMenuControllerDidHideMenuNotification: @"",
+                                NSUndoManagerDidUndoChangeNotification: @"",
+                                NSUndoManagerDidRedoChangeNotification: @"",
+                                UIApplicationUserDidTakeScreenshotNotification: @"",
+                                UITextFieldTextDidBeginEditingNotification: @"",
+                                UITextViewTextDidBeginEditingNotification: @"",
+                                UITextFieldTextDidEndEditingNotification: @"",
+                                UITextViewTextDidEndEditingNotification: @"",
+                                UITableViewSelectionDidChangeNotification: @"",
+
+#elif TARGET_OS_MAC
+                                NSApplicationDidBecomeActiveNotification: @"",
+                                NSApplicationDidResignActiveNotification: @"",
+                                NSApplicationDidHideNotification: @"",
+                                NSApplicationDidUnhideNotification: @"",
+                                NSApplicationWillTerminateNotification: @"",
+                                NSWorkspaceScreensDidSleepNotification: @"",
+                                NSWorkspaceScreensDidWakeNotification: @"",
+                                NSWindowWillCloseNotification: @"",
+                                NSWindowDidBecomeKeyNotification: @"",
+                                NSWindowWillMiniaturizeNotification: @"",
+                                NSWindowDidEnterFullScreenNotification: @"",
+                                NSWindowDidExitFullScreenNotification: @"",
+                                NSControlTextDidBeginEditingNotification: @"",
+                                NSControlTextDidEndEditingNotification: @"",
+                                NSMenuWillSendActionNotification: @"",
+                                NSTableViewSelectionDidChangeNotification: @"",
+#endif
+                            };
 }
 
 - (void) start {
@@ -395,6 +447,13 @@ void BSSerializeJSONDictionary(NSDictionary *dictionary, char **destination) {
     if ([self.configuration automaticallyCollectBreadcrumbs]) {
         for (NSString *name in [self automaticBreadcrumbStateEvents]) {
             [self crumbleNotification:name];
+        }
+        for (NSString *name in [self automaticBreadcrumbTableItemEvents]) {
+            [[NSNotificationCenter defaultCenter]
+             addObserver:self
+             selector:@selector(sendBreadcrumbForTableViewNotification:)
+             name:name
+             object:nil];
         }
         for (NSString *name in [self automaticBreadcrumbControlEvents]) {
             [[NSNotificationCenter defaultCenter]

--- a/Source/BugsnagNotifier.m
+++ b/Source/BugsnagNotifier.m
@@ -425,9 +425,14 @@ NSString *const kAppWillTerminate = @"App Will Terminate";
   }
   
   NSDictionary *lastBreadcrumb = [[self.configuration.breadcrumbs arrayValue] lastObject];
+  NSString *orientationNotifName = BSGBreadcrumbNameForNotificationName(notif.name);
     
-  if (lastBreadcrumb && [orientation isEqualToString:lastBreadcrumb[@"name"]]) {
-    return; // ignore duplicate orientation event
+  if (lastBreadcrumb && [orientationNotifName isEqualToString:lastBreadcrumb[@"name"]]) {
+    NSDictionary *metaData = lastBreadcrumb[@"metaData"];
+    
+    if ([orientation isEqualToString:metaData[@"orientation"]]) {
+      return; // ignore duplicate orientation event
+    }
   }
     
   [[self state] addAttribute:@"orientation"
@@ -436,7 +441,7 @@ NSString *const kAppWillTerminate = @"App Will Terminate";
   if ([self.configuration automaticallyCollectBreadcrumbs]) {
     [self addBreadcrumbWithBlock:^(BugsnagBreadcrumb *_Nonnull breadcrumb) {
       breadcrumb.type = BSGBreadcrumbTypeState;
-      breadcrumb.name = BSGBreadcrumbNameForNotificationName(notif.name);
+      breadcrumb.name = orientationNotifName;
       breadcrumb.metadata = @{ @"orientation" : orientation };
     }];
   }


### PR DESCRIPTION
This alters automatic breadcrumbs so that they use a short human-readable String, rather than the Notification name.

This also enables automatic breadcrumbs for TableView selection, which appeared not to have any observers registered.