### PR TITLE
Add travis CI Github pages docs deploy step

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -11,3 +11,13 @@ matrix:
           env: SDK=appletvsimulator10.1 BUILD_TV=1
 install: make bootstrap
 script: make test
+
+before_deploy: headerdoc2html -o docs Source -j; cd docs; gatherheaderdoc .
+
+deploy:
+  provider: pages
+  local_dir: docs # only include the contents of the generated docs dir
+  skip_cleanup: true
+  github_token: $GITHUB_TOKEN # set in travis-ci dashboard
+  on:
+    branch: add-travis-docs

--- a/.travis.yml
+++ b/.travis.yml
@@ -20,4 +20,4 @@ deploy:
   skip_cleanup: true
   github_token: $GITHUB_TOKEN # set in travis-ci dashboard
   on:
-    branch: add-travis-docs
+    tags: true # only deploy when tag is applied to commit

--- a/.travis.yml
+++ b/.travis.yml
@@ -12,7 +12,7 @@ matrix:
 install: make bootstrap
 script: make test
 
-before_deploy: headerdoc2html -o docs Source -j; cd docs; gatherheaderdoc .
+before_deploy: headerdoc2html -o docs Source -j; gatherheaderdoc docs; mv docs/masterTOC.html docs/index.html
 
 deploy:
   provider: pages


### PR DESCRIPTION
This uses headerdoc to generate HTML documentation that is deployed to GH Pages when a commit is tagged.