### PR TITLE
Fix error class parsing

### DIFF
--- a/Source/BugsnagCrashReport.h
+++ b/Source/BugsnagCrashReport.h
@@ -129,7 +129,7 @@ NSString *_Nonnull BSGFormatSeverity(BSGSeverity severity);
 /**
  *  The class of the error generating the report
  */
-@property (nonatomic, readwrite, copy, nullable) NSString *errorClass;
+@property (nonatomic, readwrite, copy, nonnull) NSString *errorClass;
 /**
  *  The message of or reason for the error generating the report
  */

--- a/Source/BugsnagCrashReport.m
+++ b/Source/BugsnagCrashReport.m
@@ -63,7 +63,7 @@ NSMutableDictionary *BSGFormatFrame(NSDictionary *frame,
   return nil;
 }
 
-NSString *BSGParseErrorClass(NSDictionary *error, NSString *errorType) {
+NSString * _Nonnull BSGParseErrorClass(NSDictionary *error, NSString *errorType) {
     NSString *errorClass;
     
     if ([errorType isEqualToString:@"cpp_exception"]) {

--- a/Source/BugsnagCrashReport.m
+++ b/Source/BugsnagCrashReport.m
@@ -64,18 +64,28 @@ NSMutableDictionary *BSGFormatFrame(NSDictionary *frame,
 }
 
 NSString *BSGParseErrorClass(NSDictionary *error, NSString *errorType) {
+    NSString *errorClass;
+    
     if ([errorType isEqualToString:@"cpp_exception"]) {
-        return error[@"cpp_exception"][@"name"];
+        errorClass = error[@"cpp_exception"][@"name"];
     } else if ([errorType isEqualToString:@"mach"]) {
-        return error[@"mach"][@"exception_name"];
+        errorClass = error[@"mach"][@"exception_name"];
     } else if ([errorType isEqualToString:@"signal"]) {
-        return error[@"signal"][@"name"];
+        errorClass = error[@"signal"][@"name"];
+        
+        if (!errorClass) { // attempt to use mach instead (special case)
+            errorClass = error[@"mach"][@"exception_name"];
+        }
     } else if ([errorType isEqualToString:@"nsexception"]) {
-        return error[@"nsexception"][@"name"];
+        errorClass = error[@"nsexception"][@"name"];
     } else if ([errorType isEqualToString:@"user"]) {
-        return error[@"user_reported"][@"name"];
+        errorClass = error[@"user_reported"][@"name"];
     }
-    return @"Exception";
+    
+    if (!errorClass) { // use a default value
+        errorClass = @"Exception";
+    }
+    return errorClass;
 }
 
 NSString *BSGParseErrorMessage(NSDictionary *report, NSDictionary *error, NSString *errorType) {

--- a/Source/BugsnagCrashReport.m
+++ b/Source/BugsnagCrashReport.m
@@ -72,10 +72,6 @@ NSString *BSGParseErrorClass(NSDictionary *error, NSString *errorType) {
         errorClass = error[@"mach"][@"exception_name"];
     } else if ([errorType isEqualToString:@"signal"]) {
         errorClass = error[@"signal"][@"name"];
-        
-        if (!errorClass) { // attempt to use mach instead (special case)
-            errorClass = error[@"mach"][@"exception_name"];
-        }
     } else if ([errorType isEqualToString:@"nsexception"]) {
         errorClass = error[@"nsexception"][@"name"];
     } else if ([errorType isEqualToString:@"user"]) {

--- a/Source/KSCrash/Source/KSCrash/Recording/Tools/BSG_KSSignalInfo.c
+++ b/Source/KSCrash/Source/KSCrash/Recording/Tools/BSG_KSSignalInfo.c
@@ -106,7 +106,7 @@ static const BSG_KSSignalInfo bsg_g_fatalSignalData[] =
     SIGNAL_INFO_NOCODES(SIGPIPE),
     SIGNAL_INFO(SIGSEGV, bsg_g_sigSegVCodes),
     SIGNAL_INFO_NOCODES(SIGSYS),
-    SIGNAL_INFO(SIGTERM, bsg_g_sigTrapCodes),
+    SIGNAL_INFO(SIGTRAP, bsg_g_sigTrapCodes),
 };
 static const int bsg_g_fatalSignalsCount = sizeof(bsg_g_fatalSignalData) / sizeof(*bsg_g_fatalSignalData);
 

--- a/examples/objective-c-ios/Bugsnag Test App.xcodeproj/project.pbxproj
+++ b/examples/objective-c-ios/Bugsnag Test App.xcodeproj/project.pbxproj
@@ -43,14 +43,12 @@
 /* End PBXContainerItemProxy section */
 
 /* Begin PBXFileReference section */
-		609ECD669F95BBE28D00C825 /* libPods-custom-keyboard.a */ = {isa = PBXFileReference; explicitFileType = archive.ar; includeInIndex = 0; path = "libPods-custom-keyboard.a"; sourceTree = BUILT_PRODUCTS_DIR; };
 		89117F5055F6B6F9FA00FBEC /* Pods-Bugsnag Test App.debug.xcconfig */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.xcconfig; name = "Pods-Bugsnag Test App.debug.xcconfig"; path = "Pods/Target Support Files/Pods-Bugsnag Test App/Pods-Bugsnag Test App.debug.xcconfig"; sourceTree = "<group>"; };
 		8ACFFA091D895D4D00357B5E /* custom-keyboard.appex */ = {isa = PBXFileReference; explicitFileType = "wrapper.app-extension"; includeInIndex = 0; path = "custom-keyboard.appex"; sourceTree = BUILT_PRODUCTS_DIR; };
 		8ACFFA0B1D895D4D00357B5E /* KeyboardViewController.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = KeyboardViewController.swift; sourceTree = "<group>"; };
 		8ACFFA0D1D895D4D00357B5E /* Info.plist */ = {isa = PBXFileReference; lastKnownFileType = text.plist.xml; path = Info.plist; sourceTree = "<group>"; };
 		8ACFFA151D895E0300357B5E /* BridgingHeader.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; path = BridgingHeader.h; sourceTree = "<group>"; };
 		9333D154DE949C52593C64D3 /* libPods-custom-keyboard.a */ = {isa = PBXFileReference; explicitFileType = archive.ar; includeInIndex = 0; path = "libPods-custom-keyboard.a"; sourceTree = BUILT_PRODUCTS_DIR; };
-		E418DB0D05F9A8F968578F10 /* libPods-Bugsnag Test App.a */ = {isa = PBXFileReference; explicitFileType = archive.ar; includeInIndex = 0; path = "libPods-Bugsnag Test App.a"; sourceTree = BUILT_PRODUCTS_DIR; };
 		E77F7CCB1F2B90800017CE04 /* BugsnagUITests.xctest */ = {isa = PBXFileReference; explicitFileType = wrapper.cfbundle; includeInIndex = 0; path = BugsnagUITests.xctest; sourceTree = BUILT_PRODUCTS_DIR; };
 		E77F7CCD1F2B90800017CE04 /* CrashyUITest.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = CrashyUITest.swift; sourceTree = "<group>"; };
 		E77F7CCF1F2B90800017CE04 /* Info.plist */ = {isa = PBXFileReference; lastKnownFileType = text.plist.xml; path = Info.plist; sourceTree = "<group>"; };
@@ -315,7 +313,7 @@
 						TestTargetID = F40B874516AA233500676BB2;
 					};
 					F40B874516AA233500676BB2 = {
-						DevelopmentTeam = LB9U9M53WT;
+						DevelopmentTeam = 372ZUL2ZB7;
 						LastSwiftMigration = 0830;
 					};
 				};
@@ -834,7 +832,7 @@
 				"CODE_SIGN_IDENTITY[sdk=iphoneos*]" = "iPhone Developer";
 				COPY_PHASE_STRIP = YES;
 				DEPLOYMENT_POSTPROCESSING = YES;
-				DEVELOPMENT_TEAM = LB9U9M53WT;
+				DEVELOPMENT_TEAM = 372ZUL2ZB7;
 				ENABLE_BITCODE = NO;
 				GCC_GENERATE_DEBUGGING_SYMBOLS = YES;
 				GCC_PRECOMPILE_PREFIX_HEADER = YES;
@@ -859,7 +857,7 @@
 				CODE_SIGN_IDENTITY = "iPhone Developer";
 				"CODE_SIGN_IDENTITY[sdk=iphoneos*]" = "iPhone Developer";
 				DEPLOYMENT_POSTPROCESSING = YES;
-				DEVELOPMENT_TEAM = LB9U9M53WT;
+				DEVELOPMENT_TEAM = 372ZUL2ZB7;
 				ENABLE_BITCODE = NO;
 				GCC_GENERATE_DEBUGGING_SYMBOLS = YES;
 				GCC_PRECOMPILE_PREFIX_HEADER = YES;

--- a/examples/objective-c-ios/Podfile.lock
+++ b/examples/objective-c-ios/Podfile.lock
@@ -1,5 +1,5 @@
 PODS:
-  - Bugsnag (5.10.1)
+  - Bugsnag (5.11.2)
 
 DEPENDENCIES:
   - Bugsnag (from `../..`)
@@ -9,7 +9,7 @@ EXTERNAL SOURCES:
     :path: ../..
 
 SPEC CHECKSUMS:
-  Bugsnag: 3996d8fcde8523a02cc18dd5f768ac885fa0dbcf
+  Bugsnag: daab816e964545823e9f9b826486bd30c67f22da
 
 PODFILE CHECKSUM: 1143756a2cf4af18c0c3b523a7c74458c0ed4899
 

--- a/examples/swift-ios/Podfile.lock
+++ b/examples/swift-ios/Podfile.lock
@@ -1,5 +1,5 @@
 PODS:
-  - Bugsnag (5.10.1)
+  - Bugsnag (5.11.2)
 
 DEPENDENCIES:
   - Bugsnag (from `../..`)
@@ -9,7 +9,7 @@ EXTERNAL SOURCES:
     :path: ../..
 
 SPEC CHECKSUMS:
-  Bugsnag: 3996d8fcde8523a02cc18dd5f768ac885fa0dbcf
+  Bugsnag: daab816e964545823e9f9b826486bd30c67f22da
 
 PODFILE CHECKSUM: 2107babfbfdb18f0288407b9d9ebd48cbee8661c
 


### PR DESCRIPTION
The `errorClass` field can be nil if data is not supplied by KSCrash. This alters how we parse the data so that the method will never return nil, which would reject the payload.

See #170 