### PR TITLE
Remove use of deprecated NSProcessInfo property

### DIFF
--- a/Source/BugsnagCrashReport.m
+++ b/Source/BugsnagCrashReport.m
@@ -104,7 +104,6 @@ NSDictionary *BSGParseDevice(NSDictionary *report) {
     
 #if TARGET_OS_MAC || TARGET_OS_TV
     NSProcessInfo *processInfo = [NSProcessInfo processInfo];
-    BSGDictSetSafeObject(data, processInfo.operatingSystemName, @"osName");
     BSGDictSetSafeObject(data, processInfo.operatingSystemVersionString, @"osVersion");
 #elif TARGET_IPHONE_SIMULATOR || TARGET_OS_IPHONE
     UIDevice *device = [UIDevice currentDevice];


### PR DESCRIPTION
I'm getting a warning on this line because `operatingSystemName` has been deprecated since iOS 8, apparently because it always returns `NSMACHOperatingSystem` instead.

If you're more comfortable wrapping this in a `#if __IPHONE_OS_VERSION_MIN_REQUIRED >= __IPHONE_8_0` conditional I'd be happy to do that as well, but given the warning it didn't seem like this value is of much use.