### PR TITLE
Simplify release versioning

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -60,12 +60,11 @@ If you're a member of the core team, you can release the cocoa pod as follows:
 ### Every time
 
 * Update the CHANGELOG. Update the README.md if appropriate.
-* Update the version number in `VERSION`, `Source/BugsnagNotifier.m`,
-  and `Bugsnag.podspec.json`
+* Update the version number by running `make VERSION=[number] bump`
 * Commit tag and push
 
     ```
-    git commit -am v5.x.x
+    git commit -am 'Release v5.x.x'
     git tag v5.x.x
     git push origin master v5.x.x
     ```

--- a/Makefile
+++ b/Makefile
@@ -19,7 +19,7 @@ else
  endif
 endif
 XCODEBUILD=set -o pipefail && xcodebuild
-VERSION=$(shell cat VERSION)
+PRESET_VERSION=$(shell cat VERSION)
 ifneq ($(strip $(shell which xcpretty)),)
  FORMATTER = | tee xcodebuild.log | xcpretty
 endif
@@ -33,11 +33,11 @@ build/Build/Products/$(RELEASE_DIR)/Bugsnag.framework:
 		-derivedDataPath build clean build $(FORMATTER)
 
 # Compressed bundle for release version of Bugsnag framework
-build/Bugsnag-%-$(VERSION).zip: build/Build/Products/$(RELEASE_DIR)/Bugsnag.framework
+build/Bugsnag-%-$(PRESET_VERSION).zip: build/Build/Products/$(RELEASE_DIR)/Bugsnag.framework
 	@cd build/Build/Products/$(RELEASE_DIR); \
-		zip --symlinks -rq ../../../Bugsnag-$*-$(VERSION).zip Bugsnag.framework
+		zip --symlinks -rq ../../../Bugsnag-$*-$(PRESET_VERSION).zip Bugsnag.framework
 
-.PHONY: all build test
+.PHONY: all build test bump
 
 bootstrap:
 	@gem install xcpretty --quiet --no-ri --no-rdoc
@@ -52,4 +52,4 @@ clean:
 test:
 	@$(XCODEBUILD) $(BUILD_FLAGS) $(BUILD_ONLY_FLAGS) test $(FORMATTER)
 
-archive: build/Bugsnag-$(PLATFORM)-$(VERSION).zip
+archive: build/Bugsnag-$(PLATFORM)-$(PRESET_VERSION).zip

--- a/Makefile
+++ b/Makefile
@@ -45,6 +45,16 @@ bootstrap:
 build:
 	@$(XCODEBUILD) $(BUILD_FLAGS) $(BUILD_ONLY_FLAGS) build $(FORMATTER)
 
+bump:
+ifeq ($(VERSION),)
+	@$(error VERSION is not defined. Run with `make VERSION=number bump`)
+endif
+	@echo Bumping the version number to $(VERSION)
+	@echo $(VERSION) > VERSION
+	@sed -i '' "s/\"version\": .*,/\"version\": \"$(VERSION)\",/" Bugsnag.podspec.json
+	@sed -i '' "s/\"tag\": .*,/\"tag\": \"v$(VERSION)\",/" Bugsnag.podspec.json
+	@sed -i '' "s/NOTIFIER_VERSION = .*;/NOTIFIER_VERSION = @\"$(VERSION)\";/" Source/BugsnagNotifier.m
+
 clean:
 	@$(XCODEBUILD) $(BUILD_FLAGS) clean $(FORMATTER)
 	@rm -rf build


### PR DESCRIPTION
Changes the release handling to add a `make bump` target, so nobody needs to manually edit the files to update version numbers. Usage:

```sh
make VERSION=5.13.0 bump
```

It could be fancy and read the version number from the top entry of the changelog, what do you think, @fractalwrench?