### PR TITLE
Parse notable addresses for Swift Assertion failure messages

### DIFF
--- a/Source/BugsnagCrashReport.h
+++ b/Source/BugsnagCrashReport.h
@@ -187,4 +187,11 @@ initWithErrorName:(NSString *_Nonnull)name
  *  Device state such as oreground status and run duration
  */
 @property(nonatomic, readwrite, copy, nullable) NSDictionary *appState;
+
+
+/**
+ * Returns the enhanced error message for the thread, or nil if none exists.
+ */
+- (NSString *_Nullable)enhancedErrorMessageForThread:(NSDictionary *_Nullable)thread;
+
 @end

--- a/Source/BugsnagCrashReport.m
+++ b/Source/BugsnagCrashReport.m
@@ -541,7 +541,11 @@ initWithErrorName:(NSString *_Nonnull)name
         NSArray *backtrace = thread[@"backtrace"][@"contents"];
         BOOL stackOverflow = [thread[@"stack"][@"overflow"] boolValue];
         
-        NSDictionary *notableAddresses = thread[@"notableAddresses"]; // TODO use me!
+        NSDictionary *notableAddresses = thread[@"notable_addresses"]; // TODO use me!
+        
+        if (notableAddresses) {
+            NSLog(@"Notable address: %@", notableAddresses);
+        }
 
         if ([thread[@"crashed"] boolValue]) {
             NSUInteger seen = 0;

--- a/Source/BugsnagCrashReport.m
+++ b/Source/BugsnagCrashReport.m
@@ -545,8 +545,8 @@ initWithErrorName:(NSString *_Nonnull)name
         if (isCrashedThread) {
             NSString *errMsg = [self enhancedErrorMessageForThread:thread];
             
-            if (errMsg) {
-                NSLog(@"Enhanced error message: %@",errMsg);
+            if (errMsg) { // use enhanced error message (currently swift assertions)
+                BSGDictInsertIfNotNil(exception, errMsg, @"message");
             }
             
             NSUInteger seen = 0;

--- a/Source/BugsnagCrashReport.m
+++ b/Source/BugsnagCrashReport.m
@@ -540,6 +540,8 @@ initWithErrorName:(NSString *_Nonnull)name
     for (NSDictionary *thread in [self threads]) {
         NSArray *backtrace = thread[@"backtrace"][@"contents"];
         BOOL stackOverflow = [thread[@"stack"][@"overflow"] boolValue];
+        
+        NSDictionary *notableAddresses = thread[@"notableAddresses"]; // TODO use me!
 
         if ([thread[@"crashed"] boolValue]) {
             NSUInteger seen = 0;

--- a/Source/BugsnagCrashSentry.m
+++ b/Source/BugsnagCrashSentry.m
@@ -23,7 +23,6 @@ NSUInteger const BSG_MAX_STORED_REPORTS = 12;
 
     BugsnagSink *sink = [[BugsnagSink alloc] initWithApiClient:apiClient];
     [BSG_KSCrash sharedInstance].sink = sink;
-    // We don't use this feature yet, so we turn it off
     [BSG_KSCrash sharedInstance].introspectMemory = YES;
     [BSG_KSCrash sharedInstance].deleteBehaviorAfterSendAll =
         BSG_KSCDeleteOnSucess;

--- a/Source/BugsnagCrashSentry.m
+++ b/Source/BugsnagCrashSentry.m
@@ -24,7 +24,7 @@ NSUInteger const BSG_MAX_STORED_REPORTS = 12;
     BugsnagSink *sink = [[BugsnagSink alloc] initWithApiClient:apiClient];
     [BSG_KSCrash sharedInstance].sink = sink;
     // We don't use this feature yet, so we turn it off
-    [BSG_KSCrash sharedInstance].introspectMemory = NO;
+    [BSG_KSCrash sharedInstance].introspectMemory = YES;
     [BSG_KSCrash sharedInstance].deleteBehaviorAfterSendAll =
         BSG_KSCDeleteOnSucess;
     [BSG_KSCrash sharedInstance].onCrash = onCrash;

--- a/Tests/BugsnagCrashReportTests.m
+++ b/Tests/BugsnagCrashReportTests.m
@@ -141,7 +141,7 @@
     
     // nil for "fatal error" with no additional dict present
     
-    for (NSString *reservedWord in @[@"fatal error", @"assert", @"preconditionFailure", @"assertionFailure"]) {
+    for (NSString *reservedWord in @[@"fatal error", @"assertion failed"]) {
         addresses[@"r14"] = @{
                               @"address": @4511089532,
                               @"type": @"string",
@@ -182,6 +182,18 @@
                           @"value": @"Swift is hard"
                           };
     XCTAssertEqualObjects(@"Swift is hard | Whoops - fatalerror", [errorReport enhancedErrorMessageForThread:thread]);
+    
+    // ignores stack frames
+    addresses[@"stack523409"] = @{
+                          @"address": @4511080001,
+                          @"type": @"string",
+                          @"value": @"Not a register"
+                          };
+    XCTAssertEqualObjects(@"Swift is hard | Whoops - fatalerror", [errorReport enhancedErrorMessageForThread:thread]);
+    
+    // ignores values if no reserved word used
+    addresses[@"r14"] = nil;
+    XCTAssertNil([errorReport enhancedErrorMessageForThread:thread]);
 }
 
 @end

--- a/examples/swift-ios/Podfile.lock
+++ b/examples/swift-ios/Podfile.lock
@@ -1,5 +1,5 @@
 PODS:
-  - Bugsnag (5.11.2)
+  - Bugsnag (5.12.1)
 
 DEPENDENCIES:
   - Bugsnag (from `../..`)
@@ -9,7 +9,7 @@ EXTERNAL SOURCES:
     :path: ../..
 
 SPEC CHECKSUMS:
-  Bugsnag: daab816e964545823e9f9b826486bd30c67f22da
+  Bugsnag: c8b1ccbb22acf100ce5b496bdc223be3184c7a57
 
 PODFILE CHECKSUM: 2107babfbfdb18f0288407b9d9ebd48cbee8661c
 

--- a/examples/swift-ios/bugsnag-example/ViewController.swift
+++ b/examples/swift-ios/bugsnag-example/ViewController.swift
@@ -23,7 +23,10 @@ import UIKit
 class ViewController: UIViewController {
 
     @IBAction func doCrash(_ sender: AnyObject) {
-        callbackModifiedException()
+//        fatalError("Whoops - fatalerror")
+        preconditionFailure("Whoops - preconditionFailure")
+        assertionFailure("Whoops - assertionFailure")
+        assert(false, "Whoops - assert")
     }
 
     func unhandledCrash() {

--- a/examples/swift-ios/bugsnag-example/ViewController.swift
+++ b/examples/swift-ios/bugsnag-example/ViewController.swift
@@ -23,10 +23,7 @@ import UIKit
 class ViewController: UIViewController {
 
     @IBAction func doCrash(_ sender: AnyObject) {
-        fatalError("Whoops - fatalerror")
-//        preconditionFailure("Whoops - preconditionFailure")
-//        assertionFailure("Whoops - assertionFailure")
-//        assert(false, "Whoops - assert")
+        callbackModifiedException()
     }
 
     func unhandledCrash() {

--- a/examples/swift-ios/bugsnag-example/ViewController.swift
+++ b/examples/swift-ios/bugsnag-example/ViewController.swift
@@ -23,10 +23,10 @@ import UIKit
 class ViewController: UIViewController {
 
     @IBAction func doCrash(_ sender: AnyObject) {
-//        fatalError("Whoops - fatalerror")
-        preconditionFailure("Whoops - preconditionFailure")
-        assertionFailure("Whoops - assertionFailure")
-        assert(false, "Whoops - assert")
+        fatalError("Whoops - fatalerror")
+//        preconditionFailure("Whoops - preconditionFailure")
+//        assertionFailure("Whoops - assertionFailure")
+//        assert(false, "Whoops - assert")
     }
 
     func unhandledCrash() {


### PR DESCRIPTION
Enables memory introspection in KSCrash, which allows us to parse the notable addresses for Swift Assertion failure messages, as requested in #159. The message should now be captured for `fatalError`, `preconditionFailure`, `assertionFailure`, and `assert`.

This approach relies on heuristics - we'll inspect the variable values, and set the error message in the following conditions:

- "fatal error" or "assertion failure" is present in at least one variable
- At least one variable is a string that contains 2 or less "/"

If this isn't the case, we won't alter the error message.