### PR TITLE
Run static analyser as part of releasing

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -36,6 +36,7 @@ Releasing a new version
 Please follow the testing instructions in [the platforms release checklist](https://github.com/bugsnag/platforms-release-checklist/blob/master/README.md), and any additional steps directly below.
 
 - Please ensure that release builds are run on a physical device with an ad-hoc archive.
+- Run the static anayser (Product -> Analyse in Xcode) to ensure that problems are introduced.
 
 ### CocoaPods
 


### PR DESCRIPTION
I think it would be a good idea to run this as apart of the release to prevent introducing any memory leaks or similar problems. This would also to prevent anyone running the analyser in their own app with Bugsnag-cocoa dependency catching memory leaks in Bugsnag sources, for example to prevent releasing potential leaks (#193).