### PR TITLE
Prefix all class extension methods

### DIFF
--- a/Source/KSCrash/Source/KSCrash/Recording/BSG_KSCrash.m
+++ b/Source/KSCrash/Source/KSCrash/Recording/BSG_KSCrash.m
@@ -444,9 +444,9 @@ BSG_SYNTHESIZE_CRASH_STATE_PROPERTY(BOOL, crashedLastLaunch)
     if (self.sink == nil) {
         bsg_kscrash_i_callCompletion(
             onCompletion, reports, NO,
-            [NSError errorWithDomain:[[self class] description]
-                                code:0
-                         description:@"No sink set. Crash reports not sent."]);
+            [NSError bsg_errorWithDomain:[[self class] description]
+                                    code:0
+                             description:@"No sink set. Crash reports not sent."]);
         return;
     }
 

--- a/Source/KSCrash/Source/KSCrash/Recording/BSG_KSCrashReportStore.m
+++ b/Source/KSCrash/Source/KSCrash/Recording/BSG_KSCrashReportStore.m
@@ -347,7 +347,7 @@
         return;
     }
 
-    [report bsg_ksc_setObjectIfNotNil:[srcDict mergedInto:dstDict]
+    [report bsg_ksc_setObjectIfNotNil:[srcDict bsg_mergedInto:dstDict]
                                forKey:dstKey];
     [report removeObjectForKey:srcKey];
 }

--- a/Source/KSCrash/Source/KSCrash/Recording/BSG_KSCrashReportStore.m
+++ b/Source/KSCrash/Source/KSCrash/Recording/BSG_KSCrashReportStore.m
@@ -423,10 +423,10 @@
 - (NSMutableDictionary *)readReport:(NSString *)path
                               error:(NSError *__autoreleasing *)error {
     if (path == nil) {
-        [NSError fillError:error
-                withDomain:[[self class] description]
-                      code:0
-               description:@"Path is nil"];
+        [NSError bsg_fillError:error
+                    withDomain:[[self class] description]
+                          code:0
+                   description:@"Path is nil"];
         return nil;
     }
 

--- a/Source/KSCrash/Source/KSCrash/Recording/Tools/BSG_KSJSONCodecObjC.m
+++ b/Source/KSCrash/Source/KSCrash/Recording/Tools/BSG_KSJSONCodecObjC.m
@@ -233,10 +233,10 @@ int bsg_ksjsoncodecobjc_i_onElement(BSG_KSJSONCodec *codec, NSString *name,
                                     id element) {
     if (codec->_currentContainer == nil) {
         codec.error = [NSError
-            errorWithDomain:@"KSJSONCodecObjC"
-                       code:0
-                description:@"Type %@ not allowed as top level container",
-                            [element class]];
+            bsg_errorWithDomain:@"KSJSONCodecObjC"
+                           code:0
+                       description:@"Type %@ not allowed as top level container",
+                                   [element class]];
         return BSG_KSJSON_ERROR_INVALID_DATA;
     }
 
@@ -337,10 +337,10 @@ int bsg_ksjsoncodecobjc_i_onEndContainer(void *const userData) {
 
     if ([codec->_containerStack count] == 0) {
         codec.error = [NSError
-            errorWithDomain:@"KSJSONCodecObjC"
-                       code:0
-                description:
-                    @"Already at the top level; no container left to end"];
+            bsg_errorWithDomain:@"KSJSONCodecObjC"
+                           code:0
+                       description:
+                           @"Already at the top level; no container left to end"];
         return BSG_KSJSON_ERROR_INVALID_DATA;
     }
     [codec->_containerStack removeLastObject];
@@ -377,9 +377,9 @@ int bsg_ksjsoncodecobjc_i_encodeObject(BSG_KSJSONCodec *codec, id object,
                                             [data length]);
         if (result == BSG_KSJSON_ERROR_INVALID_CHARACTER) {
             codec.error =
-                [NSError errorWithDomain:@"KSJSONCodecObjC"
-                                    code:0
-                             description:@"Invalid character in %@", object];
+                [NSError bsg_errorWithDomain:@"KSJSONCodecObjC"
+                                        code:0
+                                 description:@"Invalid character in %@", object];
         }
         return result;
     }
@@ -474,9 +474,9 @@ int bsg_ksjsoncodecobjc_i_encodeObject(BSG_KSJSONCodec *codec, id object,
     }
 
     codec.error = [NSError
-        errorWithDomain:@"KSJSONCodecObjC"
-                   code:0
-            description:@"Could not determine type of %@", [object class]];
+        bsg_errorWithDomain:@"KSJSONCodecObjC"
+                       code:0
+                description:@"Could not determine type of %@", [object class]];
     return BSG_KSJSON_ERROR_INVALID_DATA;
 }
 
@@ -512,10 +512,10 @@ int bsg_ksjsoncodecobjc_i_encodeObject(BSG_KSJSONCodec *codec, id object,
                          (__bridge void *)codec, &errorOffset);
     if (result != BSG_KSJSON_OK && codec.error == nil) {
         codec.error = [NSError
-            errorWithDomain:@"KSJSONCodecObjC"
-                       code:0
-                description:@"%s (offset %d)", bsg_ksjsonstringForError(result),
-                            errorOffset];
+           bsg_errorWithDomain:@"KSJSONCodecObjC"
+                          code:0
+                   description:@"%s (offset %d)", bsg_ksjsonstringForError(result),
+                               errorOffset];
     }
     if (error != nil) {
         *error = codec.error;

--- a/Source/KSCrash/Source/KSCrash/Recording/Tools/BSG_KSJSONCodecObjC.m
+++ b/Source/KSCrash/Source/KSCrash/Recording/Tools/BSG_KSJSONCodecObjC.m
@@ -235,8 +235,8 @@ int bsg_ksjsoncodecobjc_i_onElement(BSG_KSJSONCodec *codec, NSString *name,
         codec.error = [NSError
             bsg_errorWithDomain:@"KSJSONCodecObjC"
                            code:0
-                       description:@"Type %@ not allowed as top level container",
-                                   [element class]];
+                    description:@"Type %@ not allowed as top level container",
+                                [element class]];
         return BSG_KSJSON_ERROR_INVALID_DATA;
     }
 
@@ -339,7 +339,7 @@ int bsg_ksjsoncodecobjc_i_onEndContainer(void *const userData) {
         codec.error = [NSError
             bsg_errorWithDomain:@"KSJSONCodecObjC"
                            code:0
-                       description:
+                    description:
                            @"Already at the top level; no container left to end"];
         return BSG_KSJSON_ERROR_INVALID_DATA;
     }

--- a/Source/KSCrash/Source/KSCrash/Recording/Tools/NSDictionary+BSG_Merge.h
+++ b/Source/KSCrash/Source/KSCrash/Recording/Tools/NSDictionary+BSG_Merge.h
@@ -45,6 +45,6 @@
  *
  * @return The merged dictionary.
  */
-- (NSDictionary *)mergedInto:(NSDictionary *)dest;
+- (NSDictionary *)bsg_mergedInto:(NSDictionary *)dest;
 
 @end

--- a/Source/KSCrash/Source/KSCrash/Recording/Tools/NSDictionary+BSG_Merge.m
+++ b/Source/KSCrash/Source/KSCrash/Recording/Tools/NSDictionary+BSG_Merge.m
@@ -28,7 +28,7 @@
 
 @implementation NSDictionary (BSG_Merge)
 
-- (NSDictionary *)mergedInto:(NSDictionary *)dest {
+- (NSDictionary *)bsg_mergedInto:(NSDictionary *)dest {
     if ([dest count] == 0) {
         return self;
     }
@@ -42,7 +42,7 @@
         id dstEntry = [dest objectForKey:key];
         if ([dstEntry isKindOfClass:[NSDictionary class]] &&
             [srcEntry isKindOfClass:[NSDictionary class]]) {
-            srcEntry = [srcEntry mergedInto:dstEntry];
+            srcEntry = [srcEntry bsg_mergedInto:dstEntry];
         }
         [dict setObject:srcEntry forKey:key];
     }

--- a/Source/KSCrash/Source/KSCrash/Recording/Tools/NSError+BSG_SimpleConstructor.h
+++ b/Source/KSCrash/Source/KSCrash/Recording/Tools/NSError+BSG_SimpleConstructor.h
@@ -57,11 +57,4 @@
                  code:(NSInteger)code
           description:(NSString *)fmt, ...;
 
-/** Clear a pointer-to-error to nil of its pointer is not nil.
- *
- * @param error Error pointer to fill (ignored if nil).
- * @return NO (to keep the analyzer happy).
- */
-+ (BOOL)bsg_clearError:(NSError **)error;
-
 @end

--- a/Source/KSCrash/Source/KSCrash/Recording/Tools/NSError+BSG_SimpleConstructor.h
+++ b/Source/KSCrash/Source/KSCrash/Recording/Tools/NSError+BSG_SimpleConstructor.h
@@ -39,7 +39,7 @@
  * @param fmt Description of the error (gets placed into the user data with the
  * key NSLocalizedDescriptionKey).
  */
-+ (NSError *)errorWithDomain:(NSString *)domain
++ (NSError *)bsg_errorWithDomain:(NSString *)domain
                         code:(NSInteger)code
                  description:(NSString *)fmt, ...;
 
@@ -52,16 +52,16 @@
  * key NSLocalizedDescriptionKey).
  * @return NO (to keep the analyzer happy).
  */
-+ (BOOL)fillError:(NSError **)error
-       withDomain:(NSString *)domain
-             code:(NSInteger)code
-      description:(NSString *)fmt, ...;
++ (BOOL)bsg_fillError:(NSError **)error
+           withDomain:(NSString *)domain
+                 code:(NSInteger)code
+          description:(NSString *)fmt, ...;
 
 /** Clear a pointer-to-error to nil of its pointer is not nil.
  *
  * @param error Error pointer to fill (ignored if nil).
  * @return NO (to keep the analyzer happy).
  */
-+ (BOOL)clearError:(NSError **)error;
++ (BOOL)bsg_clearError:(NSError **)error;
 
 @end

--- a/Source/KSCrash/Source/KSCrash/Recording/Tools/NSError+BSG_SimpleConstructor.m
+++ b/Source/KSCrash/Source/KSCrash/Recording/Tools/NSError+BSG_SimpleConstructor.m
@@ -28,9 +28,9 @@
 
 @implementation NSError (BSG_SimpleConstructor)
 
-+ (NSError *)errorWithDomain:(NSString *)domain
-                        code:(NSInteger)code
-                 description:(NSString *)fmt, ... {
++ (NSError *)bsg_errorWithDomain:(NSString *)domain
+                            code:(NSInteger)code
+                     description:(NSString *)fmt, ... {
     va_list args;
     va_start(args, fmt);
 
@@ -45,10 +45,10 @@
                                           forKey:NSLocalizedDescriptionKey]];
 }
 
-+ (BOOL)fillError:(NSError *__autoreleasing *)error
-       withDomain:(NSString *)domain
-             code:(NSInteger)code
-      description:(NSString *)fmt, ... {
++ (BOOL)bsg_fillError:(NSError *__autoreleasing *)error
+           withDomain:(NSString *)domain
+                 code:(NSInteger)code
+          description:(NSString *)fmt, ... {
     if (error != nil) {
         va_list args;
         va_start(args, fmt);
@@ -67,7 +67,7 @@
     return NO;
 }
 
-+ (BOOL)clearError:(NSError *__autoreleasing *)error {
++ (BOOL)bsg_clearError:(NSError *__autoreleasing *)error {
     if (error != nil) {
         *error = nil;
     }

--- a/Source/KSCrash/Source/KSCrash/Recording/Tools/NSError+BSG_SimpleConstructor.m
+++ b/Source/KSCrash/Source/KSCrash/Recording/Tools/NSError+BSG_SimpleConstructor.m
@@ -67,13 +67,6 @@
     return NO;
 }
 
-+ (BOOL)bsg_clearError:(NSError *__autoreleasing *)error {
-    if (error != nil) {
-        *error = nil;
-    }
-    return NO;
-}
-
 @end
 
 @interface NSError_BSG_SimpleConstructor_AOG8G : NSObject


### PR DESCRIPTION
As there are no namespaces in Objective-C class extensions should be prefixed, most of them were but a few was not.

I've also removed the ``+ [NSError clearError]` method as it was unused.