### PR TITLE
Thread safety fixes

### DIFF
--- a/Source/Bugsnag.m
+++ b/Source/Bugsnag.m
@@ -52,9 +52,11 @@ static BugsnagNotifier *bsg_g_bugsnag_notifier = NULL;
 }
 
 + (void)startBugsnagWithConfiguration:(BugsnagConfiguration *)configuration {
-    bsg_g_bugsnag_notifier =
+    @synchronized(self) {
+        bsg_g_bugsnag_notifier =
         [[BugsnagNotifier alloc] initWithConfiguration:configuration];
-    [bsg_g_bugsnag_notifier start];
+        [bsg_g_bugsnag_notifier start];
+    }
 }
 
 + (BugsnagConfiguration *)configuration {

--- a/Source/BugsnagBreadcrumb.h
+++ b/Source/BugsnagBreadcrumb.h
@@ -75,10 +75,10 @@ typedef void (^BSGBreadcrumbConfiguration)(BugsnagBreadcrumb *_Nonnull);
 
 @interface BugsnagBreadcrumb : NSObject
 
-@property(readonly, nonatomic, nullable) NSDate *timestamp;
+@property(readonly, nullable) NSDate *timestamp;
 @property(readwrite) BSGBreadcrumbType type;
-@property(readwrite, nonatomic, copy, nonnull) NSString *name;
-@property(readwrite, nonatomic, copy, nonnull) NSDictionary *metadata;
+@property(readwrite, copy, nonnull) NSString *name;
+@property(readwrite, copy, nonnull) NSDictionary *metadata;
 
 + (instancetype _Nullable)breadcrumbWithBlock:
     (BSGBreadcrumbConfiguration _Nonnull)block;
@@ -90,7 +90,7 @@ typedef void (^BSGBreadcrumbConfiguration)(BugsnagBreadcrumb *_Nonnull);
 /**
  * The maximum number of breadcrumbs. Resizable.
  */
-@property(assign, nonatomic, readwrite) NSUInteger capacity;
+@property(assign, readwrite) NSUInteger capacity;
 
 /** Number of breadcrumbs accumulated */
 @property(assign, readonly) NSUInteger count;

--- a/Source/BugsnagConfiguration.h
+++ b/Source/BugsnagConfiguration.h
@@ -67,68 +67,68 @@ typedef NSDictionary *_Nullable (^BugsnagBeforeNotifyHook)(
 /**
  *  The API key of a Bugsnag project
  */
-@property(nonatomic, readwrite, retain, nullable) NSString *apiKey;
+@property(readwrite, retain, nullable) NSString *apiKey;
 /**
  *  The URL used to notify Bugsnag
  */
-@property(nonatomic, readwrite, retain, nullable) NSURL *notifyURL;
+@property(readwrite, retain, nullable) NSURL *notifyURL;
 /**
  *  The release stage of the application, such as production, development, beta
  *  et cetera
  */
-@property(nonatomic, readwrite, retain, nullable) NSString *releaseStage;
+@property(readwrite, retain, nullable) NSString *releaseStage;
 /**
  *  Release stages which are allowed to notify Bugsnag
  */
-@property(nonatomic, readwrite, retain, nullable) NSArray *notifyReleaseStages;
+@property(readwrite, retain, nullable) NSArray *notifyReleaseStages;
 /**
  *  A general summary of what was occuring in the application
  */
-@property(nonatomic, readwrite, retain, nullable) NSString *context;
+@property(readwrite, retain, nullable) NSString *context;
 /**
  *  The version of the application
  */
-@property(nonatomic, readwrite, retain, nullable) NSString *appVersion;
+@property(readwrite, retain, nullable) NSString *appVersion;
 
 /**
  *  The URL session used to send requests to Bugsnag.
  */
-@property(nonatomic, readwrite, strong, nonnull) NSURLSession *session;
+@property(readwrite, strong, nonnull) NSURLSession *session;
 
 /**
  *  Additional information about the state of the app or environment at the
  *  time the report was generated
  */
-@property(nonatomic, readwrite, retain, nullable) BugsnagMetaData *metaData;
+@property(readwrite, retain, nullable) BugsnagMetaData *metaData;
 /**
  *  Meta-information about the state of Bugsnag
  */
-@property(nonatomic, readwrite, retain, nullable) BugsnagMetaData *config;
+@property(readwrite, retain, nullable) BugsnagMetaData *config;
 /**
  *  Rolling snapshots of user actions leading up to a crash report
  */
-@property(nonatomic, readonly, strong, nullable)
-    BugsnagBreadcrumbs *breadcrumbs;
+@property(readonly, strong, nullable)
+BugsnagBreadcrumbs *breadcrumbs;
 
 /**
  *  Whether to allow collection of automatic breadcrumbs for notable events
  */
-@property(nonatomic, readwrite) BOOL automaticallyCollectBreadcrumbs;
+@property(readwrite) BOOL automaticallyCollectBreadcrumbs;
 
 /**
  *  Hooks for modifying crash reports before it is sent to Bugsnag
  */
-@property(nonatomic, readonly, strong, nullable)
+@property(readonly, strong, nullable)
     NSArray<BugsnagBeforeSendBlock> *beforeSendBlocks;
 /**
  *  Optional handler invoked when a crash or fatal signal occurs
  */
-@property(nonatomic) void (*_Nullable onCrashHandler)
+@property void (*_Nullable onCrashHandler)
     (const BSGCrashReportWriter *_Nonnull writer);
 /**
  *  YES if uncaught exceptions should be reported automatically
  */
-@property(nonatomic) BOOL autoNotify;
+@property BOOL autoNotify;
 
 /**
  *  Set user metadata
@@ -166,6 +166,6 @@ typedef NSDictionary *_Nullable (^BugsnagBeforeNotifyHook)(
 /**
  *  Hooks for processing raw report data before it is sent to Bugsnag
  */
-@property(nonatomic, readonly, strong, nullable)
+@property(readonly, strong, nullable)
     NSArray *beforeNotifyHooks __deprecated_msg("Use beforeNotify instead.");
 @end

--- a/Source/BugsnagCrashReport.h
+++ b/Source/BugsnagCrashReport.h
@@ -119,74 +119,74 @@ initWithErrorName:(NSString *_Nonnull)name
 /**
  *  The release stages used to notify at the time this report is captured
  */
-@property(nonatomic, readwrite, copy, nullable) NSArray *notifyReleaseStages;
+@property(readwrite, copy, nullable) NSArray *notifyReleaseStages;
 /**
  *  A loose representation of what was happening in the application at the time
  *  of the event
  */
-@property(nonatomic, readwrite, copy, nullable) NSString *context;
+@property(readwrite, copy, nullable) NSString *context;
 /**
  *  The severity of the error generating the report
  */
-@property(nonatomic, readwrite) BSGSeverity severity;
+@property(readwrite) BSGSeverity severity;
 /**
  *  The release stage of the application
  */
-@property(nonatomic, readwrite, copy, nullable) NSString *releaseStage;
+@property(readwrite, copy, nullable) NSString *releaseStage;
 /**
  *  The class of the error generating the report
  */
-@property(nonatomic, readwrite, copy, nonnull) NSString *errorClass;
+@property(readwrite, copy, nonnull) NSString *errorClass;
 /**
  *  The message of or reason for the error generating the report
  */
-@property(nonatomic, readwrite, copy, nullable) NSString *errorMessage;
+@property(readwrite, copy, nullable) NSString *errorMessage;
 /**
  *  Customized hash for grouping this report with other errors
  */
-@property(nonatomic, readwrite, copy, nullable) NSString *groupingHash;
+@property(readwrite, copy, nullable) NSString *groupingHash;
 /**
  *  Breadcrumbs from user events leading up to the error
  */
-@property(nonatomic, readwrite, copy, nullable) NSArray *breadcrumbs;
+@property(readwrite, copy, nullable) NSArray *breadcrumbs;
 /**
  *  Further information attached to an error report, where each top level key
  *  generates a section on bugsnag, displaying key/value pairs
  */
-@property(nonatomic, readwrite, copy, nonnull) NSDictionary *metaData;
+@property(readwrite, copy, nonnull) NSDictionary *metaData;
 /**
  *  The event state (whether the error is handled/unhandled)
  */
-@property(nonatomic, readonly, nonnull) BugsnagHandledState *handledState;
+@property(readonly, nonnull) BugsnagHandledState *handledState;
 
 /**
  *  Property overrides
  */
-@property(nonatomic, readonly, copy, nonnull) NSDictionary *overrides;
+@property(readonly, copy, nonnull) NSDictionary *overrides;
 /**
  *  Number of frames to discard at the top of the stacktrace
  */
-@property(nonatomic, readwrite) NSUInteger depth;
+@property(readwrite) NSUInteger depth;
 /**
  *  Raw error data
  */
-@property(nonatomic, readwrite, copy, nullable) NSDictionary *error;
+@property(readwrite, copy, nullable) NSDictionary *error;
 /**
  *  Device information such as OS name and version
  */
-@property(nonatomic, readwrite, copy, nullable) NSDictionary *device;
+@property(readwrite, copy, nullable) NSDictionary *device;
 /**
  *  Device state such as memory allocation at crash time
  */
-@property(nonatomic, readwrite, copy, nullable) NSDictionary *deviceState;
+@property(readwrite, copy, nullable) NSDictionary *deviceState;
 /**
  *  App information such as the name, version, and bundle ID
  */
-@property(nonatomic, readwrite, copy, nullable) NSDictionary *app;
+@property(readwrite, copy, nullable) NSDictionary *app;
 /**
  *  Device state such as oreground status and run duration
  */
-@property(nonatomic, readwrite, copy, nullable) NSDictionary *appState;
+@property(readwrite, copy, nullable) NSDictionary *appState;
 
 
 /**

--- a/Source/BugsnagCrashReport.m
+++ b/Source/BugsnagCrashReport.m
@@ -449,13 +449,16 @@ initWithErrorName:(NSString *_Nonnull)name
 }
 
 - (void)setOverrideProperty:(NSString *)key value:(id)value {
-    NSMutableDictionary *metadata = [self.overrides mutableCopy];
-    if (value) {
-        metadata[key] = value;
-    } else {
-        [metadata removeObjectForKey:key];
+    @synchronized (self) {
+        NSMutableDictionary *metadata = [self.overrides mutableCopy];
+        if (value) {
+            metadata[key] = value;
+        } else {
+            [metadata removeObjectForKey:key];
+        }
+        _overrides = metadata;
     }
-    _overrides = metadata;
+    
 }
 
 - (NSDictionary *)serializableValueWithTopLevelData:

--- a/Source/BugsnagMetaData.m
+++ b/Source/BugsnagMetaData.m
@@ -97,8 +97,8 @@
         } else {
             [[self getTab:tabName] removeObjectForKey:attributeName];
         }
-        [self.delegate metaDataChanged:self];
     }
+    [self.delegate metaDataChanged:self];
 }
 
 @end

--- a/Source/BugsnagNotifier.m
+++ b/Source/BugsnagNotifier.m
@@ -475,21 +475,22 @@ NSString *const kAppWillTerminate = @"App Will Terminate";
 }
 
 - (void)metaDataChanged:(BugsnagMetaData *)metaData {
-
-    if (metaData == self.configuration.metaData) {
-        if ([self.metaDataLock tryLock]) {
+    @synchronized(metaData) {
+        if (metaData == self.configuration.metaData) {
+            if ([self.metaDataLock tryLock]) {
+                BSSerializeJSONDictionary([metaData toDictionary],
+                                          &bsg_g_bugsnag_data.metaDataJSON);
+                [self.metaDataLock unlock];
+            }
+        } else if (metaData == self.configuration.config) {
+            BSSerializeJSONDictionary([metaData getTab:BSTabConfig],
+                                      &bsg_g_bugsnag_data.configJSON);
+        } else if (metaData == self.state) {
             BSSerializeJSONDictionary([metaData toDictionary],
-                                      &bsg_g_bugsnag_data.metaDataJSON);
-            [self.metaDataLock unlock];
+                                      &bsg_g_bugsnag_data.stateJSON);
+        } else {
+            bsg_log_debug(@"Unknown metadata dictionary changed");
         }
-    } else if (metaData == self.configuration.config) {
-        BSSerializeJSONDictionary([metaData getTab:BSTabConfig],
-                                  &bsg_g_bugsnag_data.configJSON);
-    } else if (metaData == self.state) {
-        BSSerializeJSONDictionary([metaData toDictionary],
-                                  &bsg_g_bugsnag_data.stateJSON);
-    } else {
-        bsg_log_debug(@"Unknown metadata dictionary changed");
     }
 }
 

--- a/Source/BugsnagNotifier.m
+++ b/Source/BugsnagNotifier.m
@@ -482,7 +482,7 @@ NSString *const kAppWillTerminate = @"App Will Terminate";
                 [self.metaDataLock unlock];
             }
         } else if (metaData == self.configuration.config) {
-            BSSerializeJSONDictionary([metaData getTab:BSTabConfig],
+            BSSerializeJSONDictionary([metaData getTab:BSGKeyConfig],
                                       &bsg_g_bugsnag_data.configJSON);
         } else if (metaData == self.state) {
             BSSerializeJSONDictionary([metaData toDictionary],


### PR DESCRIPTION
Adds locks for methods which could crash, and makes public API properties atomic. Crashes in the library can be reproduced by using the following approach:

```
for (int k = 0; k < 10000; k++) {
    NSLog(@"Attempt: %d", k);
    [Bugsnag leaveBreadcrumbWithMessage:@"generate non-fatal exception"];
    
    dispatch_async(dispatch_get_global_queue(DISPATCH_QUEUE_PRIORITY_BACKGROUND, 0), ^{
        NSError *error = [NSError errorWithDomain:@"thread test" code:0 userInfo:nil];
        [Bugsnag notifyError:error];
    });
}
```