### PR TITLE
Only set user id to device app hash if device id non-null

### DIFF
--- a/Source/BugsnagCrashReport.m
+++ b/Source/BugsnagCrashReport.m
@@ -516,7 +516,7 @@ initWithErrorName:(NSString *_Nonnull)name
         user = [NSMutableDictionary dictionary];
     BSGDictSetSafeObject(metaData, user, @"user");
 
-    if (!user[@"id"]) {
+    if (!user[@"id"] && self.device[@"id"]) { // if device id is null, don't set user id to default
         BSGDictSetSafeObject(user, [self deviceAppHash], @"id");
     }
 


### PR DESCRIPTION
Alters the SDK so that the User ID is only set to the device ID if the device ID is non-null. This allows for a developer to set the device id + user id to null for privacy reasons.

The device ID can be set to null with the following block (which presumably would need to be added to the docs):

    [[Bugsnag configuration] addBeforeSendBlock:^bool (NSDictionary *_Nonnull rawEventData,
                                      BugsnagCrashReport *report) {
        NSMutableDictionary *device = [NSMutableDictionary dictionaryWithDictionary:report.device];
        [device removeObjectForKey:@"id"];
        report.device = [NSDictionary dictionaryWithDictionary:device];
        return YES;
    }];