### PR TITLE
Set NSError as report context if null

### DIFF
--- a/Source/BugsnagNotifier.m
+++ b/Source/BugsnagNotifier.m
@@ -329,6 +329,9 @@ NSString *const kAppWillTerminate = @"App Will Terminate";
                      @"domain" : error.domain,
                      BSGKeyReason : error.localizedFailureReason ?: @""
                  };
+                   if (report.context == nil) { // set context as error domain
+                       report.context = [NSString stringWithFormat:@"%@ (%ld)", error.domain, (long)error.code];
+                   }
                  report.metaData = metadata;
 
                  if (block) {


### PR DESCRIPTION
Sets the report context to the nserror domain + code, if the context is null.