### PR TITLE
Fix report context of previous errors remaining in global variable

### DIFF
--- a/Source/BugsnagNotifier.m
+++ b/Source/BugsnagNotifier.m
@@ -441,6 +441,8 @@ NSString *const kAppWillTerminate = @"App Will Terminate";
     NSString *reportMessage = report.errorMessage ?: @"";
 
     [self.crashSentry reportUserException:reportName reason:reportMessage];
+    bsg_g_bugsnag_data.userOverridesJSON = NULL;
+    bsg_g_bugsnag_data.handledState = NULL;
 
     // Restore metaData to pre-crash state.
     [self.metaDataLock unlock];


### PR DESCRIPTION
Currently when a handled error is reported with a custom context, the context remains stored in the global`bsg_g_bugsnag_data.userOverridesJson` field. This means that any subsequent unhandled errors will erroneously use this context.

This change resets the overrides and handledstate JSON after it is written to a file, meaning the correct context is used.

