### PR TITLE
Fix for xcodebuild tool compilation error on version 8.1(8B62)

### DIFF
--- a/Source/BugsnagNotifier.m
+++ b/Source/BugsnagNotifier.m
@@ -47,7 +47,6 @@ NSString *const NOTIFIER_VERSION = @"5.13.2";
 NSString *const NOTIFIER_URL = @"https://github.com/bugsnag/bugsnag-cocoa";
 NSString *const BSTabCrash = @"crash";
 NSString *const BSAttributeDepth = @"depth";
-NSString *const BSAttributeBreadcrumbs = BSGKeyBreadcrumbs;
 NSString *const BSEventLowMemoryWarning = @"lowMemoryWarning";
 
 static NSInteger const BSGNotifierStackFrameCount = 5;
@@ -473,7 +472,7 @@ NSString *const kAppWillTerminate = @"App Will Terminate";
 - (void)serializeBreadcrumbs {
     BugsnagBreadcrumbs *crumbs = self.configuration.breadcrumbs;
     NSArray *arrayValue = crumbs.count == 0 ? nil : [crumbs arrayValue];
-    [self.state addAttribute:BSAttributeBreadcrumbs
+    [self.state addAttribute:BSGKeyBreadcrumbs
                    withValue:arrayValue
                toTabWithName:BSTabCrash];
 }


### PR DESCRIPTION
## Description
With latest changes introduced around wrapping constant names into external files, Bugsnag library stopped compiling on old Xcode versions (I was using `8.1(8B62)`). We still use old Xcode version to run Appium tests, as there is some migration needed to get test running on Xcode 9 and we are facing other issues, like slow and unstable builds.

We only need to remove the unneeded wrapper string that is initialised with another non-constant at compile time string and then everything works fine.