### PR TITLE
Fix potential buffer overflow when writing large reports

### DIFF
--- a/Source/KSCrash/Source/KSCrash/Recording/Tools/BSG_KSFileUtils.c
+++ b/Source/KSCrash/Source/KSCrash/Recording/Tools/BSG_KSFileUtils.c
@@ -44,7 +44,7 @@
 #define BSG_KSFU_WriteFmtBufferSize 1024
 #endif
 
-#define BUFFER_SIZE 131072
+#define BUFFER_SIZE 65536
 
 char charBuffer[BUFFER_SIZE];
 ssize_t bufferLen = 0;
@@ -75,19 +75,16 @@ bool bsg_ksfuflushWriteBuffer(const int fd) {
 
 bool bsg_ksfuwriteBytesToFD(const int fd, const char *const bytes,
                             ssize_t length) {
-    ssize_t newLen = bufferLen + length;
 
-    if (newLen >= BUFFER_SIZE) { // flush the current buffer
-        bsg_ksfuflushWriteBuffer(fd);
-        newLen = bufferLen + length; // recalculate new position
+    for (ssize_t k = 0; k < length; k++) {
+        if (bufferLen >= BUFFER_SIZE) {
+            if (!bsg_ksfuflushWriteBuffer(fd)) {
+                return false;
+            }
+        }
+        charBuffer[bufferLen] = bytes[k];
+        bufferLen++;
     }
-
-    for (ssize_t k = bufferLen; k < newLen;
-         k++) { // place in buffer for future write
-        ssize_t j = k - bufferLen;
-        charBuffer[k] = bytes[j];
-    }
-    bufferLen += length;
     return true;
 }
 


### PR DESCRIPTION
Fixes #209 

The original issue can be fixed by passing a very large byte array buffer to the fileUtils function - in practice this can be triggered with metaData as below:

```
[Bugsnag notify:[NSException exceptionWithName:@"wat" reason:nil userInfo:nil] 
block:^(BugsnagCrashReport * _Nonnull report) {
        
    for (int k = 0; k < 10000; k++) {
        NSString *val = [NSString stringWithFormat:@"user %d", k];
        [report addMetadata:@{@"tab": @{val: @"rar\"watrar"}} toTabWithName:@"tab"];
    }
}];
```

The implementation has been simplified so that the buffer size is checked each time before copying a byte.