### PR TITLE
Exclude address, mach, and signal from non-fatal error reports

### DIFF
--- a/Source/KSCrash/Source/KSCrash/Recording/BSG_KSCrashReport.c
+++ b/Source/KSCrash/Source/KSCrash/Recording/BSG_KSCrashReport.c
@@ -1676,9 +1676,6 @@ void bsg_kscrw_i_writeError(const BSG_KSCrashReportWriter *const writer,
         crashReason = crash->crashReason;
         break;
     }
-    
-    
-    /** Only include for fatal errors **/
 
     const char *machExceptionName = bsg_ksmachexceptionName(machExceptionType);
     const char *machCodeName =

--- a/Source/KSCrash/Source/KSCrash/Recording/BSG_KSCrashReport.c
+++ b/Source/KSCrash/Source/KSCrash/Recording/BSG_KSCrashReport.c
@@ -1685,10 +1685,26 @@ void bsg_kscrw_i_writeError(const BSG_KSCrashReportWriter *const writer,
 
     writer->beginObject(writer, key);
     {
-        
-        // only report address, mach, and signal for fatal errors
-        
+
         if (BSG_KSCrashTypeUserReported != crash->crashType) {
+            writer->addUIntegerElement(writer, BSG_KSCrashField_Address,
+                                       crash->faultAddress);
+        }
+
+        if (crashReason != NULL) {
+            writer->addStringElement(writer, BSG_KSCrashField_Reason,
+                                     crashReason);
+        }
+
+
+        // Gather specific info.
+        switch (crash->crashType) {
+        case BSG_KSCrashTypeMainThreadDeadlock:
+            writer->addStringElement(writer, BSG_KSCrashField_Type,
+                                     BSG_KSCrashExcType_Deadlock);
+            break;
+
+        case BSG_KSCrashTypeMachException:
             writer->beginObject(writer, BSG_KSCrashField_Mach);
             {
                 writer->addUIntegerElement(writer, BSG_KSCrashField_Exception,
@@ -1707,42 +1723,6 @@ void bsg_kscrw_i_writeError(const BSG_KSCrashReportWriter *const writer,
                                            (unsigned)machSubCode);
             }
             writer->endContainer(writer);
-            
-            writer->beginObject(writer, BSG_KSCrashField_Signal);
-            {
-                writer->addUIntegerElement(writer, BSG_KSCrashField_Signal,
-                                           (unsigned)sigNum);
-                if (sigName != NULL) {
-                    writer->addStringElement(writer, BSG_KSCrashField_Name,
-                                             sigName);
-                }
-                writer->addUIntegerElement(writer, BSG_KSCrashField_Code,
-                                           (unsigned)sigCode);
-                if (sigCodeName != NULL) {
-                    writer->addStringElement(writer, BSG_KSCrashField_CodeName,
-                                             sigCodeName);
-                }
-            }
-            writer->endContainer(writer);
-            
-            writer->addUIntegerElement(writer, BSG_KSCrashField_Address,
-                                       crash->faultAddress);
-        }
-        
-        if (crashReason != NULL) {
-            writer->addStringElement(writer, BSG_KSCrashField_Reason,
-                                     crashReason);
-        }
-        
-        
-        // Gather specific info.
-        switch (crash->crashType) {
-        case BSG_KSCrashTypeMainThreadDeadlock:
-            writer->addStringElement(writer, BSG_KSCrashField_Type,
-                                     BSG_KSCrashExcType_Deadlock);
-            break;
-
-        case BSG_KSCrashTypeMachException:
             writer->addStringElement(writer, BSG_KSCrashField_Type,
                                      BSG_KSCrashExcType_Mach);
             break;
@@ -1772,6 +1752,22 @@ void bsg_kscrw_i_writeError(const BSG_KSCrashReportWriter *const writer,
             break;
         }
         case BSG_KSCrashTypeSignal:
+            writer->beginObject(writer, BSG_KSCrashField_Signal);
+            {
+                writer->addUIntegerElement(writer, BSG_KSCrashField_Signal,
+                                           (unsigned)sigNum);
+                if (sigName != NULL) {
+                    writer->addStringElement(writer, BSG_KSCrashField_Name,
+                                             sigName);
+                }
+                writer->addUIntegerElement(writer, BSG_KSCrashField_Code,
+                                           (unsigned)sigCode);
+                if (sigCodeName != NULL) {
+                    writer->addStringElement(writer, BSG_KSCrashField_CodeName,
+                                             sigCodeName);
+                }
+            }
+            writer->endContainer(writer);
             writer->addStringElement(writer, BSG_KSCrashField_Type,
                                      BSG_KSCrashExcType_Signal);
             break;

--- a/examples/objective-c-ios/Podfile.lock
+++ b/examples/objective-c-ios/Podfile.lock
@@ -1,5 +1,5 @@
 PODS:
-  - Bugsnag (5.13.0)
+  - Bugsnag (5.13.3)
 
 DEPENDENCIES:
   - Bugsnag (from `../..`)
@@ -9,7 +9,7 @@ EXTERNAL SOURCES:
     :path: ../..
 
 SPEC CHECKSUMS:
-  Bugsnag: 530eda12cfc85026cb67e1c12bdfabc7a319f59c
+  Bugsnag: 365bbdf9b0d3f94c14fd0cbba027f7ec442eb72c
 
 PODFILE CHECKSUM: 1143756a2cf4af18c0c3b523a7c74458c0ed4899
 


### PR DESCRIPTION
Excludes the address, mach, and signal fields from the metadata of non-fatal error reports. These were always reported as EXC_CRASH and SIGABRT by default, which could be misleading.