### PR TITLE
Avoid generating and parsing invalid JSON files

### DIFF
--- a/Source/KSCrash/Source/KSCrash/Recording/BSG_KSCrashState.c
+++ b/Source/KSCrash/Source/KSCrash/Recording/BSG_KSCrashState.c
@@ -266,11 +266,11 @@ bool bsg_kscrashstate_i_saveState(const BSG_KSCrash_State *const state,
         goto done;
     }
     result = bsg_ksjsonendEncode(&JSONContext);
-
-done:
     if (!bsg_ksfuflushWriteBuffer(fd)) {
         BSG_KSLOG_ERROR("Failed to flush write buffer");
     }
+
+done:
     close(fd);
 
     if (result != BSG_KSJSON_OK) {

--- a/Source/KSCrash/Source/KSCrash/Recording/Tools/BSG_KSJSONCodec.c
+++ b/Source/KSCrash/Source/KSCrash/Recording/Tools/BSG_KSJSONCodec.c
@@ -974,6 +974,9 @@ int bsg_ksjsoncodec_i_decodeElement(const char **ptr, const char *const end,
         }
 
         if (!isFPChar(**ptr) && accum >= 0) {
+            if (name == NULL) {
+                return BSG_KSJSON_ERROR_INCOMPLETE;
+            }
             accum *= sign;
             return callbacks->onIntegerElement(name, accum, userData);
         }


### PR DESCRIPTION
In the case that the crash state file fails to be written completely, avoid flushing the buffer as the file contents will be inconsistent. In addition, when parsing the file, add validation to avoid comparing a string to NULL.

To reproduce:
* Install the sample app with v5.14.1 onto a device
* Download the application container and show package contents
* Change the contents of `AppData/Library/Caches/KSCrashReport/{app name}-CrashState.json` to `3 }`. This triggers the code path where the file is invalid but it is not rejected before crashing.
* Replace the app container on the device with the altered one
* Restart app

Fixes #218 