### PR TITLE
Session tracking amends

### DIFF
--- a/Source/BugsnagConfiguration.m
+++ b/Source/BugsnagConfiguration.m
@@ -30,6 +30,7 @@
 #import "BugsnagKeys.h"
 #import "BSG_RFC3339DateTool.h"
 #import "BugsnagUser.h"
+#import "BugsnagSessionTracker.h"
 
 static NSString *const kHeaderApiPayloadVersion = @"Bugsnag-Payload-Version";
 static NSString *const kHeaderApiKey = @"Bugsnag-Api-Key";
@@ -37,6 +38,10 @@ static NSString *const kHeaderApiSentAt = @"Bugsnag-Sent-At";
 
 @interface Bugsnag ()
 + (BugsnagNotifier *)notifier;
+@end
+
+@interface BugsnagNotifier ()
+@property BugsnagSessionTracker *sessionTracker;
 @end
 
 @interface BugsnagConfiguration ()
@@ -191,6 +196,23 @@ static NSString *const kHeaderApiSentAt = @"Bugsnag-Sent-At";
         [self.config addAttribute:BSGKeyAppVersion
                         withValue:newVersion
                     toTabWithName:BSGKeyConfig];
+    }
+}
+
+@synthesize shouldAutoCaptureSessions = _shouldAutoCaptureSessions;
+
+- (BOOL)shouldAutoCaptureSessions {
+    return _shouldAutoCaptureSessions;
+}
+
+- (void)setShouldAutoCaptureSessions:(BOOL)shouldAutoCaptureSessions {
+    @synchronized (self) {
+        _shouldAutoCaptureSessions = shouldAutoCaptureSessions;
+        
+        if (shouldAutoCaptureSessions) { // track any existing sessions
+            BugsnagSessionTracker *sessionTracker = [Bugsnag notifier].sessionTracker;
+            [sessionTracker onAutoCaptureEnabled];
+        }
     }
 }
 

--- a/Source/BugsnagNotifier.m
+++ b/Source/BugsnagNotifier.m
@@ -214,9 +214,8 @@ void BSSerializeJSONDictionary(NSDictionary *dictionary, char **destination) {
                                                                        hasRecordedSessions = true;
                                                                    }];
 
-        if (self.configuration.shouldAutoCaptureSessions) { // create initial session
-            [self.sessionTracker startNewSession:[NSDate date] withUser:nil autoCaptured:YES];
-        }
+        
+        [self.sessionTracker startNewSession:[NSDate date] withUser:nil autoCaptured:YES];
 
         [self metaDataChanged:self.configuration.metaData];
         [self metaDataChanged:self.configuration.config];

--- a/Source/BugsnagSessionTracker.h
+++ b/Source/BugsnagSessionTracker.h
@@ -28,6 +28,7 @@ typedef void (^SessionTrackerCallback)(BugsnagSession *newSession);
 - (void)suspendCurrentSession:(NSDate *)date;
 - (void)incrementHandledError;
 - (void)send;
+- (void)onAutoCaptureEnabled;
 
 @property (readonly) BugsnagSession *currentSession;
 @property (readonly) BOOL isInForeground;

--- a/Source/BugsnagSessionTracker.m
+++ b/Source/BugsnagSessionTracker.m
@@ -48,7 +48,7 @@
                                                      user:user
                                              autoCaptured:autoCaptured];
 
-    if (self.config.shouldAutoCaptureSessions || !autoCaptured) {
+    if ((self.config.shouldAutoCaptureSessions || !autoCaptured) && [self.config shouldSendReports]) {
         [self.sessionStore write:self.currentSession];
 
         if (self.callback) {

--- a/examples/objective-c-ios/Podfile.lock
+++ b/examples/objective-c-ios/Podfile.lock
@@ -1,5 +1,5 @@
 PODS:
-  - Bugsnag (5.14.1)
+  - Bugsnag (5.15.0)
 
 DEPENDENCIES:
   - Bugsnag (from `../..`)
@@ -9,7 +9,7 @@ EXTERNAL SOURCES:
     :path: ../..
 
 SPEC CHECKSUMS:
-  Bugsnag: bc62bf437f55cfae29a4c836f29f9e8b64af3457
+  Bugsnag: d7958a4628b967d395a09f650732a234ee7de8c9
 
 PODFILE CHECKSUM: 4c48f26cc704429f747c4af7a40e026b20fdc83e
 


### PR DESCRIPTION
- Respect notifyReleaseStages by not tracking sessions if this config is set
- When autoCaptureSessions is set via config after initialisation, track an existing session if present (required for downstream notifiers)