### PR TITLE
[Platform Word Size] Add platform word size to Device tab

### DIFF
--- a/Source/BugsnagKSCrashSysInfoParser.m
+++ b/Source/BugsnagKSCrashSysInfoParser.m
@@ -13,6 +13,8 @@
 #import "BugsnagConfiguration.h"
 #import "BugsnagLogger.h"
 
+#define PLATFORM_WORD_SIZE sizeof(void*)*8
+
 NSDictionary *BSGParseDevice(NSDictionary *report) {
     NSMutableDictionary *device =
     [[report valueForKeyPath:@"user.state.deviceState"] mutableCopy];
@@ -103,6 +105,7 @@ NSDictionary *BSGParseDeviceState(NSDictionary *report) {
     BSGDictSetSafeObject(deviceState, report[@"machine"], @"model");
     BSGDictSetSafeObject(deviceState, report[@"system_name"], @"osName");
     BSGDictSetSafeObject(deviceState, report[@"system_version"], @"osVersion");
+    BSGDictSetSafeObject(deviceState, @(PLATFORM_WORD_SIZE), @"wordSize");
     BSGDictSetSafeObject(deviceState, @"Apple", @"manufacturer");
     BSGDictSetSafeObject(deviceState, report[@"jailbroken"], @"jailbroken");
     return deviceState;


### PR DESCRIPTION
This commit adds the platform word size to the Device tab of
all snags to help users quickly classify whether a set of bugs
is architecture specific (e.g. 32 bit devices only).