### PR TITLE
Remove noisy session tracking log

### DIFF
--- a/Source/BugsnagNotifier.m
+++ b/Source/BugsnagNotifier.m
@@ -410,7 +410,6 @@ NSString *const kAppWillTerminate = @"App Will Terminate";
 
 - (void)sessionTick:(id)sender {
     [self.sessionTracker send];
-    NSLog(@"Session Tick!");
 }
 
 - (void)flushPendingReports {


### PR DESCRIPTION
Removes a potentially noisy session tracking log, which occurs once every minute. Addresses #229 