### PR TITLE
handle unknown CPU archs, improve error messaging

### DIFF
--- a/OSX/Bugsnag.xcodeproj/project.pbxproj
+++ b/OSX/Bugsnag.xcodeproj/project.pbxproj
@@ -25,7 +25,6 @@
 		8A2C8FDD1C6BC2C800846019 /* BugsnagSink.h in Headers */ = {isa = PBXBuildFile; fileRef = 8A2C8FCB1C6BC2C800846019 /* BugsnagSink.h */; };
 		8A2C8FDE1C6BC2C800846019 /* BugsnagSink.m in Sources */ = {isa = PBXBuildFile; fileRef = 8A2C8FCC1C6BC2C800846019 /* BugsnagSink.m */; };
 		8A2C8FEA1C6BC38900846019 /* BugsnagBreadcrumbsTest.m in Sources */ = {isa = PBXBuildFile; fileRef = 8A2C8FE01C6BC38200846019 /* BugsnagBreadcrumbsTest.m */; };
-		8A2C8FEB1C6BC38900846019 /* BugsnagCrashReportTests.m in Sources */ = {isa = PBXBuildFile; fileRef = 8A2C8FE11C6BC38200846019 /* BugsnagCrashReportTests.m */; };
 		8A2C8FEC1C6BC38900846019 /* BugsnagSinkTests.m in Sources */ = {isa = PBXBuildFile; fileRef = 8A2C8FE21C6BC38200846019 /* BugsnagSinkTests.m */; };
 		8A2C8FEE1C6BC38900846019 /* report.json in Resources */ = {isa = PBXBuildFile; fileRef = 8A2C8FE41C6BC38200846019 /* report.json */; };
 		8A2C8FF01C6BC3A200846019 /* SystemConfiguration.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = 8A2C8FEF1C6BC3A200846019 /* SystemConfiguration.framework */; };
@@ -34,6 +33,7 @@
 		8A627CD91EC3B75200F7C04E /* BSGSerialization.h in Headers */ = {isa = PBXBuildFile; fileRef = 8A627CD71EC3B75200F7C04E /* BSGSerialization.h */; };
 		8A627CDA1EC3B75200F7C04E /* BSGSerialization.m in Sources */ = {isa = PBXBuildFile; fileRef = 8A627CD81EC3B75200F7C04E /* BSGSerialization.m */; };
 		8A87352C1C6D3B1600EDBD5B /* BSG_KSCrashReportWriter.h in Headers */ = {isa = PBXBuildFile; fileRef = 8A87352B1C6D3B1600EDBD5B /* BSG_KSCrashReportWriter.h */; settings = {ATTRIBUTES = (Public, ); }; };
+		8ACF0F752018136200173809 /* BugsnagCrashReportTests.m in Sources */ = {isa = PBXBuildFile; fileRef = 8A2C8FE11C6BC38200846019 /* BugsnagCrashReportTests.m */; };
 		8AD9FA891E086351002859A7 /* BugsnagConfigurationTests.m in Sources */ = {isa = PBXBuildFile; fileRef = 8AD9FA851E0862DC002859A7 /* BugsnagConfigurationTests.m */; };
 		E72352C11F55924A00436528 /* BSGConnectivity.h in Headers */ = {isa = PBXBuildFile; fileRef = E72352BF1F55924A00436528 /* BSGConnectivity.h */; };
 		E72352C21F55924A00436528 /* BSGConnectivity.m in Sources */ = {isa = PBXBuildFile; fileRef = E72352C01F55924A00436528 /* BSGConnectivity.m */; };
@@ -930,13 +930,13 @@
 			isa = PBXSourcesBuildPhase;
 			buildActionMask = 2147483647;
 			files = (
+				8ACF0F752018136200173809 /* BugsnagCrashReportTests.m in Sources */,
 				E7CE78CC1FD94E77001D07E0 /* KSSystemInfo_Tests.m in Sources */,
 				E7CE78C91FD94E77001D07E0 /* KSSignalInfo_Tests.m in Sources */,
 				E7CE78C61FD94E77001D07E0 /* KSMach_Tests.m in Sources */,
 				E7CE78D61FD94E9E001D07E0 /* FileBasedTestCase.m in Sources */,
 				E7CE78D51FD94E93001D07E0 /* XCTestCase+KSCrash.m in Sources */,
 				E7CE78CD1FD94E77001D07E0 /* KSZombie_Tests.m in Sources */,
-				8AD9FA881E08633F002859A7 /* BugsnagConfigurationSpec.m in Sources */,
 				E7CE78CF1FD94E77001D07E0 /* NSError+SimpleConstructor_Tests.m in Sources */,
 				E7CE78C81FD94E77001D07E0 /* KSSafeCollections_Tests.m in Sources */,
 				E7CE78BF1FD94E77001D07E0 /* KSCrashSentry_Signal_Tests.m in Sources */,
@@ -959,11 +959,9 @@
 				E7CE78BD1FD94E77001D07E0 /* KSCrashSentry_Deadlock_Tests.m in Sources */,
 				E7CE78C51FD94E77001D07E0 /* KSLogger_Tests.m in Sources */,
 				E7CE78C11FD94E77001D07E0 /* KSCrashState_Tests.m in Sources */,
-				8A2C8FEB1C6BC38900846019 /* BugsnagCrashReportTests.m in Sources */,
 				E7CE78C31FD94E77001D07E0 /* KSFileUtils_Tests.m in Sources */,
 				E7CE78BC1FD94E77001D07E0 /* KSCrashReportStore_Tests.m in Sources */,
 				E79148611FD82BB7003EFEBF /* BugsnagSessionTrackerTest.m in Sources */,
-				8A2C8FEB1C6BC38900846019 /* BugsnagCrashReportTests.m in Sources */,
 				E79148591FD82BAE003EFEBF /* BugsnagSessionTest.m in Sources */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;

--- a/Source/BugsnagCrashReport.h
+++ b/Source/BugsnagCrashReport.h
@@ -197,6 +197,6 @@ __deprecated_msg("Use toJson: instead.");
 /**
  * Returns the enhanced error message for the thread, or nil if none exists.
  */
-- (NSString *_Nullable)enhancedErrorMessageForThread:(NSDictionary *_Nullable)thread;
+- (NSString *_Nullable)enhancedErrorMessageForThread:(NSDictionary *_Nullable)thread __deprecated;
 
 @end

--- a/Source/BugsnagCrashReport.m
+++ b/Source/BugsnagCrashReport.m
@@ -621,12 +621,14 @@ initWithErrorName:(NSString *_Nonnull)name
                 continue;
             }
             NSDictionary *data = notableAddresses[key];
+            if (![@"string" isEqualToString:data[BSGKeyType]]) {
+                continue;
+            }
             NSString *contentValue = data[@"value"];
 
             if ([self isReservedWord:contentValue]) {
                 reservedWord = contentValue;
-            } else if ([@"string" isEqualToString:data[BSGKeyType]]
-                       && !([[contentValue componentsSeparatedByString:@"/"] count] > 2)) {
+            } else if (!([[contentValue componentsSeparatedByString:@"/"] count] > 2)) {
                 // must be a string that isn't a reserved word and isn't a filepath
                 [interestingValues addObject:contentValue];
             }

--- a/Source/BugsnagCrashReport.m
+++ b/Source/BugsnagCrashReport.m
@@ -652,7 +652,8 @@ initWithErrorName:(NSString *_Nonnull)name
  */
 + (BOOL)isReservedWord:(NSString *)contentValue {
     return [@"assertion failed" caseInsensitiveCompare:contentValue] == NSOrderedSame
-    || [@"fatal error" caseInsensitiveCompare:contentValue] == NSOrderedSame;
+    || [@"fatal error" caseInsensitiveCompare:contentValue] == NSOrderedSame
+    || [@"precondition failed" caseInsensitiveCompare:contentValue] == NSOrderedSame;
 }
 
 - (instancetype)init {

--- a/Source/BugsnagCrashReport.m
+++ b/Source/BugsnagCrashReport.m
@@ -638,8 +638,8 @@ initWithErrorName:(NSString *_Nonnull)name
  * For assert, "assertion failed" will be in one of the registers.
  */
 - (BOOL)isReservedWord:(NSString *)contentValue {
-    return [@"assertion failed" isEqualToString:contentValue]
-    || [@"fatal error" isEqualToString:contentValue];
+    return [@"assertion failed" caseInsensitiveCompare:contentValue] == NSOrderedSame
+    || [@"fatal error" caseInsensitiveCompare:contentValue] == NSOrderedSame;
 }
 
 @end

--- a/Source/KSCrash/Source/KSCrash/Recording/BSG_KSCrashDoctor.m
+++ b/Source/KSCrash/Source/KSCrash/Recording/BSG_KSCrashDoctor.m
@@ -15,6 +15,7 @@
 typedef enum {
     BSG_CPUFamilyUnknown,
     BSG_CPUFamilyArm,
+    BSG_CPUFamilyArm64,
     BSG_CPUFamilyX86,
     BSG_CPUFamilyX86_64
 } BSG_CPUFamily;
@@ -170,6 +171,9 @@ typedef enum {
 - (BSG_CPUFamily)cpuFamily:(NSDictionary *)report {
     NSDictionary *system = [self systemReport:report];
     NSString *cpuArch = system[@BSG_KSSystemField_CPUArch];
+    if ([cpuArch isEqualToString:@"arm64"]) {
+        return BSG_CPUFamilyArm64;
+    }
     if ([cpuArch rangeOfString:@"arm"].location == 0) {
         return BSG_CPUFamilyArm;
     }
@@ -196,6 +200,18 @@ typedef enum {
             return @"r2";
         case 3:
             return @"r3";
+        }
+    }
+    case BSG_CPUFamilyArm64: {
+        switch (index) {
+            case 0:
+                return @"x0";
+            case 1:
+                return @"x1";
+            case 2:
+                return @"x2";
+            case 3:
+                return @"x3";
         }
     }
     case BSG_CPUFamilyX86: {

--- a/Source/KSCrash/Source/KSCrash/Recording/BSG_KSCrashDoctor.m
+++ b/Source/KSCrash/Source/KSCrash/Recording/BSG_KSCrashDoctor.m
@@ -366,10 +366,13 @@ typedef enum {
     BSG_CPUFamily family = [self cpuFamily:report];
     NSDictionary *registers =
         [self basicRegistersFromThreadReport:crashedThread];
-    NSArray *regNames = @[[self registerNameForFamily:family paramIndex:0],
-            [self registerNameForFamily:family paramIndex:1],
-            [self registerNameForFamily:family paramIndex:2],
-            [self registerNameForFamily:family paramIndex:3]];
+    NSMutableArray *regNames = [NSMutableArray arrayWithCapacity:4];
+    for (int paramIndex = 0; paramIndex <= 3; paramIndex++) {
+        NSString *regName = [self registerNameForFamily:family paramIndex:paramIndex];
+        if (regName.length > 0) {
+            [regNames addObject:regName];
+        }
+    }
     NSMutableArray *params = [NSMutableArray arrayWithCapacity:4];
     for (NSString *regName in regNames) {
         BSG_KSCrashDoctorParam *param = [[BSG_KSCrashDoctorParam alloc] init];

--- a/Source/KSCrash/Source/KSCrash/Recording/BSG_KSCrashDoctor.m
+++ b/Source/KSCrash/Source/KSCrash/Recording/BSG_KSCrashDoctor.m
@@ -177,8 +177,7 @@ typedef enum {
         [cpuArch rangeOfString:@"86"].location == 2) {
         return BSG_CPUFamilyX86;
     }
-    if ([cpuArch rangeOfString:@"x86_64" options:NSCaseInsensitiveSearch]
-            .location != NSNotFound) {
+    if ([@[@"x86_64", @"x86"] containsObject:cpuArch]) {
         return BSG_CPUFamilyX86_64;
     }
     return BSG_CPUFamilyUnknown;

--- a/Tests/BugsnagCrashReportTests.m
+++ b/Tests/BugsnagCrashReportTests.m
@@ -9,10 +9,10 @@
 #import <Foundation/Foundation.h>
 #import <XCTest/XCTest.h>
 
+#import "BSG_RFC3339DateTool.h"
 #import "Bugsnag.h"
 #import "BugsnagHandledState.h"
 #import "BugsnagSession.h"
-#import "BSG_RFC3339DateTool.h"
 
 @interface BugsnagCrashReportTests : XCTestCase
 @property BugsnagCrashReport *report;
@@ -28,9 +28,9 @@
                                                    encoding:NSUTF8StringEncoding
                                                       error:nil];
     NSDictionary *dictionary = [NSJSONSerialization
-                                JSONObjectWithData:[contents dataUsingEncoding:NSUTF8StringEncoding]
-                                options:0
-                                error:nil];
+        JSONObjectWithData:[contents dataUsingEncoding:NSUTF8StringEncoding]
+                   options:0
+                     error:nil];
     self.report = [[BugsnagCrashReport alloc] initWithKSReport:dictionary];
 }
 
@@ -102,14 +102,14 @@
     config.notifyReleaseStages = @[ @"foo" ];
     config.releaseStage = @"foo";
     BugsnagHandledState *state =
-    [BugsnagHandledState handledStateWithSeverityReason:HandledException];
+        [BugsnagHandledState handledStateWithSeverityReason:HandledException];
     BugsnagCrashReport *report =
-    [[BugsnagCrashReport alloc] initWithErrorName:@"Bad error"
-                                     errorMessage:@"it was so bad"
-                                    configuration:config
-                                         metaData:@{}
-                                     handledState:state
-                                          session:nil];
+        [[BugsnagCrashReport alloc] initWithErrorName:@"Bad error"
+                                         errorMessage:@"it was so bad"
+                                        configuration:config
+                                             metaData:@{}
+                                         handledState:state
+                                              session:nil];
     XCTAssertTrue([report shouldBeSent]);
 }
 
@@ -117,16 +117,16 @@
     BugsnagConfiguration *config = [BugsnagConfiguration new];
     config.notifyReleaseStages = @[ @"foo", @"bar" ];
     config.releaseStage = @"not foo or bar";
-    
+
     BugsnagHandledState *state =
-    [BugsnagHandledState handledStateWithSeverityReason:HandledException];
+        [BugsnagHandledState handledStateWithSeverityReason:HandledException];
     BugsnagCrashReport *report =
-    [[BugsnagCrashReport alloc] initWithErrorName:@"Bad error"
-                                     errorMessage:@"it was so bad"
-                                    configuration:config
-                                         metaData:@{}
-                                     handledState:state
-                                          session:nil];
+        [[BugsnagCrashReport alloc] initWithErrorName:@"Bad error"
+                                         errorMessage:@"it was so bad"
+                                        configuration:config
+                                             metaData:@{}
+                                         handledState:state
+                                              session:nil];
     XCTAssertFalse([report shouldBeSent]);
 }
 
@@ -134,7 +134,7 @@
     BugsnagConfiguration *config = [BugsnagConfiguration new];
 
     BugsnagHandledState *state =
-            [BugsnagHandledState handledStateWithSeverityReason:HandledException];
+        [BugsnagHandledState handledStateWithSeverityReason:HandledException];
     NSDate *now = [NSDate date];
     BugsnagSession *bugsnagSession = [[BugsnagSession alloc] initWithId:@"123"
                                                               startDate:now
@@ -142,21 +142,22 @@
                                                            autoCaptured:NO];
     bugsnagSession.handledCount = 2;
     bugsnagSession.unhandledCount = 1;
-    
+
     BugsnagCrashReport *report =
-            [[BugsnagCrashReport alloc] initWithErrorName:@"Bad error"
-                                             errorMessage:@"it was so bad"
-                                            configuration:config
-                                                 metaData:@{}
-                                             handledState:state
-                                                  session:bugsnagSession];
+        [[BugsnagCrashReport alloc] initWithErrorName:@"Bad error"
+                                         errorMessage:@"it was so bad"
+                                        configuration:config
+                                             metaData:@{}
+                                         handledState:state
+                                              session:bugsnagSession];
     NSDictionary *json = [report toJson];
     XCTAssertNotNil(json);
 
     NSDictionary *session = json[@"session"];
     XCTAssertNotNil(session);
     XCTAssertEqualObjects(@"123", session[@"id"]);
-    XCTAssertEqualObjects([BSG_RFC3339DateTool stringFromDate:now], session[@"startedAt"]);
+    XCTAssertEqualObjects([BSG_RFC3339DateTool stringFromDate:now],
+                          session[@"startedAt"]);
 
     NSDictionary *events = session[@"events"];
     XCTAssertNotNil(events);
@@ -164,73 +165,288 @@
     XCTAssertEqualObjects(@1, events[@"unhandled"]);
 }
 
-- (void)testEnhancedErrorMessage {
-    BugsnagCrashReport *errorReport = [BugsnagCrashReport new];
-    NSMutableDictionary *thread = [NSMutableDictionary new];
-    
-    // nil for empty threads
-    XCTAssertNil([errorReport enhancedErrorMessageForThread:thread]);
-    NSMutableDictionary *addresses = [NSMutableDictionary new];
-    
-    // nil for empty notable addresses
-    thread[@"notable_addresses"] = addresses;
-    XCTAssertNil([errorReport enhancedErrorMessageForThread:thread]);
-    
-    // nil for "fatal error" with no additional dict present
-    
-    for (NSString *reservedWord in @[@"fatal error", @"assertion failed"]) {
-        addresses[@"r14"] = @{
-                              @"address": @4511089532,
-                              @"type": @"string",
-                              @"value": reservedWord
-                              };
-        XCTAssertNil([errorReport enhancedErrorMessageForThread:thread]);
+- (void)testDefaultErrorMessageNil {
+    BugsnagCrashReport *report =
+        [[BugsnagCrashReport alloc] initWithKSReport:@{}];
+    NSDictionary *payload = [report toJson];
+    XCTAssertEqualObjects(@"Exception",
+                          payload[@"exceptions"][0][@"errorClass"]);
+    XCTAssertEqualObjects(@"", payload[@"exceptions"][0][@"message"]);
+    XCTAssertEqualObjects(report.errorClass,
+                          payload[@"exceptions"][0][@"errorClass"]);
+    XCTAssertEqualObjects(report.errorMessage,
+                          payload[@"exceptions"][0][@"message"]);
+}
+
+- (void)testDefaultErrorMessageNilForEmptyThreads {
+    BugsnagCrashReport *report = [[BugsnagCrashReport alloc] initWithKSReport:@{
+        @"threads" : @[]
+    }];
+    NSDictionary *payload = [report toJson];
+    XCTAssertEqualObjects(@"Exception",
+                          payload[@"exceptions"][0][@"errorClass"]);
+    XCTAssertEqualObjects(@"", payload[@"exceptions"][0][@"message"]);
+    XCTAssertEqualObjects(report.errorClass,
+                          payload[@"exceptions"][0][@"errorClass"]);
+    XCTAssertEqualObjects(report.errorMessage,
+                          payload[@"exceptions"][0][@"message"]);
+}
+
+- (void)testEnhancedErrorMessageNilForEmptyNotableAddresses {
+    BugsnagCrashReport *report = [[BugsnagCrashReport alloc] initWithKSReport:@{
+        @"threads" : @[ @{@"crashed" : @YES, @"notable_addresses" : @{}} ]
+    }];
+    NSDictionary *payload = [report toJson];
+    XCTAssertEqualObjects(@"Exception",
+                          payload[@"exceptions"][0][@"errorClass"]);
+    XCTAssertEqualObjects(@"", payload[@"exceptions"][0][@"message"]);
+    XCTAssertEqualObjects(report.errorClass,
+                          payload[@"exceptions"][0][@"errorClass"]);
+    XCTAssertEqualObjects(report.errorMessage,
+                          payload[@"exceptions"][0][@"message"]);
+}
+
+- (void)testEnhancedErrorMessageForFatalErrorWithoutAdditionalMessage {
+    BugsnagCrashReport *report = [[BugsnagCrashReport alloc] initWithKSReport:@{
+        @"crash" : @{
+            @"threads" : @[ @{
+                @"crashed" : @YES,
+                @"notable_addresses" : @{
+                    @"r14" : @{
+                        @"address" : @4511089532,
+                        @"type" : @"string",
+                        @"value" : @"fatal error"
+                    }
+                }
+            } ]
+        }
+    }];
+    NSDictionary *payload = [report toJson];
+    XCTAssertEqualObjects(@"fatal error",
+                          payload[@"exceptions"][0][@"errorClass"]);
+    XCTAssertEqualObjects(@"", payload[@"exceptions"][0][@"message"]);
+    XCTAssertEqualObjects(report.errorClass,
+                          payload[@"exceptions"][0][@"errorClass"]);
+    XCTAssertEqualObjects(report.errorMessage,
+                          payload[@"exceptions"][0][@"message"]);
+}
+
+- (void)testEnhancedErrorMessageForAssertionWithoutAdditionalMessage {
+    BugsnagCrashReport *report = [[BugsnagCrashReport alloc] initWithKSReport:@{
+        @"crash" : @{
+            @"threads" : @[ @{
+                @"crashed" : @YES,
+                @"notable_addresses" : @{
+                    @"r14" : @{
+                        @"address" : @4511089532,
+                        @"type" : @"string",
+                        @"value" : @"assertion failed"
+                    }
+                }
+            } ]
+        }
+    }];
+    NSDictionary *payload = [report toJson];
+    XCTAssertEqualObjects(@"assertion failed",
+                          payload[@"exceptions"][0][@"errorClass"]);
+    XCTAssertEqualObjects(@"", payload[@"exceptions"][0][@"message"]);
+    XCTAssertEqualObjects(report.errorClass,
+                          payload[@"exceptions"][0][@"errorClass"]);
+    XCTAssertEqualObjects(report.errorMessage,
+                          payload[@"exceptions"][0][@"message"]);
+}
+
+- (void)testEnhancedErrorMessageForAssertionError {
+    for (NSString *assertionName in @[
+             @"assertion failed", @"Assertion failed", @"fatal error",
+             @"Fatal error"
+         ]) {
+        BugsnagCrashReport *report =
+            [[BugsnagCrashReport alloc] initWithKSReport:@{
+                @"crash" : @{
+                    @"threads" : @[ @{
+                        @"crashed" : @YES,
+                        @"notable_addresses" : @{
+                            @"x9" : @{
+                                @"address" : @4511086448,
+                                @"type" : @"string",
+                                @"value" : @"Something went wrong"
+                            },
+                            @"r16" : @{
+                                @"address" : @4511089532,
+                                @"type" : @"string",
+                                @"value" : assertionName
+                            }
+                        }
+                    } ]
+                }
+            }];
+        NSDictionary *payload = [report toJson];
+        XCTAssertEqualObjects(assertionName,
+                              payload[@"exceptions"][0][@"errorClass"]);
+        XCTAssertEqualObjects(@"Something went wrong",
+                              payload[@"exceptions"][0][@"message"]);
+        XCTAssertEqualObjects(report.errorClass,
+                              payload[@"exceptions"][0][@"errorClass"]);
+        XCTAssertEqualObjects(report.errorMessage,
+                              payload[@"exceptions"][0][@"message"]);
     }
-    
-    // returns msg for "fatal error" with additional dict present
-    addresses[@"r12"] = @{
-                          @"address": @4511086448,
-                          @"type": @"string",
-                          @"value": @"Whoops - fatalerror"
-                          };
-    XCTAssertEqualObjects(@"Whoops - fatalerror", [errorReport enhancedErrorMessageForThread:thread]);
-    
-    
-    // ignores additional dict if more than 2 "/" present
-    addresses[@"r24"] = @{
-                          @"address": @4511084983,
-                          @"type": @"string",
-                          @"value": @"/usr/include/lib/something.swift"
-                          };
-    XCTAssertEqualObjects(@"Whoops - fatalerror", [errorReport enhancedErrorMessageForThread:thread]);
-    
-    // ignores dict if not type string
-    addresses[@"r25"] = @{
-                          @"address": @4511084983,
-                          @"type": @"long",
-                          @"value": @"Swift is hard"
-                          };
-    XCTAssertEqualObjects(@"Whoops - fatalerror", [errorReport enhancedErrorMessageForThread:thread]);
-    
-    // sorts and concatenates multiple multiple messages
-    addresses[@"r26"] = @{
-                          @"address": @4511082095,
-                          @"type": @"string",
-                          @"value": @"Swift is hard"
-                          };
-    XCTAssertEqualObjects(@"Swift is hard | Whoops - fatalerror", [errorReport enhancedErrorMessageForThread:thread]);
-    
-    // ignores stack frames
-    addresses[@"stack523409"] = @{
-                                  @"address": @4511080001,
-                                  @"type": @"string",
-                                  @"value": @"Not a register"
-                                  };
-    XCTAssertEqualObjects(@"Swift is hard | Whoops - fatalerror", [errorReport enhancedErrorMessageForThread:thread]);
-    
-    // ignores values if no reserved word used
-    addresses[@"r14"] = nil;
-    XCTAssertNil([errorReport enhancedErrorMessageForThread:thread]);
+}
+
+- (void)testEnhancedErrorMessageIgnoresFilePaths {
+    BugsnagCrashReport *report = [[BugsnagCrashReport alloc] initWithKSReport:@{
+        @"crash" : @{
+            @"threads" : @[ @{
+                @"crashed" : @YES,
+                @"notable_addresses" : @{
+                    @"x9" : @{
+                        @"address" : @4511086448,
+                        @"type" : @"string",
+                        @"value" : @"/usr/include/lib/something.swift"
+                    },
+                    @"r16" : @{
+                        @"address" : @4511089532,
+                        @"type" : @"string",
+                        @"value" : @"fatal error"
+                    }
+                }
+            } ]
+        }
+    }];
+    NSDictionary *payload = [report toJson];
+    XCTAssertEqualObjects(@"fatal error",
+                          payload[@"exceptions"][0][@"errorClass"]);
+    XCTAssertEqualObjects(@"", payload[@"exceptions"][0][@"message"]);
+    XCTAssertEqualObjects(report.errorClass,
+                          payload[@"exceptions"][0][@"errorClass"]);
+    XCTAssertEqualObjects(report.errorMessage,
+                          payload[@"exceptions"][0][@"message"]);
+}
+
+- (void)testEnhancedErrorMessageIgnoresStackFrames {
+    BugsnagCrashReport *report = [[BugsnagCrashReport alloc] initWithKSReport:@{
+        @"crash" : @{
+            @"threads" : @[ @{
+                @"crashed" : @YES,
+                @"notable_addresses" : @{
+                    @"stack@2342387" : @{
+                        @"address" : @4511086448,
+                        @"type" : @"string",
+                        @"value" : @"some nonsense"
+                    },
+                    @"r16" : @{
+                        @"address" : @4511089532,
+                        @"type" : @"string",
+                        @"value" : @"fatal error"
+                    }
+                }
+            } ]
+        }
+    }];
+    NSDictionary *payload = [report toJson];
+    XCTAssertEqualObjects(@"fatal error",
+                          payload[@"exceptions"][0][@"errorClass"]);
+    XCTAssertEqualObjects(@"", payload[@"exceptions"][0][@"message"]);
+    XCTAssertEqualObjects(report.errorClass,
+                          payload[@"exceptions"][0][@"errorClass"]);
+    XCTAssertEqualObjects(report.errorMessage,
+                          payload[@"exceptions"][0][@"message"]);
+}
+
+- (void)testEnhancedErrorMessageIgnoresNonStrings {
+    BugsnagCrashReport *report = [[BugsnagCrashReport alloc] initWithKSReport:@{
+        @"crash" : @{
+            @"threads" : @[ @{
+                @"crashed" : @YES,
+                @"notable_addresses" : @{
+                    @"x9" : @{
+                        @"address" : @4511086448,
+                        @"type" : @"long",
+                        @"value" : @"A message from beyond"
+                    },
+                    @"r16" : @{
+                        @"address" : @4511089532,
+                        @"type" : @"string",
+                        @"value" : @"fatal error"
+                    }
+                }
+            } ]
+        }
+    }];
+    NSDictionary *payload = [report toJson];
+    XCTAssertEqualObjects(@"fatal error",
+                          payload[@"exceptions"][0][@"errorClass"]);
+    XCTAssertEqualObjects(@"", payload[@"exceptions"][0][@"message"]);
+    XCTAssertEqualObjects(report.errorClass,
+                          payload[@"exceptions"][0][@"errorClass"]);
+    XCTAssertEqualObjects(report.errorMessage,
+                          payload[@"exceptions"][0][@"message"]);
+}
+
+- (void)testEnhancedErrorMessageConcatenatesMultipleMessages {
+    BugsnagCrashReport *report = [[BugsnagCrashReport alloc] initWithKSReport:@{
+        @"crash" : @{
+            @"threads" : @[ @{
+                @"crashed" : @YES,
+                @"notable_addresses" : @{
+                    @"x9" : @{
+                        @"address" : @4511086448,
+                        @"type" : @"string",
+                        @"value" : @"A message from beyond"
+                    },
+                    @"r14" : @{
+                        @"address" : @4511086448,
+                        @"type" : @"string",
+                        @"value" : @"Wo0o0o"
+                    },
+                    @"r16" : @{
+                        @"address" : @4511089532,
+                        @"type" : @"string",
+                        @"value" : @"Fatal error"
+                    }
+                }
+            } ]
+        }
+    }];
+    NSDictionary *payload = [report toJson];
+    XCTAssertEqualObjects(@"Fatal error",
+                          payload[@"exceptions"][0][@"errorClass"]);
+    XCTAssertEqualObjects(@"A message from beyond | Wo0o0o",
+                          payload[@"exceptions"][0][@"message"]);
+    XCTAssertEqualObjects(report.errorClass,
+                          payload[@"exceptions"][0][@"errorClass"]);
+    XCTAssertEqualObjects(report.errorMessage,
+                          payload[@"exceptions"][0][@"message"]);
+}
+
+- (void)testEnhancedErrorMessageIgnoresUnknownAssertionTypes {
+    BugsnagCrashReport *report = [[BugsnagCrashReport alloc] initWithKSReport:@{
+        @"crash" : @{
+            @"threads" : @[ @{
+                @"crashed" : @YES,
+                @"notable_addresses" : @{
+                    @"x9" : @{
+                        @"address" : @4511086448,
+                        @"type" : @"string",
+                        @"value" : @"A message from beyond"
+                    },
+                    @"r14" : @{
+                        @"address" : @4511086448,
+                        @"type" : @"string",
+                        @"value" : @"Wo0o0o"
+                    }
+                }
+            } ]
+        }
+    }];
+    NSDictionary *payload = [report toJson];
+    XCTAssertEqualObjects(@"Exception",
+                          payload[@"exceptions"][0][@"errorClass"]);
+    XCTAssertEqualObjects(@"", payload[@"exceptions"][0][@"message"]);
+    XCTAssertEqualObjects(report.errorClass,
+                          payload[@"exceptions"][0][@"errorClass"]);
+    XCTAssertEqualObjects(report.errorMessage,
+                          payload[@"exceptions"][0][@"message"]);
 }
 
 @end

--- a/tvOS/Bugsnag.xcodeproj/project.pbxproj
+++ b/tvOS/Bugsnag.xcodeproj/project.pbxproj
@@ -13,8 +13,8 @@
 		8AB151171D41356800C9B218 /* Bugsnag.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = 8A8D51241D41343500D33797 /* Bugsnag.framework */; };
 		8AB151211D41361700C9B218 /* BugsnagBreadcrumbsTest.m in Sources */ = {isa = PBXBuildFile; fileRef = 8AB1511D1D41361700C9B218 /* BugsnagBreadcrumbsTest.m */; };
 		8AB151221D41361700C9B218 /* BugsnagCrashReportTests.m in Sources */ = {isa = PBXBuildFile; fileRef = 8AB1511E1D41361700C9B218 /* BugsnagCrashReportTests.m */; };
-		8AB151231D41361700C9B218 /* BugsnagSinkTests.m in Sources */ = {isa = PBXBuildFile; fileRef = 8AB1511F1D41361700C9B218 /* BugsnagSinkTests.m */; };
 		8AB151241D41361700C9B218 /* report.json in Resources */ = {isa = PBXBuildFile; fileRef = 8AB151201D41361700C9B218 /* report.json */; };
+		8ACF0F74201812AD00173809 /* BugsnagSinkTests.m in Sources */ = {isa = PBXBuildFile; fileRef = 8AB1511F1D41361700C9B218 /* BugsnagSinkTests.m */; };
 		8AD9A4F51D42EE87004E1CC5 /* Bugsnag.h in Headers */ = {isa = PBXBuildFile; fileRef = 8AB151261D41366400C9B218 /* Bugsnag.h */; settings = {ATTRIBUTES = (Public, ); }; };
 		8AD9A4F61D42EE8E004E1CC5 /* BugsnagBreadcrumb.h in Headers */ = {isa = PBXBuildFile; fileRef = 8AB151281D41366400C9B218 /* BugsnagBreadcrumb.h */; settings = {ATTRIBUTES = (Public, ); }; };
 		8AD9A4F71D42EE90004E1CC5 /* BugsnagCollections.h in Headers */ = {isa = PBXBuildFile; fileRef = 8AB1512A1D41366400C9B218 /* BugsnagCollections.h */; };
@@ -927,6 +927,7 @@
 			isa = PBXSourcesBuildPhase;
 			buildActionMask = 2147483647;
 			files = (
+				8ACF0F74201812AD00173809 /* BugsnagSinkTests.m in Sources */,
 				E7CE78F21FD94F1B001D07E0 /* KSMach_Tests.m in Sources */,
 				E7CE79071FD94F1B001D07E0 /* KSSysCtl_Tests.m in Sources */,
 				E7CE78F71FD94F1B001D07E0 /* KSCrashSentry_Signal_Tests.m in Sources */,
@@ -938,11 +939,9 @@
 				E7CE78F31FD94F1B001D07E0 /* NSError+SimpleConstructor_Tests.m in Sources */,
 				E7CE79001FD94F1B001D07E0 /* KSJSONCodec_Tests.m in Sources */,
 				E7CE79051FD94F1B001D07E0 /* KSDynamicLinker_Tests.m in Sources */,
-				8AB151231D41361700C9B218 /* BugsnagSinkTests.m in Sources */,
 				E7CE78F61FD94F1B001D07E0 /* FileBasedTestCase.m in Sources */,
 				E7CE79031FD94F1B001D07E0 /* KSCrashReportConverter_Tests.m in Sources */,
 				E79148911FD82E77003EFEBF /* BugsnagUserTest.m in Sources */,
-				8AB151231D41361700C9B218 /* BugsnagSinkTests.m in Sources */,
 				E791488E1FD82E77003EFEBF /* BugsnagSessionTrackerTest.m in Sources */,
 				E79148901FD82E77003EFEBF /* BugsnagSessionTest.m in Sources */,
 				8AB151211D41361700C9B218 /* BugsnagBreadcrumbsTest.m in Sources */,


### PR DESCRIPTION
The register parser handling made assumptions about there always being a CPU arch match for the registry being parsed. These changes:

* Handle unknown architectures gracefully
* Add support for missing architectures (x64 by @paulz)
* Fix support for arm64 (register names were incorrect)
* Fix detection of Swift assertions (message contents changed in Swift 4)
* Improve formatting of Swift assertion messages to indicate the assertion type in the error class 