### PR TITLE
Enable oclint

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -19,3 +19,5 @@ DerivedData
 Pods
 Carthage
 *.idea
+compile_commands.json
+

--- a/.oclint
+++ b/.oclint
@@ -1,0 +1,18 @@
+rule-configurations:
+  - key: LONG_VARIABLE_NAME
+    value: 100
+  - key: SHORT_VARIABLE_NAME
+    value: 1
+  - key: LONG_METHOD
+    value: 300
+  - key: NCSS_METHOD
+    value: 300
+  - key: NPATH_COMPLEXITY
+    value: 9000
+  - key: LONG_LINE
+    value: 300
+  - key: CYCLOMATIC_COMPLEXITY
+    value: 300
+max-priority-1: 0
+max-priority-2: 9000
+max-priority-3: 9000

--- a/Gemfile
+++ b/Gemfile
@@ -1,0 +1,3 @@
+source 'https://rubygems.org'
+
+gem 'xcpretty'

--- a/Makefile
+++ b/Makefile
@@ -1,5 +1,5 @@
 ifeq ($(SDK),)
- SDK=iphonesimulator10.3
+ SDK=iphonesimulator11.2
 endif
 ifeq ($(BUILD_OSX), 1)
  PLATFORM=OSX
@@ -70,5 +70,12 @@ clean:
 
 test:
 	@$(XCODEBUILD) $(BUILD_FLAGS) $(BUILD_ONLY_FLAGS) test $(FORMATTER)
+
+lint:
+	@$(XCODEBUILD) $(BUILD_FLAGS) $(BUILD_ONLY_FLAGS) \
+    	COMPILER_INDEX_STORE_ENABLE=NO | \
+		tee xcodebuild.log | \
+		xcpretty -r json-compilation-database -o compile_commands.json
+	@oclint-json-compilation-database
 
 archive: build/Bugsnag-$(PLATFORM)-$(PRESET_VERSION).zip

--- a/buddybuild_postclone.sh
+++ b/buddybuild_postclone.sh
@@ -1,0 +1,6 @@
+bundle install
+brew cask install oclint
+xcodebuild -project iOS/Bugsnag.xcodeproj -scheme Bugsnag \
+    COMPILER_INDEX_STORE_ENABLE=NO | tee xcodebuild.log | xcpretty -r json-compilation-database -o compile_commands.json
+# Running analysis
+oclint-json-compilation-database


### PR DESCRIPTION
Enables OCLint on the iOS project, with the current baseline number of warnings.