### PR TITLE
match variable length of 3+

### DIFF
--- a/Source/BugsnagFileStore.m
+++ b/Source/BugsnagFileStore.m
@@ -86,8 +86,8 @@
 
 - (NSArray *)fileIds {
     NSError *error = nil;
-    NSFileManager *fm = [NSFileManager defaultManager];
-    NSArray *filenames = [fm contentsOfDirectoryAtPath:self.path error:&error];
+    NSFileManager *fileManager = [NSFileManager defaultManager];
+    NSArray *filenames = [fileManager contentsOfDirectoryAtPath:self.path error:&error];
     if (filenames == nil) {
         BSG_KSLOG_ERROR(@"Could not get contents of directory %@: %@",
                 self.path, error);
@@ -102,7 +102,7 @@
             NSString *fullPath =
                     [self.path stringByAppendingPathComponent:filename];
             NSDictionary *fileAttribs =
-                    [fm attributesOfItemAtPath:fullPath error:&error];
+                    [fileManager attributesOfItemAtPath:fullPath error:&error];
             if (fileAttribs == nil) {
                 BSG_KSLOG_ERROR(@"Could not read file attributes for %@: %@",
                         fullPath, error);
@@ -216,10 +216,10 @@
 
 + (BOOL)ensureDirectoryExists:(NSString *)path {
     NSError *error = nil;
-    NSFileManager *fm = [NSFileManager defaultManager];
+    NSFileManager *fileManager = [NSFileManager defaultManager];
 
-    if (![fm fileExistsAtPath:path]) {
-        if (![fm createDirectoryAtPath:path
+    if (![fileManager fileExistsAtPath:path]) {
+        if (![fileManager createDirectoryAtPath:path
            withIntermediateDirectories:YES
                             attributes:nil
                                  error:&error]) {

--- a/Source/KSCrash/Source/KSCrash/Recording/BSG_KSCrashState.c
+++ b/Source/KSCrash/Source/KSCrash/Recording/BSG_KSCrashState.c
@@ -150,8 +150,8 @@ int bsg_kscrashstate_i_onEndData(__unused void *const userData) {
  */
 int bsg_kscrashstate_i_addJSONData(const char *const data, const size_t length,
                                    void *const userData) {
-    const int fd = *((int *)userData);
-    const bool success = bsg_ksfuwriteBytesToFD(fd, data, (ssize_t)length);
+    const int fileDescriptor = *((int *)userData);
+    const bool success = bsg_ksfuwriteBytesToFD(fileDescriptor, data, (ssize_t)length);
     return success ? BSG_KSJSON_OK : BSG_KSJSON_ERROR_CANNOT_ADD_DATA;
 }
 

--- a/Source/KSCrash/Source/KSCrash/Recording/Tools/BSG_KSBacktrace.c
+++ b/Source/KSCrash/Source/KSCrash/Recording/Tools/BSG_KSBacktrace.c
@@ -128,16 +128,16 @@ int bsg_ksbt_backtraceThreadState(
         return 0;
     }
 
-    int i = 0;
+    int entryIndex = 0;
 
     if (skipEntries == 0) {
         const uintptr_t instructionAddress =
             bsg_ksmachinstructionAddress(machineContext);
-        backtraceBuffer[i] = instructionAddress;
-        i++;
+        backtraceBuffer[entryIndex] = instructionAddress;
+        entryIndex++;
 
-        if (i == maxEntries) {
-            return i;
+        if (entryIndex == maxEntries) {
+            return entryIndex;
         }
     }
 
@@ -145,11 +145,11 @@ int bsg_ksbt_backtraceThreadState(
         uintptr_t linkRegister = bsg_ksmachlinkRegister(machineContext);
 
         if (linkRegister) {
-            backtraceBuffer[i] = linkRegister;
-            i++;
+            backtraceBuffer[entryIndex] = linkRegister;
+            entryIndex++;
 
-            if (i == maxEntries) {
-                return i;
+            if (entryIndex == maxEntries) {
+                return entryIndex;
             }
         }
     }
@@ -169,15 +169,15 @@ int bsg_ksbt_backtraceThreadState(
         }
     }
 
-    for (; i < maxEntries; i++) {
-        backtraceBuffer[i] = frame.return_address;
-        if (backtraceBuffer[i] == 0 || frame.previous == 0 ||
+    for (; entryIndex < maxEntries; entryIndex++) {
+        backtraceBuffer[entryIndex] = frame.return_address;
+        if (backtraceBuffer[entryIndex] == 0 || frame.previous == 0 ||
             bsg_ksmachcopyMem(frame.previous, &frame, sizeof(frame)) !=
                 KERN_SUCCESS) {
             break;
         }
     }
-    return i;
+    return entryIndex;
 }
 
 int bsg_ksbt_backtraceThread(const thread_t thread,
@@ -212,15 +212,15 @@ int bsg_ksbt_backtraceSelf(uintptr_t *const backtraceBuffer,
 void bsg_ksbt_symbolicate(const uintptr_t *const backtraceBuffer,
                           Dl_info *const symbolsBuffer, const int numEntries,
                           const int skippedEntries) {
-    int i = 0;
+    int entryIndex = 0;
 
-    if (!skippedEntries && i < numEntries) {
-        bsg_ksdldladdr(backtraceBuffer[i], &symbolsBuffer[i]);
-        i++;
+    if (!skippedEntries && entryIndex < numEntries) {
+        bsg_ksdldladdr(backtraceBuffer[entryIndex], &symbolsBuffer[entryIndex]);
+        entryIndex++;
     }
 
-    for (; i < numEntries; i++) {
-        bsg_ksdldladdr(CALL_INSTRUCTION_FROM_RETURN_ADDRESS(backtraceBuffer[i]),
-                       &symbolsBuffer[i]);
+    for (; entryIndex < numEntries; entryIndex++) {
+        bsg_ksdldladdr(CALL_INSTRUCTION_FROM_RETURN_ADDRESS(backtraceBuffer[entryIndex]),
+                       &symbolsBuffer[entryIndex]);
     }
 }

--- a/Source/KSCrash/Source/KSCrash/Recording/Tools/BSG_KSLogger.m
+++ b/Source/KSCrash/Source/KSCrash/Recording/Tools/BSG_KSLogger.m
@@ -121,12 +121,12 @@ static inline void flushLog(void) {
     // Nothing to do.
 }
 
-static inline void setLogFD(int fd) {
+static inline void setLogFD(int fileDescriptor) {
     if (bsg_g_fd >= 0 && bsg_g_fd != STDOUT_FILENO &&
         bsg_g_fd != STDERR_FILENO && bsg_g_fd != STDIN_FILENO) {
         close(bsg_g_fd);
     }
-    bsg_g_fd = fd;
+    bsg_g_fd = fileDescriptor;
 }
 
 bool bsg_kslog_setLogFilename(const char *filename, bool overwrite) {

--- a/Source/KSCrash/Source/KSCrash/Recording/Tools/BSG_KSMach.c
+++ b/Source/KSCrash/Source/KSCrash/Recording/Tools/BSG_KSMach.c
@@ -178,14 +178,14 @@ bool bsg_ksmachfillState(const thread_t thread, const thread_state_t state,
 void bsg_ksmach_init(void) {
     static volatile sig_atomic_t initialized = 0;
     if (!initialized) {
-        kern_return_t kr;
+        kern_return_t kernelReturn;
         const task_t thisTask = mach_task_self();
         thread_act_array_t threads;
         mach_msg_type_number_t numThreads;
 
-        if ((kr = task_threads(thisTask, &threads, &numThreads)) !=
+        if ((kernelReturn = task_threads(thisTask, &threads, &numThreads)) !=
             KERN_SUCCESS) {
-            BSG_KSLOG_ERROR("task_threads: %s", mach_error_string(kr));
+            BSG_KSLOG_ERROR("task_threads: %s", mach_error_string(kernelReturn));
             return;
         }
 
@@ -452,9 +452,9 @@ double bsg_ksmachtimeDifferenceInSeconds(const uint64_t endTime,
 
     if (conversion == 0) {
         mach_timebase_info_data_t info = {0};
-        kern_return_t kr = mach_timebase_info(&info);
-        if (kr != KERN_SUCCESS) {
-            BSG_KSLOG_ERROR("mach_timebase_info: %s", mach_error_string(kr));
+        kern_return_t kernelReturn = mach_timebase_info(&info);
+        if (kernelReturn != KERN_SUCCESS) {
+            BSG_KSLOG_ERROR("mach_timebase_info: %s", mach_error_string(kernelReturn));
             return 0;
         }
 

--- a/Source/KSCrash/Source/KSCrash/Recording/Tools/BSG_KSObjC.c
+++ b/Source/KSCrash/Source/KSCrash/Recording/Tools/BSG_KSObjC.c
@@ -279,8 +279,8 @@ static inline bool isRootClass(const void *const classPtr) {
 }
 
 static inline const char *getClassName(const void *classPtr) {
-    const struct class_ro_t *ro = getClassRO(classPtr);
-    return ro->name;
+    const struct class_ro_t *classRo = getClassRO(classPtr);
+    return classRo->name;
 }
 
 /** Check if a tagged pointer is a number.
@@ -518,24 +518,24 @@ static bool isValidIvarType(const char *const type) {
 
 static bool containsValidROData(const void *const classPtr) {
     struct class_t class;
-    struct class_rw_t rw;
-    struct class_ro_t ro;
+    struct class_rw_t classRw;
+    struct class_ro_t classRo;
     if (bsg_ksmachcopyMem(classPtr, &class, sizeof(class)) != KERN_SUCCESS) {
         return false;
     }
-    if (bsg_ksmachcopyMem(getClassRW(&class), &rw, sizeof(rw)) !=
+    if (bsg_ksmachcopyMem(getClassRW(&class), &classRw, sizeof(classRw)) !=
         KERN_SUCCESS) {
         return false;
     }
-    if (bsg_ksmachcopyMem(rw.ro, &ro, sizeof(ro)) != KERN_SUCCESS) {
+    if (bsg_ksmachcopyMem(classRw.ro, &classRo, sizeof(classRo)) != KERN_SUCCESS) {
         return false;
     }
     return true;
 }
 
 static bool containsValidIvarData(const void *const classPtr) {
-    const struct class_ro_t *ro = getClassRO(classPtr);
-    const struct ivar_list_t *ivars = ro->ivars;
+    const struct class_ro_t *classRo = getClassRO(classPtr);
+    const struct ivar_list_t *ivars = classRo->ivars;
     if (ivars == NULL) {
         return true;
     }
@@ -572,8 +572,8 @@ static bool containsValidIvarData(const void *const classPtr) {
 }
 
 static bool containsValidClassName(const void *const classPtr) {
-    const struct class_ro_t *ro = getClassRO(classPtr);
-    return isValidName(ro->name, kMaxNameLength);
+    const struct class_ro_t *classRo = getClassRO(classPtr);
+    return isValidName(classRo->name, kMaxNameLength);
 }
 
 //======================================================================


### PR DESCRIPTION
Renames variables whose length is less than 3, as per OCLint rules