### PR TITLE
Detect whether running in simulator

### DIFF
--- a/Source/BugsnagKSCrashSysInfoParser.m
+++ b/Source/BugsnagKSCrashSysInfoParser.m
@@ -49,6 +49,13 @@ NSDictionary *BSGParseDevice(NSDictionary *report) {
     NSNumber *freeBytes = [fileSystemAttrs objectForKey:NSFileSystemFreeSize];
     BSGDictSetSafeObject(device, freeBytes, @"freeDisk");
     BSGDictSetSafeObject(device, report[@"system"][@"device_app_hash"], @"id");
+
+#if TARGET_OS_SIMULATOR
+    BSGDictSetSafeObject(device, @YES, @"simulator");
+#elif TARGET_OS_IPHONE || TARGET_OS_TV
+    BSGDictSetSafeObject(device, @NO, @"simulator");
+#endif
+
     return device;
 }
 

--- a/Tests/BugsnagSinkTests.m
+++ b/Tests/BugsnagSinkTests.m
@@ -256,8 +256,12 @@
     NSDictionary *event = [self.processedData[@"events"] firstObject];
     NSDictionary *device = event[@"device"];
     XCTAssertNotNil(device);
-    XCTAssertEqual(16, device.count); // includes some legacy metadata 
-    
+#if TARGET_OS_IPHONE || TARGET_OS_TV || TARGET_IPHONE_SIMULATOR
+    XCTAssertEqual(17, device.count);
+#else
+    XCTAssertEqual(16, device.count);
+#endif
+
     XCTAssertEqualObjects(device[@"id"], @"f6d519a74213a57f8d052c53febfeee6f856d062");
     XCTAssertEqualObjects(device[@"manufacturer"], @"Apple");
     XCTAssertEqualObjects(device[@"model"], @"x86_64");


### PR DESCRIPTION
Detects whether an app is running in a simulator or not, and adds to the Device tab if appropriate.