### PR TITLE
Always write error info when thread tracing disabled

### DIFF
--- a/Source/KSCrash/Source/KSCrash/Recording/BSG_KSCrashReport.c
+++ b/Source/KSCrash/Source/KSCrash/Recording/BSG_KSCrashReport.c
@@ -2084,9 +2084,9 @@ void bsg_kscrashreport_writeStandardReport(
                     crashContext->config.introspectionRules.enabled,
                     crashContext->config.searchThreadNames,
                     crashContext->config.searchQueueNames);
-                bsg_kscrw_i_writeError(writer, BSG_KSCrashField_Error,
-                                       &crashContext->crash);
             }
+            bsg_kscrw_i_writeError(writer, BSG_KSCrashField_Error,
+                    &crashContext->crash);
         }
         writer->endContainer(writer);
 


### PR DESCRIPTION
This improves the error messages displayed for Unity.