### PR TITLE
Add timezone to device payload

### DIFF
--- a/Source/BugsnagKSCrashSysInfoParser.m
+++ b/Source/BugsnagKSCrashSysInfoParser.m
@@ -24,7 +24,7 @@ NSDictionary *BSGParseDevice(NSDictionary *report) {
     BSGDictSetSafeObject(device, [[NSLocale currentLocale] localeIdentifier],
                          @"locale");
     
-    BSGDictSetSafeObject(device, report[@"time_zone"], @"timezone");
+    BSGDictSetSafeObject(device, [report valueForKeyPath:@"system.time_zone"], @"timezone");
     BSGDictSetSafeObject(device, [report valueForKeyPath:@"system.memory.usable"],
                          @"totalMemory");
     

--- a/Tests/BugsnagSinkTests.m
+++ b/Tests/BugsnagSinkTests.m
@@ -270,6 +270,7 @@
     XCTAssertEqualObjects(device[@"osVersion"], @"8.1");
     XCTAssertEqualObjects(device[@"totalMemory"], @15065522176);
     XCTAssertNotNil(device[@"freeDisk"]);
+    XCTAssertEqualObjects(device[@"timezone"], @"PST");
     XCTAssertEqualObjects(device[@"jailbroken"], @YES);
     XCTAssertEqualObjects(device[@"freeMemory"], @742920192);
     XCTAssertEqualObjects(device[@"orientation"], @"unknown");

--- a/examples/swift-ios/Podfile.lock
+++ b/examples/swift-ios/Podfile.lock
@@ -1,5 +1,5 @@
 PODS:
-  - Bugsnag (5.15.3)
+  - Bugsnag (5.15.4)
 
 DEPENDENCIES:
   - Bugsnag (from `../..`)
@@ -9,7 +9,7 @@ EXTERNAL SOURCES:
     :path: ../..
 
 SPEC CHECKSUMS:
-  Bugsnag: 49464c6c2fb7a2eb5a66064586c64a6e23454c04
+  Bugsnag: 904211a0230f254808b47f3adb4b684900772962
 
 PODFILE CHECKSUM: 2107babfbfdb18f0288407b9d9ebd48cbee8661c
 


### PR DESCRIPTION
The timezone was being serialised from the wrong keyPath when mapping the KSCrash report to the Bugsnag crash report.