### PR TITLE
Update Travis CI matrix

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,14 +1,14 @@
 language: objective-c
 matrix:
     include:
-        - osx_image: xcode7.3
-          env: SDK=macosx10.11 BUILD_OSX=1
-        - osx_image: xcode7.3
-          env: SDK=iphonesimulator9.3
-        - osx_image: xcode8.2
-          env: SDK=iphonesimulator10.2
-        - osx_image: xcode8.2
-          env: SDK=appletvsimulator10.1 BUILD_TV=1
+        - osx_image: xcode8.3
+          env: SDK=macosx10.12 BUILD_OSX=1
+        - osx_image: xcode8.3
+          env: SDK=iphonesimulator10.3
+        - osx_image: xcode9.2
+          env: SDK=iphonesimulator11.2
+        - osx_image: xcode9.2
+          env: SDK=appletvsimulator11.2 BUILD_TV=1
 install: make bootstrap
 script: make test
 

--- a/.travis.yml
+++ b/.travis.yml
@@ -8,7 +8,7 @@ matrix:
         - osx_image: xcode9.2
           env: SDK=iphonesimulator11.2
         - osx_image: xcode9.2
-          env: SDK=appletvsimulator11.2 BUILD_TV=1
+          env: BUILD_TV=1
 install: make bootstrap
 script: make test
 

--- a/.travis.yml
+++ b/.travis.yml
@@ -8,7 +8,7 @@ matrix:
         - osx_image: xcode9.2
           env: SDK=iphonesimulator11.2
         - osx_image: xcode9.2
-          env: BUILD_TV=1
+          env: SDK=appletvsimulator11.2 BUILD_TV=1
 install: make bootstrap
 script: make test
 

--- a/Makefile
+++ b/Makefile
@@ -10,7 +10,7 @@ else
  ifeq ($(BUILD_TV), 1)
   PLATFORM=tvOS
   BUILD_FLAGS=-workspace tvOS.xcworkspace -scheme Bugsnag
-  BUILD_ONLY_FLAGS=-sdk $(SDK) -configuration Debug -destination "platform=tvOS Simulator,name=Apple TV 1080p"
+  BUILD_ONLY_FLAGS=-sdk $(SDK) -configuration Debug -destination "platform=tvOS Simulator,name=Apple TV"
  else
   PLATFORM=iOS
   RELEASE_DIR=Release-iphoneos


### PR DESCRIPTION
Updates to more modern test matrix, as the XCode 8.2 image has been retired, and most users will be on XCode 8/9.