### PR TITLE
Downgrade travis ruby version to 2.3.7

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -3,7 +3,7 @@ cache: bundler
 rvm: 2.4.1
 matrix:
     include:
-        - osx_image: xcode7.3
+        - osx_image: xcode8.3
           env: SDK=iphonesimulator9.3
           script: make test
         - osx_image: xcode8.3

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,9 +1,9 @@
 language: objective-c
 cache: bundler
-rvm: 2.4.1
+rvm: 2.3.7
 matrix:
     include:
-        - osx_image: xcode8.3
+        - osx_image: xcode7.3
           env: SDK=iphonesimulator9.3
           script: make test
         - osx_image: xcode8.3


### PR DESCRIPTION
2.4.1 is incorrectly configured on the Travis OSX 10.11 image, see https://github.com/travis-ci/travis-ci/issues/7848