### PR TITLE
[WIP] Wait for simulator at start of scenarios

### DIFF
--- a/features/support/env.rb
+++ b/features/support/env.rb
@@ -12,6 +12,7 @@ Dir.chdir('features/fixtures/ios-swift-cocoapods') do
     ['bundle', 'exec', 'pod', 'install'],
     ['../../scripts/build_ios_app.sh'],
     ['../../scripts/launch_ios_simulators.sh'],
+    ['sleep', '15']
   ])
 end
 


### PR DESCRIPTION
Adding a wait for the simulator to finish launching appears to have helped pass scenarios locally. Without this change, the first scenario in a run tends to fail with 0 requests sent.

This value may tweaking depending on the speed of Travis CI.