### PR TITLE
Stop pretty printing json

### DIFF
--- a/Source/BugsnagApiClient.m
+++ b/Source/BugsnagApiClient.m
@@ -59,7 +59,7 @@
         NSError *error = nil;
         NSData *jsonData =
                 [NSJSONSerialization dataWithJSONObject:payload
-                                                options:NSJSONWritingPrettyPrinted
+                                                options:0
                                                   error:&error];
 
         if (jsonData == nil) {


### PR DESCRIPTION
Pretty printing json makes requests easier to read, but increases their size due to extra whitespace. This change stops pretty printing, Which reduces the request size of a sample notify request from 22kb to 16kb, a saving of around 25% of mobile data previously used.