### PR TITLE
Enforce requiring API key to initialise notifier

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,10 @@
 Changelog
 =========
 
+## 5.X.X (TBD)
+
+* Enforce requiring API key to initialise notifier [#280](https://github.com/bugsnag/bugsnag-cocoa/pull/280)
+
 ## 5.15.5 (25 Apr 2018)
 
 ### Bug Fixes

--- a/Source/Bugsnag.m
+++ b/Source/Bugsnag.m
@@ -177,7 +177,7 @@ static BugsnagNotifier *bsg_g_bugsnag_notifier = NULL;
 }
 
 + (BOOL)bugsnagStarted {
-    if (self.notifier == nil) {
+    if (!self.notifier.started) {
         bsg_log_err(@"Ensure you have started Bugsnag with startWithApiKey: "
                     @"before calling any other Bugsnag functions.");
 

--- a/Source/Bugsnag.m
+++ b/Source/Bugsnag.m
@@ -51,9 +51,13 @@ static BugsnagNotifier *bsg_g_bugsnag_notifier = NULL;
 
 + (void)startBugsnagWithConfiguration:(BugsnagConfiguration *)configuration {
     @synchronized(self) {
-        bsg_g_bugsnag_notifier =
-        [[BugsnagNotifier alloc] initWithConfiguration:configuration];
-        [bsg_g_bugsnag_notifier start];
+        if (configuration != nil && configuration.apiKey != nil) {
+            bsg_g_bugsnag_notifier =
+                    [[BugsnagNotifier alloc] initWithConfiguration:configuration];
+            [bsg_g_bugsnag_notifier start];
+        } else {
+            bsg_log_err(@"Bugsnag not initialized - a valid API key must be supplied.");
+        }
     }
 }
 
@@ -73,75 +77,87 @@ static BugsnagNotifier *bsg_g_bugsnag_notifier = NULL;
 }
 
 + (void)notify:(NSException *)exception {
-    [self.notifier notifyException:exception
-                             block:^(BugsnagCrashReport *_Nonnull report) {
-                               report.depth += 2;
-                             }];
+    if ([self bugsnagStarted]) {
+        [self.notifier notifyException:exception
+                                 block:^(BugsnagCrashReport *_Nonnull report) {
+                                     report.depth += 2;
+                                 }];
+    }
 }
 
 + (void)notify:(NSException *)exception block:(BugsnagNotifyBlock)block {
-    [[self notifier] notifyException:exception
-                               block:^(BugsnagCrashReport *_Nonnull report) {
-                                 report.depth += 2;
+    if ([self bugsnagStarted]) {
+        [[self notifier] notifyException:exception
+                                   block:^(BugsnagCrashReport *_Nonnull report) {
+                                       report.depth += 2;
 
-                                 if (block) {
-                                     block(report);
-                                 }
-                               }];
+                                       if (block) {
+                                           block(report);
+                                       }
+                                   }];
+    }
 }
 
 + (void)notifyError:(NSError *)error {
-    [self.notifier notifyError:error
-                         block:^(BugsnagCrashReport *_Nonnull report) {
-                           report.depth += 2;
-                         }];
+    if ([self bugsnagStarted]) {
+        [self.notifier notifyError:error
+                             block:^(BugsnagCrashReport *_Nonnull report) {
+                                 report.depth += 2;
+                             }];
+    }
 }
 
 + (void)notifyError:(NSError *)error block:(BugsnagNotifyBlock)block {
-    [[self notifier] notifyError:error
-                           block:^(BugsnagCrashReport *_Nonnull report) {
-                             report.depth += 2;
+    if ([self bugsnagStarted]) {
+        [[self notifier] notifyError:error
+                               block:^(BugsnagCrashReport *_Nonnull report) {
+                                   report.depth += 2;
 
-                             if (block) {
-                                 block(report);
-                             }
-                           }];
+                                   if (block) {
+                                       block(report);
+                                   }
+                               }];
+    }
 }
 
 + (void)notify:(NSException *)exception withData:(NSDictionary *)metaData {
-
-    [[self notifier]
-        notifyException:exception
-                  block:^(BugsnagCrashReport *_Nonnull report) {
-                    report.depth += 2;
-                    report.metaData = [metaData
-                        BSG_mergedInto:[self.notifier.configuration
-                                               .metaData toDictionary]];
-                  }];
+    if ([self bugsnagStarted]) {
+        [[self notifier]
+                notifyException:exception
+                          block:^(BugsnagCrashReport *_Nonnull report) {
+                              report.depth += 2;
+                              report.metaData = [metaData
+                                      BSG_mergedInto:[self.notifier.configuration
+                                              .metaData toDictionary]];
+                          }];
+    }
 }
 
 + (void)notify:(NSException *)exception
       withData:(NSDictionary *)metaData
     atSeverity:(NSString *)severity {
-
-    [[self notifier]
-        notifyException:exception
-             atSeverity:BSGParseSeverity(severity)
-                  block:^(BugsnagCrashReport *_Nonnull report) {
-                    report.depth += 2;
-                    report.metaData = [metaData
-                        BSG_mergedInto:[self.notifier.configuration
-                                               .metaData toDictionary]];
-                    report.severity = BSGParseSeverity(severity);
-                  }];
+    if ([self bugsnagStarted]) {
+        [[self notifier]
+                notifyException:exception
+                     atSeverity:BSGParseSeverity(severity)
+                          block:^(BugsnagCrashReport *_Nonnull report) {
+                              report.depth += 2;
+                              report.metaData = [metaData
+                                      BSG_mergedInto:[self.notifier.configuration
+                                              .metaData toDictionary]];
+                              report.severity = BSGParseSeverity(severity);
+                          }];
+    }
 }
 
 + (void)internalClientNotify:(NSException *_Nonnull)exception
                     withData:(NSDictionary *_Nullable)metaData
                        block:(BugsnagNotifyBlock _Nullable)block {
-    [self.notifier internalClientNotify:exception
-                               withData:metaData
-                                  block:block];
+    if ([self bugsnagStarted]) {
+        [self.notifier internalClientNotify:exception
+                                   withData:metaData
+                                      block:block];
+    }
 }
 
 + (void)addAttribute:(NSString *)attributeName
@@ -171,31 +187,43 @@ static BugsnagNotifier *bsg_g_bugsnag_notifier = NULL;
 }
 
 + (void)leaveBreadcrumbWithMessage:(NSString *)message {
-    [self leaveBreadcrumbWithBlock:^(BugsnagBreadcrumb *_Nonnull crumbs) {
-      crumbs.metadata = @{BSGKeyMessage : message};
-    }];
+    if ([self bugsnagStarted]) {
+        [self leaveBreadcrumbWithBlock:^(BugsnagBreadcrumb *_Nonnull crumbs) {
+            crumbs.metadata = @{BSGKeyMessage: message};
+        }];
+    }
 }
 
 + (void)leaveBreadcrumbWithBlock:
     (void (^_Nonnull)(BugsnagBreadcrumb *_Nonnull))block {
-    [self.notifier addBreadcrumbWithBlock:block];
+    if ([self bugsnagStarted]) {
+        [self.notifier addBreadcrumbWithBlock:block];
+    }
 }
 
 + (void)leaveBreadcrumbForNotificationName:
     (NSString *_Nonnull)notificationName {
-    [self.notifier crumbleNotification:notificationName];
+    if ([self bugsnagStarted]) {
+        [self.notifier crumbleNotification:notificationName];
+    }
 }
 
 + (void)setBreadcrumbCapacity:(NSUInteger)capacity {
-    self.notifier.configuration.breadcrumbs.capacity = capacity;
+    if ([self bugsnagStarted]) {
+        self.notifier.configuration.breadcrumbs.capacity = capacity;
+    }
 }
 
 + (void)clearBreadcrumbs {
-    [self.notifier clearBreadcrumbs];
+    if ([self bugsnagStarted]) {
+        [self.notifier clearBreadcrumbs];
+    }
 }
 
 + (void)startSession {
-    [self.notifier startSession];
+    if ([self bugsnagStarted]) {
+        [self.notifier startSession];
+    }
 }
 
 + (NSDateFormatter *)payloadDateFormatter {
@@ -209,23 +237,31 @@ static BugsnagNotifier *bsg_g_bugsnag_notifier = NULL;
 }
 
 + (void)setSuspendThreadsForUserReported:(BOOL)suspendThreadsForUserReported {
-    [[BSG_KSCrash sharedInstance]
-        setSuspendThreadsForUserReported:suspendThreadsForUserReported];
+    if ([self bugsnagStarted]) {
+        [[BSG_KSCrash sharedInstance]
+                setSuspendThreadsForUserReported:suspendThreadsForUserReported];
+    }
 }
 
 + (void)setReportWhenDebuggerIsAttached:(BOOL)reportWhenDebuggerIsAttached {
-    [[BSG_KSCrash sharedInstance]
-        setReportWhenDebuggerIsAttached:reportWhenDebuggerIsAttached];
+    if ([self bugsnagStarted]) {
+        [[BSG_KSCrash sharedInstance]
+                setReportWhenDebuggerIsAttached:reportWhenDebuggerIsAttached];
+    }
 }
 
 + (void)setThreadTracingEnabled:(BOOL)threadTracingEnabled {
-    [[BSG_KSCrash sharedInstance] setThreadTracingEnabled:threadTracingEnabled];
+    if ([self bugsnagStarted]) {
+        [[BSG_KSCrash sharedInstance] setThreadTracingEnabled:threadTracingEnabled];
+    }
 }
 
 + (void)setWriteBinaryImagesForUserReported:
     (BOOL)writeBinaryImagesForUserReported {
-    [[BSG_KSCrash sharedInstance]
-        setWriteBinaryImagesForUserReported:writeBinaryImagesForUserReported];
+    if ([self bugsnagStarted]) {
+        [[BSG_KSCrash sharedInstance]
+                setWriteBinaryImagesForUserReported:writeBinaryImagesForUserReported];
+    }
 }
 
 @end

--- a/Source/Bugsnag.m
+++ b/Source/Bugsnag.m
@@ -51,7 +51,7 @@ static BugsnagNotifier *bsg_g_bugsnag_notifier = NULL;
 
 + (void)startBugsnagWithConfiguration:(BugsnagConfiguration *)configuration {
     @synchronized(self) {
-        if (configuration != nil && configuration.apiKey != nil) {
+        if ([configuration hasValidApiKey]) {
             bsg_g_bugsnag_notifier =
                     [[BugsnagNotifier alloc] initWithConfiguration:configuration];
             [bsg_g_bugsnag_notifier start];

--- a/Source/BugsnagConfiguration.h
+++ b/Source/BugsnagConfiguration.h
@@ -69,7 +69,7 @@ typedef NSDictionary *_Nullable (^BugsnagBeforeNotifyHook)(
 /**
  *  The API key of a Bugsnag project
  */
-@property(readwrite, retain, nonnull) NSString *apiKey;
+@property(readwrite, retain, nullable) NSString *apiKey;
 /**
  *  The URL used to notify Bugsnag
  */

--- a/Source/BugsnagConfiguration.h
+++ b/Source/BugsnagConfiguration.h
@@ -193,4 +193,6 @@ BugsnagBreadcrumbs *breadcrumbs;
 @property(nullable) NSString *codeBundleId;
 @property(nullable) NSString *notifierType;
 
+- (BOOL)hasValidApiKey;
+
 @end

--- a/Source/BugsnagConfiguration.h
+++ b/Source/BugsnagConfiguration.h
@@ -69,7 +69,7 @@ typedef NSDictionary *_Nullable (^BugsnagBeforeNotifyHook)(
 /**
  *  The API key of a Bugsnag project
  */
-@property(readwrite, retain, nullable) NSString *apiKey;
+@property(readwrite, retain, nonnull) NSString *apiKey;
 /**
  *  The URL used to notify Bugsnag
  */

--- a/Source/BugsnagConfiguration.m
+++ b/Source/BugsnagConfiguration.m
@@ -208,7 +208,9 @@ static NSString *const kHeaderApiSentAt = @"Bugsnag-Sent-At";
 
 - (void)setApiKey:(NSString *)apiKey {
     if ([apiKey length] > 0) {
+        [self willChangeValueForKey:NSStringFromSelector(@selector(apiKey))];
         _apiKey = apiKey;
+        [self didChangeValueForKey:NSStringFromSelector(@selector(apiKey))];
     } else {
         bsg_log_err(@"Attempted to override non-null API key with nil - ignoring.");
     }

--- a/Source/BugsnagConfiguration.m
+++ b/Source/BugsnagConfiguration.m
@@ -246,4 +246,9 @@ static NSString *const kHeaderApiSentAt = @"Bugsnag-Sent-At";
              kHeaderApiSentAt: [BSG_RFC3339DateTool stringFromDate:[NSDate new]]
              };
 }
+
+- (BOOL)hasValidApiKey {
+    return _apiKey != nil && ![@"" isEqualToString:_apiKey];
+}
+
 @end

--- a/Source/BugsnagConfiguration.m
+++ b/Source/BugsnagConfiguration.m
@@ -207,7 +207,7 @@ static NSString *const kHeaderApiSentAt = @"Bugsnag-Sent-At";
 }
 
 - (void)setApiKey:(NSString *)apiKey {
-    if (apiKey != nil) {
+    if ([apiKey length] > 0) {
         _apiKey = apiKey;
     } else {
         bsg_log_err(@"Attempted to override non-null API key with nil - ignoring.");
@@ -248,7 +248,7 @@ static NSString *const kHeaderApiSentAt = @"Bugsnag-Sent-At";
 }
 
 - (BOOL)hasValidApiKey {
-    return _apiKey != nil && ![@"" isEqualToString:_apiKey];
+    return [_apiKey length] > 0;
 }
 
 @end

--- a/Source/BugsnagConfiguration.m
+++ b/Source/BugsnagConfiguration.m
@@ -31,6 +31,7 @@
 #import "BSG_RFC3339DateTool.h"
 #import "BugsnagUser.h"
 #import "BugsnagSessionTracker.h"
+#import "BugsnagLogger.h"
 
 static NSString *const kHeaderApiPayloadVersion = @"Bugsnag-Payload-Version";
 static NSString *const kHeaderApiKey = @"Bugsnag-Api-Key";
@@ -196,6 +197,20 @@ static NSString *const kHeaderApiSentAt = @"Bugsnag-Sent-At";
         [self.config addAttribute:BSGKeyAppVersion
                         withValue:newVersion
                     toTabWithName:BSGKeyConfig];
+    }
+}
+
+@synthesize apiKey = _apiKey;
+
+- (NSString *)apiKey {
+    return _apiKey;
+}
+
+- (void)setApiKey:(NSString *)apiKey {
+    if (apiKey != nil) {
+        _apiKey = apiKey;
+    } else {
+        bsg_log_err(@"Attempted to override non-null API key with nil - ignoring.");
     }
 }
 

--- a/Source/BugsnagNotifier.h
+++ b/Source/BugsnagNotifier.h
@@ -40,7 +40,7 @@
 @property(nonatomic, readwrite, retain) NSLock *_Nonnull metaDataLock;
 
 @property(nonatomic) BSGConnectivity *_Nonnull networkReachable;
-@property(nonatomic, readonly) BOOL started;
+@property(readonly) BOOL started;
 
 - (instancetype _Nonnull)initWithConfiguration:
     (BugsnagConfiguration *_Nonnull)configuration;

--- a/Source/BugsnagNotifier.h
+++ b/Source/BugsnagNotifier.h
@@ -40,6 +40,7 @@
 @property(nonatomic, readwrite, retain) NSLock *_Nonnull metaDataLock;
 
 @property(nonatomic) BSGConnectivity *_Nonnull networkReachable;
+@property(nonatomic, readonly) BOOL started;
 
 - (instancetype _Nonnull)initWithConfiguration:
     (BugsnagConfiguration *_Nonnull)configuration;

--- a/Source/BugsnagNotifier.m
+++ b/Source/BugsnagNotifier.m
@@ -356,6 +356,7 @@ NSString *const kAppWillTerminate = @"App Will Terminate";
 
     // notification not received in time on initial startup, so trigger manually
     [self willEnterForeground:self];
+    _started = YES;
 }
 
 - (void)watchLifecycleEvents:(NSNotificationCenter *)center {

--- a/Tests/BugsnagConfigurationTests.m
+++ b/Tests/BugsnagConfigurationTests.m
@@ -114,5 +114,16 @@
     XCTAssertEqualObjects(@"test", config.apiKey);
 }
 
+- (void)testHasValidApiKey {
+    BugsnagConfiguration *config = nil;
+    XCTAssertFalse([config hasValidApiKey]);
+
+    config = [BugsnagConfiguration new];
+    XCTAssertFalse([config hasValidApiKey]);
+
+    config.apiKey = @"5adf89e0aaa";
+    XCTAssertTrue([config hasValidApiKey]);
+}
+
 
 @end

--- a/Tests/BugsnagConfigurationTests.m
+++ b/Tests/BugsnagConfigurationTests.m
@@ -99,4 +99,20 @@
     
 }
 
+- (void)testApiKeySetter {
+    BugsnagConfiguration *config = [BugsnagConfiguration new];
+    XCTAssertEqualObjects(@"", config.apiKey);
+
+    config.apiKey = @"test";
+    XCTAssertEqualObjects(@"test", config.apiKey);
+
+#pragma clang diagnostic push
+#pragma clang diagnostic ignored "-Wnonnull"
+    config.apiKey = nil;
+#pragma clang diagnostic pop
+
+    XCTAssertEqualObjects(@"test", config.apiKey);
+}
+
+
 @end


### PR DESCRIPTION
## Goal

Avoid instantiating the Notifier in an invalid state (without an API key).

## Changeset

### Changed
- Nullability annotations on API
- Gate all required methods in `Bugsnag.m` with a check to see if the notifier has been initialised, and NOP if not.
- Avoid initialising notifier if the supplied API key is nil.
- Attempting to set a non-nil API key as nil is ignored

## Tests

Added a unit test for API key setter override.

## Discussion

Much of the discussion for this changeset took place here: https://github.com/bugsnag/bugsnag-react-native/pull/237

## Review

<!-- When submitting for review, consider the points for self-review and the
     criteria which will be used for secondary review -->

For the submitter, initial self-review:

- [ ] Commented on code changes inline explain the reasoning behind the approach
- [x] Reviewed the test cases added for completeness and possible points for discussion
- [x] A changelog entry was added for the goal of this pull request
- [x] Check the scope of the changeset - is everything in the diff required for the pull request?
- This pull request is ready for:
  - [x] Initial review of the intended approach, not yet feature complete
  - [x] Structural review of the classes, functions, and properties modified
  - [x] Final review

For the pull request reviewer(s), this changeset has been reviewed for:

- [ ] Consistency across platforms for structures or concepts added or modified
- [ ] Consistency between the changeset and the goal stated above
- [ ] Internal consistency with the rest of the library - is there any overlap between existing interfaces and any which have been added?
- [ ] Usage friction - is the proposed change in usage cumbersome or complicated?
- [ ] Performance and complexity - are there any cases of unexpected O(n^3) when iterating, recursing, flat mapping, etc?
- [ ] Concurrency concerns - if components are accessed asynchronously, what issues will arise
- [ ] Thoroughness of added tests and any missing edge cases
- [ ] Idiomatic use of the language
