### PR TITLE
Handled/unhandled error state serialisation fix

### DIFF
--- a/Source/BSG_KSCrashReportWriter.h
+++ b/Source/BSG_KSCrashReportWriter.h
@@ -213,7 +213,7 @@ typedef struct BSG_KSCrashReportWriter {
 } BSG_KSCrashReportWriter;
 
 typedef void (*BSG_KSReportWriteCallback)(
-    const BSG_KSCrashReportWriter *writer);
+    const BSG_KSCrashReportWriter *writer, int type);
 
 #ifdef __cplusplus
 }

--- a/Source/BSG_KSCrashReportWriter.h
+++ b/Source/BSG_KSCrashReportWriter.h
@@ -213,7 +213,10 @@ typedef struct BSG_KSCrashReportWriter {
 } BSG_KSCrashReportWriter;
 
 typedef void (*BSG_KSReportWriteCallback)(
-    const BSG_KSCrashReportWriter *writer, int type);
+    const BSG_KSCrashReportWriter *writer);
+
+typedef void (*BSGReportCallback)(
+        const BSG_KSCrashReportWriter *writer, int type);
 
 #ifdef __cplusplus
 }

--- a/Source/BugsnagConfiguration.h
+++ b/Source/BugsnagConfiguration.h
@@ -132,6 +132,7 @@ BugsnagBreadcrumbs *breadcrumbs;
  */
 @property void (*_Nullable onCrashHandler)
     (const BSG_KSCrashReportWriter *_Nonnull writer);
+
 /**
  *  YES if uncaught exceptions should be reported automatically
  */

--- a/Source/BugsnagCrashReport.m
+++ b/Source/BugsnagCrashReport.m
@@ -235,10 +235,6 @@ static NSString *const DEFAULT_EXCEPTION_TYPE = @"cocoa";
         }
         _binaryImages = report[@"binary_images"];
         _breadcrumbs = BSGParseBreadcrumbs(report);
-        _severity = BSGParseSeverity(
-            [report valueForKeyPath:@"user.state.crash.severity"]);
-        _depth = [[report valueForKeyPath:@"user.state.crash.depth"]
-            unsignedIntegerValue];
         _dsymUUID = [report valueForKeyPath:@"system.app_uuid"];
         _deviceAppHash = [report valueForKeyPath:@"system.device_app_hash"];
         _metaData =
@@ -259,6 +255,10 @@ static NSString *const DEFAULT_EXCEPTION_TYPE = @"cocoa";
         if (recordedState) {
             _handledState =
                 [[BugsnagHandledState alloc] initWithDictionary:recordedState];
+
+            // only makes sense to use serialised value for handled exceptions
+            _depth = [[report valueForKeyPath:@"user.state.crash.depth"]
+                    unsignedIntegerValue];
         } else { // the event was unhandled.
             BOOL isSignal = [BSGKeySignal isEqualToString:_errorType];
             SeverityReasonType severityReason =
@@ -267,6 +267,7 @@ static NSString *const DEFAULT_EXCEPTION_TYPE = @"cocoa";
                 handledStateWithSeverityReason:severityReason
                                       severity:BSGSeverityError
                                      attrValue:_errorClass];
+            _depth = 0;
         }
         _severity = _handledState.currentSeverity;
 

--- a/Source/BugsnagCrashSentry.h
+++ b/Source/BugsnagCrashSentry.h
@@ -16,7 +16,7 @@
 
 - (void)install:(BugsnagConfiguration *)config
       apiClient:(BugsnagErrorReportApiClient *)apiClient
-        onCrash:(BSG_KSReportWriteCallback)onCrash;
+        onCrash:(BSGReportCallback)onCrash;
 
 - (void)reportUserException:(NSString *)reportName
                      reason:(NSString *)reportMessage;

--- a/Source/BugsnagCrashSentry.m
+++ b/Source/BugsnagCrashSentry.m
@@ -19,7 +19,7 @@ NSUInteger const BSG_MAX_STORED_REPORTS = 12;
 
 - (void)install:(BugsnagConfiguration *)config
       apiClient:(BugsnagErrorReportApiClient *)apiClient
-        onCrash:(BSG_KSReportWriteCallback)onCrash {
+        onCrash:(BSGReportCallback)onCrash {
 
     BugsnagSink *sink = [[BugsnagSink alloc] initWithApiClient:apiClient];
     [BSG_KSCrash sharedInstance].sink = sink;

--- a/Source/BugsnagNotifier.m
+++ b/Source/BugsnagNotifier.m
@@ -103,12 +103,12 @@ void BSSerializeDataCrashHandler(const BSG_KSCrashReportWriter *writer, int type
     if (bsg_g_bugsnag_data.stateJSON) {
         writer->addJSONElement(writer, "state", bsg_g_bugsnag_data.stateJSON);
     }
+    if (bsg_g_bugsnag_data.metaDataJSON) {
+        writer->addJSONElement(writer, "metaData", bsg_g_bugsnag_data.metaDataJSON);
+    }
 
     // write additional user-supplied metadata
     if (userReported) {
-        if (bsg_g_bugsnag_data.metaDataJSON) {
-            writer->addJSONElement(writer, "metaData", bsg_g_bugsnag_data.metaDataJSON);
-        }
         if (bsg_g_bugsnag_data.handledState) {
             writer->addJSONElement(writer, "handledState", bsg_g_bugsnag_data.handledState);
         }

--- a/Source/BugsnagNotifier.m
+++ b/Source/BugsnagNotifier.m
@@ -34,6 +34,7 @@
 #import "BugsnagSessionTracker.h"
 #import "BugsnagSessionTrackingApiClient.h"
 #import "BSG_RFC3339DateTool.h"
+#import "BSG_KSCrashType.h"
 
 #if TARGET_IPHONE_SIMULATOR || TARGET_OS_IPHONE
 #import <UIKit/UIKit.h>
@@ -81,14 +82,8 @@ static bool hasRecordedSessions;
  *
  *  @param writer report writer which will receive updated metadata
  */
-void BSSerializeDataCrashHandler(const BSG_KSCrashReportWriter *writer) {
-    if (bsg_g_bugsnag_data.configJSON) {
-        writer->addJSONElement(writer, "config", bsg_g_bugsnag_data.configJSON);
-    }
-    if (bsg_g_bugsnag_data.metaDataJSON) {
-        writer->addJSONElement(writer, "metaData",
-                               bsg_g_bugsnag_data.metaDataJSON);
-    }
+void BSSerializeDataCrashHandler(const BSG_KSCrashReportWriter *writer, int type) {
+    BOOL userReported = BSG_KSCrashTypeUserReported == type;
 
     if (hasRecordedSessions) { // a session is available
         // persist session info
@@ -96,25 +91,32 @@ void BSSerializeDataCrashHandler(const BSG_KSCrashReportWriter *writer) {
         writer->addStringElement(writer, "startedAt", (const char *) sessionStartDate);
         writer->addUIntegerElement(writer, "handledCount", handledCount);
 
-        if (!bsg_g_bugsnag_data.handledState) {
+        if (!userReported) {
             writer->addUIntegerElement(writer, "unhandledCount", 1);
         } else {
             writer->addUIntegerElement(writer, "unhandledCount", 0);
         }
     }
-
-    if (bsg_g_bugsnag_data.handledState) {
-        writer->addJSONElement(writer, "handledState",
-                               bsg_g_bugsnag_data.handledState);
+    if (bsg_g_bugsnag_data.configJSON) {
+        writer->addJSONElement(writer, "config", bsg_g_bugsnag_data.configJSON);
     }
-
     if (bsg_g_bugsnag_data.stateJSON) {
         writer->addJSONElement(writer, "state", bsg_g_bugsnag_data.stateJSON);
     }
-    if (bsg_g_bugsnag_data.userOverridesJSON) {
-        writer->addJSONElement(writer, "overrides",
-                               bsg_g_bugsnag_data.userOverridesJSON);
+
+    // write additional user-supplied metadata
+    if (userReported) {
+        if (bsg_g_bugsnag_data.metaDataJSON) {
+            writer->addJSONElement(writer, "metaData", bsg_g_bugsnag_data.metaDataJSON);
+        }
+        if (bsg_g_bugsnag_data.handledState) {
+            writer->addJSONElement(writer, "handledState", bsg_g_bugsnag_data.handledState);
+        }
+        if (bsg_g_bugsnag_data.userOverridesJSON) {
+            writer->addJSONElement(writer, "overrides", bsg_g_bugsnag_data.userOverridesJSON);
+        }
     }
+
     if (bsg_g_bugsnag_data.onCrash) {
         bsg_g_bugsnag_data.onCrash(writer);
     }

--- a/Source/KSCrash/Source/KSCrash/Recording/BSG_KSCrash.m
+++ b/Source/KSCrash/Source/KSCrash/Recording/BSG_KSCrash.m
@@ -73,7 +73,7 @@
 @property(nonatomic, readwrite, retain) NSString *logFilePath;
 @property(nonatomic, readwrite, retain)
     BSG_KSCrashReportStore *crashReportStore;
-@property(nonatomic, readwrite, assign) BSG_KSReportWriteCallback onCrash;
+@property(nonatomic, readwrite, assign) BSGReportCallback onCrash;
 @property(nonatomic, readwrite, assign) bool printTraceToStdout;
 @property(nonatomic, readwrite, assign) int maxStoredReports;
 
@@ -203,7 +203,7 @@ IMPLEMENT_EXCLUSIVE_SHARED_INSTANCE(BSG_KSCrash)
     bsg_kscrash_setPrintTraceToStdout(printTraceToStdout);
 }
 
-- (void)setOnCrash:(BSG_KSReportWriteCallback)onCrash {
+- (void)setOnCrash:(BSGReportCallback)onCrash {
     _onCrash = onCrash;
     bsg_kscrash_setCrashNotifyCallback(onCrash);
 }

--- a/Source/KSCrash/Source/KSCrash/Recording/BSG_KSCrashAdvanced.h
+++ b/Source/KSCrash/Source/KSCrash/Recording/BSG_KSCrashAdvanced.h
@@ -112,7 +112,7 @@ typedef enum {
  * Note: If you use an installation, it will automatically set this property.
  *       Do not modify it in such a case.
  */
-@property(nonatomic, readwrite, assign) BSG_KSReportWriteCallback onCrash;
+@property(nonatomic, readwrite, assign) BSGReportCallback onCrash;
 
 /** Path where the log of BSG_KSCrash's activities will be written.
  * If nil, log entries will be printed to the console.

--- a/Source/KSCrash/Source/KSCrash/Recording/BSG_KSCrashC.c
+++ b/Source/KSCrash/Source/KSCrash/Recording/BSG_KSCrashC.c
@@ -236,7 +236,7 @@ void bsg_kscrash_setDoNotIntrospectClasses(const char **doNotIntrospectClasses,
 }
 
 void bsg_kscrash_setCrashNotifyCallback(
-    const BSG_KSReportWriteCallback onCrashNotify) {
+    const BSGReportCallback onCrashNotify) {
     BSG_KSLOG_TRACE("Set onCrashNotify to %p", onCrashNotify);
     crashContext()->config.onCrashNotify = onCrashNotify;
 }

--- a/Source/KSCrash/Source/KSCrash/Recording/BSG_KSCrashC.h
+++ b/Source/KSCrash/Source/KSCrash/Recording/BSG_KSCrashC.h
@@ -166,7 +166,7 @@ void bsg_kscrash_setDoNotIntrospectClasses(const char **doNotIntrospectClasses,
  * Default: NULL
  */
 void bsg_kscrash_setCrashNotifyCallback(
-    const BSG_KSReportWriteCallback onCrashNotify);
+    const BSGReportCallback onCrashNotify);
 
 /** Report a custom, user defined exception.
  * This can be useful when dealing with scripting languages.

--- a/Source/KSCrash/Source/KSCrash/Recording/BSG_KSCrashContext.h
+++ b/Source/KSCrash/Source/KSCrash/Recording/BSG_KSCrashContext.h
@@ -88,7 +88,7 @@ typedef struct {
     /** Callback allowing the application the opportunity to add extra data to
      * the report file. Application MUST NOT call async-unsafe methods!
      */
-    BSG_KSReportWriteCallback onCrashNotify;
+    BSGReportCallback onCrashNotify;
 } BSG_KSCrash_Configuration;
 
 /** Contextual data used by the crash report writer.

--- a/Source/KSCrash/Source/KSCrash/Recording/BSG_KSCrashReport.c
+++ b/Source/KSCrash/Source/KSCrash/Recording/BSG_KSCrashReport.c
@@ -40,6 +40,7 @@
 
 //#define BSG_kSLogger_LocalLevel TRACE
 #include "BSG_KSLogger.h"
+#include "BSG_KSCrashContext.h"
 
 #ifdef __arm64__
 #include <sys/_types/_ucontext64.h>
@@ -1963,7 +1964,8 @@ void bsg_kscrw_i_updateStackOverflowStatus(
 
 void bsg_kscrw_i_callUserCrashHandler(BSG_KSCrash_Context *const crashContext,
                                       BSG_KSCrashReportWriter *writer) {
-    crashContext->config.onCrashNotify(writer);
+    BSG_KSCrashType type = crashContext->crash.crashType;
+    crashContext->config.onCrashNotify(writer, type);
 }
 
 // ============================================================================

--- a/Tests/BugsnagCrashReportTests.m
+++ b/Tests/BugsnagCrashReportTests.m
@@ -449,4 +449,35 @@
                           payload[@"exceptions"][0][@"message"]);
 }
 
+- (void)testEmptyReport {
+    BugsnagCrashReport *report = [[BugsnagCrashReport alloc] initWithKSReport:@{}];
+    XCTAssertNotNil(report);
+}
+
+- (void)testReportDepth {
+    // unhandled reports should calculate their own depth
+    NSDictionary *dict = @{@"user.state.crash.depth": @2};
+    BugsnagCrashReport *report = [[BugsnagCrashReport alloc] initWithKSReport:dict];
+    XCTAssertEqual(report.depth, 0);
+
+    // handled reports should use the serialised depth
+    BugsnagHandledState *state = [BugsnagHandledState handledStateWithSeverityReason:HandledException];
+    dict = @{@"user.state.crash.depth": @2, @"user.handledState": [state toJson]};
+    report = [[BugsnagCrashReport alloc] initWithKSReport:dict];
+    XCTAssertEqual(report.depth, 2);
+}
+
+- (void)testReportSeverity {
+    // unhandled reports should calculate their own severity
+    NSDictionary *dict = @{@"user.state.crash.severity": @"info"};
+    BugsnagCrashReport *report = [[BugsnagCrashReport alloc] initWithKSReport:dict];
+    XCTAssertEqual(report.severity, BSGSeverityError);
+
+    // handled reports should use the serialised depth
+    BugsnagHandledState *state = [BugsnagHandledState handledStateWithSeverityReason:HandledException];
+    dict = @{@"user.state.crash.severity": @"info", @"user.handledState": [state toJson]};
+    report = [[BugsnagCrashReport alloc] initWithKSReport:dict];
+    XCTAssertEqual(report.severity, BSGSeverityWarning);
+}
+
 @end

--- a/Tests/BugsnagCrashReportTests.m
+++ b/Tests/BugsnagCrashReportTests.m
@@ -454,29 +454,33 @@
     XCTAssertNotNil(report);
 }
 
-- (void)testReportDepth {
+- (void)testUnhandledReportDepth {
     // unhandled reports should calculate their own depth
     NSDictionary *dict = @{@"user.state.crash.depth": @2};
     BugsnagCrashReport *report = [[BugsnagCrashReport alloc] initWithKSReport:dict];
     XCTAssertEqual(report.depth, 0);
+}
 
+- (void)testHandledReportDepth {
     // handled reports should use the serialised depth
     BugsnagHandledState *state = [BugsnagHandledState handledStateWithSeverityReason:HandledException];
-    dict = @{@"user.state.crash.depth": @2, @"user.handledState": [state toJson]};
-    report = [[BugsnagCrashReport alloc] initWithKSReport:dict];
+    NSDictionary *dict = @{@"user.state.crash.depth": @2, @"user.handledState": [state toJson]};
+    BugsnagCrashReport *report = [[BugsnagCrashReport alloc] initWithKSReport:dict];
     XCTAssertEqual(report.depth, 2);
 }
 
-- (void)testReportSeverity {
+- (void)testUnhandledReportSeverity {
     // unhandled reports should calculate their own severity
     NSDictionary *dict = @{@"user.state.crash.severity": @"info"};
     BugsnagCrashReport *report = [[BugsnagCrashReport alloc] initWithKSReport:dict];
     XCTAssertEqual(report.severity, BSGSeverityError);
+}
 
+- (void)testHandledReportSeverity {
     // handled reports should use the serialised depth
     BugsnagHandledState *state = [BugsnagHandledState handledStateWithSeverityReason:HandledException];
-    dict = @{@"user.state.crash.severity": @"info", @"user.handledState": [state toJson]};
-    report = [[BugsnagCrashReport alloc] initWithKSReport:dict];
+    NSDictionary *dict = @{@"user.state.crash.severity": @"info", @"user.handledState": [state toJson]};
+    BugsnagCrashReport *report = [[BugsnagCrashReport alloc] initWithKSReport:dict];
     XCTAssertEqual(report.severity, BSGSeverityWarning);
 }
 

--- a/Tests/BugsnagCrashReportTests.m
+++ b/Tests/BugsnagCrashReportTests.m
@@ -484,4 +484,33 @@
     XCTAssertEqual(report.severity, BSGSeverityWarning);
 }
 
+- (void)testHandledReportMetaData {
+    BugsnagHandledState *state = [BugsnagHandledState handledStateWithSeverityReason:HandledException];
+    BugsnagMetaData *metaData = [BugsnagMetaData new];
+    [metaData addAttribute:@"Foo" withValue:@"Bar" toTabWithName:@"Custom"];
+    NSDictionary *dict = @{@"user.handledState": [state toJson], @"user.metaData": [metaData toDictionary]};
+
+    BugsnagCrashReport *report = [[BugsnagCrashReport alloc] initWithKSReport:dict];
+    XCTAssertNotNil(report.metaData);
+    XCTAssertEqual(report.metaData.count, 1);
+    XCTAssertEqualObjects(report.metaData[@"Custom"][@"Foo"], @"Bar");
+}
+
+- (void)testUnhandledReportMetaData {
+    BugsnagMetaData *metaData = [BugsnagMetaData new];
+    [metaData addAttribute:@"Foo" withValue:@"Bar" toTabWithName:@"Custom"];
+    NSDictionary *dict = @{@"user.metaData": [metaData toDictionary]};
+
+    BugsnagCrashReport *report = [[BugsnagCrashReport alloc] initWithKSReport:dict];
+    XCTAssertNotNil(report.metaData);
+    XCTAssertEqual(report.metaData.count, 1);
+    XCTAssertEqualObjects(report.metaData[@"Custom"][@"Foo"], @"Bar");
+}
+
+- (void)testNoReportMetaData {
+    BugsnagCrashReport *report = [[BugsnagCrashReport alloc] initWithKSReport:@{}];
+    XCTAssertNotNil(report.metaData);
+    XCTAssertEqual(report.metaData.count, 0);
+}
+
 @end


### PR DESCRIPTION
## Goal
Handled error data serialisation is synchronised through the use of `NSLock`. However, this does not apply to unhandled errors, which suspend all threads and can therefore unintentionally serialise data belonging to a handled error. 

This fix alters serialisation of error data by ignoring some unnecessary fields for unhandled errors, and calculating `severity` and other items using existing data.

## Changeset

### Added
- New internal typedef for a report write callback, which passes information on the whether a report is handled/unhandled.

### Changed
Ignore serialised values on unhandled errors for:

- depth
- severity
- handledStateJSON
- metaDataJSON
- userOverridesJSON

Calculate severity/depth using existing information for unhandled errors in `BugsnagCrashReport`

## Tests

New unit tests for serialisation of report depth + severity, mazerunner run on CI, manual testing to ensure that one handled/unhandled error were received.

## Discussion

### Outstanding Questions

- We may want to make `BSGReportCallback` public and deprecated `onCrashHandler`. I'm not 100% convinced that the information available in context makes this worth doing as it can mostly be obtained by other means, so I've left as-is for now.
- I'm fairly sure that depth, severity, and handledStateJSON don't need to be serialised, but it would be good to confirm that this doesn't cause some unintended side effect or misses an edge-case.

<!-- Are there any parts of the design or the implementation which seem
     less than ideal and that could require additional discussion?
     List here: -->

<!--

Fixes #
Related to #

-->

## Review

<!-- When submitting for review, consider the points for self-review and the
     criteria which will be used for secondary review -->

For the submitter, initial self-review:

- [ ] Commented on code changes inline explain the reasoning behind the approach
- [x] Reviewed the test cases added for completeness and possible points for discussion
- [ ] A changelog entry was added for the goal of this pull request
- [x] Check the scope of the changeset - is everything in the diff required for the pull request?
- This pull request is ready for:
  - [x] Initial review of the intended approach, not yet feature complete
  - [x] Structural review of the classes, functions, and properties modified
  - [ ] Final review

For the pull request reviewer(s), this changeset has been reviewed for:

- [ ] Consistency across platforms for structures or concepts added or modified
- [ ] Consistency between the changeset and the goal stated above
- [ ] Internal consistency with the rest of the library - is there any overlap between existing interfaces and any which have been added?
- [ ] Usage friction - is the proposed change in usage cumbersome or complicated?
- [ ] Performance and complexity - are there any cases of unexpected O(n^3) when iterating, recursing, flat mapping, etc?
- [ ] Concurrency concerns - if components are accessed asynchronously, what issues will arise
- [ ] Thoroughness of added tests and any missing edge cases
- [ ] Idiomatic use of the language
