### PR TITLE
set _started before reporting

### DIFF
--- a/Source/BugsnagNotifier.m
+++ b/Source/BugsnagNotifier.m
@@ -356,9 +356,10 @@ NSString *const kAppWillTerminate = @"App Will Terminate";
                  object:nil];
 #endif
 
+    _started = YES;
+
     // notification not received in time on initial startup, so trigger manually
     [self willEnterForeground:self];
-    _started = YES;
 }
 
 - (void)watchLifecycleEvents:(NSNotificationCenter *)center {


### PR DESCRIPTION
I'm using `[Bugsnag startBugsnagWithConfiguration:config];`

When starting Bugsnag, several sessions are not sent to the server, and instead this is logged many times:

```
Ensure you have started Bugsnag with startWithApiKey: before calling any other Bugsnag functions.
```

This seems to be due to `_started` not being set yet when `willEnterForeground` is called.

Moving the `_started` value change fixes the issue and correctly reports existing session data.