### PR TITLE
handle nil contentValue

### DIFF
--- a/Source/BugsnagCrashReport.m
+++ b/Source/BugsnagCrashReport.m
@@ -629,6 +629,9 @@ initWithErrorName:(NSString *_Nonnull)name
                 continue;
             }
             NSString *contentValue = data[@"value"];
+            if (!contentValue) {
+                continue;
+            }
 
             if ([self isReservedWord:contentValue]) {
                 reservedWord = contentValue;


### PR DESCRIPTION
`contentValue` (`data[@"value"]`) can be `nil`. I have seen entries in `notable_addresses` which have only `address` and `type`. When this occurs, the code crashed trying to handle nil `contentValue`, and ignoring it worked.