### PR TITLE
docs: document that beforeSendBlocks won't be called on same queue

### DIFF
--- a/Source/BugsnagConfiguration.h
+++ b/Source/BugsnagConfiguration.h
@@ -42,7 +42,10 @@
 typedef void (^BugsnagNotifyBlock)(BugsnagCrashReport *_Nonnull report);
 
 /**
- *  A handler for modifying data before sending it to Bugsnag
+ *  A handler for modifying data before sending it to Bugsnag.
+ *
+ * It is worth noting that beforeSendBlocks will be invoked on a dedicated
+ * background queue, which will be different from the queue where the block was originally added.
  *
  *  @param rawEventData The raw event data written at crash time. This
  *                      includes data added in onCrashHandler.

--- a/Source/BugsnagConfiguration.h
+++ b/Source/BugsnagConfiguration.h
@@ -44,7 +44,7 @@ typedef void (^BugsnagNotifyBlock)(BugsnagCrashReport *_Nonnull report);
 /**
  *  A handler for modifying data before sending it to Bugsnag.
  *
- * It is worth noting that beforeSendBlocks will be invoked on a dedicated
+ * beforeSendBlocks will be invoked on a dedicated
  * background queue, which will be different from the queue where the block was originally added.
  *
  *  @param rawEventData The raw event data written at crash time. This


### PR DESCRIPTION
Documents which queue beforeSendBlocks will be called on, resolving the following ticket: bugsnag.atlassian.net/browse/PLAT-1179