### PR TITLE
Ensure sessions are sent in the background

### DIFF
--- a/Source/BugsnagNotifier.m
+++ b/Source/BugsnagNotifier.m
@@ -395,7 +395,7 @@ NSString *const kAppWillTerminate = @"App Will Terminate";
                                                        selector:@selector(sessionTick:)
                                                        userInfo:nil
                                                         repeats:YES];
-        [self sessionTick:self];
+        [self.sessionTimer fire];
     }
 }
 


### PR DESCRIPTION
When starting the app we can send sessions on the main thread which causes a slowdown on boot. This changes the timer to fire immediately rather than calling the session tick function manually.