### PR TITLE
Add `osBuild` as a reported device value

### DIFF
--- a/Source/BugsnagKSCrashSysInfoParser.m
+++ b/Source/BugsnagKSCrashSysInfoParser.m
@@ -119,6 +119,7 @@ NSDictionary *BSGParseDeviceState(NSDictionary *report) {
     BSGDictSetSafeObject(deviceState, report[@"machine"], @"model");
     BSGDictSetSafeObject(deviceState, report[@"system_name"], @"osName");
     BSGDictSetSafeObject(deviceState, report[@"system_version"], @"osVersion");
+    BSGDictSetSafeObject(deviceState, report[@"os_version"], @"osBuild");
     BSGDictSetSafeObject(deviceState, @(PLATFORM_WORD_SIZE), @"wordSize");
     BSGDictSetSafeObject(deviceState, @"Apple", @"manufacturer");
     BSGDictSetSafeObject(deviceState, report[@"jailbroken"], @"jailbroken");

--- a/Tests/BugsnagSessionTrackingPayloadTest.m
+++ b/Tests/BugsnagSessionTrackingPayloadTest.m
@@ -41,7 +41,7 @@
 - (void)testDeviceSerialisation {
     NSDictionary *device = self.payload[@"device"];
     XCTAssertNotNil(device);
-    XCTAssertEqual(7, device.count);
+    XCTAssertEqual(8, device.count);
     
     XCTAssertEqualObjects(device[@"manufacturer"], @"Apple");
     XCTAssertNotNil(device[@"model"]);

--- a/Tests/BugsnagSinkTests.m
+++ b/Tests/BugsnagSinkTests.m
@@ -259,9 +259,9 @@
     NSDictionary *device = event[@"device"];
     XCTAssertNotNil(device);
 #if TARGET_OS_IPHONE || TARGET_OS_TV || TARGET_IPHONE_SIMULATOR
-    XCTAssertEqual(17, device.count);
+    XCTAssertEqual(18, device.count);
 #else
-    XCTAssertEqual(16, device.count);
+    XCTAssertEqual(17, device.count);
 #endif
 
     XCTAssertEqualObjects(device[@"id"], @"f6d519a74213a57f8d052c53febfeee6f856d062");
@@ -270,6 +270,7 @@
     XCTAssertEqualObjects(device[@"modelNumber"], @"MacBookPro11,3");
     XCTAssertEqualObjects(device[@"osName"], @"iPhone OS");
     XCTAssertEqualObjects(device[@"osVersion"], @"8.1");
+    XCTAssertEqualObjects(device[@"osBuild"], @"14B25");
     XCTAssertEqualObjects(device[@"totalMemory"], @15065522176);
     XCTAssertNotNil(device[@"freeDisk"]);
     XCTAssertEqualObjects(device[@"timezone"], @"PST");


### PR DESCRIPTION
This adds `osBuild` as a new value that's being reported for every
device. This can be useful to tell apart release versions from beta
versions of the OS.

The technical name used by `sysctl` is "os version", but since the
`osVersion` key was already in use for reporting the marketing version
(e.g. 11.4), I used `osBuild` as the key instead.

Tests are updated and pass. I'm not entirely sure if there's more
that needs to be done to make this visible in the web UI, but it seems
like this should do it.