### PR TITLE
Update contributing guide

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -35,7 +35,7 @@ Releasing a new version
 ## Release Checklist
 Please follow the testing instructions in [the platforms release checklist](https://github.com/bugsnag/platforms-release-checklist/blob/master/README.md), and any additional steps directly below.
 
-- Please ensure that release builds are run on a physical device with an ad-hoc archive.
+- Please ensure that release builds are run on a physical device with an ad-hoc archive. (For release builds, select Edit Scheme, change the Build Configuration to Release, and uncheck Debug Executable)
 - Run the static analyzer (Product -> Analyze in Xcode) to ensure that no problems are introduced.
 
 ### CocoaPods

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -35,6 +35,7 @@ Releasing a new version
 ## Release Checklist
 Please follow the testing instructions in [the platforms release checklist](https://github.com/bugsnag/platforms-release-checklist/blob/master/README.md), and any additional steps directly below.
 
+- Send a handled error whilst using the [network link conditioner](https://nshipster.com/network-link-conditioner/) (accessible via Settings > Developer > Network Link Conditioner > Very Bad Network Connection), and ensure there is no visual freeze in the UI
 - Please ensure that release builds are run on a physical device with an ad-hoc archive. (For release builds, select Edit Scheme, change the Build Configuration to Release, and uncheck Debug Executable)
 - Run the static analyzer (Product -> Analyze in Xcode) to ensure that no problems are introduced.
 

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -36,7 +36,7 @@ Releasing a new version
 Please follow the testing instructions in [the platforms release checklist](https://github.com/bugsnag/platforms-release-checklist/blob/master/README.md), and any additional steps directly below.
 
 - Please ensure that release builds are run on a physical device with an ad-hoc archive.
-- Run the static anayser (Product -> Analyse in Xcode) to ensure that no problems are introduced.
+- Run the static analyzer (Product -> Analyze in Xcode) to ensure that no problems are introduced.
 
 ### CocoaPods
 

--- a/Makefile
+++ b/Makefile
@@ -64,7 +64,7 @@ endif
 	@git commit -m "v$(VERSION)"
 	@git tag v$(VERSION)
 	@git push origin master v$(VERSION)
-	@pod trunk push
+	@pod trunk push --allow-warnings
 
 
 clean:

--- a/examples/objective-c-ios/README.md
+++ b/examples/objective-c-ios/README.md
@@ -1,0 +1,6 @@
+# Example iOS integration with Bugsnag
+
+1. Run `pod install`
+2. Open this project in XCode
+3. Insert your API key in the AppDelegate: `[Bugsnag startBugsnagWithApiKey:@"YOUR-API-KEY"];` 
+4. Run the app! There are several examples of different kinds of errors which can be thrown.

--- a/examples/objective-c-osx/README.md
+++ b/examples/objective-c-osx/README.md
@@ -1,0 +1,6 @@
+# Example iOS integration with Bugsnag
+
+1. Run `pod install`
+2. Open this project in XCode
+3. Insert your API key in the AppDelegate: `[Bugsnag startBugsnagWithApiKey:@"API-KEY"];` 
+4. Run the app! There are several examples of different kinds of errors which can be thrown.

--- a/examples/objective-c-osx/objective-c-osx/Base.lproj/Main.storyboard
+++ b/examples/objective-c-osx/objective-c-osx/Base.lproj/Main.storyboard
@@ -1,7 +1,8 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<document type="com.apple.InterfaceBuilder3.Cocoa.Storyboard.XIB" version="3.0" toolsVersion="12121" systemVersion="16F2073" targetRuntime="MacOSX.Cocoa" propertyAccessControl="none" useAutolayout="YES" initialViewController="B8D-0N-5wS">
+<document type="com.apple.InterfaceBuilder3.Cocoa.Storyboard.XIB" version="3.0" toolsVersion="14113" targetRuntime="MacOSX.Cocoa" propertyAccessControl="none" useAutolayout="YES" initialViewController="B8D-0N-5wS">
     <dependencies>
-        <plugIn identifier="com.apple.InterfaceBuilder.CocoaPlugin" version="12121"/>
+        <deployment identifier="macosx"/>
+        <plugIn identifier="com.apple.InterfaceBuilder.CocoaPlugin" version="14113"/>
         <capability name="documents saved in the Xcode 8 format" minToolsVersion="8.0"/>
     </dependencies>
     <scenes>
@@ -656,6 +657,9 @@
                         <windowPositionMask key="initialPositionMask" leftStrut="YES" rightStrut="YES" topStrut="YES" bottomStrut="YES"/>
                         <rect key="contentRect" x="196" y="240" width="480" height="270"/>
                         <rect key="screenRect" x="0.0" y="0.0" width="1680" height="1027"/>
+                        <connections>
+                            <outlet property="delegate" destination="B8D-0N-5wS" id="vpK-e3-Hor"/>
+                        </connections>
                     </window>
                     <connections>
                         <segue destination="XfG-lQ-9wD" kind="relationship" relationship="window.shadowedContentViewController" id="cq2-FE-JQM"/>
@@ -683,21 +687,8 @@
                                     <action selector="uncaughtExceptionClick:" target="XfG-lQ-9wD" id="yaX-jB-dub"/>
                                 </connections>
                             </button>
-                            <button verticalHuggingPriority="750" translatesAutoresizingMaskIntoConstraints="NO" id="2bk-9O-Qjq">
-                                <rect key="frame" x="134" y="118" width="212" height="32"/>
-                                <constraints>
-                                    <constraint firstAttribute="width" constant="200" id="7ou-JR-HME"/>
-                                </constraints>
-                                <buttonCell key="cell" type="push" title="Caught Exception No Notify" bezelStyle="rounded" alignment="center" borderStyle="border" imageScaling="proportionallyDown" inset="2" id="eKb-Gv-RdZ">
-                                    <behavior key="behavior" pushIn="YES" lightByBackground="YES" lightByGray="YES"/>
-                                    <font key="font" metaFont="system"/>
-                                </buttonCell>
-                                <connections>
-                                    <action selector="caughtExceptionNoNotifyClick:" target="XfG-lQ-9wD" id="4a6-iM-7WG"/>
-                                </connections>
-                            </button>
                             <button verticalHuggingPriority="750" translatesAutoresizingMaskIntoConstraints="NO" id="eg7-h0-j0y">
-                                <rect key="frame" x="145" y="85" width="191" height="32"/>
+                                <rect key="frame" x="145" y="118" width="191" height="32"/>
                                 <constraints>
                                     <constraint firstAttribute="width" constant="179" id="cv2-X7-wWG"/>
                                 </constraints>
@@ -726,13 +717,11 @@
                         <constraints>
                             <constraint firstItem="3Vr-xS-gh5" firstAttribute="top" secondItem="HHl-Qj-Vaa" secondAttribute="bottom" constant="12" symbolic="YES" id="2bB-oQ-hu4"/>
                             <constraint firstItem="3Vr-xS-gh5" firstAttribute="leading" secondItem="HHl-Qj-Vaa" secondAttribute="leading" id="2bN-0f-Jpx"/>
-                            <constraint firstItem="2bk-9O-Qjq" firstAttribute="top" secondItem="3Vr-xS-gh5" secondAttribute="bottom" constant="12" symbolic="YES" id="8IA-bc-ngg"/>
+                            <constraint firstItem="eg7-h0-j0y" firstAttribute="centerX" secondItem="3Vr-xS-gh5" secondAttribute="centerX" id="5d3-lh-mlS"/>
                             <constraint firstItem="HHl-Qj-Vaa" firstAttribute="top" secondItem="m2S-Jp-Qdl" secondAttribute="top" constant="58" id="BUj-36-Q64"/>
-                            <constraint firstItem="eg7-h0-j0y" firstAttribute="centerX" secondItem="2bk-9O-Qjq" secondAttribute="centerX" id="XRW-rW-d6Z"/>
-                            <constraint firstItem="2bk-9O-Qjq" firstAttribute="centerX" secondItem="3Vr-xS-gh5" secondAttribute="centerX" id="YsU-J8-9fZ"/>
                             <constraint firstItem="3Vr-xS-gh5" firstAttribute="trailing" secondItem="HHl-Qj-Vaa" secondAttribute="trailing" id="Z2z-Bt-Bf9"/>
-                            <constraint firstItem="eg7-h0-j0y" firstAttribute="top" secondItem="2bk-9O-Qjq" secondAttribute="bottom" constant="12" symbolic="YES" id="aHj-nO-xAL"/>
                             <constraint firstItem="HHl-Qj-Vaa" firstAttribute="centerX" secondItem="m2S-Jp-Qdl" secondAttribute="centerX" id="jJa-AF-yrD"/>
+                            <constraint firstItem="eg7-h0-j0y" firstAttribute="top" secondItem="3Vr-xS-gh5" secondAttribute="bottom" constant="12" symbolic="YES" id="tA3-Un-6ry"/>
                         </constraints>
                     </view>
                 </viewController>

--- a/examples/objective-c-osx/objective-c-osx/ViewController.m
+++ b/examples/objective-c-osx/objective-c-osx/ViewController.m
@@ -29,15 +29,6 @@
     }
 }
 
-- (IBAction)caughtExceptionNoNotifyClick:(id)sender {
-    @try {
-        @throw [NSException exceptionWithName:@"caughtExceptionNoNotify" reason:@"reason" userInfo:nil];
-    }
-    @catch (NSException *exception) {
-        NSLog(@"Bad times");
-    }
-}
-
 - (IBAction)uncaughtExceptionClick:(id)sender {
     @throw [NSException exceptionWithName:@"uncaughtException" reason:@"reason" userInfo:nil];
 }

--- a/examples/swift-ios/README.md
+++ b/examples/swift-ios/README.md
@@ -1,0 +1,6 @@
+# Example iOS integration with Bugsnag
+
+1. Run `pod install`
+2. Open this project in XCode
+3. Insert your API key in the AppDelegate: `Bugsnag.start(withApiKey: "your-api-key")` 
+4. Run the app! There are several examples of different kinds of errors which can be thrown.


### PR DESCRIPTION
Updates the contributing guide to make several steps clearer, and to eliminate some snags. Changeset includes:

- README for all example projects detailing how to run project and change API key
- `pod trunk push` uses `--allow-warnings` flag
- Removes confusing 'No Notify' button from OSX example project
- Clarifies how to generate a release build in XCode
- Americanizes spellings
- Adds network link conditioning note