### PR TITLE
Prevent potential crash during app teardown

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,12 @@
 Changelog
 =========
 
+## 5.X.X (TBD)
+
+### Bug Fixes
+
+* Prevent potential crash in session delivery during app teardown [#308](https://github.com/bugsnag/bugsnag-cocoa/pull/308)
+
 ## 5.16.3 (14 Aug 2018)
 
 ### Bug Fixes

--- a/Source/BugsnagApiClient.m
+++ b/Source/BugsnagApiClient.m
@@ -135,6 +135,10 @@
     return request;
 }
 
+- (void)dealloc {
+    [self.sendQueue cancelAllOperations];
+}
+
 @end
 
 @implementation BSGDelayOperation

--- a/Source/BugsnagSessionTrackingApiClient.m
+++ b/Source/BugsnagSessionTrackingApiClient.m
@@ -19,8 +19,8 @@
 }
 
 - (void)deliverSessionsInStore:(BugsnagSessionFileStore *)store {
-    NSString *apiKey = self.config.apiKey;
-    NSURL *sessionURL = self.config.sessionURL;
+    NSString *apiKey = [self.config.apiKey copy];
+    NSURL *sessionURL = [self.config.sessionURL copy];
 
     [self.sendQueue addOperationWithBlock:^{
         if (!apiKey) {

--- a/Source/BugsnagSessionTrackingApiClient.m
+++ b/Source/BugsnagSessionTrackingApiClient.m
@@ -19,8 +19,11 @@
 }
 
 - (void)deliverSessionsInStore:(BugsnagSessionFileStore *)store {
+    NSString *apiKey = self.config.apiKey;
+    NSURL *sessionURL = self.config.sessionURL;
+
     [self.sendQueue addOperationWithBlock:^{
-        if (!self.config.apiKey) {
+        if (!apiKey) {
             bsg_log_err(@"No API key set. Refusing to send sessions.");
             return;
         }
@@ -41,16 +44,16 @@
         if (sessionCount > 0) {
             NSDictionary *HTTPHeaders = @{
                                           @"Bugsnag-Payload-Version": @"1.0",
-                                          @"Bugsnag-API-Key": self.config.apiKey,
+                                          @"Bugsnag-API-Key": apiKey,
                                           @"Bugsnag-Sent-At": [BSG_RFC3339DateTool stringFromDate:[NSDate new]]
                                           };
             [self sendData:payload
                withPayload:[payload toJson]
-                     toURL:self.config.sessionURL
+                     toURL:sessionURL
                    headers:HTTPHeaders
               onCompletion:^(id data, BOOL success, NSError *error) {
                   if (success && error == nil) {
-                      bsg_log_info(@"Sent %lu sessions to Bugsnag", (unsigned long)sessionCount);
+                      bsg_log_info(@"Sent %lu sessions to Bugsnag", (unsigned long) sessionCount);
 
                       for (NSString *fileId in fileIds) {
                           [store deleteFileWithId:fileId];


### PR DESCRIPTION
## Goal

If the session API client is garbage collected while sessions are enqueued to be delivered, there
can be a crash when accessing self.config.apiKey from the operation queue. This changeset fixes that by copying the API key/session URL accessed from within the operation block.

## Changeset

Copy the `sessionURL` and `apiKey` values so that `self` is not accessed from the operation block.

## Tests

Existing unit tests/mazerunner.

## Review

<!-- When submitting for review, consider the points for self-review and the
     criteria which will be used for secondary review -->

For the submitter, initial self-review:

- [ ] Commented on code changes inline explain the reasoning behind the approach
- [x] Reviewed the test cases added for completeness and possible points for discussion
- [ ] A changelog entry was added for the goal of this pull request
- [x] Check the scope of the changeset - is everything in the diff required for the pull request?
- This pull request is ready for:
  - [x] Initial review of the intended approach, not yet feature complete
  - [x] Structural review of the classes, functions, and properties modified
  - [x] Final review

For the pull request reviewer(s), this changeset has been reviewed for:

- [ ] Consistency across platforms for structures or concepts added or modified
- [ ] Consistency between the changeset and the goal stated above
- [ ] Internal consistency with the rest of the library - is there any overlap between existing interfaces and any which have been added?
- [ ] Usage friction - is the proposed change in usage cumbersome or complicated?
- [ ] Performance and complexity - are there any cases of unexpected O(n^3) when iterating, recursing, flat mapping, etc?
- [ ] Concurrency concerns - if components are accessed asynchronously, what issues will arise
- [ ] Thoroughness of added tests and any missing edge cases
- [ ] Idiomatic use of the language
