### PR TITLE
Remove ios-specific steps which clashed with global mazerunner steps

### DIFF
--- a/features/steps/ios_steps.rb
+++ b/features/steps/ios_steps.rb
@@ -36,41 +36,6 @@ When("I crash the app using {string}") do |event|
   }
 end
 
-# TODO: move upstream into maze-runner
-Then("request {int} is valid for the session tracking API") do |index|
-  steps %Q{
-    Then the "Bugsnag-API-Key" header is not null for request #{index}
-    And the "Content-Type" header equals "application/json" for request #{index}
-    And the "Bugsnag-Payload-Version" header equals "1.0" for request #{index}
-    And the "Bugsnag-Sent-At" header is a timestamp for request #{index}
-
-    And the payload field "app" is not null for request #{index}
-    And the payload field "device" is not null for request #{index}
-    And the payload field "notifier.name" is not null for request #{index}
-    And the payload field "notifier.url" is not null for request #{index}
-    And the payload field "notifier.version" is not null for request #{index}
-    And the payload has a valid sessions array for request #{index}
-  }
-end
-
-Then("request {int} is valid for the error reporting API") do |index|
-  steps %Q{
-    Then the "Bugsnag-API-Key" header is not null for request #{index}
-    And the "Content-Type" header equals "application/json" for request #{index}
-    And the "Bugsnag-Sent-At" header is a timestamp for request #{index}
-
-    And the payload field "notifier.name" is not null for request #{index}
-    And the payload field "notifier.url" is not null for request #{index}
-    And the payload field "notifier.version" is not null for request #{index}
-    And the payload field "events" is a non-empty array for request #{index}
-
-    And each element in payload field "events" has "severity" for request #{index}
-    And each element in payload field "events" has "severityReason.type" for request #{index}
-    And each element in payload field "events" has "unhandled" for request #{index}
-    And each element in payload field "events" has "exceptions" for request #{index}
-  }
-end
-
 Then("the payload field {string} of request {int} equals the payload field {string} of request {int}") do |field1, request_index1, field2, request_index2|
   value1 = read_key_path(find_request(request_index1)[:body], field1)
   value2 = read_key_path(find_request(request_index2)[:body], field2)


### PR DESCRIPTION
Removes iOS specific steps which are already present in the mazerunner repo. These were failing session tracking mazerunner scenarios.