### PR TITLE
Handle NSExceptions within C++ exception handler

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,10 @@
 Changelog
 =========
 
+## 5.X.X (TBD)
+
+Handle NSExceptions within C++ exception handler for PLCR compatibility [312](https://github.com/bugsnag/bugsnag-cocoa/pull/312)
+
 ## 5.16.3 (14 Aug 2018)
 
 ### Bug Fixes

--- a/Source/KSCrash/Source/KSCrash/Recording/Sentry/BSG_KSCrashSentry.c
+++ b/Source/KSCrash/Source/KSCrash/Recording/Sentry/BSG_KSCrashSentry.c
@@ -62,10 +62,6 @@ static BSG_CrashSentry bsg_g_sentries[] = {
         bsg_kscrashsentry_uninstallCPPExceptionHandler,
     },
     {
-        BSG_KSCrashTypeNSException, bsg_kscrashsentry_installNSExceptionHandler,
-        bsg_kscrashsentry_uninstallNSExceptionHandler,
-    },
-    {
         BSG_KSCrashTypeMainThreadDeadlock,
         bsg_kscrashsentry_installDeadlockHandler,
         bsg_kscrashsentry_uninstallDeadlockHandler,

--- a/Source/KSCrash/Source/KSCrash/Recording/Sentry/BSG_KSCrashSentry_CPPException.mm
+++ b/Source/KSCrash/Source/KSCrash/Recording/Sentry/BSG_KSCrashSentry_CPPException.mm
@@ -222,9 +222,8 @@ static void CPPExceptionTerminate(void) {
             @"Crash handling complete. Restoring original handlers.");
         bsg_kscrashsentry_uninstall((BSG_KSCrashType)BSG_KSCrashTypeAll);
         bsg_kscrashsentry_resumeThreads();
+        bsg_g_originalTerminateHandler();
     }
-
-    bsg_g_originalTerminateHandler();
 }
 
 // ============================================================================

--- a/Source/KSCrash/Source/KSCrash/Recording/Sentry/BSG_KSCrashSentry_CPPException.mm
+++ b/Source/KSCrash/Source/KSCrash/Recording/Sentry/BSG_KSCrashSentry_CPPException.mm
@@ -155,8 +155,7 @@ static void CPPExceptionTerminate(void) {
     try {
         throw;
     } catch (NSException *exception) {
-        BSG_KSLOG_DEBUG(@"Detected NSException. Letting the current "
-                        @"NSException handler deal with it.");
+        BSG_KSLOG_DEBUG(@"Detected NSException, beginning report serialisation.");
         isNSException = true;
         handleNSException(exception);
     } catch (std::exception &exc) {

--- a/Source/KSCrash/Source/KSCrash/Recording/Sentry/BSG_KSCrashSentry_CPPException.mm
+++ b/Source/KSCrash/Source/KSCrash/Recording/Sentry/BSG_KSCrashSentry_CPPException.mm
@@ -222,7 +222,10 @@ static void CPPExceptionTerminate(void) {
             @"Crash handling complete. Restoring original handlers.");
         bsg_kscrashsentry_uninstall((BSG_KSCrashType)BSG_KSCrashTypeAll);
         bsg_kscrashsentry_resumeThreads();
-        bsg_g_originalTerminateHandler();
+
+        if (bsg_g_originalTerminateHandler != NULL) {
+            bsg_g_originalTerminateHandler();
+        }
     }
 }
 

--- a/Source/KSCrash/Source/KSCrash/Recording/Sentry/BSG_KSCrashSentry_CPPException.mm
+++ b/Source/KSCrash/Source/KSCrash/Recording/Sentry/BSG_KSCrashSentry_CPPException.mm
@@ -130,6 +130,13 @@ static void handleNSException(NSException *exception) {
 
         BSG_KSLOG_DEBUG(@"Crash handling complete. Restoring original handlers.");
         bsg_kscrashsentry_uninstall((BSG_KSCrashType)BSG_KSCrashTypeAll);
+
+        NSUncaughtExceptionHandler* handler = NSGetUncaughtExceptionHandler();
+
+        if (handler != NULL) {
+            BSG_KSLOG_DEBUG(@"Calling original exception handler.");
+            handler(exception);
+        }
     }
 }
 


### PR DESCRIPTION
## Goal

Capture uncaught NSExceptions when PLCrashReporter is initialised in a project after Bugsnag.

## Design

`NSException` crashes were previously discarded from within Bugsnag's C++ exception handler, as they were handled by `NSUncaughtExceptionHandler` (within `BSG_KSCrashSentry_NSException`) instead.

PLCrashReporter does not appear to call the previously registered `NSUncaughtExceptionHandler`, meaning that if PLCR was initialised after Bugsnag, no report could be captured. However, Bugsnag's C++ exception handler is triggered when PLCR is installed. This changeset adapts the C++ exception handler to serialise `NSException` instead of `BSG_KSCrashSentry_NSException`.

## Changeset

- Move the logic for capturing `NSException` into the C++ sentry
- Stop registering `BSG_KSCrashSentry_NSException`

## Tests

Raised an `NSException` in the objective-c-ios example app and verified that a report was received by the Bugsnag dashboard for the following matrix:

- Only bugsnag installed
- Bugsnag initialised first
- PLCrashReporter initialised first

## Review

<!-- When submitting for review, consider the points for self-review and the
     criteria which will be used for secondary review -->

For the submitter, initial self-review:

- [x] Commented on code changes inline explain the reasoning behind the approach
- [x] Reviewed the test cases added for completeness and possible points for discussion
- [x] A changelog entry was added for the goal of this pull request
- [x] Check the scope of the changeset - is everything in the diff required for the pull request?
- This pull request is ready for:
  - [x] Initial review of the intended approach, not yet feature complete
  - [x] Structural review of the classes, functions, and properties modified
  - [ ] Final review

For the pull request reviewer(s), this changeset has been reviewed for:

- [x] Consistency across platforms for structures or concepts added or modified
- [x] Consistency between the changeset and the goal stated above
- [x] Internal consistency with the rest of the library - is there any overlap between existing interfaces and any which have been added?
- [x] Usage friction - is the proposed change in usage cumbersome or complicated?
- [x] Performance and complexity - are there any cases of unexpected O(n^3) when iterating, recursing, flat mapping, etc?
- [x] Concurrency concerns - if components are accessed asynchronously, what issues will arise
- [x] Thoroughness of added tests and any missing edge cases
- [x] Idiomatic use of the language
