### PR TITLE
Add Device time of report capture to JSON payload

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,13 @@
 Changelog
 =========
 
+## 5.17.1 (TBD)
+
+### Bug Fixes
+
+* Add Device time of report capture to JSON payload
+  [#315](https://github.com/bugsnag/bugsnag-cocoa/pull/315)
+
 ## 5.17.0 (2018-09-25)
 
 ### Enhancements

--- a/Source/BugsnagKSCrashSysInfoParser.m
+++ b/Source/BugsnagKSCrashSysInfoParser.m
@@ -33,6 +33,7 @@ NSDictionary *BSGParseDevice(NSDictionary *report) {
                          [report valueForKeyPath:@"system.memory.free"],
                          @"freeMemory");
     
+    BSGDictSetSafeObject(device, [report valueForKeyPath:@"report.timestamp"], @"time");
     
     NSFileManager *fileManager = [NSFileManager defaultManager];
     NSArray *searchPaths = NSSearchPathForDirectoriesInDomains(

--- a/Tests/BugsnagSinkTests.m
+++ b/Tests/BugsnagSinkTests.m
@@ -277,7 +277,7 @@
     XCTAssertEqualObjects(device[@"jailbroken"], @YES);
     XCTAssertEqualObjects(device[@"freeMemory"], @742920192);
     XCTAssertEqualObjects(device[@"orientation"], @"unknown");
-    XCTAssertNotNil(device[@"time"]); // TODO make more specific!
+    XCTAssertEqualObjects(device[@"time"], @"2014-12-02T01:56:13Z");
 
 #if defined(__LP64__)
     XCTAssertEqualObjects(device[@"wordSize"], @64);

--- a/Tests/BugsnagSinkTests.m
+++ b/Tests/BugsnagSinkTests.m
@@ -259,9 +259,9 @@
     NSDictionary *device = event[@"device"];
     XCTAssertNotNil(device);
 #if TARGET_OS_IPHONE || TARGET_OS_TV || TARGET_IPHONE_SIMULATOR
-    XCTAssertEqual(18, device.count);
+    XCTAssertEqual(19, device.count);
 #else
-    XCTAssertEqual(17, device.count);
+    XCTAssertEqual(18, device.count);
 #endif
 
     XCTAssertEqualObjects(device[@"id"], @"f6d519a74213a57f8d052c53febfeee6f856d062");
@@ -277,6 +277,8 @@
     XCTAssertEqualObjects(device[@"jailbroken"], @YES);
     XCTAssertEqualObjects(device[@"freeMemory"], @742920192);
     XCTAssertEqualObjects(device[@"orientation"], @"unknown");
+    XCTAssertNotNil(device[@"time"]); // TODO make more specific!
+
 #if defined(__LP64__)
     XCTAssertEqualObjects(device[@"wordSize"], @64);
 #else

--- a/features/crashprobe.feature
+++ b/features/crashprobe.feature
@@ -218,6 +218,7 @@ Scenario: Throw a NSException
     And the "method" of stack frame 0 equals "__exceptionPreprocess"
     And the "method" of stack frame 1 equals "objc_exception_throw"
     And the "method" of stack frame 2 equals "-[ObjCExceptionScenario run]"
+    And the payload field "events.0.device.time" is not null
 
 Scenario: Access a non-object as an object
     When I set environment variable "BUGSNAG_API_KEY" to "a35a2a72bd230ac0aa0f52715bbdc6aa"

--- a/features/crashprobe.feature
+++ b/features/crashprobe.feature
@@ -218,7 +218,7 @@ Scenario: Throw a NSException
     And the "method" of stack frame 0 equals "__exceptionPreprocess"
     And the "method" of stack frame 1 equals "objc_exception_throw"
     And the "method" of stack frame 2 equals "-[ObjCExceptionScenario run]"
-    And the event "device.time" is a timestamp
+    And the event "device.time" is within 30000 ms of the current timestamp
 
 Scenario: Access a non-object as an object
     When I set environment variable "BUGSNAG_API_KEY" to "a35a2a72bd230ac0aa0f52715bbdc6aa"

--- a/features/crashprobe.feature
+++ b/features/crashprobe.feature
@@ -218,7 +218,7 @@ Scenario: Throw a NSException
     And the "method" of stack frame 0 equals "__exceptionPreprocess"
     And the "method" of stack frame 1 equals "objc_exception_throw"
     And the "method" of stack frame 2 equals "-[ObjCExceptionScenario run]"
-    And the payload field "events.0.device.time" is not null
+    And the event "device.time" is a timestamp
 
 Scenario: Access a non-object as an object
     When I set environment variable "BUGSNAG_API_KEY" to "a35a2a72bd230ac0aa0f52715bbdc6aa"

--- a/features/crashprobe.feature
+++ b/features/crashprobe.feature
@@ -218,7 +218,7 @@ Scenario: Throw a NSException
     And the "method" of stack frame 0 equals "__exceptionPreprocess"
     And the "method" of stack frame 1 equals "objc_exception_throw"
     And the "method" of stack frame 2 equals "-[ObjCExceptionScenario run]"
-    And the event "device.time" is within 30000 ms of the current timestamp
+    And the event "device.time" is within 30 seconds of the current timestamp
 
 Scenario: Access a non-object as an object
     When I set environment variable "BUGSNAG_API_KEY" to "a35a2a72bd230ac0aa0f52715bbdc6aa"

--- a/features/handled_errors.feature
+++ b/features/handled_errors.feature
@@ -6,7 +6,7 @@ Scenario: Override errorClass and message from a notifyError() callback
     And the request is a valid for the error reporting API
     And the exception "errorClass" equals "Bar"
     And the exception "message" equals "Foo"
-    And the payload field "events.0.device.time" is not null
+    And the event "device.time" is a timestamp
 
 Scenario: Reporting an NSError
     When I run "HandledErrorScenario" with the defaults on "iPhone8-11.2"

--- a/features/handled_errors.feature
+++ b/features/handled_errors.feature
@@ -6,7 +6,7 @@ Scenario: Override errorClass and message from a notifyError() callback
     And the request is a valid for the error reporting API
     And the exception "errorClass" equals "Bar"
     And the exception "message" equals "Foo"
-    And the event "device.time" is within 30000 ms of the current timestamp
+    And the event "device.time" is within 30 seconds of the current timestamp
 
 Scenario: Reporting an NSError
     When I run "HandledErrorScenario" with the defaults on "iPhone8-11.2"

--- a/features/handled_errors.feature
+++ b/features/handled_errors.feature
@@ -6,7 +6,7 @@ Scenario: Override errorClass and message from a notifyError() callback
     And the request is a valid for the error reporting API
     And the exception "errorClass" equals "Bar"
     And the exception "message" equals "Foo"
-    And the event "device.time" is a timestamp
+    And the event "device.time" is within 30000 ms of the current timestamp
 
 Scenario: Reporting an NSError
     When I run "HandledErrorScenario" with the defaults on "iPhone8-11.2"

--- a/features/handled_errors.feature
+++ b/features/handled_errors.feature
@@ -6,6 +6,7 @@ Scenario: Override errorClass and message from a notifyError() callback
     And the request is a valid for the error reporting API
     And the exception "errorClass" equals "Bar"
     And the exception "message" equals "Foo"
+    And the payload field "events.0.device.time" is not null
 
 Scenario: Reporting an NSError
     When I run "HandledErrorScenario" with the defaults on "iPhone8-11.2"

--- a/features/steps/ios_steps.rb
+++ b/features/steps/ios_steps.rb
@@ -1,3 +1,5 @@
+require 'date'
+
 When("I run {string} with the defaults on {string}") do |eventType, simulator|
   wait_time = '4'
   steps %Q{
@@ -62,4 +64,13 @@ Then("each event in the payload for request {int} matches one of:") do |request_
         error_class == values["class"]
     end, "No event matches the following values: #{values}")
   end
+end
+
+Then("the event {string} is within {int} ms of the current timestamp") do |field, threshold_ms|
+  value = read_key_path(find_request(0)[:body], "events.0.#{field}")
+  assert_not_nil(value, "Expected a timestamp")
+  nowMs = Time.now.to_i
+  thenMs = Time.parse(value).to_i
+  delta = nowMs - thenMs
+  assert_true(delta.abs < threshold_ms, "Expected current timestamp, but received #{value}")
 end

--- a/features/steps/ios_steps.rb
+++ b/features/steps/ios_steps.rb
@@ -1,5 +1,3 @@
-require 'date'
-
 When("I run {string} with the defaults on {string}") do |eventType, simulator|
   wait_time = '4'
   steps %Q{
@@ -66,11 +64,11 @@ Then("each event in the payload for request {int} matches one of:") do |request_
   end
 end
 
-Then("the event {string} is within {int} ms of the current timestamp") do |field, threshold_ms|
+Then("the event {string} is within {int} seconds of the current timestamp") do |field, threshold_secs|
   value = read_key_path(find_request(0)[:body], "events.0.#{field}")
   assert_not_nil(value, "Expected a timestamp")
-  nowMs = Time.now.to_i
-  thenMs = Time.parse(value).to_i
-  delta = nowMs - thenMs
-  assert_true(delta.abs < threshold_ms, "Expected current timestamp, but received #{value}")
+  nowSecs = Time.now.to_i
+  thenSecs = Time.parse(value).to_i
+  delta = nowSecs - thenSecs
+  assert_true(delta.abs < threshold_secs, "Expected current timestamp, but received #{value}")
 end


### PR DESCRIPTION
## Goal

Reports may be cached on a device if no network connection is available. In this case, the report may not be delivered for hours, or even days, after the error was originally captured by Bugsnag.

Sending the time at which the report was originally captured allows for timestamps to be normalised. This avoids confusing information similar to the following being shown:

<img width="254" alt="screen shot 2018-10-23 at 16 19 51" src="https://user-images.githubusercontent.com/11800640/47371326-7ee83b80-d6df-11e8-8829-f9b00e295012.png">


## Design

The pipeline normalises timestamps based off the `device.time` field.

## Changeset

Serialises the time at which the report was generated into the `device.time` payload field.

## Tests

- Added mazerunner tests for handled/unhandled errors, payload serialisation unit test
- Checked payload manually for presence of `device.time` in handled/unhandled error
- Checked breadcrumb time is updated in the dashboard when sending in a payload that has been cached and had the timestamp manually edited

## Review

<!-- When submitting for review, consider the points for self-review and the
     criteria which will be used for secondary review -->

For the submitter, initial self-review:

- [ ] Commented on code changes inline explain the reasoning behind the approach
- [x] Reviewed the test cases added for completeness and possible points for discussion
- [x] A changelog entry was added for the goal of this pull request
- [ ] Check the scope of the changeset - is everything in the diff required for the pull request?
- This pull request is ready for:
  - [ ] Initial review of the intended approach, not yet feature complete
  - [ ] Structural review of the classes, functions, and properties modified
  - [ ] Final review

For the pull request reviewer(s), this changeset has been reviewed for:

- [ ] Consistency across platforms for structures or concepts added or modified
- [ ] Consistency between the changeset and the goal stated above
- [ ] Internal consistency with the rest of the library - is there any overlap between existing interfaces and any which have been added?
- [ ] Usage friction - is the proposed change in usage cumbersome or complicated?
- [ ] Performance and complexity - are there any cases of unexpected O(n^3) when iterating, recursing, flat mapping, etc?
- [ ] Concurrency concerns - if components are accessed asynchronously, what issues will arise
- [ ] Thoroughness of added tests and any missing edge cases
- [ ] Idiomatic use of the language
