### PR TITLE
Modify wait times between and before mazerunner scenarios

### DIFF
--- a/features/scripts/pre_launch.sh
+++ b/features/scripts/pre_launch.sh
@@ -1,0 +1,4 @@
+#!/usr/bin/env bash
+
+echo "Waiting for simulator to heat up"
+sleep 30

--- a/features/steps/ios_steps.rb
+++ b/features/steps/ios_steps.rb
@@ -1,5 +1,5 @@
 When("I run {string} with the defaults on {string}") do |eventType, simulator|
-  wait_time = RUNNING_CI ? '20' : '1'
+  wait_time = '4'
   steps %Q{
     When I set environment variable "BUGSNAG_API_KEY" to "a35a2a72bd230ac0aa0f52715bbdc6aa"
     And I set environment variable "EVENT_TYPE" to "#{eventType}"
@@ -10,14 +10,14 @@ When("I run {string} with the defaults on {string}") do |eventType, simulator|
 end
 
 When("I launch the app") do
-  wait_time = RUNNING_CI ? '10' : '5'
+  wait_time = '4'
   steps %Q{
     When I run the script "features/scripts/launch_ios_app.sh"
     And I wait for #{wait_time} seconds
   }
 end
 When("I relaunch the app") do
-  wait_time = RUNNING_CI ? '20' : '9'
+  wait_time = '4'
   steps %Q{
     When I run the script "features/scripts/launch_ios_app.sh"
     And I wait for #{wait_time} seconds
@@ -29,6 +29,7 @@ When("I configure the app to run on {string}") do |device|
   }
 end
 When("I crash the app using {string}") do |event|
+  wait_time = '4'
   steps %Q{
     When I set environment variable "EVENT_TYPE" to "#{event}"
     And I set environment variable "EVENT_MODE" to "normal"

--- a/features/support/env.rb
+++ b/features/support/env.rb
@@ -12,6 +12,7 @@ Dir.chdir('features/fixtures/ios-swift-cocoapods') do
     ['../../scripts/build_ios_app.sh'],
     ['../../scripts/remove_installed_simulators.sh'],
     ['../../scripts/launch_ios_simulators.sh'],
+    ['../../scripts/pre_launch.sh'],
   ])
 end
 


### PR DESCRIPTION
## Goal

Mazerunner Cocoa scenarios currently fail on some machines locally. This attempts to fix this problem for *handled* scenarios. Additionally, the approach used should greatly reduce the time required to run mazerunner jobs on CI.

## Design

Mazerunner currently uses arbitrary waits, which appear to be necessary for two reasons:

1. Allowing the simulator to fully boot before the first scenario is run
2. Allowing the process to launch, crash, and serialise/send crash reports, within each scenario

Without a sufficient wait for 1., the first few scenarios tend to fail due to receiving no requests, then all subsequent scenarios pass.

Without a sufficient wait for 2., all scenarios fail due to receiving no requests within the expected time (the simulator can't keep up with mazerunner).

## Changeset

Note: all wait times have been determined through trial and error.

1. A pre-launch script has been added which waits for 30 seconds at the start of each mazerunner run. This allows the simulator to launch fully before the first scenario, which was previously achieved by a very large wait between scenarios on CI (20 seconds each time)
2. The wait time for scenario steps is now set at 4 seconds. This has decreased the wait for most steps, but increased it for `I run {string} with the defaults` when running locally - I believe an insufficient wait was the cause of handled errors not sending any requests.

## Discussion

This does not fix unhandled scenarios, which still don't work locally. I believe they suffer from a similar issue, but was unable to reproduce it within a timebox of 2 hours - I'd suggest we look into this separately.

It'd also be good to understand fully why we need these waits, and check whether other platforms could have their time reduced.  The mazerunner CI job now completes in 9 mins, compared to 22 mins on the latest master commit, and I believe there's probably further optimisations to be had...

## Review

<!-- When submitting for review, consider the points for self-review and the
     criteria which will be used for secondary review -->

For the submitter, initial self-review:

- [ ] Commented on code changes inline explain the reasoning behind the approach
- [ ] Reviewed the test cases added for completeness and possible points for discussion
- [ ] A changelog entry was added for the goal of this pull request
- [ ] Check the scope of the changeset - is everything in the diff required for the pull request?
- This pull request is ready for:
  - [ ] Initial review of the intended approach, not yet feature complete
  - [ ] Structural review of the classes, functions, and properties modified
  - [ ] Final review

For the pull request reviewer(s), this changeset has been reviewed for:

- [ ] Consistency across platforms for structures or concepts added or modified
- [ ] Consistency between the changeset and the goal stated above
- [ ] Internal consistency with the rest of the library - is there any overlap between existing interfaces and any which have been added?
- [ ] Usage friction - is the proposed change in usage cumbersome or complicated?
- [ ] Performance and complexity - are there any cases of unexpected O(n^3) when iterating, recursing, flat mapping, etc?
- [ ] Concurrency concerns - if components are accessed asynchronously, what issues will arise
- [ ] Thoroughness of added tests and any missing edge cases
- [ ] Idiomatic use of the language
