### PR TITLE
fix(backtrace): Strip pointer auth mask before returning usable IP

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,14 @@
 Changelog
 =========
 
+## TBD
+
+### Bug Fixes
+
+* Fix stack trace resolution on iPhone XS sometimes reporting incorrect
+  addresses
+  [#319](https://github.com/bugsnag/bugsnag-cocoa/pull/319)
+
 ## 5.17.0 (2018-09-25)
 
 ### Enhancements

--- a/Source/KSCrash/Source/KSCrash/Recording/Tools/BSG_KSBacktrace.c
+++ b/Source/KSCrash/Source/KSCrash/Recording/Tools/BSG_KSBacktrace.c
@@ -29,6 +29,13 @@
 #include "BSG_KSDynamicLinker.h"
 #include "BSG_KSMach.h"
 
+/**
+ * Mask to strip pointer authentication codes from pointers on Arm64e
+ * devices. Example usage, assuming the usage is guarded for __arm64__:
+ *     uintptr_t ptr_address = ptr & BSG_PACStrippingMaskArm64e;
+ */
+#define BSG_PACStrippingMaskArm64e 0x0000000fffffffff
+
 /** Remove any pointer tagging from an instruction address
  * On armv7 the least significant bit of the pointer distinguishes
  * between thumb mode (2-byte instructions) and normal mode (4-byte
@@ -170,7 +177,13 @@ int bsg_ksbt_backtraceThreadState(
     }
 
     for (; i < maxEntries; i++) {
+#if defined(__arm64__)
+        // Strip program auth code from address prior to storing address.
+        // Intended for Arm64e but is a no-op on other Arm64 archs.
+        backtraceBuffer[i] = frame.return_address & BSG_PACStrippingMaskArm64e;
+#else
         backtraceBuffer[i] = frame.return_address;
+#endif
         if (backtraceBuffer[i] == 0 || frame.previous == 0 ||
             bsg_ksmachcopyMem(frame.previous, &frame, sizeof(frame)) !=
                 KERN_SUCCESS) {


### PR DESCRIPTION
## Background

The Arm64e architecture introduces pointer authentication codes to
detect and guard against unexpected changes to pointers in memory. For
most application functions, this is a nice bonus that nobody needs to
think about, however, for a crash reporting library, we need to strip
this extraneous value ahead of time to avoid reporting a stack frame
address which does not align to a function exactly, causing unreadable
stack traces.

PACs work by adding a signature to the higher order bits of a pointer
before it is stored. When the pointer is read, the signature is
validated prior to executing a function. If the signature has been
tampered with, then the app is forced to crash rather than execute
altered code.

## Design

Modified the Arm64-specific method for reading the instruction
pointer from a crash context to strip a value prior to reporting the
value.

## Tests

* Tested by [compiling a sample app with PACs](https://developer.apple.com/documentation/security/preparing_your_app_to_work_with_pointer_authentication?language=objc) and causing crashes on an iPhone XS