### PR TITLE
Strip top bits from pointers before reading memory contents

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,11 @@ Changelog
   addresses
   [#319](https://github.com/bugsnag/bugsnag-cocoa/pull/319)
 
+* Add `fatalError` and other assertion failure messages in reports for
+  Swift 4.2 apps. Note that this only includes messages which are 16
+  characters or longer. See the linked pull request for more information.
+  [#320](https://github.com/bugsnag/bugsnag-cocoa/pull/320)
+
 ## 5.17.0 (2018-09-25)
 
 ### Enhancements

--- a/Source/KSCrash/Source/KSCrash/Recording/BSG_KSCrashReport.c
+++ b/Source/KSCrash/Source/KSCrash/Recording/BSG_KSCrashReport.c
@@ -983,6 +983,12 @@ bool bsg_kscrw_i_isValidPointer(const uintptr_t address) {
     return true;
 }
 
+/**
+ * Strip higher order bits from addresses which aren't related to the actual
+ * location.
+ */
+#define BSG_ValidPointerMask  0x0000000fffffffff
+
 /** Write the contents of a memory location only if it contains notable data.
  * Also writes meta information about the data.
  *
@@ -990,13 +996,17 @@ bool bsg_kscrw_i_isValidPointer(const uintptr_t address) {
  *
  * @param key The object key, if needed.
  *
- * @param address The memory address.
+ * @param rawAddress The memory address.
  */
 void bsg_kscrw_i_writeMemoryContentsIfNotable(
     const BSG_KSCrashReportWriter *const writer, const char *const key,
-    const uintptr_t address) {
+    const uintptr_t rawAddress) {
+    uintptr_t address = rawAddress;
     if (!bsg_kscrw_i_isValidPointer(address)) {
-        return;
+        address &= BSG_ValidPointerMask;
+        if (!bsg_kscrw_i_isValidPointer(address)) {
+            return;
+        }
     }
 
     const void *object = (const void *)address;

--- a/features/crashprobe.feature
+++ b/features/crashprobe.feature
@@ -166,8 +166,15 @@ Scenario: Crash within Swift code
     And the exception "message" equals "Unexpectedly found nil while unwrapping an Optional value"
     And the exception "errorClass" equals "Fatal error"
 
-    And the "method" of stack frame 0 starts with "_T0s18_fatalErrorMessages5NeverOs12StaticStringV_A2E4fileSu4lines6UInt32V5"
-    And the "method" of stack frame 1 starts with "_T010iOSTestApp10SwiftCrashC3run"
+Scenario: Assertion failure in Swift code
+    When I set environment variable "BUGSNAG_API_KEY" to "a35a2a72bd230ac0aa0f52715bbdc6aa"
+    And I configure the app to run on "iPhone8-11.2"
+    And I crash the app using "SwiftAssertion"
+    And I relaunch the app
+    Then I should receive a request
+    And the request is a valid for the error reporting API
+    And the exception "errorClass" equals "Fatal error"
+    And the exception "message" equals "several unfortunate things just happened"
 
 Scenario: Dereference a null pointer
     When I set environment variable "BUGSNAG_API_KEY" to "a35a2a72bd230ac0aa0f52715bbdc6aa"

--- a/features/fixtures/ios-swift-cocoapods/Podfile.lock
+++ b/features/fixtures/ios-swift-cocoapods/Podfile.lock
@@ -1,16 +1,16 @@
 PODS:
-  - Bugsnag (5.15.6)
+  - Bugsnag (5.17.0)
 
 DEPENDENCIES:
   - Bugsnag (from `../../..`)
 
 EXTERNAL SOURCES:
   Bugsnag:
-    :path: ../../..
+    :path: "../../.."
 
 SPEC CHECKSUMS:
-  Bugsnag: ff5f5e3059e6a9c9d27a899f3bf3774067553483
+  Bugsnag: 2d163d2f4c7acdb9bbcfc7a938c646f3aa39f566
 
 PODFILE CHECKSUM: 4d026fb83571f098c9fb4fa71c1564c72c55ab1a
 
-COCOAPODS: 1.4.0
+COCOAPODS: 1.5.3

--- a/features/fixtures/ios-swift-cocoapods/iOSTestApp.xcodeproj/project.pbxproj
+++ b/features/fixtures/ios-swift-cocoapods/iOSTestApp.xcodeproj/project.pbxproj
@@ -7,6 +7,7 @@
 	objects = {
 
 /* Begin PBXBuildFile section */
+		8A840FBA21AF5C450041DBFA /* SwiftAssertion.swift in Sources */ = {isa = PBXBuildFile; fileRef = 8A840FB921AF5C450041DBFA /* SwiftAssertion.swift */; };
 		8A98400320FD11BF0023ECD1 /* AutoSessionCustomVersionScenario.m in Sources */ = {isa = PBXBuildFile; fileRef = 8A98400220FD11BF0023ECD1 /* AutoSessionCustomVersionScenario.m */; };
 		8AB8866420404DD30003E444 /* AppDelegate.swift in Sources */ = {isa = PBXBuildFile; fileRef = 8AB8866320404DD30003E444 /* AppDelegate.swift */; };
 		8AB8866620404DD30003E444 /* ViewController.swift in Sources */ = {isa = PBXBuildFile; fileRef = 8AB8866520404DD30003E444 /* ViewController.swift */; };
@@ -54,6 +55,7 @@
 
 /* Begin PBXFileReference section */
 		4994F05E0421A0B037DD2CC5 /* Pods_iOSTestApp.framework */ = {isa = PBXFileReference; explicitFileType = wrapper.framework; includeInIndex = 0; path = Pods_iOSTestApp.framework; sourceTree = BUILT_PRODUCTS_DIR; };
+		8A840FB921AF5C450041DBFA /* SwiftAssertion.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = SwiftAssertion.swift; sourceTree = "<group>"; };
 		8A98400120FD11BF0023ECD1 /* AutoSessionCustomVersionScenario.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; path = AutoSessionCustomVersionScenario.h; sourceTree = "<group>"; };
 		8A98400220FD11BF0023ECD1 /* AutoSessionCustomVersionScenario.m */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.objc; path = AutoSessionCustomVersionScenario.m; sourceTree = "<group>"; };
 		8AB8866020404DD30003E444 /* iOSTestApp.app */ = {isa = PBXFileReference; explicitFileType = wrapper.application; includeInIndex = 0; path = iOSTestApp.app; sourceTree = BUILT_PRODUCTS_DIR; };
@@ -196,6 +198,7 @@
 		F42953DE2BB41023C0B07F41 /* scenarios */ = {
 			isa = PBXGroup;
 			children = (
+				8A840FB921AF5C450041DBFA /* SwiftAssertion.swift */,
 				F42957FA1A3724BFBDC22E14 /* NSExceptionScenario.swift */,
 				F4295F595986A279FA3BDEA7 /* UserEmailScenario.swift */,
 				F42954E2B3FF0C5C0474DA74 /* UserEnabledScenario.swift */,
@@ -277,7 +280,6 @@
 				8AB8865D20404DD30003E444 /* Frameworks */,
 				8AB8865E20404DD30003E444 /* Resources */,
 				4D2139E03F8B071F7DB7C7A6 /* [CP] Embed Pods Frameworks */,
-				F4E835AC090FCF28B6B12EC4 /* [CP] Copy Pods Resources */,
 			);
 			buildRules = (
 			);
@@ -373,21 +375,6 @@
 			shellScript = "\"${SRCROOT}/Pods/Target Support Files/Pods-iOSTestApp/Pods-iOSTestApp-frameworks.sh\"\n";
 			showEnvVarsInLog = 0;
 		};
-		F4E835AC090FCF28B6B12EC4 /* [CP] Copy Pods Resources */ = {
-			isa = PBXShellScriptBuildPhase;
-			buildActionMask = 2147483647;
-			files = (
-			);
-			inputPaths = (
-			);
-			name = "[CP] Copy Pods Resources";
-			outputPaths = (
-			);
-			runOnlyForDeploymentPostprocessing = 0;
-			shellPath = /bin/sh;
-			shellScript = "\"${SRCROOT}/Pods/Target Support Files/Pods-iOSTestApp/Pods-iOSTestApp-resources.sh\"\n";
-			showEnvVarsInLog = 0;
-		};
 /* End PBXShellScriptBuildPhase section */
 
 /* Begin PBXSourcesBuildPhase section */
@@ -415,6 +402,7 @@
 				F42955DB6D08642528917FAB /* CxxExceptionScenario.mm in Sources */,
 				F42954B7318A02824C65C514 /* ObjCMsgSendScenario.m in Sources */,
 				F42953498545B853CC0B635E /* NullPointerScenario.m in Sources */,
+				8A840FBA21AF5C450041DBFA /* SwiftAssertion.swift in Sources */,
 				F429538D8941382EC2C857CE /* AsyncSafeThreadScenario.m in Sources */,
 				F42955869D33EE0E510B9651 /* ReadGarbagePointerScenario.m in Sources */,
 				8AEFC73420F8D1BB00A78779 /* ManualSessionWithUserScenario.m in Sources */,

--- a/features/fixtures/ios-swift-cocoapods/iOSTestApp/scenarios/SwiftAssertion.swift
+++ b/features/fixtures/ios-swift-cocoapods/iOSTestApp/scenarios/SwiftAssertion.swift
@@ -1,0 +1,12 @@
+import Foundation
+
+class SwiftAssertion: Scenario {
+    override func startBugsnag() {
+      self.config.shouldAutoCaptureSessions = false;
+      super.startBugsnag()
+    }
+
+    override func run() {
+        fatalError("several unfortunate things just happened")
+    }
+}


### PR DESCRIPTION
In the new Xcode 10 build system, Swift object register values have the
top bit used as a flag. This change strips the flag while not losing
anything relevant to us in our quest to see error messages for assertion
failures.

## Design

Added a new validation to `bsg_kscrw_i_writeMemoryContentsIfNotable` which strips the top from the address if it is not valid and rechecks the new value. If it is then valid, it is used as the object address.

## Tests

* Tested manually on physical devices and emulators for iOS 11 & 12
* Added a new integration test, which runs successfully on Xcode 10.1 + iOS 12.1

## Discussion

This technique no longer works at all for assertion messages less than 16 characters, as they aren't stored in the register values.

### Linked issues

Fixes #318

## Review

- [ ] Consistency between the changeset and the goal stated above
- [ ] Internal consistency with the rest of the library - is there any overlap between existing interfaces and any which have been added?
- [ ] Performance and complexity - are there any cases of unexpected O(n^3) when iterating, recursing, flat mapping, etc?
- [ ] Thoroughness of added tests and any missing edge cases
- [ ] Idiomatic use of the language
