### PR TITLE
fix: Check for null image name before comparing strings

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,13 @@
 Changelog
 =========
 
+## TBD
+
+### Bug Fixes
+
+* Fix possible crash when fetching system info to append to a crash report
+  [#321](https://github.com/bugsnag/bugsnag-cocoa/pull/321)
+
 ## 5.17.2 (2018-12-05)
 
 * Add Device time of report capture to JSON payload

--- a/Source/KSCrash/Source/KSCrash/Recording/Tools/BSG_KSDynamicLinker.c
+++ b/Source/KSCrash/Source/KSCrash/Recording/Tools/BSG_KSDynamicLinker.c
@@ -79,6 +79,9 @@ const uint8_t *bsg_ksdlimageUUID(const char *const imageName, bool exactMatch) {
 }
 
 uintptr_t bsg_ksdlfirstCmdAfterHeader(const struct mach_header *const header) {
+    if (header == NULL) {
+      return 0;
+    }
     switch (header->magic) {
     case MH_MAGIC:
     case MH_CIGAM:
@@ -133,6 +136,9 @@ uint32_t bsg_ksdlimageIndexContainingAddress(const uintptr_t address) {
 
 uintptr_t bsg_ksdlsegmentBaseOfImageIndex(const uint32_t idx) {
     const struct mach_header *header = _dyld_get_image_header(idx);
+    if (header == NULL) {
+        return 0;
+    }
 
     // Look for a segment command and return the file image address.
     uintptr_t cmdPtr = bsg_ksdlfirstCmdAfterHeader(header);
@@ -171,6 +177,9 @@ bool bsg_ksdldladdr(const uintptr_t address, Dl_info *const info) {
         return false;
     }
     const struct mach_header *header = _dyld_get_image_header(idx);
+    if (header == NULL) {
+        return false;
+    }
     const uintptr_t imageVMAddrSlide =
         (uintptr_t)_dyld_get_image_vmaddr_slide(idx);
     const uintptr_t addressWithSlide = address - imageVMAddrSlide;

--- a/Source/KSCrash/Source/KSCrash/Recording/Tools/BSG_KSDynamicLinker.c
+++ b/Source/KSCrash/Source/KSCrash/Recording/Tools/BSG_KSDynamicLinker.c
@@ -37,7 +37,9 @@ uint32_t bsg_ksdlimageNamed(const char *const imageName, bool exactMatch) {
 
         for (uint32_t iImg = 0; iImg < imageCount; iImg++) {
             const char *name = _dyld_get_image_name(iImg);
-            if (exactMatch) {
+            if (name == NULL) {
+                continue; // name is null if the index is out of range per dyld(3)
+            } else if (exactMatch) {
                 if (strcmp(name, imageName) == 0) {
                     return iImg;
                 }


### PR DESCRIPTION
If the number of loaded images changes between when _dyld_image_count()
is computed and when _dyld_get_image_name() is called, there can be less
images than the count suggests. In this case, _dyld_get_image_name()
returns NULL, and the lack of a check would crash the app (again?) 
because both arguments to strcmp are required to be non-null. The 
resulting exception backtrace looks somewhat like this:

```
_platform_strcmp
bsg_ksdlimageNamed (BSG_KSDynamicLinker.c:41:21)
bsg_ksdlimageUUID (BSG_KSDynamicLinker.c:56:31)
+[BSG_KSSystemInfo appUUID] (BSG_KSSystemInfo.m:158:13)
+[BSG_KSSystemInfo systemInfo] (BSG_KSSystemInfo.m:432:5)
(any access to systemInfo, from an API client, etc)
```

## Tests

This one is difficult to verify manually or to write a test for, (short of swapping out the implementation of `_dyld_image_count()` to immediately unload an image), but the intent should be easy to follow from the source exception.

## Review

### Outstanding Questions

<!-- Are there any parts of the design or the implementation which seem
     less than ideal and that could require additional discussion?
     List here: -->

<!-- Preflight checks. Have I:

* Added a changelog entry?
* Checked the scope to ensure the commits are only related to the goal above?

-->

- This pull request is ready for:
  - [ ] Initial review of the intended approach, not yet feature complete
  - [ ] Structural review of the classes, functions, and properties modified
  - [x] Final review

<!-- What do you need from a reviewer to get this changeset
     ready for release -->

- [ ] Consistency between the changeset and the goal stated above
- [ ] Idiomatic use of the language
