### PR TITLE
Add stopSession() and resumeSession() to Bugsnag

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,11 @@ Note for Carthage users: this release updates the Xcode configuration to the set
 * Update workspace to recommended settings suggested by XCode 10
   [#324](https://github.com/bugsnag/bugsnag-cocoa/pull/324)
 
+### Enhancements
+
+* Add stopSession() and resumeSession() to Bugsnag
+  [#325](https://github.com/bugsnag/bugsnag-cocoa/pull/325)
+
 ## 5.17.3 (2018-12-19)
 
 ### Bug Fixes

--- a/Source/Bugsnag.h
+++ b/Source/Bugsnag.h
@@ -220,4 +220,8 @@ static NSString *_Nonnull const BugsnagSeverityInfo = @"info";
 
 + (void)startSession;
 
++ (void)stopSession;
+
++ (BOOL)resumeSession;
+
 @end

--- a/Source/Bugsnag.h
+++ b/Source/Bugsnag.h
@@ -211,17 +211,60 @@ static NSString *_Nonnull const BugsnagSeverityInfo = @"info";
     (BOOL)writeBinaryImagesForUserReported;
 
 /**
- * Manually starts tracking a new session.
+ * Starts tracking a new session.
  *
- * Sessions automatically start when the application enters the foreground state, and end when the application exits
- * the foreground.If you wish to manually start sessions, simply call this method from the relevant part of your
- * application. Starting a new session will automatically end the previous one.
+ * By default, sessions are automatically started when the application enters the foreground.
+ * If you wish to manually call startSession at
+ * the appropriate time in your application instead, the default behaviour can be disabled via
+ * shouldAutoCaptureSessions.
+ *
+ * Any errors which occur in an active session count towards your application's
+ * stability score. You can prevent errors from counting towards your stability
+ * score by calling stopSession and resumeSession at the appropriate
+ * time in your application.
+ *
+ * @see stopSession:
+ * @see resumeSession:
  */
-
 + (void)startSession;
 
+/**
+ * Stops tracking a session.
+ *
+ * When a session is stopped, errors will not count towards your application's
+ * stability score. This can be advantageous if you do not wish these calculations to
+ * include a certain type of error, for example, a crash in a background service.
+ * You should disable automatic session tracking via shouldAutoCaptureSessions if you call this method.
+ *
+ * A stopped session can be resumed by calling resumeSession,
+ * which will make any subsequent errors count towards your application's
+ * stability score. Alternatively, an entirely new session can be created by calling startSession.
+ *
+ * @see startSession:
+ * @see resumeSession:
+ */
 + (void)stopSession;
 
+/**
+ * Resumes a session which has previously been stopped, or starts a new session if none exists.
+ *
+ * If a session has already been resumed or started and has not been stopped, calling this
+ * method will have no effect. You should disable automatic session tracking via
+ * shouldAutoCaptureSessions if you call this method.
+ *
+ * It's important to note that sessions are stored in memory for the lifetime of the
+ * application process and are not persisted on disk. Therefore calling this method on app
+ * startup would start a new session, rather than continuing any previous session.
+ *
+ * You should call this at the appropriate time in your application when you wish to
+ * resume a previously started session. Any subsequent errors which occur in your application
+ * will still be reported to Bugsnag but will not count towards your application's stability score.
+ *
+ * @see startSession:
+ * @see stopSession:
+ *
+ * @return true if a previous session was resumed, false if a new session was started.
+ */
 + (BOOL)resumeSession;
 
 @end

--- a/Source/Bugsnag.m
+++ b/Source/Bugsnag.m
@@ -226,6 +226,20 @@ static BugsnagNotifier *bsg_g_bugsnag_notifier = NULL;
     }
 }
 
++ (void)stopSession {
+    if ([self bugsnagStarted]) {
+        [self.notifier stopSession];
+    }
+}
+
++ (BOOL)resumeSession {
+    if ([self bugsnagStarted]) {
+        return [self.notifier resumeSession];
+    } else {
+        return false;
+    }
+}
+
 + (NSDateFormatter *)payloadDateFormatter {
     static NSDateFormatter *formatter;
     static dispatch_once_t onceToken;

--- a/Source/BugsnagNotifier.h
+++ b/Source/BugsnagNotifier.h
@@ -47,6 +47,8 @@
 - (void)start;
 
 - (void)startSession;
+- (void)stopSession;
+- (BOOL)resumeSession;
 
 /**
  *  Notify Bugsnag of an exception

--- a/Source/BugsnagNotifier.m
+++ b/Source/BugsnagNotifier.m
@@ -157,6 +157,7 @@ void BSSerializeJSONDictionary(NSDictionary *dictionary, char **destination) {
  */
 void BSGWriteSessionCrashData(BugsnagSession *session) {
     if (session == nil) {
+        hasRecordedSessions = false;
         return;
     }
     // copy session id
@@ -409,6 +410,14 @@ NSString *const kAppWillTerminate = @"App Will Terminate";
 
 - (void)startSession {
     [self.sessionTracker startNewSession];
+}
+
+- (void)stopSession {
+    [self.sessionTracker stopSession];
+}
+
+- (BOOL)resumeSession {
+    return [self.sessionTracker resumeSession];
 }
 
 - (void)flushPendingReports {

--- a/Source/BugsnagNotifier.m
+++ b/Source/BugsnagNotifier.m
@@ -528,7 +528,7 @@ NSString *const kAppWillTerminate = @"App Will Terminate";
             configuration:self.configuration
                  metaData:[self.configuration.metaData toDictionary]
              handledState:handledState
-                  session:self.sessionTracker.currentSession];
+                  session:self.sessionTracker.runningSession];
     if (block) {
         block(report);
     }

--- a/Source/BugsnagSession.h
+++ b/Source/BugsnagSession.h
@@ -20,12 +20,14 @@
 - (_Nonnull instancetype)initWithDictionary:(NSDictionary *_Nonnull)dict;
 
 - (NSDictionary *_Nonnull)toJson;
+- (void)stop;
+- (void)resume;
 
 @property(readonly) NSString *_Nonnull sessionId;
 @property(readonly) NSDate *_Nonnull startedAt;
 @property(readonly) BugsnagUser *_Nullable user;
 @property(readonly) BOOL autoCaptured;
-@property BOOL isStopped;
+@property(readonly, getter=isStopped) BOOL stopped;
 
 @property NSUInteger unhandledCount;
 @property NSUInteger handledCount;

--- a/Source/BugsnagSession.h
+++ b/Source/BugsnagSession.h
@@ -25,6 +25,7 @@
 @property(readonly) NSDate *_Nonnull startedAt;
 @property(readonly) BugsnagUser *_Nullable user;
 @property(readonly) BOOL autoCaptured;
+@property BOOL isStopped;
 
 @property NSUInteger unhandledCount;
 @property NSUInteger handledCount;

--- a/Source/BugsnagSession.m
+++ b/Source/BugsnagSession.m
@@ -16,6 +16,10 @@ static NSString *const kBugsnagHandledCount = @"handledCount";
 static NSString *const kBugsnagStartedAt = @"startedAt";
 static NSString *const kBugsnagUser = @"user";
 
+@interface BugsnagSession ()
+@property(readwrite, getter=isStopped) BOOL stopped;
+@end
+
 @implementation BugsnagSession
 
 - (instancetype)initWithId:(NSString *_Nonnull)sessionId
@@ -60,11 +64,11 @@ static NSString *const kBugsnagUser = @"user";
 }
 
 - (void)stop {
-    _stopped = YES;
+    self.stopped = YES;
 }
 
 - (void)resume {
-    _stopped = NO;
+    self.stopped = NO;
 }
 
 @end

--- a/Source/BugsnagSession.m
+++ b/Source/BugsnagSession.m
@@ -59,4 +59,12 @@ static NSString *const kBugsnagUser = @"user";
     return [NSDictionary dictionaryWithDictionary:dict];
 }
 
+- (void)stop {
+    _stopped = YES;
+}
+
+- (void)resume {
+    _stopped = NO;
+}
+
 @end

--- a/Source/BugsnagSessionTracker.h
+++ b/Source/BugsnagSessionTracker.h
@@ -63,7 +63,9 @@ typedef void (^SessionTrackerCallback)(BugsnagSession *newSession);
  */
 - (void)handleHandledErrorEvent;
 
-
+/**
+ * Retrieves the current session, or nil if the session is stopped or has not yet been started/resumed.
+ */
 @property (nonatomic, strong, readonly) BugsnagSession *currentSession;
 
 @end

--- a/Source/BugsnagSessionTracker.h
+++ b/Source/BugsnagSessionTracker.h
@@ -64,8 +64,8 @@ typedef void (^SessionTrackerCallback)(BugsnagSession *newSession);
 - (void)handleHandledErrorEvent;
 
 /**
- * Retrieves the current session, or nil if the session is stopped or has not yet been started/resumed.
+ * Retrieves the running session, or nil if the session is stopped or has not yet been started/resumed.
  */
-@property (nonatomic, strong, readonly) BugsnagSession *currentSession;
+@property (nonatomic, strong, readonly) BugsnagSession *runningSession;
 
 @end

--- a/Source/BugsnagSessionTracker.h
+++ b/Source/BugsnagSessionTracker.h
@@ -32,6 +32,9 @@ typedef void (^SessionTrackerCallback)(BugsnagSession *newSession);
  */
 - (void)startNewSession;
 
+- (void)stopSession;
+- (BOOL)resumeSession;
+
 /**
  Record a new auto-captured session if neededed. Auto-captured sessions are only
  recorded and sent if -[BugsnagConfiguration shouldAutoCaptureSessions] is YES

--- a/Source/BugsnagSessionTracker.m
+++ b/Source/BugsnagSessionTracker.m
@@ -24,7 +24,7 @@ NSTimeInterval const BSGNewSessionBackgroundDuration = 60;
 @property (strong, nonatomic) BugsnagSessionTrackingApiClient *apiClient;
 @property (strong, nonatomic) NSDate *backgroundStartTime;
 
-@property (strong, readwrite) BugsnagSession *runningSession;
+@property (strong, readwrite) BugsnagSession *currentSession;
 
 /**
  * Called when a session is altered
@@ -57,7 +57,7 @@ NSTimeInterval const BSGNewSessionBackgroundDuration = 60;
 }
 
 - (void)stopSession {
-    [[self runningSession] stop];
+    [[self currentSession] stop];
 
     if (self.callback) {
         self.callback(nil);
@@ -65,7 +65,7 @@ NSTimeInterval const BSGNewSessionBackgroundDuration = 60;
 }
 
 - (BOOL)resumeSession {
-    BugsnagSession *session = _runningSession;
+    BugsnagSession *session = self.currentSession;
 
     if (session == nil) {
         [self startNewSessionWithAutoCaptureValue:NO];
@@ -78,7 +78,7 @@ NSTimeInterval const BSGNewSessionBackgroundDuration = 60;
 }
 
 - (BugsnagSession *)runningSession {
-    BugsnagSession *session = _runningSession;
+    BugsnagSession *session = self.currentSession;
 
     if (session == nil || session.isStopped) {
         return nil;
@@ -98,13 +98,11 @@ NSTimeInterval const BSGNewSessionBackgroundDuration = 60;
         return;
     }
 
-    // when starting a new session, the ivar is used directly rather than the property setter,
-    // as self.currentSession uses custom accessors
     BugsnagSession *session = [[BugsnagSession alloc] initWithId:[[NSUUID UUID] UUIDString]
                                                        startDate:[NSDate date]
                                                             user:self.config.currentUser
                                                     autoCaptured:isAutoCaptured];
-    self.runningSession = session;
+    self.currentSession = session;
 
     [self.sessionStore write:session];
 

--- a/Source/BugsnagSessionTracker.m
+++ b/Source/BugsnagSessionTracker.m
@@ -98,16 +98,15 @@ NSTimeInterval const BSGNewSessionBackgroundDuration = 60;
         return;
     }
 
-    BugsnagSession *session = [[BugsnagSession alloc] initWithId:[[NSUUID UUID] UUIDString]
-                                                       startDate:[NSDate date]
-                                                            user:self.config.currentUser
-                                                    autoCaptured:isAutoCaptured];
-    self.currentSession = session;
+    self.currentSession = [[BugsnagSession alloc] initWithId:[[NSUUID UUID] UUIDString]
+                                                   startDate:[NSDate date]
+                                                        user:self.config.currentUser
+                                                autoCaptured:isAutoCaptured];
 
-    [self.sessionStore write:session];
+    [self.sessionStore write:self.currentSession];
 
     if (self.callback) {
-        self.callback(session);
+        self.callback(self.currentSession);
     }
     [self.apiClient deliverSessionsInStore:self.sessionStore];
 }
@@ -127,15 +126,14 @@ NSTimeInterval const BSGNewSessionBackgroundDuration = 60;
 }
 
 - (void)handleHandledErrorEvent {
-    BugsnagSession *session = self.runningSession;
-    if (session == nil) {
+    if (self.currentSession == nil) {
         return;
     }
 
-    @synchronized (session) {
-        session.handledCount++;
-        if (self.callback && (self.config.shouldAutoCaptureSessions || !session.autoCaptured)) {
-            self.callback(session);
+    @synchronized (self.currentSession) {
+        self.currentSession.handledCount++;
+        if (self.callback && (self.config.shouldAutoCaptureSessions || !self.currentSession.autoCaptured)) {
+            self.callback(self.currentSession);
         }
     }
 }

--- a/Source/BugsnagSessionTracker.m
+++ b/Source/BugsnagSessionTracker.m
@@ -126,14 +126,16 @@ NSTimeInterval const BSGNewSessionBackgroundDuration = 60;
 }
 
 - (void)handleHandledErrorEvent {
-    if (self.currentSession == nil) {
+    BugsnagSession *session = [self runningSession];
+
+    if (session == nil) {
         return;
     }
 
-    @synchronized (self.currentSession) {
-        self.currentSession.handledCount++;
-        if (self.callback && (self.config.shouldAutoCaptureSessions || !self.currentSession.autoCaptured)) {
-            self.callback(self.currentSession);
+    @synchronized (session) {
+        session.handledCount++;
+        if (self.callback && (self.config.shouldAutoCaptureSessions || !session.autoCaptured)) {
+            self.callback(session);
         }
     }
 }

--- a/Tests/BugsnagConfigurationTests.m
+++ b/Tests/BugsnagConfigurationTests.m
@@ -121,9 +121,9 @@
     BugsnagSessionTracker *sessionTracker
             = [[BugsnagSessionTracker alloc] initWithConfig:config postRecordCallback:nil];
 
-    XCTAssertNil(sessionTracker.currentSession);
+    XCTAssertNil(sessionTracker.runningSession);
     [sessionTracker startNewSession];
-    XCTAssertNil(sessionTracker.currentSession);
+    XCTAssertNil(sessionTracker.runningSession);
 }
 
 - (void)testSetMalformedSessionsEndpoint {
@@ -132,9 +132,9 @@
     BugsnagSessionTracker *sessionTracker
             = [[BugsnagSessionTracker alloc] initWithConfig:config postRecordCallback:nil];
 
-    XCTAssertNil(sessionTracker.currentSession);
+    XCTAssertNil(sessionTracker.runningSession);
     [sessionTracker startNewSession];
-    XCTAssertNil(sessionTracker.currentSession);
+    XCTAssertNil(sessionTracker.runningSession);
 }
 
 - (void)testUser {

--- a/Tests/BugsnagSessionTrackerStopTest.m
+++ b/Tests/BugsnagSessionTrackerStopTest.m
@@ -1,0 +1,119 @@
+//
+//  BugsnagSessionTrackerStopTest.m
+//  Tests
+//
+//  Created by Jamie Lynch on 15/02/2019.
+//  Copyright © 2019 Bugsnag. All rights reserved.
+//
+
+#import <XCTest/XCTest.h>
+#import "BugsnagConfiguration.h"
+#import "BugsnagSessionTracker.h"
+
+@interface BugsnagSessionTrackerStopTest : XCTestCase
+@property BugsnagConfiguration *configuration;
+@property BugsnagSessionTracker *tracker;
+@end
+
+@implementation BugsnagSessionTrackerStopTest
+
+- (void)setUp {
+    [super setUp];
+    self.configuration = [BugsnagConfiguration new];
+    self.configuration.apiKey = @"test";
+    self.configuration.shouldAutoCaptureSessions = NO;
+    self.tracker = [[BugsnagSessionTracker alloc] initWithConfig:self.configuration postRecordCallback:nil];
+}
+
+/**
+ * Verifies that a session can be resumed after it is stopped
+ */
+- (void)testResumeFromStoppedSession {
+    [self.tracker startNewSession];
+    BugsnagSession *original = self.tracker.currentSession;
+    XCTAssertNotNil(original);
+
+    [self.tracker stopSession];
+    XCTAssertNil(self.tracker.currentSession);
+
+    XCTAssertTrue([self.tracker resumeSession]);
+    XCTAssertEqual(original, self.self.tracker.currentSession);
+}
+
+/**
+ * Verifies that a new session is started when calling resumeSession,
+ * if there is no stopped session
+ */
+- (void)testResumeWithNoStoppedSession {
+    XCTAssertNil(self.tracker.currentSession);
+    XCTAssertFalse([self.tracker resumeSession]);
+    XCTAssertNotNil(self.tracker.currentSession);
+}
+
+/**
+ * Verifies that a new session can be created after the previous one is stopped
+ */
+- (void)testStartNewAfterStoppedSession {
+    [self.tracker startNewSession];
+    BugsnagSession *originalSession = self.tracker.currentSession;
+
+    [self.tracker stopSession];
+    [self.tracker startNewSession];
+    XCTAssertNotEqual(originalSession, self.tracker.currentSession);
+}
+
+/**
+ * Verifies that calling resumeSession multiple times only starts one session
+ */
+- (void)testMultipleResumesHaveNoEffect {
+    [self.tracker startNewSession];
+    BugsnagSession *original = self.tracker.currentSession;
+    [self.tracker stopSession];
+
+    XCTAssertTrue([self.tracker resumeSession]);
+    XCTAssertEqual(original, self.tracker.currentSession);
+
+    XCTAssertFalse([self.tracker resumeSession]);
+    XCTAssertEqual(original, self.tracker.currentSession);
+}
+
+/**
+ * Verifies that calling stopSession multiple times only stops one session
+ */
+- (void)testMultipleStopsHaveNoEffect {
+    [self.tracker startNewSession];
+    XCTAssertNotNil(self.tracker.currentSession);
+
+    [self.tracker stopSession];
+    XCTAssertNil(self.tracker.currentSession);
+
+    [self.tracker stopSession];
+    XCTAssertNil(self.tracker.currentSession);
+}
+
+/**
+ * Verifies that if a handled or unhandled error occurs when a session is stopped, the
+ * error count is not updated
+ */
+- (void)testStoppedSessionDoesNotIncrement {
+    [self.tracker startNewSession];
+
+    self.tracker.currentSession.handledCount++;
+    self.tracker.currentSession.unhandledCount++;
+    XCTAssertEqual(1, self.tracker.currentSession.handledCount);
+    XCTAssertEqual(1, self.tracker.currentSession.unhandledCount);
+
+    [self.tracker stopSession];
+    self.tracker.currentSession.handledCount++;
+    self.tracker.currentSession.unhandledCount++;
+    [self.tracker resumeSession];
+    XCTAssertEqual(1, self.tracker.currentSession.handledCount);
+    XCTAssertEqual(1, self.tracker.currentSession.unhandledCount);
+
+    self.tracker.currentSession.handledCount++;
+    self.tracker.currentSession.unhandledCount++;
+    XCTAssertEqual(2, self.tracker.currentSession.handledCount);
+    XCTAssertEqual(2, self.tracker.currentSession.unhandledCount);
+}
+
+@end

--- a/Tests/BugsnagSessionTrackerStopTest.m
+++ b/Tests/BugsnagSessionTrackerStopTest.m
@@ -30,14 +30,14 @@
  */
 - (void)testResumeFromStoppedSession {
     [self.tracker startNewSession];
-    BugsnagSession *original = self.tracker.currentSession;
+    BugsnagSession *original = self.tracker.runningSession;
     XCTAssertNotNil(original);
 
     [self.tracker stopSession];
-    XCTAssertNil(self.tracker.currentSession);
+    XCTAssertNil(self.tracker.runningSession);
 
     XCTAssertTrue([self.tracker resumeSession]);
-    XCTAssertEqual(original, self.self.tracker.currentSession);
+    XCTAssertEqual(original, self.self.tracker.runningSession);
 }
 
 /**
@@ -45,9 +45,9 @@
  * if there is no stopped session
  */
 - (void)testResumeWithNoStoppedSession {
-    XCTAssertNil(self.tracker.currentSession);
+    XCTAssertNil(self.tracker.runningSession);
     XCTAssertFalse([self.tracker resumeSession]);
-    XCTAssertNotNil(self.tracker.currentSession);
+    XCTAssertNotNil(self.tracker.runningSession);
 }
 
 /**
@@ -55,11 +55,11 @@
  */
 - (void)testStartNewAfterStoppedSession {
     [self.tracker startNewSession];
-    BugsnagSession *originalSession = self.tracker.currentSession;
+    BugsnagSession *originalSession = self.tracker.runningSession;
 
     [self.tracker stopSession];
     [self.tracker startNewSession];
-    XCTAssertNotEqual(originalSession, self.tracker.currentSession);
+    XCTAssertNotEqual(originalSession, self.tracker.runningSession);
 }
 
 /**
@@ -67,14 +67,14 @@
  */
 - (void)testMultipleResumesHaveNoEffect {
     [self.tracker startNewSession];
-    BugsnagSession *original = self.tracker.currentSession;
+    BugsnagSession *original = self.tracker.runningSession;
     [self.tracker stopSession];
 
     XCTAssertTrue([self.tracker resumeSession]);
-    XCTAssertEqual(original, self.tracker.currentSession);
+    XCTAssertEqual(original, self.tracker.runningSession);
 
     XCTAssertFalse([self.tracker resumeSession]);
-    XCTAssertEqual(original, self.tracker.currentSession);
+    XCTAssertEqual(original, self.tracker.runningSession);
 }
 
 /**
@@ -82,13 +82,13 @@
  */
 - (void)testMultipleStopsHaveNoEffect {
     [self.tracker startNewSession];
-    XCTAssertNotNil(self.tracker.currentSession);
+    XCTAssertNotNil(self.tracker.runningSession);
 
     [self.tracker stopSession];
-    XCTAssertNil(self.tracker.currentSession);
+    XCTAssertNil(self.tracker.runningSession);
 
     [self.tracker stopSession];
-    XCTAssertNil(self.tracker.currentSession);
+    XCTAssertNil(self.tracker.runningSession);
 }
 
 /**
@@ -98,22 +98,22 @@
 - (void)testStoppedSessionDoesNotIncrement {
     [self.tracker startNewSession];
 
-    self.tracker.currentSession.handledCount++;
-    self.tracker.currentSession.unhandledCount++;
-    XCTAssertEqual(1, self.tracker.currentSession.handledCount);
-    XCTAssertEqual(1, self.tracker.currentSession.unhandledCount);
+    self.tracker.runningSession.handledCount++;
+    self.tracker.runningSession.unhandledCount++;
+    XCTAssertEqual(1, self.tracker.runningSession.handledCount);
+    XCTAssertEqual(1, self.tracker.runningSession.unhandledCount);
 
     [self.tracker stopSession];
-    self.tracker.currentSession.handledCount++;
-    self.tracker.currentSession.unhandledCount++;
+    self.tracker.runningSession.handledCount++;
+    self.tracker.runningSession.unhandledCount++;
     [self.tracker resumeSession];
-    XCTAssertEqual(1, self.tracker.currentSession.handledCount);
-    XCTAssertEqual(1, self.tracker.currentSession.unhandledCount);
+    XCTAssertEqual(1, self.tracker.runningSession.handledCount);
+    XCTAssertEqual(1, self.tracker.runningSession.unhandledCount);
 
-    self.tracker.currentSession.handledCount++;
-    self.tracker.currentSession.unhandledCount++;
-    XCTAssertEqual(2, self.tracker.currentSession.handledCount);
-    XCTAssertEqual(2, self.tracker.currentSession.unhandledCount);
+    self.tracker.runningSession.handledCount++;
+    self.tracker.runningSession.unhandledCount++;
+    XCTAssertEqual(2, self.tracker.runningSession.handledCount);
+    XCTAssertEqual(2, self.tracker.runningSession.unhandledCount);
 }
 
 @end

--- a/Tests/BugsnagSessionTrackerTest.m
+++ b/Tests/BugsnagSessionTrackerTest.m
@@ -30,9 +30,9 @@
 }
 
 - (void)testStartNewSession {
-    XCTAssertNil(self.sessionTracker.currentSession);
+    XCTAssertNil(self.sessionTracker.runningSession);
     [self.sessionTracker startNewSession];
-    BugsnagSession *session = self.sessionTracker.currentSession;
+    BugsnagSession *session = self.sessionTracker.runningSession;
     XCTAssertNotNil(session);
     XCTAssertNotNil(session.sessionId);
     XCTAssertTrue([[NSDate date] timeIntervalSinceDate:session.startedAt] < 1);
@@ -42,9 +42,9 @@
 
 - (void)testStartNewSessionWithUser {
     [self.configuration setUser:@"123" withName:@"Bill" andEmail:nil];
-    XCTAssertNil(self.sessionTracker.currentSession);
+    XCTAssertNil(self.sessionTracker.runningSession);
     [self.sessionTracker startNewSession];
-    BugsnagSession *session = self.sessionTracker.currentSession;
+    BugsnagSession *session = self.sessionTracker.runningSession;
 
     XCTAssertNotNil(session);
     XCTAssertNotNil(session.sessionId);
@@ -56,9 +56,9 @@
 }
 
 - (void)testStartNewAutoCapturedSession {
-    XCTAssertNil(self.sessionTracker.currentSession);
+    XCTAssertNil(self.sessionTracker.runningSession);
     [self.sessionTracker startNewSessionIfAutoCaptureEnabled];
-    BugsnagSession *session = self.sessionTracker.currentSession;
+    BugsnagSession *session = self.sessionTracker.runningSession;
 
     XCTAssertNotNil(session);
     XCTAssertNotNil(session.sessionId);
@@ -71,9 +71,9 @@
 
 - (void)testStartNewAutoCapturedSessionWithUser {
     [self.configuration setUser:@"123" withName:@"Bill" andEmail:@"bill@example.com"];
-    XCTAssertNil(self.sessionTracker.currentSession);
+    XCTAssertNil(self.sessionTracker.runningSession);
     [self.sessionTracker startNewSessionIfAutoCaptureEnabled];
-    BugsnagSession *session = self.sessionTracker.currentSession;
+    BugsnagSession *session = self.sessionTracker.runningSession;
 
     XCTAssertNotNil(session);
     XCTAssertNotNil(session.sessionId);
@@ -85,21 +85,21 @@
 }
 
 - (void)testStartNewAutoCapturedSessionWithAutoCaptureDisabled {
-    XCTAssertNil(self.sessionTracker.currentSession);
+    XCTAssertNil(self.sessionTracker.runningSession);
     self.configuration.shouldAutoCaptureSessions = NO;
     [self.sessionTracker startNewSessionIfAutoCaptureEnabled];
-    BugsnagSession *session = self.sessionTracker.currentSession;
+    BugsnagSession *session = self.sessionTracker.runningSession;
 
     XCTAssertNil(session);
 }
 
 - (void)testUniqueSessionIds {
     [self.sessionTracker startNewSession];
-    BugsnagSession *firstSession = self.sessionTracker.currentSession;
+    BugsnagSession *firstSession = self.sessionTracker.runningSession;
 
     [self.sessionTracker startNewSession];
 
-    BugsnagSession *secondSession = self.sessionTracker.currentSession;
+    BugsnagSession *secondSession = self.sessionTracker.runningSession;
     XCTAssertNotEqualObjects(firstSession.sessionId, secondSession.sessionId);
 }
 
@@ -109,14 +109,14 @@
     [self.sessionTracker handleHandledErrorEvent];
     [self.sessionTracker handleHandledErrorEvent];
 
-    BugsnagSession *session = self.sessionTracker.currentSession;
+    BugsnagSession *session = self.sessionTracker.runningSession;
     XCTAssertNotNil(session);
     XCTAssertEqual(2, session.handledCount);
     XCTAssertEqual(0, session.unhandledCount);
 
     [self.sessionTracker startNewSession];
 
-    session = self.sessionTracker.currentSession;
+    session = self.sessionTracker.runningSession;
     XCTAssertEqual(0, session.handledCount);
     XCTAssertEqual(0, session.unhandledCount);
 }

--- a/features/fixtures/ios-swift-cocoapods/Podfile.lock
+++ b/features/fixtures/ios-swift-cocoapods/Podfile.lock
@@ -1,5 +1,5 @@
 PODS:
-  - Bugsnag (5.17.0)
+  - Bugsnag (5.17.3)
 
 DEPENDENCIES:
   - Bugsnag (from `../../..`)
@@ -9,7 +9,7 @@ EXTERNAL SOURCES:
     :path: "../../.."
 
 SPEC CHECKSUMS:
-  Bugsnag: 2d163d2f4c7acdb9bbcfc7a938c646f3aa39f566
+  Bugsnag: 45ee8446ac012adc1fb24224839cd4d941b09448
 
 PODFILE CHECKSUM: 4d026fb83571f098c9fb4fa71c1564c72c55ab1a
 

--- a/features/fixtures/ios-swift-cocoapods/iOSTestApp.xcodeproj/project.pbxproj
+++ b/features/fixtures/ios-swift-cocoapods/iOSTestApp.xcodeproj/project.pbxproj
@@ -20,6 +20,9 @@
 		8AEFC79920F9132C00A78779 /* AutoSessionHandledEventsScenario.m in Sources */ = {isa = PBXBuildFile; fileRef = 8AEFC79820F9132C00A78779 /* AutoSessionHandledEventsScenario.m */; };
 		8AEFC79C20F92E2200A78779 /* AutoSessionUnhandledScenario.m in Sources */ = {isa = PBXBuildFile; fileRef = 8AEFC79B20F92E2200A78779 /* AutoSessionUnhandledScenario.m */; };
 		C4D0B5FF8E60C0835B86DFE9 /* Pods_iOSTestApp.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = 4994F05E0421A0B037DD2CC5 /* Pods_iOSTestApp.framework */; };
+		E7767F11221C21D90006648C /* StoppedSessionScenario.swift in Sources */ = {isa = PBXBuildFile; fileRef = E7767F10221C21D90006648C /* StoppedSessionScenario.swift */; };
+		E7767F13221C21E30006648C /* ResumedSessionScenario.swift in Sources */ = {isa = PBXBuildFile; fileRef = E7767F12221C21E30006648C /* ResumedSessionScenario.swift */; };
+		E7767F15221C223C0006648C /* NewSessionScenario.swift in Sources */ = {isa = PBXBuildFile; fileRef = E7767F14221C223C0006648C /* NewSessionScenario.swift */; };
 		F429502603396F8671B333B3 /* HandledExceptionScenario.swift in Sources */ = {isa = PBXBuildFile; fileRef = F429526319377A8848136413 /* HandledExceptionScenario.swift */; };
 		F4295109FCAB93708FDAFE12 /* DisabledSessionTrackingScenario.m in Sources */ = {isa = PBXBuildFile; fileRef = F429563584D9BC3A5B86BECF /* DisabledSessionTrackingScenario.m */; };
 		F42951A9FD696D9047149DA8 /* UndefinedInstructionScenario.m in Sources */ = {isa = PBXBuildFile; fileRef = F429538D19421F28D8EB0446 /* UndefinedInstructionScenario.m */; };
@@ -77,6 +80,9 @@
 		8AEFC79A20F92E2200A78779 /* AutoSessionUnhandledScenario.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; path = AutoSessionUnhandledScenario.h; sourceTree = "<group>"; };
 		8AEFC79B20F92E2200A78779 /* AutoSessionUnhandledScenario.m */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.objc; path = AutoSessionUnhandledScenario.m; sourceTree = "<group>"; };
 		960A6E7D4E847F1D76A4FD06 /* Pods-iOSTestApp.release.xcconfig */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.xcconfig; name = "Pods-iOSTestApp.release.xcconfig"; path = "Pods/Target Support Files/Pods-iOSTestApp/Pods-iOSTestApp.release.xcconfig"; sourceTree = "<group>"; };
+		E7767F10221C21D90006648C /* StoppedSessionScenario.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = StoppedSessionScenario.swift; sourceTree = "<group>"; };
+		E7767F12221C21E30006648C /* ResumedSessionScenario.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ResumedSessionScenario.swift; sourceTree = "<group>"; };
+		E7767F14221C223C0006648C /* NewSessionScenario.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = NewSessionScenario.swift; sourceTree = "<group>"; };
 		EE18B3777C62D7BCA8DDBE30 /* Pods-iOSTestApp.debug.xcconfig */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.xcconfig; name = "Pods-iOSTestApp.debug.xcconfig"; path = "Pods/Target Support Files/Pods-iOSTestApp/Pods-iOSTestApp.debug.xcconfig"; sourceTree = "<group>"; };
 		F42950588CE34967588DF438 /* ObjCExceptionScenario.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = ObjCExceptionScenario.h; sourceTree = "<group>"; };
 		F42950D49A5F24FF7155EEE1 /* NonExistentMethodScenario.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = NonExistentMethodScenario.h; sourceTree = "<group>"; };
@@ -264,6 +270,9 @@
 				8AEEBBCF20FC9E1D00C60763 /* AutoSessionMixedEventsScenario.m */,
 				8A98400120FD11BF0023ECD1 /* AutoSessionCustomVersionScenario.h */,
 				8A98400220FD11BF0023ECD1 /* AutoSessionCustomVersionScenario.m */,
+				E7767F10221C21D90006648C /* StoppedSessionScenario.swift */,
+				E7767F12221C21E30006648C /* ResumedSessionScenario.swift */,
+				E7767F14221C223C0006648C /* NewSessionScenario.swift */,
 			);
 			path = scenarios;
 			sourceTree = "<group>";
@@ -389,6 +398,7 @@
 				F42955E0916B8851F074D9B3 /* UserEmailScenario.swift in Sources */,
 				F4295968571A4118D6A4606A /* UserEnabledScenario.swift in Sources */,
 				F4295A036B228AF608641699 /* UserDisabledScenario.swift in Sources */,
+				E7767F13221C21E30006648C /* ResumedSessionScenario.swift in Sources */,
 				8AEFC73120F8D1A000A78779 /* AutoSessionWithUserScenario.m in Sources */,
 				F429565A951303E2C3136D0D /* UserIdScenario.swift in Sources */,
 				8AEEBBD020FC9E1D00C60763 /* AutoSessionMixedEventsScenario.m in Sources */,
@@ -409,11 +419,13 @@
 				F4295B56219D228FAA99BC14 /* ObjCExceptionScenario.m in Sources */,
 				F4295218A62E41518DC3C057 /* AccessNonObjectScenario.m in Sources */,
 				F4295262625F84A80282E520 /* CorruptMallocScenario.m in Sources */,
+				E7767F11221C21D90006648C /* StoppedSessionScenario.swift in Sources */,
 				F4295D19B9E67F5786011698 /* OverwriteLinkRegisterScenario.m in Sources */,
 				F42959124DB949EEF1420957 /* ReadOnlyPageScenario.m in Sources */,
 				F4295B75B2244F442D84D9CA /* StackOverflowScenario.m in Sources */,
 				F42951A9FD696D9047149DA8 /* UndefinedInstructionScenario.m in Sources */,
 				F429532277D8B4DAE53F3F77 /* MinimalCrashReportScenario.m in Sources */,
+				E7767F15221C223C0006648C /* NewSessionScenario.swift in Sources */,
 				F42951BEB2518C610A85FE0D /* BuiltinTrapScenario.m in Sources */,
 				8AEFC79C20F92E2200A78779 /* AutoSessionUnhandledScenario.m in Sources */,
 				F4295397AD31C1C1E64144F5 /* NonExistentMethodScenario.m in Sources */,

--- a/features/fixtures/ios-swift-cocoapods/iOSTestApp/scenarios/NewSessionScenario.swift
+++ b/features/fixtures/ios-swift-cocoapods/iOSTestApp/scenarios/NewSessionScenario.swift
@@ -1,0 +1,30 @@
+//
+//  NewSessionScenario.swift
+//  iOSTestApp
+//
+//  Created by Jamie Lynch on 19/02/2019.
+//  Copyright © 2019 Bugsnag. All rights reserved.
+//
+
+import Foundation
+import Bugsnag
+
+internal class NewSessionScenario: Scenario {
+    override func startBugsnag() {
+        self.config.shouldAutoCaptureSessions = false;
+        super.startBugsnag()
+    }
+
+    override func run() {
+        // send 1st exception which should include session info
+        Bugsnag.startSession()
+        Bugsnag.notifyError(NSError(domain: "First error", code: 101, userInfo: nil))
+
+        // stop tracking the existing session
+        Bugsnag.stopSession()
+
+        // send 2nd exception which should contain new session info
+        Bugsnag.startSession()
+        Bugsnag.notifyError(NSError(domain: "Second error", code: 101, userInfo: nil))
+    }
+}

--- a/features/fixtures/ios-swift-cocoapods/iOSTestApp/scenarios/ResumedSessionScenario.swift
+++ b/features/fixtures/ios-swift-cocoapods/iOSTestApp/scenarios/ResumedSessionScenario.swift
@@ -1,0 +1,28 @@
+//
+//  ResumedSessionScenario.swift
+//  iOSTestApp
+//
+//  Created by Jamie Lynch on 19/02/2019.
+//  Copyright © 2019 Bugsnag. All rights reserved.
+//
+
+import Foundation
+import Bugsnag
+
+internal class ResumedSessionScenario: Scenario {
+    override func startBugsnag() {
+        self.config.shouldAutoCaptureSessions = false;
+        super.startBugsnag()
+    }
+
+    override func run() {
+        // send 1st exception
+        Bugsnag.startSession()
+        Bugsnag.notifyError(NSError(domain: "First error", code: 101, userInfo: nil))
+
+        // send 2nd exception after resuming a session
+        Bugsnag.stopSession()
+        Bugsnag.resumeSession()
+        Bugsnag.notifyError(NSError(domain: "Second error", code: 101, userInfo: nil))
+    }
+}

--- a/features/fixtures/ios-swift-cocoapods/iOSTestApp/scenarios/StoppedSessionScenario.swift
+++ b/features/fixtures/ios-swift-cocoapods/iOSTestApp/scenarios/StoppedSessionScenario.swift
@@ -1,0 +1,27 @@
+//
+//  StoppedSessionScenario.swift
+//  iOSTestApp
+//
+//  Created by Jamie Lynch on 19/02/2019.
+//  Copyright © 2019 Bugsnag. All rights reserved.
+//
+
+import Foundation
+import Bugsnag
+
+internal class StoppedSessionScenario: Scenario {
+    override func startBugsnag() {
+        self.config.shouldAutoCaptureSessions = false;
+        super.startBugsnag()
+    }
+
+    override func run() {
+        // send 1st exception which should include session info
+        Bugsnag.startSession()
+        Bugsnag.notifyError(NSError(domain: "First error", code: 101, userInfo: nil))
+
+        // send 2nd exception which should not include session info
+        Bugsnag.stopSession()
+        Bugsnag.notifyError(NSError(domain: "Second error", code: 101, userInfo: nil))
+    }
+}

--- a/features/session_stopping.feature
+++ b/features/session_stopping.feature
@@ -1,0 +1,29 @@
+Feature: Stopping and resuming sessions
+
+Scenario: When a session is stopped the error has no session information
+    When I run "StoppedSessionScenario"
+    Then I should receive 2 requests
+    And the request 0 is valid for the session tracking API
+    And the request 1 is valid for the error reporting API
+    And the payload field "events.0.session" is not null for request 1
+    And the payload field "events.1.session" is null for request 1
+
+Scenario: When a session is resumed the error uses the previous session information
+    When I run "ResumedSessionScenario"
+    Then I should receive 2 requests
+    And the request 0 is valid for the session tracking API
+    And the request 1 is valid for the error reporting API
+    And the payload field "events.0.session.events.handled" equals 1 for request 1
+    And the payload field "events.1.session.events.handled" equals 2 for request 1
+    And the payload field "events.1.session.id" of request 1 equals the payload field "events.0.session.id" of request 1
+    And the payload field "events.1.session.startedAt" of request 1 equals the payload field "events.0.session.startedAt" of request 1
+
+Scenario: When a new session is started the error uses different session information
+    When I run "NewSessionScenario"
+    Then I should receive 3 requests
+    And the request 0 is valid for the session tracking API
+    And the request 1 is valid for the session tracking API
+    And the request 2 is valid for the error reporting API
+    And the payload field "events.0.session.events.handled" equals 1 for request 2
+    And the payload field "events.1.session.events.handled" equals 1 for request 2
+    And the payload field "events.0.session.id" of request 2 does not equal the payload field "events.1.session.id" of request 2

--- a/iOS/Bugsnag.xcodeproj/project.pbxproj
+++ b/iOS/Bugsnag.xcodeproj/project.pbxproj
@@ -34,6 +34,7 @@
 		8A627CD01EC2A5FD00F7C04E /* BSGSerialization.h in Headers */ = {isa = PBXBuildFile; fileRef = 8A627CCF1EC2A5FD00F7C04E /* BSGSerialization.h */; };
 		8A627CD21EC2A62900F7C04E /* BSGSerialization.m in Sources */ = {isa = PBXBuildFile; fileRef = 8A627CD11EC2A62900F7C04E /* BSGSerialization.m */; };
 		8AE1BC951DEFCE8B00D16CEF /* BugsnagConfigurationSpec.m in Sources */ = {isa = PBXBuildFile; fileRef = 8AE1BC941DEFCE8B00D16CEF /* BugsnagConfigurationSpec.m */; };
+		E70E52152216E41C00A590AB /* BugsnagSessionTrackerStopTest.m in Sources */ = {isa = PBXBuildFile; fileRef = E70E52142216E41C00A590AB /* BugsnagSessionTrackerStopTest.m */; };
 		E70EE0781FD7039E00FA745C /* RFC3339DateTool_Tests.m in Sources */ = {isa = PBXBuildFile; fileRef = E70EE0771FD7039D00FA745C /* RFC3339DateTool_Tests.m */; };
 		E70EE07E1FD703D600FA745C /* NSError+SimpleConstructor_Tests.m in Sources */ = {isa = PBXBuildFile; fileRef = E70EE07A1FD703D500FA745C /* NSError+SimpleConstructor_Tests.m */; };
 		E70EE07F1FD703D600FA745C /* NSDictionary+Merge_Tests.m in Sources */ = {isa = PBXBuildFile; fileRef = E70EE07B1FD703D500FA745C /* NSDictionary+Merge_Tests.m */; };
@@ -445,6 +446,7 @@
 		8A627CCF1EC2A5FD00F7C04E /* BSGSerialization.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; name = BSGSerialization.h; path = ../Source/BSGSerialization.h; sourceTree = SOURCE_ROOT; };
 		8A627CD11EC2A62900F7C04E /* BSGSerialization.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; name = BSGSerialization.m; path = ../Source/BSGSerialization.m; sourceTree = SOURCE_ROOT; };
 		8AE1BC941DEFCE8B00D16CEF /* BugsnagConfigurationSpec.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; name = BugsnagConfigurationSpec.m; path = ../Tests/BugsnagConfigurationSpec.m; sourceTree = SOURCE_ROOT; };
+		E70E52142216E41C00A590AB /* BugsnagSessionTrackerStopTest.m */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.objc; name = BugsnagSessionTrackerStopTest.m; path = ../../Tests/BugsnagSessionTrackerStopTest.m; sourceTree = "<group>"; };
 		E70EE0771FD7039D00FA745C /* RFC3339DateTool_Tests.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; name = RFC3339DateTool_Tests.m; path = ../Tests/KSCrash/RFC3339DateTool_Tests.m; sourceTree = SOURCE_ROOT; };
 		E70EE07A1FD703D500FA745C /* NSError+SimpleConstructor_Tests.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; name = "NSError+SimpleConstructor_Tests.m"; path = "../Tests/KSCrash/NSError+SimpleConstructor_Tests.m"; sourceTree = SOURCE_ROOT; };
 		E70EE07B1FD703D500FA745C /* NSDictionary+Merge_Tests.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; name = "NSDictionary+Merge_Tests.m"; path = "../Tests/KSCrash/NSDictionary+Merge_Tests.m"; sourceTree = SOURCE_ROOT; };
@@ -732,6 +734,7 @@
 				F429554A50F3ABE60537F70E /* BugsnagKSCrashSysInfoParserTest.m */,
 				F42954B7D892334E7551F0F3 /* RegisterErrorDataTest.m */,
 				F429551527EAE3AFE1F605FE /* BugsnagThreadTest.m */,
+				E70E52142216E41C00A590AB /* BugsnagSessionTrackerStopTest.m */,
 			);
 			name = Tests;
 			path = BugsnagTests;
@@ -1243,6 +1246,7 @@
 				E78C1EF31FCC615400B976D3 /* BugsnagSessionTrackingPayloadTest.m in Sources */,
 				E78C1EF11FCC2F1700B976D3 /* BugsnagSessionTrackerTest.m in Sources */,
 				F4295995C3259BF7D9730BC4 /* BugsnagKSCrashSysInfoParserTest.m in Sources */,
+				E70E52152216E41C00A590AB /* BugsnagSessionTrackerStopTest.m in Sources */,
 				F4295F017754324FD52CCE46 /* RegisterErrorDataTest.m in Sources */,
 				F42952D83435C02F8D891C40 /* BugsnagThreadTest.m in Sources */,
 			);


### PR DESCRIPTION
## Goal
Adds the ability to stop and resume sessions. This prevents the handled/unhandled error count from incrementing when a session is in the stopped state, which may be desirable if a user manually tracks sessions and does not care about crashes that occur in the background.

## Changeset

Added the public interface for stopping/resuming a session, along with the initial implementation and unit test coverage.

__NOTE__: mazerunner scenarios and documentation will be added in separate PRs.