### PR TITLE
refactor: Set crashedThisLaunch value only if the "crash" wasn't notify()

### DIFF
--- a/Source/KSCrash/Source/KSCrash/Recording/BSG_KSCrashC.c
+++ b/Source/KSCrash/Source/KSCrash/Recording/BSG_KSCrashC.c
@@ -122,9 +122,10 @@ int bsg_create_filepath(char *base, char filepath[bsg_filepath_len], char severi
  */
 void bsg_kscrash_i_onCrash(char severity, char *errorClass) {
     BSG_KSLOG_DEBUG("Updating application state to note crash.");
-    bsg_kscrashstate_notifyAppCrash();
 
     BSG_KSCrash_Context *context = crashContext();
+
+    bsg_kscrashstate_notifyAppCrash(context->crash.crashType);
 
     if (context->config.printTraceToStdout) {
         bsg_kscrashreport_logCrash(context);

--- a/Source/KSCrash/Source/KSCrash/Recording/BSG_KSCrashState.c
+++ b/Source/KSCrash/Source/KSCrash/Recording/BSG_KSCrashState.c
@@ -352,7 +352,7 @@ void bsg_kscrashstate_notifyAppTerminate(void) {
     bsg_kscrashstate_i_saveState(state, stateFilePath);
 }
 
-void bsg_kscrashstate_notifyAppCrash(void) {
+void bsg_kscrashstate_notifyAppCrash(BSG_KSCrashType type) {
     BSG_KSCrash_State *const state = bsg_g_state;
     const char *const stateFilePath = bsg_g_stateFilePath;
 
@@ -365,7 +365,7 @@ void bsg_kscrashstate_notifyAppCrash(void) {
         state->backgroundDurationSinceLaunch += duration;
         state->backgroundDurationSinceLastCrash += duration;
     }
-    state->crashedThisLaunch = true;
+    state->crashedThisLaunch |= type != BSG_KSCrashTypeUserReported;
     bsg_kscrashstate_i_saveState(state, stateFilePath);
 }
 

--- a/Source/KSCrash/Source/KSCrash/Recording/BSG_KSCrashState.h
+++ b/Source/KSCrash/Source/KSCrash/Recording/BSG_KSCrashState.h
@@ -37,6 +37,7 @@ extern "C" {
 
 #include <stdbool.h>
 #include <stdint.h>
+#include "BSG_KSCrashType.h"
 
 typedef struct {
     // Saved data
@@ -114,7 +115,7 @@ void bsg_kscrashstate_notifyAppTerminate(void);
 
 /** Notify the crash reporter that the application has crashed.
  */
-void bsg_kscrashstate_notifyAppCrash(void);
+void bsg_kscrashstate_notifyAppCrash(BSG_KSCrashType type);
 
 /** Read-only access into the current state.
  */

--- a/Tests/KSCrash/KSCrashState_Tests.m
+++ b/Tests/KSCrash/KSCrashState_Tests.m
@@ -88,7 +88,7 @@
     BSG_KSCrash_State checkpoint0 = context;
 
     usleep(1);
-    bsg_kscrashstate_notifyAppCrash();
+    bsg_kscrashstate_notifyAppCrash(BSG_KSCrashTypeSignal);
     BSG_KSCrash_State checkpointC = context;
 
     XCTAssertTrue(checkpointC.applicationIsInForeground ==
@@ -194,6 +194,30 @@
     XCTAssertFalse(context.crashedLastLaunch, @"");
 }
 
+- (void)testCrashThisLaunchWithUserReported
+{
+    BSG_KSCrash_State context = {0};
+    NSString* stateFile = [self.tempPath stringByAppendingPathComponent:@"state.json"];
+
+    bsg_kscrashstate_init([stateFile cStringUsingEncoding:NSUTF8StringEncoding],
+                          &context);
+    bsg_kscrashstate_notifyAppCrash(BSG_KSCrashTypeUserReported);
+    XCTAssertFalse(context.crashedThisLaunch, @"");
+    bsg_kscrashstate_notifyAppCrash(BSG_KSCrashTypeSignal);
+    XCTAssertTrue(context.crashedThisLaunch, @"");
+}
+
+- (void)testCrashThisLaunch
+{
+    BSG_KSCrash_State context = {0};
+    NSString* stateFile = [self.tempPath stringByAppendingPathComponent:@"state.json"];
+
+    bsg_kscrashstate_init([stateFile cStringUsingEncoding:NSUTF8StringEncoding],
+                          &context);
+    bsg_kscrashstate_notifyAppCrash(BSG_KSCrashTypeSignal);
+    XCTAssertTrue(context.crashedThisLaunch, @"");
+}
+
 - (void) testActCrash
 {
     BSG_KSCrash_State context = {0};
@@ -206,7 +230,7 @@
     BSG_KSCrash_State checkpoint0 = context;
 
     usleep(1);
-    bsg_kscrashstate_notifyAppCrash();
+    bsg_kscrashstate_notifyAppCrash(BSG_KSCrashTypeSignal);
     BSG_KSCrash_State checkpointC = context;
 
     XCTAssertTrue(checkpointC.applicationIsInForeground ==
@@ -330,7 +354,7 @@
     BSG_KSCrash_State checkpoint0 = context;
 
     usleep(1);
-    bsg_kscrashstate_notifyAppCrash();
+    bsg_kscrashstate_notifyAppCrash(BSG_KSCrashTypeSignal);
     BSG_KSCrash_State checkpointC = context;
 
     XCTAssertTrue(checkpointC.applicationIsInForeground ==
@@ -496,7 +520,7 @@
     BSG_KSCrash_State checkpoint0 = context;
 
     usleep(1);
-    bsg_kscrashstate_notifyAppCrash();
+    bsg_kscrashstate_notifyAppCrash(BSG_KSCrashTypeSignal);
     BSG_KSCrash_State checkpointC = context;
 
     XCTAssertTrue(checkpointC.applicationIsInForeground ==
@@ -629,7 +653,7 @@
     BSG_KSCrash_State checkpoint0 = context;
 
     usleep(1);
-    bsg_kscrashstate_notifyAppCrash();
+    bsg_kscrashstate_notifyAppCrash(BSG_KSCrashTypeSignal);
     BSG_KSCrash_State checkpointC = context;
 
     XCTAssertTrue(checkpointC.applicationIsInForeground ==


### PR DESCRIPTION
The cached app state in CrashState.json incorrectly sets crashed this/
last launch based on the usage of user reported exceptions. This change
fixes them to only set the value if actually encountering a crash. This is
largely an internals-only change.

## Tests

* Added a few new unit tests around this behavior and tested manually
