### PR TITLE
fix: Add helper for syncing a unity session to native reports

### DIFF
--- a/Source/BugsnagNotifier.h
+++ b/Source/BugsnagNotifier.h
@@ -29,7 +29,7 @@
 #import "BugsnagConfiguration.h"
 #import "BugsnagMetaData.h"
 
-@class BSGConnectivity;
+@class BSGConnectivity, BugsnagSessionTracker;
 
 @interface BugsnagNotifier : NSObject <BugsnagMetaDataDelegate>
 
@@ -38,6 +38,7 @@
 @property(nonatomic, readwrite, retain) BugsnagMetaData *_Nonnull state;
 @property(nonatomic, readwrite, retain) NSDictionary *_Nonnull details;
 @property(nonatomic, readwrite, retain) NSLock *_Nonnull metaDataLock;
+@property(nonatomic, readonly) BugsnagSessionTracker *_Nonnull sessionTracker;
 
 @property(nonatomic) BSGConnectivity *_Nonnull networkReachable;
 @property(readonly) BOOL started;

--- a/Source/BugsnagNotifier.m
+++ b/Source/BugsnagNotifier.m
@@ -178,7 +178,7 @@ void BSGWriteSessionCrashData(BugsnagSession *session) {
 @interface BugsnagNotifier ()
 @property(nonatomic) BugsnagCrashSentry *crashSentry;
 @property(nonatomic) BugsnagErrorReportApiClient *errorReportApiClient;
-@property(nonatomic) BugsnagSessionTracker *sessionTracker;
+@property(nonatomic, readwrite) BugsnagSessionTracker *sessionTracker;
 @end
 
 @implementation BugsnagNotifier

--- a/Source/BugsnagSession.h
+++ b/Source/BugsnagSession.h
@@ -19,6 +19,12 @@
 
 - (_Nonnull instancetype)initWithDictionary:(NSDictionary *_Nonnull)dict;
 
+- (_Nonnull instancetype)initWithId:(NSString *_Nonnull)sessionId
+                          startDate:(NSDate *_Nonnull)startDate
+                               user:(BugsnagUser *_Nullable)user
+                       handledCount:(NSUInteger)handledCount
+                     unhandledCount:(NSUInteger)unhandledCount;
+
 - (NSDictionary *_Nonnull)toJson;
 
 @property(readonly) NSString *_Nonnull sessionId;

--- a/Source/BugsnagSession.m
+++ b/Source/BugsnagSession.m
@@ -48,6 +48,21 @@ static NSString *const kBugsnagUser = @"user";
     return self;
 }
 
+- (_Nonnull instancetype)initWithId:(NSString *_Nonnull)sessionId
+                          startDate:(NSDate *_Nonnull)startDate
+                               user:(BugsnagUser *_Nullable)user
+                       handledCount:(NSUInteger)handledCount
+                     unhandledCount:(NSUInteger)unhandledCount {
+    if (self = [super init]) {
+        _sessionId = sessionId;
+        _startedAt = startDate;
+        _unhandledCount = unhandledCount;
+        _handledCount = handledCount;
+        _user = user;
+    }
+    return self;
+}
+
 - (NSDictionary *)toJson {
     NSMutableDictionary *dict = [NSMutableDictionary new];
     BSGDictInsertIfNotNil(dict, self.sessionId, kBugsnagSessionId);

--- a/Source/BugsnagSessionTracker.h
+++ b/Source/BugsnagSessionTracker.h
@@ -39,6 +39,17 @@ typedef void (^SessionTrackerCallback)(BugsnagSession *newSession);
 - (void)startNewSessionIfAutoCaptureEnabled;
 
 /**
+ Update the details of the current session to account for externally reported
+ session information. Current session details are included in subsequent crash
+ reports.
+ */
+- (void)registerExistingSession:(NSString *)sessionId
+                      startedAt:(NSDate *)startedAt
+                           user:(BugsnagUser *)user
+                   handledCount:(NSUInteger)handledCount
+                 unhandledCount:(NSUInteger)unhandledCount;
+
+/**
  Handle the app foregrounding event. If more than 30s has elapsed since being
  sent to the background, records a new session if session auto-capture is
  enabled.

--- a/Source/BugsnagSessionTracker.m
+++ b/Source/BugsnagSessionTracker.m
@@ -80,6 +80,21 @@ NSTimeInterval const BSGNewSessionBackgroundDuration = 60;
     [self.apiClient deliverSessionsInStore:self.sessionStore];
 }
 
+- (void)registerExistingSession:(NSString *)sessionId
+                      startedAt:(NSDate *)startedAt
+                           user:(BugsnagUser *)user
+                   handledCount:(NSUInteger)handledCount
+                 unhandledCount:(NSUInteger)unhandledCount {
+    self.currentSession = [[BugsnagSession alloc] initWithId:sessionId
+                                                   startDate:startedAt
+                                                        user:user
+                                                handledCount:handledCount
+                                              unhandledCount:unhandledCount];
+    if (self.callback) {
+        self.callback(self.currentSession);
+    }
+}
+
 #pragma mark - Handling events
 
 - (void)handleAppBackgroundEvent {

--- a/Source/BugsnagSessionTracker.m
+++ b/Source/BugsnagSessionTracker.m
@@ -85,11 +85,15 @@ NSTimeInterval const BSGNewSessionBackgroundDuration = 60;
                            user:(BugsnagUser *)user
                    handledCount:(NSUInteger)handledCount
                  unhandledCount:(NSUInteger)unhandledCount {
-    self.currentSession = [[BugsnagSession alloc] initWithId:sessionId
-                                                   startDate:startedAt
-                                                        user:user
-                                                handledCount:handledCount
-                                              unhandledCount:unhandledCount];
+    if (sessionId != nil) {
+        self.currentSession = nil;
+    } else {
+        self.currentSession = [[BugsnagSession alloc] initWithId:sessionId
+                                                       startDate:startedAt
+                                                            user:user
+                                                    handledCount:handledCount
+                                                  unhandledCount:unhandledCount];
+    }
     if (self.callback) {
         self.callback(self.currentSession);
     }


### PR DESCRIPTION
## Goal

Allow registering a session with the `SessionTracker` to be propagated to crash reports. This allows the session to be tracked separately via bugsnag-unity while preserving the stability score. The change is internally facing only.

Related to bugsnag/bugsnag-unity#138

## Tests

Tested manually as a part of bugsnag/bugsnag-unity#138

## Review

### Outstanding Questions

- This pull request is ready for:
  - [ ] Initial review of the intended approach, not yet feature complete
  - [ ] Structural review of the classes, functions, and properties modified
  - [x] Final review