### PR TITLE
feat: Persist breadcrumbs on disk

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,13 @@
 Changelog
 =========
 
+## TBD
+
+### Enhancements
+
+* Persist breadcrumbs on disk to allow reading upon next boot in the event of an
+  uncatchable app termination.
+
 ## 5.19.1 (2019-03-27)
 
 ### Bug fixes

--- a/Source/BugsnagBreadcrumb.h
+++ b/Source/BugsnagBreadcrumb.h
@@ -94,6 +94,10 @@ typedef void (^BSGBreadcrumbConfiguration)(BugsnagBreadcrumb *_Nonnull);
 
 /** Number of breadcrumbs accumulated */
 @property(assign, readonly) NSUInteger count;
+/**
+ * Path where breadcrumbs are persisted on disk
+ */
+@property (nonatomic, readonly, strong, nullable) NSString *cachePath;
 
 /**
  * Store a new breadcrumb with a provided message.

--- a/Source/BugsnagBreadcrumb.m
+++ b/Source/BugsnagBreadcrumb.m
@@ -181,11 +181,18 @@ NSString *BSGBreadcrumbTypeValue(BSGBreadcrumbType type) {
 NSUInteger BreadcrumbsDefaultCapacity = 20;
 
 - (instancetype)init {
+    static NSString *const BSGBreadcrumbCacheFileName = @"bugsnag_breadcrumbs.json";
     if (self = [super init]) {
         _breadcrumbs = [NSMutableArray new];
         _capacity = BreadcrumbsDefaultCapacity;
         _readWriteQueue = dispatch_queue_create("com.bugsnag.BreadcrumbRead",
                                                 DISPATCH_QUEUE_SERIAL);
+        NSString *cacheDir = [NSSearchPathForDirectoriesInDomains(
+                                 NSCachesDirectory, NSUserDomainMask, YES) firstObject];
+        if (cacheDir != nil) {
+            _cachePath = [cacheDir stringByAppendingPathComponent:
+                             BSGBreadcrumbCacheFileName];
+        }
     }
     return self;
 }
@@ -205,7 +212,23 @@ NSUInteger BreadcrumbsDefaultCapacity = 20;
     if (crumb) {
         [self resizeToFitCapacity:self.capacity - 1];
         dispatch_barrier_sync(self.readWriteQueue, ^{
-          [self.breadcrumbs addObject:crumb];
+            [self.breadcrumbs addObject:crumb];
+            // Serialize crumbs to disk inside barrier to avoid simultaneous
+            // access to the file
+            if (self.cachePath != nil) {
+                static NSString *const arrayKeyPath = @"objectValue";
+                NSArray *items = [self.breadcrumbs valueForKeyPath:arrayKeyPath];
+                if ([NSJSONSerialization isValidJSONObject:items]) {
+                    NSError *error = nil;
+                    NSData *data = [NSJSONSerialization dataWithJSONObject:items
+                                                                   options:0
+                                                                     error:&error];
+                    [data writeToFile:self.cachePath atomically:NO];
+                    if (error != nil) {
+                        bsg_log_err(@"Failed to write breadcrumbs to disk: %@", error);
+                    }
+                }
+            }
         });
     }
 }


### PR DESCRIPTION
## Goal

Persist breadcrumbs on disk to allow reading upon next boot in the event of an uncatchable app termination.

## Design

When adding breadcrumbs, this change serializes the collection to disk on the crumb read/write queue.

## Changeset

Added `cachePath` to `BugsnagBreadcrumbs`. This is the location used for serialization.

## Tests

Added new unit tests for the contents of crumbs on disk.

## Review

- This pull request is ready for:
  - [ ] Initial review of the intended approach, not yet feature complete
  - [ ] Structural review of the classes, functions, and properties modified
  - [x] Final review

<!-- What do you need from a reviewer to get this changeset
     ready for release -->

- [ ] Internal consistency with the rest of the library - is there any overlap between existing interfaces and any which have been added?
- [ ] Concurrency concerns - if components are accessed asynchronously, what issues will arise
- [ ] Thoroughness of added tests and any missing edge cases
- [ ] Idiomatic use of the language
