### PR TITLE
Capture and report out-of-memory app terminations

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,8 @@ Changelog
   uncatchable app termination.
 * Add `+[Bugsnag appDidCrashLastLaunch]` as a helper to determine if the
   previous launch of the app ended in a crash or otherwise unexpected termination.
+* Report unexpected app terminations on iOS as likely out of memory events where
+  the operating system killed the app
 
 ## 5.19.1 (2019-03-27)
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,8 @@ Changelog
 
 * Persist breadcrumbs on disk to allow reading upon next boot in the event of an
   uncatchable app termination.
+* Add `+[Bugsnag appDidCrashLastLaunch]` as a helper to determine if the
+  previous launch of the app ended in a crash or otherwise unexpected termination.
 
 ## 5.19.1 (2019-03-27)
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,13 @@
 Changelog
 =========
 
+## TBD
+
+### Enhancements
+
+* Persist breadcrumbs on disk to allow reading upon next boot in the event of an
+  uncatchable app termination.
+
 ## 5.19.1 (2019-03-27)
 
 ### Bug fixes

--- a/OSX/Bugsnag.xcodeproj/project.pbxproj
+++ b/OSX/Bugsnag.xcodeproj/project.pbxproj
@@ -33,6 +33,8 @@
 		8A48EF271EAA805D00B70024 /* BugsnagLogger.h in Headers */ = {isa = PBXBuildFile; fileRef = 8A48EF261EAA805D00B70024 /* BugsnagLogger.h */; };
 		8A627CD91EC3B75200F7C04E /* BSGSerialization.h in Headers */ = {isa = PBXBuildFile; fileRef = 8A627CD71EC3B75200F7C04E /* BSGSerialization.h */; };
 		8A627CDA1EC3B75200F7C04E /* BSGSerialization.m in Sources */ = {isa = PBXBuildFile; fileRef = 8A627CD81EC3B75200F7C04E /* BSGSerialization.m */; };
+		8A6C6FB12257884C00E8EF24 /* BSGOutOfMemoryWatchdog.m in Sources */ = {isa = PBXBuildFile; fileRef = 8A6C6FAF2257884C00E8EF24 /* BSGOutOfMemoryWatchdog.m */; };
+		8A6C6FB22257884C00E8EF24 /* BSGOutOfMemoryWatchdog.h in Headers */ = {isa = PBXBuildFile; fileRef = 8A6C6FB02257884C00E8EF24 /* BSGOutOfMemoryWatchdog.h */; };
 		8A87352C1C6D3B1600EDBD5B /* BSG_KSCrashReportWriter.h in Headers */ = {isa = PBXBuildFile; fileRef = 8A87352B1C6D3B1600EDBD5B /* BSG_KSCrashReportWriter.h */; settings = {ATTRIBUTES = (Public, ); }; };
 		8ACF0F752018136200173809 /* BugsnagCrashReportTests.m in Sources */ = {isa = PBXBuildFile; fileRef = 8A2C8FE11C6BC38200846019 /* BugsnagCrashReportTests.m */; };
 		8AD9FA891E086351002859A7 /* BugsnagConfigurationTests.m in Sources */ = {isa = PBXBuildFile; fileRef = 8AD9FA851E0862DC002859A7 /* BugsnagConfigurationTests.m */; };
@@ -223,6 +225,8 @@
 		8A48EF261EAA805D00B70024 /* BugsnagLogger.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; name = BugsnagLogger.h; path = ../Source/BugsnagLogger.h; sourceTree = SOURCE_ROOT; };
 		8A627CD71EC3B75200F7C04E /* BSGSerialization.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; name = BSGSerialization.h; path = ../Source/BSGSerialization.h; sourceTree = SOURCE_ROOT; };
 		8A627CD81EC3B75200F7C04E /* BSGSerialization.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; name = BSGSerialization.m; path = ../Source/BSGSerialization.m; sourceTree = SOURCE_ROOT; };
+		8A6C6FAF2257884C00E8EF24 /* BSGOutOfMemoryWatchdog.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; name = BSGOutOfMemoryWatchdog.m; path = ../Source/BSGOutOfMemoryWatchdog.m; sourceTree = "<group>"; };
+		8A6C6FB02257884C00E8EF24 /* BSGOutOfMemoryWatchdog.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; name = BSGOutOfMemoryWatchdog.h; path = ../Source/BSGOutOfMemoryWatchdog.h; sourceTree = "<group>"; };
 		8A87352B1C6D3B1600EDBD5B /* BSG_KSCrashReportWriter.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; name = BSG_KSCrashReportWriter.h; path = ../Source/BSG_KSCrashReportWriter.h; sourceTree = SOURCE_ROOT; };
 		8AD9FA851E0862DC002859A7 /* BugsnagConfigurationTests.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; name = BugsnagConfigurationTests.m; path = ../Tests/BugsnagConfigurationTests.m; sourceTree = SOURCE_ROOT; };
 		E72352BF1F55924A00436528 /* BSGConnectivity.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; name = BSGConnectivity.h; path = ../Source/BSGConnectivity.h; sourceTree = SOURCE_ROOT; };
@@ -414,6 +418,8 @@
 		8A2C8FA31C6BC1F700846019 /* Bugsnag */ = {
 			isa = PBXGroup;
 			children = (
+				8A6C6FB02257884C00E8EF24 /* BSGOutOfMemoryWatchdog.h */,
+				8A6C6FAF2257884C00E8EF24 /* BSGOutOfMemoryWatchdog.m */,
 				E791483E1FD82B35003EFEBF /* BugsnagApiClient.h */,
 				E791483D1FD82B35003EFEBF /* BugsnagApiClient.m */,
 				E79148401FD82B35003EFEBF /* BugsnagFileStore.h */,
@@ -698,6 +704,7 @@
 			buildActionMask = 2147483647;
 			files = (
 				E79E6BB91F4E3850002B35F9 /* BSG_KSJSONCodec.h in Headers */,
+				8A6C6FB22257884C00E8EF24 /* BSGOutOfMemoryWatchdog.h in Headers */,
 				E79148471FD82B36003EFEBF /* BugsnagKSCrashSysInfoParser.h in Headers */,
 				E79E6B881F4E3850002B35F9 /* BSG_KSCrash.h in Headers */,
 				E79E6BA71F4E3850002B35F9 /* BSG_KSCrashSentry_NSException.h in Headers */,
@@ -883,6 +890,7 @@
 				E791484E1FD82B36003EFEBF /* BugsnagKSCrashSysInfoParser.m in Sources */,
 				E791484F1FD82B36003EFEBF /* BugsnagSessionTrackingPayload.m in Sources */,
 				E79E6B971F4E3850002B35F9 /* BSG_KSCrashState.c in Sources */,
+				8A6C6FB12257884C00E8EF24 /* BSGOutOfMemoryWatchdog.m in Sources */,
 				E79E6BB31F4E3850002B35F9 /* BSG_KSCrashCallCompletion.m in Sources */,
 				E79E6BA21F4E3850002B35F9 /* BSG_KSCrashSentry_CPPException.mm in Sources */,
 				E79E6BBD1F4E3850002B35F9 /* BSG_KSLogger.m in Sources */,

--- a/Source/BSGOutOfMemoryWatchdog.h
+++ b/Source/BSGOutOfMemoryWatchdog.h
@@ -1,0 +1,26 @@
+#import <Foundation/Foundation.h>
+
+@class BugsnagConfiguration;
+
+@interface BSGOutOfMemoryWatchdog : NSObject
+
+@property(nonatomic, strong, readonly) NSDictionary *lastBootCachedFileInfo;
+
+/**
+ * Create a new watchdog using the sentinel path to store app/device state
+ */
+- (instancetype)initWithSentinelPath:(NSString *)sentinelFilePath
+                       configuration:(BugsnagConfiguration *)config NS_DESIGNATED_INITIALIZER;
+/**
+ * @return YES if the app was killed to end the previous app launch
+ */
+- (BOOL)didOOMLastLaunch;
+/**
+ * Begin monitoring for lifecycle events and report the OOM from the last launch (if any)
+ */
+- (void)enable;
+/**
+ * Stop monitoring for lifecycle events
+ */
+- (void)disable;
+@end

--- a/Source/BSGOutOfMemoryWatchdog.m
+++ b/Source/BSGOutOfMemoryWatchdog.m
@@ -67,6 +67,10 @@
                selector:@selector(handleLowMemoryChange:)
                    name:UIApplicationDidReceiveMemoryWarningNotification
                  object:nil];
+    [center addObserver:self
+               selector:@selector(handleUpdateSession:)
+                   name:BSGSessionUpdateNotification
+                 object:nil];
     [[Bugsnag configuration]
         addObserver:self
          forKeyPath:NSStringFromSelector(@selector(releaseStage))
@@ -123,6 +127,17 @@
 - (void)handleLowMemoryChange:(NSNotification *)note {
     self.cachedFileInfo[@"device"][@"lowMemory"] = [[Bugsnag payloadDateFormatter]
                                                     stringFromDate:[NSDate date]];
+    [self writeSentinelFile];
+}
+
+- (void)handleUpdateSession:(NSNotification *)note {
+    id session = [note object];
+    NSMutableDictionary *cache = (id)self.cachedFileInfo;
+    if (session) {
+        cache[@"session"] = session;
+    } else {
+        [cache removeObjectForKey:@"session"];
+    }
     [self writeSentinelFile];
 }
 

--- a/Source/BSGOutOfMemoryWatchdog.m
+++ b/Source/BSGOutOfMemoryWatchdog.m
@@ -1,0 +1,228 @@
+#if (TARGET_OS_TV || TARGET_OS_IPHONE)
+#define BSGOOMAvailable 1
+#else
+#define BSGOOMAvailable 0
+#endif
+
+#if BSGOOMAvailable
+#import <UIKit/UIKit.h>
+#endif
+#import "BSGOutOfMemoryWatchdog.h"
+#import "BSG_KSSystemInfo.h"
+#import "BugsnagLogger.h"
+#import "Bugsnag.h"
+#import "BugsnagKSCrashSysInfoParser.h"
+#import "BugsnagSessionTracker.h"
+
+@interface BSGOutOfMemoryWatchdog ()
+@property(nonatomic, getter=isWatching) BOOL watching;
+@property(nonatomic, strong) NSString *sentinelFilePath;
+@property(nonatomic, getter=didOOMLastLaunch) BOOL oomLastLaunch;
+@property(nonatomic, strong, readwrite) NSMutableDictionary *cachedFileInfo;
+@property(nonatomic, strong, readwrite) NSDictionary *lastBootCachedFileInfo;
+@end
+
+@implementation BSGOutOfMemoryWatchdog
+
+- (instancetype)init {
+    self = [self initWithSentinelPath:nil configuration:nil];
+    return self;
+}
+
+- (instancetype)initWithSentinelPath:(NSString *)sentinelFilePath
+                       configuration:(BugsnagConfiguration *)config {
+    if (sentinelFilePath.length == 0) {
+        return nil; // disallow enabling a watcher without a file path
+    }
+    if (self = [super init]) {
+        _sentinelFilePath = sentinelFilePath;
+#ifdef BSGOOMAvailable
+        _oomLastLaunch = [self computeDidOOMLastLaunchWithConfig:config];
+        _cachedFileInfo = [self generateCacheInfoWithConfig:config];
+#endif
+    }
+    return self;
+}
+
+- (void)enable {
+#if BSGOOMAvailable
+    if ([self isWatching]) {
+        return;
+    }
+    [self writeSentinelFile];
+    NSNotificationCenter *center = [NSNotificationCenter defaultCenter];
+    [center addObserver:self
+               selector:@selector(disable:)
+                   name:UIApplicationWillTerminateNotification
+                 object:nil];
+    [center addObserver:self
+               selector:@selector(handleTransitionToBackground:)
+                   name:UIApplicationDidEnterBackgroundNotification
+                 object:nil];
+    [center addObserver:self
+               selector:@selector(handleTransitionToForeground:)
+                   name:UIApplicationWillEnterForegroundNotification
+                 object:nil];
+    [center addObserver:self
+               selector:@selector(handleLowMemoryChange:)
+                   name:UIApplicationDidReceiveMemoryWarningNotification
+                 object:nil];
+    [[Bugsnag configuration]
+        addObserver:self
+         forKeyPath:NSStringFromSelector(@selector(releaseStage))
+            options:NSKeyValueObservingOptionNew
+            context:nil];
+    self.watching = YES;
+#endif
+}
+
+- (void)disable:(NSNotification *)note {
+    [self disable];
+}
+
+- (void)disable {
+    if (![self isWatching]) {
+        // Avoid unsubscribing from KVO when not observing
+        // From the docs:
+        // > Asking to be removed as an observer if not already registered as
+        // > one results in an NSRangeException. You either call
+        // > `removeObserver:forKeyPath:context: exactly once for the
+        // > corresponding call to `addObserver:forKeyPath:options:context:`
+        return;
+    }
+    self.watching = NO;
+    [self deleteSentinelFile];
+    [[NSNotificationCenter defaultCenter] removeObserver:self];
+    @try {
+        [[Bugsnag configuration]
+            removeObserver:self
+                forKeyPath:NSStringFromSelector(@selector(releaseStage))];
+    } @catch (NSException *exception) {
+        // Shouldn't happen, but if for some reason, unregistration happens
+        // without registration, catch the resulting exception.
+    }
+}
+
+- (void)observeValueForKeyPath:(NSString *)keyPath
+                      ofObject:(id)object
+                        change:(NSDictionary<NSString *, id> *)change
+                       context:(void *)context {
+    self.cachedFileInfo[@"app"][@"releaseStage"] = change[NSKeyValueChangeNewKey];
+    [self writeSentinelFile];
+}
+- (void)handleTransitionToForeground:(NSNotification *)note {
+    self.cachedFileInfo[@"app"][@"inForeground"] = @YES;
+    [self writeSentinelFile];
+}
+
+- (void)handleTransitionToBackground:(NSNotification *)note {
+    self.cachedFileInfo[@"app"][@"inForeground"] = @NO;
+    [self writeSentinelFile];
+}
+
+- (void)handleLowMemoryChange:(NSNotification *)note {
+    self.cachedFileInfo[@"device"][@"lowMemory"] = [[Bugsnag payloadDateFormatter]
+                                                    stringFromDate:[NSDate date]];
+    [self writeSentinelFile];
+}
+
+- (BOOL)computeDidOOMLastLaunchWithConfig:(BugsnagConfiguration *)config {
+    if ([[NSFileManager defaultManager] fileExistsAtPath:self.sentinelFilePath]) {
+        NSDictionary *lastBootInfo = [self readSentinelFile];
+        if (lastBootInfo != nil) {
+            self.lastBootCachedFileInfo = lastBootInfo;
+            NSString *lastBootAppVersion =
+                [lastBootInfo valueForKeyPath:@"app.version"];
+            NSString *lastBootOSVersion =
+                [lastBootInfo valueForKeyPath:@"device.osBuild"];
+            BOOL lastBootInForeground =
+                [[lastBootInfo valueForKeyPath:@"app.inForeground"] boolValue];
+            NSString *osVersion = [BSG_KSSystemInfo osBuildVersion];
+            NSDictionary *appInfo = [[NSBundle mainBundle] infoDictionary];
+            NSString *appVersion =
+                [appInfo valueForKey:(__bridge NSString *)kCFBundleVersionKey];
+            BOOL sameVersions = [lastBootOSVersion isEqualToString:osVersion] &&
+                                [lastBootAppVersion isEqualToString:appVersion];
+            BOOL shouldReport = config.reportBackgroundOOMs || lastBootInForeground;
+            [self deleteSentinelFile];
+            return sameVersions && shouldReport;
+        }
+    }
+    return NO;
+}
+
+- (void)deleteSentinelFile {
+    NSError *error = nil;
+    [[NSFileManager defaultManager] removeItemAtPath:self.sentinelFilePath
+                                               error:&error];
+    if (error) {
+        bsg_log_err(@"Failed to delete oom watchdog file: %@", error);
+        unlink([self.sentinelFilePath UTF8String]);
+    }
+}
+
+- (NSDictionary *)readSentinelFile {
+    NSError *error = nil;
+    NSData *data = [NSData dataWithContentsOfFile:self.sentinelFilePath options:0 error:&error];
+    if (error) {
+        bsg_log_err(@"Failed to read oom watchdog file: %@", error);
+        return nil;
+    }
+    NSDictionary *contents = [NSJSONSerialization JSONObjectWithData:data options:0 error:&error];
+    if (error) {
+        bsg_log_err(@"Failed to read oom watchdog file: %@", error);
+        return nil;
+    }
+    return contents;
+}
+
+
+- (void)writeSentinelFile {
+    NSError *error = nil;
+    if (![NSJSONSerialization isValidJSONObject:self.cachedFileInfo]) {
+        bsg_log_err(@"Cached oom watchdog data cannot be written as JSON");
+        return;
+    }
+    NSData *data = [NSJSONSerialization dataWithJSONObject:self.cachedFileInfo options:0 error:&error];
+    if (error) {
+        bsg_log_err(@"Cached oom watchdog data cannot be written as JSON: %@", error);
+        return;
+    }
+    [data writeToFile:self.sentinelFilePath atomically:YES];
+}
+
+- (NSMutableDictionary *)generateCacheInfoWithConfig:(BugsnagConfiguration *)config {
+    NSDictionary *systemInfo = [BSG_KSSystemInfo systemInfo];
+    NSMutableDictionary *cache = [NSMutableDictionary new];
+    NSMutableDictionary *app = [NSMutableDictionary new];
+
+    app[@"id"] = systemInfo[@BSG_KSSystemField_BundleID] ?: @"";
+    app[@"name"] = systemInfo[@BSG_KSSystemField_BundleName] ?: @"";
+    app[@"releaseStage"] = config.releaseStage;
+    app[@"version"] = systemInfo[@BSG_KSSystemField_BundleVersion] ?: @"";
+    app[@"inForeground"] = @YES;
+#if TARGET_OS_TV
+    app[@"type"] = @"tvOS";
+#elif TARGET_IPHONE_SIMULATOR || TARGET_OS_IPHONE
+    app[@"type"] = @"iOS";
+#endif
+    cache[@"app"] = app;
+
+    NSMutableDictionary *device = [NSMutableDictionary new];
+    device[@"id"] = systemInfo[@BSG_KSSystemField_DeviceAppHash];
+    // device[@"lowMemory"] is initially unset
+    device[@"osBuild"] = systemInfo[@BSG_KSSystemField_OSVersion];
+    device[@"osVersion"] = systemInfo[@BSG_KSSystemField_SystemVersion];
+    device[@"model"] = systemInfo[@BSG_KSSystemField_Machine];
+    device[@"wordSize"] = @(PLATFORM_WORD_SIZE);
+#if TARGET_OS_SIMULATOR
+    device[@"simulator"] = @YES;
+#else
+    device[@"simulator"] = @NO;
+#endif
+    cache[@"device"] = device;
+
+    return cache;
+}
+
+@end

--- a/Source/Bugsnag.h
+++ b/Source/Bugsnag.h
@@ -67,6 +67,11 @@ static NSString *_Nonnull const BugsnagSeverityInfo = @"info";
 + (void)startBugsnagWithConfiguration:
     (BugsnagConfiguration *_Nonnull)configuration;
 
+/**
+ * @return YES if Bugsnag has been started and the previous launch crashed
+ */
++ (BOOL)appDidCrashLastLaunch;
+
 /** Send a custom or caught exception to Bugsnag.
  *
  * The exception will be sent to Bugsnag in the background allowing your

--- a/Source/Bugsnag.m
+++ b/Source/Bugsnag.m
@@ -76,6 +76,13 @@ static BugsnagNotifier *bsg_g_bugsnag_notifier = NULL;
     return bsg_g_bugsnag_notifier;
 }
 
++ (BOOL)appDidCrashLastLaunch {
+    if ([self bugsnagStarted]) {
+        return [self.notifier appCrashedLastLaunch];
+    }
+    return NO;
+}
+
 + (void)notify:(NSException *)exception {
     if ([self bugsnagStarted]) {
         [self.notifier notifyException:exception

--- a/Source/BugsnagBreadcrumb.h
+++ b/Source/BugsnagBreadcrumb.h
@@ -129,4 +129,9 @@ typedef void (^BSGBreadcrumbConfiguration)(BugsnagBreadcrumb *_Nonnull);
  */
 - (NSArray *_Nullable)arrayValue;
 
+/**
+ * Reads and return breadcrumb data currently stored on disk
+ */
+- (NSDictionary *_Nullable)cachedBreadcrumbs;
+
 @end

--- a/Source/BugsnagBreadcrumb.h
+++ b/Source/BugsnagBreadcrumb.h
@@ -94,6 +94,10 @@ typedef void (^BSGBreadcrumbConfiguration)(BugsnagBreadcrumb *_Nonnull);
 
 /** Number of breadcrumbs accumulated */
 @property(assign, readonly) NSUInteger count;
+/**
+ * Path where breadcrumbs are persisted on disk
+ */
+@property (nonatomic, readonly, strong, nullable) NSString *cachePath;
 
 /**
  * Store a new breadcrumb with a provided message.

--- a/Source/BugsnagBreadcrumb.m
+++ b/Source/BugsnagBreadcrumb.m
@@ -232,6 +232,22 @@ NSUInteger BreadcrumbsDefaultCapacity = 20;
         });
     }
 }
+
+- (NSDictionary *)cachedBreadcrumbs {
+    __block NSDictionary *cache = nil;
+    dispatch_barrier_sync(self.readWriteQueue, ^{
+        NSError *error = nil;
+        NSData *data = [NSData dataWithContentsOfFile:self.cachePath options:0 error:&error];
+        if (error == nil) {
+            cache = [NSJSONSerialization JSONObjectWithData:data options:0 error:&error];
+        }
+        if (error != nil) {
+            bsg_log_err(@"Failed to read breadcrumbs from disk: %@", error);
+        }
+    });
+    return cache;
+}
+
 @synthesize capacity = _capacity;
 
 - (NSUInteger)capacity {

--- a/Source/BugsnagBreadcrumb.m
+++ b/Source/BugsnagBreadcrumb.m
@@ -181,11 +181,18 @@ NSString *BSGBreadcrumbTypeValue(BSGBreadcrumbType type) {
 NSUInteger BreadcrumbsDefaultCapacity = 20;
 
 - (instancetype)init {
+    static NSString *const BSGBreadcrumbCacheFileName = @"bugsnag_breadcrumbs.json";
     if (self = [super init]) {
         _breadcrumbs = [NSMutableArray new];
         _capacity = BreadcrumbsDefaultCapacity;
         _readWriteQueue = dispatch_queue_create("com.bugsnag.BreadcrumbRead",
                                                 DISPATCH_QUEUE_SERIAL);
+        NSString *cacheDir = [NSSearchPathForDirectoriesInDomains(
+                                 NSCachesDirectory, NSUserDomainMask, YES) firstObject];
+        if (cacheDir != nil) {
+            _cachePath = [cacheDir stringByAppendingPathComponent:
+                             BSGBreadcrumbCacheFileName];
+        }
     }
     return self;
 }
@@ -205,7 +212,23 @@ NSUInteger BreadcrumbsDefaultCapacity = 20;
     if (crumb) {
         [self resizeToFitCapacity:self.capacity - 1];
         dispatch_barrier_sync(self.readWriteQueue, ^{
-          [self.breadcrumbs addObject:crumb];
+            [self.breadcrumbs addObject:crumb];
+            // Serialize crumbs to disk inside barrier to avoid simultaneous
+            // access to the file
+            if (self.cachePath != nil) {
+                static NSString *const arrayKeyPath = @"objectValue";
+                NSArray *items = [self.breadcrumbs valueForKeyPath:arrayKeyPath];
+                if ([NSJSONSerialization isValidJSONObject:items]) {
+                    NSError *error = nil;
+                    NSData *data = [NSJSONSerialization dataWithJSONObject:items
+                                                                   options:0
+                                                                     error:&error];
+                    [data writeToFile:self.cachePath atomically:NO];
+                    if (error != nil) {
+                        bsg_log_err(@"Failed to write breadcrumbs to disk: %@", error);
+                    }
+                }
+            }
         });
     }
 }

--- a/Source/BugsnagConfiguration.h
+++ b/Source/BugsnagConfiguration.h
@@ -145,6 +145,12 @@ BugsnagBreadcrumbs *breadcrumbs;
 @property BOOL shouldAutoCaptureSessions;
 
 /**
+ * Whether the app should report out of memory events which terminate the app
+ * while the app is in the background.
+ */
+@property BOOL reportBackgroundOOMs;
+
+/**
  * Retrieves the endpoint used to notify Bugsnag of errors
  *
  * NOTE: If you want to set this value, you should do so via setEndpointsForNotify:sessions: instead.

--- a/Source/BugsnagConfiguration.m
+++ b/Source/BugsnagConfiguration.m
@@ -124,7 +124,10 @@ static NSString *const kHeaderApiSentAt = @"Bugsnag-Sent-At";
 
 - (void)setReleaseStage:(NSString *)newReleaseStage {
     @synchronized (self) {
+        NSString *key = NSStringFromSelector(@selector(releaseStage));
+        [self willChangeValueForKey:key];
         _releaseStage = newReleaseStage;
+        [self didChangeValueForKey:key];
         [self.config addAttribute:BSGKeyReleaseStage
                         withValue:newReleaseStage
                     toTabWithName:BSGKeyConfig];

--- a/Source/BugsnagConfiguration.m
+++ b/Source/BugsnagConfiguration.m
@@ -66,6 +66,7 @@ static NSString *const kHeaderApiSentAt = @"Bugsnag-Sent-At";
         _breadcrumbs = [BugsnagBreadcrumbs new];
         _automaticallyCollectBreadcrumbs = YES;
         _shouldAutoCaptureSessions = YES;
+        _reportBackgroundOOMs = YES;
 
         if ([NSURLSession class]) {
             _session = [NSURLSession

--- a/Source/BugsnagHandledState.h
+++ b/Source/BugsnagHandledState.h
@@ -17,7 +17,8 @@ typedef NS_ENUM(NSUInteger, SeverityReasonType) {
     UserSpecifiedSeverity,
     UserCallbackSetSeverity,
     PromiseRejection,
-    LogMessage
+    LogMessage,
+    LikelyOutOfMemory,
 };
 
 @interface BugsnagHandledState : NSObject

--- a/Source/BugsnagHandledState.m
+++ b/Source/BugsnagHandledState.m
@@ -19,6 +19,7 @@ static NSString *const kUnhandledException = @"unhandledException";
 static NSString *const kSignal = @"signal";
 static NSString *const kPromiseRejection = @"unhandledPromiseRejection";
 static NSString *const kHandledError = @"handledError";
+static NSString *const kLikelyOutOfMemory = @"outOfMemory";
 static NSString *const kLogGenerated = @"log";
 static NSString *const kHandledException = @"handledException";
 static NSString *const kUserSpecifiedSeverity = @"userSpecifiedSeverity";
@@ -58,6 +59,7 @@ static NSString *const kUserCallbackSetSeverity = @"userCallbackSetSeverity";
     case UserSpecifiedSeverity:
     case UserCallbackSetSeverity:
         break;
+    case LikelyOutOfMemory:
     case UnhandledException:
         severity = BSGSeverityError;
         unhandled = YES;
@@ -127,6 +129,8 @@ static NSString *const kUserCallbackSetSeverity = @"userCallbackSetSeverity";
         return kLogGenerated;
     case UnhandledException:
         return kUnhandledException;
+    case LikelyOutOfMemory:
+        return kLikelyOutOfMemory;
     }
 }
 
@@ -147,6 +151,8 @@ static NSString *const kUserCallbackSetSeverity = @"userCallbackSetSeverity";
         return UserCallbackSetSeverity;
     } else if ([kPromiseRejection isEqualToString:string]) {
         return PromiseRejection;
+    } else if ([kLikelyOutOfMemory isEqualToString:string]) {
+        return LikelyOutOfMemory;
     } else {
         return UnhandledException;
     }

--- a/Source/BugsnagKSCrashSysInfoParser.h
+++ b/Source/BugsnagKSCrashSysInfoParser.h
@@ -8,6 +8,8 @@
 
 #import <Foundation/Foundation.h>
 
+#define PLATFORM_WORD_SIZE sizeof(void*)*8
+
 NSDictionary *_Nonnull BSGParseDevice(NSDictionary *_Nonnull report);
 NSDictionary *_Nonnull BSGParseApp(NSDictionary *_Nonnull report);
 NSDictionary *_Nonnull BSGParseAppState(NSDictionary *_Nonnull report, NSString *_Nullable preferredVersion);

--- a/Source/BugsnagKSCrashSysInfoParser.m
+++ b/Source/BugsnagKSCrashSysInfoParser.m
@@ -13,8 +13,6 @@
 #import "BugsnagConfiguration.h"
 #import "BugsnagLogger.h"
 
-#define PLATFORM_WORD_SIZE sizeof(void*)*8
-
 NSDictionary *BSGParseDevice(NSDictionary *report) {
     NSMutableDictionary *device = [NSMutableDictionary new];
     NSDictionary *state = [report valueForKeyPath:@"user.state.deviceState"];

--- a/Source/BugsnagNotifier.h
+++ b/Source/BugsnagNotifier.h
@@ -51,6 +51,8 @@
 - (void)stopSession;
 - (BOOL)resumeSession;
 
+- (BOOL)appCrashedLastLaunch;
+
 /**
  *  Notify Bugsnag of an exception
  *

--- a/Source/BugsnagSession.h
+++ b/Source/BugsnagSession.h
@@ -25,7 +25,16 @@
                        handledCount:(NSUInteger)handledCount
                      unhandledCount:(NSUInteger)unhandledCount;
 
+/**
+ * Representation used in report payloads
+ */
 - (NSDictionary *_Nonnull)toJson;
+
+/**
+ * Full representation of a session suitable for creating an identical session
+ * using initWithDictionary
+ */
+- (NSDictionary *_Nonnull)toDictionary;
 - (void)stop;
 - (void)resume;
 

--- a/Source/BugsnagSession.m
+++ b/Source/BugsnagSession.m
@@ -78,6 +78,18 @@ static NSString *const kBugsnagUser = @"user";
     return [NSDictionary dictionaryWithDictionary:dict];
 }
 
+- (NSDictionary *)toDictionary {
+    NSMutableDictionary *dict = [NSMutableDictionary new];
+    dict[kBugsnagSessionId] = self.sessionId ?: @"";
+    dict[kBugsnagStartedAt] = self.startedAt ? [BSG_RFC3339DateTool stringFromDate:self.startedAt] : @"";
+    dict[kBugsnagHandledCount] = @(self.handledCount);
+    dict[kBugsnagUnhandledCount] = @(self.unhandledCount);
+    if (self.user) {
+        dict[kBugsnagUser] = [self.user toJson];
+    }
+    return dict;
+}
+
 - (void)stop {
     self.stopped = YES;
 }

--- a/Source/BugsnagSessionTracker.h
+++ b/Source/BugsnagSessionTracker.h
@@ -15,6 +15,8 @@
 
 typedef void (^SessionTrackerCallback)(BugsnagSession *newSession);
 
+extern NSString *const BSGSessionUpdateNotification;
+
 @interface BugsnagSessionTracker : NSObject
 
 /**

--- a/Source/BugsnagSessionTracker.m
+++ b/Source/BugsnagSessionTracker.m
@@ -18,6 +18,8 @@
  */
 NSTimeInterval const BSGNewSessionBackgroundDuration = 60;
 
+NSString *const BSGSessionUpdateNotification = @"BugsnagSessionChanged";
+
 @interface BugsnagSessionTracker ()
 @property (weak, nonatomic) BugsnagConfiguration *config;
 @property (strong, nonatomic) BugsnagSessionFileStore *sessionStore;
@@ -62,6 +64,7 @@ NSTimeInterval const BSGNewSessionBackgroundDuration = 60;
     if (self.callback) {
         self.callback(nil);
     }
+    [self postUpdateNotice];
 }
 
 - (BOOL)resumeSession {
@@ -73,6 +76,7 @@ NSTimeInterval const BSGNewSessionBackgroundDuration = 60;
     } else {
         BOOL stopped = session.isStopped;
         [session resume];
+        [self postUpdateNotice];
         return stopped;
     }
 }
@@ -108,6 +112,8 @@ NSTimeInterval const BSGNewSessionBackgroundDuration = 60;
     if (self.callback) {
         self.callback(self.currentSession);
     }
+    [self postUpdateNotice];
+
     [self.apiClient deliverSessionsInStore:self.sessionStore];
 }
 
@@ -128,6 +134,12 @@ NSTimeInterval const BSGNewSessionBackgroundDuration = 60;
     if (self.callback) {
         self.callback(self.currentSession);
     }
+    [self postUpdateNotice];
+}
+
+- (void)postUpdateNotice {
+    [[NSNotificationCenter defaultCenter] postNotificationName:BSGSessionUpdateNotification
+                                                        object:[self.runningSession toDictionary]];
 }
 
 #pragma mark - Handling events
@@ -156,6 +168,7 @@ NSTimeInterval const BSGNewSessionBackgroundDuration = 60;
         if (self.callback && (self.config.shouldAutoCaptureSessions || !session.autoCaptured)) {
             self.callback(session);
         }
+        [self postUpdateNotice];
     }
 }
 

--- a/Source/KSCrash/Source/KSCrash/Recording/BSG_KSSystemInfo.h
+++ b/Source/KSCrash/Source/KSCrash/Recording/BSG_KSSystemInfo.h
@@ -67,4 +67,9 @@
  */
 + (NSDictionary *)systemInfo;
 
+/**
+ * The build version of the OS
+ */
++ (NSString *)osBuildVersion;
+
 @end

--- a/Source/KSCrash/Source/KSCrash/Recording/BSG_KSSystemInfo.m
+++ b/Source/KSCrash/Source/KSCrash/Recording/BSG_KSSystemInfo.m
@@ -406,7 +406,7 @@
     }
     [sysInfo bsg_ksc_safeSetObject:[self stringSysctl:@"kern.version"]
                             forKey:@BSG_KSSystemField_KernelVersion];
-    [sysInfo bsg_ksc_safeSetObject:[self stringSysctl:@"kern.osversion"]
+    [sysInfo bsg_ksc_safeSetObject:[self osBuildVersion]
                             forKey:@BSG_KSSystemField_OSVersion];
     [sysInfo bsg_ksc_safeSetObject:@([self isJailbroken])
                             forKey:@BSG_KSSystemField_Jailbroken];
@@ -458,6 +458,10 @@
     [sysInfo bsg_ksc_safeSetObject:memory forKey:@BSG_KSSystemField_Memory];
 
     return sysInfo;
+}
+
++ (NSString *)osBuildVersion {
+    return [self stringSysctl:@"kern.osversion"];
 }
 
 @end

--- a/Tests/BugsnagConfigurationTests.m
+++ b/Tests/BugsnagConfigurationTests.m
@@ -60,6 +60,11 @@
     XCTAssertTrue([config shouldAutoCaptureSessions]);
 }
 
+- (void)testDefaultReportBackgroundOOMs {
+    BugsnagConfiguration *config = [BugsnagConfiguration new];
+    XCTAssertTrue([config reportBackgroundOOMs]);
+}
+
 - (void)testErrorApiHeaders {
     BugsnagConfiguration *config = [BugsnagConfiguration new];
     NSDictionary *headers = [config errorApiHeaders];

--- a/Tests/BugsnagSessionTest.m
+++ b/Tests/BugsnagSessionTest.m
@@ -58,4 +58,26 @@
     XCTAssertNotNil(rootNode[@"user"]);
 }
 
+- (void)testFullSerialization {
+    NSDate *startDate = [NSDate date];
+    NSDictionary *dict = @{
+                           @"id": @"test",
+                           @"startedAt": [BSG_RFC3339DateTool stringFromDate:[NSDate date]],
+                           @"unhandledCount": @1,
+                           @"handledCount": @2,
+                           @"user": @{
+                                   @"name": @"Joe Bloggs"
+                                   }
+                           };
+
+    BugsnagSession *session = [[BugsnagSession alloc] initWithDictionary:dict];
+    NSDictionary *newDict = [session toDictionary];
+    XCTAssertEqualObjects(@"test", newDict[@"id"]);
+    XCTAssertEqualObjects(@1, newDict[@"unhandledCount"]);
+    XCTAssertEqualObjects(@2, newDict[@"handledCount"]);
+    XCTAssertEqualObjects(@"Joe Bloggs", newDict[@"user"][@"name"]);
+    // same date within a reasonable delta
+    XCTAssert([startDate timeIntervalSince1970] - [[BSG_RFC3339DateTool dateFromString:newDict[@"startedAt"]] timeIntervalSince1970] < 1);
+}
+
 @end

--- a/examples/objective-c-ios/Bugsnag Test App.xcodeproj/project.pbxproj
+++ b/examples/objective-c-ios/Bugsnag Test App.xcodeproj/project.pbxproj
@@ -7,6 +7,8 @@
 	objects = {
 
 /* Begin PBXBuildFile section */
+		8A4882E2224BCC130035B94C /* WebKit.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = 8A4882E1224BCC130035B94C /* WebKit.framework */; };
+		8A4882E5224BCD5D0035B94C /* BigHonkinWebViewController.m in Sources */ = {isa = PBXBuildFile; fileRef = 8A4882E4224BCD5D0035B94C /* BigHonkinWebViewController.m */; };
 		8ACFFA0C1D895D4D00357B5E /* KeyboardViewController.swift in Sources */ = {isa = PBXBuildFile; fileRef = 8ACFFA0B1D895D4D00357B5E /* KeyboardViewController.swift */; };
 		DB7A2D239A0F25E0ED01EBF7 /* libPods-Bugsnag Test App.a in Frameworks */ = {isa = PBXBuildFile; fileRef = F4DBCA8024A91BC0C2D34FB5 /* libPods-Bugsnag Test App.a */; };
 		E77F7CCE1F2B90800017CE04 /* CrashyUITest.swift in Sources */ = {isa = PBXBuildFile; fileRef = E77F7CCD1F2B90800017CE04 /* CrashyUITest.swift */; };
@@ -44,6 +46,9 @@
 
 /* Begin PBXFileReference section */
 		89117F5055F6B6F9FA00FBEC /* Pods-Bugsnag Test App.debug.xcconfig */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.xcconfig; name = "Pods-Bugsnag Test App.debug.xcconfig"; path = "Pods/Target Support Files/Pods-Bugsnag Test App/Pods-Bugsnag Test App.debug.xcconfig"; sourceTree = "<group>"; };
+		8A4882E1224BCC130035B94C /* WebKit.framework */ = {isa = PBXFileReference; lastKnownFileType = wrapper.framework; name = WebKit.framework; path = System/Library/Frameworks/WebKit.framework; sourceTree = SDKROOT; };
+		8A4882E3224BCD5D0035B94C /* BigHonkinWebViewController.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; path = BigHonkinWebViewController.h; sourceTree = "<group>"; };
+		8A4882E4224BCD5D0035B94C /* BigHonkinWebViewController.m */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.objc; path = BigHonkinWebViewController.m; sourceTree = "<group>"; };
 		8ACFFA091D895D4D00357B5E /* custom-keyboard.appex */ = {isa = PBXFileReference; explicitFileType = "wrapper.app-extension"; includeInIndex = 0; path = "custom-keyboard.appex"; sourceTree = BUILT_PRODUCTS_DIR; };
 		8ACFFA0B1D895D4D00357B5E /* KeyboardViewController.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = KeyboardViewController.swift; sourceTree = "<group>"; };
 		8ACFFA0D1D895D4D00357B5E /* Info.plist */ = {isa = PBXFileReference; lastKnownFileType = text.plist.xml; path = Info.plist; sourceTree = "<group>"; };
@@ -105,6 +110,7 @@
 			isa = PBXFrameworksBuildPhase;
 			buildActionMask = 2147483647;
 			files = (
+				8A4882E2224BCC130035B94C /* WebKit.framework in Frameworks */,
 				F40B874B16AA233500676BB2 /* UIKit.framework in Frameworks */,
 				F40B874D16AA233500676BB2 /* Foundation.framework in Frameworks */,
 				F40B874F16AA233500676BB2 /* CoreGraphics.framework in Frameworks */,
@@ -170,6 +176,7 @@
 		F40B874916AA233500676BB2 /* Frameworks */ = {
 			isa = PBXGroup;
 			children = (
+				8A4882E1224BCC130035B94C /* WebKit.framework */,
 				E7EC041E1F4CCA5B00C2E9D5 /* libc++.tbd */,
 				E7EC041C1F4CCA5500C2E9D5 /* libz.tbd */,
 				E7EC04121F4CC87300C2E9D5 /* libc++.1.dylib */,
@@ -187,6 +194,8 @@
 		F40B875016AA233500676BB2 /* Bugsnag Test App */ = {
 			isa = PBXGroup;
 			children = (
+				8A4882E3224BCD5D0035B94C /* BigHonkinWebViewController.h */,
+				8A4882E4224BCD5D0035B94C /* BigHonkinWebViewController.m */,
 				F40B875916AA233500676BB2 /* AppDelegate.h */,
 				F40B875A16AA233500676BB2 /* AppDelegate.m */,
 				F40B876216AA233500676BB2 /* MainStoryboard.storyboard */,
@@ -440,6 +449,7 @@
 			buildActionMask = 2147483647;
 			files = (
 				F40B875716AA233500676BB2 /* main.m in Sources */,
+				8A4882E5224BCD5D0035B94C /* BigHonkinWebViewController.m in Sources */,
 				F40B875B16AA233500676BB2 /* AppDelegate.m in Sources */,
 				F40B876A16AA233500676BB2 /* ViewController.m in Sources */,
 			);

--- a/examples/objective-c-ios/Bugsnag Test App/BigHonkinWebViewController.h
+++ b/examples/objective-c-ios/Bugsnag Test App/BigHonkinWebViewController.h
@@ -1,0 +1,4 @@
+#import <UIKit/UIKit.h>
+@interface BigHonkinWebViewController : UIViewController
+
+@end

--- a/examples/objective-c-ios/Bugsnag Test App/BigHonkinWebViewController.m
+++ b/examples/objective-c-ios/Bugsnag Test App/BigHonkinWebViewController.m
@@ -1,0 +1,38 @@
+#import <WebKit/WebKit.h>
+#import <signal.h>
+#import "BigHonkinWebViewController.h"
+#import <Bugsnag/Bugsnag.h>
+
+@interface BigHonkinWebViewController ()
+@property (nonatomic, strong) UIWebView *webView;
+@end
+
+@implementation BigHonkinWebViewController
+
+- (void)viewDidLoad {
+    [super viewDidLoad];
+    self.webView = [[UIWebView alloc] initWithFrame:self.view.bounds];
+    [self.webView loadHTMLString:@"<h2>Loading a lot of JavaScript. Please wait.</h2>"
+                                  "<p>You can follow along in Console.app</p>"
+                         baseURL:nil];
+    [self.view addSubview:self.webView];
+}
+
+- (void)didReceiveMemoryWarning {
+    NSLog(@"--> Received a low memory warning");
+}
+
+- (void)viewDidAppear:(BOOL)animated {
+    [super viewDidAppear:animated];
+    NSString *format = @"var b = document.createElement('div'); div.innerHTML = 'Hello item %d'; document.documentElement.appendChild(div);";
+    for (int i = 0; i < 3000 * 1024; i++) {
+        NSString *item = [NSString stringWithFormat:format, i];
+        [self.webView stringByEvaluatingJavaScriptFromString:item];
+
+        if (i % 1000 == 0) {
+            NSLog(@"Loaded %d items", i);
+        }
+    }
+}
+
+@end

--- a/examples/objective-c-ios/Bugsnag Test App/ViewController.m
+++ b/examples/objective-c-ios/Bugsnag Test App/ViewController.m
@@ -7,8 +7,10 @@
 //
 
 #import "ViewController.h"
+#import "BigHonkinWebViewController.h"
 #import "Bugsnag.h"
 #import <pthread.h>
+#import <stdlib.h>
 
 @interface ViewController ()
 
@@ -24,6 +26,11 @@
 - (void)didReceiveMemoryWarning {
     [super didReceiveMemoryWarning];
     [Bugsnag leaveBreadcrumbWithMessage:@"Received memory warning"];
+}
+
+- (IBAction)generateOOM:(id)sender {
+    BigHonkinWebViewController *controller = [BigHonkinWebViewController new];
+    [self.navigationController pushViewController:controller animated:YES];
 }
 
 - (IBAction)generateException:(id)sender {

--- a/examples/objective-c-ios/Bugsnag Test App/en.lproj/MainStoryboard.storyboard
+++ b/examples/objective-c-ios/Bugsnag Test App/en.lproj/MainStoryboard.storyboard
@@ -1,15 +1,30 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<document type="com.apple.InterfaceBuilder3.CocoaTouch.Storyboard.XIB" version="3.0" toolsVersion="12121" systemVersion="16F2073" targetRuntime="iOS.CocoaTouch" propertyAccessControl="none" useAutolayout="YES" colorMatched="YES" initialViewController="2">
+<document type="com.apple.InterfaceBuilder3.CocoaTouch.Storyboard.XIB" version="3.0" toolsVersion="14460.31" targetRuntime="iOS.CocoaTouch" propertyAccessControl="none" useAutolayout="YES" colorMatched="YES" initialViewController="ogA-pf-q3e">
     <device id="retina4_7" orientation="portrait">
         <adaptation id="fullscreen"/>
     </device>
     <dependencies>
         <deployment identifier="iOS"/>
-        <plugIn identifier="com.apple.InterfaceBuilder.IBCocoaTouchPlugin" version="12089"/>
-        <capability name="Constraints to layout margins" minToolsVersion="6.0"/>
+        <plugIn identifier="com.apple.InterfaceBuilder.IBCocoaTouchPlugin" version="14460.20"/>
         <capability name="documents saved in the Xcode 8 format" minToolsVersion="8.0"/>
     </dependencies>
     <scenes>
+        <!--Navigation Controller-->
+        <scene sceneID="zpQ-TA-uk7">
+            <objects>
+                <navigationController id="ogA-pf-q3e" sceneMemberID="viewController">
+                    <navigationBar key="navigationBar" contentMode="scaleToFill" insetsLayoutMarginsFromSafeArea="NO" id="eMo-dQ-Ee0">
+                        <rect key="frame" x="0.0" y="20" width="375" height="44"/>
+                        <autoresizingMask key="autoresizingMask"/>
+                    </navigationBar>
+                    <connections>
+                        <segue destination="2" kind="relationship" relationship="rootViewController" id="kgl-3x-76P"/>
+                    </connections>
+                </navigationController>
+                <placeholder placeholderIdentifier="IBFirstResponder" id="ktm-VJ-qMZ" userLabel="First Responder" sceneMemberID="firstResponder"/>
+            </objects>
+            <point key="canvasLocation" x="-343" y="282"/>
+        </scene>
         <!--View Controller-->
         <scene sceneID="5">
             <objects>
@@ -22,12 +37,10 @@
                         <rect key="frame" x="0.0" y="0.0" width="375" height="667"/>
                         <autoresizingMask key="autoresizingMask" flexibleMaxX="YES" flexibleMaxY="YES"/>
                         <subviews>
-
                             <button opaque="NO" contentMode="scaleToFill" contentHorizontalAlignment="center" contentVerticalAlignment="center" buttonType="roundedRect" lineBreakMode="middleTruncation" translatesAutoresizingMaskIntoConstraints="NO" id="Oxr-6H-zaP">
-                                <rect key="frame" x="36" y="84" width="303" height="40"/>
+                                <rect key="frame" x="36" y="128" width="303" height="40"/>
                                 <constraints>
                                     <constraint firstAttribute="height" constant="40" id="Jdg-Wd-JMi"/>
-
                                 </constraints>
                                 <state key="normal" title="Generate Exception">
                                     <color key="titleShadowColor" red="0.5" green="0.5" blue="0.5" alpha="1" colorSpace="custom" customColorSpace="sRGB"/>
@@ -36,10 +49,8 @@
                                     <action selector="generateException:" destination="2" eventType="touchUpInside" id="BzY-pb-0qk"/>
                                 </connections>
                             </button>
-
                             <button opaque="NO" contentMode="scaleToFill" contentHorizontalAlignment="center" contentVerticalAlignment="center" buttonType="roundedRect" lineBreakMode="middleTruncation" translatesAutoresizingMaskIntoConstraints="NO" id="8xv-Hz-oaJ">
-                                <rect key="frame" x="36" y="124" width="303" height="40"/>
-
+                                <rect key="frame" x="36" y="168" width="303" height="40"/>
                                 <state key="normal" title="Generate Signal">
                                     <color key="titleShadowColor" red="0.5" green="0.5" blue="0.5" alpha="1" colorSpace="custom" customColorSpace="sRGB"/>
                                 </state>
@@ -47,10 +58,8 @@
                                     <action selector="generateSignal:" destination="2" eventType="touchUpInside" id="UPD-MJ-coG"/>
                                 </connections>
                             </button>
-
                             <button opaque="NO" contentMode="scaleToFill" contentHorizontalAlignment="center" contentVerticalAlignment="center" buttonType="roundedRect" lineBreakMode="middleTruncation" translatesAutoresizingMaskIntoConstraints="NO" id="YW2-Lb-cb2">
-                                <rect key="frame" x="36" y="204" width="303" height="40"/>
-
+                                <rect key="frame" x="36" y="248" width="303" height="40"/>
                                 <state key="normal" title="Non-Fatal Exception">
                                     <color key="titleShadowColor" red="0.5" green="0.5" blue="0.5" alpha="1" colorSpace="custom" customColorSpace="sRGB"/>
                                 </state>
@@ -58,11 +67,8 @@
                                     <action selector="nonFatalException:" destination="2" eventType="touchUpInside" id="8xi-pG-IRm"/>
                                 </connections>
                             </button>
-
-                          
                             <button opaque="NO" contentMode="scaleToFill" contentHorizontalAlignment="center" contentVerticalAlignment="center" buttonType="roundedRect" lineBreakMode="middleTruncation" translatesAutoresizingMaskIntoConstraints="NO" id="sFG-vI-9OD">
-                                <rect key="frame" x="36" y="164" width="303" height="40"/>
-
+                                <rect key="frame" x="36" y="208" width="303" height="40"/>
                                 <state key="normal" title="Delayed Exception">
                                     <color key="titleShadowColor" red="0.5" green="0.5" blue="0.5" alpha="1" colorSpace="custom" customColorSpace="sRGB"/>
                                 </state>
@@ -70,10 +76,8 @@
                                     <action selector="delayedException:" destination="2" eventType="touchUpInside" id="VYs-GP-qcw"/>
                                 </connections>
                             </button>
-
                             <button opaque="NO" contentMode="scaleToFill" contentHorizontalAlignment="center" contentVerticalAlignment="center" buttonType="roundedRect" lineBreakMode="middleTruncation" translatesAutoresizingMaskIntoConstraints="NO" id="rbY-70-dIG">
-                                <rect key="frame" x="36" y="284" width="303" height="40"/>
-
+                                <rect key="frame" x="36" y="328" width="303" height="40"/>
                                 <state key="normal" title="Objective-C Lock Signal">
                                     <color key="titleShadowColor" red="0.5" green="0.5" blue="0.5" alpha="1" colorSpace="custom" customColorSpace="sRGB"/>
                                 </state>
@@ -81,10 +85,8 @@
                                     <action selector="objectiveCLockSignal:" destination="2" eventType="touchUpInside" id="UUf-ch-eLp"/>
                                 </connections>
                             </button>
-
                             <button opaque="NO" contentMode="scaleToFill" contentHorizontalAlignment="center" contentVerticalAlignment="center" buttonType="roundedRect" lineBreakMode="middleTruncation" translatesAutoresizingMaskIntoConstraints="NO" id="gtT-rK-OwM">
-                                <rect key="frame" x="36" y="324" width="303" height="40"/>
-
+                                <rect key="frame" x="36" y="368" width="303" height="40"/>
                                 <state key="normal" title="PThreads Lock Signal">
                                     <color key="titleShadowColor" red="0.5" green="0.5" blue="0.5" alpha="1" colorSpace="custom" customColorSpace="sRGB"/>
                                 </state>
@@ -92,10 +94,8 @@
                                     <action selector="pthreadsLockSignal:" destination="2" eventType="touchUpInside" id="3EZ-Te-dHj"/>
                                 </connections>
                             </button>
-
                             <button opaque="NO" contentMode="scaleToFill" contentHorizontalAlignment="center" contentVerticalAlignment="center" buttonType="roundedRect" lineBreakMode="middleTruncation" translatesAutoresizingMaskIntoConstraints="NO" id="HZ8-LN-PKe">
-                                <rect key="frame" x="36" y="364" width="303" height="40"/>
-
+                                <rect key="frame" x="36" y="408" width="303" height="40"/>
                                 <state key="normal" title="StackOverflow">
                                     <color key="titleShadowColor" red="0.5" green="0.5" blue="0.5" alpha="1" colorSpace="custom" customColorSpace="sRGB"/>
                                 </state>
@@ -103,10 +103,8 @@
                                     <action selector="stackOverflow:" destination="2" eventType="touchUpInside" id="2Ia-la-7OK"/>
                                 </connections>
                             </button>
-
                             <button opaque="NO" contentMode="scaleToFill" contentHorizontalAlignment="center" contentVerticalAlignment="center" buttonType="roundedRect" lineBreakMode="middleTruncation" translatesAutoresizingMaskIntoConstraints="NO" id="1M3-pO-mjr">
-                                <rect key="frame" x="36" y="404" width="303" height="40"/>
-
+                                <rect key="frame" x="36" y="448" width="303" height="40"/>
                                 <state key="normal" title="Check Event Loop Spin">
                                     <color key="titleShadowColor" red="0.5" green="0.5" blue="0.5" alpha="1" colorSpace="custom" customColorSpace="sRGB"/>
                                 </state>
@@ -114,10 +112,16 @@
                                     <action selector="checkEventLoopSpin:" destination="2" eventType="touchUpInside" id="71j-ee-LE7"/>
                                 </connections>
                             </button>
+                            <button opaque="NO" contentMode="scaleToFill" contentHorizontalAlignment="center" contentVerticalAlignment="center" buttonType="roundedRect" lineBreakMode="middleTruncation" translatesAutoresizingMaskIntoConstraints="NO" id="az6-L5-tEc">
+                                <rect key="frame" x="136" y="496" width="103" height="30"/>
+                                <state key="normal" title="Generate OOM"/>
+                                <connections>
+                                    <action selector="generateOOM:" destination="2" eventType="touchUpInside" id="K3I-Se-IF4"/>
+                                </connections>
+                            </button>
                         </subviews>
                         <color key="backgroundColor" red="1" green="1" blue="1" alpha="1" colorSpace="custom" customColorSpace="sRGB"/>
                         <constraints>
-
                             <constraint firstItem="rbY-70-dIG" firstAttribute="height" secondItem="YW2-Lb-cb2" secondAttribute="height" id="2Xz-LL-SDN"/>
                             <constraint firstItem="1M3-pO-mjr" firstAttribute="leading" secondItem="HZ8-LN-PKe" secondAttribute="leading" id="2jL-Sa-BxP"/>
                             <constraint firstItem="gtT-rK-OwM" firstAttribute="leading" secondItem="rbY-70-dIG" secondAttribute="leading" id="56p-af-6Jh"/>
@@ -125,6 +129,7 @@
                             <constraint firstItem="8xv-Hz-oaJ" firstAttribute="leading" secondItem="Oxr-6H-zaP" secondAttribute="leading" id="8RT-x2-v9b"/>
                             <constraint firstItem="sFG-vI-9OD" firstAttribute="leading" secondItem="8xv-Hz-oaJ" secondAttribute="leading" id="C4e-aT-udS"/>
                             <constraint firstItem="rbY-70-dIG" firstAttribute="leading" secondItem="YW2-Lb-cb2" secondAttribute="leading" id="E60-5U-9HR"/>
+                            <constraint firstItem="az6-L5-tEc" firstAttribute="top" secondItem="1M3-pO-mjr" secondAttribute="bottom" constant="8" id="F1y-wh-FLB"/>
                             <constraint firstItem="YW2-Lb-cb2" firstAttribute="trailing" secondItem="sFG-vI-9OD" secondAttribute="trailing" id="FnQ-fN-qF8"/>
                             <constraint firstItem="HZ8-LN-PKe" firstAttribute="trailing" secondItem="gtT-rK-OwM" secondAttribute="trailing" id="Jp2-Ie-kuL"/>
                             <constraint firstItem="rbY-70-dIG" firstAttribute="top" secondItem="YW2-Lb-cb2" secondAttribute="bottom" constant="40" id="LBZ-Q4-fFJ"/>
@@ -133,6 +138,7 @@
                             <constraint firstItem="gtT-rK-OwM" firstAttribute="trailing" secondItem="rbY-70-dIG" secondAttribute="trailing" id="Ot3-Db-Den"/>
                             <constraint firstItem="HZ8-LN-PKe" firstAttribute="height" secondItem="gtT-rK-OwM" secondAttribute="height" id="SLd-L6-ltK"/>
                             <constraint firstItem="HZ8-LN-PKe" firstAttribute="top" secondItem="gtT-rK-OwM" secondAttribute="bottom" id="U4c-H6-Kua"/>
+                            <constraint firstItem="az6-L5-tEc" firstAttribute="centerX" secondItem="3" secondAttribute="centerX" id="URR-aY-4Dz"/>
                             <constraint firstItem="Oxr-6H-zaP" firstAttribute="top" secondItem="adP-me-sk4" secondAttribute="bottom" constant="64" id="Ulk-Hh-7HW"/>
                             <constraint firstItem="1M3-pO-mjr" firstAttribute="top" secondItem="HZ8-LN-PKe" secondAttribute="bottom" id="WNz-ab-DAb"/>
                             <constraint firstItem="YW2-Lb-cb2" firstAttribute="leading" secondItem="sFG-vI-9OD" secondAttribute="leading" id="X1B-jc-lu0"/>
@@ -149,18 +155,13 @@
                             <constraint firstItem="HZ8-LN-PKe" firstAttribute="leading" secondItem="gtT-rK-OwM" secondAttribute="leading" id="oip-gY-kQZ"/>
                             <constraint firstItem="rbY-70-dIG" firstAttribute="trailing" secondItem="YW2-Lb-cb2" secondAttribute="trailing" id="qaB-xi-PYJ"/>
                             <constraint firstItem="8xv-Hz-oaJ" firstAttribute="height" secondItem="Oxr-6H-zaP" secondAttribute="height" id="uZ8-p7-PHX"/>
-
                         </constraints>
                     </view>
+                    <navigationItem key="navigationItem" id="Xwx-BY-cwr"/>
                 </viewController>
                 <placeholder placeholderIdentifier="IBFirstResponder" id="4" sceneMemberID="firstResponder"/>
             </objects>
-            <point key="canvasLocation" x="368" y="314"/>
+            <point key="canvasLocation" x="588.79999999999995" y="282.4587706146927"/>
         </scene>
     </scenes>
-    <simulatedMetricsContainer key="defaultSimulatedMetrics">
-        <simulatedStatusBarMetrics key="statusBar"/>
-        <simulatedOrientationMetrics key="orientation"/>
-        <simulatedScreenMetrics key="destination" type="retina4_7.fullscreen"/>
-    </simulatedMetricsContainer>
 </document>

--- a/features/fixtures/ios-swift-cocoapods/iOSTestApp.xcodeproj/project.pbxproj
+++ b/features/fixtures/ios-swift-cocoapods/iOSTestApp.xcodeproj/project.pbxproj
@@ -7,7 +7,9 @@
 	objects = {
 
 /* Begin PBXBuildFile section */
+		8A22FC66225B598500CA8895 /* OOMScenario.m in Sources */ = {isa = PBXBuildFile; fileRef = 8A22FC65225B598500CA8895 /* OOMScenario.m */; };
 		8A32DB8222424E3000EDD92F /* NSExceptionShiftScenario.m in Sources */ = {isa = PBXBuildFile; fileRef = 8A32DB8122424E3000EDD92F /* NSExceptionShiftScenario.m */; };
+		8A42FD35225DEE04007AE561 /* SessionOOMScenario.m in Sources */ = {isa = PBXBuildFile; fileRef = 8A42FD33225DEE04007AE561 /* SessionOOMScenario.m */; };
 		8A840FBA21AF5C450041DBFA /* SwiftAssertion.swift in Sources */ = {isa = PBXBuildFile; fileRef = 8A840FB921AF5C450041DBFA /* SwiftAssertion.swift */; };
 		8A98400320FD11BF0023ECD1 /* AutoSessionCustomVersionScenario.m in Sources */ = {isa = PBXBuildFile; fileRef = 8A98400220FD11BF0023ECD1 /* AutoSessionCustomVersionScenario.m */; };
 		8AB8866420404DD30003E444 /* AppDelegate.swift in Sources */ = {isa = PBXBuildFile; fileRef = 8AB8866320404DD30003E444 /* AppDelegate.swift */; };
@@ -20,6 +22,8 @@
 		8AEFC73420F8D1BB00A78779 /* ManualSessionWithUserScenario.m in Sources */ = {isa = PBXBuildFile; fileRef = 8AEFC73320F8D1BB00A78779 /* ManualSessionWithUserScenario.m */; };
 		8AEFC79920F9132C00A78779 /* AutoSessionHandledEventsScenario.m in Sources */ = {isa = PBXBuildFile; fileRef = 8AEFC79820F9132C00A78779 /* AutoSessionHandledEventsScenario.m */; };
 		8AEFC79C20F92E2200A78779 /* AutoSessionUnhandledScenario.m in Sources */ = {isa = PBXBuildFile; fileRef = 8AEFC79B20F92E2200A78779 /* AutoSessionUnhandledScenario.m */; };
+		8AF6FD77225E3F870056EF9E /* StopSessionOOMScenario.m in Sources */ = {isa = PBXBuildFile; fileRef = 8AF6FD76225E3F870056EF9E /* StopSessionOOMScenario.m */; };
+		8AF6FD7A225E3FA00056EF9E /* ResumeSessionOOMScenario.m in Sources */ = {isa = PBXBuildFile; fileRef = 8AF6FD79225E3FA00056EF9E /* ResumeSessionOOMScenario.m */; };
 		C4D0B5FF8E60C0835B86DFE9 /* Pods_iOSTestApp.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = 4994F05E0421A0B037DD2CC5 /* Pods_iOSTestApp.framework */; };
 		E7767F11221C21D90006648C /* StoppedSessionScenario.swift in Sources */ = {isa = PBXBuildFile; fileRef = E7767F10221C21D90006648C /* StoppedSessionScenario.swift */; };
 		E7767F13221C21E30006648C /* ResumedSessionScenario.swift in Sources */ = {isa = PBXBuildFile; fileRef = E7767F12221C21E30006648C /* ResumedSessionScenario.swift */; };
@@ -59,8 +63,13 @@
 
 /* Begin PBXFileReference section */
 		4994F05E0421A0B037DD2CC5 /* Pods_iOSTestApp.framework */ = {isa = PBXFileReference; explicitFileType = wrapper.framework; includeInIndex = 0; path = Pods_iOSTestApp.framework; sourceTree = BUILT_PRODUCTS_DIR; };
+		8A22FC62225B3E4800CA8895 /* ReportDidCrashScenario.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ReportDidCrashScenario.swift; sourceTree = "<group>"; };
+		8A22FC64225B598500CA8895 /* OOMScenario.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; path = OOMScenario.h; sourceTree = "<group>"; };
+		8A22FC65225B598500CA8895 /* OOMScenario.m */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.objc; path = OOMScenario.m; sourceTree = "<group>"; };
 		8A32DB8022424E3000EDD92F /* NSExceptionShiftScenario.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = NSExceptionShiftScenario.h; sourceTree = "<group>"; };
 		8A32DB8122424E3000EDD92F /* NSExceptionShiftScenario.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; path = NSExceptionShiftScenario.m; sourceTree = "<group>"; };
+		8A42FD33225DEE04007AE561 /* SessionOOMScenario.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; path = SessionOOMScenario.m; sourceTree = "<group>"; };
+		8A42FD34225DEE04007AE561 /* SessionOOMScenario.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = SessionOOMScenario.h; sourceTree = "<group>"; };
 		8A840FB921AF5C450041DBFA /* SwiftAssertion.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = SwiftAssertion.swift; sourceTree = "<group>"; };
 		8A98400120FD11BF0023ECD1 /* AutoSessionCustomVersionScenario.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; path = AutoSessionCustomVersionScenario.h; sourceTree = "<group>"; };
 		8A98400220FD11BF0023ECD1 /* AutoSessionCustomVersionScenario.m */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.objc; path = AutoSessionCustomVersionScenario.m; sourceTree = "<group>"; };
@@ -82,6 +91,10 @@
 		8AEFC79820F9132C00A78779 /* AutoSessionHandledEventsScenario.m */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.objc; path = AutoSessionHandledEventsScenario.m; sourceTree = "<group>"; };
 		8AEFC79A20F92E2200A78779 /* AutoSessionUnhandledScenario.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; path = AutoSessionUnhandledScenario.h; sourceTree = "<group>"; };
 		8AEFC79B20F92E2200A78779 /* AutoSessionUnhandledScenario.m */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.objc; path = AutoSessionUnhandledScenario.m; sourceTree = "<group>"; };
+		8AF6FD75225E3F870056EF9E /* StopSessionOOMScenario.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; path = StopSessionOOMScenario.h; sourceTree = "<group>"; };
+		8AF6FD76225E3F870056EF9E /* StopSessionOOMScenario.m */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.objc; path = StopSessionOOMScenario.m; sourceTree = "<group>"; };
+		8AF6FD78225E3FA00056EF9E /* ResumeSessionOOMScenario.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; path = ResumeSessionOOMScenario.h; sourceTree = "<group>"; };
+		8AF6FD79225E3FA00056EF9E /* ResumeSessionOOMScenario.m */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.objc; path = ResumeSessionOOMScenario.m; sourceTree = "<group>"; };
 		960A6E7D4E847F1D76A4FD06 /* Pods-iOSTestApp.release.xcconfig */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.xcconfig; name = "Pods-iOSTestApp.release.xcconfig"; path = "Pods/Target Support Files/Pods-iOSTestApp/Pods-iOSTestApp.release.xcconfig"; sourceTree = "<group>"; };
 		E7767F10221C21D90006648C /* StoppedSessionScenario.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = StoppedSessionScenario.swift; sourceTree = "<group>"; };
 		E7767F12221C21E30006648C /* ResumedSessionScenario.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ResumedSessionScenario.swift; sourceTree = "<group>"; };
@@ -278,6 +291,15 @@
 				E7767F10221C21D90006648C /* StoppedSessionScenario.swift */,
 				E7767F12221C21E30006648C /* ResumedSessionScenario.swift */,
 				E7767F14221C223C0006648C /* NewSessionScenario.swift */,
+				8A22FC62225B3E4800CA8895 /* ReportDidCrashScenario.swift */,
+				8A22FC64225B598500CA8895 /* OOMScenario.h */,
+				8A22FC65225B598500CA8895 /* OOMScenario.m */,
+				8A42FD34225DEE04007AE561 /* SessionOOMScenario.h */,
+				8A42FD33225DEE04007AE561 /* SessionOOMScenario.m */,
+				8AF6FD75225E3F870056EF9E /* StopSessionOOMScenario.h */,
+				8AF6FD76225E3F870056EF9E /* StopSessionOOMScenario.m */,
+				8AF6FD78225E3FA00056EF9E /* ResumeSessionOOMScenario.h */,
+				8AF6FD79225E3FA00056EF9E /* ResumeSessionOOMScenario.m */,
 			);
 			path = scenarios;
 			sourceTree = "<group>";
@@ -405,18 +427,21 @@
 				F4295A036B228AF608641699 /* UserDisabledScenario.swift in Sources */,
 				E7767F13221C21E30006648C /* ResumedSessionScenario.swift in Sources */,
 				8AEFC73120F8D1A000A78779 /* AutoSessionWithUserScenario.m in Sources */,
+				8AF6FD7A225E3FA00056EF9E /* ResumeSessionOOMScenario.m in Sources */,
 				F429565A951303E2C3136D0D /* UserIdScenario.swift in Sources */,
 				8AEEBBD020FC9E1D00C60763 /* AutoSessionMixedEventsScenario.m in Sources */,
 				F4295A94DD2D131A594A212C /* HandledErrorScenario.swift in Sources */,
 				F4295A7AA9B4A18992A2F020 /* HandledErrorOverrideScenario.swift in Sources */,
 				F429502603396F8671B333B3 /* HandledExceptionScenario.swift in Sources */,
 				F4295497A1582010C16F1861 /* AbortScenario.m in Sources */,
+				8A42FD35225DEE04007AE561 /* SessionOOMScenario.m in Sources */,
 				F4295CEAD7C915EFA04898A5 /* Scenario.m in Sources */,
 				F4295836C8AF75547C675E8D /* ReleasedObjectScenario.m in Sources */,
 				F42958881D3F34A76CADE4EC /* SwiftCrash.swift in Sources */,
 				F42955DB6D08642528917FAB /* CxxExceptionScenario.mm in Sources */,
 				8A32DB8222424E3000EDD92F /* NSExceptionShiftScenario.m in Sources */,
 				F42954B7318A02824C65C514 /* ObjCMsgSendScenario.m in Sources */,
+				8A22FC66225B598500CA8895 /* OOMScenario.m in Sources */,
 				F42953498545B853CC0B635E /* NullPointerScenario.m in Sources */,
 				8A840FBA21AF5C450041DBFA /* SwiftAssertion.swift in Sources */,
 				F429538D8941382EC2C857CE /* AsyncSafeThreadScenario.m in Sources */,
@@ -439,6 +464,7 @@
 				F4295A0B0DA0AF3B5502D29C /* PrivilegedInstructionScenario.m in Sources */,
 				F42958BE5DDACDBF653CA926 /* ManualSessionScenario.m in Sources */,
 				F42951BF19D7F35A03273CFB /* AutoSessionScenario.m in Sources */,
+				8AF6FD77225E3F870056EF9E /* StopSessionOOMScenario.m in Sources */,
 				F4295109FCAB93708FDAFE12 /* DisabledSessionTrackingScenario.m in Sources */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;

--- a/features/fixtures/ios-swift-cocoapods/iOSTestApp/scenarios/OOMScenario.h
+++ b/features/fixtures/ios-swift-cocoapods/iOSTestApp/scenarios/OOMScenario.h
@@ -1,0 +1,5 @@
+#import "Scenario.h"
+
+@interface OOMScenario : Scenario
+
+@end

--- a/features/fixtures/ios-swift-cocoapods/iOSTestApp/scenarios/OOMScenario.m
+++ b/features/fixtures/ios-swift-cocoapods/iOSTestApp/scenarios/OOMScenario.m
@@ -1,0 +1,20 @@
+
+#import "OOMScenario.h"
+#import <signal.h>
+
+@implementation OOMScenario
+
+- (void)startBugsnag {
+    self.config.shouldAutoCaptureSessions = NO;
+    self.config.releaseStage = @"alpha";
+    [super startBugsnag];
+}
+
+- (void)run {
+    [Bugsnag leaveBreadcrumbWithMessage:@"Crumb left before crash"];
+    [Bugsnag configuration].releaseStage = @"beta";
+    dispatch_after(dispatch_time(DISPATCH_TIME_NOW, (int64_t)(6 * NSEC_PER_SEC)), dispatch_get_main_queue(), ^{
+        raise(SIGKILL);
+    });
+}
+@end

--- a/features/fixtures/ios-swift-cocoapods/iOSTestApp/scenarios/ReportDidCrashScenario.swift
+++ b/features/fixtures/ios-swift-cocoapods/iOSTestApp/scenarios/ReportDidCrashScenario.swift
@@ -1,0 +1,15 @@
+
+import UIKit
+import Bugsnag
+
+@objc class ReportDidCrashScenario: Scenario {
+
+    override func startBugsnag() {
+        self.config.shouldAutoCaptureSessions = false;
+        super.startBugsnag()
+    }
+    
+    override func run() {
+        Bugsnag.notifyError(NSError(domain: "com.example", code: 43, userInfo: nil))
+    }
+}

--- a/features/fixtures/ios-swift-cocoapods/iOSTestApp/scenarios/ResumeSessionOOMScenario.h
+++ b/features/fixtures/ios-swift-cocoapods/iOSTestApp/scenarios/ResumeSessionOOMScenario.h
@@ -1,0 +1,5 @@
+#import "Scenario.h"
+
+@interface ResumeSessionOOMScenario : Scenario
+
+@end

--- a/features/fixtures/ios-swift-cocoapods/iOSTestApp/scenarios/ResumeSessionOOMScenario.m
+++ b/features/fixtures/ios-swift-cocoapods/iOSTestApp/scenarios/ResumeSessionOOMScenario.m
@@ -1,0 +1,20 @@
+#import "ResumeSessionOOMScenario.h"
+
+@implementation ResumeSessionOOMScenario
+
+- (void)startBugsnag {
+    self.config.shouldAutoCaptureSessions = NO;
+    [super startBugsnag];
+}
+
+- (void)run {
+    [Bugsnag startSession];
+    [Bugsnag notify:[NSException exceptionWithName:@"foo" reason:nil userInfo:nil]];
+    [Bugsnag stopSession];
+    [Bugsnag resumeSession];
+    dispatch_after(dispatch_time(DISPATCH_TIME_NOW, (int64_t)(3 * NSEC_PER_SEC)), dispatch_get_main_queue(), ^{
+        raise(SIGKILL);
+    });
+}
+
+@end

--- a/features/fixtures/ios-swift-cocoapods/iOSTestApp/scenarios/SessionOOMScenario.h
+++ b/features/fixtures/ios-swift-cocoapods/iOSTestApp/scenarios/SessionOOMScenario.h
@@ -1,0 +1,5 @@
+#import "Scenario.h"
+
+@interface SessionOOMScenario : Scenario
+
+@end

--- a/features/fixtures/ios-swift-cocoapods/iOSTestApp/scenarios/SessionOOMScenario.m
+++ b/features/fixtures/ios-swift-cocoapods/iOSTestApp/scenarios/SessionOOMScenario.m
@@ -1,0 +1,19 @@
+#import "SessionOOMScenario.h"
+#import <signal.h>
+
+@implementation SessionOOMScenario
+
+- (void)startBugsnag {
+    self.config.shouldAutoCaptureSessions = NO;
+    [super startBugsnag];
+}
+
+- (void)run {
+    [Bugsnag startSession];
+    [Bugsnag notify:[NSException exceptionWithName:@"foo" reason:nil userInfo:nil]];
+    dispatch_after(dispatch_time(DISPATCH_TIME_NOW, (int64_t)(3 * NSEC_PER_SEC)), dispatch_get_main_queue(), ^{
+        raise(SIGKILL);
+    });
+}
+
+@end

--- a/features/fixtures/ios-swift-cocoapods/iOSTestApp/scenarios/StopSessionOOMScenario.h
+++ b/features/fixtures/ios-swift-cocoapods/iOSTestApp/scenarios/StopSessionOOMScenario.h
@@ -1,0 +1,5 @@
+#import "Scenario.h"
+
+@interface StopSessionOOMScenario : Scenario
+
+@end

--- a/features/fixtures/ios-swift-cocoapods/iOSTestApp/scenarios/StopSessionOOMScenario.m
+++ b/features/fixtures/ios-swift-cocoapods/iOSTestApp/scenarios/StopSessionOOMScenario.m
@@ -1,0 +1,19 @@
+#import "StopSessionOOMScenario.h"
+
+@implementation StopSessionOOMScenario
+
+- (void)startBugsnag {
+    self.config.shouldAutoCaptureSessions = NO;
+    [super startBugsnag];
+}
+
+- (void)run {
+    [Bugsnag startSession];
+    [Bugsnag notify:[NSException exceptionWithName:@"foo" reason:nil userInfo:nil]];
+    [Bugsnag stopSession];
+    dispatch_after(dispatch_time(DISPATCH_TIME_NOW, (int64_t)(3 * NSEC_PER_SEC)), dispatch_get_main_queue(), ^{
+        raise(SIGKILL);
+    });
+}
+
+@end

--- a/features/oom.feature
+++ b/features/oom.feature
@@ -1,0 +1,81 @@
+Feature: Reporting out of memory events
+    If the app is terminated without either a reported crash or a "will
+    terminate" event, and the underlying OS and app versions remain the same,
+    it is likely that the app has been killed.
+
+    Scenario: The OS kills the application in the foreground
+        When I crash the app using "OOMScenario"
+        And I wait for 4 seconds
+        And I relaunch the app
+        Then I should receive a request
+        And the request is a valid for the error reporting API
+        And the payload field "events" is an array with 1 element
+        And the exception "errorClass" equals "Out Of Memory"
+        And the exception "message" equals "The app was likely terminated by the operating system while in the foreground"
+        And the event "unhandled" is true
+        And the event "severity" equals "error"
+        And the event "severityReason.type" equals "outOfMemory"
+        And the event "app.releaseStage" equals "beta"
+        And the event breadcrumbs contain "Crumb left before crash"
+
+    Scenario: The OS kills the application in the background
+        When I crash the app using "OOMScenario"
+        And I put the app in the background
+        And I wait for 4 seconds
+        And I relaunch the app
+        Then I should receive a request
+        And the request is a valid for the error reporting API
+        And the payload field "events" is an array with 1 element
+        And the exception "errorClass" equals "Out Of Memory"
+        And the exception "message" equals "The app was likely terminated by the operating system while in the background"
+        And the event "unhandled" is true
+        And the event "severity" equals "error"
+        And the event "severityReason.type" equals "outOfMemory"
+        And the event "app.releaseStage" equals "beta"
+        And the event breadcrumbs contain "Crumb left before crash"
+
+    Scenario: The OS kills the application after a session is sent
+        When I crash the app using "SessionOOMScenario"
+        And I wait for 2 seconds
+        And I relaunch the app
+        Then I should receive 3 requests
+        And request 0 is a valid for the session tracking API
+        And request 1 is a valid for the error reporting API
+        And request 2 is a valid for the error reporting API
+        And the payload field "events" is an array with 1 element for request 2
+        And the payload field "events.0.session.events.handled" equals 1 for request 1
+        And the payload field "events.0.session.events.unhandled" equals 0 for request 1
+        And the payload field "events.0.session.events.handled" equals 1 for request 2
+        And the payload field "events.0.session.events.unhandled" equals 1 for request 2
+        And the payload field "events.0.session.id" of request 1 equals the payload field "sessions.0.id" of request 0
+        And the payload field "events.0.session.id" of request 1 equals the payload field "events.0.session.id" of request 2
+
+    Scenario: The OS kills the application after a session is stopped
+        When I crash the app using "StopSessionOOMScenario"
+        And I wait for 2 seconds
+        And I relaunch the app
+        Then I should receive 3 requests
+        And request 0 is a valid for the session tracking API
+        And request 1 is a valid for the error reporting API
+        And request 2 is a valid for the error reporting API
+        And the payload field "events" is an array with 1 element for request 2
+        And the payload field "events.0.session.events.handled" equals 1 for request 1
+        And the payload field "events.0.session.events.unhandled" equals 0 for request 1
+        And the payload field "events.0.session" is null for request 2
+        And the payload field "events.0.session.id" of request 1 equals the payload field "sessions.0.id" of request 0
+
+    Scenario: The OS kills the application after a session is resumed
+        When I crash the app using "ResumeSessionOOMScenario"
+        And I wait for 2 seconds
+        And I relaunch the app
+        Then I should receive 3 requests
+        And request 0 is a valid for the session tracking API
+        And request 1 is a valid for the error reporting API
+        And request 2 is a valid for the error reporting API
+        And the payload field "events" is an array with 1 element for request 2
+        And the payload field "events.0.session.events.handled" equals 1 for request 1
+        And the payload field "events.0.session.events.unhandled" equals 0 for request 1
+        And the payload field "events.0.session.events.handled" equals 1 for request 2
+        And the payload field "events.0.session.events.unhandled" equals 1 for request 2
+        And the payload field "events.0.session.id" of request 1 equals the payload field "sessions.0.id" of request 0
+        And the payload field "events.0.session.id" of request 1 equals the payload field "events.0.session.id" of request 2

--- a/features/scripts/launch_ios_safari.sh
+++ b/features/scripts/launch_ios_safari.sh
@@ -1,0 +1,3 @@
+#!/usr/bin/env bash
+
+xcrun simctl openurl "$iOS_Simulator" "http://example.com"

--- a/features/steps/ios_steps.rb
+++ b/features/steps/ios_steps.rb
@@ -30,6 +30,12 @@ When("I crash the app using {string}") do |event|
     And I set environment variable "EVENT_MODE" to "noevent"
   }
 end
+When("I put the app in the background") do
+  steps %Q{
+    When I run the script "features/scripts/launch_ios_safari.sh"
+    And I wait for 2 seconds
+  }
+end
 
 Then("the payload field {string} of request {int} equals the payload field {string} of request {int}") do |field1, request_index1, field2, request_index2|
   value1 = read_key_path(find_request(request_index1)[:body], field1)
@@ -83,4 +89,13 @@ Then("the event {string} is within {int} seconds of the current timestamp") do |
   thenSecs = Time.parse(value).to_i
   delta = nowSecs - thenSecs
   assert_true(delta.abs < threshold_secs, "Expected current timestamp, but received #{value}")
+end
+
+Then("the event breadcrumbs contain {string}") do |string|
+  crumbs = read_key_path(find_request(0)[:body], "events.0.breadcrumbs")
+  assert_not_equal(0, crumbs.length, "There are no breadcrumbs on this event")
+  match = crumbs.detect do |crumb|
+    read_key_path(crumb, "metaData.message") == string
+  end
+  assert_not_nil(match, "No crumb matches the provided message")
 end

--- a/features/support/env.rb
+++ b/features/support/env.rb
@@ -22,8 +22,20 @@ Before do
   set_script_env('iOS_Simulator', 'maze-sim')
 end
 
+After do
+  # Clean up caches
+  files = Dir.glob("#{app_file_path}/**/Library/Caches/{KSCrashReports/,bugsnag_}*")
+  files.each {|f| FileUtils.rm_rf(f) }
+end
+
 at_exit do
   run_required_commands([
     ['features/scripts/remove_installed_simulators.sh'],
   ])
 end
+
+def app_file_path
+  app_path = `xcrun simctl get_app_container maze-sim com.bugsnag.iOSTestApp`.chomp
+  app_path.gsub(/(.*Containers).*/, '\1')
+end
+

--- a/iOS/Bugsnag.xcodeproj/project.pbxproj
+++ b/iOS/Bugsnag.xcodeproj/project.pbxproj
@@ -34,6 +34,10 @@
 		8A4E733F1DC13281001F7CC8 /* BugsnagConfigurationTests.m in Sources */ = {isa = PBXBuildFile; fileRef = 8A4E733E1DC13281001F7CC8 /* BugsnagConfigurationTests.m */; };
 		8A627CD01EC2A5FD00F7C04E /* BSGSerialization.h in Headers */ = {isa = PBXBuildFile; fileRef = 8A627CCF1EC2A5FD00F7C04E /* BSGSerialization.h */; };
 		8A627CD21EC2A62900F7C04E /* BSGSerialization.m in Sources */ = {isa = PBXBuildFile; fileRef = 8A627CD11EC2A62900F7C04E /* BSGSerialization.m */; };
+		8A70D9C922539C81006B696F /* BSGOutOfMemoryWatchdog.h in Headers */ = {isa = PBXBuildFile; fileRef = 8A70D9C722539C81006B696F /* BSGOutOfMemoryWatchdog.h */; };
+		8A70D9CA22539C81006B696F /* BSGOutOfMemoryWatchdog.m in Sources */ = {isa = PBXBuildFile; fileRef = 8A70D9C822539C81006B696F /* BSGOutOfMemoryWatchdog.m */; };
+		8A70D9CB22539C81006B696F /* BSGOutOfMemoryWatchdog.m in Sources */ = {isa = PBXBuildFile; fileRef = 8A70D9C822539C81006B696F /* BSGOutOfMemoryWatchdog.m */; };
+		8A70D9CD2253C484006B696F /* BSGOutOfMemoryWatchdogTests.m in Sources */ = {isa = PBXBuildFile; fileRef = 8A70D9CC2253C484006B696F /* BSGOutOfMemoryWatchdogTests.m */; };
 		8AE1BC951DEFCE8B00D16CEF /* BugsnagConfigurationSpec.m in Sources */ = {isa = PBXBuildFile; fileRef = 8AE1BC941DEFCE8B00D16CEF /* BugsnagConfigurationSpec.m */; };
 		E70E52152216E41C00A590AB /* BugsnagSessionTrackerStopTest.m in Sources */ = {isa = PBXBuildFile; fileRef = E70E52142216E41C00A590AB /* BugsnagSessionTrackerStopTest.m */; };
 		E70EE0781FD7039E00FA745C /* RFC3339DateTool_Tests.m in Sources */ = {isa = PBXBuildFile; fileRef = E70EE0771FD7039D00FA745C /* RFC3339DateTool_Tests.m */; };
@@ -447,6 +451,9 @@
 		8A4E733E1DC13281001F7CC8 /* BugsnagConfigurationTests.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; name = BugsnagConfigurationTests.m; path = ../Tests/BugsnagConfigurationTests.m; sourceTree = SOURCE_ROOT; };
 		8A627CCF1EC2A5FD00F7C04E /* BSGSerialization.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; name = BSGSerialization.h; path = ../Source/BSGSerialization.h; sourceTree = SOURCE_ROOT; };
 		8A627CD11EC2A62900F7C04E /* BSGSerialization.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; name = BSGSerialization.m; path = ../Source/BSGSerialization.m; sourceTree = SOURCE_ROOT; };
+		8A70D9C722539C81006B696F /* BSGOutOfMemoryWatchdog.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; name = BSGOutOfMemoryWatchdog.h; path = ../Source/BSGOutOfMemoryWatchdog.h; sourceTree = "<group>"; };
+		8A70D9C822539C81006B696F /* BSGOutOfMemoryWatchdog.m */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.objc; name = BSGOutOfMemoryWatchdog.m; path = ../Source/BSGOutOfMemoryWatchdog.m; sourceTree = "<group>"; };
+		8A70D9CC2253C484006B696F /* BSGOutOfMemoryWatchdogTests.m */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.objc; path = BSGOutOfMemoryWatchdogTests.m; sourceTree = "<group>"; };
 		8AE1BC941DEFCE8B00D16CEF /* BugsnagConfigurationSpec.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; name = BugsnagConfigurationSpec.m; path = ../Tests/BugsnagConfigurationSpec.m; sourceTree = SOURCE_ROOT; };
 		E70E52142216E41C00A590AB /* BugsnagSessionTrackerStopTest.m */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.objc; name = BugsnagSessionTrackerStopTest.m; path = ../../Tests/BugsnagSessionTrackerStopTest.m; sourceTree = "<group>"; };
 		E70EE0771FD7039D00FA745C /* RFC3339DateTool_Tests.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; name = RFC3339DateTool_Tests.m; path = ../Tests/KSCrash/RFC3339DateTool_Tests.m; sourceTree = SOURCE_ROOT; };
@@ -714,6 +721,8 @@
 				8A2C8F1D1C6BBD2300846019 /* Info.plist */,
 				E7107BB31F4C97F100BB3F98 /* KSCrash */,
 				8A2C8F321C6BBD7200846019 /* module.modulemap */,
+				8A70D9C722539C81006B696F /* BSGOutOfMemoryWatchdog.h */,
+				8A70D9C822539C81006B696F /* BSGOutOfMemoryWatchdog.m */,
 			);
 			name = Bugsnag;
 			sourceTree = SOURCE_ROOT;
@@ -738,6 +747,7 @@
 				F429551527EAE3AFE1F605FE /* BugsnagThreadTest.m */,
 				E70E52142216E41C00A590AB /* BugsnagSessionTrackerStopTest.m */,
 				8A120069221C36420008C9C3 /* BSGFilepathTests.m */,
+				8A70D9CC2253C484006B696F /* BSGOutOfMemoryWatchdogTests.m */,
 			);
 			name = Tests;
 			path = BugsnagTests;
@@ -949,6 +959,7 @@
 			buildActionMask = 2147483647;
 			files = (
 				E7107C411F4C97F100BB3F98 /* BSG_KSCrashReportWriter.h in Headers */,
+				8A70D9C922539C81006B696F /* BSGOutOfMemoryWatchdog.h in Headers */,
 				8A2C8F4F1C6BBE3C00846019 /* Bugsnag.h in Headers */,
 				8A2C8F5B1C6BBE3C00846019 /* BugsnagMetaData.h in Headers */,
 				8A2C8F551C6BBE3C00846019 /* BugsnagConfiguration.h in Headers */,
@@ -1164,6 +1175,7 @@
 				E7107C3A1F4C97F100BB3F98 /* BSG_KSCrashDoctor.m in Sources */,
 				E7107C421F4C97F100BB3F98 /* BSG_KSCrashState.c in Sources */,
 				E72BF77B1FC869F7004BE82F /* BugsnagSession.m in Sources */,
+				8A70D9CA22539C81006B696F /* BSGOutOfMemoryWatchdog.m in Sources */,
 				E7107C5E1F4C97F100BB3F98 /* BSG_KSCrashCallCompletion.m in Sources */,
 				E7107C4D1F4C97F100BB3F98 /* BSG_KSCrashSentry_CPPException.mm in Sources */,
 				E7107C681F4C97F100BB3F98 /* BSG_KSLogger.m in Sources */,
@@ -1214,6 +1226,7 @@
 			isa = PBXSourcesBuildPhase;
 			buildActionMask = 2147483647;
 			files = (
+				8A70D9CD2253C484006B696F /* BSGOutOfMemoryWatchdogTests.m in Sources */,
 				E7B970341FD7031500590C27 /* XCTestCase+KSCrash.m in Sources */,
 				E70EE07E1FD703D600FA745C /* NSError+SimpleConstructor_Tests.m in Sources */,
 				E70EE08D1FD705A700FA745C /* KSSafeCollections_Tests.m in Sources */,
@@ -1275,6 +1288,7 @@
 				E7397E3D1F83BC320034242A /* BSG_KSJSONCodec.c in Sources */,
 				E7397E3E1F83BC320034242A /* BSG_KSMach.c in Sources */,
 				E72BF77C1FC869F7004BE82F /* BugsnagSession.m in Sources */,
+				8A70D9CB22539C81006B696F /* BSGOutOfMemoryWatchdog.m in Sources */,
 				E7397E3F1F83BC320034242A /* BSG_KSMach_Arm.c in Sources */,
 				E7397E401F83BC320034242A /* BSG_KSMach_Arm64.c in Sources */,
 				E7397E411F83BC320034242A /* BSG_KSMach_x86_32.c in Sources */,

--- a/iOS/BugsnagTests/BSGOutOfMemoryWatchdogTests.m
+++ b/iOS/BugsnagTests/BSGOutOfMemoryWatchdogTests.m
@@ -1,0 +1,19 @@
+
+#import "BSGOutOfMemoryWatchdog.h"
+#import "BSG_KSSystemInfo.h"
+#import "BugsnagConfiguration.h"
+#import <XCTest/XCTest.h>
+
+@interface BSGOutOfMemoryWatchdogTests : XCTestCase
+
+@end
+
+@implementation BSGOutOfMemoryWatchdogTests
+
+- (void)testNilPathDoesNotCreateWatchdog {
+    XCTAssertNil([[BSGOutOfMemoryWatchdog alloc] init]);
+    XCTAssertNil([[BSGOutOfMemoryWatchdog alloc] initWithSentinelPath:nil
+                                                        configuration:nil]);
+}
+
+@end

--- a/tvOS/Bugsnag.xcodeproj/project.pbxproj
+++ b/tvOS/Bugsnag.xcodeproj/project.pbxproj
@@ -11,6 +11,8 @@
 		8A48EF291EAA824100B70024 /* BugsnagLogger.h in Headers */ = {isa = PBXBuildFile; fileRef = 8A48EF281EAA824100B70024 /* BugsnagLogger.h */; };
 		8A627CD51EC3B69300F7C04E /* BSGSerialization.h in Headers */ = {isa = PBXBuildFile; fileRef = 8A627CD31EC3B69300F7C04E /* BSGSerialization.h */; };
 		8A627CD61EC3B69300F7C04E /* BSGSerialization.m in Sources */ = {isa = PBXBuildFile; fileRef = 8A627CD41EC3B69300F7C04E /* BSGSerialization.m */; };
+		8A6C6FAD2257882400E8EF24 /* BSGOutOfMemoryWatchdog.m in Sources */ = {isa = PBXBuildFile; fileRef = 8A6C6FAB2257882400E8EF24 /* BSGOutOfMemoryWatchdog.m */; };
+		8A6C6FAE2257882400E8EF24 /* BSGOutOfMemoryWatchdog.h in Headers */ = {isa = PBXBuildFile; fileRef = 8A6C6FAC2257882400E8EF24 /* BSGOutOfMemoryWatchdog.h */; };
 		8AB151171D41356800C9B218 /* Bugsnag.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = 8A8D51241D41343500D33797 /* Bugsnag.framework */; };
 		8AB151211D41361700C9B218 /* BugsnagBreadcrumbsTest.m in Sources */ = {isa = PBXBuildFile; fileRef = 8AB1511D1D41361700C9B218 /* BugsnagBreadcrumbsTest.m */; };
 		8AB151221D41361700C9B218 /* BugsnagCrashReportTests.m in Sources */ = {isa = PBXBuildFile; fileRef = 8AB1511E1D41361700C9B218 /* BugsnagCrashReportTests.m */; };
@@ -192,6 +194,8 @@
 		8A48EF281EAA824100B70024 /* BugsnagLogger.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; name = BugsnagLogger.h; path = ../Source/BugsnagLogger.h; sourceTree = "<group>"; };
 		8A627CD31EC3B69300F7C04E /* BSGSerialization.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; name = BSGSerialization.h; path = ../Source/BSGSerialization.h; sourceTree = "<group>"; };
 		8A627CD41EC3B69300F7C04E /* BSGSerialization.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; name = BSGSerialization.m; path = ../Source/BSGSerialization.m; sourceTree = "<group>"; };
+		8A6C6FAB2257882400E8EF24 /* BSGOutOfMemoryWatchdog.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; name = BSGOutOfMemoryWatchdog.m; path = ../Source/BSGOutOfMemoryWatchdog.m; sourceTree = "<group>"; };
+		8A6C6FAC2257882400E8EF24 /* BSGOutOfMemoryWatchdog.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; name = BSGOutOfMemoryWatchdog.h; path = ../Source/BSGOutOfMemoryWatchdog.h; sourceTree = "<group>"; };
 		8A8D51241D41343500D33797 /* Bugsnag.framework */ = {isa = PBXFileReference; explicitFileType = wrapper.framework; includeInIndex = 0; path = Bugsnag.framework; sourceTree = BUILT_PRODUCTS_DIR; };
 		8A8D51291D41343500D33797 /* Info.plist */ = {isa = PBXFileReference; lastKnownFileType = text.plist.xml; path = Info.plist; sourceTree = "<group>"; };
 		8AB151121D41356800C9B218 /* Tests.xctest */ = {isa = PBXFileReference; explicitFileType = wrapper.cfbundle; includeInIndex = 0; path = Tests.xctest; sourceTree = BUILT_PRODUCTS_DIR; };
@@ -410,6 +414,8 @@
 		8A8D51261D41343500D33797 /* tvOS */ = {
 			isa = PBXGroup;
 			children = (
+				8A6C6FAC2257882400E8EF24 /* BSGOutOfMemoryWatchdog.h */,
+				8A6C6FAB2257882400E8EF24 /* BSGOutOfMemoryWatchdog.m */,
 				E791486F1FD82E6C003EFEBF /* BugsnagApiClient.h */,
 				E791486E1FD82E6B003EFEBF /* BugsnagApiClient.m */,
 				E79148711FD82E6C003EFEBF /* BugsnagFileStore.h */,
@@ -695,6 +701,7 @@
 			buildActionMask = 2147483647;
 			files = (
 				E76617AE1F4E459C0094CECF /* BSG_KSJSONCodec.h in Headers */,
+				8A6C6FAE2257882400E8EF24 /* BSGOutOfMemoryWatchdog.h in Headers */,
 				E79148781FD82E6D003EFEBF /* BugsnagKSCrashSysInfoParser.h in Headers */,
 				E766177D1F4E459C0094CECF /* BSG_KSCrash.h in Headers */,
 				E766179C1F4E459C0094CECF /* BSG_KSCrashSentry_NSException.h in Headers */,
@@ -880,6 +887,7 @@
 				E791487F1FD82E6D003EFEBF /* BugsnagKSCrashSysInfoParser.m in Sources */,
 				E76617B51F4E459C0094CECF /* BSG_KSMach_Arm.c in Sources */,
 				8AD9A4FE1D42EE9D004E1CC5 /* BugsnagBreadcrumb.m in Sources */,
+				8A6C6FAD2257882400E8EF24 /* BSGOutOfMemoryWatchdog.m in Sources */,
 				E76617841F4E459C0094CECF /* BSG_KSCrashDoctor.m in Sources */,
 				E766178C1F4E459C0094CECF /* BSG_KSCrashState.c in Sources */,
 				E79148811FD82E6D003EFEBF /* BugsnagApiClient.m in Sources */,


### PR DESCRIPTION
## Goal

The bugsnag-cocoa library detects and reports app terminations resulting from Cocoa exceptions (NSException), C++ exceptions, Mach exceptions, and POSIX signals. However, the application can also be terminated by the operating system by a POSIX signal which cannot be captured by an in-process crash handler (`SIGKILL`). The following events can lead to the application being immediately killed:

* The app uses too much memory and the OS kills the app to reclaim memory for other device functions
* The OS is upgraded, terminating all running apps
* The app is upgraded, terminating the app
* The app is restarted in a development environment, such as the Xcode debugger or `simctl`

The goal of this project is to inform customers about possible out-of-memory events including as much diagnostic information as possible.

Fixes #243

## Design

Of the above events, bugsnag-cocoa should only report out-of-memory events as they indicate a problem with the application. Out of memory events should also be differentiated by whether the application is in the foreground or background, as there are different memory thresholds for a foreground app vs one in the background and a foreground termination is worse from a user retention perspective as the app seems to "disappear".
Given that these events cannot be detected directly, we can infer when one occurs by ruling out known app termination causes:

* app killed by the user (issues an "app will terminate" notification)
* app killed by the device shutting down (issues an "app will terminate" notification)
* app killed by the device shutting down due to loss of power (issues an "app will terminate" notification)
* app killed by the OS upgrading (no notification)
* app killed by the app upgrading (no notification)
* app killed by an exception or signal (detected by `bugsnag-cocoa`)
* app killed intentionally by a debugger (no notification)

By writing the app and OS version to a file and then deleting the file if a known case occurs, if the file exists when the app boots and the versions match, then an out-of-memory event likely occurred.

<details>
<summary>Flow diagram</summary>

```

                 ┌───────────────────────┐                             
                 │ Does the file exist?  │                             
                 └───────────────────────┘                             
                             │                                         
         ┌───────────────────┴───────────────────┐                     
     No  │                                       │  Yes                
         ▼                                       ▼                     
┌─────────────────┐                    ┌──────────────────┐            
│No out-of-memory │               No   │Is the current OS │            
│ crash happened  │◀──┬─────┬──────────│ version the same │            
└─────────────────┘   │     │          │ as in the file?  │            
                      │     │          └──────────────────┘            
                      │     │                    │  Yes                
                      │     │                    ▼                     
                      │     │          ┌──────────────────┐            
                      │     │     No   │Is the current app│            
                      │     └──────────│ version the same │            
                      │                │ as in the file?  │            
                      │                └──────────────────┘            
                      │                          │  Yes                
                      │                          ▼                     
                      │                ┌──────────────────┐            
                      │                │      Is the      │            
                      │                │   inForeground   │            
                      │                │ property true in │            
                      │                │    the file?     │            
                      │                └──────────────────┘            
                      │                          │                     
                      │                          │                     
                      │            ┌─────────────┴────────────┐        
                      │            │                          │        
                      │         No │                          │ Yes    
                      │            ▼                          ▼        
                   No │   ┌─────────────────┐        ┌─────────────────┐
                      │   │  Is the config  │        │ Foreground OOM  │
                      │   │option to report │        └─────────────────┘
                      └───│ background OOMs │                          
                          │      true?      │                          
                          └─────────────────┘                          
                                   │                                   
                                   ▼                                   
                          ┌─────────────────┐                          
                          │ Background OOM  │                          
                          └─────────────────┘
```
</details>

0. At launch, check for a file which should contain the app version, OS version and whether the app was in the foregorund.
1. If the file exists but the OS version is different, the app was terminated to upgrade the OS. Delete the file.
2. If the file exists but the app version is different, the app was terminated to update the app. Delete the file.
3. If the file exists but config.reportBackgroundOOMs is false and app.inForeground is false, the user has chosen to ignore this report. Delete the file.
4. If the file exists then an out of memory event occurred. Record the metadata in the file as a new report.
5. If no debugger is attached, write a file containing the app and OS version.
6. If an "app will terminate" notification is received, delete the file. This is an expected app termination.
7. If a crash occurs, delete the file. The crash is already being handled by `bugsnag-cocoa`.

## Changeset

### Added

0. `BSGOutofMemoryWatchdog` - monitors for app lifecycle events and updates the out of memory sentinel file. When created, it calculates `didOOMLastLaunch` based on the contents of the file.
1. `+[Bugsnag appDidCrashLastLaunch]` - a user-facing accessor for whether the last launch ended in a crash (including both detected crashes and out of memory events).
2. `-[BugsnagBreadcrumbs cachePath]` - Breadcrumbs are now cached on disk (explained in further detail in #336).
3. `-[BugsnagConfiguration reportBackgroundOOMs]` - An option to disable reporting out of memory events which occur while the app is the background.

### Changed

0. `-[BugsnagNotifier start]` - the notifier object owns the watchdog and computes `appDidCrashLastLaunch`. If the previous app launch ended because of an out of memory event, it creates a report based on the contents of the sentinel file and the breadcrumb cache from the previous app launch. The watchdog is only enabled if a debugger is not attached.
1. `-[BugsnagCrashReport initWithKSReport:]` - before initializing report state, checks for the presence of `didOOM` in the report dictionary. When present, initializes the report only with the contents of the `oom` dictionary, excluding content which may not be relevant to an out of memory event (like the current state of threads).

## Testing

Added two new tests, simulating the effect of an out of memory event by invoking `SIGKILL` directly and inspecting the subsequent report for the correct app and device info, severity, and breadcrumbs.

### Manual testing

One of the most common ways to force the OS to evict the app from memory is to load a web view with a constantly increasing amount of page content. This example view controller loads divs into a page until the app is terminated. This example has been added to the `objective-c-ios` example app.

<details>
<summary>BigHonkinWebViewController.m</summary>

```objc
#import <WebKit/WebKit.h>
#import "BigHonkinWebViewController.h"
#import <Bugsnag/Bugsnag.h>

@interface BigHonkinWebViewController ()
@property (nonatomic, strong) UIWebView *webView;
@end

@implementation BigHonkinWebViewController

- (void)viewDidLoad {
    [super viewDidLoad];
    self.webView = [[UIWebView alloc] initWithFrame:self.view.bounds];
    [self.webView loadHTMLString:@"<h2>Loading a lot of JavaScript. Please wait.</h2>"
                                  "<p>You can follow along in Console.app</p>"
                         baseURL:nil];
    [self.view addSubview:self.webView];
}

- (void)didReceiveMemoryWarning {
    NSLog(@"--> Received a low memory warning");
}

- (void)viewDidAppear:(BOOL)animated {
    [super viewDidAppear:animated];
    NSString *format = @"var b = document.createElement('div'); div.innerHTML = 'Hello item %d'; document.documentElement.appendChild(div);";
    for (int i = 0; i < 3000 * 1024; i++) {
        NSString *item = [NSString stringWithFormat:format, i];
        [self.webView stringByEvaluatingJavaScriptFromString:item];

        if (i % 1000 == 0) {
            NSLog(@"Loaded %d items", i);
        }
    }
}

@end
```
</details>

This could also be done more simply by allocating unreasonable amounts of memory without releasing it:

<details>
<summary> AbsoluteUnitViewController.m</summary>

```objc
@implementation AbsoluteUnitViewController

- (void)viewDidLoad {
    [super viewDidLoad];
    long long counter = 0;
    while (true) {
        void *memory = malloc(100000);
        NSLog(@"%llu - allocated some memory. Pointer size: %lu", counter++, sizeof(memory));
    }
}

@end
```
</details>

**Note:** Testing manually requires being disconnected from a debugger.

1. Running out of memory in the foreground or background sends a report with the correct message & metadata
2. Starting a session before an out of memory event includes session data in the report (and thus affects stability score)
3. Changing release stage is reflected in subsequent out of memory reports
4. `notify()` before an out of memory event increments the handled event count