### PR TITLE
Migrate version information to device.runtimeVersions

### DIFF
--- a/Source/BugsnagKSCrashSysInfoParser.m
+++ b/Source/BugsnagKSCrashSysInfoParser.m
@@ -118,7 +118,13 @@ NSDictionary *BSGParseDeviceState(NSDictionary *report) {
     BSGDictSetSafeObject(deviceState, report[@"machine"], @"model");
     BSGDictSetSafeObject(deviceState, report[@"system_name"], @"osName");
     BSGDictSetSafeObject(deviceState, report[@"system_version"], @"osVersion");
-    BSGDictSetSafeObject(deviceState, report[@"os_version"], @"osBuild");
+
+    NSString *osVersion = report[@"os_version"];
+
+    if (osVersion != nil) {
+        BSGDictSetSafeObject(deviceState, @{@"osBuild": osVersion}, @"runtimeVersions");
+    }
+
     BSGDictSetSafeObject(deviceState, @(PLATFORM_WORD_SIZE), @"wordSize");
     BSGDictSetSafeObject(deviceState, @"Apple", @"manufacturer");
     BSGDictSetSafeObject(deviceState, report[@"jailbroken"], @"jailbroken");

--- a/Tests/BugsnagSinkTests.m
+++ b/Tests/BugsnagSinkTests.m
@@ -270,7 +270,7 @@
     XCTAssertEqualObjects(device[@"modelNumber"], @"MacBookPro11,3");
     XCTAssertEqualObjects(device[@"osName"], @"iPhone OS");
     XCTAssertEqualObjects(device[@"osVersion"], @"8.1");
-    XCTAssertEqualObjects(device[@"osBuild"], @"14B25");
+    XCTAssertEqualObjects(device[@"runtimeVersions"][@"osBuild"], @"14B25");
     XCTAssertEqualObjects(device[@"totalMemory"], @15065522176);
     XCTAssertNotNil(device[@"freeDisk"]);
     XCTAssertEqualObjects(device[@"timezone"], @"PST");

--- a/features/runtime_versions.feature
+++ b/features/runtime_versions.feature
@@ -1,0 +1,14 @@
+Feature: Runtime versions are included in all requests
+
+Scenario: Runtime versions included in Cocoa error
+    When I run "HandledErrorScenario"
+    Then I should receive a request
+    And the request is valid for the error reporting API
+    And the payload field "events.0.device.runtimeVersions.osBuild" is not null
+
+Scenario: Runtime versions included in Cocoa session
+    When I run "ManualSessionScenario"
+    And I wait for 10 seconds
+    Then I should receive a request
+    And the request is a valid for the session tracking API
+    And the payload field "device.runtimeVersions.osBuild" is not null


### PR DESCRIPTION
## Goal
We should collect the OS build field in `device.runtimeVersions.apiLevel` for all error reports and sessions.

## Changeset
Moved `device.osBuild` to `device.runtimeVersions.osBuild`

## Tests

Ran existing tests and created new mazerunner scenarios, which verify that an error and session payload both include `device.runtimeVersions.osBuild`.
