### PR TITLE
Add internal api for mutating session payload before sending

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,9 @@ Changelog
 
 ### Enhancements
 
+* Add internal api for mutating session payload before sending
+  [#341](https://github.com/bugsnag/bugsnag-cocoa/pull/341)
+
 * Persist breadcrumbs on disk to allow reading upon next boot in the event of an
   uncatchable app termination.
 * Add `+[Bugsnag appDidCrashLastLaunch]` as a helper to determine if the

--- a/Source/BugsnagConfiguration.h
+++ b/Source/BugsnagConfiguration.h
@@ -57,6 +57,13 @@ typedef bool (^BugsnagBeforeSendBlock)(NSDictionary *_Nonnull rawEventData,
                                        BugsnagCrashReport *_Nonnull reports);
 
 /**
+ * A configuration block for modifying a session. Intended for internal usage only.
+ *
+ * @param sessionPayload The session about to be delivered
+ */
+typedef void(^BeforeSendSession)(NSMutableDictionary *_Nonnull sessionPayload);
+
+/**
  *  A handler for modifying data before sending it to Bugsnag
  *
  *  @param rawEventReports The raw event data written at crash time. This
@@ -126,6 +133,13 @@ BugsnagBreadcrumbs *breadcrumbs;
  */
 @property(readonly, strong, nullable)
     NSArray<BugsnagBeforeSendBlock> *beforeSendBlocks;
+
+/**
+ *  Hooks for modifying sessions before they are sent to Bugsnag. Intended for internal use only by React Native/Unity.
+ */
+@property(readonly, strong, nullable)
+NSArray<BeforeSendSession> *beforeSendSessionBlocks;
+
 /**
  *  Optional handler invoked when a crash or fatal signal occurs
  */
@@ -204,6 +218,13 @@ BugsnagBreadcrumbs *breadcrumbs;
  *  @param block A block which returns YES if the report should be sent
  */
 - (void)addBeforeSendBlock:(BugsnagBeforeSendBlock _Nonnull)block;
+
+/**
+ *  Add a callback to be invoked before a session is sent to Bugsnag. Intended for internal usage only.
+ *
+ *  @param block A block which can modify the session
+ */
+- (void)addBeforeSendSession:(BeforeSendSession _Nonnull)block;
 
 /**
  * Clear all callbacks

--- a/Source/BugsnagConfiguration.m
+++ b/Source/BugsnagConfiguration.m
@@ -48,6 +48,7 @@ static NSString *const kHeaderApiSentAt = @"Bugsnag-Sent-At";
 @interface BugsnagConfiguration ()
 @property(nonatomic, readwrite, strong) NSMutableArray *beforeNotifyHooks;
 @property(nonatomic, readwrite, strong) NSMutableArray *beforeSendBlocks;
+@property(nonatomic, readwrite, strong) NSMutableArray *beforeSendSessionBlocks;
 @end
 
 @implementation BugsnagConfiguration
@@ -62,6 +63,7 @@ static NSString *const kHeaderApiSentAt = @"Bugsnag-Sent-At";
         _notifyURL = [NSURL URLWithString:BSGDefaultNotifyUrl];
         _beforeNotifyHooks = [NSMutableArray new];
         _beforeSendBlocks = [NSMutableArray new];
+        _beforeSendSessionBlocks = [NSMutableArray new];
         _notifyReleaseStages = nil;
         _breadcrumbs = [BugsnagBreadcrumbs new];
         _automaticallyCollectBreadcrumbs = YES;
@@ -104,6 +106,10 @@ static NSString *const kHeaderApiSentAt = @"Bugsnag-Sent-At";
 
 - (void)addBeforeSendBlock:(BugsnagBeforeSendBlock)block {
     [(NSMutableArray *)self.beforeSendBlocks addObject:[block copy]];
+}
+
+- (void)addBeforeSendSession:(BeforeSendSession)block {
+    [(NSMutableArray *)self.beforeSendSessionBlocks addObject:[block copy]];
 }
 
 - (void)clearBeforeSendBlocks {

--- a/Source/BugsnagSessionTrackingApiClient.m
+++ b/Source/BugsnagSessionTrackingApiClient.m
@@ -41,6 +41,12 @@
         }
         BugsnagSessionTrackingPayload *payload = [[BugsnagSessionTrackingPayload alloc] initWithSessions:sessions];
         NSUInteger sessionCount = payload.sessions.count;
+        NSMutableDictionary *data = [payload toJson];
+
+        for (BeforeSendSession cb in self.config.beforeSendSessionBlocks) {
+            cb(data);
+        }
+
         if (sessionCount > 0) {
             NSDictionary *HTTPHeaders = @{
                                           @"Bugsnag-Payload-Version": @"1.0",
@@ -48,7 +54,7 @@
                                           @"Bugsnag-Sent-At": [BSG_RFC3339DateTool stringFromDate:[NSDate new]]
                                           };
             [self sendItems:sessions.count
-                withPayload:[payload toJson]
+                withPayload:data
                       toURL:sessionURL
                     headers:HTTPHeaders
                onCompletion:^(NSUInteger sentCount, BOOL success, NSError *error) {

--- a/Source/BugsnagSessionTrackingPayload.h
+++ b/Source/BugsnagSessionTrackingPayload.h
@@ -14,7 +14,7 @@
 
 - (instancetype)initWithSessions:(NSArray<BugsnagSession *> *)sessions;
 
-- (NSDictionary *)toJson;
+- (NSMutableDictionary *)toJson;
 
 @property NSArray<BugsnagSession *> *sessions;
 

--- a/Source/BugsnagSessionTrackingPayload.m
+++ b/Source/BugsnagSessionTrackingPayload.m
@@ -28,8 +28,7 @@
 }
 
 
-- (NSDictionary *)toJson {
-    
+- (NSMutableDictionary *)toJson {
     NSMutableDictionary *dict = [NSMutableDictionary new];
     NSMutableArray *sessionData = [NSMutableArray new];
     
@@ -42,7 +41,7 @@
     NSDictionary *systemInfo = [BSG_KSSystemInfo systemInfo];
     BSGDictSetSafeObject(dict, BSGParseAppState(systemInfo, [Bugsnag configuration].appVersion), @"app");
     BSGDictSetSafeObject(dict, BSGParseDeviceState(systemInfo), @"device");
-    return [NSDictionary dictionaryWithDictionary:dict];
+    return dict;
 }
 
 @end


### PR DESCRIPTION
## Goal

We require an internal API for mutating a session payload before it is sent, for notifiers such as React Native/Unity which need to write runtime version info.

## Changeset

- Added `BeforeSendSession` block
- Invoked collection of send session callbacks prior to delivering a session

## Tests

Manually verified in an example app that the callback is invoked when set
