### PR TITLE
Add compiler version to runtime versions

### DIFF
--- a/Source/BugsnagKSCrashSysInfoParser.m
+++ b/Source/BugsnagKSCrashSysInfoParser.m
@@ -119,11 +119,10 @@ NSDictionary *BSGParseDeviceState(NSDictionary *report) {
     BSGDictSetSafeObject(deviceState, report[@"system_name"], @"osName");
     BSGDictSetSafeObject(deviceState, report[@"system_version"], @"osVersion");
 
-    NSString *osVersion = report[@"os_version"];
-
-    if (osVersion != nil) {
-        BSGDictSetSafeObject(deviceState, @{@"osBuild": osVersion}, @"runtimeVersions");
-    }
+    NSMutableDictionary *runtimeVersions = [NSMutableDictionary new];
+    BSGDictSetSafeObject(runtimeVersions, report[@"os_version"], @"osBuild");
+    BSGDictSetSafeObject(runtimeVersions, report[@"clang_version"], @"clangVersion");
+    BSGDictSetSafeObject(deviceState, runtimeVersions, @"runtimeVersions");
 
     BSGDictSetSafeObject(deviceState, @(PLATFORM_WORD_SIZE), @"wordSize");
     BSGDictSetSafeObject(deviceState, @"Apple", @"manufacturer");

--- a/Source/KSCrash/Source/KSCrash/Recording/BSG_KSSystemInfo.h
+++ b/Source/KSCrash/Source/KSCrash/Recording/BSG_KSSystemInfo.h
@@ -51,6 +51,7 @@
 #define BSG_KSSystemField_Size "size"
 #define BSG_KSSystemField_SystemName "system_name"
 #define BSG_KSSystemField_SystemVersion "system_version"
+#define BSG_KSSystemField_ClangVersion "clang_version"
 #define BSG_KSSystemField_TimeZone "time_zone"
 #define BSG_KSSystemField_BuildType "build_type"
 

--- a/Source/KSCrash/Source/KSCrash/Recording/BSG_KSSystemInfo.m
+++ b/Source/KSCrash/Source/KSCrash/Recording/BSG_KSSystemInfo.m
@@ -362,7 +362,10 @@
     NSBundle *mainBundle = [NSBundle mainBundle];
     NSDictionary *infoDict = [mainBundle infoDictionary];
     const struct mach_header *header = _dyld_get_image_header(0);
-
+#ifdef __clang_version__
+    [sysInfo bsg_ksc_safeSetObject:@__clang_version__
+                            forKey:@BSG_KSSystemField_ClangVersion];
+#endif
 #if BSG_KSCRASH_HAS_UIDEVICE
     [sysInfo bsg_ksc_safeSetObject:[UIDevice currentDevice].systemName
                             forKey:@BSG_KSSystemField_SystemName];

--- a/Tests/BugsnagSinkTests.m
+++ b/Tests/BugsnagSinkTests.m
@@ -271,6 +271,7 @@
     XCTAssertEqualObjects(device[@"osName"], @"iPhone OS");
     XCTAssertEqualObjects(device[@"osVersion"], @"8.1");
     XCTAssertEqualObjects(device[@"runtimeVersions"][@"osBuild"], @"14B25");
+    XCTAssertEqualObjects(device[@"runtimeVersions"][@"clangVersion"], @"10.0.0 (clang-1000.11.45.5)");
     XCTAssertEqualObjects(device[@"totalMemory"], @15065522176);
     XCTAssertNotNil(device[@"freeDisk"]);
     XCTAssertEqualObjects(device[@"timezone"], @"PST");

--- a/Tests/report.json
+++ b/Tests/report.json
@@ -33,6 +33,7 @@
         "jailbroken": true,
         "model": "MacBookPro11,3",
         "os_version": "14B25",
+        "clang_version": "10.0.0 (clang-1000.11.45.5)",
         "parent_process_name": "launchd_sim",
         "CFBundleExecutablePath": "/Users/snmaynard/Library/Developer/CoreSimulator/Devices/709A3B98-034E-4ED5-A248-C5D22A73381E/data/Containers/Bundle/Application/496719A8-30A8-4625-979A-C9A7AB577E9B/CrashProbeiOS.app/CrashProbeiOS",
         "time_zone": "PST",

--- a/features/runtime_versions.feature
+++ b/features/runtime_versions.feature
@@ -5,6 +5,7 @@ Scenario: Runtime versions included in Cocoa error
     Then I should receive a request
     And the request is valid for the error reporting API
     And the payload field "events.0.device.runtimeVersions.osBuild" is not null
+    And the payload field "events.0.device.runtimeVersions.clangVersion" is not null
 
 Scenario: Runtime versions included in Cocoa session
     When I run "ManualSessionScenario"
@@ -12,3 +13,4 @@ Scenario: Runtime versions included in Cocoa session
     Then I should receive a request
     And the request is a valid for the session tracking API
     And the payload field "device.runtimeVersions.osBuild" is not null
+    And the payload field "device.runtimeVersions.clangVersion" is not null


### PR DESCRIPTION
Records the compiler version used to build the app/library.

## Changeset

* Added `clang_version` to the system info collected at launch
* Added `clang_version` to runtime versions

## Tests

* Updated sink tests and runtime version scenarios to check for `clangVersion`