### PR TITLE
Fix handled stacktrace generation

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,11 @@
 Changelog
 =========
 
+## 5.22.1 (2019-05-20)
+
+* Fix handled stacktrace generation
+  [#348](https://github.com/bugsnag/bugsnag-cocoa/pull/348)
+
 ## 5.22.0 (2019-05-09)
 
 This release disables background out-of-memory termination reporting by default,

--- a/Source/KSCrash/Source/KSCrash/Recording/Sentry/BSG_KSCrashSentry_User.c
+++ b/Source/KSCrash/Source/KSCrash/Recording/Sentry/BSG_KSCrashSentry_User.c
@@ -64,6 +64,11 @@ void bsg_kscrashsentry_reportUserException(const char *name,
         BSG_KSLOG_WARN("User-reported exception sentry is not installed. "
                        "Exception has not been recorded.");
     } else {
+        // We want these variables to persist until the onCrash
+        // call later
+        int callstackCount = 100;
+        uintptr_t callstack[callstackCount];
+        
         bsg_kscrashsentry_beginHandlingCrash(bsg_g_context);
 
         if (bsg_g_context->suspendThreadsForUserReported) {
@@ -71,14 +76,11 @@ void bsg_kscrashsentry_reportUserException(const char *name,
             bsg_kscrashsentry_suspendThreads();
         }
 
-
         if (stackAddresses != NULL && stackLength > 0) {
             bsg_g_context->stackTrace = stackAddresses;
             bsg_g_context->stackTraceLength = (int)stackLength;
         } else {
             BSG_KSLOG_DEBUG("Fetching call stack.");
-            int callstackCount = 100;
-            uintptr_t callstack[callstackCount];
             callstackCount = backtrace((void **)callstack, callstackCount);
             if (callstackCount <= 0) {
                 BSG_KSLOG_ERROR("backtrace() returned call stack length of %d",

--- a/features/handled_errors.feature
+++ b/features/handled_errors.feature
@@ -7,6 +7,7 @@ Scenario: Override errorClass and message from a notifyError() callback
     And the exception "errorClass" equals "Bar"
     And the exception "message" equals "Foo"
     And the event "device.time" is within 30 seconds of the current timestamp
+    And the stack trace is an array with 22 stack frames
 
 Scenario: Reporting an NSError
     When I run "HandledErrorScenario"
@@ -17,6 +18,7 @@ Scenario: Reporting an NSError
     And the payload field "events" is an array with 1 element
     And the exception "errorClass" equals "NSError"
     And the exception "message" equals "The operation couldn’t be completed. (HandledErrorScenario error 100.)"
+    And the stack trace is an array with 22 stack frames
 
 Scenario: Reporting a handled exception
     When I run "HandledExceptionScenario"
@@ -27,6 +29,7 @@ Scenario: Reporting a handled exception
     And the payload field "events" is an array with 1 element
     And the exception "errorClass" equals "HandledExceptionScenario"
     And the exception "message" equals "Message: HandledExceptionScenario"
+    And the stack trace is an array with 22 stack frames
 
 Scenario: Reporting a handled exception's stacktrace
     When I run "NSExceptionShiftScenario"

--- a/features/steps/ios_steps.rb
+++ b/features/steps/ios_steps.rb
@@ -113,3 +113,8 @@ Then("the event breadcrumbs contain {string}") do |string|
   end
   assert_not_nil(match, "No crumb matches the provided message")
 end
+
+Then("the stack trace is an array with {int} stack frames") do |expected_length|
+  stack_trace = read_key_path(find_request(0)[:body], "events.0.exceptions.0.stacktrace")
+  assert_equal(stack_trace.length, expected_length)
+end


### PR DESCRIPTION
We have a variable scope issue with stacktrace generation. This pulls the stack variables into the outer else block so they persist until the onCrash call.