### PR TITLE
fix(oom): Report short version as app.version

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,11 @@ Changelog
 ## 5.22.1 (2019-05-20)
 
 * Fix handled stacktrace generation
+* Report correct app version in out-of-memory reports. Previously the bundle
+  version was reported as the version number rather than the short version
+  string.
+  [#349](https://github.com/bugsnag/bugsnag-cocoa/pull/349)
+
   [#348](https://github.com/bugsnag/bugsnag-cocoa/pull/348)
 
 ## 5.22.0 (2019-05-09)

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,14 +1,14 @@
 Changelog
 =========
 
-## 5.22.1 (2019-05-20)
+## TBD
 
-* Fix handled stacktrace generation
 * Report correct app version in out-of-memory reports. Previously the bundle
   version was reported as the version number rather than the short version
   string.
   [#349](https://github.com/bugsnag/bugsnag-cocoa/pull/349)
 
+* Fix missing stacktraces in reports generated from `notify()`
   [#348](https://github.com/bugsnag/bugsnag-cocoa/pull/348)
 
 ## 5.22.0 (2019-05-09)

--- a/Source/BSGOutOfMemoryWatchdog.m
+++ b/Source/BSGOutOfMemoryWatchdog.m
@@ -146,6 +146,8 @@
         NSDictionary *lastBootInfo = [self readSentinelFile];
         if (lastBootInfo != nil) {
             self.lastBootCachedFileInfo = lastBootInfo;
+            NSString *lastBootBundleVersion =
+                [lastBootInfo valueForKeyPath:@"app.bundleVersion"];
             NSString *lastBootAppVersion =
                 [lastBootInfo valueForKeyPath:@"app.version"];
             NSString *lastBootOSVersion =
@@ -154,9 +156,12 @@
                 [[lastBootInfo valueForKeyPath:@"app.inForeground"] boolValue];
             NSString *osVersion = [BSG_KSSystemInfo osBuildVersion];
             NSDictionary *appInfo = [[NSBundle mainBundle] infoDictionary];
+            NSString *bundleVersion =
+                [appInfo valueForKey:@BSG_KSSystemField_BundleVersion];
             NSString *appVersion =
-                [appInfo valueForKey:(__bridge NSString *)kCFBundleVersionKey];
+                [appInfo valueForKey:@BSG_KSSystemField_BundleShortVersion];
             BOOL sameVersions = [lastBootOSVersion isEqualToString:osVersion] &&
+                                [lastBootBundleVersion isEqualToString:bundleVersion] &&
                                 [lastBootAppVersion isEqualToString:appVersion];
             BOOL shouldReport = config.reportOOMs && (config.reportBackgroundOOMs || lastBootInForeground);
             [self deleteSentinelFile];
@@ -214,7 +219,8 @@
     app[@"id"] = systemInfo[@BSG_KSSystemField_BundleID] ?: @"";
     app[@"name"] = systemInfo[@BSG_KSSystemField_BundleName] ?: @"";
     app[@"releaseStage"] = config.releaseStage;
-    app[@"version"] = systemInfo[@BSG_KSSystemField_BundleVersion] ?: @"";
+    app[@"version"] = systemInfo[@BSG_KSSystemField_BundleShortVersion] ?: @"";
+    app[@"bundleVersion"] = systemInfo[@BSG_KSSystemField_BundleVersion] ?: @"";
     app[@"inForeground"] = @YES;
 #if TARGET_OS_TV
     app[@"type"] = @"tvOS";

--- a/Tests/BugsnagCrashReportTests.m
+++ b/Tests/BugsnagCrashReportTests.m
@@ -556,6 +556,7 @@
 - (void)testAppVersion {
     NSDictionary *dictionary = [self.report toJson];
     XCTAssertEqualObjects(@"1.0", dictionary[@"app"][@"version"]);
+    XCTAssertEqualObjects(@"1", dictionary[@"app"][@"bundleVersion"]);
 }
 
 - (void)testAppVersionOverride {

--- a/features/oom.feature
+++ b/features/oom.feature
@@ -16,6 +16,8 @@ Feature: Reporting out of memory events
         And the event "severity" equals "error"
         And the event "severityReason.type" equals "outOfMemory"
         And the event "app.releaseStage" equals "beta"
+        And the event "app.version" equals "1.0.3"
+        And the event "app.bundleVersion" equals "5"
         And the event breadcrumbs contain "Crumb left before crash"
 
     Scenario: The OS kills the application in the background
@@ -39,6 +41,8 @@ Feature: Reporting out of memory events
         And the event "severity" equals "error"
         And the event "severityReason.type" equals "outOfMemory"
         And the event "app.releaseStage" equals "beta"
+        And the event "app.version" equals "1.0.3"
+        And the event "app.bundleVersion" equals "5"
         And the event breadcrumbs contain "Crumb left before crash"
 
     Scenario: The OS kills the application after a session is sent


### PR DESCRIPTION
Out-of-memory reports are incorrectly reporting the build number as the version number. This change fixes that error and adds a few assertions for it in OOM report tests.