### PR TITLE
docs: Update code samples in example iOS apps

### DIFF
--- a/examples/objective-c-ios/Bugsnag Test App.xcodeproj/xcshareddata/xcschemes/Bugsnag Test App.xcscheme
+++ b/examples/objective-c-ios/Bugsnag Test App.xcodeproj/xcshareddata/xcschemes/Bugsnag Test App.xcscheme
@@ -1,0 +1,111 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<Scheme
+   LastUpgradeVersion = "1010"
+   version = "1.3">
+   <BuildAction
+      parallelizeBuildables = "YES"
+      buildImplicitDependencies = "YES">
+      <BuildActionEntries>
+         <BuildActionEntry
+            buildForTesting = "YES"
+            buildForRunning = "YES"
+            buildForProfiling = "YES"
+            buildForArchiving = "YES"
+            buildForAnalyzing = "YES">
+            <BuildableReference
+               BuildableIdentifier = "primary"
+               BlueprintIdentifier = "F40B874516AA233500676BB2"
+               BuildableName = "Bugsnag Test App.app"
+               BlueprintName = "Bugsnag Test App"
+               ReferencedContainer = "container:Bugsnag Test App.xcodeproj">
+            </BuildableReference>
+         </BuildActionEntry>
+      </BuildActionEntries>
+   </BuildAction>
+   <TestAction
+      buildConfiguration = "Debug"
+      selectedDebuggerIdentifier = "Xcode.DebuggerFoundation.Debugger.LLDB"
+      selectedLauncherIdentifier = "Xcode.DebuggerFoundation.Launcher.LLDB"
+      shouldUseLaunchSchemeArgsEnv = "YES">
+      <Testables>
+         <TestableReference
+            skipped = "NO">
+            <BuildableReference
+               BuildableIdentifier = "primary"
+               BlueprintIdentifier = "E77F7CCA1F2B90800017CE04"
+               BuildableName = "BugsnagUITests.xctest"
+               BlueprintName = "BugsnagUITests"
+               ReferencedContainer = "container:Bugsnag Test App.xcodeproj">
+            </BuildableReference>
+         </TestableReference>
+         <TestableReference
+            skipped = "NO">
+            <BuildableReference
+               BuildableIdentifier = "primary"
+               BlueprintIdentifier = "E7AB1DDE1F2F3AC0000AAF94"
+               BuildableName = "BugsnagUIHarness.xctest"
+               BlueprintName = "BugsnagUIHarness"
+               ReferencedContainer = "container:Bugsnag Test App.xcodeproj">
+            </BuildableReference>
+         </TestableReference>
+      </Testables>
+      <MacroExpansion>
+         <BuildableReference
+            BuildableIdentifier = "primary"
+            BlueprintIdentifier = "F40B874516AA233500676BB2"
+            BuildableName = "Bugsnag Test App.app"
+            BlueprintName = "Bugsnag Test App"
+            ReferencedContainer = "container:Bugsnag Test App.xcodeproj">
+         </BuildableReference>
+      </MacroExpansion>
+      <AdditionalOptions>
+      </AdditionalOptions>
+   </TestAction>
+   <LaunchAction
+      buildConfiguration = "Debug"
+      selectedDebuggerIdentifier = ""
+      selectedLauncherIdentifier = "Xcode.IDEFoundation.Launcher.PosixSpawn"
+      launchStyle = "0"
+      useCustomWorkingDirectory = "NO"
+      ignoresPersistentStateOnLaunch = "NO"
+      debugDocumentVersioning = "YES"
+      debugServiceExtension = "internal"
+      allowLocationSimulation = "YES">
+      <BuildableProductRunnable
+         runnableDebuggingMode = "0">
+         <BuildableReference
+            BuildableIdentifier = "primary"
+            BlueprintIdentifier = "F40B874516AA233500676BB2"
+            BuildableName = "Bugsnag Test App.app"
+            BlueprintName = "Bugsnag Test App"
+            ReferencedContainer = "container:Bugsnag Test App.xcodeproj">
+         </BuildableReference>
+      </BuildableProductRunnable>
+      <AdditionalOptions>
+      </AdditionalOptions>
+   </LaunchAction>
+   <ProfileAction
+      buildConfiguration = "Release"
+      shouldUseLaunchSchemeArgsEnv = "YES"
+      savedToolIdentifier = ""
+      useCustomWorkingDirectory = "NO"
+      debugDocumentVersioning = "YES">
+      <BuildableProductRunnable
+         runnableDebuggingMode = "0">
+         <BuildableReference
+            BuildableIdentifier = "primary"
+            BlueprintIdentifier = "F40B874516AA233500676BB2"
+            BuildableName = "Bugsnag Test App.app"
+            BlueprintName = "Bugsnag Test App"
+            ReferencedContainer = "container:Bugsnag Test App.xcodeproj">
+         </BuildableReference>
+      </BuildableProductRunnable>
+   </ProfileAction>
+   <AnalyzeAction
+      buildConfiguration = "Debug">
+   </AnalyzeAction>
+   <ArchiveAction
+      buildConfiguration = "Release"
+      revealArchiveInOrganizer = "YES">
+   </ArchiveAction>
+</Scheme>

--- a/examples/objective-c-ios/Bugsnag Test App/AppDelegate.m
+++ b/examples/objective-c-ios/Bugsnag Test App/AppDelegate.m
@@ -13,22 +13,9 @@
 
 - (BOOL)application:(UIApplication *)application didFinishLaunchingWithOptions:(NSDictionary *)launchOptions
 {
-    [self startBugsnagWithAPIKey];
+    [Bugsnag startBugsnagWithApiKey:@"YOUR-API-KEY-HERE"];
     //[self startBugsnagWithConfiguration];
     return YES;
 }
 
-- (void)startBugsnagWithConfiguration {
-    BugsnagConfiguration *config = [BugsnagConfiguration new];
-    config.apiKey = @"API-KEY";
-    config.releaseStage = @"production";
-    config.notifyReleaseStages = @[@"production"];
-    [Bugsnag startBugsnagWithConfiguration:config];
-}
-
-- (void)startBugsnagWithAPIKey {
-    [Bugsnag startBugsnagWithApiKey:@"6ef10e3707a961373e8592ae65d68ff1"];
-    [Bugsnag configuration].releaseStage = @"production";
-    [Bugsnag configuration].notifyReleaseStages = @[@"production"];
-}
 @end

--- a/examples/objective-c-ios/Bugsnag Test App/Bugsnag Test App-Info.plist
+++ b/examples/objective-c-ios/Bugsnag Test App/Bugsnag Test App-Info.plist
@@ -21,7 +21,7 @@
 	<key>CFBundleSignature</key>
 	<string>????</string>
 	<key>CFBundleVersion</key>
-	<string>1.0</string>
+	<string>4</string>
 	<key>LSRequiresIPhoneOS</key>
 	<true/>
 	<key>UIMainStoryboardFile</key>

--- a/examples/objective-c-ios/Bugsnag Test App/ViewController.h
+++ b/examples/objective-c-ios/Bugsnag Test App/ViewController.h
@@ -8,10 +8,6 @@
 
 #import <UIKit/UIKit.h>
 
-@interface ViewController : UIViewController
-- (IBAction)generateException:(id)sender;
-- (IBAction)generateSignal:(id)sender;
-- (IBAction)delayedException:(id)sender;
-- (IBAction)nonFatalException:(id)sender;
+@interface ViewController : UITableViewController
 
 @end

--- a/examples/objective-c-ios/Bugsnag Test App/en.lproj/MainStoryboard.storyboard
+++ b/examples/objective-c-ios/Bugsnag Test App/en.lproj/MainStoryboard.storyboard
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <document type="com.apple.InterfaceBuilder3.CocoaTouch.Storyboard.XIB" version="3.0" toolsVersion="14460.31" targetRuntime="iOS.CocoaTouch" propertyAccessControl="none" useAutolayout="YES" colorMatched="YES" initialViewController="ogA-pf-q3e">
-    <device id="retina4_7" orientation="portrait">
+    <device id="retina6_1" orientation="portrait">
         <adaptation id="fullscreen"/>
     </device>
     <dependencies>
@@ -14,154 +14,259 @@
             <objects>
                 <navigationController id="ogA-pf-q3e" sceneMemberID="viewController">
                     <navigationBar key="navigationBar" contentMode="scaleToFill" insetsLayoutMarginsFromSafeArea="NO" id="eMo-dQ-Ee0">
-                        <rect key="frame" x="0.0" y="20" width="375" height="44"/>
+                        <rect key="frame" x="0.0" y="44" width="414" height="44"/>
                         <autoresizingMask key="autoresizingMask"/>
                     </navigationBar>
                     <connections>
-                        <segue destination="2" kind="relationship" relationship="rootViewController" id="kgl-3x-76P"/>
+                        <segue destination="uYB-Rg-v98" kind="relationship" relationship="rootViewController" id="ts1-mk-sku"/>
                     </connections>
                 </navigationController>
                 <placeholder placeholderIdentifier="IBFirstResponder" id="ktm-VJ-qMZ" userLabel="First Responder" sceneMemberID="firstResponder"/>
             </objects>
             <point key="canvasLocation" x="-343" y="282"/>
         </scene>
-        <!--View Controller-->
-        <scene sceneID="5">
+        <!--Bugsnag Examples-->
+        <scene sceneID="il4-S5-IMy">
             <objects>
-                <viewController id="2" customClass="ViewController" sceneMemberID="viewController">
-                    <layoutGuides>
-                        <viewControllerLayoutGuide type="top" id="adP-me-sk4"/>
-                        <viewControllerLayoutGuide type="bottom" id="9E6-Jk-SeH"/>
-                    </layoutGuides>
-                    <view key="view" contentMode="scaleToFill" id="3">
-                        <rect key="frame" x="0.0" y="0.0" width="375" height="667"/>
-                        <autoresizingMask key="autoresizingMask" flexibleMaxX="YES" flexibleMaxY="YES"/>
-                        <subviews>
-                            <button opaque="NO" contentMode="scaleToFill" contentHorizontalAlignment="center" contentVerticalAlignment="center" buttonType="roundedRect" lineBreakMode="middleTruncation" translatesAutoresizingMaskIntoConstraints="NO" id="Oxr-6H-zaP">
-                                <rect key="frame" x="36" y="128" width="303" height="40"/>
-                                <constraints>
-                                    <constraint firstAttribute="height" constant="40" id="Jdg-Wd-JMi"/>
-                                </constraints>
-                                <state key="normal" title="Generate Exception">
-                                    <color key="titleShadowColor" red="0.5" green="0.5" blue="0.5" alpha="1" colorSpace="custom" customColorSpace="sRGB"/>
-                                </state>
-                                <connections>
-                                    <action selector="generateException:" destination="2" eventType="touchUpInside" id="BzY-pb-0qk"/>
-                                </connections>
-                            </button>
-                            <button opaque="NO" contentMode="scaleToFill" contentHorizontalAlignment="center" contentVerticalAlignment="center" buttonType="roundedRect" lineBreakMode="middleTruncation" translatesAutoresizingMaskIntoConstraints="NO" id="8xv-Hz-oaJ">
-                                <rect key="frame" x="36" y="168" width="303" height="40"/>
-                                <state key="normal" title="Generate Signal">
-                                    <color key="titleShadowColor" red="0.5" green="0.5" blue="0.5" alpha="1" colorSpace="custom" customColorSpace="sRGB"/>
-                                </state>
-                                <connections>
-                                    <action selector="generateSignal:" destination="2" eventType="touchUpInside" id="UPD-MJ-coG"/>
-                                </connections>
-                            </button>
-                            <button opaque="NO" contentMode="scaleToFill" contentHorizontalAlignment="center" contentVerticalAlignment="center" buttonType="roundedRect" lineBreakMode="middleTruncation" translatesAutoresizingMaskIntoConstraints="NO" id="YW2-Lb-cb2">
-                                <rect key="frame" x="36" y="248" width="303" height="40"/>
-                                <state key="normal" title="Non-Fatal Exception">
-                                    <color key="titleShadowColor" red="0.5" green="0.5" blue="0.5" alpha="1" colorSpace="custom" customColorSpace="sRGB"/>
-                                </state>
-                                <connections>
-                                    <action selector="nonFatalException:" destination="2" eventType="touchUpInside" id="8xi-pG-IRm"/>
-                                </connections>
-                            </button>
-                            <button opaque="NO" contentMode="scaleToFill" contentHorizontalAlignment="center" contentVerticalAlignment="center" buttonType="roundedRect" lineBreakMode="middleTruncation" translatesAutoresizingMaskIntoConstraints="NO" id="sFG-vI-9OD">
-                                <rect key="frame" x="36" y="208" width="303" height="40"/>
-                                <state key="normal" title="Delayed Exception">
-                                    <color key="titleShadowColor" red="0.5" green="0.5" blue="0.5" alpha="1" colorSpace="custom" customColorSpace="sRGB"/>
-                                </state>
-                                <connections>
-                                    <action selector="delayedException:" destination="2" eventType="touchUpInside" id="VYs-GP-qcw"/>
-                                </connections>
-                            </button>
-                            <button opaque="NO" contentMode="scaleToFill" contentHorizontalAlignment="center" contentVerticalAlignment="center" buttonType="roundedRect" lineBreakMode="middleTruncation" translatesAutoresizingMaskIntoConstraints="NO" id="rbY-70-dIG">
-                                <rect key="frame" x="36" y="328" width="303" height="40"/>
-                                <state key="normal" title="Objective-C Lock Signal">
-                                    <color key="titleShadowColor" red="0.5" green="0.5" blue="0.5" alpha="1" colorSpace="custom" customColorSpace="sRGB"/>
-                                </state>
-                                <connections>
-                                    <action selector="objectiveCLockSignal:" destination="2" eventType="touchUpInside" id="UUf-ch-eLp"/>
-                                </connections>
-                            </button>
-                            <button opaque="NO" contentMode="scaleToFill" contentHorizontalAlignment="center" contentVerticalAlignment="center" buttonType="roundedRect" lineBreakMode="middleTruncation" translatesAutoresizingMaskIntoConstraints="NO" id="gtT-rK-OwM">
-                                <rect key="frame" x="36" y="368" width="303" height="40"/>
-                                <state key="normal" title="PThreads Lock Signal">
-                                    <color key="titleShadowColor" red="0.5" green="0.5" blue="0.5" alpha="1" colorSpace="custom" customColorSpace="sRGB"/>
-                                </state>
-                                <connections>
-                                    <action selector="pthreadsLockSignal:" destination="2" eventType="touchUpInside" id="3EZ-Te-dHj"/>
-                                </connections>
-                            </button>
-                            <button opaque="NO" contentMode="scaleToFill" contentHorizontalAlignment="center" contentVerticalAlignment="center" buttonType="roundedRect" lineBreakMode="middleTruncation" translatesAutoresizingMaskIntoConstraints="NO" id="HZ8-LN-PKe">
-                                <rect key="frame" x="36" y="408" width="303" height="40"/>
-                                <state key="normal" title="StackOverflow">
-                                    <color key="titleShadowColor" red="0.5" green="0.5" blue="0.5" alpha="1" colorSpace="custom" customColorSpace="sRGB"/>
-                                </state>
-                                <connections>
-                                    <action selector="stackOverflow:" destination="2" eventType="touchUpInside" id="2Ia-la-7OK"/>
-                                </connections>
-                            </button>
-                            <button opaque="NO" contentMode="scaleToFill" contentHorizontalAlignment="center" contentVerticalAlignment="center" buttonType="roundedRect" lineBreakMode="middleTruncation" translatesAutoresizingMaskIntoConstraints="NO" id="1M3-pO-mjr">
-                                <rect key="frame" x="36" y="448" width="303" height="40"/>
-                                <state key="normal" title="Check Event Loop Spin">
-                                    <color key="titleShadowColor" red="0.5" green="0.5" blue="0.5" alpha="1" colorSpace="custom" customColorSpace="sRGB"/>
-                                </state>
-                                <connections>
-                                    <action selector="checkEventLoopSpin:" destination="2" eventType="touchUpInside" id="71j-ee-LE7"/>
-                                </connections>
-                            </button>
-                            <button opaque="NO" contentMode="scaleToFill" contentHorizontalAlignment="center" contentVerticalAlignment="center" buttonType="roundedRect" lineBreakMode="middleTruncation" translatesAutoresizingMaskIntoConstraints="NO" id="az6-L5-tEc">
-                                <rect key="frame" x="136" y="496" width="103" height="30"/>
-                                <state key="normal" title="Generate OOM"/>
-                                <connections>
-                                    <action selector="generateOOM:" destination="2" eventType="touchUpInside" id="K3I-Se-IF4"/>
-                                </connections>
-                            </button>
-                        </subviews>
-                        <color key="backgroundColor" red="1" green="1" blue="1" alpha="1" colorSpace="custom" customColorSpace="sRGB"/>
-                        <constraints>
-                            <constraint firstItem="rbY-70-dIG" firstAttribute="height" secondItem="YW2-Lb-cb2" secondAttribute="height" id="2Xz-LL-SDN"/>
-                            <constraint firstItem="1M3-pO-mjr" firstAttribute="leading" secondItem="HZ8-LN-PKe" secondAttribute="leading" id="2jL-Sa-BxP"/>
-                            <constraint firstItem="gtT-rK-OwM" firstAttribute="leading" secondItem="rbY-70-dIG" secondAttribute="leading" id="56p-af-6Jh"/>
-                            <constraint firstItem="1M3-pO-mjr" firstAttribute="height" secondItem="HZ8-LN-PKe" secondAttribute="height" id="64O-ux-rBK"/>
-                            <constraint firstItem="8xv-Hz-oaJ" firstAttribute="leading" secondItem="Oxr-6H-zaP" secondAttribute="leading" id="8RT-x2-v9b"/>
-                            <constraint firstItem="sFG-vI-9OD" firstAttribute="leading" secondItem="8xv-Hz-oaJ" secondAttribute="leading" id="C4e-aT-udS"/>
-                            <constraint firstItem="rbY-70-dIG" firstAttribute="leading" secondItem="YW2-Lb-cb2" secondAttribute="leading" id="E60-5U-9HR"/>
-                            <constraint firstItem="az6-L5-tEc" firstAttribute="top" secondItem="1M3-pO-mjr" secondAttribute="bottom" constant="8" id="F1y-wh-FLB"/>
-                            <constraint firstItem="YW2-Lb-cb2" firstAttribute="trailing" secondItem="sFG-vI-9OD" secondAttribute="trailing" id="FnQ-fN-qF8"/>
-                            <constraint firstItem="HZ8-LN-PKe" firstAttribute="trailing" secondItem="gtT-rK-OwM" secondAttribute="trailing" id="Jp2-Ie-kuL"/>
-                            <constraint firstItem="rbY-70-dIG" firstAttribute="top" secondItem="YW2-Lb-cb2" secondAttribute="bottom" constant="40" id="LBZ-Q4-fFJ"/>
-                            <constraint firstItem="8xv-Hz-oaJ" firstAttribute="trailing" secondItem="Oxr-6H-zaP" secondAttribute="trailing" id="LMT-ik-PHL"/>
-                            <constraint firstItem="sFG-vI-9OD" firstAttribute="trailing" secondItem="8xv-Hz-oaJ" secondAttribute="trailing" id="OTh-Wy-uLu"/>
-                            <constraint firstItem="gtT-rK-OwM" firstAttribute="trailing" secondItem="rbY-70-dIG" secondAttribute="trailing" id="Ot3-Db-Den"/>
-                            <constraint firstItem="HZ8-LN-PKe" firstAttribute="height" secondItem="gtT-rK-OwM" secondAttribute="height" id="SLd-L6-ltK"/>
-                            <constraint firstItem="HZ8-LN-PKe" firstAttribute="top" secondItem="gtT-rK-OwM" secondAttribute="bottom" id="U4c-H6-Kua"/>
-                            <constraint firstItem="az6-L5-tEc" firstAttribute="centerX" secondItem="3" secondAttribute="centerX" id="URR-aY-4Dz"/>
-                            <constraint firstItem="Oxr-6H-zaP" firstAttribute="top" secondItem="adP-me-sk4" secondAttribute="bottom" constant="64" id="Ulk-Hh-7HW"/>
-                            <constraint firstItem="1M3-pO-mjr" firstAttribute="top" secondItem="HZ8-LN-PKe" secondAttribute="bottom" id="WNz-ab-DAb"/>
-                            <constraint firstItem="YW2-Lb-cb2" firstAttribute="leading" secondItem="sFG-vI-9OD" secondAttribute="leading" id="X1B-jc-lu0"/>
-                            <constraint firstAttribute="trailingMargin" secondItem="Oxr-6H-zaP" secondAttribute="trailing" constant="20" id="XIm-qv-Dsr"/>
-                            <constraint firstItem="YW2-Lb-cb2" firstAttribute="height" secondItem="sFG-vI-9OD" secondAttribute="height" id="bgF-Fe-15F"/>
-                            <constraint firstItem="gtT-rK-OwM" firstAttribute="top" secondItem="rbY-70-dIG" secondAttribute="bottom" id="fI6-Gd-B54"/>
-                            <constraint firstItem="gtT-rK-OwM" firstAttribute="height" secondItem="rbY-70-dIG" secondAttribute="height" id="gJc-i2-rHI"/>
-                            <constraint firstItem="sFG-vI-9OD" firstAttribute="height" secondItem="8xv-Hz-oaJ" secondAttribute="height" id="gP2-oE-9ib"/>
-                            <constraint firstItem="8xv-Hz-oaJ" firstAttribute="top" secondItem="Oxr-6H-zaP" secondAttribute="bottom" id="gSt-cG-Wid"/>
-                            <constraint firstItem="Oxr-6H-zaP" firstAttribute="leading" secondItem="3" secondAttribute="leadingMargin" constant="20" id="gfn-if-qx1"/>
-                            <constraint firstItem="YW2-Lb-cb2" firstAttribute="top" secondItem="sFG-vI-9OD" secondAttribute="bottom" id="h9y-he-yna"/>
-                            <constraint firstItem="sFG-vI-9OD" firstAttribute="top" secondItem="8xv-Hz-oaJ" secondAttribute="bottom" id="lAZ-Zb-Y5v"/>
-                            <constraint firstItem="1M3-pO-mjr" firstAttribute="trailing" secondItem="HZ8-LN-PKe" secondAttribute="trailing" id="m2W-8c-Xld"/>
-                            <constraint firstItem="HZ8-LN-PKe" firstAttribute="leading" secondItem="gtT-rK-OwM" secondAttribute="leading" id="oip-gY-kQZ"/>
-                            <constraint firstItem="rbY-70-dIG" firstAttribute="trailing" secondItem="YW2-Lb-cb2" secondAttribute="trailing" id="qaB-xi-PYJ"/>
-                            <constraint firstItem="8xv-Hz-oaJ" firstAttribute="height" secondItem="Oxr-6H-zaP" secondAttribute="height" id="uZ8-p7-PHX"/>
-                        </constraints>
-                    </view>
-                    <navigationItem key="navigationItem" id="Xwx-BY-cwr"/>
-                </viewController>
-                <placeholder placeholderIdentifier="IBFirstResponder" id="4" sceneMemberID="firstResponder"/>
+                <tableViewController id="uYB-Rg-v98" customClass="ViewController" sceneMemberID="viewController">
+                    <tableView key="view" clipsSubviews="YES" contentMode="scaleToFill" alwaysBounceVertical="YES" dataMode="static" style="grouped" separatorStyle="default" rowHeight="-1" estimatedRowHeight="-1" sectionHeaderHeight="18" sectionFooterHeight="18" id="MAi-ET-29z">
+                        <rect key="frame" x="0.0" y="0.0" width="414" height="896"/>
+                        <autoresizingMask key="autoresizingMask" widthSizable="YES" heightSizable="YES"/>
+                        <color key="backgroundColor" cocoaTouchSystemColor="groupTableViewBackgroundColor"/>
+                        <sections>
+                            <tableViewSection headerTitle="Crashes" footerTitle="Events which terminate the app are sent to Bugsnag automatically. Reopen the app after a crash to send reports." id="gmD-Jb-yFA">
+                                <cells>
+                                    <tableViewCell clipsSubviews="YES" contentMode="scaleToFill" insetsLayoutMarginsFromSafeArea="NO" selectionStyle="blue" hidesAccessoryWhenEditing="NO" indentationLevel="1" indentationWidth="0.0" id="bDh-CK-h1h">
+                                        <rect key="frame" x="0.0" y="55.5" width="414" height="44"/>
+                                        <autoresizingMask key="autoresizingMask"/>
+                                        <tableViewCellContentView key="contentView" opaque="NO" clipsSubviews="YES" multipleTouchEnabled="YES" contentMode="center" insetsLayoutMarginsFromSafeArea="NO" tableViewCell="bDh-CK-h1h" id="Z68-om-Prg">
+                                            <rect key="frame" x="0.0" y="0.0" width="414" height="43.5"/>
+                                            <autoresizingMask key="autoresizingMask"/>
+                                            <subviews>
+                                                <button opaque="NO" contentMode="scaleToFill" contentHorizontalAlignment="center" contentVerticalAlignment="center" buttonType="roundedRect" lineBreakMode="middleTruncation" translatesAutoresizingMaskIntoConstraints="NO" id="MkL-AZ-Bqt">
+                                                    <rect key="frame" x="16" y="7" width="138" height="30"/>
+                                                    <state key="normal" title="Uncaught exception">
+                                                        <color key="titleShadowColor" red="0.5" green="0.5" blue="0.5" alpha="1" colorSpace="custom" customColorSpace="sRGB"/>
+                                                    </state>
+                                                    <connections>
+                                                        <action selector="generateException:" destination="uYB-Rg-v98" eventType="touchUpInside" id="Eq7-nh-qPa"/>
+                                                    </connections>
+                                                </button>
+                                            </subviews>
+                                            <constraints>
+                                                <constraint firstItem="MkL-AZ-Bqt" firstAttribute="leading" secondItem="Z68-om-Prg" secondAttribute="leading" constant="16" id="GkU-vp-bD7"/>
+                                                <constraint firstItem="MkL-AZ-Bqt" firstAttribute="centerY" secondItem="Z68-om-Prg" secondAttribute="centerY" id="SL6-tG-UhJ"/>
+                                                <constraint firstAttribute="trailing" relation="greaterThanOrEqual" secondItem="MkL-AZ-Bqt" secondAttribute="trailing" constant="20" symbolic="YES" id="YLh-wO-kxn"/>
+                                            </constraints>
+                                        </tableViewCellContentView>
+                                    </tableViewCell>
+                                    <tableViewCell clipsSubviews="YES" contentMode="scaleToFill" insetsLayoutMarginsFromSafeArea="NO" selectionStyle="blue" hidesAccessoryWhenEditing="NO" indentationLevel="1" indentationWidth="0.0" id="8Sn-lK-a7g">
+                                        <rect key="frame" x="0.0" y="99.5" width="414" height="44"/>
+                                        <autoresizingMask key="autoresizingMask"/>
+                                        <tableViewCellContentView key="contentView" opaque="NO" clipsSubviews="YES" multipleTouchEnabled="YES" contentMode="center" insetsLayoutMarginsFromSafeArea="NO" tableViewCell="8Sn-lK-a7g" id="3dJ-Ye-puY">
+                                            <rect key="frame" x="0.0" y="0.0" width="414" height="43.5"/>
+                                            <autoresizingMask key="autoresizingMask"/>
+                                            <subviews>
+                                                <button opaque="NO" contentMode="scaleToFill" contentHorizontalAlignment="center" contentVerticalAlignment="center" buttonType="roundedRect" lineBreakMode="middleTruncation" translatesAutoresizingMaskIntoConstraints="NO" id="wc6-pu-JVA">
+                                                    <rect key="frame" x="16" y="7" width="248" height="30"/>
+                                                    <state key="normal" title="POSIX signal (not simulator friendly)">
+                                                        <color key="titleShadowColor" red="0.5" green="0.5" blue="0.5" alpha="1" colorSpace="custom" customColorSpace="sRGB"/>
+                                                    </state>
+                                                    <connections>
+                                                        <action selector="generateSignal:" destination="uYB-Rg-v98" eventType="touchUpInside" id="R1G-6f-8lH"/>
+                                                    </connections>
+                                                </button>
+                                            </subviews>
+                                            <constraints>
+                                                <constraint firstItem="wc6-pu-JVA" firstAttribute="centerY" secondItem="3dJ-Ye-puY" secondAttribute="centerY" id="4cy-R4-sKX"/>
+                                                <constraint firstItem="wc6-pu-JVA" firstAttribute="leading" secondItem="3dJ-Ye-puY" secondAttribute="leading" constant="16" id="NnE-fc-KKo"/>
+                                                <constraint firstAttribute="trailing" relation="greaterThanOrEqual" secondItem="wc6-pu-JVA" secondAttribute="trailing" constant="20" symbolic="YES" id="e6s-IQ-CSI"/>
+                                            </constraints>
+                                        </tableViewCellContentView>
+                                    </tableViewCell>
+                                    <tableViewCell clipsSubviews="YES" contentMode="scaleToFill" insetsLayoutMarginsFromSafeArea="NO" selectionStyle="blue" hidesAccessoryWhenEditing="NO" indentationLevel="1" indentationWidth="0.0" id="Yhl-gQ-P06">
+                                        <rect key="frame" x="0.0" y="143.5" width="414" height="44"/>
+                                        <autoresizingMask key="autoresizingMask"/>
+                                        <tableViewCellContentView key="contentView" opaque="NO" clipsSubviews="YES" multipleTouchEnabled="YES" contentMode="center" insetsLayoutMarginsFromSafeArea="NO" tableViewCell="Yhl-gQ-P06" id="zVu-Ug-2Kf">
+                                            <rect key="frame" x="0.0" y="0.0" width="414" height="43.5"/>
+                                            <autoresizingMask key="autoresizingMask"/>
+                                            <subviews>
+                                                <button opaque="NO" contentMode="scaleToFill" contentHorizontalAlignment="center" contentVerticalAlignment="center" buttonType="roundedRect" lineBreakMode="middleTruncation" translatesAutoresizingMaskIntoConstraints="NO" id="Ylc-KZ-kmq">
+                                                    <rect key="frame" x="16" y="7" width="132" height="30"/>
+                                                    <state key="normal" title="Memory corruption">
+                                                        <color key="titleShadowColor" red="0.5" green="0.5" blue="0.5" alpha="1" colorSpace="custom" customColorSpace="sRGB"/>
+                                                    </state>
+                                                    <connections>
+                                                        <action selector="objectiveCLockSignal:" destination="uYB-Rg-v98" eventType="touchUpInside" id="3Qs-lw-WsX"/>
+                                                    </connections>
+                                                </button>
+                                            </subviews>
+                                            <constraints>
+                                                <constraint firstItem="Ylc-KZ-kmq" firstAttribute="centerY" secondItem="zVu-Ug-2Kf" secondAttribute="centerY" id="LE4-lF-8bi"/>
+                                                <constraint firstItem="Ylc-KZ-kmq" firstAttribute="leading" secondItem="zVu-Ug-2Kf" secondAttribute="leading" constant="16" id="TeK-yh-cXX"/>
+                                                <constraint firstAttribute="trailing" relation="greaterThanOrEqual" secondItem="Ylc-KZ-kmq" secondAttribute="trailing" constant="20" symbolic="YES" id="dUb-Zc-1qJ"/>
+                                            </constraints>
+                                        </tableViewCellContentView>
+                                    </tableViewCell>
+                                    <tableViewCell clipsSubviews="YES" contentMode="scaleToFill" insetsLayoutMarginsFromSafeArea="NO" selectionStyle="blue" hidesAccessoryWhenEditing="NO" indentationLevel="1" indentationWidth="0.0" id="CSh-nu-bQF">
+                                        <rect key="frame" x="0.0" y="187.5" width="414" height="44"/>
+                                        <autoresizingMask key="autoresizingMask"/>
+                                        <tableViewCellContentView key="contentView" opaque="NO" clipsSubviews="YES" multipleTouchEnabled="YES" contentMode="center" insetsLayoutMarginsFromSafeArea="NO" tableViewCell="CSh-nu-bQF" id="O0Y-bH-MiN">
+                                            <rect key="frame" x="0.0" y="0.0" width="414" height="43.5"/>
+                                            <autoresizingMask key="autoresizingMask"/>
+                                            <subviews>
+                                                <button opaque="NO" contentMode="scaleToFill" contentHorizontalAlignment="center" contentVerticalAlignment="center" buttonType="roundedRect" lineBreakMode="middleTruncation" translatesAutoresizingMaskIntoConstraints="NO" id="B1f-Jm-0Hk">
+                                                    <rect key="frame" x="16" y="7" width="65" height="30"/>
+                                                    <state key="normal" title="Deadlock">
+                                                        <color key="titleShadowColor" red="0.5" green="0.5" blue="0.5" alpha="1" colorSpace="custom" customColorSpace="sRGB"/>
+                                                    </state>
+                                                    <connections>
+                                                        <action selector="pthreadsLockSignal:" destination="uYB-Rg-v98" eventType="touchUpInside" id="Rs4-f6-oES"/>
+                                                    </connections>
+                                                </button>
+                                            </subviews>
+                                            <constraints>
+                                                <constraint firstAttribute="trailing" relation="greaterThanOrEqual" secondItem="B1f-Jm-0Hk" secondAttribute="trailing" constant="20" symbolic="YES" id="IWg-KD-i5I"/>
+                                                <constraint firstItem="B1f-Jm-0Hk" firstAttribute="leading" secondItem="O0Y-bH-MiN" secondAttribute="leading" constant="16" id="KoA-6n-0ju"/>
+                                                <constraint firstItem="B1f-Jm-0Hk" firstAttribute="centerY" secondItem="O0Y-bH-MiN" secondAttribute="centerY" id="qyV-ok-1pf"/>
+                                            </constraints>
+                                        </tableViewCellContentView>
+                                    </tableViewCell>
+                                    <tableViewCell clipsSubviews="YES" contentMode="scaleToFill" insetsLayoutMarginsFromSafeArea="NO" selectionStyle="blue" hidesAccessoryWhenEditing="NO" indentationLevel="1" indentationWidth="0.0" id="Oxa-rC-wVQ">
+                                        <rect key="frame" x="0.0" y="231.5" width="414" height="44"/>
+                                        <autoresizingMask key="autoresizingMask"/>
+                                        <tableViewCellContentView key="contentView" opaque="NO" clipsSubviews="YES" multipleTouchEnabled="YES" contentMode="center" insetsLayoutMarginsFromSafeArea="NO" tableViewCell="Oxa-rC-wVQ" id="rYc-OF-DON">
+                                            <rect key="frame" x="0.0" y="0.0" width="414" height="43.5"/>
+                                            <autoresizingMask key="autoresizingMask"/>
+                                            <subviews>
+                                                <button opaque="NO" contentMode="scaleToFill" contentHorizontalAlignment="center" contentVerticalAlignment="center" buttonType="roundedRect" lineBreakMode="middleTruncation" translatesAutoresizingMaskIntoConstraints="NO" id="6K4-3G-uRI">
+                                                    <rect key="frame" x="16" y="7" width="102" height="30"/>
+                                                    <state key="normal" title="Stack overflow">
+                                                        <color key="titleShadowColor" red="0.5" green="0.5" blue="0.5" alpha="1" colorSpace="custom" customColorSpace="sRGB"/>
+                                                    </state>
+                                                    <connections>
+                                                        <action selector="stackOverflow:" destination="uYB-Rg-v98" eventType="touchUpInside" id="ESl-gn-byo"/>
+                                                    </connections>
+                                                </button>
+                                            </subviews>
+                                            <constraints>
+                                                <constraint firstAttribute="trailing" relation="greaterThanOrEqual" secondItem="6K4-3G-uRI" secondAttribute="trailing" constant="20" symbolic="YES" id="jKf-UF-UBC"/>
+                                                <constraint firstItem="6K4-3G-uRI" firstAttribute="centerY" secondItem="rYc-OF-DON" secondAttribute="centerY" id="sBt-w1-I2i"/>
+                                                <constraint firstItem="6K4-3G-uRI" firstAttribute="leading" secondItem="rYc-OF-DON" secondAttribute="leading" constant="16" id="uZu-cs-KjR"/>
+                                            </constraints>
+                                        </tableViewCellContentView>
+                                    </tableViewCell>
+                                    <tableViewCell clipsSubviews="YES" contentMode="scaleToFill" insetsLayoutMarginsFromSafeArea="NO" selectionStyle="blue" hidesAccessoryWhenEditing="NO" indentationLevel="1" indentationWidth="0.0" id="kTk-Cf-4A3">
+                                        <rect key="frame" x="0.0" y="275.5" width="414" height="44"/>
+                                        <autoresizingMask key="autoresizingMask"/>
+                                        <tableViewCellContentView key="contentView" opaque="NO" clipsSubviews="YES" multipleTouchEnabled="YES" contentMode="center" insetsLayoutMarginsFromSafeArea="NO" tableViewCell="kTk-Cf-4A3" id="WsA-pq-zKg">
+                                            <rect key="frame" x="0.0" y="0.0" width="414" height="43.5"/>
+                                            <autoresizingMask key="autoresizingMask"/>
+                                            <subviews>
+                                                <button opaque="NO" contentMode="scaleToFill" contentHorizontalAlignment="center" contentVerticalAlignment="center" buttonType="roundedRect" lineBreakMode="middleTruncation" translatesAutoresizingMaskIntoConstraints="NO" id="6kT-FU-9Vb">
+                                                    <rect key="frame" x="16" y="7" width="280" height="30"/>
+                                                    <state key="normal" title="Memory pressure (not simulator friendly)"/>
+                                                    <connections>
+                                                        <action selector="generateOOM:" destination="uYB-Rg-v98" eventType="touchUpInside" id="Y1X-XQ-w3V"/>
+                                                    </connections>
+                                                </button>
+                                            </subviews>
+                                            <constraints>
+                                                <constraint firstItem="6kT-FU-9Vb" firstAttribute="leading" secondItem="WsA-pq-zKg" secondAttribute="leading" constant="16" id="bNp-H9-TyN"/>
+                                                <constraint firstItem="6kT-FU-9Vb" firstAttribute="centerY" secondItem="WsA-pq-zKg" secondAttribute="centerY" id="fid-St-MgN"/>
+                                                <constraint firstAttribute="trailing" relation="greaterThanOrEqual" secondItem="6kT-FU-9Vb" secondAttribute="trailing" constant="20" symbolic="YES" id="vI0-vT-sH8"/>
+                                            </constraints>
+                                        </tableViewCellContentView>
+                                    </tableViewCell>
+                                </cells>
+                            </tableViewSection>
+                            <tableViewSection headerTitle="Handled errors and exceptions" footerTitle="Events which can be handled gracefully can also be reported to Bugsnag." id="h1c-YR-XV7">
+                                <cells>
+                                    <tableViewCell clipsSubviews="YES" contentMode="scaleToFill" insetsLayoutMarginsFromSafeArea="NO" selectionStyle="blue" hidesAccessoryWhenEditing="NO" indentationLevel="1" indentationWidth="0.0" id="Ofe-wk-wKd">
+                                        <rect key="frame" x="0.0" y="411" width="414" height="44"/>
+                                        <autoresizingMask key="autoresizingMask"/>
+                                        <tableViewCellContentView key="contentView" opaque="NO" clipsSubviews="YES" multipleTouchEnabled="YES" contentMode="center" insetsLayoutMarginsFromSafeArea="NO" tableViewCell="Ofe-wk-wKd" id="qW2-pi-SzL">
+                                            <rect key="frame" x="0.0" y="0.0" width="414" height="43.5"/>
+                                            <autoresizingMask key="autoresizingMask"/>
+                                            <subviews>
+                                                <button opaque="NO" contentMode="scaleToFill" contentHorizontalAlignment="center" contentVerticalAlignment="center" buttonType="roundedRect" lineBreakMode="middleTruncation" translatesAutoresizingMaskIntoConstraints="NO" id="gsL-Pw-GHc">
+                                                    <rect key="frame" x="16" y="7" width="182" height="30"/>
+                                                    <state key="normal" title="Use notify() from try/catch">
+                                                        <color key="titleShadowColor" red="0.5" green="0.5" blue="0.5" alpha="1" colorSpace="custom" customColorSpace="sRGB"/>
+                                                    </state>
+                                                    <connections>
+                                                        <action selector="nonFatalException:" destination="uYB-Rg-v98" eventType="touchUpInside" id="CMl-qH-KQB"/>
+                                                    </connections>
+                                                </button>
+                                            </subviews>
+                                            <constraints>
+                                                <constraint firstAttribute="trailing" relation="greaterThanOrEqual" secondItem="gsL-Pw-GHc" secondAttribute="trailing" constant="20" symbolic="YES" id="7NW-yY-qCN"/>
+                                                <constraint firstItem="gsL-Pw-GHc" firstAttribute="leading" secondItem="qW2-pi-SzL" secondAttribute="leading" constant="16" id="I3Y-kv-nic"/>
+                                                <constraint firstItem="gsL-Pw-GHc" firstAttribute="centerY" secondItem="qW2-pi-SzL" secondAttribute="centerY" id="aMI-c6-aRD"/>
+                                            </constraints>
+                                        </tableViewCellContentView>
+                                    </tableViewCell>
+                                    <tableViewCell clipsSubviews="YES" contentMode="scaleToFill" insetsLayoutMarginsFromSafeArea="NO" selectionStyle="blue" hidesAccessoryWhenEditing="NO" indentationLevel="1" indentationWidth="0.0" id="fZi-2v-vlx">
+                                        <rect key="frame" x="0.0" y="455" width="414" height="44"/>
+                                        <autoresizingMask key="autoresizingMask"/>
+                                        <tableViewCellContentView key="contentView" opaque="NO" clipsSubviews="YES" multipleTouchEnabled="YES" contentMode="center" insetsLayoutMarginsFromSafeArea="NO" tableViewCell="fZi-2v-vlx" id="DfY-Um-9hb">
+                                            <rect key="frame" x="0.0" y="0.0" width="414" height="43.5"/>
+                                            <autoresizingMask key="autoresizingMask"/>
+                                            <subviews>
+                                                <button opaque="NO" contentMode="scaleToFill" contentHorizontalAlignment="center" contentVerticalAlignment="center" buttonType="roundedRect" lineBreakMode="middleTruncation" translatesAutoresizingMaskIntoConstraints="NO" id="Lq8-kV-y3N">
+                                                    <rect key="frame" x="16" y="7" width="191" height="30"/>
+                                                    <state key="normal" title="Call notify() asynchronously">
+                                                        <color key="titleShadowColor" red="0.5" green="0.5" blue="0.5" alpha="1" colorSpace="custom" customColorSpace="sRGB"/>
+                                                    </state>
+                                                    <connections>
+                                                        <action selector="delayedException:" destination="uYB-Rg-v98" eventType="touchUpInside" id="DGf-vT-ptW"/>
+                                                    </connections>
+                                                </button>
+                                            </subviews>
+                                            <constraints>
+                                                <constraint firstItem="Lq8-kV-y3N" firstAttribute="centerY" secondItem="DfY-Um-9hb" secondAttribute="centerY" id="2uQ-Mb-H2n"/>
+                                                <constraint firstItem="Lq8-kV-y3N" firstAttribute="leading" secondItem="DfY-Um-9hb" secondAttribute="leading" constant="16" id="7dz-H7-SsO"/>
+                                                <constraint firstAttribute="trailing" relation="greaterThanOrEqual" secondItem="Lq8-kV-y3N" secondAttribute="trailing" constant="20" symbolic="YES" id="XFU-uc-xRe"/>
+                                            </constraints>
+                                        </tableViewCellContentView>
+                                    </tableViewCell>
+                                    <tableViewCell clipsSubviews="YES" contentMode="scaleToFill" insetsLayoutMarginsFromSafeArea="NO" selectionStyle="blue" hidesAccessoryWhenEditing="NO" indentationLevel="1" indentationWidth="0.0" id="t4o-vg-er6">
+                                        <rect key="frame" x="0.0" y="499" width="414" height="44"/>
+                                        <autoresizingMask key="autoresizingMask"/>
+                                        <tableViewCellContentView key="contentView" opaque="NO" clipsSubviews="YES" multipleTouchEnabled="YES" contentMode="center" insetsLayoutMarginsFromSafeArea="NO" tableViewCell="t4o-vg-er6" id="bUh-rr-kY1">
+                                            <rect key="frame" x="0.0" y="0.0" width="414" height="43.5"/>
+                                            <autoresizingMask key="autoresizingMask"/>
+                                            <subviews>
+                                                <button opaque="NO" contentMode="scaleToFill" contentHorizontalAlignment="center" contentVerticalAlignment="center" buttonType="roundedRect" lineBreakMode="middleTruncation" translatesAutoresizingMaskIntoConstraints="NO" id="T16-Wx-wJ1">
+                                                    <rect key="frame" x="16" y="7" width="234" height="30"/>
+                                                    <state key="normal" title="Send an NSError with notifyError()">
+                                                        <color key="titleShadowColor" red="0.5" green="0.5" blue="0.5" alpha="1" colorSpace="custom" customColorSpace="sRGB"/>
+                                                    </state>
+                                                    <connections>
+                                                        <action selector="generateNSError:" destination="uYB-Rg-v98" eventType="touchUpInside" id="2cT-DA-qrm"/>
+                                                    </connections>
+                                                </button>
+                                            </subviews>
+                                            <constraints>
+                                                <constraint firstItem="T16-Wx-wJ1" firstAttribute="leading" secondItem="bUh-rr-kY1" secondAttribute="leading" constant="16" id="F9k-Ak-XPA"/>
+                                                <constraint firstItem="T16-Wx-wJ1" firstAttribute="centerY" secondItem="bUh-rr-kY1" secondAttribute="centerY" id="hZj-aP-sC4"/>
+                                                <constraint firstAttribute="trailing" relation="greaterThanOrEqual" secondItem="T16-Wx-wJ1" secondAttribute="trailing" constant="20" symbolic="YES" id="jW4-xd-O0r"/>
+                                            </constraints>
+                                        </tableViewCellContentView>
+                                    </tableViewCell>
+                                </cells>
+                            </tableViewSection>
+                        </sections>
+                        <connections>
+                            <outlet property="dataSource" destination="uYB-Rg-v98" id="fzJ-dF-04e"/>
+                            <outlet property="delegate" destination="uYB-Rg-v98" id="02C-3r-HP9"/>
+                        </connections>
+                    </tableView>
+                    <navigationItem key="navigationItem" title="Bugsnag Examples" id="9es-Z2-aL9"/>
+                </tableViewController>
+                <placeholder placeholderIdentifier="IBFirstResponder" id="Pa0-Qh-NQH" userLabel="First Responder" sceneMemberID="firstResponder"/>
             </objects>
-            <point key="canvasLocation" x="588.79999999999995" y="282.4587706146927"/>
+            <point key="canvasLocation" x="586" y="281"/>
         </scene>
     </scenes>
 </document>

--- a/examples/swift-ios/bugsnag-example.xcodeproj/project.pbxproj
+++ b/examples/swift-ios/bugsnag-example.xcodeproj/project.pbxproj
@@ -211,11 +211,11 @@
 					D175F4B71ACDBD81009AFFB7 = {
 						CreatedOnToolsVersion = 6.2;
 						DevelopmentTeam = 372ZUL2ZB7;
-						LastSwiftMigration = 0900;
+						LastSwiftMigration = 1010;
 					};
 					D175F4CC1ACDBD81009AFFB7 = {
 						CreatedOnToolsVersion = 6.2;
-						LastSwiftMigration = 0900;
+						LastSwiftMigration = 1010;
 						TestTargetID = D175F4B71ACDBD81009AFFB7;
 					};
 				};
@@ -463,7 +463,7 @@
 				PRODUCT_NAME = "$(TARGET_NAME)";
 				PROVISIONING_PROFILE = "";
 				SWIFT_OBJC_BRIDGING_HEADER = "bugsnag-example/bugsnag-example-Bridging-Header.h";
-				SWIFT_VERSION = 4.0;
+				SWIFT_VERSION = 4.2;
 			};
 			name = Debug;
 		};
@@ -482,7 +482,7 @@
 				PRODUCT_NAME = "$(TARGET_NAME)";
 				PROVISIONING_PROFILE = "";
 				SWIFT_OBJC_BRIDGING_HEADER = "bugsnag-example/bugsnag-example-Bridging-Header.h";
-				SWIFT_VERSION = 4.0;
+				SWIFT_VERSION = 4.2;
 			};
 			name = Release;
 		};
@@ -502,7 +502,7 @@
 				LD_RUNPATH_SEARCH_PATHS = "$(inherited) @executable_path/Frameworks @loader_path/Frameworks";
 				PRODUCT_BUNDLE_IDENTIFIER = "com.isaacwaller.$(PRODUCT_NAME:rfc1034identifier)";
 				PRODUCT_NAME = "$(TARGET_NAME)";
-				SWIFT_VERSION = 4.0;
+				SWIFT_VERSION = 4.2;
 				TEST_HOST = "$(BUILT_PRODUCTS_DIR)/bugsnag-example.app/bugsnag-example";
 			};
 			name = Debug;
@@ -519,7 +519,7 @@
 				LD_RUNPATH_SEARCH_PATHS = "$(inherited) @executable_path/Frameworks @loader_path/Frameworks";
 				PRODUCT_BUNDLE_IDENTIFIER = "com.isaacwaller.$(PRODUCT_NAME:rfc1034identifier)";
 				PRODUCT_NAME = "$(TARGET_NAME)";
-				SWIFT_VERSION = 4.0;
+				SWIFT_VERSION = 4.2;
 				TEST_HOST = "$(BUILT_PRODUCTS_DIR)/bugsnag-example.app/bugsnag-example";
 			};
 			name = Release;

--- a/examples/swift-ios/bugsnag-example.xcodeproj/xcshareddata/xcschemes/bugsnag-example.xcscheme
+++ b/examples/swift-ios/bugsnag-example.xcodeproj/xcshareddata/xcschemes/bugsnag-example.xcscheme
@@ -1,0 +1,101 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<Scheme
+   LastUpgradeVersion = "1010"
+   version = "1.3">
+   <BuildAction
+      parallelizeBuildables = "YES"
+      buildImplicitDependencies = "YES">
+      <BuildActionEntries>
+         <BuildActionEntry
+            buildForTesting = "YES"
+            buildForRunning = "YES"
+            buildForProfiling = "YES"
+            buildForArchiving = "YES"
+            buildForAnalyzing = "YES">
+            <BuildableReference
+               BuildableIdentifier = "primary"
+               BlueprintIdentifier = "D175F4B71ACDBD81009AFFB7"
+               BuildableName = "bugsnag-example.app"
+               BlueprintName = "bugsnag-example"
+               ReferencedContainer = "container:bugsnag-example.xcodeproj">
+            </BuildableReference>
+         </BuildActionEntry>
+      </BuildActionEntries>
+   </BuildAction>
+   <TestAction
+      buildConfiguration = "Debug"
+      selectedDebuggerIdentifier = "Xcode.DebuggerFoundation.Debugger.LLDB"
+      selectedLauncherIdentifier = "Xcode.DebuggerFoundation.Launcher.LLDB"
+      shouldUseLaunchSchemeArgsEnv = "YES">
+      <Testables>
+         <TestableReference
+            skipped = "NO">
+            <BuildableReference
+               BuildableIdentifier = "primary"
+               BlueprintIdentifier = "D175F4CC1ACDBD81009AFFB7"
+               BuildableName = "bugsnag-exampleTests.xctest"
+               BlueprintName = "bugsnag-exampleTests"
+               ReferencedContainer = "container:bugsnag-example.xcodeproj">
+            </BuildableReference>
+         </TestableReference>
+      </Testables>
+      <MacroExpansion>
+         <BuildableReference
+            BuildableIdentifier = "primary"
+            BlueprintIdentifier = "D175F4B71ACDBD81009AFFB7"
+            BuildableName = "bugsnag-example.app"
+            BlueprintName = "bugsnag-example"
+            ReferencedContainer = "container:bugsnag-example.xcodeproj">
+         </BuildableReference>
+      </MacroExpansion>
+      <AdditionalOptions>
+      </AdditionalOptions>
+   </TestAction>
+   <LaunchAction
+      buildConfiguration = "Debug"
+      selectedDebuggerIdentifier = ""
+      selectedLauncherIdentifier = "Xcode.IDEFoundation.Launcher.PosixSpawn"
+      launchStyle = "0"
+      useCustomWorkingDirectory = "NO"
+      ignoresPersistentStateOnLaunch = "NO"
+      debugDocumentVersioning = "YES"
+      debugServiceExtension = "internal"
+      allowLocationSimulation = "YES">
+      <BuildableProductRunnable
+         runnableDebuggingMode = "0">
+         <BuildableReference
+            BuildableIdentifier = "primary"
+            BlueprintIdentifier = "D175F4B71ACDBD81009AFFB7"
+            BuildableName = "bugsnag-example.app"
+            BlueprintName = "bugsnag-example"
+            ReferencedContainer = "container:bugsnag-example.xcodeproj">
+         </BuildableReference>
+      </BuildableProductRunnable>
+      <AdditionalOptions>
+      </AdditionalOptions>
+   </LaunchAction>
+   <ProfileAction
+      buildConfiguration = "Release"
+      shouldUseLaunchSchemeArgsEnv = "YES"
+      savedToolIdentifier = ""
+      useCustomWorkingDirectory = "NO"
+      debugDocumentVersioning = "YES">
+      <BuildableProductRunnable
+         runnableDebuggingMode = "0">
+         <BuildableReference
+            BuildableIdentifier = "primary"
+            BlueprintIdentifier = "D175F4B71ACDBD81009AFFB7"
+            BuildableName = "bugsnag-example.app"
+            BlueprintName = "bugsnag-example"
+            ReferencedContainer = "container:bugsnag-example.xcodeproj">
+         </BuildableReference>
+      </BuildableProductRunnable>
+   </ProfileAction>
+   <AnalyzeAction
+      buildConfiguration = "Debug">
+   </AnalyzeAction>
+   <ArchiveAction
+      buildConfiguration = "Release"
+      revealArchiveInOrganizer = "YES">
+   </ArchiveAction>
+</Scheme>

--- a/examples/swift-ios/bugsnag-example/AnObjCClass.h
+++ b/examples/swift-ios/bugsnag-example/AnObjCClass.h
@@ -22,8 +22,7 @@
 
 @interface AnObjCClass : NSObject
 
-- (void)makeAStackTrace:(id)other;
 - (void)trap;
-- (void)raise;
+- (void)corruptSomeMemory;
 
 @end

--- a/examples/swift-ios/bugsnag-example/AnObjCClass.m
+++ b/examples/swift-ios/bugsnag-example/AnObjCClass.m
@@ -23,20 +23,34 @@
 
 @implementation AnObjCClass
 
-- (void)makeAStackTrace:(AnotherClass *)other {
-    [self bounce:other];
-}
-
-- (void)bounce:(AnotherClass *)other {
-    [other crash3];
-}
-
 - (void)trap {
     __builtin_trap();
 }
 
-- (void)raise {
-    [NSException raise:@"UNHANDLED EXCEPTION WEEWOOO WEEWOOOOOO" format:@"Shouldn't have had too much coffee"];
+- (void)corruptSomeMemory {
+    /* Some random data */
+    void *cache[] = {
+        NULL, NULL, NULL
+    };
+
+    void *displayStrings[6] = {
+        "This little piggy went to the meerket",
+        "This little piggy stayed at home",
+        cache,
+        "This little piggy had roast beef.",
+        "This little piggy had none.",
+        "And this little piggy went 'Wee! Wee! Wee!' all the way home",
+    };
+
+    /* A corrupted/under-retained/re-used piece of memory */
+    struct {
+        void *isa;
+    } corruptObj;
+    corruptObj.isa = displayStrings;
+
+    /* Message an invalid/corrupt object. This will deadlock crash reporters
+     * using Objective-C. */
+    [(__bridge id)&corruptObj class];
 }
 
 @end

--- a/examples/swift-ios/bugsnag-example/AnotherClass.swift
+++ b/examples/swift-ios/bugsnag-example/AnotherClass.swift
@@ -20,22 +20,7 @@
 
 class AnotherClass: NSObject {
 
-    func crash() {
-        crash2()
-    }
-
-    func crash2() {
-        makingAStackTrace() {
-            let objC = AnObjCClass()
-            objC.makeAStackTrace(self)
-        }
-    }
-
-   func makingAStackTrace(_ block: () -> ()) {
-        block()
-    }
-
-   @objc func crash3() {
+   @objc static func crash3() {
         preconditionFailure("This should NEVER happen")
     }
 }

--- a/examples/swift-ios/bugsnag-example/AppDelegate.swift
+++ b/examples/swift-ios/bugsnag-example/AppDelegate.swift
@@ -25,8 +25,8 @@ class AppDelegate: UIResponder, UIApplicationDelegate {
 
     var window: UIWindow?
 
-    func application(_ application: UIApplication, didFinishLaunchingWithOptions launchOptions: [UIApplicationLaunchOptionsKey: Any]?) -> Bool {
-        Bugsnag.start(withApiKey: "your-api-key")
+    func application(_ application: UIApplication, didFinishLaunchingWithOptions launchOptions: [UIApplication.LaunchOptionsKey: Any]?) -> Bool {
+        Bugsnag.start(withApiKey: "YOUR-API-KEY-HERE")
         return true
     }
     

--- a/examples/swift-ios/bugsnag-example/Base.lproj/Main.storyboard
+++ b/examples/swift-ios/bugsnag-example/Base.lproj/Main.storyboard
@@ -1,48 +1,190 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<document type="com.apple.InterfaceBuilder3.CocoaTouch.Storyboard.XIB" version="3.0" toolsVersion="12121" systemVersion="16F2073" targetRuntime="iOS.CocoaTouch" propertyAccessControl="none" useAutolayout="YES" useTraitCollections="YES" colorMatched="YES" initialViewController="BYZ-38-t0r">
-    <device id="retina4_7" orientation="portrait">
+<document type="com.apple.InterfaceBuilder3.CocoaTouch.Storyboard.XIB" version="3.0" toolsVersion="14460.31" targetRuntime="iOS.CocoaTouch" propertyAccessControl="none" useAutolayout="YES" useTraitCollections="YES" colorMatched="YES" initialViewController="G92-m4-VCF">
+    <device id="retina6_1" orientation="portrait">
         <adaptation id="fullscreen"/>
     </device>
     <dependencies>
         <deployment identifier="iOS"/>
-        <plugIn identifier="com.apple.InterfaceBuilder.IBCocoaTouchPlugin" version="12089"/>
-        <capability name="Constraints to layout margins" minToolsVersion="6.0"/>
+        <plugIn identifier="com.apple.InterfaceBuilder.IBCocoaTouchPlugin" version="14460.20"/>
         <capability name="documents saved in the Xcode 8 format" minToolsVersion="8.0"/>
     </dependencies>
     <scenes>
-        <!--View Controller-->
-        <scene sceneID="tne-QT-ifu">
+        <!--Bugsnag Examples-->
+        <scene sceneID="Z3J-7T-myz">
             <objects>
-                <viewController id="BYZ-38-t0r" customClass="ViewController" customModule="bugsnag_example" customModuleProvider="target" sceneMemberID="viewController">
-                    <layoutGuides>
-                        <viewControllerLayoutGuide type="top" id="y3c-jy-aDJ"/>
-                        <viewControllerLayoutGuide type="bottom" id="wfy-db-euE"/>
-                    </layoutGuides>
-                    <view key="view" contentMode="scaleToFill" id="8bC-Xf-vdC">
-                        <rect key="frame" x="0.0" y="0.0" width="375" height="667"/>
+                <tableViewController id="9hK-Do-Aqc" customClass="ViewController" customModule="bugsnag_example" customModuleProvider="target" sceneMemberID="viewController">
+                    <tableView key="view" clipsSubviews="YES" contentMode="scaleToFill" alwaysBounceVertical="YES" dataMode="static" style="grouped" separatorStyle="default" rowHeight="-1" estimatedRowHeight="-1" sectionHeaderHeight="18" sectionFooterHeight="18" id="KsG-nG-XCO">
+                        <rect key="frame" x="0.0" y="0.0" width="414" height="896"/>
                         <autoresizingMask key="autoresizingMask" widthSizable="YES" heightSizable="YES"/>
-                        <subviews>
-                            <button opaque="NO" contentMode="scaleToFill" contentHorizontalAlignment="center" contentVerticalAlignment="center" buttonType="roundedRect" lineBreakMode="middleTruncation" translatesAutoresizingMaskIntoConstraints="NO" id="cAZ-QF-pum">
-                                <rect key="frame" x="36" y="84" width="303" height="40"/>
-                                <constraints>
-                                    <constraint firstAttribute="height" constant="40" id="CFE-m7-ghl"/>
-                                </constraints>
-                                <state key="normal" title="Crash App"/>
-                                <connections>
-                                    <action selector="doCrash:" destination="BYZ-38-t0r" eventType="touchUpInside" id="Dh9-jh-Rew"/>
-                                </connections>
-                            </button>
-                        </subviews>
-                        <color key="backgroundColor" red="1" green="1" blue="1" alpha="1" colorSpace="custom" customColorSpace="sRGB"/>
-                        <constraints>
-                            <constraint firstItem="cAZ-QF-pum" firstAttribute="top" secondItem="y3c-jy-aDJ" secondAttribute="bottom" constant="64" id="NZr-2s-nv8"/>
-                            <constraint firstAttribute="trailingMargin" secondItem="cAZ-QF-pum" secondAttribute="trailing" constant="20" id="b8w-cH-Ghm"/>
-                            <constraint firstItem="cAZ-QF-pum" firstAttribute="leading" secondItem="8bC-Xf-vdC" secondAttribute="leadingMargin" constant="20" id="fAp-Jf-Zo0"/>
-                        </constraints>
-                    </view>
-                </viewController>
-                <placeholder placeholderIdentifier="IBFirstResponder" id="dkx-z0-nzr" sceneMemberID="firstResponder"/>
+                        <color key="backgroundColor" cocoaTouchSystemColor="groupTableViewBackgroundColor"/>
+                        <sections>
+                            <tableViewSection headerTitle="Crashes" footerTitle="Events which terminate the app are sent to Bugsnag automatically. Reopen the app after a crash to send reports." id="7h6-1h-5UO">
+                                <cells>
+                                    <tableViewCell clipsSubviews="YES" contentMode="scaleToFill" preservesSuperviewLayoutMargins="YES" selectionStyle="default" indentationWidth="10" id="QbB-rU-kYH">
+                                        <rect key="frame" x="0.0" y="55.5" width="414" height="44"/>
+                                        <autoresizingMask key="autoresizingMask"/>
+                                        <tableViewCellContentView key="contentView" opaque="NO" clipsSubviews="YES" multipleTouchEnabled="YES" contentMode="center" preservesSuperviewLayoutMargins="YES" insetsLayoutMarginsFromSafeArea="NO" tableViewCell="QbB-rU-kYH" id="NUP-7Y-ZOe">
+                                            <rect key="frame" x="0.0" y="0.0" width="414" height="43.5"/>
+                                            <autoresizingMask key="autoresizingMask"/>
+                                            <subviews>
+                                                <button opaque="NO" contentMode="scaleToFill" contentHorizontalAlignment="leading" contentVerticalAlignment="center" buttonType="roundedRect" lineBreakMode="middleTruncation" translatesAutoresizingMaskIntoConstraints="NO" id="dKl-4y-FY8">
+                                                    <rect key="frame" x="16" y="7" width="398" height="30"/>
+                                                    <state key="normal" title="Uncaught exception"/>
+                                                    <connections>
+                                                        <action selector="generateUncaughtException:" destination="9hK-Do-Aqc" eventType="touchUpInside" id="0Aq-hf-LLG"/>
+                                                    </connections>
+                                                </button>
+                                            </subviews>
+                                            <constraints>
+                                                <constraint firstItem="dKl-4y-FY8" firstAttribute="leading" secondItem="NUP-7Y-ZOe" secondAttribute="leading" constant="16" id="9YH-qf-ekK"/>
+                                                <constraint firstAttribute="trailing" secondItem="dKl-4y-FY8" secondAttribute="trailing" id="CXd-m2-NBN"/>
+                                                <constraint firstItem="dKl-4y-FY8" firstAttribute="centerY" secondItem="NUP-7Y-ZOe" secondAttribute="centerY" id="irp-6n-Bin"/>
+                                            </constraints>
+                                        </tableViewCellContentView>
+                                    </tableViewCell>
+                                    <tableViewCell clipsSubviews="YES" contentMode="scaleToFill" preservesSuperviewLayoutMargins="YES" selectionStyle="default" indentationWidth="10" id="faP-iZ-xbK">
+                                        <rect key="frame" x="0.0" y="99.5" width="414" height="44"/>
+                                        <autoresizingMask key="autoresizingMask"/>
+                                        <tableViewCellContentView key="contentView" opaque="NO" clipsSubviews="YES" multipleTouchEnabled="YES" contentMode="center" preservesSuperviewLayoutMargins="YES" insetsLayoutMarginsFromSafeArea="NO" tableViewCell="faP-iZ-xbK" id="TXb-Wu-rDg">
+                                            <rect key="frame" x="0.0" y="0.0" width="414" height="43.5"/>
+                                            <autoresizingMask key="autoresizingMask"/>
+                                            <subviews>
+                                                <button opaque="NO" contentMode="scaleToFill" contentHorizontalAlignment="leading" contentVerticalAlignment="center" buttonType="roundedRect" lineBreakMode="middleTruncation" translatesAutoresizingMaskIntoConstraints="NO" id="VDE-Mo-ZHy">
+                                                    <rect key="frame" x="16" y="7" width="398" height="30"/>
+                                                    <state key="normal" title="POSIX signal"/>
+                                                    <connections>
+                                                        <action selector="generatePOSIXSignal:" destination="9hK-Do-Aqc" eventType="touchUpInside" id="82J-Un-gBe"/>
+                                                    </connections>
+                                                </button>
+                                            </subviews>
+                                            <constraints>
+                                                <constraint firstItem="VDE-Mo-ZHy" firstAttribute="centerY" secondItem="TXb-Wu-rDg" secondAttribute="centerY" id="coE-hL-TaQ"/>
+                                                <constraint firstAttribute="trailing" secondItem="VDE-Mo-ZHy" secondAttribute="trailing" id="nWf-VD-d0u"/>
+                                                <constraint firstItem="VDE-Mo-ZHy" firstAttribute="leading" secondItem="TXb-Wu-rDg" secondAttribute="leading" constant="16" id="wjq-2L-8Xo"/>
+                                            </constraints>
+                                        </tableViewCellContentView>
+                                    </tableViewCell>
+                                    <tableViewCell clipsSubviews="YES" contentMode="scaleToFill" preservesSuperviewLayoutMargins="YES" selectionStyle="default" indentationWidth="10" id="0Jp-Zg-DPd">
+                                        <rect key="frame" x="0.0" y="143.5" width="414" height="44"/>
+                                        <autoresizingMask key="autoresizingMask"/>
+                                        <tableViewCellContentView key="contentView" opaque="NO" clipsSubviews="YES" multipleTouchEnabled="YES" contentMode="center" preservesSuperviewLayoutMargins="YES" insetsLayoutMarginsFromSafeArea="NO" tableViewCell="0Jp-Zg-DPd" id="bhB-G9-rkY">
+                                            <rect key="frame" x="0.0" y="0.0" width="414" height="43.5"/>
+                                            <autoresizingMask key="autoresizingMask"/>
+                                            <subviews>
+                                                <button opaque="NO" contentMode="scaleToFill" contentHorizontalAlignment="leading" contentVerticalAlignment="center" buttonType="roundedRect" lineBreakMode="middleTruncation" translatesAutoresizingMaskIntoConstraints="NO" id="zHv-iF-OX3">
+                                                    <rect key="frame" x="16" y="7" width="398" height="30"/>
+                                                    <state key="normal" title="Memory corruption"/>
+                                                    <connections>
+                                                        <action selector="generateMemoryCorruption:" destination="9hK-Do-Aqc" eventType="touchUpInside" id="DIu-04-fPT"/>
+                                                    </connections>
+                                                </button>
+                                            </subviews>
+                                            <constraints>
+                                                <constraint firstItem="zHv-iF-OX3" firstAttribute="centerY" secondItem="bhB-G9-rkY" secondAttribute="centerY" id="YKs-9D-1aO"/>
+                                                <constraint firstItem="zHv-iF-OX3" firstAttribute="leading" secondItem="bhB-G9-rkY" secondAttribute="leading" constant="16" id="eIw-6h-ycy"/>
+                                                <constraint firstAttribute="trailing" secondItem="zHv-iF-OX3" secondAttribute="trailing" id="qsL-7T-vDd"/>
+                                            </constraints>
+                                        </tableViewCellContentView>
+                                    </tableViewCell>
+                                    <tableViewCell clipsSubviews="YES" contentMode="scaleToFill" preservesSuperviewLayoutMargins="YES" selectionStyle="default" indentationWidth="10" id="nl4-Ib-Cug">
+                                        <rect key="frame" x="0.0" y="187.5" width="414" height="44"/>
+                                        <autoresizingMask key="autoresizingMask"/>
+                                        <tableViewCellContentView key="contentView" opaque="NO" clipsSubviews="YES" multipleTouchEnabled="YES" contentMode="center" preservesSuperviewLayoutMargins="YES" insetsLayoutMarginsFromSafeArea="NO" tableViewCell="nl4-Ib-Cug" id="igM-Ms-EQN">
+                                            <rect key="frame" x="0.0" y="0.0" width="414" height="43.5"/>
+                                            <autoresizingMask key="autoresizingMask"/>
+                                            <subviews>
+                                                <button opaque="NO" contentMode="scaleToFill" contentHorizontalAlignment="leading" contentVerticalAlignment="center" buttonType="roundedRect" lineBreakMode="middleTruncation" translatesAutoresizingMaskIntoConstraints="NO" id="gTW-a1-OEW">
+                                                    <rect key="frame" x="16" y="7" width="398" height="30"/>
+                                                    <state key="normal" title="Stack overflow"/>
+                                                    <connections>
+                                                        <action selector="generateStackOverflow:" destination="9hK-Do-Aqc" eventType="touchUpInside" id="IQg-0a-NSe"/>
+                                                    </connections>
+                                                </button>
+                                            </subviews>
+                                            <constraints>
+                                                <constraint firstItem="gTW-a1-OEW" firstAttribute="leading" secondItem="igM-Ms-EQN" secondAttribute="leading" constant="16" id="3qf-uZ-RjK"/>
+                                                <constraint firstItem="gTW-a1-OEW" firstAttribute="centerY" secondItem="igM-Ms-EQN" secondAttribute="centerY" id="nrI-IA-JwF"/>
+                                                <constraint firstAttribute="trailing" secondItem="gTW-a1-OEW" secondAttribute="trailing" id="png-g2-qC6"/>
+                                            </constraints>
+                                        </tableViewCellContentView>
+                                    </tableViewCell>
+                                    <tableViewCell clipsSubviews="YES" contentMode="scaleToFill" preservesSuperviewLayoutMargins="YES" selectionStyle="default" indentationWidth="10" id="i5r-OQ-QyO">
+                                        <rect key="frame" x="0.0" y="231.5" width="414" height="44"/>
+                                        <autoresizingMask key="autoresizingMask"/>
+                                        <tableViewCellContentView key="contentView" opaque="NO" clipsSubviews="YES" multipleTouchEnabled="YES" contentMode="center" preservesSuperviewLayoutMargins="YES" insetsLayoutMarginsFromSafeArea="NO" tableViewCell="i5r-OQ-QyO" id="5qq-qB-YDh">
+                                            <rect key="frame" x="0.0" y="0.0" width="414" height="43.5"/>
+                                            <autoresizingMask key="autoresizingMask"/>
+                                            <subviews>
+                                                <button opaque="NO" contentMode="scaleToFill" contentHorizontalAlignment="leading" contentVerticalAlignment="center" buttonType="roundedRect" lineBreakMode="middleTruncation" translatesAutoresizingMaskIntoConstraints="NO" id="Wh1-Fq-EmE">
+                                                    <rect key="frame" x="16" y="7" width="398" height="30"/>
+                                                    <state key="normal" title="Assertion failure"/>
+                                                    <connections>
+                                                        <action selector="generateAssertionFailure:" destination="9hK-Do-Aqc" eventType="touchUpInside" id="nCO-qY-oCh"/>
+                                                    </connections>
+                                                </button>
+                                            </subviews>
+                                            <constraints>
+                                                <constraint firstItem="Wh1-Fq-EmE" firstAttribute="centerY" secondItem="5qq-qB-YDh" secondAttribute="centerY" id="8Id-9q-WrG"/>
+                                                <constraint firstItem="Wh1-Fq-EmE" firstAttribute="leading" secondItem="5qq-qB-YDh" secondAttribute="leading" constant="16" id="OFk-Dh-Oie"/>
+                                                <constraint firstAttribute="trailing" secondItem="Wh1-Fq-EmE" secondAttribute="trailing" id="c4f-Jl-GwQ"/>
+                                            </constraints>
+                                        </tableViewCellContentView>
+                                    </tableViewCell>
+                                </cells>
+                            </tableViewSection>
+                            <tableViewSection headerTitle="Handled errors" footerTitle="Events which can be handled gracefully can also be reported to Bugsnag." id="h0h-sl-rgg">
+                                <cells>
+                                    <tableViewCell clipsSubviews="YES" contentMode="scaleToFill" preservesSuperviewLayoutMargins="YES" selectionStyle="default" indentationWidth="10" id="lC1-Sl-uHl">
+                                        <rect key="frame" x="0.0" y="367" width="414" height="44"/>
+                                        <autoresizingMask key="autoresizingMask"/>
+                                        <tableViewCellContentView key="contentView" opaque="NO" clipsSubviews="YES" multipleTouchEnabled="YES" contentMode="center" preservesSuperviewLayoutMargins="YES" insetsLayoutMarginsFromSafeArea="NO" tableViewCell="lC1-Sl-uHl" id="Sdc-Gj-y4b">
+                                            <rect key="frame" x="0.0" y="0.0" width="414" height="43.5"/>
+                                            <autoresizingMask key="autoresizingMask"/>
+                                            <subviews>
+                                                <button opaque="NO" contentMode="scaleToFill" contentHorizontalAlignment="leading" contentVerticalAlignment="center" buttonType="roundedRect" lineBreakMode="middleTruncation" translatesAutoresizingMaskIntoConstraints="NO" id="rQs-Qy-wfI">
+                                                    <rect key="frame" x="16" y="7" width="398" height="30"/>
+                                                    <state key="normal" title="Send error with notifyError()"/>
+                                                    <connections>
+                                                        <action selector="sendAnError:" destination="9hK-Do-Aqc" eventType="touchUpInside" id="Hds-Ph-aIh"/>
+                                                    </connections>
+                                                </button>
+                                            </subviews>
+                                            <constraints>
+                                                <constraint firstAttribute="trailing" secondItem="rQs-Qy-wfI" secondAttribute="trailing" id="Q0q-1e-hAB"/>
+                                                <constraint firstItem="rQs-Qy-wfI" firstAttribute="centerY" secondItem="Sdc-Gj-y4b" secondAttribute="centerY" id="Zya-9j-h7I"/>
+                                                <constraint firstItem="rQs-Qy-wfI" firstAttribute="leading" secondItem="Sdc-Gj-y4b" secondAttribute="leading" constant="16" id="si3-ZM-QaO"/>
+                                            </constraints>
+                                        </tableViewCellContentView>
+                                    </tableViewCell>
+                                </cells>
+                            </tableViewSection>
+                        </sections>
+                        <connections>
+                            <outlet property="dataSource" destination="9hK-Do-Aqc" id="DWO-X3-PCL"/>
+                            <outlet property="delegate" destination="9hK-Do-Aqc" id="DrM-cu-cDA"/>
+                        </connections>
+                    </tableView>
+                    <navigationItem key="navigationItem" title="Bugsnag Examples" id="emN-8u-3yg"/>
+                </tableViewController>
+                <placeholder placeholderIdentifier="IBFirstResponder" id="kkh-t9-6oq" userLabel="First Responder" sceneMemberID="firstResponder"/>
             </objects>
+            <point key="canvasLocation" x="236" y="145"/>
+        </scene>
+        <!--Navigation Controller-->
+        <scene sceneID="Xjk-6i-Tg7">
+            <objects>
+                <navigationController id="G92-m4-VCF" sceneMemberID="viewController">
+                    <navigationBar key="navigationBar" contentMode="scaleToFill" insetsLayoutMarginsFromSafeArea="NO" id="dOo-8v-HUF">
+                        <rect key="frame" x="0.0" y="44" width="414" height="44"/>
+                        <autoresizingMask key="autoresizingMask"/>
+                    </navigationBar>
+                    <connections>
+                        <segue destination="9hK-Do-Aqc" kind="relationship" relationship="rootViewController" id="ruM-ze-IvU"/>
+                    </connections>
+                </navigationController>
+                <placeholder placeholderIdentifier="IBFirstResponder" id="4vV-ZD-7se" userLabel="First Responder" sceneMemberID="firstResponder"/>
+            </objects>
+            <point key="canvasLocation" x="-478" y="146"/>
         </scene>
     </scenes>
 </document>

--- a/examples/swift-ios/bugsnag-example/ViewController.swift
+++ b/examples/swift-ios/bugsnag-example/ViewController.swift
@@ -20,43 +20,50 @@
 
 import UIKit
 
-class ViewController: UIViewController {
+class ViewController: UITableViewController {
 
-    override func viewDidLoad() {
-        super.viewDidLoad()
-    }
-
-    @IBAction func doCrash(_ sender: AnyObject) {
-        handledError()
-    }
-
-    func unhandledCrash() {
-        AnObjCClass().raise()
-    }
-
-    func handledError() {
-        let error = NSError(domain: "com.bugsnag", code: 402, userInfo: nil)
-        Bugsnag.notifyError(error)
-    }
-
-    func handledException() {
-        let ex = NSException(name: NSExceptionName("handled exception"), reason: "Should've had coffee", userInfo: nil)
-        Bugsnag.notify(ex)
-    }
-
-    func callbackModifiedException() {
-        let ex = NSException(name: NSExceptionName("handled exception in callback"), reason: "Should've had coffee", userInfo: nil)
-        Bugsnag.notify(ex) { (report) in
-            report.severity = .info
+    @IBAction func generateUncaughtException(_ sender: AnyObject) {
+        let someJson : Dictionary = ["foo":self]
+        do {
+            let data = try JSONSerialization.data(withJSONObject: someJson, options: .prettyPrinted)
+            print("Received data: %@", data)
+        } catch {
+            // Why does this crash the app? A very good question.
         }
     }
 
-    func userSetSeverity() {
-        let ex = NSException(name: NSExceptionName("handled exception with custom severity"), reason: "Should've had coffee", userInfo: nil)
-        Bugsnag.notify(ex, withData: nil, atSeverity: "error")
+    @IBAction func generatePOSIXSignal(_ sender: Any) {
+        AnObjCClass().trap()
     }
 
-    func signal() {
-        AnObjCClass().trap()
+    @IBAction func generateStackOverflow(_ sender: Any) {
+        let items = ["Something!"]
+
+        if sender is ViewController || sender is UIButton {
+            generateStackOverflow(self)
+        }
+
+        print("items: %@", items)
+    }
+
+    @IBAction func generateMemoryCorruption(_ sender: Any) {
+        AnObjCClass().corruptSomeMemory()
+    }
+
+    @IBAction func generateAssertionFailure(_ sender: Any) {
+        AnotherClass.crash3()
+    }
+
+    @IBAction func sendAnError(_ sender: Any) {
+
+
+        do {
+            try FileManager.default.removeItem(atPath:"//invalid/file")
+        } catch {
+            Bugsnag.notifyError(error) { report in
+                // modify report properties in the (optional) block
+                report.severity = .info
+            }
+        }
     }
 }

--- a/iOS/Bugsnag.xcodeproj/project.xcworkspace/xcshareddata/IDEWorkspaceChecks.plist
+++ b/iOS/Bugsnag.xcodeproj/project.xcworkspace/xcshareddata/IDEWorkspaceChecks.plist
@@ -1,0 +1,8 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
+<plist version="1.0">
+<dict>
+	<key>IDEDidComputeMac32BitWarning</key>
+	<true/>
+</dict>
+</plist>


### PR DESCRIPTION
## Goal

Did some general cleanup on the example iOS apps to remove unused bits, use more common crash types, simplify config, and make the app vaguely more attractive.

<img width="200" alt="example-app" src="https://user-images.githubusercontent.com/333454/58110900-50d0c880-7be8-11e9-831b-872064a94d61.png">
