### PR TITLE
enable latest simulator SDK by default

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,5 +1,5 @@
 ifeq ($(SDK),)
- SDK=iphonesimulator11.2
+ SDK=iphonesimulator
 endif
 ifeq ($(BUILD_OSX), 1)
  PLATFORM=OSX
@@ -15,7 +15,7 @@ else
   PLATFORM=iOS
   RELEASE_DIR=Release-iphoneos
   BUILD_FLAGS=-workspace iOS.xcworkspace -scheme Bugsnag -derivedDataPath build
-  BUILD_ONLY_FLAGS=-sdk $(SDK) -destination "platform=iOS Simulator,name=iPhone 5" -configuration Debug
+  BUILD_ONLY_FLAGS=-sdk $(SDK) -destination "platform=iOS Simulator,name=iPhone 5s" -configuration Debug
  endif
 endif
 XCODEBUILD=set -o pipefail && xcodebuild

--- a/features/fixtures/ios-swift-cocoapods/Podfile.lock
+++ b/features/fixtures/ios-swift-cocoapods/Podfile.lock
@@ -1,5 +1,5 @@
 PODS:
-  - Bugsnag (5.17.3)
+  - Bugsnag (5.22.1)
 
 DEPENDENCIES:
   - Bugsnag (from `../../..`)
@@ -9,7 +9,7 @@ EXTERNAL SOURCES:
     :path: "../../.."
 
 SPEC CHECKSUMS:
-  Bugsnag: 45ee8446ac012adc1fb24224839cd4d941b09448
+  Bugsnag: 2f44880d3f61a629adfb846baa86da18e8ab4721
 
 PODFILE CHECKSUM: 4d026fb83571f098c9fb4fa71c1564c72c55ab1a
 


### PR DESCRIPTION
use iPhone 5s by default as iPhone 5 is no longer supported by latest Xcode

## Goal

Enable running tests from the command line using latest version of Xcode:
`make test`

## Design

Developer can still override SDK

## Changeset

Podfile.lock was automatically updated to the latest Bugsnag pod

## Tests

`make test`

## Review

### Outstanding Questions

- This pull request is ready for:
  - [] Initial review of the intended approach, not yet feature complete
  - [ ] Structural review of the classes, functions, and properties modified
  - [X] Final review

<!-- What do you need from a reviewer to get this changeset
     ready for release -->

- [] The correct target branch has been selected (`master` for fixes, `next` for
  features)
- [ ] Consistency across platforms for structures or concepts added or modified
- [ ] Consistency between the changeset and the goal stated above
- [ ] Internal consistency with the rest of the library - is there any overlap between existing interfaces and any which have been added?
- [X] Usage friction - is the proposed change in usage cumbersome or complicated?
- [ ] Performance and complexity - are there any cases of unexpected O(n^3) when iterating, recursing, flat mapping, etc?
- [ ] Concurrency concerns - if components are accessed asynchronously, what issues will arise
- [ ] Thoroughness of added tests and any missing edge cases
- [ ] Idiomatic use of the language
