### PR TITLE
Run tests against old OS versions

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -9,8 +9,8 @@ matrix:
           env: PLATFORM=iOS
           script:
             - make test
-            - make test DESTINATION="platform=iOS Simulator,name=iPhone 5s,OS=10.3.1"
-            - make test DESTINATION="platform=iOS Simulator,name=iPhone 5s,OS=9.3"
+            - make test OS=10.3.1
+            - make test OS=9.3
         - osx_image: xcode9.4
           env: PLATFORM=OSX
           script:
@@ -19,8 +19,8 @@ matrix:
           env: PLATFORM=tvOS
           script:
             - make test
-            - make test DESTINATION="platform=tvOS Simulator,name=Apple TV,OS=10.2"
-            - make test DESTINATION="platform=tvOS Simulator,name=Apple TV,OS=9.3"
+            - make test OS=10.2
+            - make test OS=9.2
         - osx_image: xcode9.2
           env: MAZE_SDK=11.2 SDK=iphonesimulator11.2
           script: bundle exec maze-runner -c

--- a/.travis.yml
+++ b/.travis.yml
@@ -6,10 +6,13 @@ rvm: 2.4.3
 matrix:
     include:
         - osx_image: xcode9.4
-          env: SDK=iphonesimulator11.4
-          script: make test
+          env: PLATFORM=iOS
+          script:
+            make test
+            make test DESTINATION="platform=iOS Simulator,name=iPhone 5s,OS=10.3.1"
+            make test DESTINATION="platform=iOS Simulator,name=iPhone 5s,OS=9.3"
         - osx_image: xcode9.4
-          env: SDK=appletvsimulator11.4 BUILD_TV=1
+          env: PLATFORM=tvOS
           script: make test
 install: make bootstrap
 

--- a/.travis.yml
+++ b/.travis.yml
@@ -8,12 +8,14 @@ matrix:
         - osx_image: xcode9.4
           env: PLATFORM=iOS
           script:
-            make test
-            make test DESTINATION="platform=iOS Simulator,name=iPhone 5s,OS=10.3.1"
-            make test DESTINATION="platform=iOS Simulator,name=iPhone 5s,OS=9.3"
+            - make test
+            - make test DESTINATION="platform=iOS Simulator,name=iPhone 5s,OS=10.3.1"
+            - make test DESTINATION="platform=iOS Simulator,name=iPhone 5s,OS=9.3"
         - osx_image: xcode9.4
           env: PLATFORM=tvOS
-          script: make test
+          script:
+            - make test
+            - make test DESTINATION="platform=tvOS Simulator,name=Apple TV,OS=10.2"
 install: make bootstrap
 
 before_deploy: headerdoc2html -o docs Source -j; gatherheaderdoc docs; mv docs/masterTOC.html docs/index.html

--- a/.travis.yml
+++ b/.travis.yml
@@ -12,10 +12,18 @@ matrix:
             - make test DESTINATION="platform=iOS Simulator,name=iPhone 5s,OS=10.3.1"
             - make test DESTINATION="platform=iOS Simulator,name=iPhone 5s,OS=9.3"
         - osx_image: xcode9.4
+          env: PLATFORM=OSX
+          script:
+            - make test
+        - osx_image: xcode9.4
           env: PLATFORM=tvOS
           script:
             - make test
             - make test DESTINATION="platform=tvOS Simulator,name=Apple TV,OS=10.2"
+            - make test DESTINATION="platform=tvOS Simulator,name=Apple TV,OS=9.3"
+        - osx_image: xcode9.2
+          env: MAZE_SDK=11.2 SDK=iphonesimulator11.2
+          script: bundle exec maze-runner -c
 install: make bootstrap
 
 before_deploy: headerdoc2html -o docs Source -j; gatherheaderdoc docs; mv docs/masterTOC.html docs/index.html

--- a/.travis.yml
+++ b/.travis.yml
@@ -6,17 +6,11 @@ rvm: 2.4.3
 matrix:
     include:
         - osx_image: xcode9.4
-          env: SDK=macosx10.13 BUILD_OSX=1
-          script: make test
-        - osx_image: xcode9.4
           env: SDK=iphonesimulator11.4
           script: make test
         - osx_image: xcode9.4
           env: SDK=appletvsimulator11.4 BUILD_TV=1
           script: make test
-        - osx_image: xcode9.2
-          env: MAZE_SDK=11.2 SDK=iphonesimulator11.2
-          script: bundle exec maze-runner -c
 install: make bootstrap
 
 before_deploy: headerdoc2html -o docs Source -j; gatherheaderdoc docs; mv docs/masterTOC.html docs/index.html

--- a/Makefile
+++ b/Makefile
@@ -1,4 +1,5 @@
 PLATFORM?=iOS
+OS?=latest
 
 ifeq ($(PLATFORM),OSX)
  SDK?=macosx
@@ -9,12 +10,12 @@ ifeq ($(PLATFORM),OSX)
 else
  ifeq ($(PLATFORM),tvOS)
   SDK?=appletvsimulator
-	DESTINATION?=platform=tvOS Simulator,name=Apple TV
+	DESTINATION?=platform=tvOS Simulator,name=Apple TV,OS=$(OS)
   BUILD_FLAGS=-workspace tvOS.xcworkspace -scheme Bugsnag -derivedDataPath build
   BUILD_ONLY_FLAGS=-sdk $(SDK) -configuration Debug -destination "$(DESTINATION)"
  else
   SDK?=iphonesimulator
-	DESTINATION?=platform=iOS Simulator,name=iPhone 5s
+	DESTINATION?=platform=iOS Simulator,name=iPhone 5s,OS=$(OS)
   RELEASE_DIR=Release-iphoneos
   BUILD_FLAGS=-workspace iOS.xcworkspace -scheme Bugsnag -derivedDataPath build
   BUILD_ONLY_FLAGS=-sdk $(SDK) -destination "$(DESTINATION)" -configuration Debug

--- a/Makefile
+++ b/Makefile
@@ -21,7 +21,7 @@ else
   PLATFORM=iOS
   RELEASE_DIR=Release-iphoneos
   BUILD_FLAGS=-workspace iOS.xcworkspace -scheme Bugsnag -derivedDataPath build
-  BUILD_ONLY_FLAGS=-sdk $(SDK) -destination "platform=iOS Simulator,name=iPhone 5s" -configuration Debug
+  BUILD_ONLY_FLAGS=-sdk $(SDK) -destination "platform=iOS Simulator,name=iPhone 5s" -destination "platform=iOS Simulator,name=iPhone 5s,OS=9.3" -destination "platform=iOS Simulator,name=iPhone 5s,OS=10.3.1" -configuration Debug
  endif
 endif
 XCODEBUILD=set -o pipefail && xcodebuild
@@ -95,7 +95,7 @@ clean: ## Clean build artifacts
 	@rm -rf build
 
 test: ## Run unit tests
-	@$(XCODEBUILD) $(BUILD_FLAGS) $(BUILD_ONLY_FLAGS) -destination "platform=iOS Simulator,name=iPhone 5s,OS=9.3" -destination "platform=iOS Simulator,name=iPhone 5s,OS=10.3" test $(FORMATTER)
+	@$(XCODEBUILD) $(BUILD_FLAGS) $(BUILD_ONLY_FLAGS) test $(FORMATTER)
 
 e2e: ## Run integration tests
 	@bundle exec maze-runner

--- a/Makefile
+++ b/Makefile
@@ -1,25 +1,22 @@
 PLATFORM?=iOS
 OS?=latest
+BUILD_FLAGS=-workspace $(PLATFORM).xcworkspace -scheme Bugsnag -derivedDataPath build
 
 ifeq ($(PLATFORM),OSX)
  SDK?=macosx
  PLATFORM=OSX
  RELEASE_DIR=Release
- BUILD_FLAGS=-workspace OSX.xcworkspace -scheme Bugsnag -derivedDataPath build
  BUILD_ONLY_FLAGS=-sdk $(SDK) CODE_SIGN_IDENTITY="" CODE_SIGNING_REQUIRED=NO
 else
  ifeq ($(PLATFORM),tvOS)
   SDK?=appletvsimulator
 	DESTINATION?=platform=tvOS Simulator,name=Apple TV,OS=$(OS)
-  BUILD_FLAGS=-workspace tvOS.xcworkspace -scheme Bugsnag -derivedDataPath build
-  BUILD_ONLY_FLAGS=-sdk $(SDK) -configuration Debug -destination "$(DESTINATION)"
  else
   SDK?=iphonesimulator
 	DESTINATION?=platform=iOS Simulator,name=iPhone 5s,OS=$(OS)
   RELEASE_DIR=Release-iphoneos
-  BUILD_FLAGS=-workspace iOS.xcworkspace -scheme Bugsnag -derivedDataPath build
-  BUILD_ONLY_FLAGS=-sdk $(SDK) -destination "$(DESTINATION)" -configuration Debug
  endif
+ BUILD_ONLY_FLAGS=-sdk $(SDK) -destination "$(DESTINATION)" -configuration Debug
 endif
 XCODEBUILD=set -o pipefail && xcodebuild
 PRESET_VERSION=$(shell cat VERSION)

--- a/Makefile
+++ b/Makefile
@@ -95,7 +95,7 @@ clean: ## Clean build artifacts
 	@rm -rf build
 
 test: ## Run unit tests
-	@$(XCODEBUILD) $(BUILD_FLAGS) $(BUILD_ONLY_FLAGS) test $(FORMATTER)
+	@$(XCODEBUILD) $(BUILD_FLAGS) $(BUILD_ONLY_FLAGS) -destination "platform=iOS Simulator,name=iPhone 5s,OS=9.3" -destination "platform=iOS Simulator,name=iPhone 5s,OS=10.3" test $(FORMATTER)
 
 e2e: ## Run integration tests
 	@bundle exec maze-runner

--- a/Makefile
+++ b/Makefile
@@ -4,16 +4,15 @@ BUILD_FLAGS=-workspace $(PLATFORM).xcworkspace -scheme Bugsnag -derivedDataPath 
 
 ifeq ($(PLATFORM),OSX)
  SDK?=macosx
- PLATFORM=OSX
  RELEASE_DIR=Release
  BUILD_ONLY_FLAGS=-sdk $(SDK) CODE_SIGN_IDENTITY="" CODE_SIGNING_REQUIRED=NO
 else
  ifeq ($(PLATFORM),tvOS)
   SDK?=appletvsimulator
-	DESTINATION?=platform=tvOS Simulator,name=Apple TV,OS=$(OS)
+  DESTINATION?=platform=tvOS Simulator,name=Apple TV,OS=$(OS)
  else
   SDK?=iphonesimulator
-	DESTINATION?=platform=iOS Simulator,name=iPhone 5s,OS=$(OS)
+  DESTINATION?=platform=iOS Simulator,name=iPhone 5s,OS=$(OS)
   RELEASE_DIR=Release-iphoneos
  endif
  BUILD_ONLY_FLAGS=-sdk $(SDK) -destination "$(DESTINATION)" -configuration Debug

--- a/Makefile
+++ b/Makefile
@@ -1,27 +1,23 @@
-ifeq ($(BUILD_OSX), 1)
- ifeq ($(SDK),)
-  SDK=macosx
- endif
+PLATFORM?=iOS
+
+ifeq ($(PLATFORM),OSX)
+ SDK?=macosx
  PLATFORM=OSX
  RELEASE_DIR=Release
  BUILD_FLAGS=-workspace OSX.xcworkspace -scheme Bugsnag -derivedDataPath build
  BUILD_ONLY_FLAGS=-sdk $(SDK) CODE_SIGN_IDENTITY="" CODE_SIGNING_REQUIRED=NO
 else
- ifeq ($(BUILD_TV), 1)
-  ifeq ($(SDK),)
-   SDK=appletvsimulator
-  endif
-  PLATFORM=tvOS
+ ifeq ($(PLATFORM),tvOS)
+  SDK?=appletvsimulator
+	DESTINATION?=platform=tvOS Simulator,name=Apple TV
   BUILD_FLAGS=-workspace tvOS.xcworkspace -scheme Bugsnag -derivedDataPath build
-  BUILD_ONLY_FLAGS=-sdk $(SDK) -configuration Debug -destination "platform=tvOS Simulator,name=Apple TV"
+  BUILD_ONLY_FLAGS=-sdk $(SDK) -configuration Debug -destination "$(DESTINATION)"
  else
-  ifeq ($(SDK),)
-   SDK=iphonesimulator
-  endif
-  PLATFORM=iOS
+  SDK?=iphonesimulator
+	DESTINATION?=platform=iOS Simulator,name=iPhone 5s
   RELEASE_DIR=Release-iphoneos
   BUILD_FLAGS=-workspace iOS.xcworkspace -scheme Bugsnag -derivedDataPath build
-  BUILD_ONLY_FLAGS=-sdk $(SDK) -destination "platform=iOS Simulator,name=iPhone 5s" -destination "platform=iOS Simulator,name=iPhone 5s,OS=9.3" -destination "platform=iOS Simulator,name=iPhone 5s,OS=10.3.1" -configuration Debug
+  BUILD_ONLY_FLAGS=-sdk $(SDK) -destination "$(DESTINATION)" -configuration Debug
  endif
 endif
 XCODEBUILD=set -o pipefail && xcodebuild


### PR DESCRIPTION
## Goal

Build once using the latest compatible SDK and run tests against latest and previous versions of OS.

## Design

Instead of using old no longer supported SDKs, use the latest SDK to build tests.
To verify product works with older versions of OS run tests multiple times

## Changeset

Refactor Makefile to specify PLATFORM
Refactor Makefile to allow either specifying DESTINATION or OS, like
make test DESTINATION="platform=iOS Simulator,name=iPhone 8"
or
make test OS=9.3
resulting DESTINATION="platform=iOS Simulator,name=iPhone 5s,OS=9.3"

## Tests

added tests for Apple TV 9.2 and 10.2 in addition to latest 11.4
added tests for iOS 9.3 and 10.3.1 in addition to latest 11.4

## Review

### Outstanding Questions

- This pull request is ready for:
  - [ ] Initial review of the intended approach, not yet feature complete
  - [ ] Structural review of the classes, functions, and properties modified
  - [X] Final review

<!-- What do you need from a reviewer to get this changeset
     ready for release -->

- [ ] The correct target branch has been selected (`master` for fixes, `next` for
  features)
- [X] Consistency across platforms for structures or concepts added or modified
- [ ] Consistency between the changeset and the goal stated above
- [ ] Internal consistency with the rest of the library - is there any overlap between existing interfaces and any which have been added?
- [ ] Usage friction - is the proposed change in usage cumbersome or complicated?
- [ ] Performance and complexity - are there any cases of unexpected O(n^3) when iterating, recursing, flat mapping, etc?
- [ ] Concurrency concerns - if components are accessed asynchronously, what issues will arise
- [ ] Thoroughness of added tests and any missing edge cases
- [ ] Idiomatic use of the language