### PR TITLE
ci: Update end-to-end tests environment

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -21,8 +21,8 @@ matrix:
             - make test
             - make test OS=10.2
             - make test OS=9.2
-        - osx_image: xcode9.2
-          env: MAZE_SDK=11.2 SDK=iphonesimulator11.2
+        - osx_image: xcode10.1
+          env: MAZE_SDK=12.1 SDK=iphonesimulator12.1
           script: bundle exec maze-runner -c
 install: make bootstrap
 

--- a/.travis.yml
+++ b/.travis.yml
@@ -23,7 +23,7 @@ matrix:
             - make test OS=9.2
         - osx_image: xcode10.1
           env: MAZE_SDK=12.1 SDK=iphonesimulator12.1
-          script: bundle exec maze-runner -c
+          script: bundle exec maze-runner -c || (cat maze_output/* && exit 1)
 install: make bootstrap
 
 before_deploy: headerdoc2html -o docs Source -j; gatherheaderdoc docs; mv docs/masterTOC.html docs/index.html

--- a/features/scripts/build_ios_app.sh
+++ b/features/scripts/build_ios_app.sh
@@ -9,7 +9,7 @@ xcrun xcodebuild \
   -scheme iOSTestApp \
   -workspace iOSTestApp.xcworkspace \
   -configuration Debug \
-  -destination 'platform=iOS Simulator,name=iPhone 8,OS=11.2' \
+  -destination 'platform=iOS Simulator,name=iPhone 8,OS=12.1' \
   -derivedDataPath build \
   -quiet \
   clean build

--- a/features/scripts/build_ios_app.sh
+++ b/features/scripts/build_ios_app.sh
@@ -9,7 +9,7 @@ xcrun xcodebuild \
   -scheme iOSTestApp \
   -workspace iOSTestApp.xcworkspace \
   -configuration Debug \
-  -destination 'platform=iOS Simulator,name=iPhone 8,OS=12.1' \
+  -destination "platform=iOS Simulator,name=iPhone 8,OS=$MAZE_SDK" \
   -derivedDataPath build \
   -quiet \
   clean build

--- a/features/scripts/launch_ios_simulators.sh
+++ b/features/scripts/launch_ios_simulators.sh
@@ -1,7 +1,7 @@
 #!/usr/bin/env bash
 
 INSTALL_PATH=build/Build/Products/Debug-iphonesimulator/iOSTestApp.app
-OS_VERSION=${MAZE_SDK:="11.2"}
+OS_VERSION=${MAZE_SDK:="12.1"}
 
 # Create required simulators
 xcrun simctl create "maze-sim" "iPhone 8" "$OS_VERSION"

--- a/features/scripts/launch_ios_simulators.sh
+++ b/features/scripts/launch_ios_simulators.sh
@@ -3,13 +3,8 @@
 INSTALL_PATH=build/Build/Products/Debug-iphonesimulator/iOSTestApp.app
 HOST_OS_VERSION=$(sw_vers | grep ProductVersion)
 OS_VERSION=${MAZE_SDK:="12.1"}
-
-if [[ $HOST_OS_VERSION == "ProductVersion: 10.13"* ]]; then
-SIM_DEVICE="iPhone 8"
-else
 OS_VERSION=com.apple.CoreSimulator.SimRuntime.iOS-"${OS_VERSION//\./$'-'}"
-SIM_DEVICE=com.apple.CoreSimulator.SimDeviceType.iPhone-8
-fi
+SIM_DEVICE="iPhone 8"
 
 # Create required simulators
 xcrun simctl create "maze-sim" "$SIM_DEVICE" "$OS_VERSION"

--- a/features/scripts/launch_ios_simulators.sh
+++ b/features/scripts/launch_ios_simulators.sh
@@ -1,10 +1,18 @@
 #!/usr/bin/env bash
 
 INSTALL_PATH=build/Build/Products/Debug-iphonesimulator/iOSTestApp.app
+HOST_OS_VERSION=$(sw_vers | grep ProductVersion)
 OS_VERSION=${MAZE_SDK:="12.1"}
 
+if [[ $HOST_OS_VERSION == "ProductVersion: 10.13"* ]]; then
+SIM_DEVICE="iPhone 8"
+else
+OS_VERSION=com.apple.CoreSimulator.SimRuntime.iOS-"${OS_VERSION//\./$'-'}"
+SIM_DEVICE=com.apple.CoreSimulator.SimDeviceType.iPhone-8
+fi
+
 # Create required simulators
-xcrun simctl create "maze-sim" "iPhone 8" "$OS_VERSION"
+xcrun simctl create "maze-sim" "$SIM_DEVICE" "$OS_VERSION"
 
 # Simulators used in the test suite:
 xcrun simctl boot "maze-sim"; true

--- a/features/scripts/launch_ios_simulators.sh
+++ b/features/scripts/launch_ios_simulators.sh
@@ -2,7 +2,7 @@
 
 INSTALL_PATH=build/Build/Products/Debug-iphonesimulator/iOSTestApp.app
 HOST_OS_VERSION=$(sw_vers | grep ProductVersion)
-OS_VERSION=${MAZE_SDK:="12.1"}
+OS_VERSION=$MAZE_SDK
 OS_VERSION=com.apple.CoreSimulator.SimRuntime.iOS-"${OS_VERSION//\./$'-'}"
 SIM_DEVICE="iPhone 8"
 

--- a/features/session_tracking.feature
+++ b/features/session_tracking.feature
@@ -13,7 +13,7 @@ Scenario: Launching using the default configuration sends a single session
     And the payload field "app.bundleVersion" equals "5"
     And the payload field "app.releaseStage" equals "development"
     And the payload field "app.type" equals "iOS"
-    And the payload field "device.osVersion" equals "11.2"
+    And the payload field "device.osVersion" equals "12.1"
     And the payload field "device.osName" equals "iOS"
     And the payload field "device.model" equals "iPhone10,4"
 
@@ -36,7 +36,7 @@ Scenario: Configuring a custom version sends it in a session request
     And the payload field "app.bundleVersion" equals "5"
     And the payload field "app.releaseStage" equals "development"
     And the payload field "app.type" equals "iOS"
-    And the payload field "device.osVersion" equals "11.2"
+    And the payload field "device.osVersion" equals "12.1"
     And the payload field "device.osName" equals "iOS"
     And the payload field "device.model" equals "iPhone10,4"
 

--- a/features/session_tracking.feature
+++ b/features/session_tracking.feature
@@ -13,7 +13,7 @@ Scenario: Launching using the default configuration sends a single session
     And the payload field "app.bundleVersion" equals "5"
     And the payload field "app.releaseStage" equals "development"
     And the payload field "app.type" equals "iOS"
-    And the payload field "device.osVersion" equals "12.1"
+    And the payload field "device.osVersion" equals the device version
     And the payload field "device.osName" equals "iOS"
     And the payload field "device.model" equals "iPhone10,4"
 
@@ -36,7 +36,7 @@ Scenario: Configuring a custom version sends it in a session request
     And the payload field "app.bundleVersion" equals "5"
     And the payload field "app.releaseStage" equals "development"
     And the payload field "app.type" equals "iOS"
-    And the payload field "device.osVersion" equals "12.1"
+    And the payload field "device.osVersion" equals the device version
     And the payload field "device.osName" equals "iOS"
     And the payload field "device.model" equals "iPhone10,4"
 

--- a/features/steps/crash_assertion_steps.rb
+++ b/features/steps/crash_assertion_steps.rb
@@ -2,16 +2,27 @@ Then("The exception reflects malloc corruption occurred") do
   # Two different outcomes can arise from this scenario, either:
   # * Write will fail on non-writable memory
   # * malloc fails in NSLog
+  #
+  # Depending on OS version, this changes the stacktrace contents
   body = find_request(0)[:body]
   exception = read_key_path(body, "events.0.exceptions.0")
   stacktrace = exception["stacktrace"]
   assert_true(stacktrace.length > 0, "The stacktrace must have more than 0 elements")
 
   case stacktrace.first["method"]
-  when "__pthread_kill"
+  when "__pthread_kill" # Any
     assert_equal(exception["errorClass"], "SIGABRT")
     assert_equal(stacktrace[1]["method"], "abort")
-  when "_nc_table_find_64"
+  when "nanov2_allocate_from_block" # iOS 12.1
+    assert_equal(exception["errorClass"], "EXC_BAD_INSTRUCTION")
+    assert_equal(stacktrace[1]["method"], "nanov2_allocate")
+    assert_equal(stacktrace[15]["method"], "NSLog")
+    assert_equal(stacktrace[16]["method"], "-[CorruptMallocScenario run]")
+  when "notify_dump_status" # iOS 12.1
+    assert_equal(exception["errorClass"], "EXC_BAD_ACCESS")
+    assert_equal(stacktrace[10]["method"], "NSLog")
+    assert_equal(stacktrace[11]["method"], "-[CorruptMallocScenario run]")
+  when "_nc_table_find_64" # iOS 11.2
     # We don't know whether the mach handler or the signal handler will catch this
     assert_true(["SIGSEGV", "EXC_BAD_ACCESS"].include?(exception["errorClass"]), "Error class was '#{exception["errorClass"]}'")
     assert_true(

--- a/features/steps/ios_steps.rb
+++ b/features/steps/ios_steps.rb
@@ -1,4 +1,7 @@
+SLOW_CI_TESTS = ['PrivilegedInstructionScenario', 'BuiltinTrapScenario']
+
 When("I run {string}") do |event_type|
+  @scenario_class = event_type
   wait_time = '4'
   steps %Q{
     When I set environment variable "BUGSNAG_API_KEY" to "a35a2a72bd230ac0aa0f52715bbdc6aa"
@@ -9,7 +12,8 @@ When("I run {string}") do |event_type|
 end
 
 When("I launch the app") do
-  wait_time = '4'
+  wait_time = 4
+  wait_time += 10 if RUNNING_CI && SLOW_CI_TESTS.include?(@scenario_class)
   steps %Q{
     When I run the script "features/scripts/launch_ios_app.sh"
     And I wait for #{wait_time} seconds
@@ -17,12 +21,14 @@ When("I launch the app") do
 end
 When("I relaunch the app") do
   wait_time = RUNNING_CI ? 20 : 5
+  wait_time += 40 if RUNNING_CI && SLOW_CI_TESTS.include?(@scenario_class)
   steps %Q{
     When I run the script "features/scripts/launch_ios_app.sh"
     And I wait for #{wait_time} seconds
   }
 end
 When("I crash the app using {string}") do |event|
+  @scenario_class = event
   steps %Q{
     When I set environment variable "EVENT_TYPE" to "#{event}"
     And I set environment variable "EVENT_MODE" to "normal"

--- a/features/steps/ios_steps.rb
+++ b/features/steps/ios_steps.rb
@@ -20,7 +20,7 @@ When("I launch the app") do
   }
 end
 When("I relaunch the app") do
-  wait_time = RUNNING_CI ? 20 : 5
+  wait_time = RUNNING_CI ? 20 : 10
   wait_time += 40 if RUNNING_CI && SLOW_CI_TESTS.include?(@scenario_class)
   steps %Q{
     When I run the script "features/scripts/launch_ios_app.sh"

--- a/features/steps/ios_steps.rb
+++ b/features/steps/ios_steps.rb
@@ -124,3 +124,7 @@ Then("the stack trace is an array with {int} stack frames") do |expected_length|
   stack_trace = read_key_path(find_request(0)[:body], "events.0.exceptions.0.stacktrace")
   assert_equal(stack_trace.length, expected_length)
 end
+Then("the payload field {string} equals the device version") do |field|
+  value = read_key_path(find_request(0)[:body], field)
+  assert_equal(MAZE_SDK, value)
+end

--- a/features/steps/ios_steps.rb
+++ b/features/steps/ios_steps.rb
@@ -16,7 +16,7 @@ When("I launch the app") do
   }
 end
 When("I relaunch the app") do
-  wait_time = '4'
+  wait_time = RUNNING_CI ? 20 : 5
   steps %Q{
     When I run the script "features/scripts/launch_ios_app.sh"
     And I wait for #{wait_time} seconds

--- a/features/support/env.rb
+++ b/features/support/env.rb
@@ -5,6 +5,9 @@
 
 RUNNING_CI = ENV['TRAVIS'] == 'true'
 
+ENV['MAZE_SDK'] = '12.1' unless ENV['MAZE_SDK']
+MAZE_SDK = ENV['MAZE_SDK']
+
 Dir.chdir('features/fixtures/ios-swift-cocoapods') do
   run_required_commands([
     ['bundle', 'install'],


### PR DESCRIPTION
* Bumps the SDK version on CI
* Updates the wait time for crash reports
* Printing failing request payloads on CI (if any)
* Support Xcode 10.2 `simctl create` format