### PR TITLE
support selecting simulators independent of xcode version

### DIFF
--- a/features/scripts/launch_ios_simulators.sh
+++ b/features/scripts/launch_ios_simulators.sh
@@ -3,13 +3,8 @@
 INSTALL_PATH=build/Build/Products/Debug-iphonesimulator/iOSTestApp.app
 XCODE_VERSION=$(xcodebuild -version)
 OS_VERSION=${MAZE_SDK:="12.1"}
-
-if [[ $XCODE_VERSION == "Xcode 10.1"* ]]; then
-SIM_DEVICE="iPhone 8"
-else
 OS_VERSION=com.apple.CoreSimulator.SimRuntime.iOS-"${OS_VERSION//\./$'-'}"
-SIM_DEVICE=com.apple.CoreSimulator.SimDeviceType.iPhone-8
-fi
+SIM_DEVICE="iPhone 8"
 
 # Create required simulators
 xcrun simctl create "maze-sim" "$SIM_DEVICE" "$OS_VERSION"


### PR DESCRIPTION
## Goal

<!-- What is the intent of this change? -->

<!--
Fixes #
Related to #
-->

## Design

<!-- How does this change work? Why was this approach to the goal used? -->

## Changeset

cleanup launch simulators, so we can use either Xcode 10.2.1 with downloaded SDK 11.2 or Xcode 10.1 with bundled 

## Tests

Passed on travis

## Review

