### PR TITLE
Fix acceptance tests running on Mojave

### DIFF
--- a/features/crashprobe.feature
+++ b/features/crashprobe.feature
@@ -183,8 +183,9 @@ Scenario: Trigger a crash with libsystem_pthread's _pthread_list_lock held
     And the payload field "events" is an array with 1 element
     And the exception "message" equals "Attempted to dereference garbage pointer 0x1."
     And the exception "errorClass" equals "EXC_BAD_ACCESS"
-    And the "method" of stack frame 1 equals "pthread_getname_np"
-    And the "method" of stack frame 2 equals "-[AsyncSafeThreadScenario run]"
+    And the stacktrace contains methods:
+    |pthread_getname_np|
+    |-[AsyncSafeThreadScenario run]|
 
 Scenario: Read a garbage pointer
     When I set environment variable "BUGSNAG_API_KEY" to "a35a2a72bd230ac0aa0f52715bbdc6aa"

--- a/features/steps/ios_steps.rb
+++ b/features/steps/ios_steps.rb
@@ -134,3 +134,11 @@ Then("the payload field {string} equals the device version") do |field|
   value = read_key_path(find_request(0)[:body], field)
   assert_equal(MAZE_SDK, value)
 end
+
+Then("the stacktrace contains methods:") do |table|
+  stack_trace = read_key_path(find_request(0)[:body], "events.0.exceptions.0.stacktrace")
+  expected = table.raw.flatten
+  actual = stack_trace.map{|s| s["method"]}
+  contains = actual.each_cons(expected.length).to_a.include? expected
+  assert_true(contains, "Stacktrace methods #{actual} did not contain #{expected}")
+end


### PR DESCRIPTION
## Goal

Verify stack trace contains list of methods (in order)

Fixes failure on when running on Mojave when simulator runtime contains an extra method
`_platform_strlcpy` in addition to expected `pthread_getname_np` and `-[AsyncSafeThreadScenario run]`

## Tests

Locally on Mojave and on High Sierra on travis

## Review

### Outstanding Questions

Can new step be reused somewhere else?

- This pull request is ready for:
  - [X] Initial review of the intended approach, not yet feature complete
  - [X] Structural review of the classes, functions, and properties modified
  - [X] Final review

<!-- What do you need from a reviewer to get this changeset
     ready for release -->

- [x] Internal consistency with the rest of the library - is there any overlap between existing interfaces and any which have been added?
- [x] Usage friction - is the proposed change in usage cumbersome or complicated?
- [x] Idiomatic use of the language