### PR TITLE
fix(codec): Parse numbers in arrays correctly

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,8 @@ Changelog
   property.
   [Paul Zabelin](https://github.com/paulz)
   [#363](https://github.com/bugsnag/bugsnag-cocoa/pull/363)
+* Fix crash report parsing logic around arrays of numbers. Metadata which
+  included arrays of numbers could previously had missing values.
 
 
 ## 5.22.1 (2019-05-21)

--- a/Source/KSCrash/Source/KSCrash/Recording/Tools/BSG_KSJSONCodec.c
+++ b/Source/KSCrash/Source/KSCrash/Recording/Tools/BSG_KSJSONCodec.c
@@ -974,9 +974,6 @@ int bsg_ksjsoncodec_i_decodeElement(const char **ptr, const char *const end,
         }
 
         if (!isFPChar(**ptr) && accum >= 0) {
-            if (name == NULL) {
-                return BSG_KSJSON_ERROR_INCOMPLETE;
-            }
             accum *= sign;
             return callbacks->onIntegerElement(name, accum, userData);
         }

--- a/Source/KSCrash/Source/KSCrash/Recording/Tools/BSG_KSJSONCodecObjC.m
+++ b/Source/KSCrash/Source/KSCrash/Recording/Tools/BSG_KSJSONCodecObjC.m
@@ -285,7 +285,7 @@ int bsg_ksjsoncodecobjc_i_onFloatingPointElement(const char *const cName,
 int bsg_ksjsoncodecobjc_i_onIntegerElement(const char *const cName,
                                            const long long value,
                                            void *const userData) {
-    NSString *name = cName == NULL ? nil : stringFromCString(cName);
+    NSString *name = stringFromCString(cName);
     id element = @(value);
     BSG_KSJSONCodec *codec = (__bridge BSG_KSJSONCodec *)userData;
     return bsg_ksjsoncodecobjc_i_onElement(codec, name, element);

--- a/Source/KSCrash/Source/KSCrash/Recording/Tools/BSG_KSJSONCodecObjC.m
+++ b/Source/KSCrash/Source/KSCrash/Recording/Tools/BSG_KSJSONCodecObjC.m
@@ -285,7 +285,7 @@ int bsg_ksjsoncodecobjc_i_onFloatingPointElement(const char *const cName,
 int bsg_ksjsoncodecobjc_i_onIntegerElement(const char *const cName,
                                            const long long value,
                                            void *const userData) {
-    NSString *name = stringFromCString(cName);
+    NSString *name = cName == NULL ? nil : stringFromCString(cName);
     id element = @(value);
     BSG_KSJSONCodec *codec = (__bridge BSG_KSJSONCodec *)userData;
     return bsg_ksjsoncodecobjc_i_onElement(codec, name, element);

--- a/Tests/KSCrash/KSJSONCodec_Tests.m
+++ b/Tests/KSCrash/KSJSONCodec_Tests.m
@@ -210,24 +210,24 @@ static NSString* toString(NSData* data)
     XCTAssertEqualObjects(result, original, @"");
 }
 
-//- (void)testSerializeDeserializeArrayMultipleEntries
-//{
-//    NSError* error = (NSError*)self;
-//    NSString* expected = @"[\"One\",1000,true]";
-//    id original = @[@"One",
-//            @1000,
-//            @YES];
-//    NSString* jsonString = toString([BSG_KSJSONCodec encode:original
-//                                                options:BSG_KSJSONEncodeOptionSorted
-//                                                  error:&error]);
-//    XCTAssertNotNil(jsonString, @"");
-//    XCTAssertNil(error, @"");
-//    XCTAssertEqualObjects(jsonString, expected, @"");
-//    id result = [BSG_KSJSONCodec decode:toData(jsonString) options:0 error:&error];
-//    XCTAssertNotNil(result, @"");
-//    XCTAssertNil(error, @"");
-//    XCTAssertEqualObjects(result, original, @"");
-//}
+- (void)testSerializeDeserializeArrayMultipleEntries
+{
+    NSError* error = (NSError*)self;
+    NSString* expected = @"[\"One\",1000,true]";
+    id original = @[@"One",
+            @1000,
+            @YES];
+    NSString* jsonString = toString([BSG_KSJSONCodec encode:original
+                                                options:BSG_KSJSONEncodeOptionSorted
+                                                  error:&error]);
+    XCTAssertNotNil(jsonString, @"");
+    XCTAssertNil(error, @"");
+    XCTAssertEqualObjects(jsonString, expected, @"");
+    id result = [BSG_KSJSONCodec decode:toData(jsonString) options:0 error:&error];
+    XCTAssertNotNil(result, @"");
+    XCTAssertNil(error, @"");
+    XCTAssertEqualObjects(result, original, @"");
+}
 
 - (void)testSerializeDeserializeArrayMultipleEntriesSorted
 {
@@ -814,107 +814,107 @@ static NSString* toString(NSData* data)
     XCTAssertTrue([[result objectAtIndex:0] floatValue] ==  [[original objectAtIndex:0] floatValue], @"");
 }
 
-//- (void) testSerializeDeserializeChar
-//{
-//    NSError* error = (NSError*)self;
-//    NSString* expected = @"[20]";
-//    id original = @[@20];
-//    NSString* jsonString = toString([BSG_KSJSONCodec encode:original
-//                                                options:BSG_KSJSONEncodeOptionSorted
-//                                                  error:&error]);
-//    XCTAssertNotNil(jsonString, @"");
-//    XCTAssertNil(error, @"");
-//    XCTAssertEqualObjects(jsonString, expected, @"");
-//    id result = [BSG_KSJSONCodec decode:toData(jsonString) options:0 error:&error];
-//    XCTAssertNotNil(result, @"");
-//    XCTAssertNil(error, @"");
-//    XCTAssertEqualObjects(result, original, @"");
-//}
-//
-//- (void) testSerializeDeserializeShort
-//{
-//    NSError* error = (NSError*)self;
-//    NSString* expected = @"[2000]";
-//    id original = @[@2000];
-//    NSString* jsonString = toString([BSG_KSJSONCodec encode:original
-//                                                options:BSG_KSJSONEncodeOptionSorted
-//                                                  error:&error]);
-//    XCTAssertNotNil(jsonString, @"");
-//    XCTAssertNil(error, @"");
-//    XCTAssertEqualObjects(jsonString, expected, @"");
-//    id result = [BSG_KSJSONCodec decode:toData(jsonString) options:0 error:&error];
-//    XCTAssertNotNil(result, @"");
-//    XCTAssertNil(error, @"");
-//    XCTAssertEqualObjects(result, original, @"");
-//}
-//
-//- (void) testSerializeDeserializeLong
-//{
-//    NSError* error = (NSError*)self;
-//    NSString* expected = @"[2000000000]";
-//    id original = @[@2000000000];
-//    NSString* jsonString = toString([BSG_KSJSONCodec encode:original
-//                                                options:BSG_KSJSONEncodeOptionSorted
-//                                                  error:&error]);
-//    XCTAssertNotNil(jsonString, @"");
-//    XCTAssertNil(error, @"");
-//    XCTAssertEqualObjects(jsonString, expected, @"");
-//    id result = [BSG_KSJSONCodec decode:toData(jsonString) options:0 error:&error];
-//    XCTAssertNotNil(result, @"");
-//    XCTAssertNil(error, @"");
-//    XCTAssertEqualObjects(result, original, @"");
-//}
-//
-//- (void) testSerializeDeserializeLongLong
-//{
-//    NSError* error = (NSError*)self;
-//    NSString* expected = @"[200000000000]";
-//    id original = @[@200000000000];
-//    NSString* jsonString = toString([BSG_KSJSONCodec encode:original
-//                                                options:BSG_KSJSONEncodeOptionSorted
-//                                                  error:&error]);
-//    XCTAssertNotNil(jsonString, @"");
-//    XCTAssertNil(error, @"");
-//    XCTAssertEqualObjects(jsonString, expected, @"");
-//    id result = [BSG_KSJSONCodec decode:toData(jsonString) options:0 error:&error];
-//    XCTAssertNotNil(result, @"");
-//    XCTAssertNil(error, @"");
-//    XCTAssertEqualObjects(result, original, @"");
-//}
-//
-//- (void) testSerializeDeserializeNegative
-//{
-//    NSError* error = (NSError*)self;
-//    NSString* expected = @"[-2000]";
-//    id original = @[@(-2000)];
-//    NSString* jsonString = toString([BSG_KSJSONCodec encode:original
-//                                                options:BSG_KSJSONEncodeOptionSorted
-//                                                  error:&error]);
-//    XCTAssertNotNil(jsonString, @"");
-//    XCTAssertNil(error, @"");
-//    XCTAssertEqualObjects(jsonString, expected, @"");
-//    id result = [BSG_KSJSONCodec decode:toData(jsonString) options:0 error:&error];
-//    XCTAssertNotNil(result, @"");
-//    XCTAssertNil(error, @"");
-//    XCTAssertEqualObjects(result, original, @"");
-//}
-//
-//- (void) testSerializeDeserialize0
-//{
-//    NSError* error = (NSError*)self;
-//    NSString* expected = @"[0]";
-//    id original = @[@0];
-//    NSString* jsonString = toString([BSG_KSJSONCodec encode:original
-//                                                options:BSG_KSJSONEncodeOptionSorted
-//                                                  error:&error]);
-//    XCTAssertNotNil(jsonString, @"");
-//    XCTAssertNil(error, @"");
-//    XCTAssertEqualObjects(jsonString, expected, @"");
-//    id result = [BSG_KSJSONCodec decode:toData(jsonString) options:0 error:&error];
-//    XCTAssertNotNil(result, @"");
-//    XCTAssertNil(error, @"");
-//    XCTAssertEqualObjects(result, original, @"");
-//}
+- (void) testSerializeDeserializeChar
+{
+    NSError* error = (NSError*)self;
+    NSString* expected = @"[20]";
+    id original = @[@20];
+    NSString* jsonString = toString([BSG_KSJSONCodec encode:original
+                                                options:BSG_KSJSONEncodeOptionSorted
+                                                  error:&error]);
+    XCTAssertNotNil(jsonString, @"");
+    XCTAssertNil(error, @"");
+    XCTAssertEqualObjects(jsonString, expected, @"");
+    id result = [BSG_KSJSONCodec decode:toData(jsonString) options:0 error:&error];
+    XCTAssertNotNil(result, @"");
+    XCTAssertNil(error, @"");
+    XCTAssertEqualObjects(result, original, @"");
+}
+
+- (void) testSerializeDeserializeShort
+{
+    NSError* error = (NSError*)self;
+    NSString* expected = @"[2000]";
+    id original = @[@2000];
+    NSString* jsonString = toString([BSG_KSJSONCodec encode:original
+                                                options:BSG_KSJSONEncodeOptionSorted
+                                                  error:&error]);
+    XCTAssertNotNil(jsonString, @"");
+    XCTAssertNil(error, @"");
+    XCTAssertEqualObjects(jsonString, expected, @"");
+    id result = [BSG_KSJSONCodec decode:toData(jsonString) options:0 error:&error];
+    XCTAssertNotNil(result, @"");
+    XCTAssertNil(error, @"");
+    XCTAssertEqualObjects(result, original, @"");
+}
+
+- (void) testSerializeDeserializeLong
+{
+    NSError* error = (NSError*)self;
+    NSString* expected = @"[2000000000]";
+    id original = @[@2000000000];
+    NSString* jsonString = toString([BSG_KSJSONCodec encode:original
+                                                options:BSG_KSJSONEncodeOptionSorted
+                                                  error:&error]);
+    XCTAssertNotNil(jsonString, @"");
+    XCTAssertNil(error, @"");
+    XCTAssertEqualObjects(jsonString, expected, @"");
+    id result = [BSG_KSJSONCodec decode:toData(jsonString) options:0 error:&error];
+    XCTAssertNotNil(result, @"");
+    XCTAssertNil(error, @"");
+    XCTAssertEqualObjects(result, original, @"");
+}
+
+- (void) testSerializeDeserializeLongLong
+{
+    NSError* error = (NSError*)self;
+    NSString* expected = @"[200000000000]";
+    id original = @[@200000000000];
+    NSString* jsonString = toString([BSG_KSJSONCodec encode:original
+                                                options:BSG_KSJSONEncodeOptionSorted
+                                                  error:&error]);
+    XCTAssertNotNil(jsonString, @"");
+    XCTAssertNil(error, @"");
+    XCTAssertEqualObjects(jsonString, expected, @"");
+    id result = [BSG_KSJSONCodec decode:toData(jsonString) options:0 error:&error];
+    XCTAssertNotNil(result, @"");
+    XCTAssertNil(error, @"");
+    XCTAssertEqualObjects(result, original, @"");
+}
+
+- (void) testSerializeDeserializeNegative
+{
+    NSError* error = (NSError*)self;
+    NSString* expected = @"[-2000]";
+    id original = @[@(-2000)];
+    NSString* jsonString = toString([BSG_KSJSONCodec encode:original
+                                                options:BSG_KSJSONEncodeOptionSorted
+                                                  error:&error]);
+    XCTAssertNotNil(jsonString, @"");
+    XCTAssertNil(error, @"");
+    XCTAssertEqualObjects(jsonString, expected, @"");
+    id result = [BSG_KSJSONCodec decode:toData(jsonString) options:0 error:&error];
+    XCTAssertNotNil(result, @"");
+    XCTAssertNil(error, @"");
+    XCTAssertEqualObjects(result, original, @"");
+}
+
+- (void) testSerializeDeserialize0
+{
+    NSError* error = (NSError*)self;
+    NSString* expected = @"[0]";
+    id original = @[@0];
+    NSString* jsonString = toString([BSG_KSJSONCodec encode:original
+                                                options:BSG_KSJSONEncodeOptionSorted
+                                                  error:&error]);
+    XCTAssertNotNil(jsonString, @"");
+    XCTAssertNil(error, @"");
+    XCTAssertEqualObjects(jsonString, expected, @"");
+    id result = [BSG_KSJSONCodec decode:toData(jsonString) options:0 error:&error];
+    XCTAssertNotNil(result, @"");
+    XCTAssertNil(error, @"");
+    XCTAssertEqualObjects(result, original, @"");
+}
 
 - (void) testSerializeDeserializeEmptyString
 {
@@ -979,36 +979,36 @@ static NSString* toString(NSData* data)
     XCTAssertEqualObjects(result, original, @"");
 }
 
-//- (void) testSerializeDeserializeLargeArray
-//{
-//    NSError* error = (NSError*)self;
-//    unsigned int numEntries = 2000;
-//
-//    NSMutableString* jsonString = [NSMutableString string];
-//    [jsonString appendString:@"["];
-//    for(unsigned int i = 0; i < numEntries; i++)
-//    {
-//        [jsonString appendFormat:@"%d,", i%10];
-//    }
-//    [jsonString deleteCharactersInRange:NSMakeRange([jsonString length]-1, 1)];
-//    [jsonString appendString:@"]"];
-//
-//    NSArray* deserialized = [BSG_KSJSONCodec decode:toData(jsonString) options:0 error:&error];
-//    unsigned int deserializedCount = (unsigned int)[deserialized count];
-//    XCTAssertNotNil(deserialized, @"");
-//    XCTAssertNil(error, @"");
-//    XCTAssertEqual(deserializedCount, numEntries, @"");
-//    NSString* serialized = toString([BSG_KSJSONCodec encode:deserialized
-//                                                options:0
-//                                                  error:&error]);
-//    XCTAssertNotNil(serialized, @"");
-//    XCTAssertNil(error, @"");
-//    XCTAssertEqualObjects(serialized, jsonString, @"");
-//    int value = [deserialized[1] intValue];
-//    XCTAssertEqual(value, 1, @"");
-//    value = [deserialized[9] intValue];
-//    XCTAssertEqual(value, 9, @"");
-//}
+- (void) testSerializeDeserializeLargeArray
+{
+    NSError* error = (NSError*)self;
+    unsigned int numEntries = 2000;
+
+    NSMutableString* jsonString = [NSMutableString string];
+    [jsonString appendString:@"["];
+    for(unsigned int i = 0; i < numEntries; i++)
+    {
+        [jsonString appendFormat:@"%d,", i%10];
+    }
+    [jsonString deleteCharactersInRange:NSMakeRange([jsonString length]-1, 1)];
+    [jsonString appendString:@"]"];
+
+    NSArray* deserialized = [BSG_KSJSONCodec decode:toData(jsonString) options:0 error:&error];
+    unsigned int deserializedCount = (unsigned int)[deserialized count];
+    XCTAssertNotNil(deserialized, @"");
+    XCTAssertNil(error, @"");
+    XCTAssertEqual(deserializedCount, numEntries, @"");
+    NSString* serialized = toString([BSG_KSJSONCodec encode:deserialized
+                                                options:0
+                                                  error:&error]);
+    XCTAssertNotNil(serialized, @"");
+    XCTAssertNil(error, @"");
+    XCTAssertEqualObjects(serialized, jsonString, @"");
+    int value = [deserialized[1] intValue];
+    XCTAssertEqual(value, 1, @"");
+    value = [deserialized[9] intValue];
+    XCTAssertEqual(value, 9, @"");
+}
 
 - (void) testSerializeDeserializeLargeDictionary
 {

--- a/features/fixtures/ios-swift-cocoapods/iOSTestApp/scenarios/HandledErrorOverrideScenario.swift
+++ b/features/fixtures/ios-swift-cocoapods/iOSTestApp/scenarios/HandledErrorOverrideScenario.swift
@@ -23,6 +23,9 @@ class HandledErrorOverrideScenario: Scenario {
             report.errorMessage = "Foo"
             report.errorClass = "Bar"
             report.depth += 2
+            report.metaData["account"] = [
+                "items": [400,200]
+            ]
         }
     }
 

--- a/features/handled_errors.feature
+++ b/features/handled_errors.feature
@@ -1,10 +1,11 @@
 Feature: Handled Errors and Exceptions
 
-Scenario: Override errorClass and message from a notifyError() callback and discard lines from stack
+Scenario: Override errorClass and message from a notifyError() callback, customize report
 
     Discard 2 lines from the stacktrace, as we have single place to report and log errors, see
     https://docs.bugsnag.com/platforms/ios-objc/reporting-handled-exceptions/#depth
     This way top of the stacktrace is not logError but run
+    Include configured metadata dictionary into the report
 
     When I run "HandledErrorOverrideScenario"
     Then I should receive a request

--- a/features/handled_errors.feature
+++ b/features/handled_errors.feature
@@ -12,6 +12,8 @@ Scenario: Override errorClass and message from a notifyError() callback and disc
     And the exception "errorClass" equals "Bar"
     And the exception "message" equals "Foo"
     And the event "device.time" is within 30 seconds of the current timestamp
+    And the event "metaData.account.items.0" equals 400
+    And the event "metaData.account.items.1" equals 200
     And the "method" of stack frame 0 demangles to "iOSTestApp.HandledErrorOverrideScenario.run() -> ()"
     And the stack trace is an array with 15 stack frames
 


### PR DESCRIPTION
## Goal

Fix parsing logic for number values within arrays

## Design

Previously, parsing numbers from JSON arrays exited prematurely if the "name" value was empty. However, name is always empty when parsing arrays, and is only used when parsing JSON objects. 

So instead of exiting early to prevent parsing an invalid name, pass nil along as the name value.

## Tests

* Added a new test for adding metadata array
* Enabled some unused (??) tests for JSON parsing

## Review

- This pull request is ready for:
  - [x] Final review
- [x] Performance and complexity - are there any cases of unexpected O(n^3) when iterating, recursing, flat mapping, etc?
- [x] Concurrency concerns - if components are accessed asynchronously, what issues will arise
- [x] Thoroughness of added tests and any missing edge cases
- [ ] Idiomatic use of the language
