### PR TITLE
Fix reporting disk free space

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -8,9 +8,9 @@ matrix:
         - osx_image: xcode9.4
           env: PLATFORM=iOS
           script:
-            - fold_start(); make test; fold_end()
-            - fold_start(); make test OS=10.3.1; fold_end()
-            - fold_start(); make test OS=9.3; fold_end()
+            - fold_start; make test; fold_end
+            - fold_start; make test OS=10.3.1; fold_end
+            - fold_start; make test OS=9.3; fold_end
         - osx_image: xcode9.4
           env: PLATFORM=OSX
           script:

--- a/.travis.yml
+++ b/.travis.yml
@@ -3,6 +3,9 @@ cache:
   - bundler
   - cocoapods
 rvm: 2.4.3
+before_script:
+  - function fold_start() { echo -e "travis_fold:start:$1\033[33;1m$2\033[0m";}
+  - function fold_end() { echo -e "\ntravis_fold:end:$1\r";}
 matrix:
     include:
         - osx_image: xcode9.4

--- a/.travis.yml
+++ b/.travis.yml
@@ -8,9 +8,9 @@ matrix:
         - osx_image: xcode9.4
           env: PLATFORM=iOS
           script:
-            - make test
-            - make test OS=10.3.1
-            - make test OS=9.3
+            - fold_start(); make test; fold_end()
+            - fold_start(); make test OS=10.3.1; fold_end()
+            - fold_start(); make test OS=9.3; fold_end()
         - osx_image: xcode9.4
           env: PLATFORM=OSX
           script:

--- a/.travis.yml
+++ b/.travis.yml
@@ -3,17 +3,14 @@ cache:
   - bundler
   - cocoapods
 rvm: 2.4.3
-before_script:
-  - function fold_start() { echo -e "travis_fold:start:$1\033[33;1m$2\033[0m";}
-  - function fold_end() { echo -e "\ntravis_fold:end:$1\r";}
 matrix:
     include:
         - osx_image: xcode9.4
           env: PLATFORM=iOS
           script:
-            - fold_start; make test; fold_end
-            - fold_start; make test OS=10.3.1; fold_end
-            - fold_start; make test OS=9.3; fold_end
+            - make test
+            - make test OS=10.3.1
+            - make test OS=9.3
         - osx_image: xcode9.4
           env: PLATFORM=OSX
           script:

--- a/OSX/Bugsnag.xcodeproj/xcshareddata/xcschemes/Bugsnag.xcscheme
+++ b/OSX/Bugsnag.xcodeproj/xcshareddata/xcschemes/Bugsnag.xcscheme
@@ -24,8 +24,8 @@
    </BuildAction>
    <TestAction
       buildConfiguration = "Debug"
-      selectedDebuggerIdentifier = "Xcode.DebuggerFoundation.Debugger.LLDB"
-      selectedLauncherIdentifier = "Xcode.DebuggerFoundation.Launcher.LLDB"
+      selectedDebuggerIdentifier = ""
+      selectedLauncherIdentifier = "Xcode.IDEFoundation.Launcher.PosixSpawn"
       shouldUseLaunchSchemeArgsEnv = "YES">
       <Testables>
          <TestableReference

--- a/Source/BugsnagKSCrashSysInfoParser.m
+++ b/Source/BugsnagKSCrashSysInfoParser.m
@@ -44,10 +44,11 @@ NSDictionary *BSGParseDevice(NSDictionary *report) {
     
     if (error) {
         bsg_log_warn(@"Failed to read free disk space: %@", error);
+    } else {
+        NSNumber *freeBytes = [fileSystemAttrs objectForKey:NSFileSystemFreeSize];
+        BSGDictSetSafeObject(device, freeBytes, @"freeDisk");
     }
     
-    NSNumber *freeBytes = [fileSystemAttrs objectForKey:NSFileSystemFreeSize];
-    BSGDictSetSafeObject(device, freeBytes, @"freeDisk");
     BSGDictSetSafeObject(device, report[@"system"][@"device_app_hash"], @"id");
 
 #if TARGET_OS_SIMULATOR

--- a/Source/BugsnagKSCrashSysInfoParser.m
+++ b/Source/BugsnagKSCrashSysInfoParser.m
@@ -35,7 +35,7 @@ NSDictionary *BSGParseDevice(NSDictionary *report) {
     
     NSFileManager *fileManager = [NSFileManager defaultManager];
     NSArray *searchPaths = NSSearchPathForDirectoriesInDomains(
-                                                               NSDocumentDirectory, NSUserDomainMask, true);
+                                                               NSUserDirectory, NSUserDomainMask, true);
     NSString *path = [searchPaths lastObject];
     
     NSError *error;

--- a/Tests/BugsnagSinkTests.m
+++ b/Tests/BugsnagSinkTests.m
@@ -258,11 +258,7 @@
     NSDictionary *event = [self.processedData[@"events"] firstObject];
     NSDictionary *device = event[@"device"];
     XCTAssertNotNil(device);
-#if TARGET_OS_IPHONE || TARGET_OS_TV || TARGET_IPHONE_SIMULATOR
-    XCTAssertEqual(19, device.count);
-#else
     XCTAssertEqual(18, device.count);
-#endif
 
     XCTAssertEqualObjects(device[@"id"], @"f6d519a74213a57f8d052c53febfeee6f856d062");
     XCTAssertEqualObjects(device[@"manufacturer"], @"Apple");
@@ -273,7 +269,7 @@
     XCTAssertEqualObjects(device[@"runtimeVersions"][@"osBuild"], @"14B25");
     XCTAssertEqualObjects(device[@"runtimeVersions"][@"clangVersion"], @"10.0.0 (clang-1000.11.45.5)");
     XCTAssertEqualObjects(device[@"totalMemory"], @15065522176);
-    XCTAssertNotNil(device[@"freeDisk"]);
+    XCTAssertNil(device[@"freeDisk"]);
     XCTAssertEqualObjects(device[@"timezone"], @"PST");
     XCTAssertEqualObjects(device[@"jailbroken"], @YES);
     XCTAssertEqualObjects(device[@"freeMemory"], @742920192);

--- a/Tests/BugsnagSinkTests.m
+++ b/Tests/BugsnagSinkTests.m
@@ -258,7 +258,11 @@
     NSDictionary *event = [self.processedData[@"events"] firstObject];
     NSDictionary *device = event[@"device"];
     XCTAssertNotNil(device);
+#if TARGET_IPHONE_SIMULATOR || TARGET_OS_IPHONE
     XCTAssertEqual(18, device.count);
+#else
+    XCTAssertEqual(17, device.count);
+#endif
 
     XCTAssertEqualObjects(device[@"id"], @"f6d519a74213a57f8d052c53febfeee6f856d062");
     XCTAssertEqualObjects(device[@"manufacturer"], @"Apple");

--- a/iOS/BugsnagTests/BugsnagKSCrashSysInfoParserTest.m
+++ b/iOS/BugsnagTests/BugsnagKSCrashSysInfoParserTest.m
@@ -33,9 +33,12 @@
 - (void)validateDeviceDict:(NSDictionary *)device {
     XCTAssertNotNil(device);
     XCTAssertNotNil(device[@"locale"]);
-    XCTAssertNotNil(device[@"freeDisk"]);
     XCTAssertNotNil(device[@"simulator"]);
 }
 
+- (void)testDeviceFreeSpaceShouldBeAbsentWhenFailsToRetrieveIt {
+    NSDictionary *device = BSGParseDevice(@{});
+    XCTAssertNil(device[@"freeDisk"]);
+}
 
 @end

--- a/tvOS/Bugsnag.xcodeproj/xcshareddata/xcschemes/Bugsnag.xcscheme
+++ b/tvOS/Bugsnag.xcodeproj/xcshareddata/xcschemes/Bugsnag.xcscheme
@@ -24,8 +24,8 @@
    </BuildAction>
    <TestAction
       buildConfiguration = "Debug"
-      selectedDebuggerIdentifier = "Xcode.DebuggerFoundation.Debugger.LLDB"
-      selectedLauncherIdentifier = "Xcode.DebuggerFoundation.Launcher.LLDB"
+      selectedDebuggerIdentifier = ""
+      selectedLauncherIdentifier = "Xcode.IDEFoundation.Launcher.PosixSpawn"
       shouldUseLaunchSchemeArgsEnv = "YES">
       <Testables>
          <TestableReference


### PR DESCRIPTION
## Goal

Skip reporting free space when getting file system attributes fails

## Design


## Changeset

Also disable debugger in test as it prevents tests from running in Xcode.

## Tests

Unit test for iOS and tvOS using failure and macOS using success paths.

## Review

### Outstanding Questions

- This pull request is ready for:
  - [X] Initial review of the intended approach, not yet feature complete
  - [ ] Structural review of the classes, functions, and properties modified
  - [X] Final review

- [ ] The correct target branch has been selected (`master` for fixes, `next` for
  features)
- [ ] Consistency across platforms for structures or concepts added or modified
- [ ] Consistency between the changeset and the goal stated above
- [ ] Internal consistency with the rest of the library - is there any overlap between existing interfaces and any which have been added?
