### PR TITLE
doc: Publish public headers only during release

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -26,7 +26,7 @@ matrix:
           script: bundle exec maze-runner -c || (cat maze_output/* && exit 1)
 install: make bootstrap
 
-before_deploy: headerdoc2html -o docs Source -j; gatherheaderdoc docs; mv docs/masterTOC.html docs/index.html
+before_deploy: make doc
 
 deploy:
   provider: pages

--- a/Makefile
+++ b/Makefile
@@ -95,5 +95,10 @@ e2e: ## Run integration tests
 
 archive: build/Bugsnag-$(PLATFORM)-$(PRESET_VERSION).zip
 
+doc: ## Generate html documentation
+	@headerdoc2html -N -o docs $(shell ruby -e "require 'json'; print Dir.glob(JSON.parse(File.read('Bugsnag.podspec.json'))['public_header_files']).join(' ')") -j
+	@gatherheaderdoc docs
+	@mv docs/masterTOC.html docs/index.html
+
 help: ## Show help text
 	@grep -E '^[a-zA-Z0-9_-]+:.*?## .*$$' $(MAKEFILE_LIST) | sort | awk 'BEGIN {FS = ":.*?## "}; {printf "\033[36m%-30s\033[0m %s\n", $$1, $$2}'


### PR DESCRIPTION
When performing a release, API docs for the library are automatically published to https://bugsnag.github.com/bugsnag-cocoa, though by default its publishing _all_ of the library rather than the public API, which is more generally useful. This change only publishes the headers included in the podspec.