### PR TITLE
Fix internal notify() unhandled count

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,14 @@
 Changelog
 =========
 
+## TBD
+
+### Bug fixes
+
+* Fix incrementing unhandled counts when using internal notify() API. This
+  resolves discrepancies in stability scores for users of bugsnag-react-native
+  after receiving unhandled JavaScript events.
+
 ## 5.22.2 (2019-06-13)
 
 ### Bug fixes

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -1,11 +1,12 @@
 GIT
   remote: https://github.com/bugsnag/maze-runner
-  revision: 24f53756011b1247a166b70fe65ddf1c40b4fc89
+  revision: 6f5af2c98c6fa1cfb07d6466a5cf3eaca5dcbc90
   specs:
     bugsnag-maze-runner (1.0.0)
       cucumber (~> 3.1.0)
       cucumber-expressions (= 5.0.15)
       minitest (~> 5.0)
+      os (~> 1.0.0)
       rack (~> 2.0.0)
       rake (~> 12.3.0)
       test-unit (~> 3.2.0)
@@ -20,7 +21,7 @@ GEM
       thread_safe (~> 0.3, >= 0.3.4)
       tzinfo (~> 1.1)
     atomos (0.1.3)
-    backports (3.11.4)
+    backports (3.15.0)
     builder (3.2.3)
     claide (1.0.2)
     cocoapods (1.5.3)
@@ -89,12 +90,13 @@ GEM
     nanaimo (0.2.6)
     nap (1.1.0)
     netrc (0.11.0)
-    power_assert (1.1.3)
-    rack (2.0.5)
-    rake (12.3.1)
+    os (1.0.1)
+    power_assert (1.1.4)
+    rack (2.0.7)
+    rake (12.3.2)
     rouge (2.0.7)
     ruby-macho (1.2.0)
-    test-unit (3.2.8)
+    test-unit (3.2.9)
       power_assert
     thread_safe (0.3.6)
     tzinfo (1.2.5)
@@ -117,4 +119,4 @@ DEPENDENCIES
   xcpretty
 
 BUNDLED WITH
-   1.16.2
+   1.17.0

--- a/Source/BugsnagHandledState.h
+++ b/Source/BugsnagHandledState.h
@@ -42,6 +42,11 @@ typedef NS_ENUM(NSUInteger, SeverityReasonType) {
                                       severity:(BSGSeverity)severity
                                      attrValue:(NSString *)attrValue;
 
+- (instancetype)initWithSeverityReason:(SeverityReasonType)severityReason
+                              severity:(BSGSeverity)severity
+                             unhandled:(BOOL)unhandled
+                             attrValue:(NSString *)attrValue;
+
 - (NSDictionary *)toJson;
 
 - (instancetype)initWithDictionary:(NSDictionary *)dict;

--- a/Source/BugsnagNotifier.m
+++ b/Source/BugsnagNotifier.m
@@ -78,6 +78,7 @@ static char *sessionStartDate[128];
 static char *watchdogSentinelPath = NULL;
 static char *crashSentinelPath = NULL;
 static NSUInteger handledCount;
+static NSUInteger unhandledCount;
 static bool hasRecordedSessions;
 
 /**
@@ -93,7 +94,8 @@ void BSSerializeDataCrashHandler(const BSG_KSCrashReportWriter *writer, int type
         writer->addStringElement(writer, "id", (const char *) sessionId);
         writer->addStringElement(writer, "startedAt", (const char *) sessionStartDate);
         writer->addUIntegerElement(writer, "handledCount", handledCount);
-        writer->addUIntegerElement(writer, "unhandledCount", isCrash ? 1 : 0);
+        NSUInteger unhandledEvents = unhandledCount + (isCrash ? 1 : 0);
+        writer->addUIntegerElement(writer, "unhandledCount", unhandledEvents);
     }
     if (isCrash) {
         if (bsg_g_bugsnag_data.configJSON) {
@@ -191,6 +193,7 @@ void BSGWriteSessionCrashData(BugsnagSession *session) {
 
     // record info for C JSON serialiser
     handledCount = session.handledCount;
+    unhandledCount = session.unhandledCount;
     hasRecordedSessions = true;
 }
 
@@ -555,19 +558,19 @@ NSString *const kAppWillTerminate = @"App Will Terminate";
                     withData:(NSDictionary *_Nullable)metaData
                        block:(BugsnagNotifyBlock _Nullable)block {
 
-    NSString *severity = metaData[BSGKeySeverity];
+    BSGSeverity severity = BSGParseSeverity(metaData[BSGKeySeverity]);
     NSString *severityReason = metaData[BSGKeySeverityReason];
+    BOOL unhandled = [metaData[BSGKeyUnhandled] boolValue];
     NSString *logLevel = metaData[BSGKeyLogLevel];
-    NSParameterAssert(severity.length > 0);
     NSParameterAssert(severityReason.length > 0);
 
     SeverityReasonType severityReasonType =
         [BugsnagHandledState severityReasonFromString:severityReason];
 
-    BugsnagHandledState *state = [BugsnagHandledState
-        handledStateWithSeverityReason:severityReasonType
-                              severity:BSGParseSeverity(severity)
-                             attrValue:logLevel];
+    BugsnagHandledState *state = [[BugsnagHandledState alloc] initWithSeverityReason:severityReasonType
+                                                                            severity:severity
+                                                                           unhandled:unhandled
+                                                                           attrValue:logLevel];
 
     [self notify:exception handledState:state block:block];
 }
@@ -603,7 +606,11 @@ NSString *const kAppWillTerminate = @"App Will Terminate";
            block:(void (^)(BugsnagCrashReport *))block {
     NSString *exceptionName = exception.name ?: NSStringFromClass([exception class]);
     NSString *message = exception.reason;
-    [self.sessionTracker handleHandledErrorEvent];
+    if (handledState.unhandled) {
+        [self.sessionTracker handleUnhandledErrorEvent];
+    } else {
+        [self.sessionTracker handleHandledErrorEvent];
+    }
 
     BugsnagCrashReport *report = [[BugsnagCrashReport alloc]
         initWithErrorName:exceptionName

--- a/Source/BugsnagSessionTracker.h
+++ b/Source/BugsnagSessionTracker.h
@@ -77,6 +77,13 @@ extern NSString *const BSGSessionUpdateNotification;
 - (void)handleHandledErrorEvent;
 
 /**
+ Handled Bugsnag.notify() being called with an event with unhandled = YES.
+ Increases the number of unhandled errors recorded for the current session, if
+ a session exists.
+ */
+- (void)handleUnhandledErrorEvent;
+
+/**
  * Retrieves the running session, or nil if the session is stopped or has not yet been started/resumed.
  */
 @property (nonatomic, strong, readonly) BugsnagSession *runningSession;

--- a/Source/BugsnagSessionTracker.m
+++ b/Source/BugsnagSessionTracker.m
@@ -165,7 +165,23 @@ NSString *const BSGSessionUpdateNotification = @"BugsnagSessionChanged";
 
     @synchronized (session) {
         session.handledCount++;
-        if (self.callback && (self.config.shouldAutoCaptureSessions || !session.autoCaptured)) {
+        if (self.callback) {
+            self.callback(session);
+        }
+        [self postUpdateNotice];
+    }
+}
+
+- (void)handleUnhandledErrorEvent {
+    BugsnagSession *session = [self runningSession];
+
+    if (session == nil) {
+        return;
+    }
+
+    @synchronized (session) {
+        session.unhandledCount++;
+        if (self.callback) {
             self.callback(session);
         }
         [self postUpdateNotice];

--- a/Tests/BugsnagSessionTrackerTest.m
+++ b/Tests/BugsnagSessionTrackerTest.m
@@ -119,6 +119,14 @@
     session = self.sessionTracker.runningSession;
     XCTAssertEqual(0, session.handledCount);
     XCTAssertEqual(0, session.unhandledCount);
+
+    [self.sessionTracker handleUnhandledErrorEvent];
+    XCTAssertEqual(0, session.handledCount);
+    XCTAssertEqual(1, session.unhandledCount);
+
+    [self.sessionTracker handleHandledErrorEvent];
+    XCTAssertEqual(1, session.handledCount);
+    XCTAssertEqual(1, session.unhandledCount);
 }
 
 @end

--- a/features/cross_notifier_notify.feature
+++ b/features/cross_notifier_notify.feature
@@ -1,0 +1,66 @@
+Feature: Communicating events between notifiers
+
+    Other Bugsnag libraries include bugsnag-cocoa as a dependency for capturing
+    native cocoa crashes, but may have additional events to report, both
+    handled and unhandled. Those events should be reported correctly when
+    using bugsnag-cocoa as the delivery layer.
+
+    Scenario: Report a handled event through internalNotify()
+        Report a handled exception, including a custom stacktrace and severity.
+        Event counts in the report's session should match the handled-ness.
+
+        When I run "HandledInternalNotifyScenario"
+        Then I should receive 2 requests
+        And request 0 is a valid for the session tracking API
+        And request 1 is a valid for the error reporting API
+        And the exception "errorClass" equals "Handled Error!" for request 1
+        And the exception "message" equals "Internally reported a handled event" for request 1
+        And the exception "type" equals "unreal" for request 1
+        And the event "severity" equals "warning" for request 1
+        And the event "severityReason.type" equals "handledException" for request 1
+
+        And the "method" of stack frame 0 equals "foo()" for request 1
+        And the "file" of stack frame 0 equals "src/Giraffe.mm" for request 1
+        And the "lineNumber" of stack frame 0 equals 200 for request 1
+        And the "method" of stack frame 1 equals "bar()" for request 1
+        And the "file" of stack frame 1 equals "parser.js" for request 1
+        And the "lineNumber" of stack frame 1 is null for request 1
+        And the "method" of stack frame 2 equals "yes()" for request 1
+        And the "file" of stack frame 2 is null for request 1
+        And the "lineNumber" of stack frame 2 is null for request 1
+        And the event "unhandled" is false for request 1
+
+        And the payload field "events" is an array with 1 element for request 1
+        And the payload field "events.0.session.events.handled" equals 1 for request 1
+        And the payload field "events.0.session.events.unhandled" equals 0 for request 1
+        And the payload field "events.0.session.id" of request 1 equals the payload field "sessions.0.id" of request 0
+
+    Scenario: Report an unhandled event through internalNotify()
+        Report an unhandled exception, including a custom stacktrace and severity.
+        Event counts in the report's session should match the handled-ness.
+
+        When I run "UnhandledInternalNotifyScenario"
+        Then I should receive 2 requests
+        And request 0 is a valid for the session tracking API
+        And request 1 is a valid for the error reporting API
+        And the exception "errorClass" equals "Unhandled Error?!" for request 1
+        And the exception "message" equals "Internally reported an unhandled event" for request 1
+        And the exception "type" equals "fake" for request 1
+        And the event "severity" equals "info" for request 1
+        And the event "severityReason.type" equals "userCallbackSetSeverity" for request 1
+
+        And the "method" of stack frame 0 equals "bar()" for request 1
+        And the "file" of stack frame 0 equals "foo.js" for request 1
+        And the "lineNumber" of stack frame 0 equals 43 for request 1
+        And the "method" of stack frame 1 equals "baz()" for request 1
+        And the "file" of stack frame 1 equals "[native code]" for request 1
+        And the "lineNumber" of stack frame 1 is null for request 1
+        And the "method" of stack frame 2 equals "is_done()" for request 1
+        And the "file" of stack frame 2 is null for request 1
+        And the "lineNumber" of stack frame 2 is null for request 1
+        And the event "unhandled" is true for request 1
+
+        And the payload field "events" is an array with 1 element for request 1
+        And the payload field "events.0.session.events.handled" equals 0 for request 1
+        And the payload field "events.0.session.events.unhandled" equals 1 for request 1
+        And the payload field "events.0.session.id" of request 1 equals the payload field "sessions.0.id" of request 0

--- a/features/fixtures/ios-swift-cocoapods/iOSTestApp.xcodeproj/project.pbxproj
+++ b/features/fixtures/ios-swift-cocoapods/iOSTestApp.xcodeproj/project.pbxproj
@@ -27,6 +27,8 @@
 		8AEFC79C20F92E2200A78779 /* AutoSessionUnhandledScenario.m in Sources */ = {isa = PBXBuildFile; fileRef = 8AEFC79B20F92E2200A78779 /* AutoSessionUnhandledScenario.m */; };
 		8AF6FD77225E3F870056EF9E /* StopSessionOOMScenario.m in Sources */ = {isa = PBXBuildFile; fileRef = 8AF6FD76225E3F870056EF9E /* StopSessionOOMScenario.m */; };
 		8AF6FD7A225E3FA00056EF9E /* ResumeSessionOOMScenario.m in Sources */ = {isa = PBXBuildFile; fileRef = 8AF6FD79225E3FA00056EF9E /* ResumeSessionOOMScenario.m */; };
+		8AF8FCAC22BD1E5400A967CA /* UnhandledInternalNotifyScenario.swift in Sources */ = {isa = PBXBuildFile; fileRef = 8AF8FCAB22BD1E5400A967CA /* UnhandledInternalNotifyScenario.swift */; };
+		8AF8FCAE22BD23BA00A967CA /* HandledInternalNotifyScenario.swift in Sources */ = {isa = PBXBuildFile; fileRef = 8AF8FCAD22BD23BA00A967CA /* HandledInternalNotifyScenario.swift */; };
 		C4D0B5FF8E60C0835B86DFE9 /* Pods_iOSTestApp.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = 4994F05E0421A0B037DD2CC5 /* Pods_iOSTestApp.framework */; };
 		E7767F11221C21D90006648C /* StoppedSessionScenario.swift in Sources */ = {isa = PBXBuildFile; fileRef = E7767F10221C21D90006648C /* StoppedSessionScenario.swift */; };
 		E7767F13221C21E30006648C /* ResumedSessionScenario.swift in Sources */ = {isa = PBXBuildFile; fileRef = E7767F12221C21E30006648C /* ResumedSessionScenario.swift */; };
@@ -104,6 +106,8 @@
 		8AF6FD76225E3F870056EF9E /* StopSessionOOMScenario.m */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.objc; path = StopSessionOOMScenario.m; sourceTree = "<group>"; };
 		8AF6FD78225E3FA00056EF9E /* ResumeSessionOOMScenario.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; path = ResumeSessionOOMScenario.h; sourceTree = "<group>"; };
 		8AF6FD79225E3FA00056EF9E /* ResumeSessionOOMScenario.m */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.objc; path = ResumeSessionOOMScenario.m; sourceTree = "<group>"; };
+		8AF8FCAB22BD1E5400A967CA /* UnhandledInternalNotifyScenario.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = UnhandledInternalNotifyScenario.swift; sourceTree = "<group>"; };
+		8AF8FCAD22BD23BA00A967CA /* HandledInternalNotifyScenario.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = HandledInternalNotifyScenario.swift; sourceTree = "<group>"; };
 		960A6E7D4E847F1D76A4FD06 /* Pods-iOSTestApp.release.xcconfig */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.xcconfig; name = "Pods-iOSTestApp.release.xcconfig"; path = "Pods/Target Support Files/Pods-iOSTestApp/Pods-iOSTestApp.release.xcconfig"; sourceTree = "<group>"; };
 		E7767F10221C21D90006648C /* StoppedSessionScenario.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = StoppedSessionScenario.swift; sourceTree = "<group>"; };
 		E7767F12221C21E30006648C /* ResumedSessionScenario.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ResumedSessionScenario.swift; sourceTree = "<group>"; };
@@ -315,6 +319,8 @@
 				8AF6FD76225E3F870056EF9E /* StopSessionOOMScenario.m */,
 				8AF6FD78225E3FA00056EF9E /* ResumeSessionOOMScenario.h */,
 				8AF6FD79225E3FA00056EF9E /* ResumeSessionOOMScenario.m */,
+				8AF8FCAB22BD1E5400A967CA /* UnhandledInternalNotifyScenario.swift */,
+				8AF8FCAD22BD23BA00A967CA /* HandledInternalNotifyScenario.swift */,
 			);
 			path = scenarios;
 			sourceTree = "<group>";
@@ -446,10 +452,12 @@
 				8AF6FD7A225E3FA00056EF9E /* ResumeSessionOOMScenario.m in Sources */,
 				F429565A951303E2C3136D0D /* UserIdScenario.swift in Sources */,
 				8AEEBBD020FC9E1D00C60763 /* AutoSessionMixedEventsScenario.m in Sources */,
+				8AF8FCAC22BD1E5400A967CA /* UnhandledInternalNotifyScenario.swift in Sources */,
 				F4295A94DD2D131A594A212C /* HandledErrorScenario.swift in Sources */,
 				F4295A7AA9B4A18992A2F020 /* HandledErrorOverrideScenario.swift in Sources */,
 				F429502603396F8671B333B3 /* HandledExceptionScenario.swift in Sources */,
 				F4295497A1582010C16F1861 /* AbortScenario.m in Sources */,
+				8AF8FCAE22BD23BA00A967CA /* HandledInternalNotifyScenario.swift in Sources */,
 				8A42FD35225DEE04007AE561 /* SessionOOMScenario.m in Sources */,
 				F4295CEAD7C915EFA04898A5 /* Scenario.m in Sources */,
 				F4295836C8AF75547C675E8D /* ReleasedObjectScenario.m in Sources */,

--- a/features/fixtures/ios-swift-cocoapods/iOSTestApp/scenarios/HandledInternalNotifyScenario.swift
+++ b/features/fixtures/ios-swift-cocoapods/iOSTestApp/scenarios/HandledInternalNotifyScenario.swift
@@ -1,0 +1,26 @@
+
+import UIKit
+import Bugsnag
+
+@objc class HandledInternalNotifyScenario: Scenario {
+
+    override func run() {
+        let exception = NSException(name: NSExceptionName("Handled Error!"),
+                                    reason: "Internally reported a handled event",
+                                    userInfo: nil);
+        let options = [
+            "severity": "warning",
+            "severityReason": "handledException",
+            "unhandled": false
+            ] as [String : Any]
+        Bugsnag.internalClientNotify(exception, withData: options) { report in
+            let frames = [
+                ["method":"foo()", "file":"src/Giraffe.mm", "lineNumber": 200],
+                ["method":"bar()", "file":"parser.js"],
+                ["method":"yes()"]
+            ]
+            report.attachCustomStacktrace(frames, withType: "unreal")
+        }
+    }
+}
+

--- a/features/fixtures/ios-swift-cocoapods/iOSTestApp/scenarios/UnhandledInternalNotifyScenario.swift
+++ b/features/fixtures/ios-swift-cocoapods/iOSTestApp/scenarios/UnhandledInternalNotifyScenario.swift
@@ -1,0 +1,26 @@
+
+import UIKit
+import Bugsnag
+
+@objc class UnhandledInternalNotifyScenario: Scenario {
+
+    override func run() {
+        let exception = NSException(name: NSExceptionName("Unhandled Error?!"),
+                                    reason: "Internally reported an unhandled event",
+                                    userInfo: nil);
+        let options = [
+            "severity": "info",
+            "severityReason": "userCallbackSetSeverity",
+            "unhandled": true
+            ] as [String : Any]
+        Bugsnag.internalClientNotify(exception, withData: options) { report in
+            let frames = [
+                ["method":"bar()", "file":"foo.js", "lineNumber": 43],
+                ["method":"baz()", "file":"[native code]"],
+                ["method":"is_done()"]
+            ]
+            report.attachCustomStacktrace(frames, withType: "fake")
+        }
+    }
+}
+

--- a/features/steps/ios_steps.rb
+++ b/features/steps/ios_steps.rb
@@ -43,18 +43,6 @@ When("I put the app in the background") do
   }
 end
 
-Then("the payload field {string} of request {int} equals the payload field {string} of request {int}") do |field1, request_index1, field2, request_index2|
-  value1 = read_key_path(find_request(request_index1)[:body], field1)
-  value2 = read_key_path(find_request(request_index2)[:body], field2)
-  assert_equal(value1, value2)
-end
-
-Then("the payload field {string} of request {int} does not equal the payload field {string} of request {int}") do |field1, request_index1, field2, request_index2|
-  value1 = read_key_path(find_request(request_index1)[:body], field1)
-  value2 = read_key_path(find_request(request_index2)[:body], field2)
-  assert_not_equal(value1, value2)
-end
-
 When("I corrupt all reports on disk") do
   app_path = `xcrun simctl get_app_container booted com.bugsnag.iOSTestApp`.chomp
   app_path.gsub!(/(.*Containers).*/, '\1')


### PR DESCRIPTION
## Goal

Fix incrementing unhandled counts when using internal notify() API. This resolves discrepancies in stability scores for users of bugsnag-react-native after receiving unhandled JavaScript events.

## Changeset

* Added a helper function to `BugsnagSessionTracker` for incrementing unhandled counts
* Cached the session `unhandledCount` in `BugsnagNotifier` as the value can be more than 1 now
* Read unhandled value passed through `internalClientNotify` to determine event handledness
* Updated `notify:handledState:block:` to respect handledness and increment either the handled or unhandled event counts as needed


## Tests

* Added new end-to-end tests using the `internalClientNotify()` function to send handled and unhandled events after a session and verifying the session event counts

This pull request is ready for final review.