### PR TITLE
ci: use latest xcode to build on travis

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -5,20 +5,20 @@ cache:
 rvm: 2.4.3
 matrix:
     include:
-        - osx_image: xcode9.4
+        - osx_image: xcode10.2
           env: PLATFORM=iOS
           script:
-            - make test
+            - make test OS=11.4
             - make test OS=10.3.1
             - make test OS=9.3
         - osx_image: xcode9.4
           env: PLATFORM=OSX
           script:
             - make test
-        - osx_image: xcode9.4
+        - osx_image: xcode10.2
           env: PLATFORM=tvOS
           script:
-            - make test
+            - make test OS=11.4
             - make test OS=10.2
             - make test OS=9.2
         - osx_image: xcode10.1


### PR DESCRIPTION
while running tests on iOS11, 10 and 9
use previous versions of macOS to run tests on Sierra, High Sierra
