### PR TITLE
Add retry to "Never crashed!" issues

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -20,9 +20,9 @@ matrix:
             - make test OS=11.4
             - make test OS=10.2
             - make test OS=9.2
-        # - osx_image: xcode10.1
-        #  script: bundle exec maze-runner -c || (cat maze_output/* && exit 1)
-        #  env: MAZE_SDK=12.1 SDK=iphonesimulator12.1 RUBYSHELL=/bin/bash
+        - osx_image: xcode10.1
+          script: bundle exec maze-runner --verbose -c || (cat maze_output/* && exit 1)
+          env: MAZE_SDK=12.1 SDK=iphonesimulator12.1 RUBYSHELL=/bin/bash
 install: make bootstrap
 
 before_deploy: make doc

--- a/features/steps/ios_steps.rb
+++ b/features/steps/ios_steps.rb
@@ -27,15 +27,7 @@ When("I relaunch the app") do
   step('I launch the app')
 end
 When('the app is unexpectedly terminated') do
-  pid = test_app_pid
-  start = Time.now
-  while pid == '0'
-    sleep 0.2
-    pid = test_app_pid
-    raise "Never received app PID! Waited #{MAX_WAIT_TIME}s." if Time.now - start > MAX_WAIT_TIME
-  end
-  sleep 1
-  `kill -9 #{pid} &` if pid
+  kill_test_app
 end
 When("I crash the app using {string}") do |event|
   steps %Q{

--- a/features/support/env.rb
+++ b/features/support/env.rb
@@ -60,3 +60,25 @@ def test_app_is_running?
   pid = test_app_pid
   !pid.nil? # check that PID is valid
 end
+
+def kill_test_app(attempt_retry = true)
+  pid = test_app_pid
+  start = Time.now
+  while pid == '0'
+    sleep 0.2
+    pid = test_app_pid
+    raise "Never received app PID! Waited #{MAX_WAIT_TIME}s." if Time.now - start > MAX_WAIT_TIME
+  end
+  sleep 1
+  `kill -9 #{pid} &` if pid
+  kill_time = Time.now
+  while test_app_is_running?
+    if Time.now - kill_time > 10
+      if attempt_retry
+        kill_test_app(false)
+      else
+        raise "Test app was not successfully killed"
+      end
+    end
+  end
+end


### PR DESCRIPTION
## Goal
Adds a very basic single-time retry when attempting to kill the app when simulating OOM issues.  This should help to prevent the "Never crashed" issues when the app doesn't stop straight away.
