### PR TITLE
CI: Add travis_retry to end-to-end tests

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -23,7 +23,7 @@ matrix:
             - make test OS=10.2
             - make test OS=9.2
         - osx_image: xcode10.1
-          script: bundle exec maze-runner -c || (cat maze_output/* && exit 1)
+          script: travis_retry bundle exec maze-runner -c || (cat maze_output/* && exit 1)
           env: MAZE_SDK=12.1 SDK=iphonesimulator12.1 RUBYSHELL=/bin/bash
 install: make bootstrap
 


### PR DESCRIPTION
## Goal

Adds an auto-retry to the maze-runner command.
