### PR TITLE
fix(oom): Disable out-of-memory reporting in debug mode

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -10,6 +10,7 @@ matrix:
             - make test OS=11.4
             - make test OS=10.3.1
             - make test OS=9.3
+            - make test OS=9.3 TEST_CONFIGURATION=Release
           after_success:
             - bash <(curl -s 'https://codecov.io/bash') -Z -J '^Bugsnag$' -X gcov -X coveragepy -X fix -D build
         - osx_image: xcode9.4

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,9 @@ Changelog
 
 ## TBD
 
+This release disables reporting out-of-memory events in debug mode, to reduce
+false positives.
+
 ### Bug fixes
 
 * Fix incrementing unhandled counts when using internal notify() API. This

--- a/Makefile
+++ b/Makefile
@@ -1,5 +1,6 @@
 PLATFORM?=iOS
 OS?=latest
+TEST_CONFIGURATION?=Debug
 BUILD_FLAGS=-workspace $(PLATFORM).xcworkspace -scheme Bugsnag -derivedDataPath build
 
 ifeq ($(PLATFORM),OSX)
@@ -15,7 +16,7 @@ else
   DESTINATION?=platform=iOS Simulator,name=iPhone 5s,OS=$(OS)
   RELEASE_DIR=Release-iphoneos
  endif
- BUILD_ONLY_FLAGS=-sdk $(SDK) -destination "$(DESTINATION)" -configuration Debug
+ BUILD_ONLY_FLAGS=-sdk $(SDK) -destination "$(DESTINATION)" -configuration $(TEST_CONFIGURATION)
 endif
 XCODEBUILD=set -o pipefail && xcodebuild
 PRESET_VERSION=$(shell cat VERSION)

--- a/Source/BugsnagConfiguration.m
+++ b/Source/BugsnagConfiguration.m
@@ -69,7 +69,9 @@ static NSString *const kHeaderApiSentAt = @"Bugsnag-Sent-At";
         _automaticallyCollectBreadcrumbs = YES;
         _shouldAutoCaptureSessions = YES;
         _reportBackgroundOOMs = NO;
+#if !DEBUG
         _reportOOMs = YES;
+#endif
 
         if ([NSURLSession class]) {
             _session = [NSURLSession

--- a/Tests/BugsnagConfigurationTests.m
+++ b/Tests/BugsnagConfigurationTests.m
@@ -55,6 +55,15 @@
     XCTAssertFalse([config shouldSendReports]);
 }
 
+- (void)testDefaultReleaseStage {
+    BugsnagConfiguration *config = [BugsnagConfiguration new];
+#if DEBUG
+    XCTAssertEqualObjects(@"development", config.releaseStage);
+#else
+    XCTAssertEqualObjects(@"production", config.releaseStage);
+#endif
+}
+
 - (void)testDefaultSessionConfig {
     BugsnagConfiguration *config = [BugsnagConfiguration new];
     XCTAssertTrue([config shouldAutoCaptureSessions]);
@@ -117,16 +126,39 @@
     XCTAssertEqualObjects([NSURL URLWithString:@"http://sessions.example.com"], config.sessionURL);
 }
 
-- (void)testSetEmptyNotifyEndpoint {
+// in debug these throw exceptions though in release are "tolerated"
+- (void)testSetNilNotifyEndpoint {
     BugsnagConfiguration *config = [BugsnagConfiguration new];
-    XCTAssertThrowsSpecificNamed([config setEndpointsForNotify:@"" sessions:@"http://sessions.example.com"],
+    NSString *notify = @"foo";
+    notify = nil;
+#if DEBUG
+    XCTAssertThrowsSpecificNamed([config setEndpointsForNotify:notify sessions:@"http://sessions.example.com"],
             NSException, NSInternalInconsistencyException);
+#else
+    XCTAssertNoThrow([config setEndpointsForNotify:@"" sessions:@"http://sessions.example.com"]);
+#endif
 }
 
+// in debug these throw exceptions though in release are "tolerated"
+- (void)testSetEmptyNotifyEndpoint {
+    BugsnagConfiguration *config = [BugsnagConfiguration new];
+#if DEBUG
+    XCTAssertThrowsSpecificNamed([config setEndpointsForNotify:@"" sessions:@"http://sessions.example.com"],
+            NSException, NSInternalInconsistencyException);
+#else
+    XCTAssertNoThrow([config setEndpointsForNotify:@"" sessions:@"http://sessions.example.com"]);
+#endif
+}
+
+// in debug these throw exceptions though in release are "tolerated"
 - (void)testSetMalformedNotifyEndpoint {
     BugsnagConfiguration *config = [BugsnagConfiguration new];
+#if DEBUG
     XCTAssertThrowsSpecificNamed([config setEndpointsForNotify:@"http://" sessions:@"http://sessions.example.com"],
             NSException, NSInternalInconsistencyException);
+#else
+    XCTAssertNoThrow([config setEndpointsForNotify:@"http://" sessions:@"http://sessions.example.com"]);
+#endif
 }
 
 - (void)testSetEmptySessionsEndpoint {

--- a/Tests/BugsnagConfigurationTests.m
+++ b/Tests/BugsnagConfigurationTests.m
@@ -62,7 +62,11 @@
 
 - (void)testDefaultReportOOMs {
     BugsnagConfiguration *config = [BugsnagConfiguration new];
+#if DEBUG
+    XCTAssertFalse([config reportOOMs]);
+#else
     XCTAssertTrue([config reportOOMs]);
+#endif
 }
 
 - (void)testDefaultReportBackgroundOOMs {

--- a/features/fixtures/ios-swift-cocoapods/iOSTestApp/AppDelegate.swift
+++ b/features/fixtures/ios-swift-cocoapods/iOSTestApp/AppDelegate.swift
@@ -49,6 +49,10 @@ class AppDelegate: UIResponder, UIApplicationDelegate {
     internal func prepareConfig(apiKey: String, mockAPIPath: String) -> BugsnagConfiguration {
         let config = BugsnagConfiguration()
         config.apiKey = apiKey
+        // Enabling by default to check not only the OOM reporting tests but 
+        // also that extra reports aren't erroneously sent in other conditions
+        // when OOM reporting is enabled
+        config.reportOOMs = true
         config.setEndpoints(notify: mockAPIPath, sessions: mockAPIPath)
         return config
     }


### PR DESCRIPTION
## Goal

Remove erroneous out-of-memory reports during development if reporting is enabled in debug mode. Since running the app via Xcode/simctl terminates the existing app launch session with a kill signal, no cleanup can be performed and the app state would indicate that a possible OOM may have occurred.

## Changeset

* Disables `reportOOMs` if in `DEBUG` mode.

## Tests

* Tested manually and by updating the end-to-end tests
