### PR TITLE
fix: Support adding pre-delivery metadata to OOM reports

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,9 @@
 Changelog
 =========
 
+* Support adding pre-delivery metadata to out-of-memory reports
+  [#393](https://github.com/bugsnag/bugsnag-cocoa/pull/393)
+
 ## 5.22.3 (2019-07-15)
 
 This release disables reporting out-of-memory events in debug mode, to reduce

--- a/Source/BugsnagCrashReport.m
+++ b/Source/BugsnagCrashReport.m
@@ -242,6 +242,7 @@ static NSString *const DEFAULT_EXCEPTION_TYPE = @"cocoa";
             _releaseStage = [report valueForKeyPath:@"user.state.oom.app.releaseStage"];
             _handledState = [BugsnagHandledState handledStateWithSeverityReason:LikelyOutOfMemory];
             _deviceAppHash = [report valueForKeyPath:@"user.state.oom.device.id"];
+            _metaData = [NSMutableDictionary new];
             NSDictionary *sessionData = [report valueForKeyPath:@"user.state.oom.session"];
             if (sessionData) {
                 _session = [[BugsnagSession alloc] initWithDictionary:sessionData];

--- a/features/fixtures/ios-swift-cocoapods/iOSTestApp/scenarios/OOMScenario.m
+++ b/features/fixtures/ios-swift-cocoapods/iOSTestApp/scenarios/OOMScenario.m
@@ -7,6 +7,12 @@
 - (void)startBugsnag {
     self.config.shouldAutoCaptureSessions = NO;
     self.config.releaseStage = @"alpha";
+    [self.config addBeforeSendBlock:^bool(NSDictionary * _Nonnull rawEventData, BugsnagCrashReport * _Nonnull report) {
+        NSMutableDictionary *metadata = [report.metaData mutableCopy];
+        metadata[@"extra"] = @{ @"shape": @"line" };
+        report.metaData = metadata;
+        return YES;
+    }];
     [super startBugsnag];
 }
 

--- a/features/out_of_memory.feature
+++ b/features/out_of_memory.feature
@@ -18,6 +18,7 @@ Feature: Reporting out of memory events
         And the event "app.releaseStage" equals "beta"
         And the event "app.version" equals "1.0.3"
         And the event "app.bundleVersion" equals "5"
+        And the event "metaData.extra.shape" equals "line"
         And the event breadcrumbs contain "Crumb left before crash"
 
     Scenario: The OS kills the application in the background


### PR DESCRIPTION
It is currently not possible to append additional metadata in before send callbacks, only override completely, which is different than the normal behavior. This change amends the behavior to ensure that adding metadata works as expected.

Fixes #392