### PR TITLE
fix(oom): Improve background app state detection

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,9 @@ Changelog
   [#393](https://github.com/bugsnag/bugsnag-cocoa/pull/393)
 * Fix erroneously reporting out-of-memory events from iOS app extensions
   [#394](https://github.com/bugsnag/bugsnag-cocoa/pull/394)
+* Fix erroneously reporting out-of-memory events when an iOS app is in the
+  foreground but inactive
+  [#394](https://github.com/bugsnag/bugsnag-cocoa/pull/394)
 
 ## 5.22.3 (2019-07-15)
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,8 +1,14 @@
 Changelog
 =========
 
+## TBD
+
+### Bug fixes
+
 * Support adding pre-delivery metadata to out-of-memory reports
   [#393](https://github.com/bugsnag/bugsnag-cocoa/pull/393)
+* Fix erroneously reporting out-of-memory events from iOS app extensions
+  [#394](https://github.com/bugsnag/bugsnag-cocoa/pull/394)
 
 ## 5.22.3 (2019-07-15)
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,10 @@ Changelog
 * Fix erroneously reporting out-of-memory events when an iOS app is in the
   foreground but inactive
   [#394](https://github.com/bugsnag/bugsnag-cocoa/pull/394)
+* Fix erroneously reporting out-of-memory events when the app terminates
+  normally and is issued a "will terminate" notification, but is terminated
+  prior to the out-of-memory watchdog processing the notification
+  [#394](https://github.com/bugsnag/bugsnag-cocoa/pull/394)
 
 ## 5.22.3 (2019-07-15)
 

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -89,6 +89,7 @@ Run the integration tests using `make e2e` (end-to-end)
   - [ ] Have the changelog and README been updated?
   - [ ] Are there pull requests for installation changes on the [dashboard](https://github.com/bugsnag/dashboard-js)?
   - [ ] Are there pull requests for new features/behavior on the [docs site](https://github.com/bugsnag/docs.bugsnag.com)?
+  - [ ] Run `./Tests/prerelease/run_prerelease_checks.sh`
   - [ ] Has all new functionality been manually tested on a release build?
   - [ ] Do the installation instructions work when creating an example app from scratch?
   - [ ] If a response is not received from the server, is the report queued for later?

--- a/Source/BugsnagBreadcrumb.h
+++ b/Source/BugsnagBreadcrumb.h
@@ -129,9 +129,4 @@ typedef void (^BSGBreadcrumbConfiguration)(BugsnagBreadcrumb *_Nonnull);
  */
 - (NSArray *_Nullable)arrayValue;
 
-/**
- * Reads and return breadcrumb data currently stored on disk
- */
-- (NSDictionary *_Nullable)cachedBreadcrumbs;
-
 @end

--- a/Source/BugsnagBreadcrumb.m
+++ b/Source/BugsnagBreadcrumb.m
@@ -233,8 +233,8 @@ NSUInteger BreadcrumbsDefaultCapacity = 20;
     }
 }
 
-- (NSDictionary *)cachedBreadcrumbs {
-    __block NSDictionary *cache = nil;
+- (NSArray *)cachedBreadcrumbs {
+    __block NSArray *cache = nil;
     dispatch_barrier_sync(self.readWriteQueue, ^{
         NSError *error = nil;
         NSData *data = [NSData dataWithContentsOfFile:self.cachePath options:0 error:&error];
@@ -245,7 +245,7 @@ NSUInteger BreadcrumbsDefaultCapacity = 20;
             bsg_log_err(@"Failed to read breadcrumbs from disk: %@", error);
         }
     });
-    return cache;
+    return [cache isKindOfClass:[NSArray class]] ? cache : nil;
 }
 
 @synthesize capacity = _capacity;

--- a/Source/BugsnagNotifier.m
+++ b/Source/BugsnagNotifier.m
@@ -27,6 +27,7 @@
 #import "BugsnagNotifier.h"
 #import "BSGConnectivity.h"
 #import "Bugsnag.h"
+#import "Private.h"
 #import "BugsnagCrashSentry.h"
 #import "BugsnagHandledState.h"
 #import "BugsnagLogger.h"

--- a/Source/KSCrash/Source/KSCrash/Recording/BSG_KSSystemInfo.h
+++ b/Source/KSCrash/Source/KSCrash/Recording/BSG_KSSystemInfo.h
@@ -73,4 +73,9 @@
  */
 + (NSString *)osBuildVersion;
 
+/**
+ * Whether the current main bundle is an iOS app extension
+ */
++ (BOOL)isRunningInAppExtension;
+
 @end

--- a/Source/KSCrash/Source/KSCrash/Recording/BSG_KSSystemInfo.m
+++ b/Source/KSCrash/Source/KSCrash/Recording/BSG_KSSystemInfo.m
@@ -433,6 +433,26 @@
     return [self stringSysctl:@"kern.osversion"];
 }
 
++ (BOOL)isRunningInAppExtension {
+#if BSG_KSCRASH_HOST_IOS
+    NSBundle *mainBundle = [NSBundle mainBundle];
+    // From the App Extension Programming Guide:
+    // > When you build an extension based on an Xcode template, you get an
+    // > extension bundle that ends in .appex.
+    return [[mainBundle executablePath] containsString:@".appex"]
+        // In the case that the extension bundle was renamed or generated
+        // outside of the Xcode template, check the Bundle OS Type Code:
+        // > This key consists of a four-letter code for the bundle type. For
+        // > apps, the code is APPL, for frameworks, it's FMWK, and for bundles,
+        // > it's BNDL.
+        // If the main bundle type is not "APPL", assume this is an extension
+        // context.
+        || ![[mainBundle infoDictionary][@"CFBundlePackageType"] isEqualToString:@"APPL"];
+#else
+    return NO;
+#endif
+}
+
 @end
 
 const char *bsg_kssysteminfo_toJSON(void) {

--- a/Source/Private.h
+++ b/Source/Private.h
@@ -1,0 +1,13 @@
+#ifndef BUGSNAG_PRIVATE_H
+#define BUGSNAG_PRIVATE_H
+
+#import "BugsnagBreadcrumb.h"
+
+@interface BugsnagBreadcrumbs ()
+/**
+ * Reads and return breadcrumb data currently stored on disk
+ */
+- (NSArray *_Nullable)cachedBreadcrumbs;
+@end
+
+#endif // BUGSNAG_PRIVATE_H

--- a/Tests/prerelease/features/out_of_memory.feature
+++ b/Tests/prerelease/features/out_of_memory.feature
@@ -1,0 +1,12 @@
+Feature: Out of memory events
+
+    Scenario: The OS kills the application while inactive
+        The application is in the foreground but inactive when interrupted 
+        by a phone call or Siri
+
+        When I run "OOMScenario"
+        And the app is interrupted by Siri
+        And the app is unexpectedly terminated
+        And I relaunch the app
+        And I wait for 10 seconds
+        Then I should receive 0 requests

--- a/Tests/prerelease/run_prerelease_checks.sh
+++ b/Tests/prerelease/run_prerelease_checks.sh
@@ -1,0 +1,6 @@
+#!/usr/bin/env bash
+
+# Run visibly to allow scripting access (pressing buttons, etc)
+open $(xcode-select -p)/Applications/Simulator.app
+
+bundle exec maze-runner Tests/prerelease/features/

--- a/features/fixtures/ios-swift-cocoapods/iOSTestApp.xcodeproj/project.pbxproj
+++ b/features/fixtures/ios-swift-cocoapods/iOSTestApp.xcodeproj/project.pbxproj
@@ -81,6 +81,8 @@
 		8A32DB8122424E3000EDD92F /* NSExceptionShiftScenario.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; path = NSExceptionShiftScenario.m; sourceTree = "<group>"; };
 		8A42FD33225DEE04007AE561 /* SessionOOMScenario.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; path = SessionOOMScenario.m; sourceTree = "<group>"; };
 		8A42FD34225DEE04007AE561 /* SessionOOMScenario.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = SessionOOMScenario.h; sourceTree = "<group>"; };
+		8A56EE7F22E22ED80066B9DC /* OOMWillTerminateScenario.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; path = OOMWillTerminateScenario.m; sourceTree = "<group>"; };
+		8A56EE8022E22ED80066B9DC /* OOMWillTerminateScenario.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = OOMWillTerminateScenario.h; sourceTree = "<group>"; };
 		8A840FB921AF5C450041DBFA /* SwiftAssertion.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = SwiftAssertion.swift; sourceTree = "<group>"; };
 		8A98400120FD11BF0023ECD1 /* AutoSessionCustomVersionScenario.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; path = AutoSessionCustomVersionScenario.h; sourceTree = "<group>"; };
 		8A98400220FD11BF0023ECD1 /* AutoSessionCustomVersionScenario.m */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.objc; path = AutoSessionCustomVersionScenario.m; sourceTree = "<group>"; };
@@ -233,6 +235,8 @@
 		F42953DE2BB41023C0B07F41 /* scenarios */ = {
 			isa = PBXGroup;
 			children = (
+				8A56EE8022E22ED80066B9DC /* OOMWillTerminateScenario.h */,
+				8A56EE7F22E22ED80066B9DC /* OOMWillTerminateScenario.m */,
 				8A14F0F42282D4AE00337B05 /* ReportBackgroundOOMsEnabledScenario.h */,
 				8A14F0F02282D4AD00337B05 /* ReportBackgroundOOMsEnabledScenario.m */,
 				8A14F0EF2282D4AD00337B05 /* ReportOOMsDisabledReportBackgroundOOMsEnabledScenario.h */,
@@ -446,6 +450,7 @@
 				F42955E0916B8851F074D9B3 /* UserEmailScenario.swift in Sources */,
 				F4295968571A4118D6A4606A /* UserEnabledScenario.swift in Sources */,
 				F4295A036B228AF608641699 /* UserDisabledScenario.swift in Sources */,
+				8A56EE8222E22ED80066B9DC /* OOMWillTerminateScenario.m in Sources */,
 				8A14F0F62282D4AE00337B05 /* ReportOOMsDisabledScenario.m in Sources */,
 				E7767F13221C21E30006648C /* ResumedSessionScenario.swift in Sources */,
 				8AEFC73120F8D1A000A78779 /* AutoSessionWithUserScenario.m in Sources */,

--- a/features/fixtures/ios-swift-cocoapods/iOSTestApp/scenarios/OOMWillTerminateScenario.h
+++ b/features/fixtures/ios-swift-cocoapods/iOSTestApp/scenarios/OOMWillTerminateScenario.h
@@ -1,0 +1,5 @@
+#import "Scenario.h"
+
+@interface OOMWillTerminateScenario : Scenario
+
+@end

--- a/features/fixtures/ios-swift-cocoapods/iOSTestApp/scenarios/OOMWillTerminateScenario.m
+++ b/features/fixtures/ios-swift-cocoapods/iOSTestApp/scenarios/OOMWillTerminateScenario.m
@@ -1,0 +1,18 @@
+
+#import "OOMWillTerminateScenario.h"
+#import <signal.h>
+#import <UIKit/UIKit.h>
+
+@implementation OOMWillTerminateScenario
+
+- (void)startBugsnag {
+    self.config.shouldAutoCaptureSessions = NO;
+    [super startBugsnag];
+}
+
+- (void)run {
+    dispatch_async(dispatch_get_main_queue(), ^{
+        exit(0);
+    });
+}
+@end

--- a/features/out_of_memory.feature
+++ b/features/out_of_memory.feature
@@ -21,6 +21,17 @@ Feature: Reporting out of memory events
         And the event "metaData.extra.shape" equals "line"
         And the event breadcrumbs contain "Crumb left before crash"
 
+    Scenario: The app is terminated normally
+        The application can be gracefully terminated by the OS if more
+        memory is needed for other applications or directly by calling
+        exit(0)
+
+        When I crash the app using "OOMWillTerminateScenario"
+        And I wait for 4 seconds
+        And I relaunch the app
+        And I wait for 10 seconds
+        Then I should receive 0 requests
+
     Scenario: The OS kills the application in the background
         When I run "OOMScenario"
         And I put the app in the background

--- a/features/out_of_memory.feature
+++ b/features/out_of_memory.feature
@@ -32,6 +32,17 @@ Feature: Reporting out of memory events
         And I wait for 10 seconds
         Then I should receive 0 requests
 
+    Scenario: The app is terminated normally
+        The application can be gracefully terminated by the OS if more
+        memory is needed for other applications or directly by calling
+        exit(0)
+
+        When I crash the app using "OOMWillTerminateScenario"
+        And I wait for 4 seconds
+        And I relaunch the app
+        And I wait for 10 seconds
+        Then I should receive 0 requests
+
     Scenario: The OS kills the application in the background
         When I run "OOMScenario"
         And I put the app in the background

--- a/features/scripts/activate_siri.sh
+++ b/features/scripts/activate_siri.sh
@@ -1,0 +1,17 @@
+#!/usr/bin/env osascript
+
+tell application "Simulator"
+    activate
+end tell
+
+tell application "System Events"
+    tell process "Simulator"
+        tell menu bar 1
+            tell menu bar item "Hardware"
+                tell menu "Hardware"
+                    click menu item "Siri"
+                end tell
+            end tell
+        end tell
+    end tell
+end tell

--- a/features/steps/ios_steps.rb
+++ b/features/steps/ios_steps.rb
@@ -29,6 +29,13 @@ end
 When('the app is unexpectedly terminated') do
   kill_test_app
 end
+When('the app is interrupted by Siri') do
+  steps %Q{
+    When I wait for 10 seconds
+    And I run the script "features/scripts/activate_siri.sh"
+    And I wait for 2 seconds
+  }
+end
 When("I crash the app using {string}") do |event|
   steps %Q{
     When I set environment variable "EVENT_TYPE" to "#{event}"


### PR DESCRIPTION
## Goal

Correctly determine foreground/active state when the app is launched via a background fetch or media playback event or extension, or is interrupted by Siri or a phone call. These cases should be regarded as in the background or inactive respectively.

## Changeset

* Added detection for app extension state
* Added initial app state (foreground and active) checking

## Tests

* Added additional end-to-end tests for when the app is interrupted and will terminate normally (for completeness)
