### PR TITLE
Fixing malloc without free causing memory leak

### DIFF
--- a/Source/KSCrash/Source/KSCrash/Recording/BSG_KSCrash.m
+++ b/Source/KSCrash/Source/KSCrash/Recording/BSG_KSCrash.m
@@ -370,6 +370,8 @@ IMPLEMENT_EXCLUSIVE_SHARED_INSTANCE(BSG_KSCrash)
                                     depth,
                                     terminateProgram);
 
+    free(callstack);
+
     // If bsg_kscrash_reportUserException() returns, we did not terminate.
     // Set up IDs and paths for the next crash.
 


### PR DESCRIPTION
Fix memory leak happening every time a user exception is reported. We found this while using the `bugsnag-react-native` SDK and profiling the app with Xcode Instruments. From there we were able to track this bug down to `bugsnag-cocoa` SDK. 

<img width="1623" alt="Screen Shot 2019-07-22 at 3 30 08 PM" src="https://user-images.githubusercontent.com/1471138/61666912-e09cfc80-ac95-11e9-81be-3b3b53c10594.png">

By adding the missing `free()` to the SDK locally we see the leak fixed and not showing in Instruments.

The `malloc` in question is found here https://github.com/bugsnag/bugsnag-cocoa/blob/master/Source/KSCrash/Source/KSCrash/Recording/BSG_KSCrash.m#L317

Since `bsg_kscrash_reportUserException` from above file could or could not return, I thought it was better to free the resource in `BSG_KSCrashSentry_User.c` which is final in call hierarchy. 

## Changeset

Adding the respectively `free()` for the `malloc`

## Review

- This pull request is ready for:
  - [ ] Initial review of the intended approach, not yet feature complete
  - [ ] Structural review of the classes, functions, and properties modified
  - [x] Final review

