### PR TITLE
fix(api): Check if generatedSession is nil before generation

### DIFF
--- a/Source/BugsnagApiClient.m
+++ b/Source/BugsnagApiClient.m
@@ -111,7 +111,7 @@
     if (session) {
         return session;
     } else {
-        if (self.generatedSession) {
+        if (!self.generatedSession) {
             _generatedSession = [NSURLSession
                     sessionWithConfiguration:[NSURLSessionConfiguration
                             defaultSessionConfiguration]];


### PR DESCRIPTION
No session would ever be returned from this block if
self.generatedSession is nil. If it was somehow set, then the
generatedSession logic would run on every request.