### PR TITLE
Fix possible crash or deadlock arising from calling notify() from multiple queues concurrently

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,14 @@
 Changelog
 =========
 
+## TBD
+
+### Bug fixes
+
+* Fix possible crash or deadlock arising from calling Bugsnag.notify() from
+  multiple queues concurrently.
+  [#401](https://github.com/bugsnag/bugsnag-cocoa/pull/401)
+
 ## 5.22.4 (2019-07-30)
 
 ### Bug fixes

--- a/OSX/Bugsnag.xcodeproj/project.pbxproj
+++ b/OSX/Bugsnag.xcodeproj/project.pbxproj
@@ -34,6 +34,9 @@
 		8A2C8FF01C6BC3A200846019 /* SystemConfiguration.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = 8A2C8FEF1C6BC3A200846019 /* SystemConfiguration.framework */; };
 		8A2C90441C6C040700846019 /* Cocoa.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = 8A2C90401C6C03F000846019 /* Cocoa.framework */; };
 		8A48EF271EAA805D00B70024 /* BugsnagLogger.h in Headers */ = {isa = PBXBuildFile; fileRef = 8A48EF261EAA805D00B70024 /* BugsnagLogger.h */; };
+		8A530CB822FDC38300F0C108 /* BSG_KSCrashIdentifier.h in Headers */ = {isa = PBXBuildFile; fileRef = 8A530CB622FDC38300F0C108 /* BSG_KSCrashIdentifier.h */; };
+		8A530CB922FDC38300F0C108 /* BSG_KSCrashIdentifier.m in Sources */ = {isa = PBXBuildFile; fileRef = 8A530CB722FDC38300F0C108 /* BSG_KSCrashIdentifier.m */; };
+		8A530CC922FDD74300F0C108 /* KSCrashIdentifierTests.m in Sources */ = {isa = PBXBuildFile; fileRef = 8A530CC722FDD73800F0C108 /* KSCrashIdentifierTests.m */; };
 		8A627CD91EC3B75200F7C04E /* BSGSerialization.h in Headers */ = {isa = PBXBuildFile; fileRef = 8A627CD71EC3B75200F7C04E /* BSGSerialization.h */; };
 		8A627CDA1EC3B75200F7C04E /* BSGSerialization.m in Sources */ = {isa = PBXBuildFile; fileRef = 8A627CD81EC3B75200F7C04E /* BSGSerialization.m */; };
 		8A6C6FB12257884C00E8EF24 /* BSGOutOfMemoryWatchdog.m in Sources */ = {isa = PBXBuildFile; fileRef = 8A6C6FAF2257884C00E8EF24 /* BSGOutOfMemoryWatchdog.m */; };
@@ -216,6 +219,9 @@
 		8A2C90401C6C03F000846019 /* Cocoa.framework */ = {isa = PBXFileReference; lastKnownFileType = wrapper.framework; name = Cocoa.framework; path = System/Library/Frameworks/Cocoa.framework; sourceTree = SDKROOT; };
 		8A2C90421C6C03FF00846019 /* Foundation.framework */ = {isa = PBXFileReference; lastKnownFileType = wrapper.framework; name = Foundation.framework; path = System/Library/Frameworks/Foundation.framework; sourceTree = SDKROOT; };
 		8A48EF261EAA805D00B70024 /* BugsnagLogger.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; name = BugsnagLogger.h; path = ../Source/BugsnagLogger.h; sourceTree = SOURCE_ROOT; };
+		8A530CB622FDC38300F0C108 /* BSG_KSCrashIdentifier.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = BSG_KSCrashIdentifier.h; sourceTree = "<group>"; };
+		8A530CB722FDC38300F0C108 /* BSG_KSCrashIdentifier.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; path = BSG_KSCrashIdentifier.m; sourceTree = "<group>"; };
+		8A530CC722FDD73800F0C108 /* KSCrashIdentifierTests.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; path = KSCrashIdentifierTests.m; sourceTree = "<group>"; };
 		8A627CD71EC3B75200F7C04E /* BSGSerialization.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; name = BSGSerialization.h; path = ../Source/BSGSerialization.h; sourceTree = SOURCE_ROOT; };
 		8A627CD81EC3B75200F7C04E /* BSGSerialization.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; name = BSGSerialization.m; path = ../Source/BSGSerialization.m; sourceTree = SOURCE_ROOT; };
 		8A6C6FAF2257884C00E8EF24 /* BSGOutOfMemoryWatchdog.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; name = BSGOutOfMemoryWatchdog.m; path = ../Source/BSGOutOfMemoryWatchdog.m; sourceTree = "<group>"; };
@@ -541,6 +547,8 @@
 				E79E6B2A1F4E3850002B35F9 /* BSG_KSCrashState.h */,
 				E79E6B2B1F4E3850002B35F9 /* BSG_KSCrashType.c */,
 				E79E6B2C1F4E3850002B35F9 /* BSG_KSCrashType.h */,
+				8A530CB622FDC38300F0C108 /* BSG_KSCrashIdentifier.h */,
+				8A530CB722FDC38300F0C108 /* BSG_KSCrashIdentifier.m */,
 				E79E6B2D1F4E3850002B35F9 /* BSG_KSSystemCapabilities.h */,
 				E79E6B2E1F4E3850002B35F9 /* BSG_KSSystemInfo.h */,
 				E79E6B2F1F4E3850002B35F9 /* BSG_KSSystemInfo.m */,
@@ -650,6 +658,7 @@
 				E7CE78A01FD94E60001D07E0 /* KSCrashState_Tests.m */,
 				E7CE789B1FD94E60001D07E0 /* KSDynamicLinker_Tests.m */,
 				E7CE78891FD94E5F001D07E0 /* KSFileUtils_Tests.m */,
+				8A530CC722FDD73800F0C108 /* KSCrashIdentifierTests.m */,
 				E7CE78961FD94E5F001D07E0 /* KSJSONCodec_Tests.m */,
 				E7CE789E1FD94E60001D07E0 /* KSLogger_Tests.m */,
 				E7CE78871FD94E5F001D07E0 /* KSMach_Tests.m */,
@@ -722,6 +731,7 @@
 				E79E6BA11F4E3850002B35F9 /* BSG_KSCrashSentry_CPPException.h in Headers */,
 				8A2C8FD51C6BC2C800846019 /* BugsnagCrashReport.h in Headers */,
 				E79E6B041F4E3847002B35F9 /* BugsnagErrorReportApiClient.h in Headers */,
+				8A530CB822FDC38300F0C108 /* BSG_KSCrashIdentifier.h in Headers */,
 				E79E6BB11F4E3850002B35F9 /* BSG_KSBacktrace_Private.h in Headers */,
 				E79E6B8C1F4E3850002B35F9 /* BSG_KSCrashC.h in Headers */,
 				E79E6BDC1F4E3850002B35F9 /* BSG_KSCrashReportFilterCompletion.h in Headers */,
@@ -897,6 +907,7 @@
 				E79148581FD82B36003EFEBF /* BugsnagFileStore.m in Sources */,
 				E79E6BDA1F4E3850002B35F9 /* BSG_RFC3339DateTool.m in Sources */,
 				E72352C21F55924A00436528 /* BSGConnectivity.m in Sources */,
+				8A530CB922FDC38300F0C108 /* BSG_KSCrashIdentifier.m in Sources */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};
@@ -914,6 +925,7 @@
 				E7CE78D51FD94E93001D07E0 /* XCTestCase+KSCrash.m in Sources */,
 				E7CE78CF1FD94E77001D07E0 /* NSError+SimpleConstructor_Tests.m in Sources */,
 				E7CE78BF1FD94E77001D07E0 /* KSCrashSentry_Signal_Tests.m in Sources */,
+				8A530CC922FDD74300F0C108 /* KSCrashIdentifierTests.m in Sources */,
 				4B406C1822CAD96400464D1D /* BugsnagCollectionsBSGDictMergeTest.m in Sources */,
 				E7CE78CB1FD94E77001D07E0 /* KSSysCtl_Tests.m in Sources */,
 				E7CE78D01FD94E77001D07E0 /* RFC3339DateTool_Tests.m in Sources */,

--- a/Source/KSCrash/Source/KSCrash/Recording/BSG_KSCrash.m
+++ b/Source/KSCrash/Source/KSCrash/Recording/BSG_KSCrash.m
@@ -315,15 +315,6 @@ IMPLEMENT_EXCLUSIVE_SHARED_INSTANCE(BSG_KSCrash)
                                     terminateProgram);
 
     free(callstack);
-
-    // If bsg_kscrash_reportUserException() returns, we did not terminate.
-    // Set up IDs and paths for the next crash.
-
-    self.nextCrashID = [NSUUID UUID].UUIDString;
-
-    bsg_kscrash_reinstall(
-        [self.crashReportPath UTF8String], [self.recrashReportPath UTF8String],
-        [self.stateFilePath UTF8String], [self.nextCrashID UTF8String]);
 }
 
 // ============================================================================

--- a/Source/KSCrash/Source/KSCrash/Recording/BSG_KSCrashC.c
+++ b/Source/KSCrash/Source/KSCrash/Recording/BSG_KSCrashC.c
@@ -112,10 +112,8 @@ int bsg_create_filepath(char *base, char filepath[bsg_filepath_len], char severi
  *
  * This function gets passed as a callback to a crash handler.
  */
-void bsg_kscrash_i_onCrash(char severity, char *errorClass) {
+void bsg_kscrash_i_onCrash(char severity, char *errorClass, BSG_KSCrash_Context *context) {
     BSG_KSLOG_DEBUG("Updating application state to note crash.");
-
-    BSG_KSCrash_Context *context = crashContext();
 
     bsg_kscrashstate_notifyAppCrash(context->crash.crashType);
 
@@ -201,7 +199,7 @@ BSG_KSCrashType bsg_kscrash_setHandlingCrashTypes(BSG_KSCrashType crashTypes) {
     if (bsg_g_installed) {
         bsg_kscrashsentry_uninstall(~crashTypes);
         crashTypes = bsg_kscrashsentry_installWithContext(
-            &context->crash, crashTypes, bsg_kscrash_i_onCrash);
+            &context->crash, crashTypes, (void(*)(char, char *, void *))bsg_kscrash_i_onCrash);
     }
 
     return crashTypes;

--- a/Source/KSCrash/Source/KSCrash/Recording/BSG_KSCrashC.c
+++ b/Source/KSCrash/Source/KSCrash/Recording/BSG_KSCrashC.c
@@ -65,7 +65,7 @@ static const int bsg_filepath_len = 512;
 static const int bsg_error_class_filepath_len = 21;
 static const char bsg_filepath_context_sep = '-';
 
-static inline BSG_KSCrash_Context *crashContext(void) {
+BSG_KSCrash_Context *crashContext(void) {
     return &bsg_g_crashReportContext;
 }
 

--- a/Source/KSCrash/Source/KSCrash/Recording/BSG_KSCrashC.h
+++ b/Source/KSCrash/Source/KSCrash/Recording/BSG_KSCrashC.h
@@ -176,6 +176,11 @@ void bsg_kscrash_setThreadTracingEnabled(bool threadTracingEnabled);
 void bsg_kscrash_setWriteBinaryImagesForUserReported(
     bool writeBinaryImagesForUserReported);
 
+/**
+ * The current crash context
+ */
+BSG_KSCrash_Context *crashContext(void);
+
 #ifdef __cplusplus
 }
 #endif

--- a/Source/KSCrash/Source/KSCrash/Recording/BSG_KSCrashContext.h
+++ b/Source/KSCrash/Source/KSCrash/Recording/BSG_KSCrashContext.h
@@ -76,6 +76,16 @@ typedef struct {
      * the report file. Application MUST NOT call async-unsafe methods!
      */
     BSGReportCallback onCrashNotify;
+
+    /**
+     * File path to write the crash report
+     */
+    const char *crashReportFilePath;
+
+    /**
+     * File path to write the recrash report, if the crash reporter crashes
+     */
+    const char *recrashReportFilePath;
 } BSG_KSCrash_Configuration;
 
 /** Contextual data used by the crash report writer.

--- a/Source/KSCrash/Source/KSCrash/Recording/BSG_KSCrashIdentifier.h
+++ b/Source/KSCrash/Source/KSCrash/Recording/BSG_KSCrashIdentifier.h
@@ -1,0 +1,25 @@
+#ifndef HDR_BSG_KSCrashIdentifier_h
+#define HDR_BSG_KSCrashIdentifier_h
+#include <stdbool.h>
+
+#ifdef __cplusplus
+extern "C" {
+#endif
+
+/**
+ * Generates a new UUID. Not async signal safe. Caller responsible for
+ * freeing allocated string.
+ */
+const char *bsg_kscrash_generate_report_identifier(void);
+/**
+ * Generates a new path string. Not async signal safe. Caller responsible
+ * for freeing allocated string.
+ */
+const char *bsg_kscrash_generate_report_path(const char *identifier,
+                                             bool is_recrash_report);
+
+#ifdef __cplusplus
+}
+#endif
+
+#endif // HDR_BSG_KSCrashIdentifier_h

--- a/Source/KSCrash/Source/KSCrash/Recording/BSG_KSCrashIdentifier.m
+++ b/Source/KSCrash/Source/KSCrash/Recording/BSG_KSCrashIdentifier.m
@@ -1,0 +1,23 @@
+#import "BSG_KSCrashIdentifier.h"
+#import "BSG_KSCrashAdvanced.h"
+#import <Foundation/Foundation.h>
+#import <string.h>
+
+const char *bsg_kscrash_generate_report_identifier(void) {
+    return strdup([[[NSUUID UUID] UUIDString] UTF8String]);
+}
+
+const char *bsg_kscrash_generate_report_path(const char *identifier,
+                                             bool is_recrash_report) {
+    if (identifier == NULL) {
+        return NULL;
+    }
+    BSG_KSCrashReportStore *store = [[BSG_KSCrash sharedInstance] crashReportStore];
+    NSString *reportID = [NSString stringWithUTF8String:identifier];
+
+    if (is_recrash_report) {
+        return strdup([[store pathToRecrashReportWithID:reportID] UTF8String]);
+    } else {
+        return strdup([[store pathToFileWithId:reportID] UTF8String]);
+    }
+}

--- a/Source/KSCrash/Source/KSCrash/Recording/BSG_KSCrashState.m
+++ b/Source/KSCrash/Source/KSCrash/Recording/BSG_KSCrashState.m
@@ -358,8 +358,11 @@ void bsg_kscrashstate_notifyAppCrash(BSG_KSCrashType type) {
         state->backgroundDurationSinceLaunch += duration;
         state->backgroundDurationSinceLastCrash += duration;
     }
-    state->crashedThisLaunch |= type != BSG_KSCrashTypeUserReported;
-    bsg_kscrashstate_i_saveState(state, stateFilePath);
+    BOOL didCrash = type != BSG_KSCrashTypeUserReported;
+    state->crashedThisLaunch |= didCrash;
+    if (didCrash) {
+        bsg_kscrashstate_i_saveState(state, stateFilePath);
+    }
 }
 
 const BSG_KSCrash_State *const bsg_kscrashstate_currentState(void) {

--- a/Source/KSCrash/Source/KSCrash/Recording/Sentry/BSG_KSCrashSentry.c
+++ b/Source/KSCrash/Source/KSCrash/Recording/Sentry/BSG_KSCrashSentry.c
@@ -90,7 +90,7 @@ static bool bsg_g_threads_are_running = true;
 BSG_KSCrashType
 bsg_kscrashsentry_installWithContext(BSG_KSCrash_SentryContext *context,
                                      BSG_KSCrashType crashTypes,
-                                     void (*onCrash)(char, char *)) {
+                                     void (*onCrash)(char, char *, void *)) {
     if (bsg_ksmachisBeingTraced()) {
         if (context->reportWhenDebuggerIsAttached) {
             BSG_KSLOG_WARN("KSCrash: App is running in a debugger. Crash "
@@ -200,7 +200,7 @@ void bsg_kscrashsentry_resumeThreads(void) {
 }
 
 void bsg_kscrashsentry_clearContext(BSG_KSCrash_SentryContext *context) {
-    void (*onCrash)(char, char *) = context->onCrash;
+    void (*onCrash)(char, char *, void *) = context->onCrash;
     bool threadTracingEnabled = context->threadTracingEnabled;
     bool reportWhenDebuggerIsAttached = context->reportWhenDebuggerIsAttached;
     bool suspendThreadsForUserReported = context->suspendThreadsForUserReported;

--- a/Source/KSCrash/Source/KSCrash/Recording/Sentry/BSG_KSCrashSentry.h
+++ b/Source/KSCrash/Source/KSCrash/Recording/Sentry/BSG_KSCrashSentry.h
@@ -51,7 +51,7 @@ typedef struct BSG_KSCrash_SentryContext {
     // Caller defined values. Caller must fill these out prior to installation.
 
     /** Called by the crash handler when a crash is detected. */
-    void (*onCrash)(char, char[21]);
+    void (*onCrash)(char, char[21], void *);
 
     /** If true, will suspend threads for user reported exceptions. */
     bool suspendThreadsForUserReported;
@@ -162,7 +162,7 @@ typedef struct BSG_KSCrash_SentryContext {
 BSG_KSCrashType
 bsg_kscrashsentry_installWithContext(BSG_KSCrash_SentryContext *context,
                                      BSG_KSCrashType crashTypes,
-                                     void (*onCrash)(char, char *));
+                                     void (*onCrash)(char, char *, void *));
 
 /** Uninstall crash sentry.
  *

--- a/Source/KSCrash/Source/KSCrash/Recording/Sentry/BSG_KSCrashSentry_CPPException.mm
+++ b/Source/KSCrash/Source/KSCrash/Recording/Sentry/BSG_KSCrashSentry_CPPException.mm
@@ -27,6 +27,7 @@
 #include "BSG_KSCrashSentry_CPPException.h"
 #include "BSG_KSCrashSentry_Private.h"
 #include "BSG_KSMach.h"
+#include "BSG_KSCrashC.h"
 
 //#define BSG_KSLogger_LocalLevel TRACE
 #include "BSG_KSLogger.h"
@@ -181,7 +182,7 @@ static void CPPExceptionTerminate(void) {
         BSG_KSLOG_DEBUG(@"Calling main crash handler.");
         char errorClass[21];
         strncpy(errorClass, bsg_g_context->CPPException.name, sizeof(errorClass));
-        bsg_g_context->onCrash('e', errorClass);
+        bsg_g_context->onCrash('e', errorClass, crashContext());
 
         BSG_KSLOG_DEBUG(
             @"Crash handling complete. Restoring original handlers.");

--- a/Source/KSCrash/Source/KSCrash/Recording/Sentry/BSG_KSCrashSentry_MachException.c
+++ b/Source/KSCrash/Source/KSCrash/Recording/Sentry/BSG_KSCrashSentry_MachException.c
@@ -29,6 +29,7 @@
 
 //#define BSG_KSLogger_LocalLevel TRACE
 #include "BSG_KSLogger.h"
+#include "BSG_KSCrashC.h"
 
 #if BSG_KSCRASH_HAS_MACH
 
@@ -287,7 +288,7 @@ void *ksmachexc_i_handleExceptions(void *const userData) {
         BSG_KSLOG_DEBUG("Calling main crash handler.");
         char errorClass[21];
         strncpy(errorClass, bsg_ksmachexceptionName(bsg_g_context->mach.type), sizeof(errorClass));
-        bsg_g_context->onCrash('e', errorClass);
+        bsg_g_context->onCrash('e', errorClass, crashContext());
 
         BSG_KSLOG_DEBUG(
             "Crash handling complete. Restoring original handlers.");

--- a/Source/KSCrash/Source/KSCrash/Recording/Sentry/BSG_KSCrashSentry_NSException.m
+++ b/Source/KSCrash/Source/KSCrash/Recording/Sentry/BSG_KSCrashSentry_NSException.m
@@ -27,6 +27,7 @@
 #import "BSG_KSCrashSentry_NSException.h"
 #import "BSG_KSCrashSentry_Private.h"
 #include "BSG_KSMach.h"
+#include "BSG_KSCrashC.h"
 
 //#define BSG_KSLogger_LocalLevel TRACE
 #import "BSG_KSLogger.h"
@@ -130,7 +131,7 @@ void bsg_recordException(NSException *exception) {
         BSG_KSLOG_DEBUG(@"Calling main crash handler.");
         char errorClass[21];
         strncpy(errorClass, bsg_g_context->NSException.name, sizeof(errorClass));
-        bsg_g_context->onCrash('e', errorClass);
+        bsg_g_context->onCrash('e', errorClass, crashContext());
     }
 }
 

--- a/Source/KSCrash/Source/KSCrash/Recording/Sentry/BSG_KSCrashSentry_Signal.c
+++ b/Source/KSCrash/Source/KSCrash/Recording/Sentry/BSG_KSCrashSentry_Signal.c
@@ -31,6 +31,7 @@
 
 #include "BSG_KSMach.h"
 #include "BSG_KSSignalInfo.h"
+#include "BSG_KSCrashC.h"
 
 //#define BSG_KSLogger_LocalLevel TRACE
 #include "BSG_KSLogger.h"
@@ -118,7 +119,8 @@ void bsg_kssighndl_i_handleSignal(int sigNum, siginfo_t *signalInfo,
                 errorClass[i] = c;
             }
         }
-        bsg_g_context->onCrash('e', errorClass);
+        
+        bsg_g_context->onCrash('e', errorClass, crashContext());
 
         BSG_KSLOG_DEBUG(
             "Crash handling complete. Restoring original handlers.");

--- a/Source/KSCrash/Source/KSCrash/Recording/Sentry/BSG_KSCrashSentry_User.c
+++ b/Source/KSCrash/Source/KSCrash/Recording/Sentry/BSG_KSCrashSentry_User.c
@@ -25,6 +25,7 @@
 #include "BSG_KSCrashSentry_User.h"
 #include "BSG_KSCrashSentry_Private.h"
 #include "BSG_KSMach.h"
+#include "BSG_KSCrashC.h"
 
 //#define BSG_KSLogger_LocalLevel TRACE
 #include "BSG_KSLogger.h"
@@ -110,7 +111,7 @@ void bsg_kscrashsentry_reportUserException(const char *name,
         strncpy(errorClass, bsg_g_context->userException.name, sizeof(errorClass));
         // default to 'w'arning level severity
         char severityChar = severity != NULL && strlen(severity) > 0 ? severity[0] : 'w';
-        bsg_g_context->onCrash(severityChar, errorClass);
+        bsg_g_context->onCrash(severityChar, errorClass, crashContext());
 
         if (terminateProgram) {
             bsg_kscrashsentry_uninstall(BSG_KSCrashTypeAll);

--- a/Tests/KSCrash/KSCrashIdentifierTests.m
+++ b/Tests/KSCrash/KSCrashIdentifierTests.m
@@ -1,0 +1,32 @@
+#import <XCTest/XCTest.h>
+#import <string.h>
+#import "BSG_KSCrashIdentifier.h"
+
+@interface KSCrashIdentifierTests : XCTestCase
+@end
+
+@implementation KSCrashIdentifierTests
+
+- (void)testGenerateUniqueIDs {
+    char *id1 = (char *)bsg_kscrash_generate_report_identifier();
+    char *id2 = (char *)bsg_kscrash_generate_report_identifier();
+    char *id3 = (char *)bsg_kscrash_generate_report_identifier();
+    XCTAssertNotEqual(0, strcmp(id1, id2));
+    XCTAssertNotEqual(0, strcmp(id1, id3));
+    XCTAssertNotEqual(0, strcmp(id2, id3));
+    free(id1);
+    free(id2);
+    free(id3);
+}
+
+- (void)testIsUUID {
+    char *id1 = (char *)bsg_kscrash_generate_report_identifier();
+    NSString *uuidString = [[NSString alloc] initWithUTF8String:id1];
+    XCTAssertNotEqual(0, uuidString.length);
+
+    NSUUID *uuid = [[NSUUID alloc] initWithUUIDString:uuidString];
+    XCTAssertEqual(0, strcmp(id1, [[uuid UUIDString] UTF8String]));
+    free(id1);
+}
+
+@end

--- a/Tests/KSCrash/KSCrashSentry_Tests.m
+++ b/Tests/KSCrash/KSCrashSentry_Tests.m
@@ -30,7 +30,7 @@
 #import "BSG_KSCrashSentry.h"
 #import "BSG_KSCrashSentry_Private.h"
 
-static void onCrash(char severity, char *errorClass)
+static void onCrash(char severity, char *errorClas, void *context)
 {
     // Do nothing
 }

--- a/features/fixtures/ios-swift-cocoapods/iOSTestApp.xcodeproj/project.pbxproj
+++ b/features/fixtures/ios-swift-cocoapods/iOSTestApp.xcodeproj/project.pbxproj
@@ -13,6 +13,7 @@
 		8A22FC66225B598500CA8895 /* OOMScenario.m in Sources */ = {isa = PBXBuildFile; fileRef = 8A22FC65225B598500CA8895 /* OOMScenario.m */; };
 		8A32DB8222424E3000EDD92F /* NSExceptionShiftScenario.m in Sources */ = {isa = PBXBuildFile; fileRef = 8A32DB8122424E3000EDD92F /* NSExceptionShiftScenario.m */; };
 		8A42FD35225DEE04007AE561 /* SessionOOMScenario.m in Sources */ = {isa = PBXBuildFile; fileRef = 8A42FD33225DEE04007AE561 /* SessionOOMScenario.m */; };
+		8A530CCC22FDDBF000F0C108 /* ManyConcurrentNotifyScenario.m in Sources */ = {isa = PBXBuildFile; fileRef = 8A530CCB22FDDBF000F0C108 /* ManyConcurrentNotifyScenario.m */; };
 		8A840FBA21AF5C450041DBFA /* SwiftAssertion.swift in Sources */ = {isa = PBXBuildFile; fileRef = 8A840FB921AF5C450041DBFA /* SwiftAssertion.swift */; };
 		8A98400320FD11BF0023ECD1 /* AutoSessionCustomVersionScenario.m in Sources */ = {isa = PBXBuildFile; fileRef = 8A98400220FD11BF0023ECD1 /* AutoSessionCustomVersionScenario.m */; };
 		8AB8866420404DD30003E444 /* AppDelegate.swift in Sources */ = {isa = PBXBuildFile; fileRef = 8AB8866320404DD30003E444 /* AppDelegate.swift */; };
@@ -81,6 +82,8 @@
 		8A32DB8122424E3000EDD92F /* NSExceptionShiftScenario.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; path = NSExceptionShiftScenario.m; sourceTree = "<group>"; };
 		8A42FD33225DEE04007AE561 /* SessionOOMScenario.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; path = SessionOOMScenario.m; sourceTree = "<group>"; };
 		8A42FD34225DEE04007AE561 /* SessionOOMScenario.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = SessionOOMScenario.h; sourceTree = "<group>"; };
+		8A530CCA22FDDBF000F0C108 /* ManyConcurrentNotifyScenario.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; path = ManyConcurrentNotifyScenario.h; sourceTree = "<group>"; };
+		8A530CCB22FDDBF000F0C108 /* ManyConcurrentNotifyScenario.m */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.objc; path = ManyConcurrentNotifyScenario.m; sourceTree = "<group>"; };
 		8A56EE7F22E22ED80066B9DC /* OOMWillTerminateScenario.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; path = OOMWillTerminateScenario.m; sourceTree = "<group>"; };
 		8A56EE8022E22ED80066B9DC /* OOMWillTerminateScenario.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = OOMWillTerminateScenario.h; sourceTree = "<group>"; };
 		8A840FB921AF5C450041DBFA /* SwiftAssertion.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = SwiftAssertion.swift; sourceTree = "<group>"; };
@@ -241,6 +244,8 @@
 				8A14F0F02282D4AD00337B05 /* ReportBackgroundOOMsEnabledScenario.m */,
 				8A14F0EF2282D4AD00337B05 /* ReportOOMsDisabledReportBackgroundOOMsEnabledScenario.h */,
 				8A14F0F32282D4AE00337B05 /* ReportOOMsDisabledReportBackgroundOOMsEnabledScenario.m */,
+				8A530CCA22FDDBF000F0C108 /* ManyConcurrentNotifyScenario.h */,
+				8A530CCB22FDDBF000F0C108 /* ManyConcurrentNotifyScenario.m */,
 				8A14F0F12282D4AD00337B05 /* ReportOOMsDisabledScenario.h */,
 				8A14F0F22282D4AD00337B05 /* ReportOOMsDisabledScenario.m */,
 				8A32DB8022424E3000EDD92F /* NSExceptionShiftScenario.h */,
@@ -466,6 +471,7 @@
 				8A42FD35225DEE04007AE561 /* SessionOOMScenario.m in Sources */,
 				F4295CEAD7C915EFA04898A5 /* Scenario.m in Sources */,
 				F4295836C8AF75547C675E8D /* ReleasedObjectScenario.m in Sources */,
+				8A530CCC22FDDBF000F0C108 /* ManyConcurrentNotifyScenario.m in Sources */,
 				F42958881D3F34A76CADE4EC /* SwiftCrash.swift in Sources */,
 				F42955DB6D08642528917FAB /* CxxExceptionScenario.mm in Sources */,
 				8A32DB8222424E3000EDD92F /* NSExceptionShiftScenario.m in Sources */,

--- a/features/fixtures/ios-swift-cocoapods/iOSTestApp/scenarios/ManyConcurrentNotifyScenario.h
+++ b/features/fixtures/ios-swift-cocoapods/iOSTestApp/scenarios/ManyConcurrentNotifyScenario.h
@@ -1,0 +1,5 @@
+#import "Scenario.h"
+
+@interface ManyConcurrentNotifyScenario : Scenario
+
+@end

--- a/features/fixtures/ios-swift-cocoapods/iOSTestApp/scenarios/ManyConcurrentNotifyScenario.m
+++ b/features/fixtures/ios-swift-cocoapods/iOSTestApp/scenarios/ManyConcurrentNotifyScenario.m
@@ -1,0 +1,47 @@
+#import "ManyConcurrentNotifyScenario.h"
+#import <Bugsnag/Bugsnag.h>
+
+@interface ManyConcurrentNotifyScenario ()
+@property (nonatomic) dispatch_queue_t queue1;
+@property (nonatomic) dispatch_queue_t queue2;
+@end
+
+@interface FooError : NSError
+@end
+@implementation FooError
+@end
+
+@implementation ManyConcurrentNotifyScenario
+
+- (instancetype)initWithConfig:(BugsnagConfiguration *)config {
+    if (self = [super initWithConfig:config]) {
+        _queue1 = dispatch_queue_create("Log Queue 1", DISPATCH_QUEUE_CONCURRENT);
+        _queue2 = dispatch_queue_create("Log Queue 2", DISPATCH_QUEUE_CONCURRENT);
+    }
+    return self;
+}
+
+- (void)run {
+    for (int i = 0; i < 4; i++) {
+        NSString *message = [NSString stringWithFormat:@"Err %ld", (long)i];
+        [self logError:[FooError errorWithDomain:@"com.example"
+                                            code:401 + i
+                                        userInfo:@{NSLocalizedDescriptionKey: message}]];
+    }
+}
+
+- (void)logError:(NSError *)error {
+    dispatch_async(self.queue1, ^{
+        [Bugsnag notifyError:error];
+    });
+    dispatch_async(self.queue2, ^{
+        [Bugsnag notifyError:error];
+    });
+}
+
+- (void)startBugsnag {
+    self.config.shouldAutoCaptureSessions = NO;
+    [super startBugsnag];
+}
+
+@end

--- a/features/handled_errors.feature
+++ b/features/handled_errors.feature
@@ -53,3 +53,17 @@ Scenario: Reporting a handled exception's stacktrace
     And the "method" of stack frame 1 equals "objc_exception_throw"
     And the "method" of stack frame 2 equals "-[NSExceptionShiftScenario causeAnException]"
     And the "method" of stack frame 3 equals "-[NSExceptionShiftScenario run]"
+
+Scenario: Reporting handled errors concurrently
+    When I run "ManyConcurrentNotifyScenario"
+    And I wait for a request
+    Then the request is valid for the error reporting API
+    And the "Bugsnag-API-Key" header equals "a35a2a72bd230ac0aa0f52715bbdc6aa"
+    And the payload field "notifier.name" equals "iOS Bugsnag Notifier"
+    And the payload field "events" is an array with 8 elements
+    And each event in the payload matches one of:
+        | exceptions.0.errorClass | exceptions.0.message |
+        | FooError                | Err 0   |
+        | FooError                | Err 1   |
+        | FooError                | Err 2   |
+        | FooError                | Err 3   |

--- a/iOS/Bugsnag.xcodeproj/project.pbxproj
+++ b/iOS/Bugsnag.xcodeproj/project.pbxproj
@@ -35,6 +35,9 @@
 		8A2C8F961C6BC08600846019 /* report.json in Resources */ = {isa = PBXBuildFile; fileRef = 8A2C8F951C6BC08600846019 /* report.json */; };
 		8A381D4B1EAA49A700AF8429 /* BugsnagLogger.h in Headers */ = {isa = PBXBuildFile; fileRef = 8A381D491EAA49A700AF8429 /* BugsnagLogger.h */; };
 		8A4E733F1DC13281001F7CC8 /* BugsnagConfigurationTests.m in Sources */ = {isa = PBXBuildFile; fileRef = 8A4E733E1DC13281001F7CC8 /* BugsnagConfigurationTests.m */; };
+		8A530CC022FDC3AF00F0C108 /* BSG_KSCrashIdentifier.h in Headers */ = {isa = PBXBuildFile; fileRef = 8A530CBE22FDC3AE00F0C108 /* BSG_KSCrashIdentifier.h */; };
+		8A530CC122FDC3AF00F0C108 /* BSG_KSCrashIdentifier.m in Sources */ = {isa = PBXBuildFile; fileRef = 8A530CBF22FDC3AE00F0C108 /* BSG_KSCrashIdentifier.m */; };
+		8A530CC422FDD51F00F0C108 /* KSCrashIdentifierTests.m in Sources */ = {isa = PBXBuildFile; fileRef = 8A530CC222FDD4C800F0C108 /* KSCrashIdentifierTests.m */; };
 		8A627CD01EC2A5FD00F7C04E /* BSGSerialization.h in Headers */ = {isa = PBXBuildFile; fileRef = 8A627CCF1EC2A5FD00F7C04E /* BSGSerialization.h */; };
 		8A627CD21EC2A62900F7C04E /* BSGSerialization.m in Sources */ = {isa = PBXBuildFile; fileRef = 8A627CD11EC2A62900F7C04E /* BSGSerialization.m */; };
 		8A70D9C922539C81006B696F /* BSGOutOfMemoryWatchdog.h in Headers */ = {isa = PBXBuildFile; fileRef = 8A70D9C722539C81006B696F /* BSGOutOfMemoryWatchdog.h */; };
@@ -430,6 +433,9 @@
 		8A2C8F951C6BC08600846019 /* report.json */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = text.json; name = report.json; path = ../Tests/report.json; sourceTree = SOURCE_ROOT; };
 		8A381D491EAA49A700AF8429 /* BugsnagLogger.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; name = BugsnagLogger.h; path = ../Source/BugsnagLogger.h; sourceTree = SOURCE_ROOT; };
 		8A4E733E1DC13281001F7CC8 /* BugsnagConfigurationTests.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; name = BugsnagConfigurationTests.m; path = ../Tests/BugsnagConfigurationTests.m; sourceTree = SOURCE_ROOT; };
+		8A530CBE22FDC3AE00F0C108 /* BSG_KSCrashIdentifier.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = BSG_KSCrashIdentifier.h; sourceTree = "<group>"; };
+		8A530CBF22FDC3AE00F0C108 /* BSG_KSCrashIdentifier.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; path = BSG_KSCrashIdentifier.m; sourceTree = "<group>"; };
+		8A530CC222FDD4C800F0C108 /* KSCrashIdentifierTests.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; path = KSCrashIdentifierTests.m; sourceTree = "<group>"; };
 		8A627CCF1EC2A5FD00F7C04E /* BSGSerialization.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; name = BSGSerialization.h; path = ../Source/BSGSerialization.h; sourceTree = SOURCE_ROOT; };
 		8A627CD11EC2A62900F7C04E /* BSGSerialization.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; name = BSGSerialization.m; path = ../Source/BSGSerialization.m; sourceTree = SOURCE_ROOT; };
 		8A70D9C722539C81006B696F /* BSGOutOfMemoryWatchdog.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; name = BSGOutOfMemoryWatchdog.h; path = ../Source/BSGOutOfMemoryWatchdog.h; sourceTree = "<group>"; };
@@ -744,6 +750,7 @@
 				E784D25D1FD70E55004B01E1 /* KSString_Tests.m */,
 				E784D2591FD70C25004B01E1 /* KSJSONCodec_Tests.m */,
 				E784D2511FD70AE6004B01E1 /* KSCrashState_Tests.m */,
+				8A530CC222FDD4C800F0C108 /* KSCrashIdentifierTests.m */,
 				E784D2521FD70AE6004B01E1 /* KSMach_Tests.m */,
 				E733A76D1FD709B7003EAA29 /* KSCrashReportStore_Tests.m */,
 				E733A76C1FD709B7003EAA29 /* KSDynamicLinker_Tests.m */,
@@ -817,6 +824,8 @@
 				E7107BD51F4C97F100BB3F98 /* BSG_KSCrashState.h */,
 				E7107BD61F4C97F100BB3F98 /* BSG_KSCrashType.c */,
 				E7107BD71F4C97F100BB3F98 /* BSG_KSCrashType.h */,
+				8A530CBE22FDC3AE00F0C108 /* BSG_KSCrashIdentifier.h */,
+				8A530CBF22FDC3AE00F0C108 /* BSG_KSCrashIdentifier.m */,
 				E7107BD81F4C97F100BB3F98 /* BSG_KSSystemCapabilities.h */,
 				E7107BD91F4C97F100BB3F98 /* BSG_KSSystemInfo.h */,
 				E7107BDA1F4C97F100BB3F98 /* BSG_KSSystemInfo.m */,
@@ -964,6 +973,7 @@
 				E7107C371F4C97F100BB3F98 /* BSG_KSCrashC.h in Headers */,
 				E7107C871F4C97F100BB3F98 /* BSG_KSCrashReportFilterCompletion.h in Headers */,
 				E7107C6F1F4C97F100BB3F98 /* BSG_KSMachApple.h in Headers */,
+				8A530CC022FDC3AF00F0C108 /* BSG_KSCrashIdentifier.h in Headers */,
 				E7107C581F4C97F100BB3F98 /* BSG_KSCrashSentry_User.h in Headers */,
 				E7107C4B1F4C97F100BB3F98 /* BSG_KSCrashSentry.h in Headers */,
 				E72BF77F1FC86A7A004BE82F /* BugsnagUser.h in Headers */,
@@ -1169,6 +1179,7 @@
 				F4295B2AC95281CBA3A42DCA /* BugsnagSessionFileStore.m in Sources */,
 				F4295C52A30DC98515F2FF02 /* BugsnagSessionTrackingApiClient.m in Sources */,
 				F4295168CDC7A77A832C9475 /* BugsnagApiClient.m in Sources */,
+				8A530CC122FDC3AF00F0C108 /* BSG_KSCrashIdentifier.m in Sources */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};
@@ -1200,6 +1211,7 @@
 				E7B3291A1FD707EC0098FC47 /* KSCrashReportConverter_Tests.m in Sources */,
 				E733A76F1FD709B7003EAA29 /* KSCrashReportStore_Tests.m in Sources */,
 				E70EE0781FD7039E00FA745C /* RFC3339DateTool_Tests.m in Sources */,
+				8A530CC422FDD51F00F0C108 /* KSCrashIdentifierTests.m in Sources */,
 				8A4E733F1DC13281001F7CC8 /* BugsnagConfigurationTests.m in Sources */,
 				E784D25A1FD70C25004B01E1 /* KSJSONCodec_Tests.m in Sources */,
 				E70EE0881FD7047800FA745C /* KSSystemInfo_Tests.m in Sources */,

--- a/tvOS/Bugsnag.xcodeproj/project.pbxproj
+++ b/tvOS/Bugsnag.xcodeproj/project.pbxproj
@@ -17,6 +17,9 @@
 		4B775FD122CBE01F004839C5 /* BugsnagCollectionsBSGDictInsertIfNotNilTest.m in Sources */ = {isa = PBXBuildFile; fileRef = 4B775FD022CBE01F004839C5 /* BugsnagCollectionsBSGDictInsertIfNotNilTest.m */; };
 		8A12006E221C51550008C9C3 /* BSGFilepathTests.m in Sources */ = {isa = PBXBuildFile; fileRef = 8A12006D221C51550008C9C3 /* BSGFilepathTests.m */; };
 		8A48EF291EAA824100B70024 /* BugsnagLogger.h in Headers */ = {isa = PBXBuildFile; fileRef = 8A48EF281EAA824100B70024 /* BugsnagLogger.h */; };
+		8A530CBC22FDC39300F0C108 /* BSG_KSCrashIdentifier.m in Sources */ = {isa = PBXBuildFile; fileRef = 8A530CBA22FDC39300F0C108 /* BSG_KSCrashIdentifier.m */; };
+		8A530CBD22FDC39300F0C108 /* BSG_KSCrashIdentifier.h in Headers */ = {isa = PBXBuildFile; fileRef = 8A530CBB22FDC39300F0C108 /* BSG_KSCrashIdentifier.h */; };
+		8A530CC622FDD71B00F0C108 /* KSCrashIdentifierTests.m in Sources */ = {isa = PBXBuildFile; fileRef = 8A530CC522FDD71B00F0C108 /* KSCrashIdentifierTests.m */; };
 		8A627CD51EC3B69300F7C04E /* BSGSerialization.h in Headers */ = {isa = PBXBuildFile; fileRef = 8A627CD31EC3B69300F7C04E /* BSGSerialization.h */; };
 		8A627CD61EC3B69300F7C04E /* BSGSerialization.m in Sources */ = {isa = PBXBuildFile; fileRef = 8A627CD41EC3B69300F7C04E /* BSGSerialization.m */; };
 		8A6C6FAD2257882400E8EF24 /* BSGOutOfMemoryWatchdog.m in Sources */ = {isa = PBXBuildFile; fileRef = 8A6C6FAB2257882400E8EF24 /* BSGOutOfMemoryWatchdog.m */; };
@@ -195,6 +198,9 @@
 		4B775FD022CBE01F004839C5 /* BugsnagCollectionsBSGDictInsertIfNotNilTest.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; name = BugsnagCollectionsBSGDictInsertIfNotNilTest.m; path = ../../Tests/BugsnagCollectionsBSGDictInsertIfNotNilTest.m; sourceTree = "<group>"; };
 		8A12006D221C51550008C9C3 /* BSGFilepathTests.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; name = BSGFilepathTests.m; path = ../../Tests/BSGFilepathTests.m; sourceTree = "<group>"; };
 		8A48EF281EAA824100B70024 /* BugsnagLogger.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; name = BugsnagLogger.h; path = ../Source/BugsnagLogger.h; sourceTree = "<group>"; };
+		8A530CBA22FDC39300F0C108 /* BSG_KSCrashIdentifier.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; path = BSG_KSCrashIdentifier.m; sourceTree = "<group>"; };
+		8A530CBB22FDC39300F0C108 /* BSG_KSCrashIdentifier.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = BSG_KSCrashIdentifier.h; sourceTree = "<group>"; };
+		8A530CC522FDD71B00F0C108 /* KSCrashIdentifierTests.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; path = KSCrashIdentifierTests.m; sourceTree = "<group>"; };
 		8A627CD31EC3B69300F7C04E /* BSGSerialization.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; name = BSGSerialization.h; path = ../Source/BSGSerialization.h; sourceTree = "<group>"; };
 		8A627CD41EC3B69300F7C04E /* BSGSerialization.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; name = BSGSerialization.m; path = ../Source/BSGSerialization.m; sourceTree = "<group>"; };
 		8A6C6FAB2257882400E8EF24 /* BSGOutOfMemoryWatchdog.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; name = BSGOutOfMemoryWatchdog.m; path = ../Source/BSGOutOfMemoryWatchdog.m; sourceTree = "<group>"; };
@@ -554,6 +560,8 @@
 				E766171F1F4E459C0094CECF /* BSG_KSCrashState.h */,
 				E76617201F4E459C0094CECF /* BSG_KSCrashType.c */,
 				E76617211F4E459C0094CECF /* BSG_KSCrashType.h */,
+				8A530CBB22FDC39300F0C108 /* BSG_KSCrashIdentifier.h */,
+				8A530CBA22FDC39300F0C108 /* BSG_KSCrashIdentifier.m */,
 				E76617221F4E459C0094CECF /* BSG_KSSystemCapabilities.h */,
 				E76617231F4E459C0094CECF /* BSG_KSSystemInfo.h */,
 				E76617241F4E459C0094CECF /* BSG_KSSystemInfo.m */,
@@ -664,6 +672,7 @@
 				E7CE78DA1FD94F18001D07E0 /* KSFileUtils_Tests.m */,
 				E7CE78E71FD94F19001D07E0 /* KSJSONCodec_Tests.m */,
 				E7CE78EF1FD94F1A001D07E0 /* KSLogger_Tests.m */,
+				8A530CC522FDD71B00F0C108 /* KSCrashIdentifierTests.m */,
 				E7CE78D81FD94F18001D07E0 /* KSMach_Tests.m */,
 				E7CE78E51FD94F19001D07E0 /* KSSignalInfo_Tests.m */,
 				E7CE78E31FD94F19001D07E0 /* KSString_Tests.m */,
@@ -734,6 +743,7 @@
 				E76617961F4E459C0094CECF /* BSG_KSCrashSentry_CPPException.h in Headers */,
 				8AD9A4F91D42EE96004E1CC5 /* BugsnagCrashReport.h in Headers */,
 				E76616F91F4E45950094CECF /* BugsnagErrorReportApiClient.h in Headers */,
+				8A530CBD22FDC39300F0C108 /* BSG_KSCrashIdentifier.h in Headers */,
 				E76617A61F4E459C0094CECF /* BSG_KSBacktrace_Private.h in Headers */,
 				E76617811F4E459C0094CECF /* BSG_KSCrashC.h in Headers */,
 				E76617D11F4E459C0094CECF /* BSG_KSCrashReportFilterCompletion.h in Headers */,
@@ -909,6 +919,7 @@
 				E76617A11F4E459C0094CECF /* BSG_KSCrashSentry_User.c in Sources */,
 				E76617CF1F4E459C0094CECF /* BSG_RFC3339DateTool.m in Sources */,
 				E72352BE1F55923700436528 /* BSGConnectivity.m in Sources */,
+				8A530CBC22FDC39300F0C108 /* BSG_KSCrashIdentifier.m in Sources */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};
@@ -940,6 +951,7 @@
 				8AB151211D41361700C9B218 /* BugsnagBreadcrumbsTest.m in Sources */,
 				E7CE78F81FD94F1B001D07E0 /* KSCrashSentry_Tests.m in Sources */,
 				E7CE78F51FD94F1B001D07E0 /* XCTestCase+KSCrash.m in Sources */,
+				8A530CC622FDD71B00F0C108 /* KSCrashIdentifierTests.m in Sources */,
 				E7CE79091FD94F1B001D07E0 /* KSCrashState_Tests.m in Sources */,
 				E7CE78FF1FD94F1B001D07E0 /* KSCrashReportStore_Tests.m in Sources */,
 				E7CE78FD1FD94F1B001D07E0 /* KSString_Tests.m in Sources */,


### PR DESCRIPTION
## Goal

Its possible that when `notify()` is called concurrently from multiple queues, that a crash occurs when caching/resetting crash state. This changeset solves the underlying issues by not sharing state between calls to `notify()` and isolating calls to suspend threads (for backtrace collection).

### Reproduction case

```objc
dispatch_queue_t queue1 = dispatch_queue_create("Queue 1", DISPATCH_QUEUE_CONCURRENT);
dispatch_queue_t queue2 = dispatch_queue_create("Queue 2", DISPATCH_QUEUE_CONCURRENT);

for (int i = 0; i < 4; i++) {
    NSString *message = [NSString stringWithFormat:@"Err %ld", (long)i];
    NSError *error = [FooError errorWithDomain:@"com.example"
                                          code:340
                                      userInfo:nil];
    dispatch_async(queue1, ^{
        [Bugsnag notifyError:error];
    });
    dispatch_async(queue2, ^{
        [Bugsnag notifyError:error];
    });
}
```

Fixes #399

## Changeset

The changes can be divided into four parts:

1. Adding a (failing on master) test which calls `notify()` several times from different concurrent queues
2. Refactoring crash reporting internals to allow providing separate crash contexts for each invocation of `notify()`
3. Implementing separate crash contexts for `notify()` calls
4. Adding locking around suspending threads and writing crash state.

The easiest way to view the changeset is one commit at a time, since each chunk can be evaluated independently.

## Tests

* Tested manually on a couple different iOS/tvOS devices running iOS 11 & 12
* Added automated tests replicating the failing scenario
