### PR TITLE
fix(oom): Ensure UIKit APIs are not called from background threads

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,13 @@
 Changelog
 =========
 
+## TBD
+
+### Bug fixes
+
+* Ensure UIKit APIs are not called from background threads if
+  `Bugsnag.start()` is called in the background
+
 ## 5.22.5 (2019-08-14)
 
 ### Bug fixes


### PR DESCRIPTION
The normal flow is to install on the main thread, immediately after app
launch to ensure as many errors and crashes are captured as possible.
However, some mobile development frameworks may prevent this flow,
instead only allowing initialization later or on a background queue. In
these cases, the library should still work and not emit additional
warnings.

Prior to this change, background initialization using Bugsnag.start()
would be detected by the main thread sanitizer as UI API usage.

Fixes bugsnag/bugsnag-react-native#396

### Tests

While I didn't find a good way to automate the check (as it only fires in an interactive debugging environment), I verified the change manually to ensure that it is only called on main now.