### PR TITLE
Fix inForeground value for reports which launch and crash without coming to the foreground

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,14 @@
 Changelog
 =========
 
+## TBD
+
+### Bug fixes
+
+* Show correct value for `app.inForeground` when an app launches and crashes in
+  the background without ever coming to the foreground.
+  [#415](https://github.com/bugsnag/bugsnag-cocoa/pull/415)
+
 ## 5.22.6 (2019-09-18)
 
 ### Enhancements

--- a/Source/BSGOutOfMemoryWatchdog.m
+++ b/Source/BSGOutOfMemoryWatchdog.m
@@ -244,7 +244,7 @@
     app[@"version"] = systemInfo[@BSG_KSSystemField_BundleShortVersion] ?: @"";
     app[@"bundleVersion"] = systemInfo[@BSG_KSSystemField_BundleVersion] ?: @"";
 #if BSGOOMAvailable
-    UIApplicationState state = [self currentAppState];
+    UIApplicationState state = [BSG_KSSystemInfo currentAppState];
     // The app is in the foreground if the current state is "active" or
     // "inactive". From the UIApplicationState docs:
     // > UIApplicationStateActive
@@ -284,35 +284,5 @@
 
     return cache;
 }
-
-// Only available on iOS/tvOS
-#if BSGOOMAvailable
-- (UIApplicationState)currentAppState {
-    // Only checked outside of app extensions since sharedApplication is
-    // unavailable to extension UIKit APIs
-    if ([BSG_KSSystemInfo isRunningInAppExtension]) {
-        return UIApplicationStateActive;
-    }
-
-    UIApplicationState(^getState)(void) = ^() {
-        // Calling this API indirectly to avoid a compile-time check that
-        // [UIApplication sharedApplication] is not called from app extensions
-        // (which is handled above)
-        UIApplication *app = [UIApplication performSelector:@selector(sharedApplication)];
-        return [app applicationState];
-    };
-
-    if ([[NSThread currentThread] isMainThread]) {
-        return getState();
-    } else {
-        // [UIApplication sharedApplication] is a main thread-only API
-        __block UIApplicationState state;
-        dispatch_sync(dispatch_get_main_queue(), ^{
-            state = getState();
-        });
-        return state;
-    }
-}
-#endif
 
 @end

--- a/Source/BSGOutOfMemoryWatchdog.m
+++ b/Source/BSGOutOfMemoryWatchdog.m
@@ -245,18 +245,7 @@
     app[@"bundleVersion"] = systemInfo[@BSG_KSSystemField_BundleVersion] ?: @"";
 #if BSGOOMAvailable
     UIApplicationState state = [BSG_KSSystemInfo currentAppState];
-    // The app is in the foreground if the current state is "active" or
-    // "inactive". From the UIApplicationState docs:
-    // > UIApplicationStateActive
-    // >   The app is running in the foreground and currently receiving events.
-    // > UIApplicationStateInactive
-    // >   The app is running in the foreground but is not receiving events.
-    // >   This might happen as a result of an interruption or because the app
-    // >   is transitioning to or from the background.
-    // > UIApplicationStateBackground
-    // >   The app is running in the background.
-    app[@"inForeground"] = @(state == UIApplicationStateInactive
-                          || state == UIApplicationStateActive);
+    app[@"inForeground"] = @([BSG_KSSystemInfo isInForeground:state]);
     app[@"isActive"] = @(state == UIApplicationStateActive);
 #else
     app[@"inForeground"] = @YES;

--- a/Source/KSCrash/Source/KSCrash/Recording/BSG_KSCrashState.m
+++ b/Source/KSCrash/Source/KSCrash/Recording/BSG_KSCrashState.m
@@ -30,10 +30,14 @@
 #include "BSG_KSJSONCodec.h"
 #include "BSG_KSJSONCodecObjC.h"
 #include "BSG_KSMach.h"
+#include "BSG_KSSystemInfo.h"
 
 //#define BSG_KSLogger_LocalLevel TRACE
 #include "BSG_KSLogger.h"
 
+#if (TARGET_OS_TV || TARGET_OS_IPHONE || TARGET_IPHONE_SIMULATOR)
+#import <UIKit/UIKit.h>
+#endif
 #include <errno.h>
 #include <fcntl.h>
 #include <mach/mach_time.h>
@@ -298,7 +302,14 @@ bool bsg_kscrashstate_init(const char *const stateFilePath,
     // Simulate first transition to foreground
     state->launchesSinceLastCrash++;
     state->sessionsSinceLastCrash++;
+#if (TARGET_OS_TV || TARGET_OS_IPHONE || TARGET_IPHONE_SIMULATOR)
+    // On iOS/tvOS, the app may have launched in the background due to a fetch
+    // event or notification
+    UIApplicationState appState = [BSG_KSSystemInfo currentAppState];
+    state->applicationIsInForeground = [BSG_KSSystemInfo isInForeground:appState];
+#else
     state->applicationIsInForeground = true;
+#endif
 
     return bsg_kscrashstate_i_saveState(state, stateFilePath);
 }

--- a/Source/KSCrash/Source/KSCrash/Recording/BSG_KSSystemInfo.h
+++ b/Source/KSCrash/Source/KSCrash/Recording/BSG_KSSystemInfo.h
@@ -56,6 +56,9 @@
 #define BSG_KSSystemField_BuildType "build_type"
 
 #import <Foundation/Foundation.h>
+#if TARGET_OS_TV || TARGET_IPHONE_SIMULATOR || TARGET_OS_IPHONE
+#import <UIKit/UIKit.h>
+#endif
 
 /**
  * Provides system information useful for a crash report.
@@ -77,5 +80,9 @@
  * Whether the current main bundle is an iOS app extension
  */
 + (BOOL)isRunningInAppExtension;
+
+#if TARGET_OS_TV || TARGET_IPHONE_SIMULATOR || TARGET_OS_IPHONE
++ (UIApplicationState)currentAppState;
+#endif
 
 @end

--- a/Source/KSCrash/Source/KSCrash/Recording/BSG_KSSystemInfo.h
+++ b/Source/KSCrash/Source/KSCrash/Recording/BSG_KSSystemInfo.h
@@ -83,6 +83,11 @@
 
 #if TARGET_OS_TV || TARGET_IPHONE_SIMULATOR || TARGET_OS_IPHONE
 + (UIApplicationState)currentAppState;
+
+/**
+ * YES if the app is currently shown in the foreground
+ */
++ (BOOL)isInForeground:(UIApplicationState)state;
 #endif
 
 @end

--- a/Source/KSCrash/Source/KSCrash/Recording/BSG_KSSystemInfo.m
+++ b/Source/KSCrash/Source/KSCrash/Recording/BSG_KSSystemInfo.m
@@ -480,6 +480,21 @@
         return state;
     }
 }
+
++ (BOOL)isInForeground:(UIApplicationState)state {
+    // The app is in the foreground if the current state is "active" or
+    // "inactive". From the UIApplicationState docs:
+    // > UIApplicationStateActive
+    // >   The app is running in the foreground and currently receiving events.
+    // > UIApplicationStateInactive
+    // >   The app is running in the foreground but is not receiving events.
+    // >   This might happen as a result of an interruption or because the app
+    // >   is transitioning to or from the background.
+    // > UIApplicationStateBackground
+    // >   The app is running in the background.
+    return state == UIApplicationStateInactive
+        || state == UIApplicationStateActive;
+}
 #endif
 
 @end

--- a/Tests/KSCrash/KSSystemInfo_Tests.m
+++ b/Tests/KSCrash/KSSystemInfo_Tests.m
@@ -75,4 +75,11 @@
     XCTAssertEqualObjects(executablePath, expectedExecutablePath);
 }
 
+#if TARGET_OS_TV || TARGET_IPHONE_SIMULATOR || TARGET_OS_IPHONE
+- (void)testCurrentAppState {
+    // Should default to active as tests aren't in an app bundle
+    XCTAssertEqual(UIApplicationStateActive, [BSG_KSSystemInfo currentAppState]);
+}
+#endif
+
 @end

--- a/Tests/KSCrash/KSSystemInfo_Tests.m
+++ b/Tests/KSCrash/KSSystemInfo_Tests.m
@@ -80,6 +80,19 @@
     // Should default to active as tests aren't in an app bundle
     XCTAssertEqual(UIApplicationStateActive, [BSG_KSSystemInfo currentAppState]);
 }
+
+- (void)testInactiveIsInForeground {
+    XCTAssertTrue([BSG_KSSystemInfo isInForeground:UIApplicationStateInactive]);
+}
+
+- (void)testActiveIsInForeground {
+    XCTAssertTrue([BSG_KSSystemInfo isInForeground:UIApplicationStateActive]);
+
+}
+
+- (void)testBackgroundIsNotInForeground {
+    XCTAssertFalse([BSG_KSSystemInfo isInForeground:UIApplicationStateBackground]);
+}
 #endif
 
 @end


### PR DESCRIPTION
When an app launches due to a background event but then crashes without ever coming to the foreground, the `inForeground` value is presumed to be `true`, a default which made sense back before background launches were possible or common. This change refactors the foreground state logic in the OutOfMemoryWatchdog to be available to the initialization process, capturing the correct initial value.

## Tests

I couldn't find a way to force a background launch via an event anymore in the simulator (though there is a "Simulate Background Fetch" debug option that doesn't seem to launch an app if it isn't already running). So manual testing covered it by using media controls to launch a player app which then crashed and showed the correct foreground state