### PR TITLE
fix: Properly retain object properties

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,9 @@ Changelog
 * Show correct value for `app.inForeground` when an app launches and crashes in
   the background without ever coming to the foreground.
   [#415](https://github.com/bugsnag/bugsnag-cocoa/pull/415)
+* Fix improperly retained properties which could result in a crash due to
+  premature deallocation
+  [#416](https://github.com/bugsnag/bugsnag-cocoa/pull/416)
 
 ## 5.22.6 (2019-09-18)
 

--- a/Source/BugsnagApiClient.m
+++ b/Source/BugsnagApiClient.m
@@ -13,7 +13,7 @@
 @end
 
 @interface BugsnagApiClient()
-@property (nonatomic) NSURLSession *generatedSession;
+@property (nonatomic, strong) NSURLSession *generatedSession;
 @end
 
 @implementation BugsnagApiClient

--- a/Source/BugsnagHandledState.h
+++ b/Source/BugsnagHandledState.h
@@ -28,8 +28,8 @@ typedef NS_ENUM(NSUInteger, SeverityReasonType) {
 @property(nonatomic, readonly) BSGSeverity originalSeverity;
 @property(nonatomic) BSGSeverity currentSeverity;
 @property(nonatomic, readonly) SeverityReasonType calculateSeverityReasonType;
-@property(nonatomic, readonly) NSString *attrValue;
-@property(nonatomic, readonly) NSString *attrKey;
+@property(nonatomic, readonly, strong) NSString *attrValue;
+@property(nonatomic, readonly, strong) NSString *attrKey;
 
 + (NSString *)stringFromSeverityReason:(SeverityReasonType)severityReason;
 + (SeverityReasonType)severityReasonFromString:(NSString *)string;

--- a/Source/BugsnagNotifier.h
+++ b/Source/BugsnagNotifier.h
@@ -35,12 +35,12 @@
 
 @property(nonatomic, readwrite, retain)
     BugsnagConfiguration *_Nullable configuration;
-@property(nonatomic, readwrite, retain) BugsnagMetaData *_Nonnull state;
-@property(nonatomic, readwrite, retain) NSDictionary *_Nonnull details;
-@property(nonatomic, readwrite, retain) NSLock *_Nonnull metaDataLock;
-@property(nonatomic, readonly) BugsnagSessionTracker *_Nonnull sessionTracker;
+@property(nonatomic, readwrite, strong) BugsnagMetaData *_Nonnull state;
+@property(nonatomic, readwrite, strong) NSDictionary *_Nonnull details;
+@property(nonatomic, readwrite, strong) NSLock *_Nonnull metaDataLock;
+@property(nonatomic, readonly, strong) BugsnagSessionTracker *_Nonnull sessionTracker;
 
-@property(nonatomic) BSGConnectivity *_Nonnull networkReachable;
+@property(nonatomic, strong) BSGConnectivity *_Nonnull networkReachable;
 @property(readonly) BOOL started;
 
 - (instancetype _Nonnull)initWithConfiguration:

--- a/Source/BugsnagNotifier.m
+++ b/Source/BugsnagNotifier.m
@@ -201,9 +201,9 @@ void BSGWriteSessionCrashData(BugsnagSession *session) {
 }
 
 @interface BugsnagNotifier ()
-@property(nonatomic) BugsnagCrashSentry *crashSentry;
-@property(nonatomic) BugsnagErrorReportApiClient *errorReportApiClient;
-@property(nonatomic, readwrite) BugsnagSessionTracker *sessionTracker;
+@property(nonatomic, strong) BugsnagCrashSentry *crashSentry;
+@property(nonatomic, strong) BugsnagErrorReportApiClient *errorReportApiClient;
+@property(nonatomic, strong, readwrite) BugsnagSessionTracker *sessionTracker;
 @property (nonatomic, strong) BSGOutOfMemoryWatchdog *oomWatchdog;
 @property (nonatomic) BOOL appCrashedLastLaunch;
 @end

--- a/Source/BugsnagSink.h
+++ b/Source/BugsnagSink.h
@@ -33,6 +33,6 @@
 @interface BugsnagSink : NSObject <BSG_KSCrashReportFilter>
 
 - (instancetype)initWithApiClient:(BugsnagErrorReportApiClient *)apiClient;
-@property(nonatomic) BugsnagErrorReportApiClient *apiClient;
+@property(nonatomic, strong) BugsnagErrorReportApiClient *apiClient;
 
 @end


### PR DESCRIPTION
Several object properties were not explicitly marked as retained due to
missing a property retention qualifier. This patch resolves that by
bringing the codebase into [conformance with ARC](https://developer.apple.com/library/archive/releasenotes/ObjectiveC/RN-TransitioningToARC/Introduction/Introduction.html).

Fixes #411