### PR TITLE
fix(handlers/notify): Fix use-after-free

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,13 @@
 Changelog
 =========
 
+## TBD
+
+### Bug fixes
+
+* Fix use-after-free in `notify()` logic which could lead to a deadlock
+  [#420](https://github.com/bugsnag/bugsnag-cocoa/pull/420)
+
 ## 5.22.7 (2019-10-03)
 
 ### Bug fixes

--- a/Source/KSCrash/Source/KSCrash/Recording/Sentry/BSG_KSCrashSentry_User.c
+++ b/Source/KSCrash/Source/KSCrash/Recording/Sentry/BSG_KSCrashSentry_User.c
@@ -143,8 +143,6 @@ void bsg_kscrashsentry_reportUserException(const char *name,
         char severityChar = severity != NULL && strlen(severity) > 0 ? severity[0] : 'w';
         localContext->onCrash(severityChar, errorClass, reportContext);
 
-        bsg_kscrashsentry_freeReportContext(reportContext);
-
         if (terminateProgram) {
             bsg_kscrashsentry_uninstall(BSG_KSCrashTypeAll);
             bsg_kscrashsentry_resumeThreads();
@@ -155,5 +153,7 @@ void bsg_kscrashsentry_reportUserException(const char *name,
         if (localContext->suspendThreadsForUserReported) {
             pthread_mutex_unlock(&bsg_suspend_threads_mutex);
         }
+
+        bsg_kscrashsentry_freeReportContext(reportContext);
     }
 }


### PR DESCRIPTION
The report context (the state used to capture a report) for the `notify()` handler was freed prior to a check for whether to release the lock holding the thread suspension logic. This could lead to states where the check erroneously fails, failing to ever resume the suspended threads. This change places the `free()` after its last use.