### PR TITLE
fix: Deprecate reportBackgroundOOMs property

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,7 +3,10 @@ Changelog
 
 ## TBD
 
-* Deprecate reportBackgroundOOMs property
+* Deprecate `config.reportBackgroundOOMs` property - designating any app
+  termination as a possible error condition can cause a lot of false positives,
+  especially since the app can die for many genuine reasons, especially when
+  running only in the background.
   [#425](https://github.com/bugsnag/bugsnag-cocoa/pull/425)
 
 ## 5.22.8 (2019-10-10)

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,11 @@
 Changelog
 =========
 
+## TBD
+
+* Deprecate reportBackgroundOOMs property
+  [#425](https://github.com/bugsnag/bugsnag-cocoa/pull/425)
+
 ## 5.22.8 (2019-10-10)
 
 ### Bug fixes

--- a/Source/BSGOutOfMemoryWatchdog.m
+++ b/Source/BSGOutOfMemoryWatchdog.m
@@ -185,7 +185,7 @@
                                 [lastBootBundleVersion isEqualToString:bundleVersion] &&
                                 [lastBootAppVersion isEqualToString:appVersion];
             BOOL shouldReport = config.reportOOMs
-                && (config.reportBackgroundOOMs || (lastBootInForeground && lastBootWasActive));
+                && (lastBootInForeground && lastBootWasActive);
             [self deleteSentinelFile];
             return sameVersions && shouldReport;
         }

--- a/Source/BugsnagConfiguration.h
+++ b/Source/BugsnagConfiguration.h
@@ -166,9 +166,10 @@ NSArray<BeforeSendSession> *beforeSendSessionBlocks;
 
 /**
  * Whether the app should report out of memory events which terminate the app
- * while the app is in the background. This setting has no effect when reportOOMs is NO.
+ * while the app is in the background. Setting this property has no effect.
  */
-@property BOOL reportBackgroundOOMs;
+@property BOOL reportBackgroundOOMs
+__deprecated_msg("This detection option is unreliable and should no longer be used.");
 
 /**
  * Retrieves the endpoint used to notify Bugsnag of errors

--- a/Source/BugsnagConfiguration.m
+++ b/Source/BugsnagConfiguration.m
@@ -68,7 +68,6 @@ static NSString *const kHeaderApiSentAt = @"Bugsnag-Sent-At";
         _breadcrumbs = [BugsnagBreadcrumbs new];
         _automaticallyCollectBreadcrumbs = YES;
         _shouldAutoCaptureSessions = YES;
-        _reportBackgroundOOMs = NO;
 #if !DEBUG
         _reportOOMs = YES;
 #endif

--- a/Tests/BugsnagConfigurationTests.m
+++ b/Tests/BugsnagConfigurationTests.m
@@ -78,11 +78,6 @@
 #endif
 }
 
-- (void)testDefaultReportBackgroundOOMs {
-    BugsnagConfiguration *config = [BugsnagConfiguration new];
-    XCTAssertFalse([config reportBackgroundOOMs]);
-}
-
 - (void)testErrorApiHeaders {
     BugsnagConfiguration *config = [BugsnagConfiguration new];
     NSDictionary *headers = [config errorApiHeaders];

--- a/features/out_of_memory.feature
+++ b/features/out_of_memory.feature
@@ -56,18 +56,8 @@ Feature: Reporting out of memory events
         And I put the app in the background
         And the app is unexpectedly terminated
         And I relaunch the app
-        And I wait for a request
-        Then the request is valid for the error reporting API
-        And the payload field "events" is an array with 1 element
-        And the exception "errorClass" equals "Out Of Memory"
-        And the exception "message" equals "The app was likely terminated by the operating system while in the background"
-        And the event "unhandled" is true
-        And the event "severity" equals "error"
-        And the event "severityReason.type" equals "outOfMemory"
-        And the event "app.releaseStage" equals "beta"
-        And the event "app.version" equals "1.0.3"
-        And the event "app.bundleVersion" equals "5"
-        And the event breadcrumbs contain "Crumb left before crash"
+        And I wait for 10 seconds
+        Then I should receive 0 requests
 
     Scenario: The OS kills the application after a session is sent
         When I crash the app using "SessionOOMScenario"


### PR DESCRIPTION
## Goal

Disable background OOM reporting as it captures many false positives.

## Changeset
Deprecated `reportBackgroundOOMs` property, and removed it from the conditional statement in `BSGOutOfMemoryWatchdog`.

## Tests
Updated existing mazerunner scenarios to verify that zero OOMs are captured in the background. Removed unit test for deprecated functionality.
