### PR TITLE
Fix unrecognized selector crash when adding metadata

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,13 @@
 Changelog
 =========
 
+## TBD
+
+### Bug fixes
+
+* Fix unrecognized selector crash when adding metadata
+  [#429](https://github.com/bugsnag/bugsnag-cocoa/pull/429)
+
 ## 5.22.9 (2019-10-16)
 
 ### Bug fixes

--- a/Source/BugsnagCrashReport.m
+++ b/Source/BugsnagCrashReport.m
@@ -373,8 +373,7 @@ initWithErrorName:(NSString *_Nonnull)name
         return;
     }
     NSMutableDictionary *allMetadata = [self.metaData mutableCopy];
-    NSMutableDictionary *allTabData =
-        allMetadata[tabName] ?: [NSMutableDictionary new];
+    NSMutableDictionary *allTabData = [self getOrCreateTab:tabName metaData:allMetadata];
     allMetadata[tabName] = [cleanedData BSG_mergedInto:allTabData];
     self.metaData = allMetadata;
 }
@@ -383,8 +382,7 @@ initWithErrorName:(NSString *_Nonnull)name
            withValue:(id)value
        toTabWithName:(NSString *)tabName {
     NSMutableDictionary *allMetadata = [self.metaData mutableCopy];
-    NSMutableDictionary *allTabData =
-        allMetadata[tabName] ?: [NSMutableDictionary new];
+    NSMutableDictionary *allTabData = [self getOrCreateTab:tabName metaData:allMetadata];
     if (value) {
         id cleanedValue = BSGSanitizeObject(value);
         if (!cleanedValue) {
@@ -399,6 +397,17 @@ initWithErrorName:(NSString *_Nonnull)name
     }
     allMetadata[tabName] = allTabData;
     self.metaData = allMetadata;
+}
+
+- (NSMutableDictionary *)getOrCreateTab:(NSString *)tab
+                               metaData:(NSMutableDictionary *)metaData {
+    NSMutableDictionary *allTabData = metaData[tab] ?: [NSMutableDictionary new];
+
+    // defensively convert to a mutable dictionary
+    if (![allTabData isKindOfClass:[NSMutableDictionary class]]) {
+        allTabData = [allTabData mutableCopy];
+    }
+    return allTabData;
 }
 
 - (BOOL)shouldBeSent {

--- a/Tests/BugsnagCrashReportTests.m
+++ b/Tests/BugsnagCrashReportTests.m
@@ -460,4 +460,28 @@
     XCTAssertEqualObjects(@"1.2.3", dictionary[@"app"][@"version"]);
 }
 
+// regression test - this should not crash the app
+- (void)testReportAddAttr {
+    NSDictionary *dict = @{@"user.state.didOOM": @YES,
+                           @"user.state.oom.session": @{
+                                   @"user": @{
+                                           @"id": @"my-user-123"
+                                   }
+                           }};
+    BugsnagCrashReport *report = [[BugsnagCrashReport alloc] initWithKSReport:dict];
+    [report addAttribute:@"foo" withValue:@"bar" toTabWithName:@"user"];
+}
+
+// regression test - this should not crash the app
+- (void)testReportAddMetadata {
+    NSDictionary *dict = @{@"user.state.didOOM": @YES,
+                           @"user.state.oom.session": @{
+                                   @"user": @{
+                                           @"id": @"my-user-123"
+                                   }
+                           }};
+    BugsnagCrashReport *report = [[BugsnagCrashReport alloc] initWithKSReport:dict];
+    [report addMetadata:@{@"foo": @"bar"} toTabWithName:@"user"];
+}
+
 @end


### PR DESCRIPTION
## Goal

Prevents an unrecognized selector crash when adding metadata to a report in a beforeSend block.

The root cause of this bug is that an `NSDictionary` can be a tab value in the metadata property, whereas we assume that this is always an `NSMutableDictionary`. Adding a new attribute therefore triggers a crash, because bugsnag-cocoa attempts to mutate an immutable dictionary here: https://github.com/bugsnag/bugsnag-cocoa/blob/master/Source/BugsnagCrashReport.m#L396

Setting a user then starting a session provides one way to manifest this bug, as this uses an `NSDictionary` rather than `NSMutableDictionary` when deserializing crash reports. If an attribute is then added to an existing tab (e.g. app, device, user) in a beforeSend callback, this will crash the app:  https://github.com/bugsnag/bugsnag-cocoa/blob/master/Source/BugsnagCrashReport.m#L259

```
private func setUpBugsnag() {
    let configuration = BugsnagConfiguration()
    configuration.add(beforeSend: self.willSendReport)
    configuration.setUser("my-user-123", withName: nil, andEmail: nil)
    Bugsnag.start(with: configuration)
    Bugsnag.startSession()
}

private func willSendReport(_ rawData: [AnyHashable: Any], report: BugsnagCrashReport) -> Bool {
    report.addMetadata(["foo": "bar"], toTabWithName: "user")
    report.addAttribute("session", withValue: "foobar", toTabWithName: "user")
    return true
}
```

## Changeset

Converted the tab value to an `NSMutableDictionary` if it was not already of this type.

## Tests

Manually verified that a report is now sent to the dashboard with the example case.

