### PR TITLE
fix: Make metadata tabs always mutable

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,13 @@
 Changelog
 =========
 
+## TBD
+
+### Bug fixes
+
+* Fix unrecognized selector crash when adding metadata
+  [#430](https://github.com/bugsnag/bugsnag-cocoa/pull/430)
+
 ## 5.22.9 (2019-10-16)
 
 ### Bug fixes

--- a/Source/BugsnagCrashReport.m
+++ b/Source/BugsnagCrashReport.m
@@ -384,7 +384,7 @@ initWithErrorName:(NSString *_Nonnull)name
        toTabWithName:(NSString *)tabName {
     NSMutableDictionary *allMetadata = [self.metaData mutableCopy];
     NSMutableDictionary *allTabData =
-        allMetadata[tabName] ?: [NSMutableDictionary new];
+        [allMetadata[tabName] mutableCopy] ?: [NSMutableDictionary new];
     if (value) {
         id cleanedValue = BSGSanitizeObject(value);
         if (!cleanedValue) {

--- a/Source/BugsnagSink.m
+++ b/Source/BugsnagSink.m
@@ -26,6 +26,7 @@
 
 #import "BugsnagSink.h"
 #import "Bugsnag.h"
+#import "BugsnagLogger.h"
 #import "BugsnagCollections.h"
 #import "BugsnagNotifier.h"
 #import "BugsnagKeys.h"
@@ -101,9 +102,13 @@
             continue;
         BOOL shouldSend = YES;
         for (BugsnagBeforeSendBlock block in configuration.beforeSendBlocks) {
-            shouldSend = block(report, bugsnagReport);
-            if (!shouldSend)
-                break;
+            @try {
+                shouldSend = block(report, bugsnagReport);
+                if (!shouldSend)
+                    break;
+            } @catch (NSException *exception) {
+                bsg_log_err(@"Error from beforeSend callback: %@", exception);
+            }
         }
         if (shouldSend) {
             [bugsnagReports addObject:bugsnagReport];

--- a/Tests/BugsnagCrashReportTests.m
+++ b/Tests/BugsnagCrashReportTests.m
@@ -460,4 +460,14 @@
     XCTAssertEqualObjects(@"1.2.3", dictionary[@"app"][@"version"]);
 }
 
+- (void)testReportAddAttr {
+    BugsnagCrashReport *report = [[BugsnagCrashReport alloc] initWithKSReport:@{@"user.metaData": @{@"user": @{@"id": @"user id"}}}];
+    [report addAttribute:@"foo" withValue:@"bar" toTabWithName:@"user"];
+}
+
+- (void)testReportAddMetadata {
+    BugsnagCrashReport *report = [[BugsnagCrashReport alloc] initWithKSReport:@{@"user.metaData": @{@"user": @{@"id": @"user id"}}}];
+    [report addMetadata:@{@"foo": @"bar"} toTabWithName:@"user"];
+}
+
 @end


### PR DESCRIPTION
This PR addresses an issue whereby a tab within metadata can be an `NSDictionary` rather than an `NSMutableDictionary`, and an exception can be generated in a `beforeSend` callback, preventing the report being sent. The dictionaries in metadata can be immutable because within the constructor of a report we don't use the property setter or call through to `BSGSanitizeDict` which will ensure the dictionary is mutable. See https://github.com/bugsnag/bugsnag-cocoa/blob/master/Source/BugsnagCrashReport.m#L280 for an example.

The fix I have gone for here is to make a `mutableCopy` of the tab within the `addAttribute:withValue:toTabWithName` function. We could also add some calls to `BSGSanitizeDict` inside the constructor when initially setting the `metadata` value, which will ensure the dictionary is mutable, but I don't know the context of why that is not already there. Maybe @kattrali had a reason to avoid the setter when constructing the class. We could add the santize call also if we think that is a good idea for a belt and braces approach.

I have also added a try-catch to the execution of each `beforeSend` callback to ensure that if they throw an exception, the result is just that the `beforeSend` don't execute, rather than preventing delivery of the reports.

It is worth pointing out that I believe`addMetadata:toTabWithName:` was not affected by this issue and so is unchanged.

The tests have also been paired back to be the bare minimum to reproduce the issue and verify the code change fixes it. This PR is an alternative to #429. 