### PR TITLE
Rename breadcrumb 'name' to 'message' removing length limit

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -55,6 +55,11 @@ Bugsnag Notifiers on other platforms.
 * Add a breadcrumb when network connectivity changes
   [#448](https://github.com/bugsnag/bugsnag-cocoa/pull/448)
 
+* Breadcrumb message values can now be arbitrarily long. This simplifies breadcrumb
+  creation using `Bugsnag.leaveBreadcrumb(string)` so that the value is
+  prominently displayed and is not truncated.
+  [#433](https://github.com/bugsnag/bugsnag-cocoa/pull/433)
+
 ## Bug fixes
 
 * Fix possible report corruption when using `notify()` from multiple threads

--- a/Source/Bugsnag.m
+++ b/Source/Bugsnag.m
@@ -215,7 +215,7 @@ static NSMutableArray <id<BugsnagPlugin>> *registeredPlugins;
 + (void)leaveBreadcrumbWithMessage:(NSString *)message {
     if ([self bugsnagStarted]) {
         [self leaveBreadcrumbWithBlock:^(BugsnagBreadcrumb *_Nonnull crumbs) {
-            crumbs.metadata = @{BSGKeyMessage: message};
+            crumbs.message = message;
         }];
     }
 }

--- a/Source/BugsnagBreadcrumb.h
+++ b/Source/BugsnagBreadcrumb.h
@@ -77,7 +77,7 @@ typedef void (^BSGBreadcrumbConfiguration)(BugsnagBreadcrumb *_Nonnull);
 
 @property(readonly, nullable) NSDate *timestamp;
 @property(readwrite) BSGBreadcrumbType type;
-@property(readwrite, copy, nonnull) NSString *name;
+@property(readwrite, copy, nonnull) NSString *message;
 @property(readwrite, copy, nonnull) NSDictionary *metadata;
 
 + (instancetype _Nullable)breadcrumbWithBlock:

--- a/Source/BugsnagNotifier.m
+++ b/Source/BugsnagNotifier.m
@@ -415,7 +415,7 @@ NSString *const BSGBreadcrumbLoadedMessage = @"Bugsnag loaded";
 
     [self addBreadcrumbWithBlock:^(BugsnagBreadcrumb *_Nonnull breadcrumb) {
         breadcrumb.type = BSGBreadcrumbTypeState;
-        breadcrumb.name = BSGBreadcrumbLoadedMessage;
+        breadcrumb.message = BSGBreadcrumbLoadedMessage;
     }];
 
     // notification not received in time on initial startup, so trigger manually
@@ -535,7 +535,7 @@ NSString *const BSGBreadcrumbLoadedMessage = @"Bugsnag loaded";
 
         if (strongSelf.configuration.automaticallyCollectBreadcrumbs) {
             [strongSelf addBreadcrumbWithBlock:^(BugsnagBreadcrumb *crumb) {
-                crumb.name = @"Connectivity change";
+                crumb.message = @"Connectivity change";
                 crumb.type = BSGBreadcrumbTypeState;
                 crumb.metadata  = @{ @"type"  :  connectionType };
             }];
@@ -700,7 +700,7 @@ NSString *const BSGBreadcrumbLoadedMessage = @"Bugsnag loaded";
 
     [self addBreadcrumbWithBlock:^(BugsnagBreadcrumb *_Nonnull crumb) {
       crumb.type = BSGBreadcrumbTypeError;
-      crumb.name = reportName;
+      crumb.message = reportName;
       crumb.metadata = @{
           BSGKeyMessage : reportMessage,
           BSGKeySeverity : BSGFormatSeverity(report.severity)
@@ -813,7 +813,7 @@ NSString *const BSGBreadcrumbLoadedMessage = @"Bugsnag loaded";
     if ([self.configuration automaticallyCollectBreadcrumbs]) {
         [self addBreadcrumbWithBlock:^(BugsnagBreadcrumb *_Nonnull breadcrumb) {
           breadcrumb.type = BSGBreadcrumbTypeState;
-          breadcrumb.name = orientationNotifName;
+          breadcrumb.message = orientationNotifName;
           breadcrumb.metadata = @{BSGKeyOrientation : orientation};
         }];
     }
@@ -985,7 +985,7 @@ NSString *const BSGBreadcrumbLoadedMessage = @"Bugsnag loaded";
 - (void)sendBreadcrumbForNotification:(NSNotification *)note {
     [self addBreadcrumbWithBlock:^(BugsnagBreadcrumb *_Nonnull breadcrumb) {
       breadcrumb.type = BSGBreadcrumbTypeState;
-      breadcrumb.name = BSGBreadcrumbNameForNotificationName(note.name);
+      breadcrumb.message = BSGBreadcrumbNameForNotificationName(note.name);
     }];
 }
 
@@ -995,7 +995,7 @@ NSString *const BSGBreadcrumbLoadedMessage = @"Bugsnag loaded";
     NSIndexPath *indexPath = [tableView indexPathForSelectedRow];
     [self addBreadcrumbWithBlock:^(BugsnagBreadcrumb *_Nonnull breadcrumb) {
       breadcrumb.type = BSGBreadcrumbTypeNavigation;
-      breadcrumb.name = BSGBreadcrumbNameForNotificationName(note.name);
+      breadcrumb.message = BSGBreadcrumbNameForNotificationName(note.name);
       if (indexPath) {
           breadcrumb.metadata =
               @{ @"row" : @(indexPath.row),
@@ -1006,7 +1006,7 @@ NSString *const BSGBreadcrumbLoadedMessage = @"Bugsnag loaded";
     NSTableView *tableView = [note object];
     [self addBreadcrumbWithBlock:^(BugsnagBreadcrumb *_Nonnull breadcrumb) {
       breadcrumb.type = BSGBreadcrumbTypeNavigation;
-      breadcrumb.name = BSGBreadcrumbNameForNotificationName(note.name);
+      breadcrumb.message = BSGBreadcrumbNameForNotificationName(note.name);
       if (tableView) {
           breadcrumb.metadata = @{
               @"selectedRow" : @(tableView.selectedRow),
@@ -1025,7 +1025,7 @@ NSString *const BSGBreadcrumbLoadedMessage = @"Bugsnag loaded";
     if ([menuItem isKindOfClass:[NSMenuItem class]]) {
         [self addBreadcrumbWithBlock:^(BugsnagBreadcrumb *_Nonnull breadcrumb) {
           breadcrumb.type = BSGBreadcrumbTypeState;
-          breadcrumb.name = BSGBreadcrumbNameForNotificationName(notif.name);
+          breadcrumb.message = BSGBreadcrumbNameForNotificationName(notif.name);
           if (menuItem.title.length > 0)
               breadcrumb.metadata = @{BSGKeyAction : menuItem.title};
         }];
@@ -1039,7 +1039,7 @@ NSString *const BSGBreadcrumbLoadedMessage = @"Bugsnag loaded";
     UIControl *control = note.object;
     [self addBreadcrumbWithBlock:^(BugsnagBreadcrumb *_Nonnull breadcrumb) {
       breadcrumb.type = BSGBreadcrumbTypeUser;
-      breadcrumb.name = BSGBreadcrumbNameForNotificationName(note.name);
+      breadcrumb.message = BSGBreadcrumbNameForNotificationName(note.name);
       NSString *label = control.accessibilityLabel;
       if (label.length > 0) {
           breadcrumb.metadata = @{BSGKeyLabel : label};
@@ -1049,7 +1049,7 @@ NSString *const BSGBreadcrumbLoadedMessage = @"Bugsnag loaded";
     NSControl *control = note.object;
     [self addBreadcrumbWithBlock:^(BugsnagBreadcrumb *_Nonnull breadcrumb) {
       breadcrumb.type = BSGBreadcrumbTypeUser;
-      breadcrumb.name = BSGBreadcrumbNameForNotificationName(note.name);
+      breadcrumb.message = BSGBreadcrumbNameForNotificationName(note.name);
       if ([control respondsToSelector:@selector(accessibilityLabel)]) {
           NSString *label = control.accessibilityLabel;
           if (label.length > 0) {

--- a/Tests/BugsnagBreadcrumbsTest.m
+++ b/Tests/BugsnagBreadcrumbsTest.m
@@ -55,10 +55,10 @@ void awaitBreadcrumbSync(BugsnagBreadcrumbs *crumbs) {
     [self.crumbs addBreadcrumb:@"Clear notifications"];
     awaitBreadcrumbSync(self.crumbs);
     XCTAssertEqual(self.crumbs.count, 3);
-    XCTAssertEqualObjects(self.crumbs[0].metadata[@"message"], @"Tap button");
-    XCTAssertEqualObjects(self.crumbs[1].metadata[@"message"],
+    XCTAssertEqualObjects(self.crumbs[0].message, @"Tap button");
+    XCTAssertEqualObjects(self.crumbs[1].message,
                           @"Close tutorial");
-    XCTAssertEqualObjects(self.crumbs[2].metadata[@"message"],
+    XCTAssertEqualObjects(self.crumbs[2].message,
                           @"Clear notifications");
     XCTAssertNil(self.crumbs[3]);
 }
@@ -86,8 +86,8 @@ void awaitBreadcrumbSync(BugsnagBreadcrumbs *crumbs) {
     self.crumbs.capacity = 2;
     awaitBreadcrumbSync(self.crumbs);
     XCTAssertEqual(self.crumbs.count, 2);
-    XCTAssertEqualObjects(self.crumbs[0].metadata[@"message"], @"Tap button");
-    XCTAssertEqualObjects(self.crumbs[1].metadata[@"message"],
+    XCTAssertEqualObjects(self.crumbs[0].message, @"Tap button");
+    XCTAssertEqualObjects(self.crumbs[1].message,
                           @"Close tutorial");
     XCTAssertNil(self.crumbs[2]);
 }
@@ -102,27 +102,26 @@ void awaitBreadcrumbSync(BugsnagBreadcrumbs *crumbs) {
     for (int i = 0; i < value.count; i++) {
         NSDictionary *item = value[i];
         XCTAssertTrue([item isKindOfClass:[NSDictionary class]]);
-        XCTAssertEqualObjects(item[@"name"], @"manual");
         XCTAssertEqualObjects(item[@"type"], @"manual");
         XCTAssertTrue([[formatter dateFromString:item[@"timestamp"]]
                        isKindOfClass:[NSDate class]]);
     }
-    XCTAssertEqualObjects(value[0][@"metaData"][@"message"], @"Launch app");
-    XCTAssertEqualObjects(value[1][@"metaData"][@"message"], @"Tap button");
-    XCTAssertEqualObjects(value[2][@"metaData"][@"message"], @"Close tutorial");
+    XCTAssertEqualObjects(value[0][@"message"], @"Launch app");
+    XCTAssertEqualObjects(value[1][@"message"], @"Tap button");
+    XCTAssertEqualObjects(value[2][@"message"], @"Close tutorial");
 }
 
 - (void)testStateType {
     BugsnagBreadcrumbs *crumbs = [BugsnagBreadcrumbs new];
     [crumbs addBreadcrumbWithBlock:^(BugsnagBreadcrumb *_Nonnull crumb) {
         crumb.type = BSGBreadcrumbTypeState;
-        crumb.name = @"Rotated Menu";
+        crumb.message = @"Rotated Menu";
         crumb.metadata = @{@"direction" : @"right"};
     }];
     awaitBreadcrumbSync(self.crumbs);
     NSArray *value = [crumbs arrayValue];
     XCTAssertEqualObjects(value[0][@"metaData"][@"direction"], @"right");
-    XCTAssertEqualObjects(value[0][@"name"], @"Rotated Menu");
+    XCTAssertEqualObjects(value[0][@"message"], @"Rotated Menu");
     XCTAssertEqualObjects(value[0][@"type"], @"state");
 }
 
@@ -131,22 +130,19 @@ void awaitBreadcrumbSync(BugsnagBreadcrumbs *crumbs) {
     NSArray *value = [NSJSONSerialization JSONObjectWithData:crumbs options:0 error:nil];
     XCTAssertEqual(value.count, 3);
     XCTAssertEqualObjects(value[0][@"type"], @"manual");
-    XCTAssertEqualObjects(value[0][@"name"], @"manual");
-    XCTAssertEqualObjects(value[0][@"metaData"][@"message"], @"Launch app");
+    XCTAssertEqualObjects(value[0][@"message"], @"Launch app");
     XCTAssertNotNil(value[0][@"timestamp"]);
     XCTAssertEqualObjects(value[1][@"type"], @"manual");
-    XCTAssertEqualObjects(value[1][@"name"], @"manual");
-    XCTAssertEqualObjects(value[1][@"metaData"][@"message"], @"Tap button");
+    XCTAssertEqualObjects(value[1][@"message"], @"Tap button");
     XCTAssertNotNil(value[1][@"timestamp"]);
     XCTAssertEqualObjects(value[2][@"type"], @"manual");
-    XCTAssertEqualObjects(value[2][@"name"], @"manual");
-    XCTAssertEqualObjects(value[2][@"metaData"][@"message"], @"Close tutorial");
+    XCTAssertEqualObjects(value[2][@"message"], @"Close tutorial");
     XCTAssertNotNil(value[2][@"timestamp"]);
 }
 
 - (void)testPersistentCrumbCustom {
     [self.crumbs addBreadcrumbWithBlock:^(BugsnagBreadcrumb *crumb) {
-        crumb.name = @"Initiate sequence";
+        crumb.message = @"Initiate sequence";
         crumb.metadata = @{ @"captain": @"Bob"};
         crumb.type = BSGBreadcrumbTypeState;
     }];
@@ -154,24 +150,9 @@ void awaitBreadcrumbSync(BugsnagBreadcrumbs *crumbs) {
     NSArray *value = [NSJSONSerialization JSONObjectWithData:crumbs options:0 error:nil];
     XCTAssertEqual(value.count, 4);
     XCTAssertEqualObjects(value[3][@"type"], @"state");
-    XCTAssertEqualObjects(value[3][@"name"], @"Initiate sequence");
+    XCTAssertEqualObjects(value[3][@"message"], @"Initiate sequence");
     XCTAssertEqualObjects(value[3][@"metaData"][@"captain"], @"Bob");
     XCTAssertNotNil(value[3][@"timestamp"]);
-}
-
-- (void)testByteSizeLimit {
-    BugsnagBreadcrumbs *crumbs = [BugsnagBreadcrumbs new];
-    [crumbs addBreadcrumbWithBlock:^(BugsnagBreadcrumb *_Nonnull crumb) {
-        crumb.type = BSGBreadcrumbTypeState;
-        crumb.name = @"Rotated Menu";
-        NSMutableDictionary *metadata = @{}.mutableCopy;
-        for (int i = 0; i < 400; i++) {
-            metadata[[NSString stringWithFormat:@"%d", i]] = @"!!";
-        }
-        crumb.metadata = metadata;
-    }];
-    NSArray *value = [crumbs arrayValue];
-    XCTAssertTrue(value.count == 0);
 }
 
 @end

--- a/UPGRADING.md
+++ b/UPGRADING.md
@@ -92,3 +92,12 @@ Swift:
 
 Note that `BugsnagMetadata.getTab()` previously would create a metadata section if it
 did not exist; the new behaviour is to return `nil`. 
+
+### `BugsnagBreadcrumb` class
+
+The short "name" value has been removed and replaced with an arbitrarily long "message".
+
+```diff
+- BugsnagBreadcrumb.name
++ BugsnagBreadcrumb.message
+```

--- a/features/steps/ios_steps.rb
+++ b/features/steps/ios_steps.rb
@@ -102,7 +102,7 @@ Then("the event breadcrumbs contain {string} with type {string}") do |string, ty
   crumbs = read_key_path(find_request(0)[:body], "events.0.breadcrumbs")
   assert_not_equal(0, crumbs.length, "There are no breadcrumbs on this event")
   match = crumbs.detect do |crumb|
-    crumb["name"] == string && crumb["type"] == type
+    crumb["message"] == string && crumb["type"] == type
   end
   assert_not_nil(match, "No crumb matches the provided message and type")
 end
@@ -111,7 +111,7 @@ Then("the event breadcrumbs contain {string}") do |string|
   crumbs = read_key_path(find_request(0)[:body], "events.0.breadcrumbs")
   assert_not_equal(0, crumbs.length, "There are no breadcrumbs on this event")
   match = crumbs.detect do |crumb|
-    read_key_path(crumb, "metaData.message") == string
+    crumb["message"] == string
   end
   assert_not_nil(match, "No crumb matches the provided message")
 end


### PR DESCRIPTION
## Goal

1. Rename 'name' to 'message'
2. Remove 4kb length limit on individual breadcrumbs
