### PR TITLE
Lay out structure for property/method renames for v6.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,8 @@ names and deprecated but still supported until the next major release.
 * `Bugsnag.setBreadcrumbCapacity()` is now `setMaxBreadcrumbs()` on the
   `BugsnagConfiguration` class. In addition, the default number of breadcrumbs
   saved has been raised to 25 and limited to no more than 100.
+* `BugsnagConfiguration.autoNotify` is now named
+  `BugsnagConfiguration.autoDetectErrors`
 
 ## 5.22.10 (2019-11-04)
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,8 @@ names and deprecated but still supported until the next major release.
   saved has been raised to 25 and limited to no more than 100.
 * `BugsnagConfiguration.autoNotify` is now named
   `BugsnagConfiguration.autoDetectErrors`
+* `BugsnagConfiguration.autoCaptureSessions` is now named
+  `BugsnagConfiguration.autoDetectSessions`
 
 ## 5.22.10 (2019-11-04)
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,16 @@
 Changelog
 =========
 
+This release renames a few configuration properties to align better with the
+intended use and other Bugsnag libraries, so people who use more than one
+platform can easily find related functionality in a different library. The old
+names and deprecated but still supported until the next major release.
+[#435](https://github.com/bugsnag/bugsnag-cocoa/pull/435)
+
+* `Bugsnag.setBreadcrumbCapacity()` is now `setMaxBreadcrumbs()` on the
+  `BugsnagConfiguration` class. In addition, the default number of breadcrumbs
+  saved has been raised to 25 and limited to no more than 100.
+
 ## 5.22.10 (2019-11-04)
 
 ### Bug fixes

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,7 +4,7 @@ Changelog
 This release renames a few configuration properties to align better with the
 intended use and other Bugsnag libraries, so people who use more than one
 platform can easily find related functionality in a different library. The old
-names and deprecated but still supported until the next major release.
+names are deprecated but still supported until the next major release.
 [#435](https://github.com/bugsnag/bugsnag-cocoa/pull/435)
 
 * `Bugsnag.setBreadcrumbCapacity()` is now `setMaxBreadcrumbs()` on the

--- a/Source/Bugsnag.h
+++ b/Source/Bugsnag.h
@@ -212,7 +212,7 @@ static NSString *_Nonnull const BugsnagSeverityInfo = @"info";
  * By default, sessions are automatically started when the application enters the foreground.
  * If you wish to manually call startSession at
  * the appropriate time in your application instead, the default behaviour can be disabled via
- * shouldAutoCaptureSessions.
+ * autoTrackSessions.
  *
  * Any errors which occur in an active session count towards your application's
  * stability score. You can prevent errors from counting towards your stability
@@ -230,7 +230,7 @@ static NSString *_Nonnull const BugsnagSeverityInfo = @"info";
  * When a session is stopped, errors will not count towards your application's
  * stability score. This can be advantageous if you do not wish these calculations to
  * include a certain type of error, for example, a crash in a background service.
- * You should disable automatic session tracking via shouldAutoCaptureSessions if you call this method.
+ * You should disable automatic session tracking via autoTrackSessions if you call this method.
  *
  * A stopped session can be resumed by calling resumeSession,
  * which will make any subsequent errors count towards your application's
@@ -246,7 +246,7 @@ static NSString *_Nonnull const BugsnagSeverityInfo = @"info";
  *
  * If a session has already been resumed or started and has not been stopped, calling this
  * method will have no effect. You should disable automatic session tracking via
- * shouldAutoCaptureSessions if you call this method.
+ * autoTrackSessions if you call this method.
  *
  * It's important to note that sessions are stored in memory for the lifetime of the
  * application process and are not persisted on disk. Therefore calling this method on app

--- a/Source/Bugsnag.h
+++ b/Source/Bugsnag.h
@@ -194,15 +194,6 @@ static NSString *_Nonnull const BugsnagSeverityInfo = @"info";
 + (void)leaveBreadcrumbForNotificationName:(NSString *_Nonnull)notificationName;
 
 /**
- * Set the maximum number of breadcrumbs to keep and sent to Bugsnag.
- * By default, we'll keep and send the 20 most recent breadcrumb log
- * messages.
- *
- * @param capacity max number of breadcrumb log messages to send
- */
-+ (void)setBreadcrumbCapacity:(NSUInteger)capacity;
-
-/**
  * Clear any breadcrumbs that have been left so far.
  */
 + (void)clearBreadcrumbs;
@@ -271,5 +262,15 @@ static NSString *_Nonnull const BugsnagSeverityInfo = @"info";
  * @return true if a previous session was resumed, false if a new session was started.
  */
 + (BOOL)resumeSession;
+
+/**
+ * Set the maximum number of breadcrumbs to keep and sent to Bugsnag.
+ * By default, we'll keep and send the 20 most recent breadcrumb log
+ * messages.
+ *
+ * @param capacity max number of breadcrumb log messages to send
+ */
++ (void)setBreadcrumbCapacity:(NSUInteger)capacity
+        __deprecated_msg("Use [BugsnagConfiguration setMaxBreadcrumbs:] instead");
 
 @end

--- a/Source/Bugsnag.m
+++ b/Source/Bugsnag.m
@@ -217,7 +217,7 @@ static BugsnagNotifier *bsg_g_bugsnag_notifier = NULL;
 
 + (void)setBreadcrumbCapacity:(NSUInteger)capacity {
     if ([self bugsnagStarted]) {
-        self.notifier.configuration.breadcrumbs.capacity = capacity;
+        [self.notifier.configuration setMaxBreadcrumbs:capacity];
     }
 }
 

--- a/Source/BugsnagBreadcrumb.m
+++ b/Source/BugsnagBreadcrumb.m
@@ -178,7 +178,7 @@ NSString *BSGBreadcrumbTypeValue(BSGBreadcrumbType type) {
 
 @implementation BugsnagBreadcrumbs
 
-NSUInteger BreadcrumbsDefaultCapacity = 20;
+NSUInteger BreadcrumbsDefaultCapacity = 25;
 
 - (instancetype)init {
     static NSString *const BSGBreadcrumbCacheFileName = @"bugsnag_breadcrumbs.json";
@@ -263,7 +263,7 @@ NSUInteger BreadcrumbsDefaultCapacity = 20;
         }
         [self resizeToFitCapacity:capacity];
         [self willChangeValueForKey:NSStringFromSelector(@selector(capacity))];
-        _capacity = capacity;
+        _capacity = MIN(100, capacity);
         [self didChangeValueForKey:NSStringFromSelector(@selector(capacity))];
     }
 }

--- a/Source/BugsnagConfiguration.h
+++ b/Source/BugsnagConfiguration.h
@@ -156,7 +156,7 @@ NSArray<BeforeSendSession> *beforeSendSessionBlocks;
  * If this value is updated after +[Bugsnag start] is called, only subsequent automatic sessions
  * will be captured.
  */
-@property BOOL shouldAutoCaptureSessions;
+@property BOOL autoTrackSessions;
 
 /**
  * Whether the app should report out of memory events which terminate the app
@@ -254,6 +254,13 @@ __deprecated_msg("This detection option is unreliable and should no longer be us
 
 - (void)addBeforeNotifyHook:(BugsnagBeforeNotifyHook _Nonnull)hook
     __deprecated_msg("Use addBeforeSendBlock: instead.");
+
+/**
+ * Determines whether app sessions should be tracked automatically. By default this value is true.
+ * If this value is updated after +[Bugsnag start] is called, only subsequent automatic sessions
+ * will be captured.
+ */
+@property BOOL shouldAutoCaptureSessions __deprecated_msg("Use autoTrackSessions instead");
 
 /**
  *  YES if uncaught exceptions should be reported automatically

--- a/Source/BugsnagConfiguration.h
+++ b/Source/BugsnagConfiguration.h
@@ -245,6 +245,13 @@ __deprecated_msg("This detection option is unreliable and should no longer be us
  */
 - (BOOL)shouldSendReports;
 
+/**
+ * The maximum number of breadcrumbs to keep and sent to Bugsnag.
+ * By default, we'll keep and send the 25 most recent breadcrumb log
+ * messages.
+ */
+@property NSUInteger maxBreadcrumbs;
+
 - (void)addBeforeNotifyHook:(BugsnagBeforeNotifyHook _Nonnull)hook
     __deprecated_msg("Use addBeforeSendBlock: instead.");
 /**

--- a/Source/BugsnagConfiguration.h
+++ b/Source/BugsnagConfiguration.h
@@ -147,9 +147,9 @@ NSArray<BeforeSendSession> *beforeSendSessionBlocks;
     (const BSG_KSCrashReportWriter *_Nonnull writer);
 
 /**
- *  YES if uncaught exceptions should be reported automatically
+ *  YES if uncaught exceptions and other crashes should be reported automatically
  */
-@property BOOL autoNotify;
+@property BOOL autoDetectErrors;
 
 /**
  * Determines whether app sessions should be tracked automatically. By default this value is true.
@@ -254,6 +254,12 @@ __deprecated_msg("This detection option is unreliable and should no longer be us
 
 - (void)addBeforeNotifyHook:(BugsnagBeforeNotifyHook _Nonnull)hook
     __deprecated_msg("Use addBeforeSendBlock: instead.");
+
+/**
+ *  YES if uncaught exceptions should be reported automatically
+ */
+@property BOOL autoNotify __deprecated_msg("Use autoDetectErrors instead");
+
 /**
  *  Hooks for processing raw report data before it is sent to Bugsnag
  */

--- a/Source/BugsnagConfiguration.m
+++ b/Source/BugsnagConfiguration.m
@@ -67,7 +67,7 @@ static NSString *const kHeaderApiSentAt = @"Bugsnag-Sent-At";
         _notifyReleaseStages = nil;
         _breadcrumbs = [BugsnagBreadcrumbs new];
         _automaticallyCollectBreadcrumbs = YES;
-        _shouldAutoCaptureSessions = YES;
+        _autoTrackSessions = YES;
 #if !DEBUG
         _reportOOMs = YES;
 #endif
@@ -183,6 +183,14 @@ static NSString *const kHeaderApiSentAt = @"Bugsnag-Sent-At";
                         withValue:notifyReleaseStagesCopy
                     toTabWithName:BSGKeyConfig];
     }
+}
+
+- (void)setShouldAutoCaptureSessions:(BOOL)shouldAutoCaptureSessions {
+    self.autoTrackSessions = shouldAutoCaptureSessions;
+}
+
+- (BOOL)shouldAutoCaptureSessions {
+    return self.autoTrackSessions;
 }
 
 @synthesize automaticallyCollectBreadcrumbs = _automaticallyCollectBreadcrumbs;

--- a/Source/BugsnagConfiguration.m
+++ b/Source/BugsnagConfiguration.m
@@ -59,7 +59,7 @@ static NSString *const kHeaderApiSentAt = @"Bugsnag-Sent-At";
         _config = [[BugsnagMetaData alloc] init];
         _apiKey = @"";
         _sessionURL = [NSURL URLWithString:@"https://sessions.bugsnag.com"];
-        _autoNotify = YES;
+        _autoDetectErrors = YES;
         _notifyURL = [NSURL URLWithString:BSGDefaultNotifyUrl];
         _beforeNotifyHooks = [NSMutableArray new];
         _beforeSendBlocks = [NSMutableArray new];
@@ -142,20 +142,28 @@ static NSString *const kHeaderApiSentAt = @"Bugsnag-Sent-At";
     }
 }
 
-@synthesize autoNotify = _autoNotify;
+@synthesize autoDetectErrors = _autoDetectErrors;
 
-- (BOOL)autoNotify {
-    return _autoNotify;
+- (BOOL)autoDetectErrors {
+    return _autoDetectErrors;
 }
 
-- (void)setAutoNotify:(BOOL)shouldAutoNotify {
-    if (shouldAutoNotify == _autoNotify) {
+- (void)setAutoDetectErrors:(BOOL)autoDetectErrors {
+    if (autoDetectErrors == _autoDetectErrors) {
         return;
     }
-    [self willChangeValueForKey:NSStringFromSelector(@selector(autoNotify))];
-    _autoNotify = shouldAutoNotify;
+    [self willChangeValueForKey:NSStringFromSelector(@selector(autoDetectErrors))];
+    _autoDetectErrors = autoDetectErrors;
     [[Bugsnag notifier] updateCrashDetectionSettings];
-    [self didChangeValueForKey:NSStringFromSelector(@selector(autoNotify))];
+    [self didChangeValueForKey:NSStringFromSelector(@selector(autoDetectErrors))];
+}
+
+- (BOOL)autoNotify {
+    return self.autoDetectErrors;
+}
+
+- (void)setAutoNotify:(BOOL)autoNotify {
+    self.autoDetectErrors = autoNotify;
 }
 
 @synthesize notifyReleaseStages = _notifyReleaseStages;

--- a/Source/BugsnagConfiguration.m
+++ b/Source/BugsnagConfiguration.m
@@ -282,4 +282,12 @@ static NSString *const kHeaderApiSentAt = @"Bugsnag-Sent-At";
     return [_apiKey length] > 0;
 }
 
+- (NSUInteger)maxBreadcrumbs {
+    return self.breadcrumbs.capacity;
+}
+
+- (void)setMaxBreadcrumbs:(NSUInteger)capacity {
+    self.breadcrumbs.capacity = capacity;
+}
+
 @end

--- a/Source/BugsnagCrashSentry.m
+++ b/Source/BugsnagCrashSentry.m
@@ -29,7 +29,7 @@ NSUInteger const BSG_MAX_STORED_REPORTS = 12;
     [BSG_KSCrash sharedInstance].onCrash = onCrash;
     [BSG_KSCrash sharedInstance].maxStoredReports = BSG_MAX_STORED_REPORTS;
 
-    if (!config.autoNotify) {
+    if (!config.autoDetectErrors) {
         bsg_kscrash_setHandlingCrashTypes(BSG_KSCrashTypeUserReported);
     }
     if (![[BSG_KSCrash sharedInstance] install]) {

--- a/Source/BugsnagNotifier.m
+++ b/Source/BugsnagNotifier.m
@@ -390,8 +390,8 @@ NSString *const kAppWillTerminate = @"App Will Terminate";
 #endif
 
     _started = YES;
-    // autoNotify disables all unhandled event reporting
-    BOOL configuredToReportOOMs = self.configuration.reportOOMs && self.configuration.autoNotify;
+    // autoDetectErrors disables all unhandled event reporting
+    BOOL configuredToReportOOMs = self.configuration.reportOOMs && self.configuration.autoDetectErrors;
     // Disable if a debugger is enabled, since the development cycle of starting
     // and restarting an app is also an uncatchable kill
     BOOL noDebuggerEnabled = !bsg_ksmachisBeingTraced();
@@ -806,7 +806,7 @@ NSString *const kAppWillTerminate = @"App Will Terminate";
 #endif
 
 - (void)updateCrashDetectionSettings {
-    if (self.configuration.autoNotify) {
+    if (self.configuration.autoDetectErrors) {
         // Enable all crash detection
         bsg_kscrash_setHandlingCrashTypes(BSG_KSCrashTypeAll);
         if (self.configuration.reportOOMs) {
@@ -815,7 +815,7 @@ NSString *const kAppWillTerminate = @"App Will Terminate";
     } else {
         // Only enable support for notify()-based reports
         bsg_kscrash_setHandlingCrashTypes(BSG_KSCrashTypeUserReported);
-        // autoNotify gates all unhandled report detection
+        // autoDetectErrors gates all unhandled report detection
         [self.oomWatchdog disable];
     }
 }

--- a/Source/BugsnagSessionTracker.h
+++ b/Source/BugsnagSessionTracker.h
@@ -39,7 +39,7 @@ extern NSString *const BSGSessionUpdateNotification;
 
 /**
  Record a new auto-captured session if neededed. Auto-captured sessions are only
- recorded and sent if -[BugsnagConfiguration shouldAutoCaptureSessions] is YES
+ recorded and sent if -[BugsnagConfiguration autoTrackSessions] is YES
  */
 - (void)startNewSessionIfAutoCaptureEnabled;
 

--- a/Source/BugsnagSessionTracker.m
+++ b/Source/BugsnagSessionTracker.m
@@ -91,7 +91,7 @@ NSString *const BSGSessionUpdateNotification = @"BugsnagSessionChanged";
 }
 
 - (void)startNewSessionIfAutoCaptureEnabled {
-    if (self.config.shouldAutoCaptureSessions  && [self.config shouldSendReports]) {
+    if (self.config.autoTrackSessions) {
         [self startNewSessionWithAutoCaptureValue:YES];
     }
 }

--- a/Tests/BugsnagBreadcrumbsTest.m
+++ b/Tests/BugsnagBreadcrumbsTest.m
@@ -35,7 +35,7 @@ void awaitBreadcrumbSync(BugsnagBreadcrumbs *crumbs) {
 }
 
 - (void)testDefaultCapacity {
-    XCTAssertTrue([BugsnagBreadcrumbs new].capacity == 20);
+    XCTAssertTrue([BugsnagBreadcrumbs new].capacity == 25);
 }
 
 - (void)testDefaultCount {
@@ -61,6 +61,11 @@ void awaitBreadcrumbSync(BugsnagBreadcrumbs *crumbs) {
     XCTAssertEqualObjects(self.crumbs[2].metadata[@"message"],
                           @"Clear notifications");
     XCTAssertNil(self.crumbs[3]);
+}
+
+- (void)testMaxMaxBreadcrumbs {
+    self.crumbs.capacity = 250;
+    XCTAssertEqual(100, self.crumbs.capacity);
 }
 
 - (void)testClearBreadcrumbs {

--- a/Tests/BugsnagConfigurationTests.m
+++ b/Tests/BugsnagConfigurationTests.m
@@ -66,7 +66,7 @@
 
 - (void)testDefaultSessionConfig {
     BugsnagConfiguration *config = [BugsnagConfiguration new];
-    XCTAssertTrue([config shouldAutoCaptureSessions]);
+    XCTAssertTrue([config autoTrackSessions]);
 }
 
 - (void)testDefaultReportOOMs {

--- a/Tests/BugsnagSessionTrackerStopTest.m
+++ b/Tests/BugsnagSessionTrackerStopTest.m
@@ -21,7 +21,7 @@
     [super setUp];
     self.configuration = [BugsnagConfiguration new];
     self.configuration.apiKey = @"test";
-    self.configuration.shouldAutoCaptureSessions = NO;
+    self.configuration.autoTrackSessions = NO;
     self.tracker = [[BugsnagSessionTracker alloc] initWithConfig:self.configuration postRecordCallback:nil];
 }
 

--- a/Tests/BugsnagSessionTrackerTest.m
+++ b/Tests/BugsnagSessionTrackerTest.m
@@ -86,7 +86,7 @@
 
 - (void)testStartNewAutoCapturedSessionWithAutoCaptureDisabled {
     XCTAssertNil(self.sessionTracker.runningSession);
-    self.configuration.shouldAutoCaptureSessions = NO;
+    self.configuration.autoTrackSessions = NO;
     [self.sessionTracker startNewSessionIfAutoCaptureEnabled];
     BugsnagSession *session = self.sessionTracker.runningSession;
 

--- a/Tests/BugsnagSinkTests.m
+++ b/Tests/BugsnagSinkTests.m
@@ -36,7 +36,7 @@
                                                          options:0
                                                            error:nil];
     BugsnagConfiguration *config = [BugsnagConfiguration new];
-    config.autoNotify = NO;
+    config.autoDetectErrors = NO;
     config.apiKey = @"apiKeyHere";
     // This value should not appear in the assertions, as it is not equal to
     // the release stage in the serialized report

--- a/UPGRADING.md
+++ b/UPGRADING.md
@@ -15,6 +15,9 @@ Version 6 introduces a number of property and method renames:
 
 - config.autoNotify
 + config.autoDetectErrors
+
+- config.autoCaptureSessions
++ config.autoTrackSessions
 ```
 
 ### `Bugsnag` class

--- a/UPGRADING.md
+++ b/UPGRADING.md
@@ -1,0 +1,23 @@
+# Upgrading
+
+Guide to ease migrations between significant changes
+
+## v5 -> v6
+
+Version 6 introduces a number of property and method renames:
+
+### `BugsnagConfiguration` class
+
+```diff
+  let config = BugsnagConfiguration()
+
++ config.setMaxBreadcrumbs()
+```
+
+### `Bugsnag` class
+
+```diff
+- Bugsnag.setBreadcrumbCapacity(40)
+  let config = BugsnagConfiguration()
++ config.setMaxBreadcrumbs(40)
+```

--- a/UPGRADING.md
+++ b/UPGRADING.md
@@ -12,6 +12,9 @@ Version 6 introduces a number of property and method renames:
   let config = BugsnagConfiguration()
 
 + config.setMaxBreadcrumbs()
+
+- config.autoNotify
++ config.autoDetectErrors
 ```
 
 ### `Bugsnag` class

--- a/features/fixtures/ios-swift-cocoapods/iOSTestApp/scenarios/ConfigChangesAfterStartScenarios.m
+++ b/features/fixtures/ios-swift-cocoapods/iOSTestApp/scenarios/ConfigChangesAfterStartScenarios.m
@@ -4,12 +4,12 @@
 
 - (void)startBugsnag {
     self.config.shouldAutoCaptureSessions = NO;
-    self.config.autoNotify = NO;
+    self.config.autoDetectErrors = NO;
     [super startBugsnag];
 }
 
 - (void)run {
-    self.config.autoNotify = YES;
+    self.config.autoDetectErrors = YES;
     __builtin_trap();
 }
 @end
@@ -23,7 +23,7 @@
 }
 
 - (void)run {
-    self.config.autoNotify = NO;
+    self.config.autoDetectErrors = NO;
     __builtin_trap();
 }
 


### PR DESCRIPTION
## Goal

This changeset lays out an initial structure for the updates necessary to get the library ready for v6.0.0. The primary change in this major revision will be to rename some properties and methods to better align with other Bugsnag notifier libraries. These changes have been added in a backwards-compatible way to allow for incremental releases leading up to v6, when all deprecated properties will be removed. 

Every change should be listed in the changelog and upgrade migration guide, and the new properties should replace the existing ones in the integration guide on docs.bugsnag.com.