### PR TITLE
fix (oom): added missing event fields

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,7 @@ Changelog
   
 * Added several additional event fields (`codeBundleId`, `osName`, `modelNumber`, 
   `locale`) that were missing from the OOM reports.
+  [#444](https://github.com/bugsnag/bugsnag-cocoa/pull/444)
 
 ## 5.23.0 (2019-12-10)
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,9 @@ Changelog
 * Fix possible report corruption when using `notify()` from multiple threads
   when configured to skip capturing/reporting background thread contents
   (generally only Unity games).
+  
+* Added several additional event fields (`codeBundleId`, `osName`, `modelNumber`, 
+  `locale`) that were missing from the OOM reports.
 
 ## 5.23.0 (2019-12-10)
 

--- a/Source/BSGOutOfMemoryWatchdog.m
+++ b/Source/BSGOutOfMemoryWatchdog.m
@@ -243,6 +243,8 @@
     app[@"releaseStage"] = config.releaseStage;
     app[@"version"] = systemInfo[@BSG_KSSystemField_BundleShortVersion] ?: @"";
     app[@"bundleVersion"] = systemInfo[@BSG_KSSystemField_BundleVersion] ?: @"";
+    // 'codeBundleId' only (optionally) exists for Unity clients and defaults otherwise to nil
+    app[@"codeBundleId"] = [config codeBundleId];
 #if BSGOOMAvailable
     UIApplicationState state = [BSG_KSSystemInfo currentAppState];
     app[@"inForeground"] = @([BSG_KSSystemInfo isInForeground:state]);
@@ -262,8 +264,12 @@
     // device[@"lowMemory"] is initially unset
     device[@"osBuild"] = systemInfo[@BSG_KSSystemField_OSVersion];
     device[@"osVersion"] = systemInfo[@BSG_KSSystemField_SystemVersion];
+    device[@"osName"] = systemInfo[@BSG_KSSystemField_SystemName];
+    // Translated from 'iDeviceMaj,Min' into human-readable "iPhone X" description on the server
     device[@"model"] = systemInfo[@BSG_KSSystemField_Machine];
+    device[@"modelNumber"] = systemInfo[@ BSG_KSSystemField_Model];
     device[@"wordSize"] = @(PLATFORM_WORD_SIZE);
+    device[@"locale"] = [[NSLocale currentLocale] localeIdentifier];
 #if TARGET_OS_SIMULATOR
     device[@"simulator"] = @YES;
 #else

--- a/Source/BSGOutOfMemoryWatchdog.m
+++ b/Source/BSGOutOfMemoryWatchdog.m
@@ -243,7 +243,7 @@
     app[@"releaseStage"] = config.releaseStage;
     app[@"version"] = systemInfo[@BSG_KSSystemField_BundleShortVersion] ?: @"";
     app[@"bundleVersion"] = systemInfo[@BSG_KSSystemField_BundleVersion] ?: @"";
-    // 'codeBundleId' only (optionally) exists for Unity clients and defaults otherwise to nil
+    // 'codeBundleId' only (optionally) exists for React Native clients and defaults otherwise to nil
     app[@"codeBundleId"] = [config codeBundleId];
 #if BSGOOMAvailable
     UIApplicationState state = [BSG_KSSystemInfo currentAppState];

--- a/iOS/BugsnagTests/BSGOutOfMemoryWatchdogTests.m
+++ b/iOS/BugsnagTests/BSGOutOfMemoryWatchdogTests.m
@@ -1,19 +1,73 @@
-
+#import <XCTest/XCTest.h>
 #import "BSGOutOfMemoryWatchdog.h"
 #import "BSG_KSSystemInfo.h"
 #import "BugsnagConfiguration.h"
-#import <XCTest/XCTest.h>
+#import "Bugsnag.h"
+#import "BugsnagNotifier.h"
+
+// Expose private identifiers for testing
+
+@interface Bugsnag (Testing)
++ (BugsnagNotifier *)notifier;
+@end
+
+@interface BugsnagNotifier (Testing)
+@property (nonatomic, strong) BSGOutOfMemoryWatchdog *oomWatchdog;
+@end
+
+@interface BSGOutOfMemoryWatchdog (Testing)
+- (NSMutableDictionary *)generateCacheInfoWithConfig:(BugsnagConfiguration *)config;
+@property(nonatomic, strong, readwrite) NSMutableDictionary *cachedFileInfo;
+@end
 
 @interface BSGOutOfMemoryWatchdogTests : XCTestCase
-
 @end
 
 @implementation BSGOutOfMemoryWatchdogTests
+
+- (void)setUp {
+    [super setUp];
+    BugsnagConfiguration *config = [BugsnagConfiguration new];
+    config.autoDetectErrors = NO;
+    config.apiKey = @"apiKeyHere";
+    config.codeBundleId = @"codeBundleIdHere";
+    config.releaseStage = @"MagicalTestingTime";
+
+    [Bugsnag startBugsnagWithConfiguration:config];
+}
 
 - (void)testNilPathDoesNotCreateWatchdog {
     XCTAssertNil([[BSGOutOfMemoryWatchdog alloc] init]);
     XCTAssertNil([[BSGOutOfMemoryWatchdog alloc] initWithSentinelPath:nil
                                                         configuration:nil]);
+}
+
+/**
+ * Test that the generated OOM report values exist and are correct (where that can be tested)
+ */
+- (void)testOOMFieldsSetCorrectly {
+    NSMutableDictionary *cachedFileInfo = [[[Bugsnag notifier] oomWatchdog] cachedFileInfo];
+    XCTAssertNotNil([cachedFileInfo objectForKey:@"app"]);
+    XCTAssertNotNil([cachedFileInfo objectForKey:@"device"]);
+    
+    NSMutableDictionary *app = [cachedFileInfo objectForKey:@"app"];
+    XCTAssertNotNil([app objectForKey:@"bundleVersion"]);
+    XCTAssertNotNil([app objectForKey:@"id"]);
+    XCTAssertNotNil([app objectForKey:@"inForeground"]);
+    XCTAssertNotNil([app objectForKey:@"version"]);
+    XCTAssertNotNil([app objectForKey:@"name"]);
+    XCTAssertEqual([app valueForKey:@"codeBundleId"], @"codeBundleIdHere");
+    XCTAssertEqual([app valueForKey:@"releaseStage"], @"MagicalTestingTime");
+    
+    NSMutableDictionary *device = [cachedFileInfo objectForKey:@"device"];
+    XCTAssertNotNil([device objectForKey:@"osName"]);
+    XCTAssertNotNil([device objectForKey:@"osBuild"]);
+    XCTAssertNotNil([device objectForKey:@"osVersion"]);
+    XCTAssertNotNil([device objectForKey:@"id"]);
+    XCTAssertNotNil([device objectForKey:@"model"]);
+    XCTAssertNotNil([device objectForKey:@"simulator"]);
+    XCTAssertNotNil([device objectForKey:@"wordSize"]);
+    XCTAssertEqual([device valueForKey:@"locale"], [[NSLocale currentLocale] localeIdentifier]);
 }
 
 @end


### PR DESCRIPTION
## Goal

To add fields that appear in non-OOM events to OOM events (codeBundleId, locale, osName and modelNumber). 

## Design

The fields are trivial additions that add values to the info cached by the OOM watchdog.

## Changeset

New fields added to the `generateCacheInfoWithConfig()` method of `BSGOutOfMemoryWatchdog`.

## Tests

Manual testing to ensure values were being sent through.  An additional unit test was added to ensure that expected keys/values are present in the cache.

## Review

### Outstanding Questions

<!-- Are there any parts of the design or the implementation which seem
     less than ideal and that could require additional discussion?
     List here: -->

There is some commonality with non-OOM fields.  Is there scope for generalising the event field population?

Expected fields are tested for.  There are no tests for unexpected fields; should there be?

<!-- Preflight checks. Have I:

* Added a changelog entry?
* Checked the scope to ensure the commits are only related to the goal above?

-->

- This pull request is ready for:
  - [ ] Initial review of the intended approach, not yet feature complete
  - [ ] Structural review of the classes, functions, and properties modified
  - [X] Final review

<!-- What do you need from a reviewer to get this changeset
     ready for release -->

- [X] The correct target branch has been selected (`master` for fixes, `next` for
  features)
- [ ] Consistency across platforms for structures or concepts added or modified
- [X] Consistency between the changeset and the goal stated above
- [ ] Internal consistency with the rest of the library - is there any overlap between existing interfaces and any which have been added?
- [ ] Usage friction - is the proposed change in usage cumbersome or complicated?
- [ ] Performance and complexity - are there any cases of unexpected O(n^3) when iterating, recursing, flat mapping, etc?
- [ ] Concurrency concerns - if components are accessed asynchronously, what issues will arise
- [X] Thoroughness of added tests and any missing edge cases
- [ ] Idiomatic use of the language
