### PR TITLE
feat: Add a breadcrumb when the library starts

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,11 @@ Changelog
 
 ## TBD
 
+## Enhancements
+
+* Add a breadcrumb when Bugsnag first starts with the message "Bugsnag loaded"
+  [#445](https://github.com/bugsnag/bugsnag-cocoa/pull/445)
+
 ## Bug fixes
 
 * Fix possible report corruption when using `notify()` from multiple threads

--- a/Source/BugsnagNotifier.m
+++ b/Source/BugsnagNotifier.m
@@ -280,6 +280,7 @@ NSString *const kUndoOperation = @"Undo Operation";
 NSString *const kRedoOperation = @"Redo Operation";
 NSString *const kTableViewSelectionChange = @"TableView Select Change";
 NSString *const kAppWillTerminate = @"App Will Terminate";
+NSString *const BSGBreadcrumbLoadedMessage = @"Bugsnag loaded";
 
 - (void)initializeNotificationNameMap {
     notificationNameMap = @{
@@ -410,6 +411,11 @@ NSString *const kAppWillTerminate = @"App Will Terminate";
     }
 
     [self.sessionTracker startNewSessionIfAutoCaptureEnabled];
+
+    [self addBreadcrumbWithBlock:^(BugsnagBreadcrumb *_Nonnull breadcrumb) {
+        breadcrumb.type = BSGBreadcrumbTypeState;
+        breadcrumb.name = BSGBreadcrumbLoadedMessage;
+    }];
 
     // notification not received in time on initial startup, so trigger manually
     [self willEnterForeground:self];

--- a/features/breadcrumbs.feature
+++ b/features/breadcrumbs.feature
@@ -1,0 +1,15 @@
+Feature: Attaching a series of notable events leading up to errors
+    A breadcrumb contains supplementary data which will be sent along with
+    events. Breadcrumbs are intended to be pieces of information which can
+    lead the developer to the cause of the event being reported.
+
+    Scenario: An app lauches and subsequently sends a manual event using notify()
+        When I run "HandledErrorScenario"
+        And I wait for a request
+        Then the event breadcrumbs contain "Bugsnag loaded" with type "state"
+
+    Scenario: An app lauches and subsequently crahes
+        When I crash the app using "BuiltinTrapScenario"
+        And I relaunch the app
+        And I wait for a request
+        Then the event breadcrumbs contain "Bugsnag loaded" with type "state"

--- a/features/steps/ios_steps.rb
+++ b/features/steps/ios_steps.rb
@@ -98,6 +98,15 @@ Then("the event {string} is within {int} seconds of the current timestamp") do |
   assert_true(delta.abs < threshold_secs, "Expected current timestamp, but received #{value}")
 end
 
+Then("the event breadcrumbs contain {string} with type {string}") do |string, type|
+  crumbs = read_key_path(find_request(0)[:body], "events.0.breadcrumbs")
+  assert_not_equal(0, crumbs.length, "There are no breadcrumbs on this event")
+  match = crumbs.detect do |crumb|
+    crumb["name"] == string && crumb["type"] == type
+  end
+  assert_not_nil(match, "No crumb matches the provided message and type")
+end
+
 Then("the event breadcrumbs contain {string}") do |string|
   crumbs = read_key_path(find_request(0)[:body], "events.0.breadcrumbs")
   assert_not_equal(0, crumbs.length, "There are no breadcrumbs on this event")


### PR DESCRIPTION
From Breadcrumbs > Behavior > Automatic breadcrumb types:

> #### Bugsnag loaded
>
> - Bugsnag loaded `Breadcrumbs` shall be implemented on every platform.
> - When the notifier has been initialized and starts tracking errors a `Breadcrumb` shall be collected.
> - The `Breadcrumb` shall have the `type` set to 'state'.
> - The `message` shall be set to 'Bugsnag loaded'.
