### PR TITLE
feat(spec): Added designated initializer to BugsnagConfiguration

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -20,3 +20,4 @@ Pods
 Carthage
 *.idea
 features/fixtures/carthage-proj
+IDEWorkspaceChecks.plist

--- a/.travis.yml
+++ b/.travis.yml
@@ -37,12 +37,12 @@ jobs:
     # https://stackoverflow.com/questions/55389080/xcode-10-2-failed-to-run-app-on-simulator-with-ios-10
     - sudo mkdir -p '/Library/Developer/CoreSimulator/Profiles/Runtimes/iOS 9.3.simruntime/Contents/Resources/RuntimeRoot/usr/lib/swift'
     script:
+    - make test OS=9.3
+    - make test OS=9.3 TEST_CONFIGURATION=Release
     - make test OS=12.2
     - make test OS=12.1
     - make test OS=11.4
     - make test OS=10.3.1
-    - make test OS=9.3
-    - make test OS=9.3 TEST_CONFIGURATION=Release
   - osx_image: xcode10.2 # macos 10.14
     name: macOS 10.14 unit tests
     stage: macOS unit tests

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,9 @@ Changelog
 
 ## TBD
 
+This release sees a number of changes across the codebase intended to align its APIs with
+Bugsnag Notifiers on other platforms.
+
 ## Enhancements
 
 * Add a breadcrumb when Bugsnag first starts with the message "Bugsnag loaded"
@@ -10,6 +13,16 @@ Changelog
 
 * BugsnagCrashReport is now BugsnagEvent
   [#449](https://github.com/bugsnag/bugsnag-cocoa/pull/449)
+
+* Added a designated initializer to `BugsnagConfiguration` and removed functionality
+  from the default convenience `init()` to ensure that `apiKey` has a value set.  The `apiKey`
+  must now be a correctly formatted one to be accepted.
+
+  * Swift: `try BugsnagConfiguration(_ apiKey)`
+  * Objective C: `[[BugsnagConfiguration alloc] initWithApiKey:error:]`
+
+  [#446](https://github.com/bugsnag/bugsnag-cocoa/pull/446)
+
 
 ## Bug fixes
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -23,6 +23,8 @@ Bugsnag Notifiers on other platforms.
 
   [#446](https://github.com/bugsnag/bugsnag-cocoa/pull/446)
 
+* Add a breadcrumb when Bugsnag first starts with the message "Bugsnag loaded"
+  [#445](https://github.com/bugsnag/bugsnag-cocoa/pull/445)
 
 ## Bug fixes
 

--- a/OSX/Bugsnag.xcodeproj/project.pbxproj
+++ b/OSX/Bugsnag.xcodeproj/project.pbxproj
@@ -8,7 +8,8 @@
 
 /* Begin PBXBuildFile section */
 		00D7AC9C23E97F8100FBE4A7 /* BugsnagEvent.m in Sources */ = {isa = PBXBuildFile; fileRef = 00D7AC9A23E97F8100FBE4A7 /* BugsnagEvent.m */; };
-		00D7AC9D23E97F8100FBE4A7 /* BugsnagEvent.h in Headers */ = {isa = PBXBuildFile; fileRef = 00D7AC9B23E97F8100FBE4A7 /* BugsnagEvent.h */; };
+		00D7AC9D23E97F8100FBE4A7 /* BugsnagEvent.h in Headers */ = {isa = PBXBuildFile; fileRef = 00D7AC9B23E97F8100FBE4A7 /* BugsnagEvent.h */; settings = {ATTRIBUTES = (Public, ); }; };
+		00D7ACA423E9854C00FBE4A7 /* BugsnagEventTests.m in Sources */ = {isa = PBXBuildFile; fileRef = 00D7ACA223E984B300FBE4A7 /* BugsnagEventTests.m */; };
 		4B406C1822CAD96400464D1D /* BugsnagCollectionsBSGDictMergeTest.m in Sources */ = {isa = PBXBuildFile; fileRef = 4B406C1622CAD96400464D1D /* BugsnagCollectionsBSGDictMergeTest.m */; };
 		4B406C1922CAD96400464D1D /* BugsnagCollectionsBSGDictSetSafeObjectTest.m in Sources */ = {isa = PBXBuildFile; fileRef = 4B406C1722CAD96400464D1D /* BugsnagCollectionsBSGDictSetSafeObjectTest.m */; };
 		4B775FD422CBE02F004839C5 /* BugsnagCollectionsBSGDictInsertIfNotNilTest.m in Sources */ = {isa = PBXBuildFile; fileRef = 4B775FD222CBE02A004839C5 /* BugsnagCollectionsBSGDictInsertIfNotNilTest.m */; };
@@ -41,7 +42,6 @@
 		8A6C6FB12257884C00E8EF24 /* BSGOutOfMemoryWatchdog.m in Sources */ = {isa = PBXBuildFile; fileRef = 8A6C6FAF2257884C00E8EF24 /* BSGOutOfMemoryWatchdog.m */; };
 		8A6C6FB22257884C00E8EF24 /* BSGOutOfMemoryWatchdog.h in Headers */ = {isa = PBXBuildFile; fileRef = 8A6C6FB02257884C00E8EF24 /* BSGOutOfMemoryWatchdog.h */; };
 		8A87352C1C6D3B1600EDBD5B /* BSG_KSCrashReportWriter.h in Headers */ = {isa = PBXBuildFile; fileRef = 8A87352B1C6D3B1600EDBD5B /* BSG_KSCrashReportWriter.h */; settings = {ATTRIBUTES = (Public, ); }; };
-		8ACF0F752018136200173809 /* BugsnagCrashReportTests.m in Sources */ = {isa = PBXBuildFile; fileRef = 8A2C8FE11C6BC38200846019 /* BugsnagCrashReportTests.m */; };
 		8AD9FA891E086351002859A7 /* BugsnagConfigurationTests.m in Sources */ = {isa = PBXBuildFile; fileRef = 8AD9FA851E0862DC002859A7 /* BugsnagConfigurationTests.m */; };
 		E72352C11F55924A00436528 /* BSGConnectivity.h in Headers */ = {isa = PBXBuildFile; fileRef = E72352BF1F55924A00436528 /* BSGConnectivity.h */; };
 		E72352C21F55924A00436528 /* BSGConnectivity.m in Sources */ = {isa = PBXBuildFile; fileRef = E72352C01F55924A00436528 /* BSGConnectivity.m */; };
@@ -185,6 +185,7 @@
 /* Begin PBXFileReference section */
 		00D7AC9A23E97F8100FBE4A7 /* BugsnagEvent.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; name = BugsnagEvent.m; path = ../Source/BugsnagEvent.m; sourceTree = "<group>"; };
 		00D7AC9B23E97F8100FBE4A7 /* BugsnagEvent.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; name = BugsnagEvent.h; path = ../Source/BugsnagEvent.h; sourceTree = "<group>"; };
+		00D7ACA223E984B300FBE4A7 /* BugsnagEventTests.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; path = BugsnagEventTests.m; sourceTree = "<group>"; };
 		4B406C1622CAD96400464D1D /* BugsnagCollectionsBSGDictMergeTest.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; path = BugsnagCollectionsBSGDictMergeTest.m; sourceTree = "<group>"; };
 		4B406C1722CAD96400464D1D /* BugsnagCollectionsBSGDictSetSafeObjectTest.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; path = BugsnagCollectionsBSGDictSetSafeObjectTest.m; sourceTree = "<group>"; };
 		4B775FD222CBE02A004839C5 /* BugsnagCollectionsBSGDictInsertIfNotNilTest.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; path = BugsnagCollectionsBSGDictInsertIfNotNilTest.m; sourceTree = "<group>"; };
@@ -207,7 +208,6 @@
 		8A2C8FCB1C6BC2C800846019 /* BugsnagSink.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; name = BugsnagSink.h; path = ../Source/BugsnagSink.h; sourceTree = SOURCE_ROOT; };
 		8A2C8FCC1C6BC2C800846019 /* BugsnagSink.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; name = BugsnagSink.m; path = ../Source/BugsnagSink.m; sourceTree = SOURCE_ROOT; };
 		8A2C8FE01C6BC38200846019 /* BugsnagBreadcrumbsTest.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; name = BugsnagBreadcrumbsTest.m; path = ../Tests/BugsnagBreadcrumbsTest.m; sourceTree = SOURCE_ROOT; };
-		8A2C8FE11C6BC38200846019 /* BugsnagCrashReportTests.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; name = BugsnagCrashReportTests.m; path = ../Tests/BugsnagCrashReportTests.m; sourceTree = SOURCE_ROOT; };
 		8A2C8FE21C6BC38200846019 /* BugsnagSinkTests.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; name = BugsnagSinkTests.m; path = ../Tests/BugsnagSinkTests.m; sourceTree = SOURCE_ROOT; };
 		8A2C8FE41C6BC38200846019 /* report.json */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = text.json; name = report.json; path = ../Tests/report.json; sourceTree = SOURCE_ROOT; };
 		8A2C8FEF1C6BC3A200846019 /* SystemConfiguration.framework */ = {isa = PBXFileReference; lastKnownFileType = wrapper.framework; name = SystemConfiguration.framework; path = System/Library/Frameworks/SystemConfiguration.framework; sourceTree = SDKROOT; };
@@ -462,6 +462,7 @@
 		8A2C8FAF1C6BC1F700846019 /* Tests */ = {
 			isa = PBXGroup;
 			children = (
+				00D7ACA223E984B300FBE4A7 /* BugsnagEventTests.m */,
 				4B406C1622CAD96400464D1D /* BugsnagCollectionsBSGDictMergeTest.m */,
 				4B406C1722CAD96400464D1D /* BugsnagCollectionsBSGDictSetSafeObjectTest.m */,
 				4B775FD222CBE02A004839C5 /* BugsnagCollectionsBSGDictInsertIfNotNilTest.m */,
@@ -473,7 +474,6 @@
 				E762E9F71F73F7E900E82B43 /* BugsnagHandledStateTest.m */,
 				8AD9FA851E0862DC002859A7 /* BugsnagConfigurationTests.m */,
 				8A2C8FE01C6BC38200846019 /* BugsnagBreadcrumbsTest.m */,
-				8A2C8FE11C6BC38200846019 /* BugsnagCrashReportTests.m */,
 				8A2C8FE21C6BC38200846019 /* BugsnagSinkTests.m */,
 				8A2C8FE41C6BC38200846019 /* report.json */,
 				8A2C8FB21C6BC1F700846019 /* TestsInfo.plist */,
@@ -682,6 +682,7 @@
 			files = (
 				E79E6BB91F4E3850002B35F9 /* BSG_KSJSONCodec.h in Headers */,
 				8A6C6FB22257884C00E8EF24 /* BSGOutOfMemoryWatchdog.h in Headers */,
+				00D7AC9D23E97F8100FBE4A7 /* BugsnagEvent.h in Headers */,
 				E79148471FD82B36003EFEBF /* BugsnagKSCrashSysInfoParser.h in Headers */,
 				E79E6B881F4E3850002B35F9 /* BSG_KSCrash.h in Headers */,
 				E79E6BA71F4E3850002B35F9 /* BSG_KSCrashSentry_NSException.h in Headers */,
@@ -729,7 +730,6 @@
 				E79E6BDB1F4E3850002B35F9 /* BSG_KSCrashReportFilter.h in Headers */,
 				E79E6BA11F4E3850002B35F9 /* BSG_KSCrashSentry_CPPException.h in Headers */,
 				E79E6B041F4E3847002B35F9 /* BugsnagErrorReportApiClient.h in Headers */,
-				00D7AC9D23E97F8100FBE4A7 /* BugsnagEvent.h in Headers */,
 				8A530CB822FDC38300F0C108 /* BSG_KSCrashIdentifier.h in Headers */,
 				E79E6BB11F4E3850002B35F9 /* BSG_KSBacktrace_Private.h in Headers */,
 				E79E6B8C1F4E3850002B35F9 /* BSG_KSCrashC.h in Headers */,
@@ -914,7 +914,6 @@
 			isa = PBXSourcesBuildPhase;
 			buildActionMask = 2147483647;
 			files = (
-				8ACF0F752018136200173809 /* BugsnagCrashReportTests.m in Sources */,
 				E7CE78CC1FD94E77001D07E0 /* KSSystemInfo_Tests.m in Sources */,
 				4B775FD422CBE02F004839C5 /* BugsnagCollectionsBSGDictInsertIfNotNilTest.m in Sources */,
 				E7CE78C91FD94E77001D07E0 /* KSSignalInfo_Tests.m in Sources */,
@@ -925,6 +924,7 @@
 				E7CE78BF1FD94E77001D07E0 /* KSCrashSentry_Signal_Tests.m in Sources */,
 				8A530CC922FDD74300F0C108 /* KSCrashIdentifierTests.m in Sources */,
 				4B406C1822CAD96400464D1D /* BugsnagCollectionsBSGDictMergeTest.m in Sources */,
+				00D7ACA423E9854C00FBE4A7 /* BugsnagEventTests.m in Sources */,
 				E7CE78CB1FD94E77001D07E0 /* KSSysCtl_Tests.m in Sources */,
 				E7CE78D01FD94E77001D07E0 /* RFC3339DateTool_Tests.m in Sources */,
 				E79148621FD82BB7003EFEBF /* BugsnagSessionTrackingPayloadTest.m in Sources */,

--- a/OSX/Bugsnag.xcodeproj/project.pbxproj
+++ b/OSX/Bugsnag.xcodeproj/project.pbxproj
@@ -7,6 +7,8 @@
 	objects = {
 
 /* Begin PBXBuildFile section */
+		00D7AC9C23E97F8100FBE4A7 /* BugsnagEvent.m in Sources */ = {isa = PBXBuildFile; fileRef = 00D7AC9A23E97F8100FBE4A7 /* BugsnagEvent.m */; };
+		00D7AC9D23E97F8100FBE4A7 /* BugsnagEvent.h in Headers */ = {isa = PBXBuildFile; fileRef = 00D7AC9B23E97F8100FBE4A7 /* BugsnagEvent.h */; };
 		4B406C1822CAD96400464D1D /* BugsnagCollectionsBSGDictMergeTest.m in Sources */ = {isa = PBXBuildFile; fileRef = 4B406C1622CAD96400464D1D /* BugsnagCollectionsBSGDictMergeTest.m */; };
 		4B406C1922CAD96400464D1D /* BugsnagCollectionsBSGDictSetSafeObjectTest.m in Sources */ = {isa = PBXBuildFile; fileRef = 4B406C1722CAD96400464D1D /* BugsnagCollectionsBSGDictSetSafeObjectTest.m */; };
 		4B775FD422CBE02F004839C5 /* BugsnagCollectionsBSGDictInsertIfNotNilTest.m in Sources */ = {isa = PBXBuildFile; fileRef = 4B775FD222CBE02A004839C5 /* BugsnagCollectionsBSGDictInsertIfNotNilTest.m */; };
@@ -19,8 +21,6 @@
 		8A2C8FD21C6BC2C800846019 /* BugsnagCollections.m in Sources */ = {isa = PBXBuildFile; fileRef = 8A2C8FC01C6BC2C800846019 /* BugsnagCollections.m */; };
 		8A2C8FD31C6BC2C800846019 /* BugsnagConfiguration.h in Headers */ = {isa = PBXBuildFile; fileRef = 8A2C8FC11C6BC2C800846019 /* BugsnagConfiguration.h */; settings = {ATTRIBUTES = (Public, ); }; };
 		8A2C8FD41C6BC2C800846019 /* BugsnagConfiguration.m in Sources */ = {isa = PBXBuildFile; fileRef = 8A2C8FC21C6BC2C800846019 /* BugsnagConfiguration.m */; };
-		8A2C8FD51C6BC2C800846019 /* BugsnagCrashReport.h in Headers */ = {isa = PBXBuildFile; fileRef = 8A2C8FC31C6BC2C800846019 /* BugsnagCrashReport.h */; settings = {ATTRIBUTES = (Public, ); }; };
-		8A2C8FD61C6BC2C800846019 /* BugsnagCrashReport.m in Sources */ = {isa = PBXBuildFile; fileRef = 8A2C8FC41C6BC2C800846019 /* BugsnagCrashReport.m */; };
 		8A2C8FD71C6BC2C800846019 /* BugsnagMetaData.h in Headers */ = {isa = PBXBuildFile; fileRef = 8A2C8FC51C6BC2C800846019 /* BugsnagMetaData.h */; settings = {ATTRIBUTES = (Public, ); }; };
 		8A2C8FD81C6BC2C800846019 /* BugsnagMetaData.m in Sources */ = {isa = PBXBuildFile; fileRef = 8A2C8FC61C6BC2C800846019 /* BugsnagMetaData.m */; };
 		8A2C8FD91C6BC2C800846019 /* BugsnagNotifier.h in Headers */ = {isa = PBXBuildFile; fileRef = 8A2C8FC71C6BC2C800846019 /* BugsnagNotifier.h */; };
@@ -183,6 +183,8 @@
 /* End PBXContainerItemProxy section */
 
 /* Begin PBXFileReference section */
+		00D7AC9A23E97F8100FBE4A7 /* BugsnagEvent.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; name = BugsnagEvent.m; path = ../Source/BugsnagEvent.m; sourceTree = "<group>"; };
+		00D7AC9B23E97F8100FBE4A7 /* BugsnagEvent.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; name = BugsnagEvent.h; path = ../Source/BugsnagEvent.h; sourceTree = "<group>"; };
 		4B406C1622CAD96400464D1D /* BugsnagCollectionsBSGDictMergeTest.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; path = BugsnagCollectionsBSGDictMergeTest.m; sourceTree = "<group>"; };
 		4B406C1722CAD96400464D1D /* BugsnagCollectionsBSGDictSetSafeObjectTest.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; path = BugsnagCollectionsBSGDictSetSafeObjectTest.m; sourceTree = "<group>"; };
 		4B775FD222CBE02A004839C5 /* BugsnagCollectionsBSGDictInsertIfNotNilTest.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; path = BugsnagCollectionsBSGDictInsertIfNotNilTest.m; sourceTree = "<group>"; };
@@ -198,8 +200,6 @@
 		8A2C8FC01C6BC2C800846019 /* BugsnagCollections.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; name = BugsnagCollections.m; path = ../Source/BugsnagCollections.m; sourceTree = SOURCE_ROOT; };
 		8A2C8FC11C6BC2C800846019 /* BugsnagConfiguration.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; name = BugsnagConfiguration.h; path = ../Source/BugsnagConfiguration.h; sourceTree = SOURCE_ROOT; };
 		8A2C8FC21C6BC2C800846019 /* BugsnagConfiguration.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; name = BugsnagConfiguration.m; path = ../Source/BugsnagConfiguration.m; sourceTree = SOURCE_ROOT; };
-		8A2C8FC31C6BC2C800846019 /* BugsnagCrashReport.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; name = BugsnagCrashReport.h; path = ../Source/BugsnagCrashReport.h; sourceTree = SOURCE_ROOT; };
-		8A2C8FC41C6BC2C800846019 /* BugsnagCrashReport.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; name = BugsnagCrashReport.m; path = ../Source/BugsnagCrashReport.m; sourceTree = SOURCE_ROOT; };
 		8A2C8FC51C6BC2C800846019 /* BugsnagMetaData.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; name = BugsnagMetaData.h; path = ../Source/BugsnagMetaData.h; sourceTree = SOURCE_ROOT; };
 		8A2C8FC61C6BC2C800846019 /* BugsnagMetaData.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; name = BugsnagMetaData.m; path = ../Source/BugsnagMetaData.m; sourceTree = SOURCE_ROOT; };
 		8A2C8FC71C6BC2C800846019 /* BugsnagNotifier.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; name = BugsnagNotifier.h; path = ../Source/BugsnagNotifier.h; sourceTree = SOURCE_ROOT; };
@@ -402,6 +402,8 @@
 		8A2C8FA31C6BC1F700846019 /* Bugsnag */ = {
 			isa = PBXGroup;
 			children = (
+				00D7AC9B23E97F8100FBE4A7 /* BugsnagEvent.h */,
+				00D7AC9A23E97F8100FBE4A7 /* BugsnagEvent.m */,
 				8A3C591123968B3600B344AA /* BugsnagPlugin.h */,
 				8A6C6FB02257884C00E8EF24 /* BSGOutOfMemoryWatchdog.h */,
 				8A6C6FAF2257884C00E8EF24 /* BSGOutOfMemoryWatchdog.m */,
@@ -445,8 +447,6 @@
 				8A627CD71EC3B75200F7C04E /* BSGSerialization.h */,
 				8A627CD81EC3B75200F7C04E /* BSGSerialization.m */,
 				8A2C8FC21C6BC2C800846019 /* BugsnagConfiguration.m */,
-				8A2C8FC31C6BC2C800846019 /* BugsnagCrashReport.h */,
-				8A2C8FC41C6BC2C800846019 /* BugsnagCrashReport.m */,
 				8A2C8FC51C6BC2C800846019 /* BugsnagMetaData.h */,
 				8A2C8FC61C6BC2C800846019 /* BugsnagMetaData.m */,
 				8A2C8FC71C6BC2C800846019 /* BugsnagNotifier.h */,
@@ -728,8 +728,8 @@
 				E79148511FD82B36003EFEBF /* BugsnagApiClient.h in Headers */,
 				E79E6BDB1F4E3850002B35F9 /* BSG_KSCrashReportFilter.h in Headers */,
 				E79E6BA11F4E3850002B35F9 /* BSG_KSCrashSentry_CPPException.h in Headers */,
-				8A2C8FD51C6BC2C800846019 /* BugsnagCrashReport.h in Headers */,
 				E79E6B041F4E3847002B35F9 /* BugsnagErrorReportApiClient.h in Headers */,
+				00D7AC9D23E97F8100FBE4A7 /* BugsnagEvent.h in Headers */,
 				8A530CB822FDC38300F0C108 /* BSG_KSCrashIdentifier.h in Headers */,
 				E79E6BB11F4E3850002B35F9 /* BSG_KSBacktrace_Private.h in Headers */,
 				E79E6B8C1F4E3850002B35F9 /* BSG_KSCrashC.h in Headers */,
@@ -869,6 +869,7 @@
 				E79E6BB31F4E3850002B35F9 /* BSG_KSCrashCallCompletion.m in Sources */,
 				E79E6BA21F4E3850002B35F9 /* BSG_KSCrashSentry_CPPException.mm in Sources */,
 				E79E6BBD1F4E3850002B35F9 /* BSG_KSLogger.m in Sources */,
+				00D7AC9C23E97F8100FBE4A7 /* BugsnagEvent.m in Sources */,
 				E79E6BCA1F4E3850002B35F9 /* BSG_KSSignalInfo.c in Sources */,
 				E79E6BC21F4E3850002B35F9 /* BSG_KSMach_x86_32.c in Sources */,
 				8A2C8FD01C6BC2C800846019 /* BugsnagBreadcrumb.m in Sources */,
@@ -888,7 +889,6 @@
 				E79E6BAF1F4E3850002B35F9 /* BSG_KSBacktrace.c in Sources */,
 				E79E6B941F4E3850002B35F9 /* BSG_KSCrashReportStore.m in Sources */,
 				E79E6B9D1F4E3850002B35F9 /* BSG_KSSystemInfo.m in Sources */,
-				8A2C8FD61C6BC2C800846019 /* BugsnagCrashReport.m in Sources */,
 				E79E6B051F4E3847002B35F9 /* BugsnagErrorReportApiClient.m in Sources */,
 				E79148571FD82B36003EFEBF /* BugsnagSession.m in Sources */,
 				E79E6BB81F4E3850002B35F9 /* BSG_KSJSONCodec.c in Sources */,

--- a/Source/Bugsnag.m
+++ b/Source/Bugsnag.m
@@ -54,14 +54,10 @@ static NSMutableArray <id<BugsnagPlugin>> *registeredPlugins;
 
 + (void)startBugsnagWithConfiguration:(BugsnagConfiguration *)configuration {
     @synchronized(self) {
-        if ([configuration hasValidApiKey]) {
-            bsg_g_bugsnag_notifier =
-                    [[BugsnagNotifier alloc] initWithConfiguration:configuration];
-            [self startPlugins];
-            [bsg_g_bugsnag_notifier start];
-        } else {
-            bsg_log_err(@"Bugsnag not initialized - a valid API key must be supplied.");
-        }
+        bsg_g_bugsnag_notifier =
+                [[BugsnagNotifier alloc] initWithConfiguration:configuration];
+        [self startPlugins];
+        [bsg_g_bugsnag_notifier start];
     }
 }
 

--- a/Source/BugsnagConfiguration.h
+++ b/Source/BugsnagConfiguration.h
@@ -35,6 +35,14 @@
 @class BugsnagUser;
 
 /**
+ * BugsnagConfiguration error constants
+ */
+extern NSString * _Nonnull const BSGConfigurationErrorDomain;
+typedef NS_ENUM(NSInteger, BSGConfigurationErrorCode) {
+    BSGConfigurationErrorInvalidApiKey = 0
+};
+
+/**
  *  A configuration block for modifying an error report
  *
  *  @param report The default report
@@ -79,7 +87,7 @@ typedef NSDictionary *_Nullable (^BugsnagBeforeNotifyHook)(
 /**
  *  The API key of a Bugsnag project
  */
-@property(readwrite, retain, nullable) NSString *apiKey;
+@property(readwrite, retain, nonnull) NSString *apiKey;
 /**
  *  The release stage of the application, such as production, development, beta
  *  et cetera
@@ -169,7 +177,7 @@ NSArray<BeforeSendSession> *beforeSendSessionBlocks;
  * while the app is in the background. Setting this property has no effect.
  */
 @property BOOL reportBackgroundOOMs
-__deprecated_msg("This detection option is unreliable and should no longer be used.");
+    __deprecated_msg("This detection option is unreliable and should no longer be used.");
 
 /**
  * Retrieves the endpoint used to notify Bugsnag of errors
@@ -188,6 +196,19 @@ __deprecated_msg("This detection option is unreliable and should no longer be us
  * @see setEndpointsForNotify:sessions:
  */
 @property(readonly, retain, nullable) NSURL *sessionURL;
+
+/**
+ * Required declaration to suppress a superclass designated-initializer error
+ */
+- (instancetype _Nonnull )init NS_UNAVAILABLE NS_SWIFT_UNAVAILABLE("Use initWithApiKey:");
+
+/**
+ * The designated initializer.
+ */
+- (instancetype _Nullable)initWithApiKey:(NSString *_Nonnull)apiKey
+                                   error:(NSError *_Nullable *_Nullable)error
+    NS_DESIGNATED_INITIALIZER
+    NS_SWIFT_NAME(init(_:)) __attribute__((swift_error(nonnull_error)));
 
 /**
  * Set the endpoints to send data to. By default we'll send error reports to
@@ -278,7 +299,5 @@ __deprecated_msg("This detection option is unreliable and should no longer be us
 
 @property(retain, nullable) NSString *codeBundleId;
 @property(retain, nullable) NSString *notifierType;
-
-- (BOOL)hasValidApiKey;
 
 @end

--- a/Source/BugsnagConfiguration.m
+++ b/Source/BugsnagConfiguration.m
@@ -36,6 +36,10 @@
 static NSString *const kHeaderApiPayloadVersion = @"Bugsnag-Payload-Version";
 static NSString *const kHeaderApiKey = @"Bugsnag-Api-Key";
 static NSString *const kHeaderApiSentAt = @"Bugsnag-Sent-At";
+static NSString *const BSGApiKeyError = @"apiKey must be a 32-digit hexadecimal value.";
+static NSString *const BSGInitError = @"Init is unavailable.  Use [[BugsnagConfiguration alloc] initWithApiKey:] instead.";
+static const int BSGApiKeyLength = 32;
+NSString * const BSGConfigurationErrorDomain = @"com.Bugsnag.CocoaNotifier.Configuration";
 
 @interface Bugsnag ()
 + (BugsnagNotifier *)notifier;
@@ -53,36 +57,58 @@ static NSString *const kHeaderApiSentAt = @"Bugsnag-Sent-At";
 
 @implementation BugsnagConfiguration
 
-- (id)init {
-    if (self = [super init]) {
-        _metaData = [[BugsnagMetaData alloc] init];
-        _config = [[BugsnagMetaData alloc] init];
-        _apiKey = @"";
-        _sessionURL = [NSURL URLWithString:@"https://sessions.bugsnag.com"];
-        _autoDetectErrors = YES;
-        _notifyURL = [NSURL URLWithString:BSGDefaultNotifyUrl];
-        _beforeNotifyHooks = [NSMutableArray new];
-        _beforeSendBlocks = [NSMutableArray new];
-        _beforeSendSessionBlocks = [NSMutableArray new];
-        _notifyReleaseStages = nil;
-        _breadcrumbs = [BugsnagBreadcrumbs new];
-        _automaticallyCollectBreadcrumbs = YES;
-        _autoTrackSessions = YES;
-#if !DEBUG
-        _reportOOMs = YES;
-#endif
+/**
+ * Should not be called, but if it _is_ then fail meaningfully rather than silently
+ */
+- (instancetype)init {
+    @throw BSGInitError;
+}
 
-        if ([NSURLSession class]) {
-            _session = [NSURLSession
-                sessionWithConfiguration:[NSURLSessionConfiguration
-                                             defaultSessionConfiguration]];
-        }
-#if DEBUG
-        _releaseStage = BSGKeyDevelopment;
-#else
-        _releaseStage = BSGKeyProduction;
-#endif
+/**
+ * The designated initializer.
+ */
+-(instancetype)initWithApiKey:(NSString *)apiKey
+                        error:(NSError * _Nullable __autoreleasing * _Nullable)error
+{
+    if (! [self isValidApiKey:apiKey]) {
+        *error = [NSError errorWithDomain:BSGConfigurationErrorDomain
+                                     code:BSGConfigurationErrorInvalidApiKey
+                                 userInfo:nil];
+        
+        return nil;
     }
+    
+    self = [super init];
+    
+    _metaData = [[BugsnagMetaData alloc] init];
+    _config = [[BugsnagMetaData alloc] init];
+    _apiKey = apiKey;
+    _sessionURL = [NSURL URLWithString:@"https://sessions.bugsnag.com"];
+    _autoDetectErrors = YES;
+    _notifyURL = [NSURL URLWithString:BSGDefaultNotifyUrl];
+    _beforeNotifyHooks = [NSMutableArray new];
+    _beforeSendBlocks = [NSMutableArray new];
+    _beforeSendSessionBlocks = [NSMutableArray new];
+    _notifyReleaseStages = nil;
+    _breadcrumbs = [BugsnagBreadcrumbs new];
+    _automaticallyCollectBreadcrumbs = YES;
+    _autoTrackSessions = YES;
+
+    #if !DEBUG
+        _reportOOMs = YES;
+    #endif
+
+    if ([NSURLSession class]) {
+        _session = [NSURLSession
+            sessionWithConfiguration:[NSURLSessionConfiguration
+                                         defaultSessionConfiguration]];
+    }
+    #if DEBUG
+        _releaseStage = BSGKeyDevelopment;
+    #else
+        _releaseStage = BSGKeyProduction;
+    #endif
+    
     return self;
 }
 
@@ -253,12 +279,12 @@ static NSString *const kHeaderApiSentAt = @"Bugsnag-Sent-At";
 }
 
 - (void)setApiKey:(NSString *)apiKey {
-    if ([apiKey length] > 0) {
+    if ([self isValidApiKey:apiKey]) {
         [self willChangeValueForKey:NSStringFromSelector(@selector(apiKey))];
         _apiKey = apiKey;
         [self didChangeValueForKey:NSStringFromSelector(@selector(apiKey))];
     } else {
-        bsg_log_err(@"Attempted to override non-null API key with nil - ignoring.");
+        @throw BSGApiKeyError;
     }
 }
 
@@ -293,9 +319,15 @@ static NSString *const kHeaderApiSentAt = @"Bugsnag-Sent-At";
     return url != nil && url.scheme != nil && url.host != nil;
 }
 
-
-- (BOOL)hasValidApiKey {
-    return [_apiKey length] > 0;
+/**
+ * Determine the apiKey-validity of a passed-in string:
+ * Exactly 32 hexadecimal digits.
+ */
+- (BOOL)isValidApiKey:(NSString *)apiKey {
+    NSCharacterSet *chars = [[NSCharacterSet
+        characterSetWithCharactersInString:@"0123456789ABCDEF"] invertedSet];
+    BOOL isHex = (NSNotFound == [[apiKey uppercaseString] rangeOfCharacterFromSet:chars].location);
+    return isHex && [apiKey length] == BSGApiKeyLength;
 }
 
 - (NSUInteger)maxBreadcrumbs {

--- a/Tests/BugsnagConfigurationTests.m
+++ b/Tests/BugsnagConfigurationTests.m
@@ -1,9 +1,10 @@
 #import "Bugsnag.h"
-#import "BugsnagConfiguration.h"
 #import "BugsnagSessionTracker.h"
 #import "BugsnagUser.h"
 
 #import <XCTest/XCTest.h>
+#import "BugsnagTestConstants.h"
+#import "BugsnagConfiguration.h"
 
 @interface BugsnagConfigurationTests : XCTestCase
 @end
@@ -11,52 +12,52 @@
 @implementation BugsnagConfigurationTests
 
 - (void)testDefaultSessionNotNil {
-    BugsnagConfiguration *config = [BugsnagConfiguration new];
+    BugsnagConfiguration *config = [[BugsnagConfiguration alloc] initWithApiKey:DUMMY_APIKEY_32CHAR_1 error:nil];
     XCTAssertNotNil(config.session);
 }
 
 - (void)testNotifyReleaseStagesDefaultSends {
-    BugsnagConfiguration *config = [BugsnagConfiguration new];
+    BugsnagConfiguration *config = [[BugsnagConfiguration alloc] initWithApiKey:DUMMY_APIKEY_32CHAR_1 error:nil];
     XCTAssertTrue([config shouldSendReports]);
 }
 
 - (void)testNotifyReleaseStagesNilSends {
-    BugsnagConfiguration *config = [BugsnagConfiguration new];
+    BugsnagConfiguration *config = [[BugsnagConfiguration alloc] initWithApiKey:DUMMY_APIKEY_32CHAR_1 error:nil];
     config.releaseStage = @"beta";
     config.notifyReleaseStages = nil;
     XCTAssertTrue([config shouldSendReports]);
 }
 
 - (void)testNotifyReleaseStagesEmptySends {
-    BugsnagConfiguration *config = [BugsnagConfiguration new];
+    BugsnagConfiguration *config = [[BugsnagConfiguration alloc] initWithApiKey:DUMMY_APIKEY_32CHAR_1 error:nil];
     config.releaseStage = @"beta";
     config.notifyReleaseStages = @[];
     XCTAssertTrue([config shouldSendReports]);
 }
 
 - (void)testNotifyReleaseStagesIncludedSends {
-    BugsnagConfiguration *config = [BugsnagConfiguration new];
+    BugsnagConfiguration *config = [[BugsnagConfiguration alloc] initWithApiKey:DUMMY_APIKEY_32CHAR_1 error:nil];
     config.releaseStage = @"beta";
     config.notifyReleaseStages = @[ @"beta" ];
     XCTAssertTrue([config shouldSendReports]);
 }
 
 - (void)testNotifyReleaseStagesIncludedInManySends {
-    BugsnagConfiguration *config = [BugsnagConfiguration new];
+    BugsnagConfiguration *config = [[BugsnagConfiguration alloc] initWithApiKey:DUMMY_APIKEY_32CHAR_1 error:nil];
     config.releaseStage = @"beta";
     config.notifyReleaseStages = @[ @"beta", @"production" ];
     XCTAssertTrue([config shouldSendReports]);
 }
 
 - (void)testNotifyReleaseStagesExcludedSkipsSending {
-    BugsnagConfiguration *config = [BugsnagConfiguration new];
+    BugsnagConfiguration *config = [[BugsnagConfiguration alloc] initWithApiKey:DUMMY_APIKEY_32CHAR_1 error:nil];
     config.releaseStage = @"beta";
     config.notifyReleaseStages = @[ @"production" ];
     XCTAssertFalse([config shouldSendReports]);
 }
 
 - (void)testDefaultReleaseStage {
-    BugsnagConfiguration *config = [BugsnagConfiguration new];
+    BugsnagConfiguration *config = [[BugsnagConfiguration alloc] initWithApiKey:DUMMY_APIKEY_32CHAR_1 error:nil];
 #if DEBUG
     XCTAssertEqualObjects(@"development", config.releaseStage);
 #else
@@ -65,12 +66,64 @@
 }
 
 - (void)testDefaultSessionConfig {
-    BugsnagConfiguration *config = [BugsnagConfiguration new];
+    BugsnagConfiguration *config = [[BugsnagConfiguration alloc] initWithApiKey:DUMMY_APIKEY_32CHAR_1 error:nil];
     XCTAssertTrue([config autoTrackSessions]);
 }
 
+/**
+ * Test correct population of an NSError in the case of an invalid apiKey
+ */
+-(void)testDesignatedInitializerInvalidApiKey {
+    NSError *error;
+    BugsnagConfiguration *invalidApiConfig = [[BugsnagConfiguration alloc] initWithApiKey:DUMMY_APIKEY_16CHAR error:&error];
+    XCTAssertNil(invalidApiConfig);
+    XCTAssertNotNil(error);
+    XCTAssertEqual([error domain], BSGConfigurationErrorDomain);
+    XCTAssertEqual([error code], BSGConfigurationErrorInvalidApiKey);
+
+// As per the docs the behaviour varies by platform
+//     https://developer.apple.com/documentation/foundation/nserror/1411580-userinfo?language=objc
+#if TARGET_OS_MAC
+    XCTAssertTrue([[error userInfo] isKindOfClass:[NSDictionary class]]);
+    XCTAssertEqual([(NSDictionary *)[error userInfo] count], 0);
+#else
+    XCTAssertNil([error userInfo]);
+#endif
+}
+
+/**
+* Test NSError is not populated in the case of a valid apiKey
+*/
+-(void)testDesignatedInitializerValidApiKey {
+    NSError *error;
+    BugsnagConfiguration *validApiConfig1 = [[BugsnagConfiguration alloc] initWithApiKey:DUMMY_APIKEY_32CHAR_1 error:&error];
+    XCTAssertNotNil(validApiConfig1);
+    XCTAssertNil(error);
+    XCTAssertEqual([validApiConfig1 apiKey], DUMMY_APIKEY_32CHAR_1);
+    
+    BugsnagConfiguration *validApiConfig2 = [[BugsnagConfiguration alloc] initWithApiKey:DUMMY_APIKEY_32CHAR_2 error:nil];
+    XCTAssertNotNil(validApiConfig2);
+    XCTAssertNil(error);
+    XCTAssertEqual([validApiConfig2 apiKey], DUMMY_APIKEY_32CHAR_2);
+}
+
+/**
+ * [BugsnagConfiguration init] is explicitly made unavailable.
+ * Test that it throws if it *is* called.  An explanation of the reason for
+ * the slightly involved code to call the method is given here (hint: ARC):
+ *
+ *     https://stackoverflow.com/a/20058585/2431627
+ */
+-(void)testUnavailableConvenienceInitializer {
+    BugsnagConfiguration *config = [BugsnagConfiguration alloc];
+    SEL selector = NSSelectorFromString(@"init");
+    IMP imp = [config methodForSelector:selector];
+    void (*func)(id, SEL) = (void *)imp;
+    XCTAssertThrows(func(config, selector));
+}
+
 - (void)testDefaultReportOOMs {
-    BugsnagConfiguration *config = [BugsnagConfiguration new];
+    BugsnagConfiguration *config = [[BugsnagConfiguration alloc] initWithApiKey:DUMMY_APIKEY_32CHAR_1 error:nil];
 #if DEBUG
     XCTAssertFalse([config reportOOMs]);
 #else
@@ -79,7 +132,7 @@
 }
 
 - (void)testErrorApiHeaders {
-    BugsnagConfiguration *config = [BugsnagConfiguration new];
+    BugsnagConfiguration *config = [[BugsnagConfiguration alloc] initWithApiKey:DUMMY_APIKEY_32CHAR_1 error:nil];
     NSDictionary *headers = [config errorApiHeaders];
     XCTAssertEqualObjects(config.apiKey, headers[@"Bugsnag-Api-Key"]);
     XCTAssertNotNil(headers[@"Bugsnag-Sent-At"]);
@@ -87,7 +140,7 @@
 }
 
 - (void)testSessionApiHeaders {
-    BugsnagConfiguration *config = [BugsnagConfiguration new];
+    BugsnagConfiguration *config = [[BugsnagConfiguration alloc] initWithApiKey:DUMMY_APIKEY_32CHAR_1 error:nil];
     NSDictionary *headers = [config sessionApiHeaders];
     XCTAssertEqualObjects(config.apiKey, headers[@"Bugsnag-Api-Key"]);
     XCTAssertNotNil(headers[@"Bugsnag-Sent-At"]);
@@ -95,7 +148,7 @@
 }
 
 - (void)testSessionEndpoints {
-    BugsnagConfiguration *config = [BugsnagConfiguration new];
+    BugsnagConfiguration *config = [[BugsnagConfiguration alloc] initWithApiKey:DUMMY_APIKEY_32CHAR_1 error:nil];
     
     // Default endpoints
     XCTAssertEqualObjects([NSURL URLWithString:@"https://sessions.bugsnag.com"], config.sessionURL);
@@ -106,7 +159,7 @@
 }
 
 - (void)testNotifyEndpoint {
-    BugsnagConfiguration *config = [BugsnagConfiguration new];
+    BugsnagConfiguration *config = [[BugsnagConfiguration alloc] initWithApiKey:DUMMY_APIKEY_32CHAR_1 error:nil];
     XCTAssertEqualObjects([NSURL URLWithString:@"https://notify.bugsnag.com/"], config.notifyURL);
 
     // Test overriding the notify endpoint (use dummy endpoints to avoid hitting production)
@@ -115,7 +168,7 @@
 }
 
 - (void)testSetEndpoints {
-    BugsnagConfiguration *config = [BugsnagConfiguration new];
+    BugsnagConfiguration *config = [[BugsnagConfiguration alloc] initWithApiKey:DUMMY_APIKEY_32CHAR_1 error:nil];
     [config setEndpointsForNotify:@"http://notify.example.com" sessions:@"http://sessions.example.com"];
     XCTAssertEqualObjects([NSURL URLWithString:@"http://notify.example.com"], config.notifyURL);
     XCTAssertEqualObjects([NSURL URLWithString:@"http://sessions.example.com"], config.sessionURL);
@@ -123,7 +176,7 @@
 
 // in debug these throw exceptions though in release are "tolerated"
 - (void)testSetNilNotifyEndpoint {
-    BugsnagConfiguration *config = [BugsnagConfiguration new];
+    BugsnagConfiguration *config = [[BugsnagConfiguration alloc] initWithApiKey:DUMMY_APIKEY_32CHAR_1 error:nil];
     NSString *notify = @"foo";
     notify = nil;
 #if DEBUG
@@ -136,7 +189,7 @@
 
 // in debug these throw exceptions though in release are "tolerated"
 - (void)testSetEmptyNotifyEndpoint {
-    BugsnagConfiguration *config = [BugsnagConfiguration new];
+    BugsnagConfiguration *config = [[BugsnagConfiguration alloc] initWithApiKey:DUMMY_APIKEY_32CHAR_1 error:nil];
 #if DEBUG
     XCTAssertThrowsSpecificNamed([config setEndpointsForNotify:@"" sessions:@"http://sessions.example.com"],
             NSException, NSInternalInconsistencyException);
@@ -147,7 +200,7 @@
 
 // in debug these throw exceptions though in release are "tolerated"
 - (void)testSetMalformedNotifyEndpoint {
-    BugsnagConfiguration *config = [BugsnagConfiguration new];
+    BugsnagConfiguration *config = [[BugsnagConfiguration alloc] initWithApiKey:DUMMY_APIKEY_32CHAR_1 error:nil];
 #if DEBUG
     XCTAssertThrowsSpecificNamed([config setEndpointsForNotify:@"http://" sessions:@"http://sessions.example.com"],
             NSException, NSInternalInconsistencyException);
@@ -157,7 +210,7 @@
 }
 
 - (void)testSetEmptySessionsEndpoint {
-    BugsnagConfiguration *config = [BugsnagConfiguration new];
+    BugsnagConfiguration *config = [[BugsnagConfiguration alloc] initWithApiKey:DUMMY_APIKEY_32CHAR_1 error:nil];
     [config setEndpointsForNotify:@"http://notify.example.com" sessions:@""];
     BugsnagSessionTracker *sessionTracker
             = [[BugsnagSessionTracker alloc] initWithConfig:config postRecordCallback:nil];
@@ -168,7 +221,7 @@
 }
 
 - (void)testSetMalformedSessionsEndpoint {
-    BugsnagConfiguration *config = [BugsnagConfiguration new];
+    BugsnagConfiguration *config = [[BugsnagConfiguration alloc] initWithApiKey:DUMMY_APIKEY_32CHAR_1 error:nil];
     [config setEndpointsForNotify:@"http://notify.example.com" sessions:@"f"];
     BugsnagSessionTracker *sessionTracker
             = [[BugsnagSessionTracker alloc] initWithConfig:config postRecordCallback:nil];
@@ -179,7 +232,7 @@
 }
 
 - (void)testUser {
-    BugsnagConfiguration *config = [BugsnagConfiguration new];
+    BugsnagConfiguration *config = [[BugsnagConfiguration alloc] initWithApiKey:DUMMY_APIKEY_32CHAR_1 error:nil];
     XCTAssertNil(config.currentUser);
     
     [config setUser:@"123" withName:@"foo" andEmail:@"test@example.com"];
@@ -187,34 +240,33 @@
     XCTAssertEqualObjects(@"123", config.currentUser.userId);
     XCTAssertEqualObjects(@"foo", config.currentUser.name);
     XCTAssertEqualObjects(@"test@example.com", config.currentUser.emailAddress);
-    
 }
 
 - (void)testApiKeySetter {
-    BugsnagConfiguration *config = [BugsnagConfiguration new];
-    XCTAssertEqualObjects(@"", config.apiKey);
-
-    config.apiKey = @"test";
-    XCTAssertEqualObjects(@"test", config.apiKey);
+    BugsnagConfiguration *config = [[BugsnagConfiguration alloc] initWithApiKey:DUMMY_APIKEY_32CHAR_1 error:nil];
+    XCTAssertTrue([config.apiKey isEqualToString:DUMMY_APIKEY_32CHAR_1]);
+    config.apiKey = DUMMY_APIKEY_32CHAR_1;
+    XCTAssertEqual(DUMMY_APIKEY_32CHAR_1, config.apiKey);
 
 #pragma clang diagnostic push
 #pragma clang diagnostic ignored "-Wnonnull"
-    config.apiKey = nil;
+    XCTAssertThrows(config.apiKey = nil);
 #pragma clang diagnostic pop
 
-    XCTAssertEqualObjects(@"test", config.apiKey);
+    XCTAssertTrue([config.apiKey isEqualToString:DUMMY_APIKEY_32CHAR_1]);
+    
+    XCTAssertThrows(config.apiKey = DUMMY_APIKEY_16CHAR);
+    XCTAssertThrows(config.apiKey = DUMMY_APIKEY_16CHAR);
 }
 
 - (void)testHasValidApiKey {
-    BugsnagConfiguration *config = nil;
-    XCTAssertFalse([config hasValidApiKey]);
+    BugsnagConfiguration *config = [[BugsnagConfiguration alloc] initWithApiKey:DUMMY_APIKEY_32CHAR_1 error:nil];
 
-    config = [BugsnagConfiguration new];
-    XCTAssertFalse([config hasValidApiKey]);
-
-    config.apiKey = @"5adf89e0aaa";
-    XCTAssertTrue([config hasValidApiKey]);
+    XCTAssertThrows(config.apiKey = DUMMY_APIKEY_16CHAR);
+    XCTAssertTrue([config.apiKey isEqualToString:DUMMY_APIKEY_32CHAR_1]);
+    
+    config.apiKey = DUMMY_APIKEY_32CHAR_2;
+    XCTAssertTrue([config.apiKey isEqualToString:DUMMY_APIKEY_32CHAR_2]);
 }
-
 
 @end

--- a/Tests/BugsnagConfigurationTests.m
+++ b/Tests/BugsnagConfigurationTests.m
@@ -80,6 +80,9 @@
     XCTAssertNotNil(error);
     XCTAssertEqual([error domain], BSGConfigurationErrorDomain);
     XCTAssertEqual([error code], BSGConfigurationErrorInvalidApiKey);
+    
+    XCTAssertTrue([[error domain] isEqualToString:@"com.Bugsnag.CocoaNotifier.Configuration"]);
+    XCTAssertEqual([error code], 0);
 
 // As per the docs the behaviour varies by platform
 //     https://developer.apple.com/documentation/foundation/nserror/1411580-userinfo?language=objc

--- a/Tests/BugsnagEventTests.m
+++ b/Tests/BugsnagEventTests.m
@@ -13,7 +13,7 @@
 #import "Bugsnag.h"
 #import "BugsnagHandledState.h"
 #import "BugsnagSession.h"
-
+#import "BugsnagTestConstants.h"
 
 @interface BugsnagEventTests : XCTestCase
 @end
@@ -21,7 +21,7 @@
 @implementation BugsnagEventTests
 
 - (void)testNotifyReleaseStagesSendsFromConfig {
-    BugsnagConfiguration *config = [BugsnagConfiguration new];
+    BugsnagConfiguration *config = [[BugsnagConfiguration alloc] initWithApiKey:DUMMY_APIKEY_32CHAR_1 error:nil];
     config.notifyReleaseStages = @[ @"foo" ];
     config.releaseStage = @"foo";
     BugsnagHandledState *state =
@@ -37,7 +37,7 @@
 }
 
 - (void)testNotifyReleaseStagesSkipsSendFromConfig {
-    BugsnagConfiguration *config = [BugsnagConfiguration new];
+    BugsnagConfiguration *config = [[BugsnagConfiguration alloc] initWithApiKey:DUMMY_APIKEY_32CHAR_1 error:nil];
     config.notifyReleaseStages = @[ @"foo", @"bar" ];
     config.releaseStage = @"not foo or bar";
 
@@ -54,7 +54,7 @@
 }
 
 - (void)testSessionJson {
-    BugsnagConfiguration *config = [BugsnagConfiguration new];
+    BugsnagConfiguration *config = [[BugsnagConfiguration alloc] initWithApiKey:DUMMY_APIKEY_32CHAR_1 error:nil];
 
     BugsnagHandledState *state =
         [BugsnagHandledState handledStateWithSeverityReason:HandledException];

--- a/Tests/BugsnagSessionTrackerStopTest.m
+++ b/Tests/BugsnagSessionTrackerStopTest.m
@@ -7,8 +7,8 @@
 //
 
 #import <XCTest/XCTest.h>
-#import "BugsnagConfiguration.h"
 #import "BugsnagSessionTracker.h"
+#import "BugsnagTestConstants.h"
 
 @interface BugsnagSessionTrackerStopTest : XCTestCase
 @property BugsnagConfiguration *configuration;
@@ -19,8 +19,7 @@
 
 - (void)setUp {
     [super setUp];
-    self.configuration = [BugsnagConfiguration new];
-    self.configuration.apiKey = @"test";
+    self.configuration = [[BugsnagConfiguration alloc] initWithApiKey:DUMMY_APIKEY_32CHAR_1 error:nil];
     self.configuration.autoTrackSessions = NO;
     self.tracker = [[BugsnagSessionTracker alloc] initWithConfig:self.configuration postRecordCallback:nil];
 }

--- a/Tests/BugsnagSessionTrackerTest.m
+++ b/Tests/BugsnagSessionTrackerTest.m
@@ -12,6 +12,7 @@
 #import "BugsnagConfiguration.h"
 #import "BugsnagSessionTracker.h"
 #import "BugsnagSessionTrackingApiClient.h"
+#import "BugsnagTestConstants.h"
 
 @interface BugsnagSessionTrackerTest : XCTestCase
 @property BugsnagConfiguration *configuration;
@@ -23,8 +24,7 @@
 
 - (void)setUp {
     [super setUp];
-    self.configuration = [BugsnagConfiguration new];
-    self.configuration.apiKey = @"test";
+    self.configuration = [[BugsnagConfiguration alloc] initWithApiKey:DUMMY_APIKEY_32CHAR_1 error:nil];
     self.sessionTracker = [[BugsnagSessionTracker alloc] initWithConfig:self.configuration
                                                      postRecordCallback:nil];
 }

--- a/Tests/BugsnagSinkTests.m
+++ b/Tests/BugsnagSinkTests.m
@@ -12,6 +12,7 @@
 #import "Bugsnag.h"
 #import "BugsnagHandledState.h"
 #import "BugsnagSink.h"
+#import "BugsnagTestConstants.h"
 
 @interface BugsnagSinkTests : XCTestCase
 @property NSDictionary *rawReportData;
@@ -35,9 +36,8 @@
     self.rawReportData = [NSJSONSerialization JSONObjectWithData:contentData
                                                          options:0
                                                            error:nil];
-    BugsnagConfiguration *config = [BugsnagConfiguration new];
+    BugsnagConfiguration *config = [[BugsnagConfiguration alloc] initWithApiKey:DUMMY_APIKEY_32CHAR_1 error:nil];
     config.autoDetectErrors = NO;
-    config.apiKey = @"apiKeyHere";
     // This value should not appear in the assertions, as it is not equal to
     // the release stage in the serialized report
     config.releaseStage = @"MagicalTestingTime";
@@ -313,7 +313,7 @@
     BugsnagEvent *report =
     [[BugsnagEvent alloc] initWithErrorName:@"TestError"
                                      errorMessage:@"Error for testing"
-                                    configuration:[BugsnagConfiguration new]
+                                    configuration:[[BugsnagConfiguration alloc] initWithApiKey:DUMMY_APIKEY_32CHAR_1 error:nil]
                                          metaData:[NSDictionary new]
                                      handledState:state
                                           session:nil];
@@ -396,7 +396,7 @@
     BugsnagEvent *report =
     [[BugsnagEvent alloc] initWithErrorName:@"TestError"
                                      errorMessage:@"Error for testing"
-                                    configuration:[BugsnagConfiguration new]
+                                    configuration:[[BugsnagConfiguration alloc] initWithApiKey:DUMMY_APIKEY_32CHAR_1 error:nil]
                                          metaData:[NSDictionary new]
                                      handledState:state
                                           session:nil];

--- a/Tests/BugsnagSwiftConfigurationTests.swift
+++ b/Tests/BugsnagSwiftConfigurationTests.swift
@@ -1,0 +1,36 @@
+//
+//  BugsnagSwiftConfigurationTests.swift
+//  Tests
+//
+//  Created by Robin Macharg on 22/01/2020.
+//  Copyright © 2020 Bugsnag. All rights reserved.
+//
+
+import XCTest
+
+class BugsnagSwiftConfigurationTests: XCTestCase {
+
+    /**
+     * Objective C trailing-NSError* initializers are translated into throwing
+     * Swift methods, allowing us to fail gracefully (at the expense of a more-explicit
+     * (read: longer) ObjC invocation).
+     */
+    func testDesignatedInitializerHasCorrectNS_SWIFT_NAME() {
+        
+        do {
+            let _ = try BugsnagConfiguration(DUMMY_APIKEY_16CHAR)
+        }
+        catch let e as NSError {
+            XCTAssertEqual(e.domain, BSGConfigurationErrorDomain)
+            XCTAssertEqual(e.code, BSGConfigurationErrorCode.invalidApiKey.rawValue)
+        }
+        
+        do {
+            let config = try BugsnagConfiguration(DUMMY_APIKEY_32CHAR_1)
+            XCTAssertEqual(config?.apiKey, DUMMY_APIKEY_32CHAR_1)
+        }
+        catch let e as NSError {
+            XCTFail("Failed to initialize a BugsnagConfiguration object with a correct apiKey: \(e.domain), \(e.code)")
+        }
+    }
+}

--- a/Tests/BugsnagTestConstants.h
+++ b/Tests/BugsnagTestConstants.h
@@ -1,0 +1,23 @@
+//
+//  BugsnagTestConstants.h
+//  Bugsnag
+//
+//  Created by Robin Macharg on 22/01/2020.
+//  Copyright © 2020 Bugsnag. All rights reserved.
+//
+
+#ifndef BugsnagTestConstants_h
+#define BugsnagTestConstants_h
+
+/**
+ * Dummy apiKey values of various lengths
+ */
+
+//                                                         0         1         2         3         4        5
+// One string to rule(r) them all:                         12345678901234567890123456789012345678901234567890
+static NSString * _Nonnull const DUMMY_APIKEY_32CHAR_1 = @"0192837465afbecd0192837465afbecd"; // the correct length
+static NSString * _Nonnull const DUMMY_APIKEY_32CHAR_2 = @"aabbccddeeff00112233445566778899";
+static NSString * _Nonnull const DUMMY_APIKEY_16CHAR   = @"0192837465afbecd"; // too short
+static NSString * _Nonnull const DUMMY_APIKEY_48CHAR   = @"0192837465afbecd0192837465afbecd0192837465afbecd"; // too long
+
+#endif /* BugsnagTestConstants_h */

--- a/UPGRADING.md
+++ b/UPGRADING.md
@@ -13,7 +13,17 @@ This is now BugsnagEvent.
 ### `BugsnagConfiguration` class
 
 ```diff
-  let config = BugsnagConfiguration()
+ObjC: 
+
+  NSError *error;
+  BugsnagConfiguration *config = [[BugsnagConfiguration alloc] initWithApiKey:"YOUR API KEY HERE" error:error];
+
+Swift:
+
+  let config = try BugsnagConfiguration("YOUR API KEY HERE")
+
++ BSGConfigurationErrorDomain
++ BSGConfigurationErrorCode
 
 + config.setMaxBreadcrumbs()
 

--- a/examples/objective-c-ios/Bugsnag Test App/ViewController.m
+++ b/examples/objective-c-ios/Bugsnag Test App/ViewController.m
@@ -66,7 +66,7 @@
         NSDictionary *actuallyReallyJSON = nil;
         [NSJSONSerialization dataWithJSONObject:actuallyReallyJSON options:0 error:nil];
     } @catch (NSException *exception) {
-        [Bugsnag notify:exception block:^(BugsnagCrashReport * _Nonnull report) {
+        [Bugsnag notify:exception block:^(BugsnagEvent * _Nonnull report) {
             report.metaData = @{@"tab": @{@"user": @"Bob Loblaw"}};
         }];
     }

--- a/features/breadcrumbs.feature
+++ b/features/breadcrumbs.feature
@@ -3,13 +3,16 @@ Feature: Attaching a series of notable events leading up to errors
     events. Breadcrumbs are intended to be pieces of information which can
     lead the developer to the cause of the event being reported.
 
+Background:
+    Given I set environment variable "BUGSNAG_API_KEY" to "a35a2a72bd230ac0aa0f52715bbdc6aa"
+
     Scenario: An app lauches and subsequently sends a manual event using notify()
-        When I run "HandledErrorScenario"
+        And I run "HandledErrorScenario"
         And I wait for a request
         Then the event breadcrumbs contain "Bugsnag loaded" with type "state"
 
     Scenario: An app lauches and subsequently crahes
-        When I crash the app using "BuiltinTrapScenario"
+        And I crash the app using "BuiltinTrapScenario"
         And I relaunch the app
         And I wait for a request
         Then the event breadcrumbs contain "Bugsnag loaded" with type "state"

--- a/features/fixtures/ios-swift-cocoapods/iOSTestApp/AppDelegate.swift
+++ b/features/fixtures/ios-swift-cocoapods/iOSTestApp/AppDelegate.swift
@@ -47,14 +47,20 @@ class AppDelegate: UIResponder, UIApplicationDelegate {
     }
 
     internal func prepareConfig(apiKey: String, mockAPIPath: String) -> BugsnagConfiguration {
-        let config = BugsnagConfiguration()
-        config.apiKey = apiKey
-        // Enabling by default to check not only the OOM reporting tests but 
-        // also that extra reports aren't erroneously sent in other conditions
-        // when OOM reporting is enabled
-        config.reportOOMs = true
-        config.setEndpoints(notify: mockAPIPath, sessions: mockAPIPath)
-        return config
+        do {
+            if let config = try BugsnagConfiguration(apiKey) {
+                // Enabling by default to check not only the OOM reporting tests but
+                // also that extra reports aren't erroneously sent in other conditions
+                // when OOM reporting is enabled
+                config.reportOOMs = true
+                config.setEndpoints(notify: mockAPIPath, sessions: mockAPIPath)
+                return config
+            }
+        }
+        catch {
+            assert(false)
+        }
+        fatalError("Unable to create BugsnagConfiguration")
     }
 
     func triggerEvent(scenario: Scenario, delay: TimeInterval, mode: String) {

--- a/features/fixtures/ios-swift-cocoapods/iOSTestApp/scenarios/AbortScenario.m
+++ b/features/fixtures/ios-swift-cocoapods/iOSTestApp/scenarios/AbortScenario.m
@@ -29,7 +29,7 @@
 @implementation AbortScenario
 
 - (void)startBugsnag {
-    self.config.shouldAutoCaptureSessions = NO;
+    self.config.autoTrackSessions = NO;
     [super startBugsnag];
 }
 

--- a/features/fixtures/ios-swift-cocoapods/iOSTestApp/scenarios/AccessNonObjectScenario.m
+++ b/features/fixtures/ios-swift-cocoapods/iOSTestApp/scenarios/AccessNonObjectScenario.m
@@ -32,7 +32,7 @@
 @implementation AccessNonObjectScenario
 
 - (void)startBugsnag {
-    self.config.shouldAutoCaptureSessions = NO;
+    self.config.autoTrackSessions = NO;
     [super startBugsnag];
 }
 

--- a/features/fixtures/ios-swift-cocoapods/iOSTestApp/scenarios/AsyncSafeThreadScenario.m
+++ b/features/fixtures/ios-swift-cocoapods/iOSTestApp/scenarios/AsyncSafeThreadScenario.m
@@ -34,7 +34,7 @@
 @implementation AsyncSafeThreadScenario
 
 - (void)startBugsnag {
-    self.config.shouldAutoCaptureSessions = NO;
+    self.config.autoTrackSessions = NO;
     [super startBugsnag];
 }
 

--- a/features/fixtures/ios-swift-cocoapods/iOSTestApp/scenarios/AutoSessionUnhandledScenario.m
+++ b/features/fixtures/ios-swift-cocoapods/iOSTestApp/scenarios/AutoSessionUnhandledScenario.m
@@ -12,9 +12,9 @@
 
 - (void)startBugsnag {
     if ([self.eventMode isEqualToString:@"noevent"])
-        self.config.shouldAutoCaptureSessions = NO;
+        self.config.autoTrackSessions = NO;
     else
-        self.config.shouldAutoCaptureSessions = YES;
+        self.config.autoTrackSessions = YES;
     [super startBugsnag];
 }
 

--- a/features/fixtures/ios-swift-cocoapods/iOSTestApp/scenarios/BuiltinTrapScenario.m
+++ b/features/fixtures/ios-swift-cocoapods/iOSTestApp/scenarios/BuiltinTrapScenario.m
@@ -11,7 +11,7 @@
 @implementation BuiltinTrapScenario
 
 - (void)startBugsnag {
-    self.config.shouldAutoCaptureSessions = NO;
+    self.config.autoTrackSessions = NO;
     [super startBugsnag];
 }
 

--- a/features/fixtures/ios-swift-cocoapods/iOSTestApp/scenarios/ConfigChangesAfterStartScenarios.m
+++ b/features/fixtures/ios-swift-cocoapods/iOSTestApp/scenarios/ConfigChangesAfterStartScenarios.m
@@ -3,7 +3,7 @@
 @implementation TurnOnCrashDetectionAfterStartScenario
 
 - (void)startBugsnag {
-    self.config.shouldAutoCaptureSessions = NO;
+    self.config.autoTrackSessions = NO;
     self.config.autoDetectErrors = NO;
     [super startBugsnag];
 }
@@ -18,7 +18,7 @@
 @implementation TurnOffCrashDetectionAfterStartScenario
 
 - (void)startBugsnag {
-    self.config.shouldAutoCaptureSessions = NO;
+    self.config.autoTrackSessions = NO;
     [super startBugsnag];
 }
 

--- a/features/fixtures/ios-swift-cocoapods/iOSTestApp/scenarios/CustomPluginNotifierDescriptionScenario.m
+++ b/features/fixtures/ios-swift-cocoapods/iOSTestApp/scenarios/CustomPluginNotifierDescriptionScenario.m
@@ -35,7 +35,7 @@
 
 - (void)startBugsnag {
     [Bugsnag registerPlugin:[DescriptionPlugin new]];
-    self.config.shouldAutoCaptureSessions = NO;
+    self.config.autoTrackSessions = NO;
     [super startBugsnag];
 }
 

--- a/features/fixtures/ios-swift-cocoapods/iOSTestApp/scenarios/CxxExceptionScenario.mm
+++ b/features/fixtures/ios-swift-cocoapods/iOSTestApp/scenarios/CxxExceptionScenario.mm
@@ -42,7 +42,7 @@ const char *kaboom_exception::what() const throw() {
 @implementation CxxExceptionScenario
 
 - (void)startBugsnag {
-    self.config.shouldAutoCaptureSessions = NO;
+    self.config.autoTrackSessions = NO;
     [super startBugsnag];
 }
 

--- a/features/fixtures/ios-swift-cocoapods/iOSTestApp/scenarios/DisabledSessionTrackingScenario.m
+++ b/features/fixtures/ios-swift-cocoapods/iOSTestApp/scenarios/DisabledSessionTrackingScenario.m
@@ -9,7 +9,7 @@
 @implementation DisabledSessionTrackingScenario
 
 - (void)startBugsnag {
-   self.config.shouldAutoCaptureSessions = NO;
+   self.config.autoTrackSessions = NO;
    [super startBugsnag];
 }
 

--- a/features/fixtures/ios-swift-cocoapods/iOSTestApp/scenarios/HandledErrorOverrideScenario.swift
+++ b/features/fixtures/ios-swift-cocoapods/iOSTestApp/scenarios/HandledErrorOverrideScenario.swift
@@ -14,7 +14,7 @@ import Bugsnag
 class HandledErrorOverrideScenario: Scenario {
 
     override func startBugsnag() {
-      self.config.shouldAutoCaptureSessions = false;
+      self.config.autoTrackSessions = false;
       super.startBugsnag()
     }
 

--- a/features/fixtures/ios-swift-cocoapods/iOSTestApp/scenarios/HandledErrorScenario.swift
+++ b/features/fixtures/ios-swift-cocoapods/iOSTestApp/scenarios/HandledErrorScenario.swift
@@ -12,7 +12,7 @@ import Bugsnag
 class HandledErrorScenario: Scenario {
 
     override func startBugsnag() {
-      self.config.shouldAutoCaptureSessions = false;
+      self.config.autoTrackSessions = false;
       super.startBugsnag()
     }
 

--- a/features/fixtures/ios-swift-cocoapods/iOSTestApp/scenarios/HandledExceptionScenario.swift
+++ b/features/fixtures/ios-swift-cocoapods/iOSTestApp/scenarios/HandledExceptionScenario.swift
@@ -12,7 +12,7 @@ import Bugsnag
 class HandledExceptionScenario: Scenario {
 
     override func startBugsnag() {
-      self.config.shouldAutoCaptureSessions = false;
+      self.config.autoTrackSessions = false;
       super.startBugsnag()
     }
 

--- a/features/fixtures/ios-swift-cocoapods/iOSTestApp/scenarios/ManualSessionScenario.m
+++ b/features/fixtures/ios-swift-cocoapods/iOSTestApp/scenarios/ManualSessionScenario.m
@@ -9,7 +9,7 @@
 @implementation ManualSessionScenario
 
 - (void)startBugsnag {
-    self.config.shouldAutoCaptureSessions = NO;
+    self.config.autoTrackSessions = NO;
     [super startBugsnag];
 }
 

--- a/features/fixtures/ios-swift-cocoapods/iOSTestApp/scenarios/ManualSessionWithUserScenario.m
+++ b/features/fixtures/ios-swift-cocoapods/iOSTestApp/scenarios/ManualSessionWithUserScenario.m
@@ -12,7 +12,7 @@
 
 - (void)startBugsnag {
     [self.config setUser:@"123" withName:@"Joe Bloggs" andEmail:@"joe@example.com"];
-    self.config.shouldAutoCaptureSessions = NO;
+    self.config.autoTrackSessions = NO;
     [super startBugsnag];
 }
 

--- a/features/fixtures/ios-swift-cocoapods/iOSTestApp/scenarios/ManyConcurrentNotifyScenario.m
+++ b/features/fixtures/ios-swift-cocoapods/iOSTestApp/scenarios/ManyConcurrentNotifyScenario.m
@@ -40,7 +40,7 @@
 }
 
 - (void)startBugsnag {
-    self.config.shouldAutoCaptureSessions = NO;
+    self.config.autoTrackSessions = NO;
     [super startBugsnag];
 }
 

--- a/features/fixtures/ios-swift-cocoapods/iOSTestApp/scenarios/NSExceptionShiftScenario.m
+++ b/features/fixtures/ios-swift-cocoapods/iOSTestApp/scenarios/NSExceptionShiftScenario.m
@@ -4,7 +4,7 @@
 @implementation NSExceptionShiftScenario
 
 - (void)startBugsnag {
-    self.config.shouldAutoCaptureSessions = NO;
+    self.config.autoTrackSessions = NO;
     [super startBugsnag];
 }
 

--- a/features/fixtures/ios-swift-cocoapods/iOSTestApp/scenarios/NewSessionScenario.swift
+++ b/features/fixtures/ios-swift-cocoapods/iOSTestApp/scenarios/NewSessionScenario.swift
@@ -11,7 +11,7 @@ import Bugsnag
 
 internal class NewSessionScenario: Scenario {
     override func startBugsnag() {
-        self.config.shouldAutoCaptureSessions = false;
+        self.config.autoTrackSessions = false;
         super.startBugsnag()
     }
 

--- a/features/fixtures/ios-swift-cocoapods/iOSTestApp/scenarios/NonExistentMethodScenario.m
+++ b/features/fixtures/ios-swift-cocoapods/iOSTestApp/scenarios/NonExistentMethodScenario.m
@@ -9,7 +9,7 @@
 @implementation NonExistentMethodScenario
 
 - (void)startBugsnag {
-    self.config.shouldAutoCaptureSessions = NO;
+    self.config.autoTrackSessions = NO;
     [super startBugsnag];
 }
 

--- a/features/fixtures/ios-swift-cocoapods/iOSTestApp/scenarios/NullPointerScenario.m
+++ b/features/fixtures/ios-swift-cocoapods/iOSTestApp/scenarios/NullPointerScenario.m
@@ -31,7 +31,7 @@
 @implementation NullPointerScenario
 
 - (void)startBugsnag {
-    self.config.shouldAutoCaptureSessions = NO;
+    self.config.autoTrackSessions = NO;
     [super startBugsnag];
 }
 

--- a/features/fixtures/ios-swift-cocoapods/iOSTestApp/scenarios/OOMScenario.m
+++ b/features/fixtures/ios-swift-cocoapods/iOSTestApp/scenarios/OOMScenario.m
@@ -5,7 +5,7 @@
 @implementation OOMScenario
 
 - (void)startBugsnag {
-    self.config.shouldAutoCaptureSessions = NO;
+    self.config.autoTrackSessions = NO;
     self.config.releaseStage = @"alpha";
     [self.config addBeforeSendBlock:^bool(NSDictionary * _Nonnull rawEventData, BugsnagCrashReport * _Nonnull report) {
         NSMutableDictionary *metadata = [report.metaData mutableCopy];

--- a/features/fixtures/ios-swift-cocoapods/iOSTestApp/scenarios/OOMScenario.m
+++ b/features/fixtures/ios-swift-cocoapods/iOSTestApp/scenarios/OOMScenario.m
@@ -5,9 +5,9 @@
 @implementation OOMScenario
 
 - (void)startBugsnag {
-    self.config.autoTrackSessions = NO;
+    self.config.shouldAutoCaptureSessions = NO;
     self.config.releaseStage = @"alpha";
-    [self.config addBeforeSendBlock:^bool(NSDictionary * _Nonnull rawEventData, BugsnagCrashReport * _Nonnull report) {
+    [self.config addBeforeSendBlock:^bool(NSDictionary * _Nonnull rawEventData, BugsnagEvent * _Nonnull report) {
         NSMutableDictionary *metadata = [report.metaData mutableCopy];
         metadata[@"extra"] = @{ @"shape": @"line" };
         report.metaData = metadata;

--- a/features/fixtures/ios-swift-cocoapods/iOSTestApp/scenarios/OOMWillTerminateScenario.m
+++ b/features/fixtures/ios-swift-cocoapods/iOSTestApp/scenarios/OOMWillTerminateScenario.m
@@ -6,7 +6,7 @@
 @implementation OOMWillTerminateScenario
 
 - (void)startBugsnag {
-    self.config.shouldAutoCaptureSessions = NO;
+    self.config.autoTrackSessions = NO;
     [super startBugsnag];
 }
 

--- a/features/fixtures/ios-swift-cocoapods/iOSTestApp/scenarios/ObjCExceptionScenario.m
+++ b/features/fixtures/ios-swift-cocoapods/iOSTestApp/scenarios/ObjCExceptionScenario.m
@@ -34,7 +34,7 @@
 @implementation ObjCExceptionScenario
 
 - (void)startBugsnag {
-    self.config.shouldAutoCaptureSessions = NO;
+    self.config.autoTrackSessions = NO;
     [super startBugsnag];
 }
 

--- a/features/fixtures/ios-swift-cocoapods/iOSTestApp/scenarios/ObjCMsgSendScenario.m
+++ b/features/fixtures/ios-swift-cocoapods/iOSTestApp/scenarios/ObjCMsgSendScenario.m
@@ -33,7 +33,7 @@
 @implementation ObjCMsgSendScenario
 
 - (void)startBugsnag {
-    self.config.shouldAutoCaptureSessions = NO;
+    self.config.autoTrackSessions = NO;
     [super startBugsnag];
 }
 

--- a/features/fixtures/ios-swift-cocoapods/iOSTestApp/scenarios/OverwriteLinkRegisterScenario.m
+++ b/features/fixtures/ios-swift-cocoapods/iOSTestApp/scenarios/OverwriteLinkRegisterScenario.m
@@ -38,7 +38,7 @@
 }
 
 - (void)startBugsnag {
-    self.config.shouldAutoCaptureSessions = NO;
+    self.config.autoTrackSessions = NO;
     [super startBugsnag];
 }
 

--- a/features/fixtures/ios-swift-cocoapods/iOSTestApp/scenarios/PrivilegedInstructionScenario.m
+++ b/features/fixtures/ios-swift-cocoapods/iOSTestApp/scenarios/PrivilegedInstructionScenario.m
@@ -32,7 +32,7 @@
 @implementation PrivilegedInstructionScenario
 
 - (void)startBugsnag {
-    self.config.shouldAutoCaptureSessions = NO;
+    self.config.autoTrackSessions = NO;
     [super startBugsnag];
 }
 

--- a/features/fixtures/ios-swift-cocoapods/iOSTestApp/scenarios/ReadGarbagePointerScenario.m
+++ b/features/fixtures/ios-swift-cocoapods/iOSTestApp/scenarios/ReadGarbagePointerScenario.m
@@ -33,7 +33,7 @@
 @implementation ReadGarbagePointerScenario
 
 - (void)startBugsnag {
-    self.config.shouldAutoCaptureSessions = NO;
+    self.config.autoTrackSessions = NO;
     [super startBugsnag];
 }
 

--- a/features/fixtures/ios-swift-cocoapods/iOSTestApp/scenarios/ReadOnlyPageScenario.m
+++ b/features/fixtures/ios-swift-cocoapods/iOSTestApp/scenarios/ReadOnlyPageScenario.m
@@ -32,7 +32,7 @@
 @implementation ReadOnlyPageScenario
 
 - (void)startBugsnag {
-    self.config.shouldAutoCaptureSessions = NO;
+    self.config.autoTrackSessions = NO;
     [super startBugsnag];
 }
 

--- a/features/fixtures/ios-swift-cocoapods/iOSTestApp/scenarios/ReleaseStageScenarios.swift
+++ b/features/fixtures/ios-swift-cocoapods/iOSTestApp/scenarios/ReleaseStageScenarios.swift
@@ -5,7 +5,7 @@ class MagicError : NSError {}
 class NotifyWhenReleaseStageInNotifyReleaseStages : Scenario {
 
     override func startBugsnag() {
-        self.config.shouldAutoCaptureSessions = false;
+        self.config.autoTrackSessions = false;
         self.config.releaseStage = "prod"
         self.config.notifyReleaseStages = ["dev", "prod"]
         super.startBugsnag()
@@ -21,7 +21,7 @@ class NotifyWhenReleaseStageInNotifyReleaseStages : Scenario {
 class CrashWhenReleaseStageInNotifyReleaseStages : Scenario {
 
     override func startBugsnag() {
-        self.config.shouldAutoCaptureSessions = false;
+        self.config.autoTrackSessions = false;
         self.config.releaseStage = "prod"
         self.config.notifyReleaseStages = ["dev", "prod"]
         super.startBugsnag()
@@ -35,7 +35,7 @@ class CrashWhenReleaseStageInNotifyReleaseStages : Scenario {
 class CrashWhenReleaseStageInNotifyReleaseStagesChanges : Scenario {
 
     override func startBugsnag() {
-        self.config.shouldAutoCaptureSessions = false;
+        self.config.autoTrackSessions = false;
         if (self.eventMode == "noevent") {
           // The event is evaluated whether to be sent
           self.config.releaseStage = "test"
@@ -55,7 +55,7 @@ class CrashWhenReleaseStageInNotifyReleaseStagesChanges : Scenario {
 class CrashWhenReleaseStageNotInNotifyReleaseStagesChanges : Scenario {
 
     override func startBugsnag() {
-        self.config.shouldAutoCaptureSessions = false;
+        self.config.autoTrackSessions = false;
         if (self.eventMode == "noevent") {
           // The event is evaluated whether to be sent
           self.config.releaseStage = "prod"
@@ -75,7 +75,7 @@ class CrashWhenReleaseStageNotInNotifyReleaseStagesChanges : Scenario {
 class NotifyWhenReleaseStageNotInNotifyReleaseStages : Scenario {
 
     override func startBugsnag() {
-        self.config.shouldAutoCaptureSessions = false;
+        self.config.autoTrackSessions = false;
         self.config.releaseStage = "dev"
         self.config.notifyReleaseStages = ["prod"]
         super.startBugsnag()
@@ -91,7 +91,7 @@ class NotifyWhenReleaseStageNotInNotifyReleaseStages : Scenario {
 class CrashWhenReleaseStageNotInNotifyReleaseStages : Scenario {
 
     override func startBugsnag() {
-        self.config.shouldAutoCaptureSessions = false;
+        self.config.autoTrackSessions = false;
         self.config.releaseStage = "dev"
         self.config.notifyReleaseStages = ["prod"]
         super.startBugsnag()

--- a/features/fixtures/ios-swift-cocoapods/iOSTestApp/scenarios/ReleasedObjectScenario.m
+++ b/features/fixtures/ios-swift-cocoapods/iOSTestApp/scenarios/ReleasedObjectScenario.m
@@ -36,7 +36,7 @@
 - (NSString *)title { return @"Message a released object"; }
 - (NSString *)desc { return @""; }
 - (void)startBugsnag {
-    self.config.shouldAutoCaptureSessions = NO;
+    self.config.autoTrackSessions = NO;
     [super startBugsnag];
 }
 

--- a/features/fixtures/ios-swift-cocoapods/iOSTestApp/scenarios/ReportBackgroundOOMsEnabledScenario.m
+++ b/features/fixtures/ios-swift-cocoapods/iOSTestApp/scenarios/ReportBackgroundOOMsEnabledScenario.m
@@ -4,8 +4,7 @@
 @implementation ReportBackgroundOOMsEnabledScenario
 
 - (void)startBugsnag {
-    self.config.shouldAutoCaptureSessions = NO;
-    self.config.reportBackgroundOOMs = YES;
+    self.config.autoTrackSessions = NO;
     [super startBugsnag];
 }
 

--- a/features/fixtures/ios-swift-cocoapods/iOSTestApp/scenarios/ReportDidCrashScenario.swift
+++ b/features/fixtures/ios-swift-cocoapods/iOSTestApp/scenarios/ReportDidCrashScenario.swift
@@ -5,7 +5,7 @@ import Bugsnag
 @objc class ReportDidCrashScenario: Scenario {
 
     override func startBugsnag() {
-        self.config.shouldAutoCaptureSessions = false;
+        self.config.autoTrackSessions = false;
         super.startBugsnag()
     }
     

--- a/features/fixtures/ios-swift-cocoapods/iOSTestApp/scenarios/ReportOOMsDisabledReportBackgroundOOMsEnabledScenario.m
+++ b/features/fixtures/ios-swift-cocoapods/iOSTestApp/scenarios/ReportOOMsDisabledReportBackgroundOOMsEnabledScenario.m
@@ -4,9 +4,8 @@
 @implementation ReportOOMsDisabledReportBackgroundOOMsEnabledScenario
 
 - (void)startBugsnag {
-    self.config.shouldAutoCaptureSessions = NO;
+    self.config.autoTrackSessions = NO;
     self.config.reportOOMs = NO;
-    self.config.reportBackgroundOOMs = YES;
     [super startBugsnag];
 }
 

--- a/features/fixtures/ios-swift-cocoapods/iOSTestApp/scenarios/ReportOOMsDisabledScenario.m
+++ b/features/fixtures/ios-swift-cocoapods/iOSTestApp/scenarios/ReportOOMsDisabledScenario.m
@@ -5,7 +5,7 @@
 @implementation ReportOOMsDisabledScenario
 
 - (void)startBugsnag {
-    self.config.shouldAutoCaptureSessions = NO;
+    self.config.autoTrackSessions = NO;
     self.config.reportOOMs = NO;
     [super startBugsnag];
 }

--- a/features/fixtures/ios-swift-cocoapods/iOSTestApp/scenarios/ResumeSessionOOMScenario.m
+++ b/features/fixtures/ios-swift-cocoapods/iOSTestApp/scenarios/ResumeSessionOOMScenario.m
@@ -3,7 +3,7 @@
 @implementation ResumeSessionOOMScenario
 
 - (void)startBugsnag {
-    self.config.shouldAutoCaptureSessions = NO;
+    self.config.autoTrackSessions = NO;
     [super startBugsnag];
 }
 

--- a/features/fixtures/ios-swift-cocoapods/iOSTestApp/scenarios/ResumedSessionScenario.swift
+++ b/features/fixtures/ios-swift-cocoapods/iOSTestApp/scenarios/ResumedSessionScenario.swift
@@ -11,7 +11,7 @@ import Bugsnag
 
 internal class ResumedSessionScenario: Scenario {
     override func startBugsnag() {
-        self.config.shouldAutoCaptureSessions = false;
+        self.config.autoTrackSessions = false;
         super.startBugsnag()
     }
 

--- a/features/fixtures/ios-swift-cocoapods/iOSTestApp/scenarios/SessionOOMScenario.m
+++ b/features/fixtures/ios-swift-cocoapods/iOSTestApp/scenarios/SessionOOMScenario.m
@@ -4,7 +4,7 @@
 @implementation SessionOOMScenario
 
 - (void)startBugsnag {
-    self.config.shouldAutoCaptureSessions = NO;
+    self.config.autoTrackSessions = NO;
     [super startBugsnag];
 }
 

--- a/features/fixtures/ios-swift-cocoapods/iOSTestApp/scenarios/StackOverflowScenario.m
+++ b/features/fixtures/ios-swift-cocoapods/iOSTestApp/scenarios/StackOverflowScenario.m
@@ -33,7 +33,7 @@
 @implementation StackOverflowScenario
 
 - (void)startBugsnag {
-    self.config.shouldAutoCaptureSessions = NO;
+    self.config.autoTrackSessions = NO;
     [super startBugsnag];
 }
 

--- a/features/fixtures/ios-swift-cocoapods/iOSTestApp/scenarios/StopSessionOOMScenario.m
+++ b/features/fixtures/ios-swift-cocoapods/iOSTestApp/scenarios/StopSessionOOMScenario.m
@@ -3,7 +3,7 @@
 @implementation StopSessionOOMScenario
 
 - (void)startBugsnag {
-    self.config.shouldAutoCaptureSessions = NO;
+    self.config.autoTrackSessions = NO;
     [super startBugsnag];
 }
 

--- a/features/fixtures/ios-swift-cocoapods/iOSTestApp/scenarios/StoppedSessionScenario.swift
+++ b/features/fixtures/ios-swift-cocoapods/iOSTestApp/scenarios/StoppedSessionScenario.swift
@@ -11,7 +11,7 @@ import Bugsnag
 
 internal class StoppedSessionScenario: Scenario {
     override func startBugsnag() {
-        self.config.shouldAutoCaptureSessions = false;
+        self.config.autoTrackSessions = false;
         super.startBugsnag()
     }
 

--- a/features/fixtures/ios-swift-cocoapods/iOSTestApp/scenarios/SwiftAssertion.swift
+++ b/features/fixtures/ios-swift-cocoapods/iOSTestApp/scenarios/SwiftAssertion.swift
@@ -2,7 +2,7 @@ import Foundation
 
 class SwiftAssertion: Scenario {
     override func startBugsnag() {
-      self.config.shouldAutoCaptureSessions = false;
+      self.config.autoTrackSessions = false;
       super.startBugsnag()
     }
 

--- a/features/fixtures/ios-swift-cocoapods/iOSTestApp/scenarios/SwiftCrash.swift
+++ b/features/fixtures/ios-swift-cocoapods/iOSTestApp/scenarios/SwiftCrash.swift
@@ -31,7 +31,7 @@ import Foundation
  */
 class SwiftCrash: Scenario {
     override func startBugsnag() {
-      self.config.shouldAutoCaptureSessions = false;
+      self.config.autoTrackSessions = false;
       super.startBugsnag()
     }
 

--- a/features/fixtures/ios-swift-cocoapods/iOSTestApp/scenarios/UndefinedInstructionScenario.m
+++ b/features/fixtures/ios-swift-cocoapods/iOSTestApp/scenarios/UndefinedInstructionScenario.m
@@ -32,7 +32,7 @@
 @implementation UndefinedInstructionScenario
 
 - (void)startBugsnag {
-    self.config.shouldAutoCaptureSessions = NO;
+    self.config.autoTrackSessions = NO;
     [super startBugsnag];
 }
 

--- a/features/fixtures/ios-swift-cocoapods/iOSTestApp/scenarios/UserDisabledScenario.swift
+++ b/features/fixtures/ios-swift-cocoapods/iOSTestApp/scenarios/UserDisabledScenario.swift
@@ -11,7 +11,7 @@ import Bugsnag
  */
 internal class UserDisabledScenario: Scenario {
     override func startBugsnag() {
-      self.config.shouldAutoCaptureSessions = false;
+      self.config.autoTrackSessions = false;
       super.startBugsnag()
     }
 

--- a/features/fixtures/ios-swift-cocoapods/iOSTestApp/scenarios/UserEmailScenario.swift
+++ b/features/fixtures/ios-swift-cocoapods/iOSTestApp/scenarios/UserEmailScenario.swift
@@ -11,7 +11,7 @@ import Bugsnag
  */
 internal class UserEmailScenario: Scenario {
     override func startBugsnag() {
-      self.config.shouldAutoCaptureSessions = false;
+      self.config.autoTrackSessions = false;
       super.startBugsnag()
     }
 

--- a/features/fixtures/ios-swift-cocoapods/iOSTestApp/scenarios/UserEnabledScenario.swift
+++ b/features/fixtures/ios-swift-cocoapods/iOSTestApp/scenarios/UserEnabledScenario.swift
@@ -12,7 +12,7 @@ import Bugsnag
 internal class UserEnabledScenario: Scenario {
 
     override func startBugsnag() {
-      self.config.shouldAutoCaptureSessions = false;
+      self.config.autoTrackSessions = false;
       super.startBugsnag()
     }
 

--- a/features/fixtures/ios-swift-cocoapods/iOSTestApp/scenarios/UserIdScenario.swift
+++ b/features/fixtures/ios-swift-cocoapods/iOSTestApp/scenarios/UserIdScenario.swift
@@ -12,7 +12,7 @@ import Bugsnag
 internal class UserIdScenario: Scenario {
 
     override func startBugsnag() {
-      self.config.shouldAutoCaptureSessions = false;
+      self.config.autoTrackSessions = false;
       super.startBugsnag()
     }
 

--- a/features/handled_errors.feature
+++ b/features/handled_errors.feature
@@ -1,5 +1,8 @@
 Feature: Handled Errors and Exceptions
 
+Background:
+    Given I set environment variable "BUGSNAG_API_KEY" to "a35a2a72bd230ac0aa0f52715bbdc6aa"
+
 Scenario: Override errorClass and message from a notifyError() callback, customize report
 
     Discard 2 lines from the stacktrace, as we have single place to report and log errors, see

--- a/features/out_of_memory.feature
+++ b/features/out_of_memory.feature
@@ -60,7 +60,8 @@ Feature: Reporting out of memory events
         Then I should receive 0 requests
 
     Scenario: The OS kills the application after a session is sent
-        When I crash the app using "SessionOOMScenario"
+        When I set environment variable "BUGSNAG_API_KEY" to "0192837465afbecd0192837465afbecd"
+        And I crash the app using "SessionOOMScenario"
         And I wait for 2 requests
         And the app is unexpectedly terminated
         And I relaunch the app
@@ -77,7 +78,8 @@ Feature: Reporting out of memory events
         And the payload field "events.0.session.id" of request 1 equals the payload field "events.0.session.id" of request 2
 
     Scenario: The OS kills the application after a session is stopped
-        When I crash the app using "StopSessionOOMScenario"
+        When I set environment variable "BUGSNAG_API_KEY" to "0192837465afbecd0192837465afbecd"
+        And I crash the app using "StopSessionOOMScenario"
         And I wait for 2 requests
         And the app is unexpectedly terminated
         And I relaunch the app
@@ -92,6 +94,7 @@ Feature: Reporting out of memory events
         And the payload field "events.0.session.id" of request 1 equals the payload field "sessions.0.id" of request 0
 
     Scenario: The OS kills the application after a session is resumed
+        When I set environment variable "BUGSNAG_API_KEY" to "0192837465afbecd0192837465afbecd"
         When I crash the app using "ResumeSessionOOMScenario"
         And I wait for 2 requests
         And the app is unexpectedly terminated

--- a/features/release_stages.feature
+++ b/features/release_stages.feature
@@ -1,5 +1,8 @@
 Feature: Discarding reports based on release stage
 
+Background:
+    Given I set environment variable "BUGSNAG_API_KEY" to "a35a2a72bd230ac0aa0f52715bbdc6aa"
+
     Scenario: Crash when release stage is not present in "notify release stages"
         When I crash the app using "CrashWhenReleaseStageNotInNotifyReleaseStages"
         And I relaunch the app

--- a/features/session_tracking.feature
+++ b/features/session_tracking.feature
@@ -1,5 +1,8 @@
 Feature: Session Tracking
 
+Background:
+    Given I set environment variable "BUGSNAG_API_KEY" to "a35a2a72bd230ac0aa0f52715bbdc6aa"
+
 Scenario: Launching using the default configuration sends a single session
     When I run "AutoSessionScenario"
     And I wait for a request

--- a/iOS/Bugsnag.xcodeproj/project.pbxproj
+++ b/iOS/Bugsnag.xcodeproj/project.pbxproj
@@ -8,6 +8,12 @@
 
 /* Begin PBXBuildFile section */
 		4B47970A22A9AE1F00FF9C2E /* BugsnagEventFromKSCrashReportTest.m in Sources */ = {isa = PBXBuildFile; fileRef = 4B47970922A9AE1F00FF9C2E /* BugsnagEventFromKSCrashReportTest.m */; };
+		000E6E9E23D8690F009D8194 /* BugsnagSwiftConfigurationTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 000E6E9D23D8690F009D8194 /* BugsnagSwiftConfigurationTests.swift */; };
+		000E6EA323D8AC8C009D8194 /* UPGRADING.md in Resources */ = {isa = PBXBuildFile; fileRef = 000E6E9F23D8AC8C009D8194 /* UPGRADING.md */; };
+		000E6EA423D8AC8C009D8194 /* README.md in Resources */ = {isa = PBXBuildFile; fileRef = 000E6EA023D8AC8C009D8194 /* README.md */; };
+		000E6EA523D8AC8C009D8194 /* VERSION in Resources */ = {isa = PBXBuildFile; fileRef = 000E6EA123D8AC8C009D8194 /* VERSION */; };
+		000E6EA623D8AC8C009D8194 /* CHANGELOG.md in Resources */ = {isa = PBXBuildFile; fileRef = 000E6EA223D8AC8C009D8194 /* CHANGELOG.md */; };
+		4B47970A22A9AE1F00FF9C2E /* BugsnagCrashReportFromKSCrashReportTest.m in Sources */ = {isa = PBXBuildFile; fileRef = 4B47970922A9AE1F00FF9C2E /* BugsnagCrashReportFromKSCrashReportTest.m */; };
 		4B775FCF22CBDEB4004839C5 /* BugsnagCollectionsBSGDictInsertIfNotNilTest.m in Sources */ = {isa = PBXBuildFile; fileRef = 4B775FCE22CBDEB4004839C5 /* BugsnagCollectionsBSGDictInsertIfNotNilTest.m */; };
 		4BE6C42622CAD61A0056305D /* BugsnagCollectionsBSGDictMergeTest.m in Sources */ = {isa = PBXBuildFile; fileRef = 4BE6C42522CAD61A0056305D /* BugsnagCollectionsBSGDictMergeTest.m */; };
 		8A2C8F231C6BBD2300846019 /* Bugsnag.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = 8A2C8F181C6BBD2300846019 /* Bugsnag.framework */; };
@@ -397,6 +403,13 @@
 /* End PBXCopyFilesBuildPhase section */
 
 /* Begin PBXFileReference section */
+		000E6E9B23D84DB1009D8194 /* BugsnagTestConstants.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; name = BugsnagTestConstants.h; path = ../../Tests/BugsnagTestConstants.h; sourceTree = "<group>"; };
+		000E6E9C23D8690E009D8194 /* Tests-Bridging-Header.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; path = "Tests-Bridging-Header.h"; sourceTree = "<group>"; };
+		000E6E9D23D8690F009D8194 /* BugsnagSwiftConfigurationTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; name = BugsnagSwiftConfigurationTests.swift; path = ../../Tests/BugsnagSwiftConfigurationTests.swift; sourceTree = "<group>"; };
+		000E6E9F23D8AC8C009D8194 /* UPGRADING.md */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = net.daringfireball.markdown; name = UPGRADING.md; path = ../UPGRADING.md; sourceTree = "<group>"; };
+		000E6EA023D8AC8C009D8194 /* README.md */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = net.daringfireball.markdown; name = README.md; path = ../README.md; sourceTree = "<group>"; };
+		000E6EA123D8AC8C009D8194 /* VERSION */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = text; name = VERSION; path = ../VERSION; sourceTree = "<group>"; };
+		000E6EA223D8AC8C009D8194 /* CHANGELOG.md */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = net.daringfireball.markdown; name = CHANGELOG.md; path = ../CHANGELOG.md; sourceTree = "<group>"; };
 		4B3B193422CA7B0900475354 /* BugsnagCollectionsBSGDictSetSafeObjectTest.m */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.objc; name = BugsnagCollectionsBSGDictSetSafeObjectTest.m; path = ../../Tests/BugsnagCollectionsBSGDictSetSafeObjectTest.m; sourceTree = "<group>"; };
 		4B47970922A9AE1F00FF9C2E /* BugsnagEventFromKSCrashReportTest.m */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.objc; path = BugsnagEventFromKSCrashReportTest.m; sourceTree = "<group>"; };
 		4B775FCE22CBDEB4004839C5 /* BugsnagCollectionsBSGDictInsertIfNotNilTest.m */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.objc; name = BugsnagCollectionsBSGDictInsertIfNotNilTest.m; path = ../../Tests/BugsnagCollectionsBSGDictInsertIfNotNilTest.m; sourceTree = "<group>"; };
@@ -622,6 +635,10 @@
 		8A2C8F0E1C6BBD2300846019 = {
 			isa = PBXGroup;
 			children = (
+				000E6EA223D8AC8C009D8194 /* CHANGELOG.md */,
+				000E6EA023D8AC8C009D8194 /* README.md */,
+				000E6E9F23D8AC8C009D8194 /* UPGRADING.md */,
+				000E6EA123D8AC8C009D8194 /* VERSION */,
 				8AF2894923339CCA00E8EB27 /* Config.xcconfig */,
 				8A2C8F1A1C6BBD2300846019 /* Bugsnag */,
 				8A2C8F261C6BBD2300846019 /* Tests */,
@@ -724,6 +741,9 @@
 				F429551527EAE3AFE1F605FE /* BugsnagThreadTest.m */,
 				E70E52142216E41C00A590AB /* BugsnagSessionTrackerStopTest.m */,
 				8A70D9CC2253C484006B696F /* BSGOutOfMemoryWatchdogTests.m */,
+				000E6E9B23D84DB1009D8194 /* BugsnagTestConstants.h */,
+				000E6E9D23D8690F009D8194 /* BugsnagSwiftConfigurationTests.swift */,
+				000E6E9C23D8690E009D8194 /* Tests-Bridging-Header.h */,
 			);
 			name = Tests;
 			path = BugsnagTests;
@@ -1069,6 +1089,7 @@
 					};
 					8A2C8F211C6BBD2300846019 = {
 						CreatedOnToolsVersion = 7.2.1;
+						LastSwiftMigration = 1130;
 					};
 					E7397DC31F83BAC50034242A = {
 						CreatedOnToolsVersion = 9.0;
@@ -1101,6 +1122,10 @@
 			isa = PBXResourcesBuildPhase;
 			buildActionMask = 2147483647;
 			files = (
+				000E6EA523D8AC8C009D8194 /* VERSION in Resources */,
+				000E6EA423D8AC8C009D8194 /* README.md in Resources */,
+				000E6EA323D8AC8C009D8194 /* UPGRADING.md in Resources */,
+				000E6EA623D8AC8C009D8194 /* CHANGELOG.md in Resources */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};
@@ -1191,6 +1216,7 @@
 			files = (
 				8A70D9CD2253C484006B696F /* BSGOutOfMemoryWatchdogTests.m in Sources */,
 				E7B970341FD7031500590C27 /* XCTestCase+KSCrash.m in Sources */,
+				000E6E9E23D8690F009D8194 /* BugsnagSwiftConfigurationTests.swift in Sources */,
 				E70EE07E1FD703D600FA745C /* NSError+SimpleConstructor_Tests.m in Sources */,
 				E70EE0931FD706C700FA745C /* KSFileUtils_Tests.m in Sources */,
 				E70EE08E1FD705A700FA745C /* KSSignalInfo_Tests.m in Sources */,
@@ -1469,24 +1495,31 @@
 		8A2C8F301C6BBD2300846019 /* Debug */ = {
 			isa = XCBuildConfiguration;
 			buildSettings = {
+				CLANG_ENABLE_MODULES = YES;
 				GCC_TREAT_WARNINGS_AS_ERRORS = YES;
 				INFOPLIST_FILE = TestsInfo.plist;
 				IPHONEOS_DEPLOYMENT_TARGET = 8.0;
 				LD_RUNPATH_SEARCH_PATHS = "$(inherited) @executable_path/Frameworks @loader_path/Frameworks";
 				PRODUCT_BUNDLE_IDENTIFIER = com.bugsnag.BugsnagTests;
 				PRODUCT_NAME = "$(TARGET_NAME)";
+				SWIFT_OBJC_BRIDGING_HEADER = "BugsnagTests/Tests-Bridging-Header.h";
+				SWIFT_OPTIMIZATION_LEVEL = "-Onone";
+				SWIFT_VERSION = 5.0;
 			};
 			name = Debug;
 		};
 		8A2C8F311C6BBD2300846019 /* Release */ = {
 			isa = XCBuildConfiguration;
 			buildSettings = {
+				CLANG_ENABLE_MODULES = YES;
 				GCC_TREAT_WARNINGS_AS_ERRORS = YES;
 				INFOPLIST_FILE = TestsInfo.plist;
 				IPHONEOS_DEPLOYMENT_TARGET = 8.0;
 				LD_RUNPATH_SEARCH_PATHS = "$(inherited) @executable_path/Frameworks @loader_path/Frameworks";
 				PRODUCT_BUNDLE_IDENTIFIER = com.bugsnag.BugsnagTests;
 				PRODUCT_NAME = "$(TARGET_NAME)";
+				SWIFT_OBJC_BRIDGING_HEADER = "BugsnagTests/Tests-Bridging-Header.h";
+				SWIFT_VERSION = 5.0;
 			};
 			name = Release;
 		};

--- a/iOS/Bugsnag.xcodeproj/project.pbxproj
+++ b/iOS/Bugsnag.xcodeproj/project.pbxproj
@@ -8,6 +8,7 @@
 
 /* Begin PBXBuildFile section */
 		4B47970A22A9AE1F00FF9C2E /* BugsnagEventFromKSCrashReportTest.m in Sources */ = {isa = PBXBuildFile; fileRef = 4B47970922A9AE1F00FF9C2E /* BugsnagEventFromKSCrashReportTest.m */; };
+		000DF29423DB4B4900A883CE /* TestConstants.m in Sources */ = {isa = PBXBuildFile; fileRef = 000DF29323DB4B4900A883CE /* TestConstants.m */; };
 		000E6E9E23D8690F009D8194 /* BugsnagSwiftConfigurationTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 000E6E9D23D8690F009D8194 /* BugsnagSwiftConfigurationTests.swift */; };
 		000E6EA323D8AC8C009D8194 /* UPGRADING.md in Resources */ = {isa = PBXBuildFile; fileRef = 000E6E9F23D8AC8C009D8194 /* UPGRADING.md */; };
 		000E6EA423D8AC8C009D8194 /* README.md in Resources */ = {isa = PBXBuildFile; fileRef = 000E6EA023D8AC8C009D8194 /* README.md */; };
@@ -403,9 +404,10 @@
 /* End PBXCopyFilesBuildPhase section */
 
 /* Begin PBXFileReference section */
+		000DF29323DB4B4900A883CE /* TestConstants.m */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.objc; path = TestConstants.m; sourceTree = "<group>"; };
 		000E6E9B23D84DB1009D8194 /* BugsnagTestConstants.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; name = BugsnagTestConstants.h; path = ../../Tests/BugsnagTestConstants.h; sourceTree = "<group>"; };
 		000E6E9C23D8690E009D8194 /* Tests-Bridging-Header.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; path = "Tests-Bridging-Header.h"; sourceTree = "<group>"; };
-		000E6E9D23D8690F009D8194 /* BugsnagSwiftConfigurationTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; name = BugsnagSwiftConfigurationTests.swift; path = ../../Tests/BugsnagSwiftConfigurationTests.swift; sourceTree = "<group>"; };
+		000E6E9D23D8690F009D8194 /* BugsnagSwiftConfigurationTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = BugsnagSwiftConfigurationTests.swift; sourceTree = "<group>"; };
 		000E6E9F23D8AC8C009D8194 /* UPGRADING.md */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = net.daringfireball.markdown; name = UPGRADING.md; path = ../UPGRADING.md; sourceTree = "<group>"; };
 		000E6EA023D8AC8C009D8194 /* README.md */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = net.daringfireball.markdown; name = README.md; path = ../README.md; sourceTree = "<group>"; };
 		000E6EA123D8AC8C009D8194 /* VERSION */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = text; name = VERSION; path = ../VERSION; sourceTree = "<group>"; };
@@ -632,6 +634,14 @@
 /* End PBXFrameworksBuildPhase section */
 
 /* Begin PBXGroup section */
+		000DF29223DB4A6B00A883CE /* Swift Tests */ = {
+			isa = PBXGroup;
+			children = (
+				000E6E9D23D8690F009D8194 /* BugsnagSwiftConfigurationTests.swift */,
+			);
+			path = "Swift Tests";
+			sourceTree = "<group>";
+		};
 		8A2C8F0E1C6BBD2300846019 = {
 			isa = PBXGroup;
 			children = (
@@ -721,6 +731,7 @@
 			isa = PBXGroup;
 			children = (
 				E70EE0891FD7047D00FA745C /* KSCrash */,
+				000DF29223DB4A6B00A883CE /* Swift Tests */,
 				8A2C8F8B1C6BBFDD00846019 /* BugsnagBreadcrumbsTest.m */,
 				4B3B193422CA7B0900475354 /* BugsnagCollectionsBSGDictSetSafeObjectTest.m */,
 				4B775FCE22CBDEB4004839C5 /* BugsnagCollectionsBSGDictInsertIfNotNilTest.m */,
@@ -742,8 +753,8 @@
 				E70E52142216E41C00A590AB /* BugsnagSessionTrackerStopTest.m */,
 				8A70D9CC2253C484006B696F /* BSGOutOfMemoryWatchdogTests.m */,
 				000E6E9B23D84DB1009D8194 /* BugsnagTestConstants.h */,
-				000E6E9D23D8690F009D8194 /* BugsnagSwiftConfigurationTests.swift */,
 				000E6E9C23D8690E009D8194 /* Tests-Bridging-Header.h */,
+				000DF29323DB4B4900A883CE /* TestConstants.m */,
 			);
 			name = Tests;
 			path = BugsnagTests;
@@ -1240,6 +1251,7 @@
 				E733A76F1FD709B7003EAA29 /* KSCrashReportStore_Tests.m in Sources */,
 				E70EE0781FD7039E00FA745C /* RFC3339DateTool_Tests.m in Sources */,
 				8A530CC422FDD51F00F0C108 /* KSCrashIdentifierTests.m in Sources */,
+				000DF29423DB4B4900A883CE /* TestConstants.m in Sources */,
 				8A4E733F1DC13281001F7CC8 /* BugsnagConfigurationTests.m in Sources */,
 				E784D25A1FD70C25004B01E1 /* KSJSONCodec_Tests.m in Sources */,
 				E70EE0881FD7047800FA745C /* KSSystemInfo_Tests.m in Sources */,

--- a/iOS/BugsnagTests/BugsnagKSCrashSysInfoParserTest.m
+++ b/iOS/BugsnagTests/BugsnagKSCrashSysInfoParserTest.m
@@ -35,7 +35,12 @@ NSNumber * _Nullable BSGDeviceFreeSpace(NSSearchPathDirectory directory);
     XCTAssertNotNil(device);
     XCTAssertNotNil(device[@"locale"]);
     XCTAssertNotNil(device[@"freeDisk"]);
-    XCTAssertNotNil(device[@"simulator"]);
+    
+    #if TARGET_OS_SIMULATOR
+        XCTAssertNotNil(device[@"simulator"]);
+    #elif TARGET_OS_IPHONE || TARGET_OS_TV
+        XCTAssertNil(device[@"simulator"]);
+    #endif
 }
 
 - (void)testDeviceFreeSpaceShouldBeLargeNumber {

--- a/iOS/BugsnagTests/Swift Tests/BugsnagSwiftConfigurationTests.swift
+++ b/iOS/BugsnagTests/Swift Tests/BugsnagSwiftConfigurationTests.swift
@@ -19,6 +19,7 @@ class BugsnagSwiftConfigurationTests: XCTestCase {
         
         do {
             let _ = try BugsnagConfiguration(DUMMY_APIKEY_16CHAR)
+            XCTFail("Erronoeusly initialized a BugsnagConfiguration object with an invalid apiKey")
         }
         catch let e as NSError {
             XCTAssertEqual(e.domain, BSGConfigurationErrorDomain)

--- a/iOS/BugsnagTests/TestConstants.m
+++ b/iOS/BugsnagTests/TestConstants.m
@@ -1,0 +1,23 @@
+//
+//  TestConstants.m
+//  Tests
+//
+//  Created by Robin Macharg on 24/01/2020.
+//  Copyright © 2020 Bugsnag. All rights reserved.
+//
+
+#import <XCTest/XCTest.h>
+#import "BugsnagConfiguration.h"
+
+@interface TestConstants : XCTestCase
+
+@end
+
+@implementation TestConstants
+
+- (void)testConfigurationConstants {
+    XCTAssertTrue([BSGConfigurationErrorDomain isEqualToString:@"com.Bugsnag.CocoaNotifier.Configuration"]);
+    XCTAssertEqual(BSGConfigurationErrorInvalidApiKey, 0);
+}
+
+@end

--- a/iOS/BugsnagTests/Tests-Bridging-Header.h
+++ b/iOS/BugsnagTests/Tests-Bridging-Header.h
@@ -1,0 +1,6 @@
+//
+//  Public headers exposed to Swift
+//
+
+#import "BugsnagConfiguration.h"
+#import "BugsnagTestConstants.h"

--- a/tvOS/Bugsnag.xcodeproj/project.pbxproj
+++ b/tvOS/Bugsnag.xcodeproj/project.pbxproj
@@ -7,6 +7,8 @@
 	objects = {
 
 /* Begin PBXBuildFile section */
+		00D7ACA023E97FBD00FBE4A7 /* BugsnagEvent.m in Sources */ = {isa = PBXBuildFile; fileRef = 00D7AC9E23E97FBD00FBE4A7 /* BugsnagEvent.m */; };
+		00D7ACA123E97FBD00FBE4A7 /* BugsnagEvent.h in Headers */ = {isa = PBXBuildFile; fileRef = 00D7AC9F23E97FBD00FBE4A7 /* BugsnagEvent.h */; };
 		4B3CD2B622C5625800DBFF33 /* BugsnagKSCrashSysInfoParserTest.m in Sources */ = {isa = PBXBuildFile; fileRef = 4B3CD2B522C5625800DBFF33 /* BugsnagKSCrashSysInfoParserTest.m */; };
 		4B3CD2BB22C5676800DBFF33 /* BSGOutOfMemoryWatchdogTests.m in Sources */ = {isa = PBXBuildFile; fileRef = 4B3CD2B722C5676700DBFF33 /* BSGOutOfMemoryWatchdogTests.m */; };
 		4B3CD2BC22C5676800DBFF33 /* BugsnagCrashReportFromKSCrashReportTest.m in Sources */ = {isa = PBXBuildFile; fileRef = 4B3CD2B822C5676700DBFF33 /* BugsnagCrashReportFromKSCrashReportTest.m */; };
@@ -15,7 +17,6 @@
 		4B406C1422CAD94100464D1D /* BugsnagCollectionsBSGDictSetSafeObjectTest.m in Sources */ = {isa = PBXBuildFile; fileRef = 4B406C1222CAD94100464D1D /* BugsnagCollectionsBSGDictSetSafeObjectTest.m */; };
 		4B406C1522CAD94100464D1D /* BugsnagCollectionsBSGDictMergeTest.m in Sources */ = {isa = PBXBuildFile; fileRef = 4B406C1322CAD94100464D1D /* BugsnagCollectionsBSGDictMergeTest.m */; };
 		4B775FD122CBE01F004839C5 /* BugsnagCollectionsBSGDictInsertIfNotNilTest.m in Sources */ = {isa = PBXBuildFile; fileRef = 4B775FD022CBE01F004839C5 /* BugsnagCollectionsBSGDictInsertIfNotNilTest.m */; };
-		8A12006E221C51550008C9C3 /* BSGFilepathTests.m in Sources */ = {isa = PBXBuildFile; fileRef = 8A12006D221C51550008C9C3 /* BSGFilepathTests.m */; };
 		8A3C591023968B2000B344AA /* BugsnagPlugin.h in Headers */ = {isa = PBXBuildFile; fileRef = 8A3C590F23968B2000B344AA /* BugsnagPlugin.h */; settings = {ATTRIBUTES = (Public, ); }; };
 		8A48EF291EAA824100B70024 /* BugsnagLogger.h in Headers */ = {isa = PBXBuildFile; fileRef = 8A48EF281EAA824100B70024 /* BugsnagLogger.h */; };
 		8A530CBC22FDC39300F0C108 /* BSG_KSCrashIdentifier.m in Sources */ = {isa = PBXBuildFile; fileRef = 8A530CBA22FDC39300F0C108 /* BSG_KSCrashIdentifier.m */; };
@@ -34,7 +35,6 @@
 		8AD9A4F61D42EE8E004E1CC5 /* BugsnagBreadcrumb.h in Headers */ = {isa = PBXBuildFile; fileRef = 8AB151281D41366400C9B218 /* BugsnagBreadcrumb.h */; settings = {ATTRIBUTES = (Public, ); }; };
 		8AD9A4F71D42EE90004E1CC5 /* BugsnagCollections.h in Headers */ = {isa = PBXBuildFile; fileRef = 8AB1512A1D41366400C9B218 /* BugsnagCollections.h */; };
 		8AD9A4F81D42EE96004E1CC5 /* BugsnagConfiguration.h in Headers */ = {isa = PBXBuildFile; fileRef = 8AB1512C1D41366400C9B218 /* BugsnagConfiguration.h */; settings = {ATTRIBUTES = (Public, ); }; };
-		8AD9A4F91D42EE96004E1CC5 /* BugsnagCrashReport.h in Headers */ = {isa = PBXBuildFile; fileRef = 8AB1512E1D41366400C9B218 /* BugsnagCrashReport.h */; settings = {ATTRIBUTES = (Public, ); }; };
 		8AD9A4FA1D42EE96004E1CC5 /* BugsnagMetaData.h in Headers */ = {isa = PBXBuildFile; fileRef = 8AB151301D41366400C9B218 /* BugsnagMetaData.h */; settings = {ATTRIBUTES = (Public, ); }; };
 		8AD9A4FB1D42EE96004E1CC5 /* BugsnagNotifier.h in Headers */ = {isa = PBXBuildFile; fileRef = 8AB151321D41366400C9B218 /* BugsnagNotifier.h */; };
 		8AD9A4FC1D42EE96004E1CC5 /* BugsnagSink.h in Headers */ = {isa = PBXBuildFile; fileRef = 8AB151341D41366400C9B218 /* BugsnagSink.h */; };
@@ -42,7 +42,6 @@
 		8AD9A4FE1D42EE9D004E1CC5 /* BugsnagBreadcrumb.m in Sources */ = {isa = PBXBuildFile; fileRef = 8AB151291D41366400C9B218 /* BugsnagBreadcrumb.m */; };
 		8AD9A4FF1D42EEA0004E1CC5 /* BugsnagCollections.m in Sources */ = {isa = PBXBuildFile; fileRef = 8AB1512B1D41366400C9B218 /* BugsnagCollections.m */; };
 		8AD9A5001D42EEA9004E1CC5 /* BugsnagConfiguration.m in Sources */ = {isa = PBXBuildFile; fileRef = 8AB1512D1D41366400C9B218 /* BugsnagConfiguration.m */; };
-		8AD9A5011D42EEB0004E1CC5 /* BugsnagCrashReport.m in Sources */ = {isa = PBXBuildFile; fileRef = 8AB1512F1D41366400C9B218 /* BugsnagCrashReport.m */; };
 		8AD9A5021D42EEB0004E1CC5 /* BugsnagMetaData.m in Sources */ = {isa = PBXBuildFile; fileRef = 8AB151311D41366400C9B218 /* BugsnagMetaData.m */; };
 		8AD9A5031D42EEB0004E1CC5 /* BugsnagNotifier.m in Sources */ = {isa = PBXBuildFile; fileRef = 8AB151331D41366400C9B218 /* BugsnagNotifier.m */; };
 		8AD9A5041D42EEB0004E1CC5 /* BugsnagSink.m in Sources */ = {isa = PBXBuildFile; fileRef = 8AB151351D41366400C9B218 /* BugsnagSink.m */; };
@@ -189,6 +188,8 @@
 /* End PBXContainerItemProxy section */
 
 /* Begin PBXFileReference section */
+		00D7AC9E23E97FBD00FBE4A7 /* BugsnagEvent.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; name = BugsnagEvent.m; path = ../Source/BugsnagEvent.m; sourceTree = "<group>"; };
+		00D7AC9F23E97FBD00FBE4A7 /* BugsnagEvent.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; name = BugsnagEvent.h; path = ../Source/BugsnagEvent.h; sourceTree = "<group>"; };
 		4B3CD2B522C5625800DBFF33 /* BugsnagKSCrashSysInfoParserTest.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; name = BugsnagKSCrashSysInfoParserTest.m; path = ../../iOS/BugsnagTests/BugsnagKSCrashSysInfoParserTest.m; sourceTree = "<group>"; };
 		4B3CD2B722C5676700DBFF33 /* BSGOutOfMemoryWatchdogTests.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; name = BSGOutOfMemoryWatchdogTests.m; path = ../../iOS/BugsnagTests/BSGOutOfMemoryWatchdogTests.m; sourceTree = "<group>"; };
 		4B3CD2B822C5676700DBFF33 /* BugsnagCrashReportFromKSCrashReportTest.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; name = BugsnagCrashReportFromKSCrashReportTest.m; path = ../../iOS/BugsnagTests/BugsnagCrashReportFromKSCrashReportTest.m; sourceTree = "<group>"; };
@@ -197,7 +198,6 @@
 		4B406C1222CAD94100464D1D /* BugsnagCollectionsBSGDictSetSafeObjectTest.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; name = BugsnagCollectionsBSGDictSetSafeObjectTest.m; path = ../../Tests/BugsnagCollectionsBSGDictSetSafeObjectTest.m; sourceTree = "<group>"; };
 		4B406C1322CAD94100464D1D /* BugsnagCollectionsBSGDictMergeTest.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; name = BugsnagCollectionsBSGDictMergeTest.m; path = ../../Tests/BugsnagCollectionsBSGDictMergeTest.m; sourceTree = "<group>"; };
 		4B775FD022CBE01F004839C5 /* BugsnagCollectionsBSGDictInsertIfNotNilTest.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; name = BugsnagCollectionsBSGDictInsertIfNotNilTest.m; path = ../../Tests/BugsnagCollectionsBSGDictInsertIfNotNilTest.m; sourceTree = "<group>"; };
-		8A12006D221C51550008C9C3 /* BSGFilepathTests.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; name = BSGFilepathTests.m; path = ../../Tests/BSGFilepathTests.m; sourceTree = "<group>"; };
 		8A3C590F23968B2000B344AA /* BugsnagPlugin.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; name = BugsnagPlugin.h; path = ../Source/BugsnagPlugin.h; sourceTree = "<group>"; };
 		8A48EF281EAA824100B70024 /* BugsnagLogger.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; name = BugsnagLogger.h; path = ../Source/BugsnagLogger.h; sourceTree = "<group>"; };
 		8A530CBA22FDC39300F0C108 /* BSG_KSCrashIdentifier.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; path = BSG_KSCrashIdentifier.m; sourceTree = "<group>"; };
@@ -224,8 +224,6 @@
 		8AB1512B1D41366400C9B218 /* BugsnagCollections.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; name = BugsnagCollections.m; path = ../Source/BugsnagCollections.m; sourceTree = "<group>"; };
 		8AB1512C1D41366400C9B218 /* BugsnagConfiguration.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; name = BugsnagConfiguration.h; path = ../Source/BugsnagConfiguration.h; sourceTree = "<group>"; };
 		8AB1512D1D41366400C9B218 /* BugsnagConfiguration.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; name = BugsnagConfiguration.m; path = ../Source/BugsnagConfiguration.m; sourceTree = "<group>"; };
-		8AB1512E1D41366400C9B218 /* BugsnagCrashReport.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; name = BugsnagCrashReport.h; path = ../Source/BugsnagCrashReport.h; sourceTree = "<group>"; };
-		8AB1512F1D41366400C9B218 /* BugsnagCrashReport.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; name = BugsnagCrashReport.m; path = ../Source/BugsnagCrashReport.m; sourceTree = "<group>"; };
 		8AB151301D41366400C9B218 /* BugsnagMetaData.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; name = BugsnagMetaData.h; path = ../Source/BugsnagMetaData.h; sourceTree = "<group>"; };
 		8AB151311D41366400C9B218 /* BugsnagMetaData.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; name = BugsnagMetaData.m; path = ../Source/BugsnagMetaData.m; sourceTree = "<group>"; };
 		8AB151321D41366400C9B218 /* BugsnagNotifier.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; name = BugsnagNotifier.h; path = ../Source/BugsnagNotifier.h; sourceTree = "<group>"; };
@@ -412,6 +410,8 @@
 		8A8D51261D41343500D33797 /* tvOS */ = {
 			isa = PBXGroup;
 			children = (
+				00D7AC9F23E97FBD00FBE4A7 /* BugsnagEvent.h */,
+				00D7AC9E23E97FBD00FBE4A7 /* BugsnagEvent.m */,
 				8A3C590F23968B2000B344AA /* BugsnagPlugin.h */,
 				8A6C6FAC2257882400E8EF24 /* BSGOutOfMemoryWatchdog.h */,
 				8A6C6FAB2257882400E8EF24 /* BSGOutOfMemoryWatchdog.m */,
@@ -455,8 +455,6 @@
 				8A48EF281EAA824100B70024 /* BugsnagLogger.h */,
 				8AB1512C1D41366400C9B218 /* BugsnagConfiguration.h */,
 				8AB1512D1D41366400C9B218 /* BugsnagConfiguration.m */,
-				8AB1512E1D41366400C9B218 /* BugsnagCrashReport.h */,
-				8AB1512F1D41366400C9B218 /* BugsnagCrashReport.m */,
 				8AB151301D41366400C9B218 /* BugsnagMetaData.h */,
 				8AB151311D41366400C9B218 /* BugsnagMetaData.m */,
 				8AB151321D41366400C9B218 /* BugsnagNotifier.h */,
@@ -744,8 +742,8 @@
 				E79148821FD82E6D003EFEBF /* BugsnagApiClient.h in Headers */,
 				E76617D01F4E459C0094CECF /* BSG_KSCrashReportFilter.h in Headers */,
 				E76617961F4E459C0094CECF /* BSG_KSCrashSentry_CPPException.h in Headers */,
-				8AD9A4F91D42EE96004E1CC5 /* BugsnagCrashReport.h in Headers */,
 				E76616F91F4E45950094CECF /* BugsnagErrorReportApiClient.h in Headers */,
+				00D7ACA123E97FBD00FBE4A7 /* BugsnagEvent.h in Headers */,
 				8A530CBD22FDC39300F0C108 /* BSG_KSCrashIdentifier.h in Headers */,
 				E76617A61F4E459C0094CECF /* BSG_KSBacktrace_Private.h in Headers */,
 				E76617811F4E459C0094CECF /* BSG_KSCrashC.h in Headers */,
@@ -885,6 +883,7 @@
 				E76617841F4E459C0094CECF /* BSG_KSCrashDoctor.m in Sources */,
 				E766178C1F4E459C0094CECF /* BSG_KSCrashState.m in Sources */,
 				E79148811FD82E6D003EFEBF /* BugsnagApiClient.m in Sources */,
+				00D7ACA023E97FBD00FBE4A7 /* BugsnagEvent.m in Sources */,
 				E76617A81F4E459C0094CECF /* BSG_KSCrashCallCompletion.m in Sources */,
 				E76617971F4E459C0094CECF /* BSG_KSCrashSentry_CPPException.mm in Sources */,
 				E76617B21F4E459C0094CECF /* BSG_KSLogger.m in Sources */,
@@ -907,7 +906,6 @@
 				E76617A41F4E459C0094CECF /* BSG_KSBacktrace.c in Sources */,
 				E76617891F4E459C0094CECF /* BSG_KSCrashReportStore.m in Sources */,
 				E76617921F4E459C0094CECF /* BSG_KSSystemInfo.m in Sources */,
-				8AD9A5011D42EEB0004E1CC5 /* BugsnagCrashReport.m in Sources */,
 				E76616FA1F4E45950094CECF /* BugsnagErrorReportApiClient.m in Sources */,
 				E76617AD1F4E459C0094CECF /* BSG_KSJSONCodec.c in Sources */,
 				E766179D1F4E459C0094CECF /* BSG_KSCrashSentry_NSException.m in Sources */,

--- a/tvOS/Bugsnag.xcodeproj/project.pbxproj
+++ b/tvOS/Bugsnag.xcodeproj/project.pbxproj
@@ -8,10 +8,12 @@
 
 /* Begin PBXBuildFile section */
 		00D7ACA023E97FBD00FBE4A7 /* BugsnagEvent.m in Sources */ = {isa = PBXBuildFile; fileRef = 00D7AC9E23E97FBD00FBE4A7 /* BugsnagEvent.m */; };
-		00D7ACA123E97FBD00FBE4A7 /* BugsnagEvent.h in Headers */ = {isa = PBXBuildFile; fileRef = 00D7AC9F23E97FBD00FBE4A7 /* BugsnagEvent.h */; };
+		00D7ACA123E97FBD00FBE4A7 /* BugsnagEvent.h in Headers */ = {isa = PBXBuildFile; fileRef = 00D7AC9F23E97FBD00FBE4A7 /* BugsnagEvent.h */; settings = {ATTRIBUTES = (Public, ); }; };
+		00D7ACA723E98A5D00FBE4A7 /* BugsnagEventTests.m in Sources */ = {isa = PBXBuildFile; fileRef = 00D7ACA623E98A5D00FBE4A7 /* BugsnagEventTests.m */; };
+		00D7ACAA23E98A9A00FBE4A7 /* TestConstants.m in Sources */ = {isa = PBXBuildFile; fileRef = 00D7ACA823E98A9A00FBE4A7 /* TestConstants.m */; };
+		00D7ACAB23E98A9A00FBE4A7 /* BugsnagEventFromKSCrashReportTest.m in Sources */ = {isa = PBXBuildFile; fileRef = 00D7ACA923E98A9A00FBE4A7 /* BugsnagEventFromKSCrashReportTest.m */; };
 		4B3CD2B622C5625800DBFF33 /* BugsnagKSCrashSysInfoParserTest.m in Sources */ = {isa = PBXBuildFile; fileRef = 4B3CD2B522C5625800DBFF33 /* BugsnagKSCrashSysInfoParserTest.m */; };
 		4B3CD2BB22C5676800DBFF33 /* BSGOutOfMemoryWatchdogTests.m in Sources */ = {isa = PBXBuildFile; fileRef = 4B3CD2B722C5676700DBFF33 /* BSGOutOfMemoryWatchdogTests.m */; };
-		4B3CD2BC22C5676800DBFF33 /* BugsnagCrashReportFromKSCrashReportTest.m in Sources */ = {isa = PBXBuildFile; fileRef = 4B3CD2B822C5676700DBFF33 /* BugsnagCrashReportFromKSCrashReportTest.m */; };
 		4B3CD2BD22C5676800DBFF33 /* BugsnagThreadTest.m in Sources */ = {isa = PBXBuildFile; fileRef = 4B3CD2B922C5676700DBFF33 /* BugsnagThreadTest.m */; };
 		4B3CD2BE22C5676800DBFF33 /* RegisterErrorDataTest.m in Sources */ = {isa = PBXBuildFile; fileRef = 4B3CD2BA22C5676800DBFF33 /* RegisterErrorDataTest.m */; };
 		4B406C1422CAD94100464D1D /* BugsnagCollectionsBSGDictSetSafeObjectTest.m in Sources */ = {isa = PBXBuildFile; fileRef = 4B406C1222CAD94100464D1D /* BugsnagCollectionsBSGDictSetSafeObjectTest.m */; };
@@ -28,7 +30,6 @@
 		8A6C6FAE2257882400E8EF24 /* BSGOutOfMemoryWatchdog.h in Headers */ = {isa = PBXBuildFile; fileRef = 8A6C6FAC2257882400E8EF24 /* BSGOutOfMemoryWatchdog.h */; };
 		8AB151171D41356800C9B218 /* Bugsnag.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = 8A8D51241D41343500D33797 /* Bugsnag.framework */; };
 		8AB151211D41361700C9B218 /* BugsnagBreadcrumbsTest.m in Sources */ = {isa = PBXBuildFile; fileRef = 8AB1511D1D41361700C9B218 /* BugsnagBreadcrumbsTest.m */; };
-		8AB151221D41361700C9B218 /* BugsnagCrashReportTests.m in Sources */ = {isa = PBXBuildFile; fileRef = 8AB1511E1D41361700C9B218 /* BugsnagCrashReportTests.m */; };
 		8AB151241D41361700C9B218 /* report.json in Resources */ = {isa = PBXBuildFile; fileRef = 8AB151201D41361700C9B218 /* report.json */; };
 		8ACF0F74201812AD00173809 /* BugsnagSinkTests.m in Sources */ = {isa = PBXBuildFile; fileRef = 8AB1511F1D41361700C9B218 /* BugsnagSinkTests.m */; };
 		8AD9A4F51D42EE87004E1CC5 /* Bugsnag.h in Headers */ = {isa = PBXBuildFile; fileRef = 8AB151261D41366400C9B218 /* Bugsnag.h */; settings = {ATTRIBUTES = (Public, ); }; };
@@ -190,9 +191,12 @@
 /* Begin PBXFileReference section */
 		00D7AC9E23E97FBD00FBE4A7 /* BugsnagEvent.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; name = BugsnagEvent.m; path = ../Source/BugsnagEvent.m; sourceTree = "<group>"; };
 		00D7AC9F23E97FBD00FBE4A7 /* BugsnagEvent.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; name = BugsnagEvent.h; path = ../Source/BugsnagEvent.h; sourceTree = "<group>"; };
+		00D7ACA523E98A5D00FBE4A7 /* BugsnagTestConstants.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; name = BugsnagTestConstants.h; path = ../../Tests/BugsnagTestConstants.h; sourceTree = "<group>"; };
+		00D7ACA623E98A5D00FBE4A7 /* BugsnagEventTests.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; name = BugsnagEventTests.m; path = ../../Tests/BugsnagEventTests.m; sourceTree = "<group>"; };
+		00D7ACA823E98A9A00FBE4A7 /* TestConstants.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; name = TestConstants.m; path = ../../iOS/BugsnagTests/TestConstants.m; sourceTree = "<group>"; };
+		00D7ACA923E98A9A00FBE4A7 /* BugsnagEventFromKSCrashReportTest.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; name = BugsnagEventFromKSCrashReportTest.m; path = ../../iOS/BugsnagTests/BugsnagEventFromKSCrashReportTest.m; sourceTree = "<group>"; };
 		4B3CD2B522C5625800DBFF33 /* BugsnagKSCrashSysInfoParserTest.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; name = BugsnagKSCrashSysInfoParserTest.m; path = ../../iOS/BugsnagTests/BugsnagKSCrashSysInfoParserTest.m; sourceTree = "<group>"; };
 		4B3CD2B722C5676700DBFF33 /* BSGOutOfMemoryWatchdogTests.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; name = BSGOutOfMemoryWatchdogTests.m; path = ../../iOS/BugsnagTests/BSGOutOfMemoryWatchdogTests.m; sourceTree = "<group>"; };
-		4B3CD2B822C5676700DBFF33 /* BugsnagCrashReportFromKSCrashReportTest.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; name = BugsnagCrashReportFromKSCrashReportTest.m; path = ../../iOS/BugsnagTests/BugsnagCrashReportFromKSCrashReportTest.m; sourceTree = "<group>"; };
 		4B3CD2B922C5676700DBFF33 /* BugsnagThreadTest.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; name = BugsnagThreadTest.m; path = ../../iOS/BugsnagTests/BugsnagThreadTest.m; sourceTree = "<group>"; };
 		4B3CD2BA22C5676800DBFF33 /* RegisterErrorDataTest.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; name = RegisterErrorDataTest.m; path = ../../iOS/BugsnagTests/RegisterErrorDataTest.m; sourceTree = "<group>"; };
 		4B406C1222CAD94100464D1D /* BugsnagCollectionsBSGDictSetSafeObjectTest.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; name = BugsnagCollectionsBSGDictSetSafeObjectTest.m; path = ../../Tests/BugsnagCollectionsBSGDictSetSafeObjectTest.m; sourceTree = "<group>"; };
@@ -212,7 +216,6 @@
 		8AB151121D41356800C9B218 /* Tests.xctest */ = {isa = PBXFileReference; explicitFileType = wrapper.cfbundle; includeInIndex = 0; path = Tests.xctest; sourceTree = BUILT_PRODUCTS_DIR; };
 		8AB151161D41356800C9B218 /* TestsInfo.plist */ = {isa = PBXFileReference; lastKnownFileType = text.plist.xml; name = TestsInfo.plist; path = ../TestsInfo.plist; sourceTree = "<group>"; };
 		8AB1511D1D41361700C9B218 /* BugsnagBreadcrumbsTest.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; name = BugsnagBreadcrumbsTest.m; path = ../../Tests/BugsnagBreadcrumbsTest.m; sourceTree = "<group>"; };
-		8AB1511E1D41361700C9B218 /* BugsnagCrashReportTests.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; name = BugsnagCrashReportTests.m; path = ../../Tests/BugsnagCrashReportTests.m; sourceTree = "<group>"; };
 		8AB1511F1D41361700C9B218 /* BugsnagSinkTests.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; name = BugsnagSinkTests.m; path = ../../Tests/BugsnagSinkTests.m; sourceTree = "<group>"; };
 		8AB151201D41361700C9B218 /* report.json */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = text.json; name = report.json; path = ../../Tests/report.json; sourceTree = "<group>"; };
 		8AB151251D41366400C9B218 /* BSG_KSCrashReportWriter.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; name = BSG_KSCrashReportWriter.h; path = ../Source/BSG_KSCrashReportWriter.h; sourceTree = "<group>"; };
@@ -469,6 +472,10 @@
 		8AB151131D41356800C9B218 /* Tests */ = {
 			isa = PBXGroup;
 			children = (
+				00D7ACA923E98A9A00FBE4A7 /* BugsnagEventFromKSCrashReportTest.m */,
+				00D7ACA823E98A9A00FBE4A7 /* TestConstants.m */,
+				00D7ACA623E98A5D00FBE4A7 /* BugsnagEventTests.m */,
+				00D7ACA523E98A5D00FBE4A7 /* BugsnagTestConstants.h */,
 				E7CE78D71FD94EF1001D07E0 /* KSCrash */,
 				4B406C1322CAD94100464D1D /* BugsnagCollectionsBSGDictMergeTest.m */,
 				4B406C1222CAD94100464D1D /* BugsnagCollectionsBSGDictSetSafeObjectTest.m */,
@@ -480,13 +487,11 @@
 				E762E9EE1F73F6CF00E82B43 /* BugsnagHandledStateTest.m */,
 				8AD9FA8B1E0863A1002859A7 /* BugsnagConfigurationTests.m */,
 				8AB1511D1D41361700C9B218 /* BugsnagBreadcrumbsTest.m */,
-				8AB1511E1D41361700C9B218 /* BugsnagCrashReportTests.m */,
 				8AB1511F1D41361700C9B218 /* BugsnagSinkTests.m */,
 				8AB151201D41361700C9B218 /* report.json */,
 				8AB151161D41356800C9B218 /* TestsInfo.plist */,
 				4B3CD2B522C5625800DBFF33 /* BugsnagKSCrashSysInfoParserTest.m */,
 				4B3CD2B722C5676700DBFF33 /* BSGOutOfMemoryWatchdogTests.m */,
-				4B3CD2B822C5676700DBFF33 /* BugsnagCrashReportFromKSCrashReportTest.m */,
 				4B3CD2B922C5676700DBFF33 /* BugsnagThreadTest.m */,
 				4B3CD2BA22C5676800DBFF33 /* RegisterErrorDataTest.m */,
 			);
@@ -700,6 +705,7 @@
 				E766177D1F4E459C0094CECF /* BSG_KSCrash.h in Headers */,
 				E766179C1F4E459C0094CECF /* BSG_KSCrashSentry_NSException.h in Headers */,
 				E791487D1FD82E6D003EFEBF /* BugsnagSessionTracker.h in Headers */,
+				00D7ACA123E97FBD00FBE4A7 /* BugsnagEvent.h in Headers */,
 				8A3C591023968B2000B344AA /* BugsnagPlugin.h in Headers */,
 				E76617881F4E459C0094CECF /* BSG_KSCrashReportStore.h in Headers */,
 				E76617A51F4E459C0094CECF /* BSG_KSBacktrace.h in Headers */,
@@ -743,7 +749,6 @@
 				E76617D01F4E459C0094CECF /* BSG_KSCrashReportFilter.h in Headers */,
 				E76617961F4E459C0094CECF /* BSG_KSCrashSentry_CPPException.h in Headers */,
 				E76616F91F4E45950094CECF /* BugsnagErrorReportApiClient.h in Headers */,
-				00D7ACA123E97FBD00FBE4A7 /* BugsnagEvent.h in Headers */,
 				8A530CBD22FDC39300F0C108 /* BSG_KSCrashIdentifier.h in Headers */,
 				E76617A61F4E459C0094CECF /* BSG_KSBacktrace_Private.h in Headers */,
 				E76617811F4E459C0094CECF /* BSG_KSCrashC.h in Headers */,
@@ -930,10 +935,12 @@
 			files = (
 				8ACF0F74201812AD00173809 /* BugsnagSinkTests.m in Sources */,
 				4B3CD2BD22C5676800DBFF33 /* BugsnagThreadTest.m in Sources */,
+				00D7ACA723E98A5D00FBE4A7 /* BugsnagEventTests.m in Sources */,
 				E7CE78F21FD94F1B001D07E0 /* KSMach_Tests.m in Sources */,
 				E7CE79071FD94F1B001D07E0 /* KSSysCtl_Tests.m in Sources */,
 				E7CE78F71FD94F1B001D07E0 /* KSCrashSentry_Signal_Tests.m in Sources */,
 				E7CE78FE1FD94F1B001D07E0 /* KSSignalInfo_Tests.m in Sources */,
+				00D7ACAB23E98A9A00FBE4A7 /* BugsnagEventFromKSCrashReportTest.m in Sources */,
 				E7CE78FC1FD94F1B001D07E0 /* KSCrashSentry_NSException_Tests.m in Sources */,
 				4B406C1522CAD94100464D1D /* BugsnagCollectionsBSGDictMergeTest.m in Sources */,
 				E7CE79081FD94F1B001D07E0 /* KSLogger_Tests.m in Sources */,
@@ -943,7 +950,6 @@
 				E7CE79051FD94F1B001D07E0 /* KSDynamicLinker_Tests.m in Sources */,
 				E7CE78F61FD94F1B001D07E0 /* FileBasedTestCase.m in Sources */,
 				E7CE79031FD94F1B001D07E0 /* KSCrashReportConverter_Tests.m in Sources */,
-				4B3CD2BC22C5676800DBFF33 /* BugsnagCrashReportFromKSCrashReportTest.m in Sources */,
 				E79148911FD82E77003EFEBF /* BugsnagUserTest.m in Sources */,
 				4B3CD2B622C5625800DBFF33 /* BugsnagKSCrashSysInfoParserTest.m in Sources */,
 				E791488E1FD82E77003EFEBF /* BugsnagSessionTrackerTest.m in Sources */,
@@ -957,12 +963,12 @@
 				E7CE78FD1FD94F1B001D07E0 /* KSString_Tests.m in Sources */,
 				E762E9F01F73F6CF00E82B43 /* BugsnagHandledStateTest.m in Sources */,
 				E791488F1FD82E77003EFEBF /* BugsnagSessionTrackingPayloadTest.m in Sources */,
-				8AB151221D41361700C9B218 /* BugsnagCrashReportTests.m in Sources */,
 				8AD9FA8D1E0863A1002859A7 /* BugsnagConfigurationTests.m in Sources */,
 				4B406C1422CAD94100464D1D /* BugsnagCollectionsBSGDictSetSafeObjectTest.m in Sources */,
 				E7CE79021FD94F1B001D07E0 /* RFC3339DateTool_Tests.m in Sources */,
 				4B3CD2BE22C5676800DBFF33 /* RegisterErrorDataTest.m in Sources */,
 				E7CE78F91FD94F1B001D07E0 /* KSSystemInfo_Tests.m in Sources */,
+				00D7ACAA23E98A9A00FBE4A7 /* TestConstants.m in Sources */,
 				4B3CD2BB22C5676800DBFF33 /* BSGOutOfMemoryWatchdogTests.m in Sources */,
 				E7CE78F41FD94F1B001D07E0 /* KSFileUtils_Tests.m in Sources */,
 			);


### PR DESCRIPTION
## Goal

The notifier spec. states that an `apiKey` must be provided when initializing a `BugsnagConfiguration`.  To this end removing the default constructor and providing a new apiKey-accepting designated initializer is the solution.

## Design

<!-- How does this change work? Why was this approach to the goal used? -->

An initializer has been added to `BugsnagConfiguration` and its designated status indicated with the `NS_DESIGNATED_INITIALIZER` macro.  `init()` is required (calls to designated initializers MUST call super) but has been made to fail if called.  It was desired to provide `apiKey` as an unnamed parameter but the `NS_SWIFT_NAME` macro doesn't appear to offer this functionality.

## Changeset

A new initializer was added.  The default `init()` was made to fail.
<!-- List what was added, removed, or changed: -->

## Tests

<!-- How was this change tested? What manual and automated tests were
     run/added? -->

Unit tests were added to ensure that the new initializer performed as expected.  All tests that depended on the default init() have been modified to use the new initializer.  A Swift test was added to ensure that the method is exposed correctly.

## Review

### Outstanding Questions

<!-- Are there any parts of the design or the implementation which seem
     less than ideal and that could require additional discussion?
     List here: -->

<!-- Preflight checks. Have I:

* Added a changelog entry?
* Checked the scope to ensure the commits are only related to the goal above?

-->

- This pull request is ready for:
  - [ ] Initial review of the intended approach, not yet feature complete
  - [ ] Structural review of the classes, functions, and properties modified
  - [x] Final review

<!-- What do you need from a reviewer to get this changeset
     ready for release -->

- [ ] The correct target branch has been selected (`master` for fixes, `next` for
  features)
- [ ] Consistency across platforms for structures or concepts added or modified
- [ ] Consistency between the changeset and the goal stated above
- [x] Internal consistency with the rest of the library - is there any overlap between existing interfaces and any which have been added?
- [x] Usage friction - is the proposed change in usage cumbersome or complicated?
- [ ] Performance and complexity - are there any cases of unexpected O(n^3) when iterating, recursing, flat mapping, etc?
- [ ] Concurrency concerns - if components are accessed asynchronously, what issues will arise
- [x] Thoroughness of added tests and any missing edge cases
- [ ] Idiomatic use of the language
