### PR TITLE
Add a breadcrumb automatically for changes in network connectivity

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -48,6 +48,8 @@ Bugsnag Notifiers on other platforms.
   `Bugsnag.notify()` callback.
   [#458](https://github.com/bugsnag/bugsnag-cocoa/pull/458)
 
+* Add a breadcrumb when network connectivity changes
+
 ## Bug fixes
 
 * Fix possible report corruption when using `notify()` from multiple threads

--- a/OSX/Bugsnag.xcodeproj/project.pbxproj
+++ b/OSX/Bugsnag.xcodeproj/project.pbxproj
@@ -42,6 +42,8 @@
 		8A6C6FB12257884C00E8EF24 /* BSGOutOfMemoryWatchdog.m in Sources */ = {isa = PBXBuildFile; fileRef = 8A6C6FAF2257884C00E8EF24 /* BSGOutOfMemoryWatchdog.m */; };
 		8A6C6FB22257884C00E8EF24 /* BSGOutOfMemoryWatchdog.h in Headers */ = {isa = PBXBuildFile; fileRef = 8A6C6FB02257884C00E8EF24 /* BSGOutOfMemoryWatchdog.h */; };
 		8A87352C1C6D3B1600EDBD5B /* BSG_KSCrashReportWriter.h in Headers */ = {isa = PBXBuildFile; fileRef = 8A87352B1C6D3B1600EDBD5B /* BSG_KSCrashReportWriter.h */; settings = {ATTRIBUTES = (Public, ); }; };
+		8ACF0F752018136200173809 /* BugsnagCrashReportTests.m in Sources */ = {isa = PBXBuildFile; fileRef = 8A2C8FE11C6BC38200846019 /* BugsnagCrashReportTests.m */; };
+		8AD1E3FA23EDDD4F0044F919 /* BSGConnectivityTest.m in Sources */ = {isa = PBXBuildFile; fileRef = 8AD1E3F823EDDD3F0044F919 /* BSGConnectivityTest.m */; };
 		8AD9FA891E086351002859A7 /* BugsnagConfigurationTests.m in Sources */ = {isa = PBXBuildFile; fileRef = 8AD9FA851E0862DC002859A7 /* BugsnagConfigurationTests.m */; };
 		E72352C11F55924A00436528 /* BSGConnectivity.h in Headers */ = {isa = PBXBuildFile; fileRef = E72352BF1F55924A00436528 /* BSGConnectivity.h */; };
 		E72352C21F55924A00436528 /* BSGConnectivity.m in Sources */ = {isa = PBXBuildFile; fileRef = E72352C01F55924A00436528 /* BSGConnectivity.m */; };
@@ -226,6 +228,7 @@
 		8A6C6FAF2257884C00E8EF24 /* BSGOutOfMemoryWatchdog.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; name = BSGOutOfMemoryWatchdog.m; path = ../Source/BSGOutOfMemoryWatchdog.m; sourceTree = "<group>"; };
 		8A6C6FB02257884C00E8EF24 /* BSGOutOfMemoryWatchdog.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; name = BSGOutOfMemoryWatchdog.h; path = ../Source/BSGOutOfMemoryWatchdog.h; sourceTree = "<group>"; };
 		8A87352B1C6D3B1600EDBD5B /* BSG_KSCrashReportWriter.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; name = BSG_KSCrashReportWriter.h; path = ../Source/BSG_KSCrashReportWriter.h; sourceTree = SOURCE_ROOT; };
+		8AD1E3F823EDDD3F0044F919 /* BSGConnectivityTest.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; path = BSGConnectivityTest.m; sourceTree = "<group>"; };
 		8AD9FA851E0862DC002859A7 /* BugsnagConfigurationTests.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; name = BugsnagConfigurationTests.m; path = ../Tests/BugsnagConfigurationTests.m; sourceTree = SOURCE_ROOT; };
 		E72352BF1F55924A00436528 /* BSGConnectivity.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; name = BSGConnectivity.h; path = ../Source/BSGConnectivity.h; sourceTree = SOURCE_ROOT; };
 		E72352C01F55924A00436528 /* BSGConnectivity.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; name = BSGConnectivity.m; path = ../Source/BSGConnectivity.m; sourceTree = SOURCE_ROOT; };
@@ -463,6 +466,7 @@
 			isa = PBXGroup;
 			children = (
 				00D7ACA223E984B300FBE4A7 /* BugsnagEventTests.m */,
+				8AD1E3F823EDDD3F0044F919 /* BSGConnectivityTest.m */,
 				4B406C1622CAD96400464D1D /* BugsnagCollectionsBSGDictMergeTest.m */,
 				4B406C1722CAD96400464D1D /* BugsnagCollectionsBSGDictSetSafeObjectTest.m */,
 				4B775FD222CBE02A004839C5 /* BugsnagCollectionsBSGDictInsertIfNotNilTest.m */,
@@ -934,6 +938,7 @@
 				4B406C1922CAD96400464D1D /* BugsnagCollectionsBSGDictSetSafeObjectTest.m in Sources */,
 				8A2C8FEC1C6BC38900846019 /* BugsnagSinkTests.m in Sources */,
 				8AD9FA891E086351002859A7 /* BugsnagConfigurationTests.m in Sources */,
+				8AD1E3FA23EDDD4F0044F919 /* BSGConnectivityTest.m in Sources */,
 				E7CE78C41FD94E77001D07E0 /* KSJSONCodec_Tests.m in Sources */,
 				E7CE78C01FD94E77001D07E0 /* KSCrashSentry_Tests.m in Sources */,
 				E7CE78BE1FD94E77001D07E0 /* KSCrashSentry_NSException_Tests.m in Sources */,

--- a/Source/BSGConnectivity.h
+++ b/Source/BSGConnectivity.h
@@ -27,17 +27,31 @@
 #import <Foundation/Foundation.h>
 #import <SystemConfiguration/SystemConfiguration.h>
 
-@class BSGConnectivity;
+/**
+ * Function signature to connectivity monitoring callback of BSGConnectivity
+ *
+ * @param connected YES if the monitored URL is reachable
+ * @param typeDescription a textual representation of the connection type
+ */
+typedef void (^BSGConnectivityChangeBlock)(BOOL connected, NSString *_Nonnull typeDescription);
 
-typedef void (^ConnectivityChange)(BSGConnectivity *connectivity);
-
+/**
+ * Monitors network connectivity using SCNetworkReachability callbacks,
+ * providing a customizable callback block invoked when connectivity changes.
+ */
 @interface BSGConnectivity : NSObject
 
-@property(nonatomic, copy) ConnectivityChange connectivityChangeBlock;
+/**
+ * Invoke a block each time network connectivity changes
+ *
+ * @param URL   The URL monitored for changes. Should be equivalent to
+ *              BugsnagConfiguration.notifyURL
+ * @param block The block called when connectivity changes
+ */
++ (void)monitorURL:(NSURL *_Nonnull)URL usingCallback:(BSGConnectivityChangeBlock _Nonnull)block;
 
-- (instancetype)initWithURL:(NSURL *)url
-                changeBlock:(ConnectivityChange)changeBlock;
-- (void)startWatchingConnectivity;
-- (void)stopWatchingConnectivity;
-
+/**
+ * Stop monitoring the URL previously configured with monitorURL:usingCallback:
+ */
++ (void)stopMonitoring;
 @end

--- a/Source/BSGConnectivity.m
+++ b/Source/BSGConnectivity.m
@@ -25,95 +25,114 @@
 //
 
 #import "BSGConnectivity.h"
+#import "Bugsnag.h"
 
-typedef void (^CallbackBlock)(SCNetworkReachabilityFlags flags);
+static SCNetworkReachabilityRef bsg_reachability_ref;
+BSGConnectivityChangeBlock bsg_reachability_change_block;
+SCNetworkReachabilityFlags bsg_current_reachability_state;
+
+NSString *const BSGConnectivityCellular = @"cellular";
+NSString *const BSGConnectivityWiFi = @"wifi";
+NSString *const BSGConnectivityNone = @"none";
+
+/**
+ * Check whether the connectivity change should be noted or ignored.
+ *
+ * @return YES if the connectivity change should be reported
+ */
+BOOL BSGConnectivityShouldReportChange(SCNetworkReachabilityFlags flags) {
+    #if TARGET_OS_TV || TARGET_OS_IPHONE
+        // kSCNetworkReachabilityFlagsIsWWAN does not exist on macOS
+        const SCNetworkReachabilityFlags importantFlags = kSCNetworkReachabilityFlagsIsWWAN | kSCNetworkReachabilityFlagsReachable;
+    #else
+        const SCNetworkReachabilityFlags importantFlags = kSCNetworkReachabilityFlagsReachable;
+    #endif
+    __block BOOL shouldReport = YES;
+    // Check if the reported state is different from the last known state (if any)
+    if ((flags & importantFlags) != (bsg_current_reachability_state & importantFlags)) {
+        // When first subscribing to be notified of changes, the callback is
+        // invoked immmediately even if nothing has changed. So this block
+        // ignores the very first check, reporting all others.
+        if (bsg_current_reachability_state == 0) {
+            shouldReport = NO;
+        }
+        // Cache the reachability state to report the previous value representation
+        bsg_current_reachability_state = flags;
+    } else {
+        shouldReport = NO;
+    }
+    return shouldReport;
+}
+
+/**
+ * Textual representation of a connection type
+ */
+NSString *BSGConnectivityFlagRepresentation(SCNetworkReachabilityFlags flags) {
+    BOOL connected = (flags & kSCNetworkReachabilityFlagsReachable);
+    #if TARGET_OS_TV || TARGET_OS_IPHONE
+        return connected
+            ? ((flags & kSCNetworkReachabilityFlagsIsWWAN) ? BSGConnectivityCellular : BSGConnectivityWiFi)
+            : BSGConnectivityNone;
+    #else
+        return connected ? BSGConnectivityWiFi : BSGConnectivityNone;
+    #endif
+}
 
 /**
  * Callback invoked by SCNetworkReachability, which calls an Objective-C block
  * that handles the connection change.
  */
-static void BSGConnectivityCallback(SCNetworkReachabilityRef target,
+void BSGConnectivityCallback(SCNetworkReachabilityRef target,
                                     SCNetworkReachabilityFlags flags,
                                     void *info) {
-    void (^callbackBlock)(SCNetworkReachabilityFlags) = (__bridge id)(info);
-    callbackBlock(flags);
+    if (bsg_reachability_change_block && BSGConnectivityShouldReportChange(flags)) {
+        BOOL connected = (flags & kSCNetworkReachabilityFlagsReachable);
+        bsg_reachability_change_block(connected, BSGConnectivityFlagRepresentation(flags));
+    }
 }
-
-@interface BSGConnectivity ()
-
-@property(nonatomic, assign) SCNetworkReachabilityRef reachabilityRef;
-@property(nonatomic, strong) dispatch_queue_t serialQueue;
-@property(nonatomic, copy) CallbackBlock callbackBlock;
-
-@end
 
 @implementation BSGConnectivity
 
-- (instancetype)initWithURL:(NSURL *)url
-                changeBlock:(ConnectivityChange)changeBlock {
-    if (self = [super init]) {
-        NSString *hostName = [url host];
-        _reachabilityRef = SCNetworkReachabilityCreateWithName(NULL, [hostName UTF8String]);
++ (void)monitorURL:(NSURL *)URL usingCallback:(BSGConnectivityChangeBlock)block {
+    static dispatch_once_t once_t;
+    static dispatch_queue_t reachabilityQueue;
+    dispatch_once(&once_t, ^{
+        reachabilityQueue = dispatch_queue_create("com.bugsnag.cocoa.connectivity", DISPATCH_QUEUE_SERIAL);
+    });
 
-        _connectivityChangeBlock = [changeBlock copy];
-        self.serialQueue = dispatch_queue_create("com.bugsnag.cocoa", NULL);
-
-        __weak id weakSelf = self;
-        self.callbackBlock = ^(SCNetworkReachabilityFlags flags) {
-          if (weakSelf) {
-              [weakSelf connectivityChanged:flags];
-          }
-        };
+    NSString *host = [URL host];
+    if (![self isValidHostname:host]) {
+        return;
     }
-    return self;
-}
 
-- (void)dealloc {
-    [self stopWatchingConnectivity];
-
-    if (self.reachabilityRef) {
-        CFRelease(self.reachabilityRef);
-        self.reachabilityRef = nil;
+    bsg_reachability_ref = SCNetworkReachabilityCreateWithName(NULL, [host UTF8String]);
+    if (bsg_reachability_ref) { // Can be null if a bad hostname was specified
+        bsg_reachability_change_block = block;
+        SCNetworkReachabilitySetCallback(bsg_reachability_ref,
+                                         BSGConnectivityCallback, NULL);
+        SCNetworkReachabilitySetDispatchQueue(bsg_reachability_ref,
+                                              reachabilityQueue);
     }
 }
 
 /**
- * Sets a callback with SCNetworkReachability
+ * Check if the host is valid and not equivalent to localhost, from which we can
+ * never truly disconnect. 🏡
+ * There are also system handlers for localhost which we don't want to catch
+ * inadvertently.
  */
-- (void)startWatchingConnectivity {
-    SCNetworkReachabilityContext context = {
-        .version = 0,
-        .info = (__bridge void *)self.callbackBlock,
-        .retain = CFRetain,
-        .release = CFRelease,
-    };
-
-    if (self.reachabilityRef) {
-        SCNetworkReachabilitySetCallback(self.reachabilityRef,
-                                         BSGConnectivityCallback, &context);
-        SCNetworkReachabilitySetDispatchQueue(self.reachabilityRef,
-                                              self.serialQueue);
-    }
++ (BOOL)isValidHostname:(NSString *)host {
+    return host.length > 0
+        && ![host isEqualToString:@"localhost"]
+        && ![host isEqualToString:@"::1"]
+        && ![host isEqualToString:@"127.0.0.1"];
 }
 
-/**
- * Stops the callback with SCNetworkReachability
- */
-- (void)stopWatchingConnectivity {
-    if (self.reachabilityRef) {
-        SCNetworkReachabilitySetCallback(self.reachabilityRef, NULL, NULL);
-        SCNetworkReachabilitySetDispatchQueue(self.reachabilityRef, NULL);
-    }
-}
-
-- (void)connectivityChanged:(SCNetworkReachabilityFlags)flags {
-    BOOL connected = YES;
-
-    if (!(flags & kSCNetworkReachabilityFlagsReachable)) {
-        connected = NO;
-    }
-    if (connected && self.connectivityChangeBlock) { // notify via block
-        self.connectivityChangeBlock(self);
++ (void)stopMonitoring {
+    bsg_reachability_change_block = nil;
+    if (bsg_reachability_ref) {
+        SCNetworkReachabilitySetCallback(bsg_reachability_ref, NULL, NULL);
+        SCNetworkReachabilitySetDispatchQueue(bsg_reachability_ref, NULL);
     }
 }
 

--- a/Source/BugsnagNotifier.h
+++ b/Source/BugsnagNotifier.h
@@ -29,7 +29,7 @@
 #import "BugsnagConfiguration.h"
 #import "BugsnagMetadata.h"
 
-@class BSGConnectivity, BugsnagSessionTracker;
+@class BugsnagSessionTracker;
 
 @interface BugsnagNotifier : NSObject <BugsnagMetadataDelegate>
 
@@ -40,7 +40,6 @@
 @property(nonatomic, readwrite, strong) NSLock *_Nonnull metadataLock;
 @property(nonatomic, readonly, strong) BugsnagSessionTracker *_Nonnull sessionTracker;
 
-@property(nonatomic, strong) BSGConnectivity *_Nonnull networkReachable;
 @property(readonly) BOOL started;
 
 - (instancetype _Nonnull)initWithConfiguration:

--- a/Source/BugsnagNotifier.m
+++ b/Source/BugsnagNotifier.m
@@ -532,6 +532,14 @@ NSString *const BSGBreadcrumbLoadedMessage = @"Bugsnag loaded";
         __strong typeof(weakSelf) strongSelf = weakSelf;
         if (connected)
             [strongSelf flushPendingReports];
+
+        if (strongSelf.configuration.automaticallyCollectBreadcrumbs) {
+            [strongSelf addBreadcrumbWithBlock:^(BugsnagBreadcrumb *crumb) {
+                crumb.name = @"Connectivity change";
+                crumb.type = BSGBreadcrumbTypeState;
+                crumb.metadata  = @{ @"type"  :  connectionType };
+            }];
+        }
     }];
 }
 

--- a/Tests/BSGConnectivityTest.m
+++ b/Tests/BSGConnectivityTest.m
@@ -1,0 +1,144 @@
+#import <XCTest/XCTest.h>
+
+#import "BSGConnectivity.h"
+
+BOOL BSGConnectivityShouldReportChange(SCNetworkReachabilityFlags flags);
+
+NSString *BSGConnectivityFlagRepresentation(SCNetworkReachabilityFlags flags);
+
+void BSGConnectivityCallback(SCNetworkReachabilityRef target,
+                                    SCNetworkReachabilityFlags flags,
+                                    void *info);
+
+@interface BSGConnectivity ()
++ (BOOL)isValidHostname:(NSString *)host;
+@end
+
+@interface BSGConnectivityTest : XCTestCase
+@end
+
+@implementation BSGConnectivityTest
+
+- (void)tearDown {
+    // Reset connectivity state cache
+    BSGConnectivityShouldReportChange(0);
+    [BSGConnectivity stopMonitoring];
+}
+
+- (void)testConnectivityRepresentations {
+    XCTAssertEqualObjects(@"none", BSGConnectivityFlagRepresentation(0));
+    XCTAssertEqualObjects(@"none", BSGConnectivityFlagRepresentation(kSCNetworkReachabilityFlagsIsDirect));
+    #if TARGET_OS_TV || TARGET_OS_IPHONE
+        // kSCNetworkReachabilityFlagsIsWWAN does not exist on macOS
+        XCTAssertEqualObjects(@"none", BSGConnectivityFlagRepresentation(kSCNetworkReachabilityFlagsIsWWAN));
+        XCTAssertEqualObjects(@"cellular", BSGConnectivityFlagRepresentation(kSCNetworkReachabilityFlagsIsWWAN | kSCNetworkReachabilityFlagsReachable));
+    #endif
+    XCTAssertEqualObjects(@"wifi", BSGConnectivityFlagRepresentation(kSCNetworkReachabilityFlagsReachable));
+    XCTAssertEqualObjects(@"wifi", BSGConnectivityFlagRepresentation(kSCNetworkReachabilityFlagsReachable | kSCNetworkReachabilityFlagsIsDirect));
+}
+
+- (void)testShouldReportChange {
+    // Duplicate invocation should be false
+    XCTAssertFalse(BSGConnectivityShouldReportChange(kSCNetworkReachabilityFlagsReachable));
+    // Different invocation but with flags we don't care about should be false
+    XCTAssertFalse(BSGConnectivityShouldReportChange(kSCNetworkReachabilityFlagsReachable | kSCNetworkReachabilityFlagsIsDirect));
+
+    #if TARGET_OS_TV || TARGET_OS_IPHONE
+    XCTAssertTrue(BSGConnectivityShouldReportChange(kSCNetworkReachabilityFlagsReachable | kSCNetworkReachabilityFlagsIsWWAN));
+    #endif
+    XCTAssertTrue(BSGConnectivityShouldReportChange(0));
+}
+
+- (void)testValidHost {
+    XCTAssertTrue([BSGConnectivity isValidHostname:@"example.com"]);
+    // Could be an internal network hostname
+    XCTAssertTrue([BSGConnectivity isValidHostname:@"foo"]);
+
+    // Definitely will not work as expected
+    XCTAssertFalse([BSGConnectivity isValidHostname:@""]);
+    XCTAssertFalse([BSGConnectivity isValidHostname:nil]);
+    XCTAssertFalse([BSGConnectivity isValidHostname:@"localhost"]);
+    XCTAssertFalse([BSGConnectivity isValidHostname:@"127.0.0.1"]);
+    XCTAssertFalse([BSGConnectivity isValidHostname:@"::1"]);
+}
+
+#if TARGET_OS_TV || TARGET_OS_IPHONE
+- (void)testCallbackInvokedForSignificantChange {
+    __block NSUInteger timesCalled = 0;
+    __block NSString *description = nil;
+    [self mockMonitorURLWithCallback:^(BOOL connected, NSString * typeDescription) {
+        timesCalled++;
+        description = typeDescription;
+    }];
+    // Changes should not be immediately reported
+    XCTAssertEqual(0, timesCalled);
+
+    // Ignore very first call to change block as "in real life" the first
+    // invocation is a false positive
+    [self simulateConnectivityChangeTo:kSCNetworkReachabilityFlagsReachable];
+    XCTAssertEqual(0, timesCalled);
+
+    [self simulateConnectivityChangeTo:kSCNetworkReachabilityFlagsReachable | kSCNetworkReachabilityFlagsIsWWAN];
+    XCTAssertEqual(1, timesCalled);
+    XCTAssertEqualObjects(@"cellular", description);
+
+    [self simulateConnectivityChangeTo:kSCNetworkReachabilityFlagsReachable];
+    XCTAssertEqual(2, timesCalled);
+    XCTAssertEqualObjects(@"wifi", description);
+
+    // No change
+    [self simulateConnectivityChangeTo:kSCNetworkReachabilityFlagsReachable | kSCNetworkReachabilityFlagsConnectionOnDemand];
+    XCTAssertEqual(2, timesCalled);
+
+    [self simulateConnectivityChangeTo:kSCNetworkReachabilityFlagsIsWWAN];
+    XCTAssertEqual(3, timesCalled);
+    XCTAssertEqualObjects(@"none", description);
+
+    // Insignificant change
+    [self simulateConnectivityChangeTo:kSCNetworkReachabilityFlagsIsWWAN | kSCNetworkReachabilityFlagsConnectionOnDemand];
+    XCTAssertEqual(3, timesCalled);
+}
+#else
+- (void)testCallbackInvokedForSignificantChange {
+    __block NSUInteger timesCalled = 0;
+    __block NSString *description = nil;
+    [self mockMonitorURLWithCallback:^(BOOL connected, NSString * typeDescription) {
+        timesCalled++;
+        description = typeDescription;
+    }];
+    // Changes should not be immediately reported
+    XCTAssertEqual(0, timesCalled);
+
+    // Ignore very first call to change block as "in real life" the first
+    // invocation is a false positive
+    [self simulateConnectivityChangeTo:kSCNetworkReachabilityFlagsReachable];
+    XCTAssertEqual(0, timesCalled);
+
+    [self simulateConnectivityChangeTo:kSCNetworkReachabilityFlagsIsDirect];
+    XCTAssertEqual(1, timesCalled);
+    XCTAssertEqualObjects(@"none", description);
+
+    // No change
+    [self simulateConnectivityChangeTo:kSCNetworkReachabilityFlagsIsDirect];
+    XCTAssertEqual(1, timesCalled);
+
+    [self simulateConnectivityChangeTo:kSCNetworkReachabilityFlagsReachable];
+    XCTAssertEqual(2, timesCalled);
+    XCTAssertEqualObjects(@"wifi", description);
+
+    // Insignificant change
+    [self simulateConnectivityChangeTo:kSCNetworkReachabilityFlagsReachable | kSCNetworkReachabilityFlagsConnectionOnDemand];
+    XCTAssertEqual(2, timesCalled);
+}
+#endif
+
+- (void)mockMonitorURLWithCallback:(BSGConnectivityChangeBlock)block {
+    [BSGConnectivity monitorURL:[NSURL URLWithString:@"cw://definitely.fake.url.seriously"]
+                  usingCallback:block];
+}
+
+- (void)simulateConnectivityChangeTo:(SCNetworkReachabilityFlags) flags {
+    BSGConnectivityCallback(nil, flags, nil);
+}
+
+@end

--- a/iOS/Bugsnag.xcodeproj/project.pbxproj
+++ b/iOS/Bugsnag.xcodeproj/project.pbxproj
@@ -52,6 +52,7 @@
 		8A70D9CB22539C81006B696F /* BSGOutOfMemoryWatchdog.m in Sources */ = {isa = PBXBuildFile; fileRef = 8A70D9C822539C81006B696F /* BSGOutOfMemoryWatchdog.m */; };
 		8A70D9CD2253C484006B696F /* BSGOutOfMemoryWatchdogTests.m in Sources */ = {isa = PBXBuildFile; fileRef = 8A70D9CC2253C484006B696F /* BSGOutOfMemoryWatchdogTests.m */; };
 		8A72A0392396590300328051 /* BugsnagPlugin.h in Headers */ = {isa = PBXBuildFile; fileRef = 8A72A0352396535000328051 /* BugsnagPlugin.h */; settings = {ATTRIBUTES = (Public, ); }; };
+		8AA661AD23D8C1F50031ECC8 /* BSGConnectivityTest.m in Sources */ = {isa = PBXBuildFile; fileRef = 8AA661AC23D8C1F50031ECC8 /* BSGConnectivityTest.m */; };
 		8AF1748E23070F0300902CC2 /* BSG_KSCrashIdentifier.m in Sources */ = {isa = PBXBuildFile; fileRef = 8A530CBF22FDC3AE00F0C108 /* BSG_KSCrashIdentifier.m */; };
 		E70E52152216E41C00A590AB /* BugsnagSessionTrackerStopTest.m in Sources */ = {isa = PBXBuildFile; fileRef = E70E52142216E41C00A590AB /* BugsnagSessionTrackerStopTest.m */; };
 		E70EE0781FD7039E00FA745C /* RFC3339DateTool_Tests.m in Sources */ = {isa = PBXBuildFile; fileRef = E70EE0771FD7039D00FA745C /* RFC3339DateTool_Tests.m */; };
@@ -463,6 +464,8 @@
 		8A70D9C822539C81006B696F /* BSGOutOfMemoryWatchdog.m */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.objc; name = BSGOutOfMemoryWatchdog.m; path = ../Source/BSGOutOfMemoryWatchdog.m; sourceTree = "<group>"; };
 		8A70D9CC2253C484006B696F /* BSGOutOfMemoryWatchdogTests.m */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.objc; path = BSGOutOfMemoryWatchdogTests.m; sourceTree = "<group>"; };
 		8A72A0352396535000328051 /* BugsnagPlugin.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; name = BugsnagPlugin.h; path = ../Source/BugsnagPlugin.h; sourceTree = "<group>"; };
+		8AA661AA23D89AE10031ECC8 /* AppKit.framework */ = {isa = PBXFileReference; lastKnownFileType = wrapper.framework; name = AppKit.framework; path = Platforms/MacOSX.platform/Developer/SDKs/MacOSX10.15.sdk/System/Library/Frameworks/AppKit.framework; sourceTree = DEVELOPER_DIR; };
+		8AA661AC23D8C1F50031ECC8 /* BSGConnectivityTest.m */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.objc; name = BSGConnectivityTest.m; path = ../../Tests/BSGConnectivityTest.m; sourceTree = "<group>"; };
 		8AF2894923339CCA00E8EB27 /* Config.xcconfig */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = text.xcconfig; name = Config.xcconfig; path = ../Configurations/Config.xcconfig; sourceTree = "<group>"; };
 		E70E52142216E41C00A590AB /* BugsnagSessionTrackerStopTest.m */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.objc; name = BugsnagSessionTrackerStopTest.m; path = ../../Tests/BugsnagSessionTrackerStopTest.m; sourceTree = "<group>"; };
 		E70EE0771FD7039D00FA745C /* RFC3339DateTool_Tests.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; name = RFC3339DateTool_Tests.m; path = ../Tests/KSCrash/RFC3339DateTool_Tests.m; sourceTree = SOURCE_ROOT; };
@@ -764,6 +767,8 @@
 				8A2C8F951C6BC08600846019 /* report.json */,
 				000DF29223DB4A6B00A883CE /* Swift Tests */,
 				E70EE0891FD7047D00FA745C /* KSCrash */,
+				000DF29323DB4B4900A883CE /* TestConstants.m */,
+				8AA661AC23D8C1F50031ECC8 /* BSGConnectivityTest.m */,
 			);
 			name = Tests;
 			path = BugsnagTests;
@@ -1248,6 +1253,7 @@
 				4B775FCF22CBDEB4004839C5 /* BugsnagCollectionsBSGDictInsertIfNotNilTest.m in Sources */,
 				E733A7681FD7091F003EAA29 /* KSCrashSentry_NSException_Tests.m in Sources */,
 				E7B970311FD702DA00590C27 /* KSLogger_Tests.m in Sources */,
+				8AA661AD23D8C1F50031ECC8 /* BSGConnectivityTest.m in Sources */,
 				E70EE0921FD706C700FA745C /* KSDynamicLinker_Tests.m in Sources */,
 				E78C1EFC1FCC759B00B976D3 /* BugsnagSessionTest.m in Sources */,
 				E78C1EFE1FCC778700B976D3 /* BugsnagUserTest.m in Sources */,


### PR DESCRIPTION
Adds a breadcrumb each time the connection status noticeably changes, such as between no connectivity, cellular, and  wifi, using the Bugsnag server URL as a proxy for overall connectivity.

Refactors the connectivity checker as a part of this change to report connectivity in a way suitable to append to reports, reduce object references and increase documentation and testing.