### PR TITLE
maintenance: made the PR template more hintful

### DIFF
--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -13,7 +13,12 @@ Related to #
 
 ## Changeset
 
-<!-- List what was added, removed, or changed: -->
+<!-- List what was added, removed, or changed.  Pitch this at a level 
+     appropriate to the scope of the change: new  classes, changed architecture,
+     minor typo, etc.  If appropriate include a list of changed files: 
+
+         $ git diff --name-status HEAD~1 | cat
+-->
 
 ## Tests
 


### PR DESCRIPTION
Expanded the PR changeset comment to clarify the appropriate type of comment.

Git maintenance change, and doc-only, so no need for tests, changelog etc.