### PR TITLE
Add get metadata section key

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -29,7 +29,7 @@ Bugsnag Notifiers on other platforms.
 * `Bugsnag.addAttribute:value:tab:` is now `Bugsnag.addMetadataToSection::key:value:`
   [#454](https://github.com/bugsnag/bugsnag-cocoa/pull/454)
   
-  *  `[Bugsnag clearTab:]` is now `[Bugsnag clearMetadataInSection:]` 
+*  `[Bugsnag clearTab:]` is now `[Bugsnag clearMetadataInSection:]` 
      (Swift: `Bugsnag.clearMetadata(_ section)`)
      [#457](https://github.com/bugsnag/bugsnag-cocoa/pull/457)
 
@@ -38,6 +38,9 @@ Bugsnag Notifiers on other platforms.
   similar functionality (e.g. `BugsnagConfiguration.getTab()` has been renamed and
   had usage aligned with this change.
   [#459](https://github.com/bugsnag/bugsnag-cocoa/pull/459)
+  
+* Added `Bugsnag.getMetadata(_ section: key:)`
+[#463](https://github.com/bugsnag/bugsnag-cocoa/pull/463)
   
 
 * Add a per-Event `apiKey` property.  This defaults to the global 

--- a/Source/Bugsnag.h
+++ b/Source/Bugsnag.h
@@ -287,7 +287,7 @@ static NSString *_Nonnull const BugsnagSeverityInfo = @"info";
 * @param key The key
 * @returns The value of the keyed value if it exists or nil.
 */
-+ (id _Nullable )getMetadata:(NSString *_Nonnull)section key:(NSString *_Nonnull)key
++ (id _Nullable )getMetadata:(NSString *_Nonnull)section    key:(NSString *_Nonnull)key
     NS_SWIFT_NAME(getMetadata(_:key:));
 
 /**

--- a/Source/BugsnagMetadata.m
+++ b/Source/BugsnagMetadata.m
@@ -60,11 +60,11 @@
     }
 }
 
-- (NSMutableDictionary *)getMetadata:(NSString *)sectionName
-                                 key:(NSString *)key
+- (id)getMetadata:(NSString *)sectionName
+              key:(NSString *)key
 {
     @synchronized(self) {
-        return [self.dictionary valueForKeyPath:[NSString stringWithFormat:@"%@.%@", sectionName, key]];
+        return [[self.dictionary objectForKey:sectionName] objectForKey:key];
     }
 }
 

--- a/Tests/BugsnagMetadataTests.m
+++ b/Tests/BugsnagMetadataTests.m
@@ -1,0 +1,33 @@
+//
+//  BugsnagMetadataTests.m
+//  Tests
+//
+//  Created by Robin Macharg on 12/02/2020.
+//  Copyright © 2020 Bugsnag. All rights reserved.
+//
+
+#import <XCTest/XCTest.h>
+#import "BugsnagMetadata.h"
+
+@interface BugsnagMetadataTests : XCTestCase
+
+@end
+
+@implementation BugsnagMetadataTests
+
+- (void)testGetMetadataSectionKey {
+    BugsnagMetadata *metadata = [BugsnagMetadata new];
+    [metadata addAttribute:@"myKey1" withValue:@"myValue1" toTabWithName:@"section1"];
+    [metadata addAttribute:@"myKey2" withValue:@"myValue2" toTabWithName:@"section1"];
+    [metadata addAttribute:@"myKey3" withValue:@"myValue3" toTabWithName:@"section2"];
+    
+    // Test known values
+    XCTAssertEqual([metadata getMetadata:@"section1" key:@"myKey1"], @"myValue1");
+    XCTAssertEqual([metadata getMetadata:@"section1" key:@"myKey2"], @"myValue2");
+    
+    // unknown values
+    XCTAssertNil([metadata getMetadata:@"sections1" key:@"noKey"]);
+    XCTAssertNil([metadata getMetadata:@"noSection" key:@"noKey"]);
+}
+
+@end

--- a/iOS/Bugsnag.xcodeproj/project.pbxproj
+++ b/iOS/Bugsnag.xcodeproj/project.pbxproj
@@ -13,6 +13,7 @@
 		000E6EA423D8AC8C009D8194 /* README.md in Resources */ = {isa = PBXBuildFile; fileRef = 000E6EA023D8AC8C009D8194 /* README.md */; };
 		000E6EA523D8AC8C009D8194 /* VERSION in Resources */ = {isa = PBXBuildFile; fileRef = 000E6EA123D8AC8C009D8194 /* VERSION */; };
 		000E6EA623D8AC8C009D8194 /* CHANGELOG.md in Resources */ = {isa = PBXBuildFile; fileRef = 000E6EA223D8AC8C009D8194 /* CHANGELOG.md */; };
+		009131BC23F46279000810D9 /* BugsnagMetadataTests.m in Sources */ = {isa = PBXBuildFile; fileRef = 009131BB23F46279000810D9 /* BugsnagMetadataTests.m */; };
 		00D7ACAD23E9C63000FBE4A7 /* BugsnagTests.m in Sources */ = {isa = PBXBuildFile; fileRef = 00D7ACAC23E9C63000FBE4A7 /* BugsnagTests.m */; };
 		00D7ACAF23EABBC800FBE4A7 /* BugsnagSwiftTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 00D7ACAE23EABBC800FBE4A7 /* BugsnagSwiftTests.swift */; };
 		4B47970A22A9AE1F00FF9C2E /* BugsnagEventFromKSCrashReportTest.m in Sources */ = {isa = PBXBuildFile; fileRef = 4B47970922A9AE1F00FF9C2E /* BugsnagEventFromKSCrashReportTest.m */; };
@@ -414,6 +415,7 @@
 		000E6EA023D8AC8C009D8194 /* README.md */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = net.daringfireball.markdown; name = README.md; path = ../README.md; sourceTree = "<group>"; };
 		000E6EA123D8AC8C009D8194 /* VERSION */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = text; name = VERSION; path = ../VERSION; sourceTree = "<group>"; };
 		000E6EA223D8AC8C009D8194 /* CHANGELOG.md */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = net.daringfireball.markdown; name = CHANGELOG.md; path = ../CHANGELOG.md; sourceTree = "<group>"; };
+		009131BB23F46279000810D9 /* BugsnagMetadataTests.m */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.objc; name = BugsnagMetadataTests.m; path = ../../Tests/BugsnagMetadataTests.m; sourceTree = "<group>"; };
 		00D7ACAC23E9C63000FBE4A7 /* BugsnagTests.m */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.objc; name = BugsnagTests.m; path = ../../Tests/BugsnagTests.m; sourceTree = "<group>"; };
 		00D7ACAE23EABBC800FBE4A7 /* BugsnagSwiftTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = BugsnagSwiftTests.swift; sourceTree = "<group>"; };
 		4B3B193422CA7B0900475354 /* BugsnagCollectionsBSGDictSetSafeObjectTest.m */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.objc; name = BugsnagCollectionsBSGDictSetSafeObjectTest.m; path = ../../Tests/BugsnagCollectionsBSGDictSetSafeObjectTest.m; sourceTree = "<group>"; };
@@ -745,6 +747,7 @@
 				4B47970922A9AE1F00FF9C2E /* BugsnagEventFromKSCrashReportTest.m */,
 				E77316E11F73B46600A14F06 /* BugsnagHandledStateTest.m */,
 				F429554A50F3ABE60537F70E /* BugsnagKSCrashSysInfoParserTest.m */,
+				009131BB23F46279000810D9 /* BugsnagMetadataTests.m */,
 				E78C1EFB1FCC759B00B976D3 /* BugsnagSessionTest.m */,
 				E78C1EF01FCC2F1700B976D3 /* BugsnagSessionTrackerTest.m */,
 				E78C1EF21FCC615400B976D3 /* BugsnagSessionTrackingPayloadTest.m */,
@@ -1261,6 +1264,7 @@
 				000DF29423DB4B4900A883CE /* TestConstants.m in Sources */,
 				8A4E733F1DC13281001F7CC8 /* BugsnagConfigurationTests.m in Sources */,
 				E784D25A1FD70C25004B01E1 /* KSJSONCodec_Tests.m in Sources */,
+				009131BC23F46279000810D9 /* BugsnagMetadataTests.m in Sources */,
 				E70EE0881FD7047800FA745C /* KSSystemInfo_Tests.m in Sources */,
 				4BE6C42622CAD61A0056305D /* BugsnagCollectionsBSGDictMergeTest.m in Sources */,
 				E70EE0871FD7047800FA745C /* KSSysCtl_Tests.m in Sources */,


### PR DESCRIPTION
## Goal

Add `Bugsnag.getMetadata(_ section, key)` to better align with other notifiers.

<!-- What is the intent of this change? -->

<!--
Fixes #
Related to #
-->

## Design

The functionality was actually added in a previous PR.  This PR tidies that up slightly.  To allow for keys with spaces more discrete dictionary access was used.  Tests were added.

- This pull request is ready for:
  - [ ] Initial review of the intended approach, not yet feature complete
  - [ ] Structural review of the classes, functions, and properties modified
  - [X] Final review

<!-- What do you need from a reviewer to get this changeset
     ready for release -->

- [ ] The correct target branch has been selected (`master` for fixes, `next` for
  features)
- [ ] Consistency across platforms for structures or concepts added or modified
- [ ] Consistency between the changeset and the goal stated above
- [ ] Internal consistency with the rest of the library - is there any overlap between existing interfaces and any which have been added?
- [ ] Usage friction - is the proposed change in usage cumbersome or complicated?
- [ ] Performance and complexity - are there any cases of unexpected O(n^3) when iterating, recursing, flat mapping, etc?
- [ ] Concurrency concerns - if components are accessed asynchronously, what issues will arise
- [ ] Thoroughness of added tests and any missing edge cases
- [ ] Idiomatic use of the language
