### PR TITLE
refactor(bugsnag): Remove public config accessor

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -100,6 +100,9 @@ Bugsnag Notifiers on other platforms.
   - Invalid values are logged and ignored.
   [#470](https://github.com/bugsnag/bugsnag-cocoa/pull/470)
 
+* Remove `Bugsnag.configuration()?`. All access to the configuration object
+  should be performed prior to calling `Bugsnag.start()`.
+
 ## Bug fixes
 
 * Fix possible report corruption when using `notify()` from multiple threads

--- a/Source/BSGOutOfMemoryWatchdog.m
+++ b/Source/BSGOutOfMemoryWatchdog.m
@@ -13,6 +13,7 @@
 #import "Bugsnag.h"
 #import "BugsnagKSCrashSysInfoParser.h"
 #import "BugsnagSessionTracker.h"
+#import "Private.h"
 
 @interface BSGOutOfMemoryWatchdog ()
 @property(nonatomic, getter=isWatching) BOOL watching;

--- a/Source/Bugsnag.h
+++ b/Source/Bugsnag.h
@@ -35,16 +35,6 @@ static NSString *_Nonnull const BugsnagSeverityInfo = @"info";
 
 @interface Bugsnag : NSObject
 
-/** Get the current Bugsnag configuration.
- *
- * This method returns nil if called before +startBugsnagWithApiKey: or
- * +startBugsnagWithConfiguration:, and otherwise returns the current
- * configuration for Bugsnag.
- *
- * @return The configuration, or nil.
- */
-+ (BugsnagConfiguration *_Nullable)configuration;
-
 /** Start listening for crashes.
  *
  * This method initializes Bugsnag with the default configuration. Any uncaught
@@ -287,7 +277,6 @@ static NSString *_Nonnull const BugsnagSeverityInfo = @"info";
 + (void)setBreadcrumbCapacity:(NSUInteger)capacity
         __deprecated_msg("Use [BugsnagConfiguration setMaxBreadcrumbs:] instead");
 
-
 /**
  * Replicates BugsnagConfiguration.context
  *
@@ -312,5 +301,16 @@ static NSString *_Nonnull const BugsnagSeverityInfo = @"info";
 + (void)clearMetadataInSection:(NSString *_Nonnull)sectionName
                        withKey:(NSString *_Nonnull)key
     NS_SWIFT_NAME(clearMetadata(section:key:));
+
+/**
+ *  Set user metadata
+ *
+ *  @param userId ID of the user
+ *  @param name   Name of the user
+ *  @param email  Email address of the user
+ */
++ (void)setUser:(NSString *_Nullable)userId
+       withName:(NSString *_Nullable)name
+       andEmail:(NSString *_Nullable)email;
 
 @end

--- a/Source/Bugsnag.m
+++ b/Source/Bugsnag.m
@@ -299,6 +299,12 @@ static NSMutableArray <id<BugsnagPlugin>> *registeredPlugins;
     [self configuration].context = context;
 }
 
++ (void)setUser:(NSString *_Nullable)userId
+       withName:(NSString *_Nullable)name
+       andEmail:(NSString *_Nullable)email {
+    [[self configuration] setUser:userId withName:name andEmail:email];
+}
+
 @end
 
 //

--- a/Source/BugsnagApiClient.m
+++ b/Source/BugsnagApiClient.m
@@ -8,6 +8,7 @@
 #import "Bugsnag.h"
 #import "BugsnagKeys.h"
 #import "BugsnagLogger.h"
+#import "Private.h"
 
 @interface BSGDelayOperation : NSOperation
 @end

--- a/Source/BugsnagEvent.m
+++ b/Source/BugsnagEvent.m
@@ -20,6 +20,7 @@
 #import "BugsnagKeys.h"
 #import "BugsnagKSCrashSysInfoParser.h"
 #import "BugsnagSession.h"
+#import "Private.h"
 #import "BSG_RFC3339DateTool.h"
 
 NSMutableDictionary *BSGFormatFrame(NSDictionary *frame,

--- a/Source/BugsnagKSCrashSysInfoParser.m
+++ b/Source/BugsnagKSCrashSysInfoParser.m
@@ -11,6 +11,7 @@
 #import "BugsnagCollections.h"
 #import "BugsnagKeys.h"
 #import "BugsnagConfiguration.h"
+#import "Private.h"
 #import "BugsnagLogger.h"
 
 NSNumber *BSGDeviceFreeSpace(NSSearchPathDirectory directory) {

--- a/Source/BugsnagSessionTrackingPayload.m
+++ b/Source/BugsnagSessionTrackingPayload.m
@@ -13,6 +13,7 @@
 #import "BugsnagKeys.h"
 #import "BSG_KSSystemInfo.h"
 #import "BugsnagKSCrashSysInfoParser.h"
+#import "Private.h"
 
 @interface Bugsnag ()
 + (BugsnagNotifier *)notifier;

--- a/Source/BugsnagSink.m
+++ b/Source/BugsnagSink.m
@@ -31,6 +31,7 @@
 #import "BugsnagNotifier.h"
 #import "BugsnagKeys.h"
 #import "BSG_KSSystemInfo.h"
+#import "Private.h"
 
 // This is private in Bugsnag, but really we want package private so define
 // it here.

--- a/Source/Private.h
+++ b/Source/Private.h
@@ -1,6 +1,7 @@
 #ifndef BUGSNAG_PRIVATE_H
 #define BUGSNAG_PRIVATE_H
 
+#import "Bugsnag.h"
 #import "BugsnagBreadcrumb.h"
 
 @interface BugsnagBreadcrumbs ()
@@ -8,6 +9,20 @@
  * Reads and return breadcrumb data currently stored on disk
  */
 - (NSArray *_Nullable)cachedBreadcrumbs;
+@end
+
+@interface Bugsnag ()
+
+/** Get the current Bugsnag configuration.
+ *
+ * This method returns nil if called before +startBugsnagWithApiKey: or
+ * +startBugsnagWithConfiguration:, and otherwise returns the current
+ * configuration for Bugsnag.
+ *
+ * @return The configuration, or nil.
+ */
++ (BugsnagConfiguration *_Nullable)configuration;
+
 @end
 
 #endif // BUGSNAG_PRIVATE_H

--- a/Tests/BugsnagEventTests.m
+++ b/Tests/BugsnagEventTests.m
@@ -17,6 +17,10 @@
 #import "BugsnagTestConstants.h"
 #import "BugsnagTestsDummyClass.h"
 
+@interface Bugsnag ()
++ (BugsnagConfiguration *)configuration;
+@end
+
 @interface BugsnagEventTests : BugsnagBaseUnitTest
 @end
 

--- a/Tests/BugsnagTests.m
+++ b/Tests/BugsnagTests.m
@@ -13,6 +13,10 @@
 
 // MARK: - BugsnagTests
 
+@interface Bugsnag ()
++ (BugsnagConfiguration *)configuration;
+@end
+
 @interface BugsnagTests : XCTestCase
 
 @end

--- a/UPGRADING.md
+++ b/UPGRADING.md
@@ -57,6 +57,9 @@ Swift:
 
 ObjC:
 
+- [Bugsnag configuration]
++ [Bugsnag setUser:withName:andEmail:]
+
 - [Bugsnag addAttribute:WithValuetoTabWithName:]
 + [Bugsnag addMetadataToSection:key:value:]
 
@@ -69,6 +72,9 @@ ObjC:
 + [Bugsnag pauseSession]
 
 Swift:
+
+- Bugsnag.configuration()
++ Bugsnag.setUser(_:name:email:)
 
 - Bugsnag.addAttribute(attributeName:withValue:toTabWithName:)
 + Bugsnag.addMetadata(_:key:value:)

--- a/features/fixtures/ios-swift-cocoapods/iOSTestApp/scenarios/OOMScenario.m
+++ b/features/fixtures/ios-swift-cocoapods/iOSTestApp/scenarios/OOMScenario.m
@@ -18,6 +18,5 @@
 
 - (void)run {
     [Bugsnag leaveBreadcrumbWithMessage:@"Crumb left before crash"];
-    [Bugsnag configuration].releaseStage = @"beta";
 }
 @end

--- a/features/fixtures/ios-swift-cocoapods/iOSTestApp/scenarios/ReportBackgroundOOMsEnabledScenario.m
+++ b/features/fixtures/ios-swift-cocoapods/iOSTestApp/scenarios/ReportBackgroundOOMsEnabledScenario.m
@@ -10,6 +10,5 @@
 
 - (void)run {
     [Bugsnag leaveBreadcrumbWithMessage:@"Crumb left before crash"];
-    [Bugsnag configuration].releaseStage = @"beta";
 }
 @end

--- a/features/fixtures/ios-swift-cocoapods/iOSTestApp/scenarios/UserDisabledScenario.swift
+++ b/features/fixtures/ios-swift-cocoapods/iOSTestApp/scenarios/UserDisabledScenario.swift
@@ -16,7 +16,7 @@ internal class UserDisabledScenario: Scenario {
     }
 
     override func run() {
-        Bugsnag.configuration()?.setUser(nil, withName: nil, andEmail: nil)
+        Bugsnag.setUser(nil, withName: nil, andEmail: nil)
         let error = NSError(domain: "UserDisabledScenario", code: 100, userInfo: nil)
         Bugsnag.notifyError(error)
     }

--- a/features/fixtures/ios-swift-cocoapods/iOSTestApp/scenarios/UserEmailScenario.swift
+++ b/features/fixtures/ios-swift-cocoapods/iOSTestApp/scenarios/UserEmailScenario.swift
@@ -16,7 +16,7 @@ internal class UserEmailScenario: Scenario {
     }
 
     override func run() {
-        Bugsnag.configuration()?.setUser(nil, withName: nil, andEmail: "user@example.com")
+        Bugsnag.setUser(nil, withName: nil, andEmail: "user@example.com")
         let error = NSError(domain: "UserEmailScenario", code: 100, userInfo: nil)
         Bugsnag.notifyError(error)
     }

--- a/features/fixtures/ios-swift-cocoapods/iOSTestApp/scenarios/UserEnabledScenario.swift
+++ b/features/fixtures/ios-swift-cocoapods/iOSTestApp/scenarios/UserEnabledScenario.swift
@@ -17,7 +17,7 @@ internal class UserEnabledScenario: Scenario {
     }
 
     override func run() {
-        Bugsnag.configuration()?.setUser("123", withName: "Joe Bloggs", andEmail: "user@example.com")
+        Bugsnag.setUser("123", withName: "Joe Bloggs", andEmail: "user@example.com")
         let error = NSError(domain: "UserEnabledScenario", code: 100, userInfo: nil)
         Bugsnag.notifyError(error)
     }

--- a/features/fixtures/ios-swift-cocoapods/iOSTestApp/scenarios/UserIdScenario.swift
+++ b/features/fixtures/ios-swift-cocoapods/iOSTestApp/scenarios/UserIdScenario.swift
@@ -17,7 +17,7 @@ internal class UserIdScenario: Scenario {
     }
 
     override func run() {
-        Bugsnag.configuration()?.setUser("abc", withName: nil, andEmail: nil)
+        Bugsnag.setUser("abc", withName: nil, andEmail: nil)
         let error = NSError(domain: "UserIdScenario", code: 100, userInfo: nil)
         Bugsnag.notifyError(error)
     }

--- a/features/out_of_memory.feature
+++ b/features/out_of_memory.feature
@@ -15,7 +15,7 @@ Feature: Reporting out of memory events
         And the event "unhandled" is true
         And the event "severity" equals "error"
         And the event "severityReason.type" equals "outOfMemory"
-        And the event "app.releaseStage" equals "beta"
+        And the event "app.releaseStage" equals "alpha"
         And the event "app.version" equals "1.0.3"
         And the event "app.bundleVersion" equals "5"
         And the event "metaData.extra.shape" equals "line"


### PR DESCRIPTION
* Add setUser to Bugsnag as a replacement

## Goal

Remove access to the internal configuration object, which should be publicly immutable after calling `start()`. 

## Changeset

* Moved `Bugsnag.configuration()` from the public API to the internal Private header
* Added `Bugsnag.setUser()` to replace setting user through the configuration object after initialization. There are further user changes in a later changeset, and this change already has associated tests (which have been updated to use the new method).

## Tests

* Existing tests cover this change, requiring calls to `Bugsnag.configuration()?.setUser()` to change to `Bugsnag.setUser()`
