### PR TITLE
Remove debugging functions from public API

### DIFF
--- a/Source/Bugsnag.h
+++ b/Source/Bugsnag.h
@@ -200,12 +200,6 @@ static NSString *_Nonnull const BugsnagSeverityInfo = @"info";
 
 + (NSDateFormatter *_Nonnull)payloadDateFormatter;
 
-+ (void)setSuspendThreadsForUserReported:(BOOL)suspendThreadsForUserReported;
-+ (void)setReportWhenDebuggerIsAttached:(BOOL)reportWhenDebuggerIsAttached;
-+ (void)setThreadTracingEnabled:(BOOL)threadTracingEnabled;
-+ (void)setWriteBinaryImagesForUserReported:
-    (BOOL)writeBinaryImagesForUserReported;
-
 /**
  * Starts tracking a new session.
  *

--- a/Source/Bugsnag.m
+++ b/Source/Bugsnag.m
@@ -276,34 +276,6 @@ static NSMutableArray <id<BugsnagPlugin>> *registeredPlugins;
     return formatter;
 }
 
-+ (void)setSuspendThreadsForUserReported:(BOOL)suspendThreadsForUserReported {
-    if ([self bugsnagStarted]) {
-        [[BSG_KSCrash sharedInstance]
-                setSuspendThreadsForUserReported:suspendThreadsForUserReported];
-    }
-}
-
-+ (void)setReportWhenDebuggerIsAttached:(BOOL)reportWhenDebuggerIsAttached {
-    if ([self bugsnagStarted]) {
-        [[BSG_KSCrash sharedInstance]
-                setReportWhenDebuggerIsAttached:reportWhenDebuggerIsAttached];
-    }
-}
-
-+ (void)setThreadTracingEnabled:(BOOL)threadTracingEnabled {
-    if ([self bugsnagStarted]) {
-        [[BSG_KSCrash sharedInstance] setThreadTracingEnabled:threadTracingEnabled];
-    }
-}
-
-+ (void)setWriteBinaryImagesForUserReported:
-    (BOOL)writeBinaryImagesForUserReported {
-    if ([self bugsnagStarted]) {
-        [[BSG_KSCrash sharedInstance]
-                setWriteBinaryImagesForUserReported:writeBinaryImagesForUserReported];
-    }
-}
-
 + (void)clearMetadataInSection:(NSString *_Nonnull)sectionName
                        withKey:(NSString *_Nonnull)key
 {

--- a/features/fixtures/ios-swift-cocoapods/iOSTestApp/scenarios/ManyConcurrentNotifyNoBackgroundThreads.m
+++ b/features/fixtures/ios-swift-cocoapods/iOSTestApp/scenarios/ManyConcurrentNotifyNoBackgroundThreads.m
@@ -1,5 +1,10 @@
 #import "ManyConcurrentNotifyNoBackgroundThreads.h"
 
+@interface BSG_KSCrash
++ (instancetype)sharedInstance;
+- (void)setSuspendThreadsForUserReported:(BOOL)suspend;
+@end
+
 @interface ManyConcurrentNotifyNoBackgroundThreads ()
 @property (nonatomic) dispatch_queue_t queue1;
 @property (nonatomic) dispatch_queue_t queue2;
@@ -41,6 +46,6 @@
 - (void)startBugsnag {
     self.config.autoTrackSessions = NO;
     [super startBugsnag];
-    [Bugsnag setSuspendThreadsForUserReported:NO];
+    [[BSG_KSCrash sharedInstance] setSuspendThreadsForUserReported:NO];
 }
 @end


### PR DESCRIPTION
Short and sweet. removing without replacement, as these weren't intended for public use. 

`setSuspendThreadsForUserReported` will be resurrected in a more useful form as a configuration option in a later changeset.