### PR TITLE
refactor(config): Rename block types to match spec

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -33,6 +33,11 @@ Bugsnag Notifiers on other platforms.
   (Swift: `Bugsnag.clearMetadata(section:)`)
   [#457](https://github.com/bugsnag/bugsnag-cocoa/pull/457)
      
+* Renamed callback functions in the Configuration class:
+  * `onCrashHandler` is now `onError`
+  * `beforeSendBlocks` is now `onSendBlocks` (add using `config.add(onSend: { ... })`)
+  * `beforeSendSessionBlocks` is now `onSessionBlocks` (add using `config.add(onSession: { ... })`)
+
 * Added `[Bugsnag clearMetadataInSection:withKey:]`
   (Swift: `Bugsnag.clearMetadata(section:key:)`)
   [#462](https://github.com/bugsnag/bugsnag-cocoa/pull/462)

--- a/Source/Bugsnag.h
+++ b/Source/Bugsnag.h
@@ -91,7 +91,7 @@ static NSString *_Nonnull const BugsnagSeverityInfo = @"info";
  *  @param block     A block for optionally configuring the error report
  */
 + (void)notify:(NSException *_Nonnull)exception
-         block:(BugsnagNotifyBlock _Nullable)block;
+         block:(BugsnagOnErrorBlock _Nullable)block;
 
 /**
  *  Send an error to Bugsnag
@@ -107,7 +107,7 @@ static NSString *_Nonnull const BugsnagSeverityInfo = @"info";
  *  @param block A block for optionally configuring the error report
  */
 + (void)notifyError:(NSError *_Nonnull)error
-              block:(BugsnagNotifyBlock _Nullable)block;
+              block:(BugsnagOnErrorBlock _Nullable)block;
 
 /** Send a custom or caught exception to Bugsnag.
  *
@@ -148,7 +148,7 @@ static NSString *_Nonnull const BugsnagSeverityInfo = @"info";
  */
 + (void)internalClientNotify:(NSException *_Nonnull)exception
                     withData:(NSDictionary *_Nullable)metadata
-                       block:(BugsnagNotifyBlock _Nullable)block;
+                       block:(BugsnagOnErrorBlock _Nullable)block;
 
 /** Add custom data to send to Bugsnag with every exception. If value is nil,
  *  delete the current value for attributeName

--- a/Source/Bugsnag.m
+++ b/Source/Bugsnag.m
@@ -107,7 +107,7 @@ static NSMutableArray <id<BugsnagPlugin>> *registeredPlugins;
     }
 }
 
-+ (void)notify:(NSException *)exception block:(BugsnagNotifyBlock)block {
++ (void)notify:(NSException *)exception block:(BugsnagOnErrorBlock)block {
     if ([self bugsnagStarted]) {
         [[self notifier] notifyException:exception
                                    block:^(BugsnagEvent *_Nonnull report) {
@@ -129,7 +129,7 @@ static NSMutableArray <id<BugsnagPlugin>> *registeredPlugins;
     }
 }
 
-+ (void)notifyError:(NSError *)error block:(BugsnagNotifyBlock)block {
++ (void)notifyError:(NSError *)error block:(BugsnagOnErrorBlock)block {
     if ([self bugsnagStarted]) {
         [[self notifier] notifyError:error
                                block:^(BugsnagEvent *_Nonnull report) {
@@ -174,7 +174,7 @@ static NSMutableArray <id<BugsnagPlugin>> *registeredPlugins;
 
 + (void)internalClientNotify:(NSException *_Nonnull)exception
                     withData:(NSDictionary *_Nullable)metadata
-                       block:(BugsnagNotifyBlock _Nullable)block {
+                       block:(BugsnagOnErrorBlock _Nullable)block {
     if ([self bugsnagStarted]) {
         [self.notifier internalClientNotify:exception
                                    withData:metadata

--- a/Source/BugsnagConfiguration.h
+++ b/Source/BugsnagConfiguration.h
@@ -47,21 +47,21 @@ typedef NS_ENUM(NSInteger, BSGConfigurationErrorCode) {
  *
  *  @param report The default report
  */
-typedef void (^BugsnagNotifyBlock)(BugsnagEvent *_Nonnull report);
+typedef void (^BugsnagOnErrorBlock)(BugsnagEvent *_Nonnull report);
 
 /**
  *  A handler for modifying data before sending it to Bugsnag.
  *
- * beforeSendBlocks will be invoked on a dedicated
+ * onSendBlocks will be invoked on a dedicated
  * background queue, which will be different from the queue where the block was originally added.
  *
  *  @param rawEventData The raw event data written at crash time. This
- *                      includes data added in onCrashHandler.
+ *                      includes data added in onError.
  *  @param reports      The report generated from the rawEventData
  *
  *  @return YES if the report should be sent
  */
-typedef bool (^BugsnagBeforeSendBlock)(NSDictionary *_Nonnull rawEventData,
+typedef bool (^BugsnagOnSendBlock)(NSDictionary *_Nonnull rawEventData,
                                        BugsnagEvent *_Nonnull reports);
 
 /**
@@ -69,13 +69,13 @@ typedef bool (^BugsnagBeforeSendBlock)(NSDictionary *_Nonnull rawEventData,
  *
  * @param sessionPayload The session about to be delivered
  */
-typedef void(^BeforeSendSession)(NSMutableDictionary *_Nonnull sessionPayload);
+typedef void(^BugsnagOnSessionBlock)(NSMutableDictionary *_Nonnull sessionPayload);
 
 /**
  *  A handler for modifying data before sending it to Bugsnag
  *
  *  @param rawEventReports The raw event data written at crash time. This
- *                         includes data added in onCrashHandler.
+ *                         includes data added in onError.
  *  @param report          The default report payload
  *
  *  @return the report payload intended to be sent or nil to cancel sending
@@ -141,18 +141,18 @@ BugsnagBreadcrumbs *breadcrumbs;
  *  Hooks for modifying crash reports before it is sent to Bugsnag
  */
 @property(readonly, strong, nullable)
-    NSArray<BugsnagBeforeSendBlock> *beforeSendBlocks;
+    NSArray<BugsnagOnSendBlock> *onSendBlocks;
 
 /**
  *  Hooks for modifying sessions before they are sent to Bugsnag. Intended for internal use only by React Native/Unity.
  */
 @property(readonly, strong, nullable)
-NSArray<BeforeSendSession> *beforeSendSessionBlocks;
+NSArray<BugsnagOnSessionBlock> *onSessionBlocks;
 
 /**
- *  Optional handler invoked when a crash or fatal signal occurs
+ *  Optional handler invoked when an error or crash occurs
  */
-@property void (*_Nullable onCrashHandler)
+@property void (*_Nullable onError)
     (const BSG_KSCrashReportWriter *_Nonnull writer);
 
 /**
@@ -246,19 +246,19 @@ NSArray<BeforeSendSession> *beforeSendSessionBlocks;
  *
  *  @param block A block which returns YES if the report should be sent
  */
-- (void)addBeforeSendBlock:(BugsnagBeforeSendBlock _Nonnull)block;
+- (void)addOnSendBlock:(BugsnagOnSendBlock _Nonnull)block;
 
 /**
  *  Add a callback to be invoked before a session is sent to Bugsnag. Intended for internal usage only.
  *
  *  @param block A block which can modify the session
  */
-- (void)addBeforeSendSession:(BeforeSendSession _Nonnull)block;
+- (void)addOnSessionBlock:(BugsnagOnSessionBlock _Nonnull)block;
 
 /**
  * Clear all callbacks
  */
-- (void)clearBeforeSendBlocks;
+- (void)clearOnSendBlocks;
 
 /**
  *  Whether reports shoould be sent, based on release stage options
@@ -274,9 +274,6 @@ NSArray<BeforeSendSession> *beforeSendSessionBlocks;
  */
 @property NSUInteger maxBreadcrumbs;
 
-- (void)addBeforeNotifyHook:(BugsnagBeforeNotifyHook _Nonnull)hook
-    __deprecated_msg("Use addBeforeSendBlock: instead.");
-
 /**
  * Determines whether app sessions should be tracked automatically. By default this value is true.
  * If this value is updated after +[Bugsnag start] is called, only subsequent automatic sessions
@@ -288,12 +285,6 @@ NSArray<BeforeSendSession> *beforeSendSessionBlocks;
  *  YES if uncaught exceptions should be reported automatically
  */
 @property BOOL autoNotify __deprecated_msg("Use autoDetectErrors instead");
-
-/**
- *  Hooks for processing raw report data before it is sent to Bugsnag
- */
-@property(readonly, strong, nullable)
-    NSArray *beforeNotifyHooks __deprecated_msg("Use beforeNotify instead.");
 
 - (NSDictionary *_Nonnull)errorApiHeaders;
 - (NSDictionary *_Nonnull)sessionApiHeaders;

--- a/Source/BugsnagConfiguration.m
+++ b/Source/BugsnagConfiguration.m
@@ -50,9 +50,8 @@ NSString * const BSGConfigurationErrorDomain = @"com.Bugsnag.CocoaNotifier.Confi
 @end
 
 @interface BugsnagConfiguration ()
-@property(nonatomic, readwrite, strong) NSMutableArray *beforeNotifyHooks;
-@property(nonatomic, readwrite, strong) NSMutableArray *beforeSendBlocks;
-@property(nonatomic, readwrite, strong) NSMutableArray *beforeSendSessionBlocks;
+@property(nonatomic, readwrite, strong) NSMutableArray *onSendBlocks;
+@property(nonatomic, readwrite, strong) NSMutableArray *onSessionBlocks;
 @end
 
 @implementation BugsnagConfiguration
@@ -101,9 +100,8 @@ NSString * const BSGConfigurationErrorDomain = @"com.Bugsnag.CocoaNotifier.Confi
     _sessionURL = [NSURL URLWithString:@"https://sessions.bugsnag.com"];
     _autoDetectErrors = YES;
     _notifyURL = [NSURL URLWithString:BSGDefaultNotifyUrl];
-    _beforeNotifyHooks = [NSMutableArray new];
-    _beforeSendBlocks = [NSMutableArray new];
-    _beforeSendSessionBlocks = [NSMutableArray new];
+    _onSendBlocks = [NSMutableArray new];
+    _onSessionBlocks = [NSMutableArray new];
     _notifyReleaseStages = nil;
     _breadcrumbs = [BugsnagBreadcrumbs new];
     _automaticallyCollectBreadcrumbs = YES;
@@ -147,20 +145,16 @@ NSString * const BSGConfigurationErrorDomain = @"com.Bugsnag.CocoaNotifier.Confi
                   toTabWithName:BSGKeyUser];
 }
 
-- (void)addBeforeSendBlock:(BugsnagBeforeSendBlock)block {
-    [(NSMutableArray *)self.beforeSendBlocks addObject:[block copy]];
+- (void)addOnSendBlock:(BugsnagOnSendBlock)block {
+    [(NSMutableArray *)self.onSendBlocks addObject:[block copy]];
 }
 
-- (void)addBeforeSendSession:(BeforeSendSession)block {
-    [(NSMutableArray *)self.beforeSendSessionBlocks addObject:[block copy]];
+- (void)addOnSessionBlock:(BugsnagOnSessionBlock)block {
+    [(NSMutableArray *)self.onSessionBlocks addObject:[block copy]];
 }
 
-- (void)clearBeforeSendBlocks {
-    [(NSMutableArray *)self.beforeSendBlocks removeAllObjects];
-}
-
-- (void)addBeforeNotifyHook:(BugsnagBeforeNotifyHook)hook {
-    [(NSMutableArray *)self.beforeNotifyHooks addObject:[hook copy]];
+- (void)clearOnSendBlocks {
+    [(NSMutableArray *)self.onSendBlocks removeAllObjects];
 }
 
 @synthesize releaseStage = _releaseStage;

--- a/Source/BugsnagNotifier.h
+++ b/Source/BugsnagNotifier.h
@@ -60,7 +60,7 @@
  * information
  */
 - (void)notifyException:(NSException *_Nonnull)exception
-                  block:(BugsnagNotifyBlock _Nullable)block;
+                  block:(BugsnagOnErrorBlock _Nullable)block;
 
 /**
  *  Notify Bugsnag of an exception
@@ -72,7 +72,7 @@
  */
 - (void)notifyException:(NSException *_Nonnull)exception
              atSeverity:(BSGSeverity)severity
-                  block:(BugsnagNotifyBlock _Nullable)block;
+                  block:(BugsnagOnErrorBlock _Nullable)block;
 
 /**
  *  Notify Bugsnag of an exception. Only intended for React Native/Unity use.
@@ -84,7 +84,7 @@
  */
 - (void)internalClientNotify:(NSException *_Nonnull)exception
                     withData:(NSDictionary *_Nullable)metadata
-                       block:(BugsnagNotifyBlock _Nullable)block;
+                       block:(BugsnagOnErrorBlock _Nullable)block;
 
 /**
  *  Notify Bugsnag of an error
@@ -93,7 +93,7 @@
  *  @param block Configuration block for adding additional report information
  */
 - (void)notifyError:(NSError *_Nonnull)error
-              block:(BugsnagNotifyBlock _Nullable)block;
+              block:(BugsnagOnErrorBlock _Nullable)block;
 
 /**
  *  Add a breadcrumb

--- a/Source/BugsnagSessionTrackingApiClient.m
+++ b/Source/BugsnagSessionTrackingApiClient.m
@@ -43,7 +43,7 @@
         NSUInteger sessionCount = payload.sessions.count;
         NSMutableDictionary *data = [payload toJson];
 
-        for (BeforeSendSession cb in self.config.beforeSendSessionBlocks) {
+        for (BugsnagOnSessionBlock cb in self.config.onSessionBlocks) {
             cb(data);
         }
 

--- a/Source/BugsnagSink.m
+++ b/Source/BugsnagSink.m
@@ -68,13 +68,13 @@
         if (![bugsnagReport shouldBeSent])
             continue;
         BOOL shouldSend = YES;
-        for (BugsnagBeforeSendBlock block in configuration.beforeSendBlocks) {
+        for (BugsnagOnSendBlock block in configuration.onSendBlocks) {
             @try {
                 shouldSend = block(report, bugsnagReport);
                 if (!shouldSend)
                     break;
             } @catch (NSException *exception) {
-                bsg_log_err(@"Error from beforeSend callback: %@", exception);
+                bsg_log_err(@"Error from onSend callback: %@", exception);
             }
         }
         if (shouldSend) {
@@ -90,17 +90,6 @@
     }
 
     NSDictionary *reportData = [self getBodyFromReports:bugsnagReports];
-
-#pragma clang diagnostic push
-#pragma clang diagnostic ignored "-Wdeprecated-declarations"
-    for (BugsnagBeforeNotifyHook hook in configuration.beforeNotifyHooks) {
-        if (reportData) {
-            reportData = hook(bugsnagReports, reportData);
-        } else {
-            break;
-        }
-    }
-#pragma clang diagnostic pop
 
     if (reportData == nil) {
         if (onCompletion) {

--- a/Tests/BugsnagBaseUnitTest.m
+++ b/Tests/BugsnagBaseUnitTest.m
@@ -30,7 +30,7 @@
     NSError *error;
     BugsnagConfiguration *configuration = [[BugsnagConfiguration alloc] initWithApiKey:DUMMY_APIKEY_32CHAR_1 error:&error];
     if (willNotify) {
-        [configuration addBeforeSendBlock:^bool(NSDictionary * _Nonnull rawEventData,
+        [configuration addOnSendBlock:^bool(NSDictionary * _Nonnull rawEventData,
                                                 BugsnagEvent * _Nonnull reports)
         {
             return false;

--- a/Tests/BugsnagTests.m
+++ b/Tests/BugsnagTests.m
@@ -26,7 +26,7 @@
     NSError *error;
     BugsnagConfiguration *configuration = [[BugsnagConfiguration alloc] initWithApiKey:DUMMY_APIKEY_32CHAR_1 error:&error];
     if (willNotify) {
-        [configuration addBeforeSendBlock:^bool(NSDictionary * _Nonnull rawEventData, BugsnagEvent * _Nonnull reports) {
+        [configuration addOnSendBlock:^bool(NSDictionary * _Nonnull rawEventData, BugsnagEvent * _Nonnull reports) {
             return false;
         }];
     }
@@ -122,7 +122,7 @@
 -(void)testBugsnagPauseSession {
     NSError *error;
     BugsnagConfiguration *configuration = [[BugsnagConfiguration alloc] initWithApiKey:DUMMY_APIKEY_32CHAR_1 error:&error];
-    [configuration addBeforeSendBlock:^bool(NSDictionary * _Nonnull rawEventData,
+    [configuration addOnSendBlock:^bool(NSDictionary * _Nonnull rawEventData,
                                             BugsnagEvent * _Nonnull reports)
     {
         return false;
@@ -144,7 +144,7 @@
     NSError *error;
     BugsnagConfiguration *configuration = [[BugsnagConfiguration alloc] initWithApiKey:DUMMY_APIKEY_32CHAR_1 error:&error];
     [configuration setContext:@"firstContext"];
-    [configuration addBeforeSendBlock:^bool(NSDictionary * _Nonnull rawEventData,
+    [configuration addOnSendBlock:^bool(NSDictionary * _Nonnull rawEventData,
                                             BugsnagEvent * _Nonnull reports)
     {
         return false;

--- a/UPGRADING.md
+++ b/UPGRADING.md
@@ -32,6 +32,19 @@ Swift:
 
 - config.autoCaptureSessions
 + config.autoTrackSessions
+
+- config.onCrashHandler
++ config.onError
+
+- config.beforeSendBlocks
+- config.add(beforeSend:)
++ config.onSendBlocks
++ config.add(onSend:)
+
+- config.beforeSessionBlocks
+- config.add(beforeSession:)
++ config.onSessionBlocks
++ config.add(onSession:)
 ```
 
 ### `Bugsnag` class

--- a/features/fixtures/ios-swift-cocoapods/iOSTestApp/scenarios/OOMScenario.m
+++ b/features/fixtures/ios-swift-cocoapods/iOSTestApp/scenarios/OOMScenario.m
@@ -7,7 +7,7 @@
 - (void)startBugsnag {
     self.config.shouldAutoCaptureSessions = NO;
     self.config.releaseStage = @"alpha";
-    [self.config addBeforeSendBlock:^bool(NSDictionary * _Nonnull rawEventData, BugsnagEvent * _Nonnull report) {
+    [self.config addOnSendBlock:^bool(NSDictionary * _Nonnull rawEventData, BugsnagEvent * _Nonnull report) {
         NSMutableDictionary *metadata = [report.metadata mutableCopy];
         metadata[@"extra"] = @{ @"shape": @"line" };
         report.metadata = metadata;


### PR DESCRIPTION
Updated the configuration with the following block names:

* beforeSend is now onSend
* beforeSendSession is now onSession
* onCrashHandler is now onError (and always ran for non-crashes anyway)
* Removed (previously deprecated) beforeNotifyHooks