### PR TITLE
feat(event): Expose breadcrumbs as objects

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -23,6 +23,20 @@ Bugsnag Notifiers on other platforms.
 
   [#446](https://github.com/bugsnag/bugsnag-cocoa/pull/446)
 
+* Support editing breadcrumbs within an Event as objects. Breadcrumbs can now be
+  inspected and modified from callbacks, for example:
+
+  ```swift
+  Bugsnag.notifyError(error) { event in
+      event.breadcrumbs?.forEach({ crumb in
+          if crumb.message == "something specific" {
+              crumb.message = "[redacted]"
+          }
+      })
+  }
+  ```
+  [#474](https://github.com/bugsnag/bugsnag-cocoa/pull/474)
+
 * Add a breadcrumb when Bugsnag first starts with the message "Bugsnag loaded"
   [#445](https://github.com/bugsnag/bugsnag-cocoa/pull/445)
   

--- a/Source/BugsnagBreadcrumb.h
+++ b/Source/BugsnagBreadcrumb.h
@@ -83,6 +83,7 @@ typedef void (^BSGBreadcrumbConfiguration)(BugsnagBreadcrumb *_Nonnull);
 + (instancetype _Nullable)breadcrumbWithBlock:
     (BSGBreadcrumbConfiguration _Nonnull)block;
 
++ (instancetype _Nullable)breadcrumbFromDict:(NSDictionary *_Nonnull)dict;
 @end
 
 @interface BugsnagBreadcrumbs : NSObject

--- a/Source/BugsnagBreadcrumb.m
+++ b/Source/BugsnagBreadcrumb.m
@@ -49,15 +49,30 @@ NSString *BSGBreadcrumbTypeValue(BSGBreadcrumbType type) {
     }
 }
 
+BSGBreadcrumbType BSGBreadcrumbTypeFromString(NSString *value) {
+    if ([value isEqual:@"log"]) {
+        return BSGBreadcrumbTypeLog;
+    } else if ([value isEqual:@"user"]) {
+        return BSGBreadcrumbTypeUser;
+    } else if ([value isEqual:@"error"]) {
+        return BSGBreadcrumbTypeError;
+    } else if ([value isEqual:@"state"]) {
+        return BSGBreadcrumbTypeState;
+    } else if ([value isEqual:@"process"]) {
+        return BSGBreadcrumbTypeProcess;
+    } else if ([value isEqual:@"request"]) {
+        return BSGBreadcrumbTypeRequest;
+    } else if ([value isEqual:@"navigation"]) {
+        return BSGBreadcrumbTypeNavigation;
+    } else {
+        return BSGBreadcrumbTypeManual;
+    }
+}
+
 @interface BugsnagBreadcrumbs ()
 
 @property(nonatomic, readwrite, strong) NSMutableArray *breadcrumbs;
 @property(nonatomic, readonly, strong) dispatch_queue_t readWriteQueue;
-@end
-
-@interface BugsnagBreadcrumb ()
-
-- (NSDictionary *_Nullable)objectValue;
 @end
 
 @implementation BugsnagBreadcrumb
@@ -166,6 +181,24 @@ NSString *BSGBreadcrumbTypeValue(BSGBreadcrumbType type) {
     }
     if ([crumb isValid]) {
         return crumb;
+    }
+    return nil;
+}
+
++ (instancetype)breadcrumbFromDict:(NSDictionary *)dict {
+    BOOL isValidCrumb = [dict[BSGKeyType] isKindOfClass:[NSString class]]
+        && [dict[BSGKeyTimestamp] isKindOfClass:[NSString class]]
+        && [dict[BSGKeyMetadata] isKindOfClass:[NSDictionary class]]
+        // Accept legacy 'name' value if provided.
+        && ([dict[BSGKeyMessage] isKindOfClass:[NSString class]]
+            || [dict[BSGKeyName] isKindOfClass:[NSString class]]);
+    if (isValidCrumb) {
+        return [self breadcrumbWithBlock:^(BugsnagBreadcrumb *crumb) {
+            crumb.message = dict[BSGKeyMessage] ?: dict[BSGKeyName];
+            crumb.metadata = dict[BSGKeyMetadata];
+            crumb.timestamp = [[Bugsnag payloadDateFormatter] dateFromString:dict[BSGKeyTimestamp]];
+            crumb.type = BSGBreadcrumbTypeFromString(dict[BSGKeyType]);
+        }];
     }
     return nil;
 }

--- a/Source/BugsnagEvent.h
+++ b/Source/BugsnagEvent.h
@@ -11,6 +11,7 @@
 @class BugsnagConfiguration;
 @class BugsnagHandledState;
 @class BugsnagSession;
+@class BugsnagBreadcrumb;
 
 typedef NS_ENUM(NSUInteger, BSGSeverity) {
     BSGSeverityError,
@@ -220,7 +221,7 @@ __deprecated_msg("Use toJson: instead.");
 /**
  *  Breadcrumbs from user events leading up to the error
  */
-@property(readwrite, copy, nullable) NSArray *breadcrumbs;
+@property(readwrite, copy, nullable) NSArray <BugsnagBreadcrumb *>*breadcrumbs;
 /**
  *  Further information attached to an error report, where each top level key
  *  generates a section on bugsnag, displaying key/value pairs

--- a/Source/Private.h
+++ b/Source/Private.h
@@ -8,6 +8,11 @@
 #import "Bugsnag.h"
 #import "BugsnagBreadcrumb.h"
 
+@interface BugsnagBreadcrumb ()
+
+- (NSDictionary *_Nullable)objectValue;
+@end
+
 @interface BugsnagBreadcrumbs ()
 /**
  * Reads and return breadcrumb data currently stored on disk

--- a/Tests/BugsnagBreadcrumbsTest.m
+++ b/Tests/BugsnagBreadcrumbsTest.m
@@ -23,6 +23,8 @@ void awaitBreadcrumbSync(BugsnagBreadcrumbs *crumbs) {
     });
 }
 
+BSGBreadcrumbType BSGBreadcrumbTypeFromString(NSString *value);
+
 @implementation BugsnagBreadcrumbsTest
 
 - (void)setUp {
@@ -153,6 +155,59 @@ void awaitBreadcrumbSync(BugsnagBreadcrumbs *crumbs) {
     XCTAssertEqualObjects(value[3][@"message"], @"Initiate sequence");
     XCTAssertEqualObjects(value[3][@"metaData"][@"captain"], @"Bob");
     XCTAssertNotNil(value[3][@"timestamp"]);
+}
+
+- (void)testConvertBreadcrumbTypeFromString {
+    XCTAssertEqual(BSGBreadcrumbTypeState, BSGBreadcrumbTypeFromString(@"state"));
+    XCTAssertEqual(BSGBreadcrumbTypeUser, BSGBreadcrumbTypeFromString(@"user"));
+    XCTAssertEqual(BSGBreadcrumbTypeManual, BSGBreadcrumbTypeFromString(@"manual"));
+    XCTAssertEqual(BSGBreadcrumbTypeNavigation, BSGBreadcrumbTypeFromString(@"navigation"));
+    XCTAssertEqual(BSGBreadcrumbTypeProcess, BSGBreadcrumbTypeFromString(@"process"));
+    XCTAssertEqual(BSGBreadcrumbTypeLog, BSGBreadcrumbTypeFromString(@"log"));
+    XCTAssertEqual(BSGBreadcrumbTypeRequest, BSGBreadcrumbTypeFromString(@"request"));
+    XCTAssertEqual(BSGBreadcrumbTypeError, BSGBreadcrumbTypeFromString(@"error"));
+
+    XCTAssertEqual(BSGBreadcrumbTypeManual, BSGBreadcrumbTypeFromString(@"random"));
+    XCTAssertEqual(BSGBreadcrumbTypeManual, BSGBreadcrumbTypeFromString(@"4"));
+}
+
+- (void)testBreadcrumbFromDict {
+    XCTAssertNil([BugsnagBreadcrumb breadcrumbFromDict:@{}]);
+    XCTAssertNil([BugsnagBreadcrumb breadcrumbFromDict:@{@"metadata": @{}}]);
+    XCTAssertNil([BugsnagBreadcrumb breadcrumbFromDict:@{@"timestamp": @""}]);
+    BugsnagBreadcrumb *crumb = [BugsnagBreadcrumb breadcrumbFromDict:@{
+        @"timestamp": @"0",
+        @"metaData": @{},
+        @"message":@"cache break",
+        @"type":@"process"}];
+    XCTAssertNil(crumb);
+
+    crumb = [BugsnagBreadcrumb breadcrumbFromDict:@{
+        @"timestamp": @"2020-02-14T16:12:22+001",
+        @"metaData": @{},
+        @"message":@"",
+        @"type":@"process"}];
+    XCTAssertNil(crumb);
+
+    crumb = [BugsnagBreadcrumb breadcrumbFromDict:@{
+        @"timestamp": @"2020-02-14T16:12:23+001",
+        @"metaData": @{},
+        @"message":@"cache break",
+        @"type":@"process"}];
+    XCTAssertNotNil(crumb);
+    XCTAssertEqualObjects(@{}, crumb.metadata);
+    XCTAssertEqualObjects(@"cache break", crumb.message);
+    XCTAssertEqual(BSGBreadcrumbTypeProcess, crumb.type);
+
+    crumb = [BugsnagBreadcrumb breadcrumbFromDict:@{
+        @"timestamp": @"2020-02-14T16:14:23+001",
+        @"metaData": @{@"foo": @"bar"},
+        @"message":@"cache break",
+        @"type":@"log"}];
+    XCTAssertNotNil(crumb);
+    XCTAssertEqualObjects(@"cache break", crumb.message);
+    XCTAssertEqualObjects(@{@"foo": @"bar"}, crumb.metadata);
+    XCTAssertEqual(BSGBreadcrumbTypeLog, crumb.type);
 }
 
 @end

--- a/Tests/BugsnagSinkTests.m
+++ b/Tests/BugsnagSinkTests.m
@@ -136,7 +136,13 @@
     [self.rawReportData valueForKeyPath:@"user.state.crash.breadcrumbs"];
     NSArray *breadcrumbs =
     [self.processedData[@"events"] firstObject][@"breadcrumbs"];
-    XCTAssertEqualObjects(breadcrumbs, expected);
+    XCTAssertEqual(2, breadcrumbs.count);
+    for (int i = 0; i < breadcrumbs.count; i++) {
+        XCTAssertEqualObjects(expected[i][@"message"], breadcrumbs[i][@"message"]);
+        XCTAssertEqualObjects(expected[i][@"type"], breadcrumbs[i][@"type"]);
+        XCTAssertEqualObjects(expected[i][@"timestamp"], breadcrumbs[i][@"timestamp"]);
+        XCTAssertEqualObjects(expected[i][@"metadata"], breadcrumbs[i][@"metadata"]);
+    }
 }
 
 - (void)testEventContext {

--- a/Tests/report.json
+++ b/Tests/report.json
@@ -2102,7 +2102,10 @@
             "crash": {
                 "depth": 4,
                 "severity": "warning",
-                "breadcrumbs": [["1442466386","App launched"],["1442466386","Tapped button"]]
+                "breadcrumbs": [
+                    {"message": "App launched", "timestamp": "2020-02-14T16:12:22+0000", "type": "manual", "metaData":{}},
+                    {"message": "Tapped button", "timestamp": "2020-02-14T16:12:24+0000", "type": "manual", "metaData":{}}
+                ]
             }
         }
     }

--- a/features/breadcrumbs.feature
+++ b/features/breadcrumbs.feature
@@ -16,3 +16,13 @@ Background:
         And I relaunch the app
         And I wait for a request
         Then the event breadcrumbs contain "Bugsnag loaded" with type "state"
+
+    Scenario: Modifying a breadcrumb name
+        When I run "ModifyBreadcrumbScenario"
+        And I wait for a request
+        Then the event breadcrumbs contain "Cache locked"
+
+    Scenario: Modifying a breadcrumb name in callback
+        When I run "ModifyBreadcrumbInNotify"
+        And I wait for a request
+        Then the event breadcrumbs contain "Cache locked"

--- a/features/fixtures/ios-swift-cocoapods/iOSTestApp.xcodeproj/project.pbxproj
+++ b/features/fixtures/ios-swift-cocoapods/iOSTestApp.xcodeproj/project.pbxproj
@@ -12,6 +12,8 @@
 		8A14F0F72282D4AE00337B05 /* ReportOOMsDisabledReportBackgroundOOMsEnabledScenario.m in Sources */ = {isa = PBXBuildFile; fileRef = 8A14F0F32282D4AE00337B05 /* ReportOOMsDisabledReportBackgroundOOMsEnabledScenario.m */; };
 		8A22FC66225B598500CA8895 /* OOMScenario.m in Sources */ = {isa = PBXBuildFile; fileRef = 8A22FC65225B598500CA8895 /* OOMScenario.m */; };
 		8A32DB8222424E3000EDD92F /* NSExceptionShiftScenario.m in Sources */ = {isa = PBXBuildFile; fileRef = 8A32DB8122424E3000EDD92F /* NSExceptionShiftScenario.m */; };
+		8A3B5F292407F66700CE4A3A /* ModifyBreadcrumbScenario.swift in Sources */ = {isa = PBXBuildFile; fileRef = 8A3B5F282407F66700CE4A3A /* ModifyBreadcrumbScenario.swift */; };
+		8A3B5F2B240807EE00CE4A3A /* ModifyBreadcrumbInNotify.swift in Sources */ = {isa = PBXBuildFile; fileRef = 8A3B5F2A240807EE00CE4A3A /* ModifyBreadcrumbInNotify.swift */; };
 		8A42FD35225DEE04007AE561 /* SessionOOMScenario.m in Sources */ = {isa = PBXBuildFile; fileRef = 8A42FD33225DEE04007AE561 /* SessionOOMScenario.m */; };
 		8A530CCC22FDDBF000F0C108 /* ManyConcurrentNotifyScenario.m in Sources */ = {isa = PBXBuildFile; fileRef = 8A530CCB22FDDBF000F0C108 /* ManyConcurrentNotifyScenario.m */; };
 		8A72A0382396574F00328051 /* CustomPluginNotifierDescriptionScenario.m in Sources */ = {isa = PBXBuildFile; fileRef = 8A72A0372396574F00328051 /* CustomPluginNotifierDescriptionScenario.m */; };
@@ -82,6 +84,8 @@
 		8A22FC65225B598500CA8895 /* OOMScenario.m */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.objc; path = OOMScenario.m; sourceTree = "<group>"; };
 		8A32DB8022424E3000EDD92F /* NSExceptionShiftScenario.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = NSExceptionShiftScenario.h; sourceTree = "<group>"; };
 		8A32DB8122424E3000EDD92F /* NSExceptionShiftScenario.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; path = NSExceptionShiftScenario.m; sourceTree = "<group>"; };
+		8A3B5F282407F66700CE4A3A /* ModifyBreadcrumbScenario.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ModifyBreadcrumbScenario.swift; sourceTree = "<group>"; };
+		8A3B5F2A240807EE00CE4A3A /* ModifyBreadcrumbInNotify.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ModifyBreadcrumbInNotify.swift; sourceTree = "<group>"; };
 		8A42FD33225DEE04007AE561 /* SessionOOMScenario.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; path = SessionOOMScenario.m; sourceTree = "<group>"; };
 		8A42FD34225DEE04007AE561 /* SessionOOMScenario.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = SessionOOMScenario.h; sourceTree = "<group>"; };
 		8A530CCA22FDDBF000F0C108 /* ManyConcurrentNotifyScenario.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; path = ManyConcurrentNotifyScenario.h; sourceTree = "<group>"; };
@@ -257,6 +261,8 @@
 				8A14F0F12282D4AD00337B05 /* ReportOOMsDisabledScenario.h */,
 				8A14F0F22282D4AD00337B05 /* ReportOOMsDisabledScenario.m */,
 				8A32DB8022424E3000EDD92F /* NSExceptionShiftScenario.h */,
+				8A3B5F282407F66700CE4A3A /* ModifyBreadcrumbScenario.swift */,
+				8A3B5F2A240807EE00CE4A3A /* ModifyBreadcrumbInNotify.swift */,
 				8A32DB8122424E3000EDD92F /* NSExceptionShiftScenario.m */,
 				8A840FB921AF5C450041DBFA /* SwiftAssertion.swift */,
 				F42957FA1A3724BFBDC22E14 /* NSExceptionScenario.swift */,
@@ -461,6 +467,7 @@
 				F429561C9CFE8750B030F369 /* NSExceptionScenario.swift in Sources */,
 				8A98400320FD11BF0023ECD1 /* AutoSessionCustomVersionScenario.m in Sources */,
 				F42955E0916B8851F074D9B3 /* UserEmailScenario.swift in Sources */,
+				8A3B5F292407F66700CE4A3A /* ModifyBreadcrumbScenario.swift in Sources */,
 				8AA05A2F23BE700C00C7AD00 /* ManyConcurrentNotifyNoBackgroundThreads.m in Sources */,
 				F4295968571A4118D6A4606A /* UserEnabledScenario.swift in Sources */,
 				F4295A036B228AF608641699 /* UserDisabledScenario.swift in Sources */,
@@ -483,6 +490,7 @@
 				8A530CCC22FDDBF000F0C108 /* ManyConcurrentNotifyScenario.m in Sources */,
 				F42958881D3F34A76CADE4EC /* SwiftCrash.swift in Sources */,
 				F42955DB6D08642528917FAB /* CxxExceptionScenario.mm in Sources */,
+				8A3B5F2B240807EE00CE4A3A /* ModifyBreadcrumbInNotify.swift in Sources */,
 				8A32DB8222424E3000EDD92F /* NSExceptionShiftScenario.m in Sources */,
 				F42954B7318A02824C65C514 /* ObjCMsgSendScenario.m in Sources */,
 				8A22FC66225B598500CA8895 /* OOMScenario.m in Sources */,

--- a/features/fixtures/ios-swift-cocoapods/iOSTestApp/scenarios/ModifyBreadcrumbInNotify.swift
+++ b/features/fixtures/ios-swift-cocoapods/iOSTestApp/scenarios/ModifyBreadcrumbInNotify.swift
@@ -1,0 +1,23 @@
+import Foundation
+import Bugsnag
+
+class ModifyBreadcrumbInNotify: Scenario {
+
+    override func startBugsnag() {
+        self.config.autoTrackSessions = false;
+        super.startBugsnag()
+    }
+
+    override func run() {
+        Bugsnag.leaveBreadcrumb(withMessage: "Cache cleared")
+        let error = NSError(domain: "HandledErrorScenario", code: 100, userInfo: nil)
+        Bugsnag.notifyError(error) { event in
+            event.breadcrumbs?.forEach({ crumb in
+                if crumb.message == "Cache cleared" {
+                    crumb.message = "Cache locked"
+                }
+            })
+        }
+    }
+
+}

--- a/features/fixtures/ios-swift-cocoapods/iOSTestApp/scenarios/ModifyBreadcrumbScenario.swift
+++ b/features/fixtures/ios-swift-cocoapods/iOSTestApp/scenarios/ModifyBreadcrumbScenario.swift
@@ -1,0 +1,25 @@
+import Foundation
+import Bugsnag
+
+class ModifyBreadcrumbScenario: Scenario {
+
+    override func startBugsnag() {
+        self.config.autoTrackSessions = false;
+        self.config.add { (raw, event) -> Bool in
+            event.breadcrumbs?.forEach({ crumb in
+                if crumb.message == "Cache cleared" {
+                    crumb.message = "Cache locked"
+                }
+            })
+            return true;
+        }
+        super.startBugsnag()
+    }
+
+    override func run() {
+        Bugsnag.leaveBreadcrumb(withMessage: "Cache cleared")
+        let error = NSError(domain: "HandledErrorScenario", code: 100, userInfo: nil)
+        Bugsnag.notifyError(error)
+    }
+
+}


### PR DESCRIPTION
Previously `breadcrumbs` was exposed as an array of dicts, now its an
array of crumb objects

## Goal
Support inspecting and editing breadcrumbs from within callbacks
