### PR TITLE
refactor: Filter breadcrumbs through type selection

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,6 +14,10 @@ Bugsnag Notifiers on other platforms.
 * BugsnagCrashReport is now BugsnagEvent
   [#449](https://github.com/bugsnag/bugsnag-cocoa/pull/449)
 
+* Add a configuration option to filter breadcrumbs by type. Use
+  `config.enabledBreadcrumbTypes` to enable or disable particular types of
+  breadcrumbs from being captured.
+
 * Added a designated initializer to `BugsnagConfiguration` and removed functionality
   from the default convenience `init()` to ensure that `apiKey` has a value set.  The `apiKey`
   must now be a correctly formatted one to be accepted.

--- a/Source/BugsnagBreadcrumb.h
+++ b/Source/BugsnagBreadcrumb.h
@@ -69,6 +69,27 @@ typedef NS_ENUM(NSUInteger, BSGBreadcrumbType) {
     BSGBreadcrumbTypeUser,
 };
 
+/**
+ * Types of breadcrumbs which can be reported
+ */
+typedef NS_OPTIONS(NSUInteger, BSGEnabledBreadcrumbType) {
+    BSGEnabledBreadcrumbTypeNone       = 0,
+    BSGEnabledBreadcrumbTypeState      = 1 << 1,
+    BSGEnabledBreadcrumbTypeUser       = 1 << 2,
+    BSGEnabledBreadcrumbTypeLog        = 1 << 3,
+    BSGEnabledBreadcrumbTypeNavigation = 1 << 4,
+    BSGEnabledBreadcrumbTypeRequest    = 1 << 5,
+    BSGEnabledBreadcrumbTypeProcess    = 1 << 6,
+    BSGEnabledBreadcrumbTypeError      = 1 << 7,
+    BSGEnabledBreadcrumbTypeAll = BSGEnabledBreadcrumbTypeState
+        | BSGEnabledBreadcrumbTypeUser
+        | BSGEnabledBreadcrumbTypeLog
+        | BSGEnabledBreadcrumbTypeNavigation
+        | BSGEnabledBreadcrumbTypeRequest
+        | BSGEnabledBreadcrumbTypeProcess
+        | BSGEnabledBreadcrumbTypeError,
+};
+
 @class BugsnagBreadcrumb;
 
 typedef void (^BSGBreadcrumbConfiguration)(BugsnagBreadcrumb *_Nonnull);
@@ -129,4 +150,8 @@ typedef void (^BSGBreadcrumbConfiguration)(BugsnagBreadcrumb *_Nonnull);
  */
 - (NSArray *_Nullable)arrayValue;
 
+/**
+ * The types of breadcrumbs which will be captured. By default, this is all types.
+ */
+@property BSGEnabledBreadcrumbType enabledBreadcrumbTypes;
 @end

--- a/Source/BugsnagBreadcrumb.m
+++ b/Source/BugsnagBreadcrumb.m
@@ -181,6 +181,7 @@ NSUInteger BreadcrumbsDefaultCapacity = 25;
     if (self = [super init]) {
         _breadcrumbs = [NSMutableArray new];
         _capacity = BreadcrumbsDefaultCapacity;
+        _enabledBreadcrumbTypes = BSGEnabledBreadcrumbTypeAll;
         _readWriteQueue = dispatch_queue_create("com.bugsnag.BreadcrumbRead",
                                                 DISPATCH_QUEUE_SERIAL);
         NSString *cacheDir = [NSSearchPathForDirectoriesInDomains(
@@ -205,7 +206,7 @@ NSUInteger BreadcrumbsDefaultCapacity = 25;
         return;
     }
     BugsnagBreadcrumb *crumb = [BugsnagBreadcrumb breadcrumbWithBlock:block];
-    if (crumb) {
+    if (crumb && [self shouldSaveType:crumb.type]) {
         [self resizeToFitCapacity:self.capacity - 1];
         dispatch_barrier_sync(self.readWriteQueue, ^{
             [self.breadcrumbs addObject:crumb];
@@ -242,6 +243,27 @@ NSUInteger BreadcrumbsDefaultCapacity = 25;
         }
     });
     return [cache isKindOfClass:[NSArray class]] ? cache : nil;
+}
+
+- (BOOL)shouldSaveType:(BSGBreadcrumbType)type {
+    switch (type) {
+        case BSGBreadcrumbTypeManual:
+            return YES;
+        case BSGBreadcrumbTypeError:
+            return self.enabledBreadcrumbTypes & BSGEnabledBreadcrumbTypeError;
+        case BSGBreadcrumbTypeLog:
+            return self.enabledBreadcrumbTypes & BSGEnabledBreadcrumbTypeLog;
+        case BSGBreadcrumbTypeNavigation:
+            return self.enabledBreadcrumbTypes & BSGEnabledBreadcrumbTypeNavigation;
+        case BSGBreadcrumbTypeProcess:
+            return self.enabledBreadcrumbTypes & BSGEnabledBreadcrumbTypeProcess;
+        case BSGBreadcrumbTypeRequest:
+            return self.enabledBreadcrumbTypes & BSGEnabledBreadcrumbTypeRequest;
+        case BSGBreadcrumbTypeState:
+            return self.enabledBreadcrumbTypes & BSGEnabledBreadcrumbTypeState;
+        case BSGBreadcrumbTypeUser:
+            return self.enabledBreadcrumbTypes & BSGEnabledBreadcrumbTypeUser;
+    }
 }
 
 @synthesize capacity = _capacity;

--- a/Source/BugsnagConfiguration.h
+++ b/Source/BugsnagConfiguration.h
@@ -133,11 +133,6 @@ typedef NSDictionary *_Nullable (^BugsnagBeforeNotifyHook)(
 BugsnagBreadcrumbs *breadcrumbs;
 
 /**
- *  Whether to allow collection of automatic breadcrumbs for notable events
- */
-@property(readwrite) BOOL automaticallyCollectBreadcrumbs;
-
-/**
  *  Hooks for modifying crash reports before it is sent to Bugsnag
  */
 @property(readonly, strong, nullable)
@@ -179,6 +174,11 @@ NSArray<BugsnagOnSessionBlock> *onSessionBlocks;
  */
 @property BOOL reportBackgroundOOMs
     __deprecated_msg("This detection option is unreliable and should no longer be used.");
+
+/**
+ * The types of breadcrumbs which will be captured. By default, this is all types.
+ */
+@property BSGEnabledBreadcrumbType enabledBreadcrumbTypes;
 
 /**
  * Retrieves the endpoint used to notify Bugsnag of errors

--- a/Source/BugsnagConfiguration.m
+++ b/Source/BugsnagConfiguration.m
@@ -104,7 +104,6 @@ NSString * const BSGConfigurationErrorDomain = @"com.Bugsnag.CocoaNotifier.Confi
     _onSessionBlocks = [NSMutableArray new];
     _notifyReleaseStages = nil;
     _breadcrumbs = [BugsnagBreadcrumbs new];
-    _automaticallyCollectBreadcrumbs = YES;
     _autoTrackSessions = YES;
 
     #if !DEBUG
@@ -228,23 +227,12 @@ NSString * const BSGConfigurationErrorDomain = @"com.Bugsnag.CocoaNotifier.Confi
     return self.autoTrackSessions;
 }
 
-@synthesize automaticallyCollectBreadcrumbs = _automaticallyCollectBreadcrumbs;
-
-- (BOOL)automaticallyCollectBreadcrumbs {
-    @synchronized (self) {
-        return _automaticallyCollectBreadcrumbs;
-    }
+- (BSGEnabledBreadcrumbType)enabledBreadcrumbTypes {
+    return self.breadcrumbs.enabledBreadcrumbTypes;
 }
 
-- (void)setAutomaticallyCollectBreadcrumbs:
-    (BOOL)automaticallyCollectBreadcrumbs {
-    @synchronized (self) {
-        if (automaticallyCollectBreadcrumbs == _automaticallyCollectBreadcrumbs)
-            return;
-
-        _automaticallyCollectBreadcrumbs = automaticallyCollectBreadcrumbs;
-        [[Bugsnag notifier] updateAutomaticBreadcrumbDetectionSettings];
-    }
+- (void)setEnabledBreadcrumbTypes:(BSGEnabledBreadcrumbType)enabledBreadcrumbTypes {
+    self.breadcrumbs.enabledBreadcrumbTypes = enabledBreadcrumbTypes;
 }
 
 @synthesize context = _context;

--- a/Source/BugsnagNotifier.h
+++ b/Source/BugsnagNotifier.h
@@ -116,11 +116,6 @@
 - (void)crumbleNotification:(NSString *_Nonnull)notificationName;
 
 /**
- *  Enable or disable automatic breadcrumb collection based on configuration
- */
-- (void)updateAutomaticBreadcrumbDetectionSettings;
-
-/**
  * Enable or disable crash reporting based on configuration state
  */
 - (void)updateCrashDetectionSettings;

--- a/Tests/BugsnagBreadcrumbsTest.m
+++ b/Tests/BugsnagBreadcrumbsTest.m
@@ -155,4 +155,76 @@ void awaitBreadcrumbSync(BugsnagBreadcrumbs *crumbs) {
     XCTAssertNotNil(value[3][@"timestamp"]);
 }
 
+- (void)testDefaultDiscardByType {
+    [self.crumbs clearBreadcrumbs];
+    awaitBreadcrumbSync(self.crumbs);
+    [self.crumbs addBreadcrumbWithBlock:^(BugsnagBreadcrumb *_Nonnull crumb) {
+        crumb.type = BSGBreadcrumbTypeState;
+        crumb.message = @"state";
+    }];
+    [self.crumbs addBreadcrumbWithBlock:^(BugsnagBreadcrumb *_Nonnull crumb) {
+        crumb.type = BSGBreadcrumbTypeUser;
+        crumb.message = @"user";
+    }];
+    [self.crumbs addBreadcrumbWithBlock:^(BugsnagBreadcrumb *_Nonnull crumb) {
+        crumb.type = BSGBreadcrumbTypeLog;
+        crumb.message = @"log";
+    }];
+    [self.crumbs addBreadcrumbWithBlock:^(BugsnagBreadcrumb *_Nonnull crumb) {
+        crumb.type = BSGBreadcrumbTypeError;
+        crumb.message = @"error";
+    }];
+    [self.crumbs addBreadcrumbWithBlock:^(BugsnagBreadcrumb *_Nonnull crumb) {
+        crumb.type = BSGBreadcrumbTypeProcess;
+        crumb.message = @"process";
+    }];
+    [self.crumbs addBreadcrumbWithBlock:^(BugsnagBreadcrumb *_Nonnull crumb) {
+        crumb.type = BSGBreadcrumbTypeRequest;
+        crumb.message = @"request";
+    }];
+    [self.crumbs addBreadcrumbWithBlock:^(BugsnagBreadcrumb *_Nonnull crumb) {
+        crumb.type = BSGBreadcrumbTypeNavigation;
+        crumb.message = @"navigation";
+    }];
+    [self.crumbs addBreadcrumbWithBlock:^(BugsnagBreadcrumb *_Nonnull crumb) {
+        crumb.message = @"manual";
+    }];
+    awaitBreadcrumbSync(self.crumbs);
+    NSArray *value = [self.crumbs arrayValue];
+    XCTAssertEqual(8, value.count);
+    XCTAssertEqualObjects(value[0][@"type"], @"state");
+    XCTAssertEqualObjects(value[1][@"type"], @"user");
+    XCTAssertEqualObjects(value[2][@"type"], @"log");
+    XCTAssertEqualObjects(value[3][@"type"], @"error");
+    XCTAssertEqualObjects(value[4][@"type"], @"process");
+    XCTAssertEqualObjects(value[5][@"type"], @"request");
+    XCTAssertEqualObjects(value[6][@"type"], @"navigation");
+    XCTAssertEqualObjects(value[7][@"type"], @"manual");
+}
+
+- (void)testAlwaysAllowManual {
+    [self.crumbs clearBreadcrumbs];
+    awaitBreadcrumbSync(self.crumbs);
+    self.crumbs.enabledBreadcrumbTypes = 0;
+    [self.crumbs addBreadcrumb:@"this is a test"];
+    awaitBreadcrumbSync(self.crumbs);
+    NSArray *value = [self.crumbs arrayValue];
+    XCTAssertEqual(1, value.count);
+    XCTAssertEqualObjects(value[0][@"type"], @"manual");
+    XCTAssertEqualObjects(value[0][@"message"], @"this is a test");
+}
+
+- (void)testDiscardByType {
+    [self.crumbs clearBreadcrumbs];
+    awaitBreadcrumbSync(self.crumbs);
+    self.crumbs.enabledBreadcrumbTypes = BSGEnabledBreadcrumbTypeProcess;
+    [self.crumbs addBreadcrumbWithBlock:^(BugsnagBreadcrumb *_Nonnull crumb) {
+        crumb.type = BSGBreadcrumbTypeState;
+        crumb.message = @"state";
+    }];
+    awaitBreadcrumbSync(self.crumbs);
+    NSArray *value = [self.crumbs arrayValue];
+    XCTAssertEqual(0, value.count);
+}
+
 @end

--- a/UPGRADING.md
+++ b/UPGRADING.md
@@ -45,6 +45,9 @@ Swift:
 - config.add(beforeSession:)
 + config.onSessionBlocks
 + config.add(onSession:)
+
+- config.automaticallyCollectBreadcrumbs
++ config.enabledBreadcrumbTypes
 ```
 
 ### `Bugsnag` class

--- a/features/breadcrumbs.feature
+++ b/features/breadcrumbs.feature
@@ -6,6 +6,12 @@ Feature: Attaching a series of notable events leading up to errors
 Background:
     Given I set environment variable "BUGSNAG_API_KEY" to "a35a2a72bd230ac0aa0f52715bbdc6aa"
 
+    Scenario: Leaving a breadcrumb of a discarded type
+        When I run "DiscardedBreadcrumbTypeScenario"
+        And I wait for a request
+        Then the event breadcrumbs do not contain "Noisy event"
+        And the event breadcrumbs contain "Important event"
+
     Scenario: An app lauches and subsequently sends a manual event using notify()
         And I run "HandledErrorScenario"
         And I wait for a request

--- a/features/fixtures/ios-swift-cocoapods/iOSTestApp.xcodeproj/project.pbxproj
+++ b/features/fixtures/ios-swift-cocoapods/iOSTestApp.xcodeproj/project.pbxproj
@@ -12,6 +12,7 @@
 		8A14F0F72282D4AE00337B05 /* ReportOOMsDisabledReportBackgroundOOMsEnabledScenario.m in Sources */ = {isa = PBXBuildFile; fileRef = 8A14F0F32282D4AE00337B05 /* ReportOOMsDisabledReportBackgroundOOMsEnabledScenario.m */; };
 		8A22FC66225B598500CA8895 /* OOMScenario.m in Sources */ = {isa = PBXBuildFile; fileRef = 8A22FC65225B598500CA8895 /* OOMScenario.m */; };
 		8A32DB8222424E3000EDD92F /* NSExceptionShiftScenario.m in Sources */ = {isa = PBXBuildFile; fileRef = 8A32DB8122424E3000EDD92F /* NSExceptionShiftScenario.m */; };
+		8A38C5D124094D7B00BC4463 /* DiscardedBreadcrumbTypeScenario.swift in Sources */ = {isa = PBXBuildFile; fileRef = 8A38C5D024094D7B00BC4463 /* DiscardedBreadcrumbTypeScenario.swift */; };
 		8A42FD35225DEE04007AE561 /* SessionOOMScenario.m in Sources */ = {isa = PBXBuildFile; fileRef = 8A42FD33225DEE04007AE561 /* SessionOOMScenario.m */; };
 		8A530CCC22FDDBF000F0C108 /* ManyConcurrentNotifyScenario.m in Sources */ = {isa = PBXBuildFile; fileRef = 8A530CCB22FDDBF000F0C108 /* ManyConcurrentNotifyScenario.m */; };
 		8A72A0382396574F00328051 /* CustomPluginNotifierDescriptionScenario.m in Sources */ = {isa = PBXBuildFile; fileRef = 8A72A0372396574F00328051 /* CustomPluginNotifierDescriptionScenario.m */; };
@@ -82,6 +83,7 @@
 		8A22FC65225B598500CA8895 /* OOMScenario.m */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.objc; path = OOMScenario.m; sourceTree = "<group>"; };
 		8A32DB8022424E3000EDD92F /* NSExceptionShiftScenario.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = NSExceptionShiftScenario.h; sourceTree = "<group>"; };
 		8A32DB8122424E3000EDD92F /* NSExceptionShiftScenario.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; path = NSExceptionShiftScenario.m; sourceTree = "<group>"; };
+		8A38C5D024094D7B00BC4463 /* DiscardedBreadcrumbTypeScenario.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = DiscardedBreadcrumbTypeScenario.swift; sourceTree = "<group>"; };
 		8A42FD33225DEE04007AE561 /* SessionOOMScenario.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; path = SessionOOMScenario.m; sourceTree = "<group>"; };
 		8A42FD34225DEE04007AE561 /* SessionOOMScenario.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = SessionOOMScenario.h; sourceTree = "<group>"; };
 		8A530CCA22FDDBF000F0C108 /* ManyConcurrentNotifyScenario.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; path = ManyConcurrentNotifyScenario.h; sourceTree = "<group>"; };
@@ -247,6 +249,7 @@
 				8AA7C2D62327DD3D002255B2 /* ConfigChangesAfterStartScenarios.h */,
 				8AA7C2D52327DD3D002255B2 /* ConfigChangesAfterStartScenarios.m */,
 				8A56EE8022E22ED80066B9DC /* OOMWillTerminateScenario.h */,
+				8A38C5D024094D7B00BC4463 /* DiscardedBreadcrumbTypeScenario.swift */,
 				8A56EE7F22E22ED80066B9DC /* OOMWillTerminateScenario.m */,
 				8A14F0F42282D4AE00337B05 /* ReportBackgroundOOMsEnabledScenario.h */,
 				8A14F0F02282D4AD00337B05 /* ReportBackgroundOOMsEnabledScenario.m */,
@@ -470,6 +473,7 @@
 				8AB1081923301FE600672818 /* ReleaseStageScenarios.swift in Sources */,
 				8AF6FD7A225E3FA00056EF9E /* ResumeSessionOOMScenario.m in Sources */,
 				F429565A951303E2C3136D0D /* UserIdScenario.swift in Sources */,
+				8A38C5D124094D7B00BC4463 /* DiscardedBreadcrumbTypeScenario.swift in Sources */,
 				8AEEBBD020FC9E1D00C60763 /* AutoSessionMixedEventsScenario.m in Sources */,
 				8AF8FCAC22BD1E5400A967CA /* UnhandledInternalNotifyScenario.swift in Sources */,
 				F4295A94DD2D131A594A212C /* HandledErrorScenario.swift in Sources */,

--- a/features/fixtures/ios-swift-cocoapods/iOSTestApp/scenarios/DiscardedBreadcrumbTypeScenario.swift
+++ b/features/fixtures/ios-swift-cocoapods/iOSTestApp/scenarios/DiscardedBreadcrumbTypeScenario.swift
@@ -1,0 +1,24 @@
+import UIKit
+
+class DiscardedBreadcrumbTypeScenario : Scenario {
+
+    override func startBugsnag() {
+        self.config.autoTrackSessions = false;
+        self.config.enabledBreadcrumbTypes = [.error, .process];
+        super.startBugsnag()
+    }
+
+    override func run() {
+        Bugsnag.leaveBreadcrumb { crumb in
+            crumb.type = .log
+            crumb.message = "Noisy event"
+        }
+        Bugsnag.leaveBreadcrumb { crumb in
+            crumb.type = .process
+            crumb.message = "Important event"
+        }
+        Bugsnag.notifyError(MagicError(domain: "com.example",
+                                       code: 43,
+                                       userInfo: [NSLocalizedDescriptionKey: "incoming!"]))
+    }
+}

--- a/features/steps/ios_steps.rb
+++ b/features/steps/ios_steps.rb
@@ -116,6 +116,14 @@ Then("the event breadcrumbs contain {string}") do |string|
   assert_not_nil(match, "No crumb matches the provided message")
 end
 
+Then("the event breadcrumbs do not contain {string}") do |string|
+  crumbs = read_key_path(find_request(0)[:body], "events.0.breadcrumbs")
+  match = crumbs.detect do |crumb|
+    crumb["message"] == string
+  end
+  assert_nil(match, "A breadcrumb was found matching the provided message")
+end
+
 Then("the {string} of stack frame {int} demangles to {string}") do |field, frame_index, expected_value|
   value = read_key_path(find_request(0)[:body], "events.0.exceptions.0.stacktrace.#{frame_index}.#{field}")
   demangled_value = `xcrun swift-demangle -compact '#{value}'`.chomp


### PR DESCRIPTION
## Goal

Allow filtering which breadcrumbs are captured using the breadcrumb `type` field

## Design

* Adds a new config option, `enabledBreadcrumbTypes`. Types can be turned off or on by modifying this property.

```swift
config.enabledBreadcrumbTypes = [.error, .log]
```

```objc
config.enabledBreadcrumbTypes = BSGEnabledBreadcrumbTypeError | BSGEnabledBreadcrumbTypeLog;
```

Subsequent calls to `leaveBreadcrumb` are then ignored or create breadcrumbs based on the type.

## Tests

* Added new unit-level tests for the breadcrumb filtering functions and default values
* Added an integration test for the correct behavior when calling `Bugsnag.leaveBreadcrumb()`