### PR TITLE
(feat)Add callback-free methods to leave breadcrumbs

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -134,6 +134,11 @@ Bugsnag Notifiers on other platforms.
   email, id and name are set on `BugsnagConfiguration` they are stored in the Keychain and
   restored if an application is restarted.  The values are also copied to the configuration metadata.
   [#469](https://github.com/bugsnag/bugsnag-cocoa/pull/469)
+  
+  * Added callback-free methods to leave breadcrumbs: 
+    - `[Bugsnag leaveBreadcrumbWithMessage:andMetadata:]` (Swift: `Bugsnag.leaveBreadcrumb(_, metadata:)`) 
+    - `[Bugsnag leaveBreadcrumbWithMessage:metadata:andType]` (Swift: `Bugsnag.leaveBreadcrumb(_, metadata:, type:)`)
+    [#482](https://github.com/bugsnag/bugsnag-cocoa/pull/482)
 
 ## Bug fixes
 

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -119,4 +119,4 @@ DEPENDENCIES
   xcpretty
 
 BUNDLED WITH
-   1.17.0
+   2.1.4

--- a/Source/Bugsnag.h
+++ b/Source/Bugsnag.h
@@ -162,7 +162,7 @@ static NSString *_Nonnull const BugsnagSeverityInfo = @"info";
  * Leave a "breadcrumb" log message, representing an action that occurred
  * in your app, to aid with debugging.
  *
- * @param message  the log message to leave (max 140 chars)
+ * @param message  the log message to leave
  */
 + (void)leaveBreadcrumbWithMessage:(NSString *_Nonnull)message;
 
@@ -182,6 +182,33 @@ static NSString *_Nonnull const BugsnagSeverityInfo = @"info";
  *  @param notificationName name of the notification to capture
  */
 + (void)leaveBreadcrumbForNotificationName:(NSString *_Nonnull)notificationName;
+
+/**
+ * Leave a "breadcrumb" log message, representing an action that occurred
+ * in your app.
+ *
+ * @param message The log message to leave
+ * @param metadata Additional metadata included with the breadcrumb
+ *
+ * , to aid with debugging, along with additional metadata.
+ */
++ (void)leaveBreadcrumbWithMessage:(NSString *_Nonnull)message
+                       andMetadata:(NSDictionary *_Nullable)metadata
+    NS_SWIFT_NAME(leaveBreadcrumb(_:metadata:));
+
+/**
+ * Leave a "breadcrumb" log message, representing an action that occurred
+ * in your app, to aid with debugging, along with additional metadata and
+ * a type.
+ *
+ * @param message The log message to leave.
+ * @param metadata Additional metadata included with the breadcrumb.
+ * @param type A BSGBreadcrumbTypeValue denoting the type of breadcrumb.
+ */
++ (void)leaveBreadcrumbWithMessage:(NSString *_Nonnull)message
+                          metadata:(NSDictionary *_Nullable)metadata
+                           andType:(BSGBreadcrumbType)type
+    NS_SWIFT_NAME(leaveBreadcrumb(_:metadata:type:));
 
 /**
  * Clear any breadcrumbs that have been left so far.

--- a/Source/Bugsnag.h
+++ b/Source/Bugsnag.h
@@ -185,19 +185,6 @@ static NSString *_Nonnull const BugsnagSeverityInfo = @"info";
 
 /**
  * Leave a "breadcrumb" log message, representing an action that occurred
- * in your app.
- *
- * @param message The log message to leave
- * @param metadata Additional metadata included with the breadcrumb
- *
- * , to aid with debugging, along with additional metadata.
- */
-+ (void)leaveBreadcrumbWithMessage:(NSString *_Nonnull)message
-                       andMetadata:(NSDictionary *_Nullable)metadata
-    NS_SWIFT_NAME(leaveBreadcrumb(_:metadata:));
-
-/**
- * Leave a "breadcrumb" log message, representing an action that occurred
  * in your app, to aid with debugging, along with additional metadata and
  * a type.
  *

--- a/Source/Bugsnag.m
+++ b/Source/Bugsnag.m
@@ -220,6 +220,17 @@ static NSMutableArray <id<BugsnagPlugin>> *registeredPlugins;
     }
 }
 
++ (void)leaveBreadcrumbWithMessage:(NSString *_Nonnull)message
+                       andMetadata:(NSDictionary *_Nullable)metadata
+{
+    if ([self bugsnagStarted]) {
+        [self leaveBreadcrumbWithBlock:^(BugsnagBreadcrumb *_Nonnull crumbs) {
+            crumbs.message = message;
+            crumbs.metadata = metadata;
+        }];
+    }
+}
+
 + (void)leaveBreadcrumbWithBlock:
     (void (^_Nonnull)(BugsnagBreadcrumb *_Nonnull))block {
     if ([self bugsnagStarted]) {
@@ -231,6 +242,19 @@ static NSMutableArray <id<BugsnagPlugin>> *registeredPlugins;
     (NSString *_Nonnull)notificationName {
     if ([self bugsnagStarted]) {
         [self.client crumbleNotification:notificationName];
+    }
+}
+
++ (void)leaveBreadcrumbWithMessage:(NSString *_Nonnull)message
+                          metadata:(NSDictionary *_Nullable)metadata
+                           andType:(BSGBreadcrumbType)type
+{
+    if ([self bugsnagStarted]) {
+        [self leaveBreadcrumbWithBlock:^(BugsnagBreadcrumb *_Nonnull crumbs) {
+            crumbs.message = message;
+            crumbs.metadata = metadata;
+            crumbs.type = type;
+        }];
     }
 }
 

--- a/Source/Bugsnag.m
+++ b/Source/Bugsnag.m
@@ -220,17 +220,6 @@ static NSMutableArray <id<BugsnagPlugin>> *registeredPlugins;
     }
 }
 
-+ (void)leaveBreadcrumbWithMessage:(NSString *_Nonnull)message
-                       andMetadata:(NSDictionary *_Nullable)metadata
-{
-    if ([self bugsnagStarted]) {
-        [self leaveBreadcrumbWithBlock:^(BugsnagBreadcrumb *_Nonnull crumbs) {
-            crumbs.message = message;
-            crumbs.metadata = metadata;
-        }];
-    }
-}
-
 + (void)leaveBreadcrumbWithBlock:
     (void (^_Nonnull)(BugsnagBreadcrumb *_Nonnull))block {
     if ([self bugsnagStarted]) {

--- a/Source/BugsnagBreadcrumb.h
+++ b/Source/BugsnagBreadcrumb.h
@@ -47,8 +47,7 @@ typedef NS_ENUM(NSUInteger, BSGBreadcrumbType) {
      */
     BSGBreadcrumbTypeLog,
     /**
-     *  A navigation action, such as pushing a view controller or dismissing an
-     *  alert
+     *  A navigation action, such as pushing a view controller or dismissing an alert
      */
     BSGBreadcrumbTypeNavigation,
     /**

--- a/Tests/BugsnagBreadcrumbsTest.m
+++ b/Tests/BugsnagBreadcrumbsTest.m
@@ -6,7 +6,10 @@
 //
 //
 
+#import "Bugsnag.h"
+#import "BugsnagClient.h"
 #import "BugsnagBreadcrumb.h"
+#import "BugsnagTestConstants.h"
 #import <XCTest/XCTest.h>
 
 @interface BugsnagBreadcrumbsTest : XCTestCase
@@ -15,6 +18,10 @@
 
 @interface BugsnagBreadcrumbs ()
 @property(nonatomic, readonly, strong) dispatch_queue_t readWriteQueue;
+@end
+
+@interface Bugsnag ()
++ (BugsnagClient *)client;
 @end
 
 void awaitBreadcrumbSync(BugsnagBreadcrumbs *crumbs) {
@@ -280,6 +287,141 @@ BSGBreadcrumbType BSGBreadcrumbTypeFromString(NSString *value);
     XCTAssertEqualObjects(@"cache break", crumb.message);
     XCTAssertEqualObjects(@{@"foo": @"bar"}, crumb.metadata);
     XCTAssertEqual(BSGBreadcrumbTypeLog, crumb.type);
+}
+
+/**
+ * Test that breadcrumb operations with no callback block work as expected.  1 of 3
+ */
+- (void)testCallbackFreeConstructors1 {
+    // Prevent sending events
+    NSError *error;
+    BugsnagConfiguration *configuration = [[BugsnagConfiguration alloc] initWithApiKey:DUMMY_APIKEY_32CHAR_1 error:&error];
+        [configuration addOnSendBlock:^bool(NSDictionary * _Nonnull rawEventData, BugsnagEvent * _Nonnull reports) {
+            return false;
+        }];
+    [Bugsnag startBugsnagWithConfiguration:configuration];
+    
+    NSDictionary *md1 = @{ @"x" : @"y"};
+    NSDictionary *md2 = @{ @"a" : @"b",
+                           @"c" : @42};
+    
+    [Bugsnag leaveBreadcrumbWithMessage:@"test message1" andMetadata:md1];
+    [Bugsnag leaveBreadcrumbWithMessage:@"test message2" andMetadata:md2];
+    
+    NSDictionary *bc0 = [Bugsnag.client.configuration.breadcrumbs arrayValue][0];
+    NSDictionary *bc1 = [Bugsnag.client.configuration.breadcrumbs arrayValue][1];
+    NSDictionary *bc2 = [Bugsnag.client.configuration.breadcrumbs arrayValue][2];
+    XCTAssertEqual(Bugsnag.client.configuration.breadcrumbs.count, 3);
+    
+    XCTAssertEqualObjects(bc0[@"type"], @"state");
+    XCTAssertEqualObjects(bc0[@"message"], @"Bugsnag loaded");
+    XCTAssertEqual([bc0[@"metaData"] count], 0);
+    
+    XCTAssertEqual([bc1[@"metaData"] count], 1);
+    XCTAssertEqualObjects(bc1[@"message"], @"test message1");
+    XCTAssertEqualObjects(bc1[@"metaData"][@"x"], @"y");
+    XCTAssertEqualObjects(bc1[@"type"], @"manual");
+    
+    XCTAssertEqual([bc2[@"metaData"] count], 2);
+    XCTAssertEqualObjects(bc2[@"message"], @"test message2");
+    XCTAssertEqualObjects(bc2[@"metaData"][@"a"], @"b");
+    XCTAssertEqualObjects(bc2[@"metaData"][@"c"], @42);
+    XCTAssertEqualObjects(bc2[@"type"], @"manual");
+}
+
+/**
+ * Test that breadcrumb operations with no callback block work as expected.  2 of 3
+ */
+- (void)testCallbackFreeConstructors2 {
+    // Prevent sending events
+    NSError *error;
+    BugsnagConfiguration *configuration = [[BugsnagConfiguration alloc] initWithApiKey:DUMMY_APIKEY_32CHAR_1 error:&error];
+        [configuration addOnSendBlock:^bool(NSDictionary * _Nonnull rawEventData, BugsnagEvent * _Nonnull reports) {
+            return false;
+        }];
+    [Bugsnag startBugsnagWithConfiguration:configuration];
+
+    NSDictionary *md1 = @{ @"x" : @"y"};
+    NSDictionary *md2 = @{ @"a" : @"b",
+                           @"c" : @42};
+
+    [Bugsnag leaveBreadcrumbWithMessage:@"manual message" metadata:md1 andType:BSGBreadcrumbTypeManual];
+    [Bugsnag leaveBreadcrumbWithMessage:@"log message" metadata:md2 andType:BSGBreadcrumbTypeLog];
+    [Bugsnag leaveBreadcrumbWithMessage:@"navigation message" metadata:md1 andType:BSGBreadcrumbTypeNavigation];
+    [Bugsnag leaveBreadcrumbWithMessage:@"process message" metadata:md2 andType:BSGBreadcrumbTypeProcess];
+    [Bugsnag leaveBreadcrumbWithMessage:@"request message" metadata:md1 andType:BSGBreadcrumbTypeRequest];
+    [Bugsnag leaveBreadcrumbWithMessage:@"state message" metadata:md2 andType:BSGBreadcrumbTypeState];
+    [Bugsnag leaveBreadcrumbWithMessage:@"user message" metadata:md1 andType:BSGBreadcrumbTypeUser];
+
+    NSDictionary *bc0 = [Bugsnag.client.configuration.breadcrumbs arrayValue][0];
+    NSDictionary *bc1 = [Bugsnag.client.configuration.breadcrumbs arrayValue][1];
+    NSDictionary *bc2 = [Bugsnag.client.configuration.breadcrumbs arrayValue][2];
+    NSDictionary *bc3 = [Bugsnag.client.configuration.breadcrumbs arrayValue][3];
+    NSDictionary *bc4 = [Bugsnag.client.configuration.breadcrumbs arrayValue][4];
+    NSDictionary *bc5 = [Bugsnag.client.configuration.breadcrumbs arrayValue][5];
+    NSDictionary *bc6 = [Bugsnag.client.configuration.breadcrumbs arrayValue][6];
+    NSDictionary *bc7 = [Bugsnag.client.configuration.breadcrumbs arrayValue][7];
+
+    XCTAssertEqual(Bugsnag.client.configuration.breadcrumbs.count, 8);
+
+    XCTAssertEqualObjects(bc0[@"type"], @"state");
+    XCTAssertEqualObjects(bc0[@"message"], @"Bugsnag loaded");
+    XCTAssertEqual([bc0[@"metaData"] count], 0);
+
+    XCTAssertEqual([bc1[@"metaData"] count], 1);
+    XCTAssertEqual([bc3[@"metaData"] count], 1);
+    XCTAssertEqual([bc5[@"metaData"] count], 1);
+    XCTAssertEqual([bc7[@"metaData"] count], 1);
+
+    XCTAssertEqual([bc2[@"metaData"] count], 2);
+    XCTAssertEqual([bc4[@"metaData"] count], 2);
+    XCTAssertEqual([bc6[@"metaData"] count], 2);
+    
+    XCTAssertEqualObjects(bc1[@"message"], @"manual message");
+    XCTAssertEqualObjects(bc1[@"type"], @"manual");
+
+    XCTAssertEqualObjects(bc2[@"message"], @"log message");
+    XCTAssertEqualObjects(bc2[@"type"], @"log");
+
+    XCTAssertEqualObjects(bc3[@"message"], @"navigation message");
+    XCTAssertEqualObjects(bc3[@"type"], @"navigation");
+
+    XCTAssertEqualObjects(bc4[@"message"], @"process message");
+    XCTAssertEqualObjects(bc4[@"type"], @"process");
+
+    XCTAssertEqualObjects(bc5[@"message"], @"request message");
+    XCTAssertEqualObjects(bc5[@"type"], @"request");
+
+    XCTAssertEqualObjects(bc6[@"message"], @"state message");
+    XCTAssertEqualObjects(bc6[@"type"], @"state");
+
+    XCTAssertEqualObjects(bc7[@"message"], @"user message");
+    XCTAssertEqualObjects(bc7[@"type"], @"user");
+}
+
+/**
+ * Test that breadcrumb operations with no callback block work as expected.  3 of 3
+ */
+- (void)testCallbackFreeConstructors3 {
+    // Prevent sending events
+    NSError *error;
+    BugsnagConfiguration *configuration = [[BugsnagConfiguration alloc] initWithApiKey:DUMMY_APIKEY_32CHAR_1 error:&error];
+        [configuration addOnSendBlock:^bool(NSDictionary * _Nonnull rawEventData, BugsnagEvent * _Nonnull reports) {
+            return false;
+        }];
+    [Bugsnag startBugsnagWithConfiguration:configuration];
+    
+    [Bugsnag leaveBreadcrumbWithMessage:@"message1" metadata:nil andType:BSGBreadcrumbTypeUser];
+    [Bugsnag leaveBreadcrumbWithMessage:@"message2" andMetadata:nil];
+    
+    NSDictionary *bc1 = [Bugsnag.client.configuration.breadcrumbs arrayValue][1];
+    NSDictionary *bc2 = [Bugsnag.client.configuration.breadcrumbs arrayValue][2];
+
+    XCTAssertEqualObjects(bc1[@"message"], @"message1");
+    XCTAssertEqualObjects(bc2[@"message"], @"message2");
+    
+    XCTAssertEqual([bc1[@"metaData"] count], 0);
+    XCTAssertEqual([bc2[@"metaData"] count], 0);
 }
 
 @end

--- a/Tests/BugsnagBreadcrumbsTest.m
+++ b/Tests/BugsnagBreadcrumbsTest.m
@@ -290,47 +290,7 @@ BSGBreadcrumbType BSGBreadcrumbTypeFromString(NSString *value);
 }
 
 /**
- * Test that breadcrumb operations with no callback block work as expected.  1 of 3
- */
-- (void)testCallbackFreeConstructors1 {
-    // Prevent sending events
-    NSError *error;
-    BugsnagConfiguration *configuration = [[BugsnagConfiguration alloc] initWithApiKey:DUMMY_APIKEY_32CHAR_1 error:&error];
-        [configuration addOnSendBlock:^bool(NSDictionary * _Nonnull rawEventData, BugsnagEvent * _Nonnull reports) {
-            return false;
-        }];
-    [Bugsnag startBugsnagWithConfiguration:configuration];
-    
-    NSDictionary *md1 = @{ @"x" : @"y"};
-    NSDictionary *md2 = @{ @"a" : @"b",
-                           @"c" : @42};
-    
-    [Bugsnag leaveBreadcrumbWithMessage:@"test message1" andMetadata:md1];
-    [Bugsnag leaveBreadcrumbWithMessage:@"test message2" andMetadata:md2];
-    
-    NSDictionary *bc0 = [Bugsnag.client.configuration.breadcrumbs arrayValue][0];
-    NSDictionary *bc1 = [Bugsnag.client.configuration.breadcrumbs arrayValue][1];
-    NSDictionary *bc2 = [Bugsnag.client.configuration.breadcrumbs arrayValue][2];
-    XCTAssertEqual(Bugsnag.client.configuration.breadcrumbs.count, 3);
-    
-    XCTAssertEqualObjects(bc0[@"type"], @"state");
-    XCTAssertEqualObjects(bc0[@"message"], @"Bugsnag loaded");
-    XCTAssertEqual([bc0[@"metaData"] count], 0);
-    
-    XCTAssertEqual([bc1[@"metaData"] count], 1);
-    XCTAssertEqualObjects(bc1[@"message"], @"test message1");
-    XCTAssertEqualObjects(bc1[@"metaData"][@"x"], @"y");
-    XCTAssertEqualObjects(bc1[@"type"], @"manual");
-    
-    XCTAssertEqual([bc2[@"metaData"] count], 2);
-    XCTAssertEqualObjects(bc2[@"message"], @"test message2");
-    XCTAssertEqualObjects(bc2[@"metaData"][@"a"], @"b");
-    XCTAssertEqualObjects(bc2[@"metaData"][@"c"], @42);
-    XCTAssertEqualObjects(bc2[@"type"], @"manual");
-}
-
-/**
- * Test that breadcrumb operations with no callback block work as expected.  2 of 3
+ * Test that breadcrumb operations with no callback block work as expected.  1 of 2
  */
 - (void)testCallbackFreeConstructors2 {
     // Prevent sending events
@@ -400,7 +360,7 @@ BSGBreadcrumbType BSGBreadcrumbTypeFromString(NSString *value);
 }
 
 /**
- * Test that breadcrumb operations with no callback block work as expected.  3 of 3
+ * Test that breadcrumb operations with no callback block work as expected.  2 of 2
  */
 - (void)testCallbackFreeConstructors3 {
     // Prevent sending events
@@ -410,9 +370,9 @@ BSGBreadcrumbType BSGBreadcrumbTypeFromString(NSString *value);
             return false;
         }];
     [Bugsnag startBugsnagWithConfiguration:configuration];
-    
-    [Bugsnag leaveBreadcrumbWithMessage:@"message1" metadata:nil andType:BSGBreadcrumbTypeUser];
-    [Bugsnag leaveBreadcrumbWithMessage:@"message2" andMetadata:nil];
+
+    [Bugsnag leaveBreadcrumbWithMessage:@"message1"];
+    [Bugsnag leaveBreadcrumbWithMessage:@"message2" metadata:nil andType:BSGBreadcrumbTypeUser];
     
     NSDictionary *bc1 = [Bugsnag.client.configuration.breadcrumbs arrayValue][1];
     NSDictionary *bc2 = [Bugsnag.client.configuration.breadcrumbs arrayValue][2];

--- a/features/breadcrumbs.feature
+++ b/features/breadcrumbs.feature
@@ -17,7 +17,7 @@ Background:
         And I wait for a request
         Then the event breadcrumbs contain "Bugsnag loaded" with type "state"
 
-    Scenario: An app lauches and subsequently crahes
+    Scenario: An app lauches and subsequently crashes
         And I crash the app using "BuiltinTrapScenario"
         And I relaunch the app
         And I wait for a request

--- a/features/fixtures/ios-swift-cocoapods/iOSTestApp/scenarios/EnabledErrorTypesScenario.m
+++ b/features/fixtures/ios-swift-cocoapods/iOSTestApp/scenarios/EnabledErrorTypesScenario.m
@@ -36,6 +36,11 @@
 
 // MARK: -
 
+
+/**
+ * Disable all crash reporting (except, implicitly, manual), send a manual report 
+ * and crash the app (one session request with 2 sessions and 1 report should be sent)
+ */
 @implementation DisableAllExceptManualExceptionsSendManualAndCrashScenario
 
 - (void)startBugsnag {

--- a/iOS/BugsnagTests/Swift Tests/BugsnagSwiftTests.swift
+++ b/iOS/BugsnagTests/Swift Tests/BugsnagSwiftTests.swift
@@ -47,7 +47,6 @@ class BugsnagSwiftTests: XCTestCase {
      * Confirm that the callback-free methods for leaving metadata are exposed to Swift correctly
      */
     func testCallbackFreeMetadataMethods() {
-        Bugsnag.leaveBreadcrumb("test1", metadata: nil)
-        Bugsnag.leaveBreadcrumb("test2", metadata: nil, type: .user)
+        Bugsnag.leaveBreadcrumb("test2", metadata: nil, type: .manual)
     }
 }

--- a/iOS/BugsnagTests/Swift Tests/BugsnagSwiftTests.swift
+++ b/iOS/BugsnagTests/Swift Tests/BugsnagSwiftTests.swift
@@ -42,4 +42,12 @@ class BugsnagSwiftTests: XCTestCase {
         // We don't need to check method's functioning, only that we can call it this way
         Bugsnag.clearMetadata(section: "testSection")
    }
+    
+    /**
+     * Confirm that the callback-free methods for leaving metadata are exposed to Swift correctly
+     */
+    func testCallbackFreeMetadataMethods() {
+        Bugsnag.leaveBreadcrumb("test1", metadata: nil)
+        Bugsnag.leaveBreadcrumb("test2", metadata: nil, type: .user)
+    }
 }


### PR DESCRIPTION
## Goal

Add additional methods to leave complex breadcrumbs without requiring a callback to be provided.

<!-- What is the intent of this change? -->

<!--
Fixes #
Related to #
-->

## Design

Two top-level `Bugsnag` methods largely following the "if started..." pattern established previously.

<!-- How does this change work? Why was this approach to the goal used? -->

## Changeset

Primarily the `Bugsnag` class and header, along with unit tests in ObjC anbd Swift.  Several other minor typographical changes are included but can be ignored.

<!-- List what was added, removed, or changed.  Pitch this at a level 
     appropriate to the scope of the change: new  classes, changed architecture,
     minor typo, etc.  If appropriate include a list of changed files: 

         $ git diff --name-status HEAD~1 | cat
-->

## Tests

It was only required to check whether breadcrumbs were set correctly and so unit testing sufficed.  A simple test for Swift exposure was also included.

<!-- How was this change tested? What manual and automated tests were
     run/added? -->

## Review

### Outstanding Questions

<!-- Are there any parts of the design or the implementation which seem
     less than ideal and that could require additional discussion?
     List here: -->

<!-- Preflight checks. Have I:

* Added a changelog entry?
* Checked the scope to ensure the commits are only related to the goal above?

-->

- This pull request is ready for:
  - [ ] Initial review of the intended approach, not yet feature complete
  - [ ] Structural review of the classes, functions, and properties modified
  - [X] Final review

<!-- What do you need from a reviewer to get this changeset
     ready for release -->

- [ ] The correct target branch has been selected (`master` for fixes, `next` for
  features)
- [ ] Consistency across platforms for structures or concepts added or modified
- [X] Consistency between the changeset and the goal stated above
- [X] Internal consistency with the rest of the library - is there any overlap between existing interfaces and any which have been added?
- [ ] Usage friction - is the proposed change in usage cumbersome or complicated?
- [ ] Performance and complexity - are there any cases of unexpected O(n^3) when iterating, recursing, flat mapping, etc?
- [ ] Concurrency concerns - if components are accessed asynchronously, what issues will arise
- [X] Thoroughness of added tests and any missing edge cases
- [ ] Idiomatic use of the language
