### PR TITLE
Implement new plugin interface

### DIFF
--- a/OSX/Bugsnag.xcodeproj/project.pbxproj
+++ b/OSX/Bugsnag.xcodeproj/project.pbxproj
@@ -52,6 +52,8 @@
 		8AD9FA891E086351002859A7 /* BugsnagConfigurationTests.m in Sources */ = {isa = PBXBuildFile; fileRef = 8AD9FA851E0862DC002859A7 /* BugsnagConfigurationTests.m */; };
 		E72352C11F55924A00436528 /* BSGConnectivity.h in Headers */ = {isa = PBXBuildFile; fileRef = E72352BF1F55924A00436528 /* BSGConnectivity.h */; };
 		E72352C21F55924A00436528 /* BSGConnectivity.m in Sources */ = {isa = PBXBuildFile; fileRef = E72352C01F55924A00436528 /* BSGConnectivity.m */; };
+		E72AE1F9241A4E7500ED8972 /* BugsnagPluginClient.m in Sources */ = {isa = PBXBuildFile; fileRef = E72AE1F7241A4E7500ED8972 /* BugsnagPluginClient.m */; };
+		E72AE1FA241A4E7500ED8972 /* BugsnagPluginClient.h in Headers */ = {isa = PBXBuildFile; fileRef = E72AE1F8241A4E7500ED8972 /* BugsnagPluginClient.h */; };
 		E7433AD21F4F64EF00C082D1 /* libz.tbd in Frameworks */ = {isa = PBXBuildFile; fileRef = 8A2C8FF11C6BC3A800846019 /* libz.tbd */; };
 		E7433AD31F4F64F400C082D1 /* libc++.tbd in Frameworks */ = {isa = PBXBuildFile; fileRef = 8A2C8FF31C6BC3AE00846019 /* libc++.tbd */; };
 		E762E9F91F73F7F300E82B43 /* BugsnagHandledStateTest.m in Sources */ = {isa = PBXBuildFile; fileRef = E762E9F71F73F7E900E82B43 /* BugsnagHandledStateTest.m */; };
@@ -245,6 +247,8 @@
 		8AD9FA851E0862DC002859A7 /* BugsnagConfigurationTests.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; name = BugsnagConfigurationTests.m; path = ../Tests/BugsnagConfigurationTests.m; sourceTree = SOURCE_ROOT; };
 		E72352BF1F55924A00436528 /* BSGConnectivity.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; name = BSGConnectivity.h; path = ../Source/BSGConnectivity.h; sourceTree = SOURCE_ROOT; };
 		E72352C01F55924A00436528 /* BSGConnectivity.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; name = BSGConnectivity.m; path = ../Source/BSGConnectivity.m; sourceTree = SOURCE_ROOT; };
+		E72AE1F7241A4E7500ED8972 /* BugsnagPluginClient.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; name = BugsnagPluginClient.m; path = ../Source/BugsnagPluginClient.m; sourceTree = "<group>"; };
+		E72AE1F8241A4E7500ED8972 /* BugsnagPluginClient.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; name = BugsnagPluginClient.h; path = ../Source/BugsnagPluginClient.h; sourceTree = "<group>"; };
 		E762E9F71F73F7E900E82B43 /* BugsnagHandledStateTest.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; name = BugsnagHandledStateTest.m; path = ../Tests/BugsnagHandledStateTest.m; sourceTree = SOURCE_ROOT; };
 		E762E9FA1F73F80200E82B43 /* BugsnagHandledState.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; name = BugsnagHandledState.h; path = ../Source/BugsnagHandledState.h; sourceTree = SOURCE_ROOT; };
 		E762E9FB1F73F80200E82B43 /* BugsnagHandledState.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; name = BugsnagHandledState.m; path = ../Source/BugsnagHandledState.m; sourceTree = SOURCE_ROOT; };
@@ -430,6 +434,8 @@
 		8A2C8FA31C6BC1F700846019 /* Bugsnag */ = {
 			isa = PBXGroup;
 			children = (
+				E72AE1F8241A4E7500ED8972 /* BugsnagPluginClient.h */,
+				E72AE1F7241A4E7500ED8972 /* BugsnagPluginClient.m */,
 				00D7AC9B23E97F8100FBE4A7 /* BugsnagEvent.h */,
 				00D7AC9A23E97F8100FBE4A7 /* BugsnagEvent.m */,
 				8A3C591123968B3600B344AA /* BugsnagPlugin.h */,
@@ -763,6 +769,7 @@
 				8A2C8FCF1C6BC2C800846019 /* BugsnagBreadcrumb.h in Headers */,
 				E79148511FD82B36003EFEBF /* BugsnagApiClient.h in Headers */,
 				E79E6BDB1F4E3850002B35F9 /* BSG_KSCrashReportFilter.h in Headers */,
+				E72AE1FA241A4E7500ED8972 /* BugsnagPluginClient.h in Headers */,
 				0089B6EC2411682000D5A7F2 /* BugsnagClient.h in Headers */,
 				E79E6BA11F4E3850002B35F9 /* BSG_KSCrashSentry_CPPException.h in Headers */,
 				E79E6B041F4E3847002B35F9 /* BugsnagErrorReportApiClient.h in Headers */,
@@ -901,6 +908,7 @@
 				E79E6B8F1F4E3850002B35F9 /* BSG_KSCrashDoctor.m in Sources */,
 				E791484E1FD82B36003EFEBF /* BugsnagKSCrashSysInfoParser.m in Sources */,
 				E791484F1FD82B36003EFEBF /* BugsnagSessionTrackingPayload.m in Sources */,
+				E72AE1F9241A4E7500ED8972 /* BugsnagPluginClient.m in Sources */,
 				E79E6B971F4E3850002B35F9 /* BSG_KSCrashState.m in Sources */,
 				8A6C6FB12257884C00E8EF24 /* BSGOutOfMemoryWatchdog.m in Sources */,
 				E79E6BB31F4E3850002B35F9 /* BSG_KSCrashCallCompletion.m in Sources */,

--- a/Source/Bugsnag.m
+++ b/Source/Bugsnag.m
@@ -32,12 +32,10 @@
 #import "BugsnagPlugin.h"
 
 static BugsnagClient *bsg_g_bugsnag_client = NULL;
-static NSMutableArray <id<BugsnagPlugin>> *registeredPlugins;
 
 @interface Bugsnag ()
 + (BugsnagClient *)client;
 + (BOOL)bugsnagStarted;
-+ (void)registerPlugin:(id<BugsnagPlugin>)plugin;
 @end
 
 @interface NSDictionary (BSGKSMerge)
@@ -56,7 +54,6 @@ static NSMutableArray <id<BugsnagPlugin>> *registeredPlugins;
     @synchronized(self) {
         bsg_g_bugsnag_client =
                 [[BugsnagClient alloc] initWithConfiguration:configuration];
-        [self startPlugins];
         [bsg_g_bugsnag_client start];
     }
 }
@@ -74,21 +71,6 @@ static NSMutableArray <id<BugsnagPlugin>> *registeredPlugins;
 
 + (BugsnagClient *)client {
     return bsg_g_bugsnag_client;
-}
-
-+ (void)registerPlugin:(id<BugsnagPlugin>)plugin {
-    static dispatch_once_t onceToken;
-    dispatch_once(&onceToken, ^{
-        registeredPlugins = [NSMutableArray new];
-    });
-    [registeredPlugins addObject:plugin];
-}
-
-+ (void)startPlugins {
-    for (id<BugsnagPlugin> plugin in registeredPlugins) {
-        if (![plugin isStarted])
-            [plugin start];
-    }
 }
 
 + (BOOL)appDidCrashLastLaunch {

--- a/Source/BugsnagClient.m
+++ b/Source/BugsnagClient.m
@@ -275,7 +275,7 @@ void BSGWriteSessionCrashData(BugsnagSession *session) {
         [self metadataChanged:self.configuration.metadata];
         [self metadataChanged:self.configuration.config];
         [self metadataChanged:self.state];
-        _pluginClient = [[BugsnagPluginClient alloc] initWithPlugins:self.configuration.plugins];
+        self.pluginClient = [[BugsnagPluginClient alloc] initWithPlugins:self.configuration.plugins];
     }
     return self;
 }

--- a/Source/BugsnagClient.m
+++ b/Source/BugsnagClient.m
@@ -349,7 +349,6 @@ NSString *const BSGBreadcrumbLoadedMessage = @"Bugsnag loaded";
 }
 
 - (void)start {
-    [self.pluginClient loadPlugins];
     [self.crashSentry install:self.configuration
                     apiClient:self.errorReportApiClient
                       onCrash:&BSSerializeDataCrashHandler];
@@ -431,6 +430,7 @@ NSString *const BSGBreadcrumbLoadedMessage = @"Bugsnag loaded";
 
     // notification not received in time on initial startup, so trigger manually
     [self willEnterForeground:self];
+    [self.pluginClient loadPlugins];
 }
 
 - (void)addTerminationObserver:(NSString *)name {

--- a/Source/BugsnagConfiguration.h
+++ b/Source/BugsnagConfiguration.h
@@ -30,6 +30,7 @@
 #import "BugsnagBreadcrumb.h"
 #import "BugsnagEvent.h"
 #import "BugsnagMetadata.h"
+#import "BugsnagPlugin.h"
 
 @class BugsnagBreadcrumbs;
 @class BugsnagUser;
@@ -322,5 +323,7 @@ NSArray<BugsnagOnSessionBlock> *onSessionBlocks;
 
 - (NSDictionary *_Nonnull)errorApiHeaders;
 - (NSDictionary *_Nonnull)sessionApiHeaders;
+
+- (void)addPlugin:(id<BugsnagPlugin> _Nonnull)plugin;
 
 @end

--- a/Source/BugsnagConfiguration.m
+++ b/Source/BugsnagConfiguration.m
@@ -59,6 +59,7 @@ NSString * const kBugsnagUserUserId = @"BugsnagUserUserId";
 @interface BugsnagConfiguration ()
 @property(nonatomic, readwrite, strong) NSMutableArray *onSendBlocks;
 @property(nonatomic, readwrite, strong) NSMutableArray *onSessionBlocks;
+@property(nonatomic, readwrite, strong) NSMutableSet *plugins;
 @end
 
 @implementation BugsnagConfiguration
@@ -116,6 +117,7 @@ NSString * const kBugsnagUserUserId = @"BugsnagUserUserId";
     _notifyURL = [NSURL URLWithString:BSGDefaultNotifyUrl];
     _onSendBlocks = [NSMutableArray new];
     _onSessionBlocks = [NSMutableArray new];
+    _plugins = [NSMutableSet new];
     _notifyReleaseStages = nil;
     _breadcrumbs = [BugsnagBreadcrumbs new];
     _autoTrackSessions = YES;
@@ -479,6 +481,10 @@ NSString * const kBugsnagUserUserId = @"BugsnagUserUserId";
     } else {
         @throw BSGApiKeyError;
     }
+}
+
+- (void)addPlugin:(id<BugsnagPlugin> _Nonnull)plugin {
+    [_plugins addObject:plugin];
 }
 
 @end

--- a/Source/BugsnagPlugin.h
+++ b/Source/BugsnagPlugin.h
@@ -10,7 +10,15 @@
 
 @required
 
+/**
+ * Loads a plugin with the given Client. When this method is invoked the plugin should
+ * activate its behaviour - for example, by capturing an additional source of errors.
+*/
 - (void)load;
+/**
+ * Unloads a plugin. When this is invoked the plugin should cease all custom behaviour and
+ * restore the application to its unloaded state.
+ */
 - (void)unload;
 
 @end

--- a/Source/BugsnagPlugin.h
+++ b/Source/BugsnagPlugin.h
@@ -1,6 +1,8 @@
 #ifndef BugsnagPlugin_h
 #define BugsnagPlugin_h
 
+@class Bugsnag;
+
 /**
  * Internal interface for adding custom behavior
  */
@@ -8,9 +10,8 @@
 
 @required
 
-- (BOOL)isStarted;
-
-- (void)start;
+- (void)load;
+- (void)unload;
 
 @end
 

--- a/Source/BugsnagPluginClient.h
+++ b/Source/BugsnagPluginClient.h
@@ -1,0 +1,22 @@
+//
+//  BugsnagPluginClient.h
+//  Bugsnag
+//
+//  Created by Jamie Lynch on 12/03/2020.
+//  Copyright © 2020 Bugsnag. All rights reserved.
+//
+
+#import <Foundation/Foundation.h>
+
+#import "BugsnagPlugin.h"
+
+NS_ASSUME_NONNULL_BEGIN
+
+@interface BugsnagPluginClient : NSObject
+
+- (instancetype _Nonnull)initWithPlugins:(NSMutableSet<id<BugsnagPlugin>> *_Nonnull)plugins;
+- (void)loadPlugins;
+
+@end
+
+NS_ASSUME_NONNULL_END

--- a/Source/BugsnagPluginClient.m
+++ b/Source/BugsnagPluginClient.m
@@ -1,0 +1,31 @@
+//
+//  BugsnagPluginClient.m
+//  Bugsnag
+//
+//  Created by Jamie Lynch on 12/03/2020.
+//  Copyright © 2020 Bugsnag. All rights reserved.
+//
+
+#import "BugsnagPluginClient.h"
+#import "BugsnagPlugin.h"
+
+@interface BugsnagPluginClient ()
+@property NSSet<id<BugsnagPlugin>> *plugins;
+@end
+
+@implementation BugsnagPluginClient
+
+- (instancetype _Nonnull)initWithPlugins:(NSMutableSet<id<BugsnagPlugin>> *_Nonnull)plugins {
+    if (self = [super init]) {
+        _plugins = [NSSet setWithSet:plugins];
+    }
+    return self;
+}
+
+- (void)loadPlugins {
+    for (id<BugsnagPlugin> plugin in self.plugins) {
+        [plugin load];
+    }
+}
+
+@end

--- a/Source/BugsnagPluginClient.m
+++ b/Source/BugsnagPluginClient.m
@@ -8,6 +8,7 @@
 
 #import "BugsnagPluginClient.h"
 #import "BugsnagPlugin.h"
+#import "BugsnagLogger.h"
 
 @interface BugsnagPluginClient ()
 @property NSSet<id<BugsnagPlugin>> *plugins;
@@ -24,7 +25,11 @@
 
 - (void)loadPlugins {
     for (id<BugsnagPlugin> plugin in self.plugins) {
-        [plugin load];
+        @try {
+            [plugin load];
+        } @catch (NSException *exception) {
+            bsg_log_err(@"Failed to load plugin %@, continuing with initialisation.", plugin);
+        }
     }
 }
 

--- a/Tests/BugsnagPluginTest.m
+++ b/Tests/BugsnagPluginTest.m
@@ -1,0 +1,49 @@
+//
+//  BugsnagPluginTest.m
+//  Tests
+//
+//  Created by Jamie Lynch on 12/03/2020.
+//  Copyright © 2020 Bugsnag. All rights reserved.
+//
+
+#import <XCTest/XCTest.h>
+
+#import "BugsnagTestConstants.h"
+#import "Bugsnag.h"
+#import "BugsnagConfiguration.h"
+
+@interface BugsnagPluginTest : XCTestCase
+
+@end
+
+@interface BugsnagConfiguration ()
+@property(nonatomic, readwrite, strong) NSMutableSet *plugins;
+@end
+
+@interface FakePlugin: NSObject<BugsnagPlugin>
+@property(nonatomic) BOOL loaded;
+@end
+@implementation FakePlugin
+    - (void)load {
+        self.loaded = true;
+    }
+    - (void)unload {}
+@end
+
+@implementation BugsnagPluginTest
+
+- (void)testAddPlugin {
+    id<BugsnagPlugin> plugin = [FakePlugin new];
+    BugsnagConfiguration *config = [[BugsnagConfiguration alloc] initWithApiKey:DUMMY_APIKEY_32CHAR_1 error:nil];
+    [config addPlugin:plugin];
+    XCTAssertEqual([config.plugins anyObject], plugin);
+}
+
+- (void)testPluginLoaded {
+    FakePlugin *plugin = [FakePlugin new];
+    BugsnagConfiguration *config = [[BugsnagConfiguration alloc] initWithApiKey:DUMMY_APIKEY_32CHAR_1 error:nil];
+    [config addPlugin:plugin];
+    [Bugsnag startBugsnagWithConfiguration:config];
+    XCTAssertTrue(plugin.loaded);
+}
+@end

--- a/features/fixtures/ios-swift-cocoapods/iOSTestApp/scenarios/CustomPluginNotifierDescriptionScenario.m
+++ b/features/fixtures/ios-swift-cocoapods/iOSTestApp/scenarios/CustomPluginNotifierDescriptionScenario.m
@@ -3,11 +3,10 @@
 
 @interface Bugsnag()
 + (id)client;
-+ (void)registerPlugin:(id<BugsnagPlugin>)plugin;
 @end
 
 @interface DescriptionPlugin : NSObject<BugsnagPlugin>
-@property (nonatomic, getter=isStarted) BOOL started;
+
 @end
 
 @implementation DescriptionPlugin
@@ -17,7 +16,7 @@
     return self;
 }
 
-- (void)start {
+- (void)load {
     id notifier = [Bugsnag client];
     NSDictionary *newDetails = @{
         @"version": @"2.1.0",
@@ -25,16 +24,15 @@
         @"url": @"https://example.com"
     };
     [notifier setValue:newDetails forKey:@"details"];
-    self.started = YES;
 }
 
-
+- (void)unload {}
 @end
 
 @implementation CustomPluginNotifierDescriptionScenario
 
 - (void)startBugsnag {
-    [Bugsnag registerPlugin:[DescriptionPlugin new]];
+    [self.config addPlugin:[DescriptionPlugin new]];
     self.config.autoTrackSessions = NO;
     [super startBugsnag];
 }

--- a/iOS/Bugsnag.xcodeproj/project.pbxproj
+++ b/iOS/Bugsnag.xcodeproj/project.pbxproj
@@ -154,6 +154,9 @@
 		E72962D71F4BBA8B00CEA15D /* BugsnagCrashSentry.m in Sources */ = {isa = PBXBuildFile; fileRef = E72962D11F4BBA8A00CEA15D /* BugsnagCrashSentry.m */; };
 		E72962D81F4BBA8B00CEA15D /* BugsnagErrorReportApiClient.h in Headers */ = {isa = PBXBuildFile; fileRef = E72962D21F4BBA8B00CEA15D /* BugsnagErrorReportApiClient.h */; };
 		E72962D91F4BBA8B00CEA15D /* BugsnagErrorReportApiClient.m in Sources */ = {isa = PBXBuildFile; fileRef = E72962D31F4BBA8B00CEA15D /* BugsnagErrorReportApiClient.m */; };
+		E72AE1F5241A4E4400ED8972 /* BugsnagPluginClient.h in Headers */ = {isa = PBXBuildFile; fileRef = E72AE1F3241A4E4400ED8972 /* BugsnagPluginClient.h */; };
+		E72AE1F6241A4E4400ED8972 /* BugsnagPluginClient.m in Sources */ = {isa = PBXBuildFile; fileRef = E72AE1F4241A4E4400ED8972 /* BugsnagPluginClient.m */; };
+		E72AE200241A57B100ED8972 /* BugsnagPluginTest.m in Sources */ = {isa = PBXBuildFile; fileRef = E72AE1FF241A57B100ED8972 /* BugsnagPluginTest.m */; };
 		E72BF7751FC867E4004BE82F /* BugsnagSessionTracker.h in Headers */ = {isa = PBXBuildFile; fileRef = E72BF7731FC867E4004BE82F /* BugsnagSessionTracker.h */; };
 		E72BF7761FC867E4004BE82F /* BugsnagSessionTracker.m in Sources */ = {isa = PBXBuildFile; fileRef = E72BF7741FC867E4004BE82F /* BugsnagSessionTracker.m */; };
 		E72BF7771FC867E4004BE82F /* BugsnagSessionTracker.m in Sources */ = {isa = PBXBuildFile; fileRef = E72BF7741FC867E4004BE82F /* BugsnagSessionTracker.m */; };
@@ -577,6 +580,9 @@
 		E72962D11F4BBA8A00CEA15D /* BugsnagCrashSentry.m */ = {isa = PBXFileReference; explicitFileType = sourcecode.c.objc; fileEncoding = 4; name = BugsnagCrashSentry.m; path = ../Source/BugsnagCrashSentry.m; sourceTree = SOURCE_ROOT; };
 		E72962D21F4BBA8B00CEA15D /* BugsnagErrorReportApiClient.h */ = {isa = PBXFileReference; explicitFileType = sourcecode.c.h; fileEncoding = 4; name = BugsnagErrorReportApiClient.h; path = ../Source/BugsnagErrorReportApiClient.h; sourceTree = SOURCE_ROOT; };
 		E72962D31F4BBA8B00CEA15D /* BugsnagErrorReportApiClient.m */ = {isa = PBXFileReference; explicitFileType = sourcecode.c.objc; fileEncoding = 4; name = BugsnagErrorReportApiClient.m; path = ../Source/BugsnagErrorReportApiClient.m; sourceTree = SOURCE_ROOT; };
+		E72AE1F3241A4E4400ED8972 /* BugsnagPluginClient.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; name = BugsnagPluginClient.h; path = ../Source/BugsnagPluginClient.h; sourceTree = "<group>"; };
+		E72AE1F4241A4E4400ED8972 /* BugsnagPluginClient.m */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.objc; name = BugsnagPluginClient.m; path = ../Source/BugsnagPluginClient.m; sourceTree = "<group>"; };
+		E72AE1FF241A57B100ED8972 /* BugsnagPluginTest.m */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.objc; name = BugsnagPluginTest.m; path = ../../Tests/BugsnagPluginTest.m; sourceTree = "<group>"; };
 		E72BF7731FC867E4004BE82F /* BugsnagSessionTracker.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; name = BugsnagSessionTracker.h; path = ../Source/BugsnagSessionTracker.h; sourceTree = "<group>"; };
 		E72BF7741FC867E4004BE82F /* BugsnagSessionTracker.m */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.objc; name = BugsnagSessionTracker.m; path = ../Source/BugsnagSessionTracker.m; sourceTree = "<group>"; };
 		E72BF7781FC869F7004BE82F /* BugsnagSession.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; name = BugsnagSession.h; path = ../Source/BugsnagSession.h; sourceTree = "<group>"; };
@@ -743,6 +749,8 @@
 				8A381D491EAA49A700AF8429 /* BugsnagLogger.h */,
 				8A2C8F491C6BBE3C00846019 /* BugsnagMetadata.h */,
 				8A2C8F4A1C6BBE3C00846019 /* BugsnagMetadata.m */,
+				E72AE1F3241A4E4400ED8972 /* BugsnagPluginClient.h */,
+				E72AE1F4241A4E4400ED8972 /* BugsnagPluginClient.m */,
 				E72BF7781FC869F7004BE82F /* BugsnagSession.h */,
 				E72BF7791FC869F7004BE82F /* BugsnagSession.m */,
 				F42955025DBE1DCEFD928CAA /* BugsnagSessionFileStore.h */,
@@ -803,6 +811,7 @@
 				00D7ACAC23E9C63000FBE4A7 /* BugsnagTests.m */,
 				00F9393723FC4F63008C7073 /* BugsnagTestsDummyClass.h */,
 				00F9393823FC4F64008C7073 /* BugsnagTestsDummyClass.m */,
+				E72AE1FF241A57B100ED8972 /* BugsnagPluginTest.m */,
 			);
 			name = Tests;
 			path = BugsnagTests;
@@ -1038,6 +1047,7 @@
 				E7107C491F4C97F100BB3F98 /* BSG_KSSystemInfoC.h in Headers */,
 				E7107C721F4C97F100BB3F98 /* BSG_KSObjCApple.h in Headers */,
 				E7107C761F4C97F100BB3F98 /* BSG_KSSignalInfo.h in Headers */,
+				E72AE1F5241A4E4400ED8972 /* BugsnagPluginClient.h in Headers */,
 				E7107C511F4C97F100BB3F98 /* BSG_KSCrashSentry_MachException.h in Headers */,
 				8A627CD01EC2A5FD00F7C04E /* BSGSerialization.h in Headers */,
 				E7107C591F4C97F100BB3F98 /* BSG_KSArchSpecific.h in Headers */,
@@ -1228,6 +1238,7 @@
 				8A2C8F5E1C6BBE3C00846019 /* BugsnagClient.m in Sources */,
 				E7107C3A1F4C97F100BB3F98 /* BSG_KSCrashDoctor.m in Sources */,
 				E7107C421F4C97F100BB3F98 /* BSG_KSCrashState.m in Sources */,
+				E72AE1F6241A4E4400ED8972 /* BugsnagPluginClient.m in Sources */,
 				E72BF77B1FC869F7004BE82F /* BugsnagSession.m in Sources */,
 				8A70D9CA22539C81006B696F /* BSGOutOfMemoryWatchdog.m in Sources */,
 				E7107C5E1F4C97F100BB3F98 /* BSG_KSCrashCallCompletion.m in Sources */,
@@ -1291,6 +1302,7 @@
 				E733A76A1FD7091F003EAA29 /* KSCrashSentry_Tests.m in Sources */,
 				E784D25E1FD70E55004B01E1 /* KSString_Tests.m in Sources */,
 				4B775FCF22CBDEB4004839C5 /* BugsnagCollectionsBSGDictInsertIfNotNilTest.m in Sources */,
+				E72AE200241A57B100ED8972 /* BugsnagPluginTest.m in Sources */,
 				E733A7681FD7091F003EAA29 /* KSCrashSentry_NSException_Tests.m in Sources */,
 				E7B970311FD702DA00590C27 /* KSLogger_Tests.m in Sources */,
 				8AA661AD23D8C1F50031ECC8 /* BSGConnectivityTest.m in Sources */,

--- a/tvOS/Bugsnag.xcodeproj/project.pbxproj
+++ b/tvOS/Bugsnag.xcodeproj/project.pbxproj
@@ -57,6 +57,8 @@
 		E72352BA1F55922F00436528 /* SystemConfiguration.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = E72352B91F55922F00436528 /* SystemConfiguration.framework */; };
 		E72352BD1F55923700436528 /* BSGConnectivity.h in Headers */ = {isa = PBXBuildFile; fileRef = E72352BB1F55923700436528 /* BSGConnectivity.h */; };
 		E72352BE1F55923700436528 /* BSGConnectivity.m in Sources */ = {isa = PBXBuildFile; fileRef = E72352BC1F55923700436528 /* BSGConnectivity.m */; };
+		E72AE1FD241A4ED600ED8972 /* BugsnagPluginClient.h in Headers */ = {isa = PBXBuildFile; fileRef = E72AE1FB241A4ED600ED8972 /* BugsnagPluginClient.h */; };
+		E72AE1FE241A4ED600ED8972 /* BugsnagPluginClient.m in Sources */ = {isa = PBXBuildFile; fileRef = E72AE1FC241A4ED600ED8972 /* BugsnagPluginClient.m */; };
 		E7433AD61F4F650C00C082D1 /* libc++.tbd in Frameworks */ = {isa = PBXBuildFile; fileRef = E7433AD51F4F650C00C082D1 /* libc++.tbd */; };
 		E7433AD81F4F651200C082D1 /* libz.tbd in Frameworks */ = {isa = PBXBuildFile; fileRef = E7433AD71F4F651200C082D1 /* libz.tbd */; };
 		E762E9F01F73F6CF00E82B43 /* BugsnagHandledStateTest.m in Sources */ = {isa = PBXBuildFile; fileRef = E762E9EE1F73F6CF00E82B43 /* BugsnagHandledStateTest.m */; };
@@ -251,6 +253,8 @@
 		E72352B91F55922F00436528 /* SystemConfiguration.framework */ = {isa = PBXFileReference; lastKnownFileType = wrapper.framework; name = SystemConfiguration.framework; path = System/Library/Frameworks/SystemConfiguration.framework; sourceTree = SDKROOT; };
 		E72352BB1F55923700436528 /* BSGConnectivity.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; name = BSGConnectivity.h; path = ../Source/BSGConnectivity.h; sourceTree = "<group>"; };
 		E72352BC1F55923700436528 /* BSGConnectivity.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; name = BSGConnectivity.m; path = ../Source/BSGConnectivity.m; sourceTree = "<group>"; };
+		E72AE1FB241A4ED600ED8972 /* BugsnagPluginClient.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; name = BugsnagPluginClient.h; path = ../Source/BugsnagPluginClient.h; sourceTree = "<group>"; };
+		E72AE1FC241A4ED600ED8972 /* BugsnagPluginClient.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; name = BugsnagPluginClient.m; path = ../Source/BugsnagPluginClient.m; sourceTree = "<group>"; };
 		E7433AD51F4F650C00C082D1 /* libc++.tbd */ = {isa = PBXFileReference; lastKnownFileType = "sourcecode.text-based-dylib-definition"; name = "libc++.tbd"; path = "usr/lib/libc++.tbd"; sourceTree = SDKROOT; };
 		E7433AD71F4F651200C082D1 /* libz.tbd */ = {isa = PBXFileReference; lastKnownFileType = "sourcecode.text-based-dylib-definition"; name = libz.tbd; path = usr/lib/libz.tbd; sourceTree = SDKROOT; };
 		E762E9EE1F73F6CF00E82B43 /* BugsnagHandledStateTest.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; name = BugsnagHandledStateTest.m; path = ../Tests/BugsnagHandledStateTest.m; sourceTree = SOURCE_ROOT; };
@@ -439,6 +443,8 @@
 		8A8D51261D41343500D33797 /* tvOS */ = {
 			isa = PBXGroup;
 			children = (
+				E72AE1FB241A4ED600ED8972 /* BugsnagPluginClient.h */,
+				E72AE1FC241A4ED600ED8972 /* BugsnagPluginClient.m */,
 				0089B6ED241168CB00D5A7F2 /* BugsnagClient.h */,
 				0089B6EE241168CB00D5A7F2 /* BugsnagClient.m */,
 				00D7AC9F23E97FBD00FBE4A7 /* BugsnagEvent.h */,
@@ -779,6 +785,7 @@
 				8AD9A4F61D42EE8E004E1CC5 /* BugsnagBreadcrumb.h in Headers */,
 				E79148821FD82E6D003EFEBF /* BugsnagApiClient.h in Headers */,
 				E76617D01F4E459C0094CECF /* BSG_KSCrashReportFilter.h in Headers */,
+				E72AE1FD241A4ED600ED8972 /* BugsnagPluginClient.h in Headers */,
 				0089B6EF241168CC00D5A7F2 /* BugsnagClient.h in Headers */,
 				E76617961F4E459C0094CECF /* BSG_KSCrashSentry_CPPException.h in Headers */,
 				E76616F91F4E45950094CECF /* BugsnagErrorReportApiClient.h in Headers */,
@@ -917,6 +924,7 @@
 				E766178E1F4E459C0094CECF /* BSG_KSCrashType.c in Sources */,
 				E791487F1FD82E6D003EFEBF /* BugsnagKSCrashSysInfoParser.m in Sources */,
 				E76617B51F4E459C0094CECF /* BSG_KSMach_Arm.c in Sources */,
+				E72AE1FE241A4ED600ED8972 /* BugsnagPluginClient.m in Sources */,
 				8AD9A4FE1D42EE9D004E1CC5 /* BugsnagBreadcrumb.m in Sources */,
 				8A6C6FAD2257882400E8EF24 /* BSGOutOfMemoryWatchdog.m in Sources */,
 				E76617841F4E459C0094CECF /* BSG_KSCrashDoctor.m in Sources */,


### PR DESCRIPTION
## Goal

Implements the new plugin interface from the notifier spec. This allows the addition of user-defined plugins up-front before Bugsnag is configured.

This changeset has been adapted from the Android implementation: https://github.com/bugsnag/bugsnag-android/pull/815

## Changeset

- Added ability to add plugins to `BugsnagConfiguration`, which are deep-copied on Bugsnag initialisation
- Extracted the majority of the plugin loading logic to the `BugsnagPluginClient` class to reduce the responsibilities of `Bugsnag`.
- Initialised `BugsnagPluginClient` within `BugsnagClient` and loaded plugins when `[client start]` is invoked
- Removed legacy non-compliant methods on `BugsnagPlugin`

## Tests

- Added unit tests to verify the `PluginClient` and `Configuration` changes
- Updated existing E2E coverage for custom plugin creation
