### PR TITLE
Add observers for state change events

### DIFF
--- a/OSX/Bugsnag.xcodeproj/project.pbxproj
+++ b/OSX/Bugsnag.xcodeproj/project.pbxproj
@@ -54,7 +54,6 @@
 		8AB65FC822DC73A7001200AB /* BSGConfigurationBuilderTests.m in Sources */ = {isa = PBXBuildFile; fileRef = 8AB65FC622DC739D001200AB /* BSGConfigurationBuilderTests.m */; };
 		8AD1E3FA23EDDD4F0044F919 /* BSGConnectivityTest.m in Sources */ = {isa = PBXBuildFile; fileRef = 8AD1E3F823EDDD3F0044F919 /* BSGConnectivityTest.m */; };
 		8AD9FA891E086351002859A7 /* BugsnagConfigurationTests.m in Sources */ = {isa = PBXBuildFile; fileRef = 8AD9FA851E0862DC002859A7 /* BugsnagConfigurationTests.m */; };
-		E71DB9DA24470FCF00D0161E /* BugsnagPluginTest.m in Sources */ = {isa = PBXBuildFile; fileRef = E71DB9D424470FCE00D0161E /* BugsnagPluginTest.m */; };
 		E71DB9DB24470FCF00D0161E /* BugsnagSessionTrackerStopTest.m in Sources */ = {isa = PBXBuildFile; fileRef = E71DB9D524470FCF00D0161E /* BugsnagSessionTrackerStopTest.m */; };
 		E71DB9DD24470FCF00D0161E /* BugsnagMetadataRedactionTest.m in Sources */ = {isa = PBXBuildFile; fileRef = E71DB9D824470FCF00D0161E /* BugsnagMetadataRedactionTest.m */; };
 		E71DB9DE24470FCF00D0161E /* BugsnagClientTests.m in Sources */ = {isa = PBXBuildFile; fileRef = E71DB9D924470FCF00D0161E /* BugsnagClientTests.m */; };
@@ -88,11 +87,11 @@
 		E7819BB9245979D200A7EBDD /* BugsnagNotifierTest.m in Sources */ = {isa = PBXBuildFile; fileRef = E7819BB8245979D200A7EBDD /* BugsnagNotifierTest.m */; };
 		E786059424229A5400CC2D28 /* BugsnagStateEvent.m in Sources */ = {isa = PBXBuildFile; fileRef = E786059224229A5400CC2D28 /* BugsnagStateEvent.m */; };
 		E786059524229A5400CC2D28 /* BugsnagStateEvent.h in Headers */ = {isa = PBXBuildFile; fileRef = E786059324229A5400CC2D28 /* BugsnagStateEvent.h */; };
-		E78605CC24229B4600CC2D28 /* BugsnagTests.m in Sources */ = {isa = PBXBuildFile; fileRef = E78605C824229B4600CC2D28 /* BugsnagTests.m */; };
 		E78605D624229B8500CC2D28 /* BugsnagEventFromKSCrashReportTest.m in Sources */ = {isa = PBXBuildFile; fileRef = E78605D024229B8500CC2D28 /* BugsnagEventFromKSCrashReportTest.m */; };
-		E78605D724229B8500CC2D28 /* BugsnagStateEventTest.m in Sources */ = {isa = PBXBuildFile; fileRef = E78605D124229B8500CC2D28 /* BugsnagStateEventTest.m */; };
 		E78605D824229B8500CC2D28 /* BSGOutOfMemoryWatchdogTests.m in Sources */ = {isa = PBXBuildFile; fileRef = E78605D224229B8500CC2D28 /* BSGOutOfMemoryWatchdogTests.m */; };
 		E78605DA24229B8500CC2D28 /* RegisterErrorDataTest.m in Sources */ = {isa = PBXBuildFile; fileRef = E78605D424229B8500CC2D28 /* RegisterErrorDataTest.m */; };
+		E78E8CAE24694B750017A314 /* BugsnagStateEventTest.m in Sources */ = {isa = PBXBuildFile; fileRef = E78E8CAD24694B750017A314 /* BugsnagStateEventTest.m */; };
+		E78E8CAF24694BC10017A314 /* BugsnagStateEventTest.m in Headers */ = {isa = PBXBuildFile; fileRef = E78E8CAD24694B750017A314 /* BugsnagStateEventTest.m */; };
 		E790C42324324528006FFB26 /* BugsnagClientMirrorTest.m in Sources */ = {isa = PBXBuildFile; fileRef = E790C41F2432314A006FFB26 /* BugsnagClientMirrorTest.m */; };
 		E790C427243354FD006FFB26 /* BugsnagClientInternal.h in Headers */ = {isa = PBXBuildFile; fileRef = E790C426243354FD006FFB26 /* BugsnagClientInternal.h */; };
 		E790C47024349CE2006FFB26 /* BugsnagStackframe.m in Sources */ = {isa = PBXBuildFile; fileRef = E790C46224349CE1006FFB26 /* BugsnagStackframe.m */; };
@@ -305,7 +304,6 @@
 		8AD1E3F823EDDD3F0044F919 /* BSGConnectivityTest.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; path = BSGConnectivityTest.m; sourceTree = "<group>"; };
 		8AD9FA851E0862DC002859A7 /* BugsnagConfigurationTests.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; name = BugsnagConfigurationTests.m; path = ../Tests/BugsnagConfigurationTests.m; sourceTree = SOURCE_ROOT; };
 		E71DB9D224470F5900D0161E /* BugsnagMetadataTests.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; path = BugsnagMetadataTests.m; sourceTree = "<group>"; };
-		E71DB9D424470FCE00D0161E /* BugsnagPluginTest.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; path = BugsnagPluginTest.m; sourceTree = "<group>"; };
 		E71DB9D524470FCF00D0161E /* BugsnagSessionTrackerStopTest.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; path = BugsnagSessionTrackerStopTest.m; sourceTree = "<group>"; };
 		E71DB9D624470FCF00D0161E /* BugsnagTestConstants.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = BugsnagTestConstants.h; sourceTree = "<group>"; };
 		E71DB9D724470FCF00D0161E /* BugsnagTests.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; path = BugsnagTests.m; sourceTree = "<group>"; };
@@ -338,15 +336,13 @@
 		E7819BB8245979D200A7EBDD /* BugsnagNotifierTest.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; path = BugsnagNotifierTest.m; sourceTree = "<group>"; };
 		E786059224229A5400CC2D28 /* BugsnagStateEvent.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; name = BugsnagStateEvent.m; path = ../Source/BugsnagStateEvent.m; sourceTree = "<group>"; };
 		E786059324229A5400CC2D28 /* BugsnagStateEvent.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; name = BugsnagStateEvent.h; path = ../Source/BugsnagStateEvent.h; sourceTree = "<group>"; };
-		E78605C724229B4600CC2D28 /* BugsnagMetadataTests.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; path = BugsnagMetadataTests.m; sourceTree = "<group>"; };
-		E78605C824229B4600CC2D28 /* BugsnagTests.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; path = BugsnagTests.m; sourceTree = "<group>"; };
 		E78605C924229B4600CC2D28 /* BugsnagSessionTrackerStopTest.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; path = BugsnagSessionTrackerStopTest.m; sourceTree = "<group>"; };
 		E78605CA24229B4600CC2D28 /* BugsnagPluginTest.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; path = BugsnagPluginTest.m; sourceTree = "<group>"; };
 		E78605D024229B8500CC2D28 /* BugsnagEventFromKSCrashReportTest.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; name = BugsnagEventFromKSCrashReportTest.m; path = ../iOS/BugsnagTests/BugsnagEventFromKSCrashReportTest.m; sourceTree = "<group>"; };
-		E78605D124229B8500CC2D28 /* BugsnagStateEventTest.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; name = BugsnagStateEventTest.m; path = ../iOS/BugsnagTests/BugsnagStateEventTest.m; sourceTree = "<group>"; };
 		E78605D224229B8500CC2D28 /* BSGOutOfMemoryWatchdogTests.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; name = BSGOutOfMemoryWatchdogTests.m; path = ../iOS/BugsnagTests/BSGOutOfMemoryWatchdogTests.m; sourceTree = "<group>"; };
 		E78605D424229B8500CC2D28 /* RegisterErrorDataTest.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; name = RegisterErrorDataTest.m; path = ../iOS/BugsnagTests/RegisterErrorDataTest.m; sourceTree = "<group>"; };
 		E78605DB24229B9600CC2D28 /* BugsnagTestConstants.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = BugsnagTestConstants.h; sourceTree = "<group>"; };
+		E78E8CAD24694B750017A314 /* BugsnagStateEventTest.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; path = BugsnagStateEventTest.m; sourceTree = "<group>"; };
 		E790C41F2432314A006FFB26 /* BugsnagClientMirrorTest.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; path = BugsnagClientMirrorTest.m; sourceTree = "<group>"; };
 		E790C426243354FD006FFB26 /* BugsnagClientInternal.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; name = BugsnagClientInternal.h; path = ../Source/BugsnagClientInternal.h; sourceTree = "<group>"; };
 		E790C46224349CE1006FFB26 /* BugsnagStackframe.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; name = BugsnagStackframe.m; path = ../Source/BugsnagStackframe.m; sourceTree = "<group>"; };
@@ -560,10 +556,6 @@
 				E7A9E5A7243B365400D99F8A /* Plugins */,
 				E7A9E5A9243B365E00D99F8A /* Storage */,
 				8A87352B1C6D3B1600EDBD5B /* BSG_KSCrashReportWriter.h */,
-				E786059324229A5400CC2D28 /* BugsnagStateEvent.h */,
-				E786059224229A5400CC2D28 /* BugsnagStateEvent.m */,
-				E72AE1F8241A4E7500ED8972 /* BugsnagPluginClient.h */,
-				E72AE1F7241A4E7500ED8972 /* BugsnagPluginClient.m */,
 				00D7AC9B23E97F8100FBE4A7 /* BugsnagEvent.h */,
 				00D7AC9A23E97F8100FBE4A7 /* BugsnagEvent.m */,
 				8A3C591123968B3600B344AA /* BugsnagPlugin.h */,
@@ -581,6 +573,10 @@
 				8A48EF261EAA805D00B70024 /* BugsnagLogger.h */,
 				E79148391FD82B34003EFEBF /* BugsnagSessionTracker.h */,
 				E79148431FD82B36003EFEBF /* BugsnagSessionTracker.m */,
+				E72AE1F8241A4E7500ED8972 /* BugsnagPluginClient.h */,
+				E72AE1F7241A4E7500ED8972 /* BugsnagPluginClient.m */,
+				E786059324229A5400CC2D28 /* BugsnagStateEvent.h */,
+				E786059224229A5400CC2D28 /* BugsnagStateEvent.m */,
 				E7529F8C243C8EBF006B4932 /* RegisterErrorData.h */,
 				E7529F8D243C8EBF006B4932 /* RegisterErrorData.m */,
 				E7D2E671243B8FA7005A3041 /* BugsnagStacktrace.h */,
@@ -602,12 +598,7 @@
 				E78605DB24229B9600CC2D28 /* BugsnagTestConstants.h */,
 				E78605D224229B8500CC2D28 /* BSGOutOfMemoryWatchdogTests.m */,
 				E78605D024229B8500CC2D28 /* BugsnagEventFromKSCrashReportTest.m */,
-				E78605D124229B8500CC2D28 /* BugsnagStateEventTest.m */,
 				E78605D424229B8500CC2D28 /* RegisterErrorDataTest.m */,
-				E78605C724229B4600CC2D28 /* BugsnagMetadataTests.m */,
-				E78605CA24229B4600CC2D28 /* BugsnagPluginTest.m */,
-				E78605C924229B4600CC2D28 /* BugsnagSessionTrackerStopTest.m */,
-				E78605C824229B4600CC2D28 /* BugsnagTests.m */,
 				00F9393123FC168F008C7073 /* BugsnagBaseUnitTest.h */,
 				00F9393223FC168F008C7073 /* BugsnagBaseUnitTest.m */,
 				8A2C8FE01C6BC38200846019 /* BugsnagBreadcrumbsTest.m */,
@@ -626,8 +617,10 @@
 				E71DB9D224470F5900D0161E /* BugsnagMetadataTests.m */,
 				E7819BB8245979D200A7EBDD /* BugsnagNotifierTest.m */,
 				E7AB4B9D2423E184004F015A /* BugsnagOnBreadcrumbTest.m */,
+				E78605CA24229B4600CC2D28 /* BugsnagPluginTest.m */,
+				E78605C924229B4600CC2D28 /* BugsnagSessionTrackerStopTest.m */,
+				E78E8CAD24694B750017A314 /* BugsnagStateEventTest.m */,
 				E728378C245184B600EE2B7D /* BugsnagOnCrashTest.m */,
-				E71DB9D424470FCE00D0161E /* BugsnagPluginTest.m */,
 				E791482D1FD82B0C003EFEBF /* BugsnagSessionTest.m */,
 				E791482B1FD82B0C003EFEBF /* BugsnagSessionTrackerTest.m */,
 				E71DB9D524470FCF00D0161E /* BugsnagSessionTrackerStopTest.m */,
@@ -891,8 +884,6 @@
 				E790C46324349CE1006FFB26 /* BugsnagDeviceWithState.m */,
 				E790C46824349CE2006FFB26 /* BugsnagError.h */,
 				E790C46424349CE1006FFB26 /* BugsnagError.m */,
-				00D7AC9B23E97F8100FBE4A7 /* BugsnagEvent.h */,
-				00D7AC9A23E97F8100FBE4A7 /* BugsnagEvent.m */,
 				E7819BAE2459759D00A7EBDD /* BugsnagNotifier.h */,
 				E7819BAF2459759D00A7EBDD /* BugsnagNotifier.m */,
 				E79148331FD82B34003EFEBF /* BugsnagSession.h */,
@@ -985,6 +976,7 @@
 				E791484C1FD82B36003EFEBF /* BugsnagSessionTracker.h in Headers */,
 				8A3C591223968B3600B344AA /* BugsnagPlugin.h in Headers */,
 				E79E6B931F4E3850002B35F9 /* BSG_KSCrashReportStore.h in Headers */,
+				E78E8CAF24694BC10017A314 /* BugsnagStateEventTest.m in Headers */,
 				E79E6BB01F4E3850002B35F9 /* BSG_KSBacktrace.h in Headers */,
 				E794E8051F9F746D00A67EE7 /* BugsnagKeys.h in Headers */,
 				E762E9FC1F73F80200E82B43 /* BugsnagHandledState.h in Headers */,
@@ -1240,10 +1232,8 @@
 				E7CE78CC1FD94E77001D07E0 /* KSSystemInfo_Tests.m in Sources */,
 				E7A9E56924361B6300D99F8A /* BugsnagAppTest.m in Sources */,
 				E71DB9DD24470FCF00D0161E /* BugsnagMetadataRedactionTest.m in Sources */,
-				E78605CC24229B4600CC2D28 /* BugsnagTests.m in Sources */,
 				4B775FD422CBE02F004839C5 /* BugsnagCollectionsBSGDictInsertIfNotNilTest.m in Sources */,
 				E7CE78C91FD94E77001D07E0 /* KSSignalInfo_Tests.m in Sources */,
-				E71DB9DA24470FCF00D0161E /* BugsnagPluginTest.m in Sources */,
 				E7CE78C61FD94E77001D07E0 /* KSMach_Tests.m in Sources */,
 				00F9393C23FD2D9B008C7073 /* BugsnagTestsDummyClass.m in Sources */,
 				E7D2E676243B8FB6005A3041 /* BugsnagStacktraceTest.m in Sources */,
@@ -1263,6 +1253,7 @@
 				E7CE78D01FD94E77001D07E0 /* RFC3339DateTool_Tests.m in Sources */,
 				E79148621FD82BB7003EFEBF /* BugsnagSessionTrackingPayloadTest.m in Sources */,
 				E7529FA2243CAE3F006B4932 /* BugsnagThreadSerializationTest.m in Sources */,
+				E78E8CAE24694B750017A314 /* BugsnagStateEventTest.m in Sources */,
 				E7819BB9245979D200A7EBDD /* BugsnagNotifierTest.m in Sources */,
 				E79148631FD82BB7003EFEBF /* BugsnagUserTest.m in Sources */,
 				8A2C8FEA1C6BC38900846019 /* BugsnagBreadcrumbsTest.m in Sources */,
@@ -1290,7 +1281,6 @@
 				E7AB4B9E2423E184004F015A /* BugsnagOnBreadcrumbTest.m in Sources */,
 				E7CE78C31FD94E77001D07E0 /* KSFileUtils_Tests.m in Sources */,
 				E7CE78BC1FD94E77001D07E0 /* KSCrashReportStore_Tests.m in Sources */,
-				E78605D724229B8500CC2D28 /* BugsnagStateEventTest.m in Sources */,
 				E79148611FD82BB7003EFEBF /* BugsnagSessionTrackerTest.m in Sources */,
 				E79148591FD82BAE003EFEBF /* BugsnagSessionTest.m in Sources */,
 				E728378D245184B600EE2B7D /* BugsnagOnCrashTest.m in Sources */,

--- a/OSX/Bugsnag.xcodeproj/project.pbxproj
+++ b/OSX/Bugsnag.xcodeproj/project.pbxproj
@@ -56,7 +56,6 @@
 		8AD9FA891E086351002859A7 /* BugsnagConfigurationTests.m in Sources */ = {isa = PBXBuildFile; fileRef = 8AD9FA851E0862DC002859A7 /* BugsnagConfigurationTests.m */; };
 		E71DB9DA24470FCF00D0161E /* BugsnagPluginTest.m in Sources */ = {isa = PBXBuildFile; fileRef = E71DB9D424470FCE00D0161E /* BugsnagPluginTest.m */; };
 		E71DB9DB24470FCF00D0161E /* BugsnagSessionTrackerStopTest.m in Sources */ = {isa = PBXBuildFile; fileRef = E71DB9D524470FCF00D0161E /* BugsnagSessionTrackerStopTest.m */; };
-		E71DB9DC24470FCF00D0161E /* BugsnagTests.m in Sources */ = {isa = PBXBuildFile; fileRef = E71DB9D724470FCF00D0161E /* BugsnagTests.m */; };
 		E71DB9DD24470FCF00D0161E /* BugsnagMetadataRedactionTest.m in Sources */ = {isa = PBXBuildFile; fileRef = E71DB9D824470FCF00D0161E /* BugsnagMetadataRedactionTest.m */; };
 		E71DB9DE24470FCF00D0161E /* BugsnagClientTests.m in Sources */ = {isa = PBXBuildFile; fileRef = E71DB9D924470FCF00D0161E /* BugsnagClientTests.m */; };
 		E71DB9DF2447100000D0161E /* BugsnagMetadataTests.m in Sources */ = {isa = PBXBuildFile; fileRef = E71DB9D224470F5900D0161E /* BugsnagMetadataTests.m */; };
@@ -69,6 +68,7 @@
 		E73D443C243E192F001686F5 /* BugsnagErrorTest.m in Sources */ = {isa = PBXBuildFile; fileRef = E73D443B243E192F001686F5 /* BugsnagErrorTest.m */; };
 		E7433AD21F4F64EF00C082D1 /* libz.tbd in Frameworks */ = {isa = PBXBuildFile; fileRef = 8A2C8FF11C6BC3A800846019 /* libz.tbd */; };
 		E7433AD31F4F64F400C082D1 /* libc++.tbd in Frameworks */ = {isa = PBXBuildFile; fileRef = 8A2C8FF31C6BC3AE00846019 /* libc++.tbd */; };
+		E744771C245860B700DFC4E8 /* BugsnagMetadataInternal.h in Headers */ = {isa = PBXBuildFile; fileRef = E744771B245860B700DFC4E8 /* BugsnagMetadataInternal.h */; };
 		E7529F8E243C8EBF006B4932 /* RegisterErrorData.h in Headers */ = {isa = PBXBuildFile; fileRef = E7529F8C243C8EBF006B4932 /* RegisterErrorData.h */; };
 		E7529F8F243C8EBF006B4932 /* RegisterErrorData.m in Sources */ = {isa = PBXBuildFile; fileRef = E7529F8D243C8EBF006B4932 /* RegisterErrorData.m */; };
 		E7529FA0243CAE35006B4932 /* BugsnagThreadTest.m in Sources */ = {isa = PBXBuildFile; fileRef = E7529F9F243CAE34006B4932 /* BugsnagThreadTest.m */; };
@@ -86,6 +86,13 @@
 		E7819BB02459759D00A7EBDD /* BugsnagNotifier.h in Headers */ = {isa = PBXBuildFile; fileRef = E7819BAE2459759D00A7EBDD /* BugsnagNotifier.h */; };
 		E7819BB12459759D00A7EBDD /* BugsnagNotifier.m in Sources */ = {isa = PBXBuildFile; fileRef = E7819BAF2459759D00A7EBDD /* BugsnagNotifier.m */; };
 		E7819BB9245979D200A7EBDD /* BugsnagNotifierTest.m in Sources */ = {isa = PBXBuildFile; fileRef = E7819BB8245979D200A7EBDD /* BugsnagNotifierTest.m */; };
+		E786059424229A5400CC2D28 /* BugsnagStateEvent.m in Sources */ = {isa = PBXBuildFile; fileRef = E786059224229A5400CC2D28 /* BugsnagStateEvent.m */; };
+		E786059524229A5400CC2D28 /* BugsnagStateEvent.h in Headers */ = {isa = PBXBuildFile; fileRef = E786059324229A5400CC2D28 /* BugsnagStateEvent.h */; };
+		E78605CC24229B4600CC2D28 /* BugsnagTests.m in Sources */ = {isa = PBXBuildFile; fileRef = E78605C824229B4600CC2D28 /* BugsnagTests.m */; };
+		E78605D624229B8500CC2D28 /* BugsnagEventFromKSCrashReportTest.m in Sources */ = {isa = PBXBuildFile; fileRef = E78605D024229B8500CC2D28 /* BugsnagEventFromKSCrashReportTest.m */; };
+		E78605D724229B8500CC2D28 /* BugsnagStateEventTest.m in Sources */ = {isa = PBXBuildFile; fileRef = E78605D124229B8500CC2D28 /* BugsnagStateEventTest.m */; };
+		E78605D824229B8500CC2D28 /* BSGOutOfMemoryWatchdogTests.m in Sources */ = {isa = PBXBuildFile; fileRef = E78605D224229B8500CC2D28 /* BSGOutOfMemoryWatchdogTests.m */; };
+		E78605DA24229B8500CC2D28 /* RegisterErrorDataTest.m in Sources */ = {isa = PBXBuildFile; fileRef = E78605D424229B8500CC2D28 /* RegisterErrorDataTest.m */; };
 		E790C42324324528006FFB26 /* BugsnagClientMirrorTest.m in Sources */ = {isa = PBXBuildFile; fileRef = E790C41F2432314A006FFB26 /* BugsnagClientMirrorTest.m */; };
 		E790C427243354FD006FFB26 /* BugsnagClientInternal.h in Headers */ = {isa = PBXBuildFile; fileRef = E790C426243354FD006FFB26 /* BugsnagClientInternal.h */; };
 		E790C47024349CE2006FFB26 /* BugsnagStackframe.m in Sources */ = {isa = PBXBuildFile; fileRef = E790C46224349CE1006FFB26 /* BugsnagStackframe.m */; };
@@ -311,6 +318,7 @@
 		E72AE1F7241A4E7500ED8972 /* BugsnagPluginClient.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; name = BugsnagPluginClient.m; path = ../Source/BugsnagPluginClient.m; sourceTree = "<group>"; };
 		E72AE1F8241A4E7500ED8972 /* BugsnagPluginClient.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; name = BugsnagPluginClient.h; path = ../Source/BugsnagPluginClient.h; sourceTree = "<group>"; };
 		E73D443B243E192F001686F5 /* BugsnagErrorTest.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; path = BugsnagErrorTest.m; sourceTree = "<group>"; };
+		E744771B245860B700DFC4E8 /* BugsnagMetadataInternal.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; name = BugsnagMetadataInternal.h; path = ../Source/BugsnagMetadataInternal.h; sourceTree = "<group>"; };
 		E7529F8C243C8EBF006B4932 /* RegisterErrorData.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; name = RegisterErrorData.h; path = ../Source/RegisterErrorData.h; sourceTree = "<group>"; };
 		E7529F8D243C8EBF006B4932 /* RegisterErrorData.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; name = RegisterErrorData.m; path = ../Source/RegisterErrorData.m; sourceTree = "<group>"; };
 		E7529F9F243CAE34006B4932 /* BugsnagThreadTest.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; path = BugsnagThreadTest.m; sourceTree = "<group>"; };
@@ -328,6 +336,17 @@
 		E7819BAE2459759D00A7EBDD /* BugsnagNotifier.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; name = BugsnagNotifier.h; path = ../Source/BugsnagNotifier.h; sourceTree = "<group>"; };
 		E7819BAF2459759D00A7EBDD /* BugsnagNotifier.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; name = BugsnagNotifier.m; path = ../Source/BugsnagNotifier.m; sourceTree = "<group>"; };
 		E7819BB8245979D200A7EBDD /* BugsnagNotifierTest.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; path = BugsnagNotifierTest.m; sourceTree = "<group>"; };
+		E786059224229A5400CC2D28 /* BugsnagStateEvent.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; name = BugsnagStateEvent.m; path = ../Source/BugsnagStateEvent.m; sourceTree = "<group>"; };
+		E786059324229A5400CC2D28 /* BugsnagStateEvent.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; name = BugsnagStateEvent.h; path = ../Source/BugsnagStateEvent.h; sourceTree = "<group>"; };
+		E78605C724229B4600CC2D28 /* BugsnagMetadataTests.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; path = BugsnagMetadataTests.m; sourceTree = "<group>"; };
+		E78605C824229B4600CC2D28 /* BugsnagTests.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; path = BugsnagTests.m; sourceTree = "<group>"; };
+		E78605C924229B4600CC2D28 /* BugsnagSessionTrackerStopTest.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; path = BugsnagSessionTrackerStopTest.m; sourceTree = "<group>"; };
+		E78605CA24229B4600CC2D28 /* BugsnagPluginTest.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; path = BugsnagPluginTest.m; sourceTree = "<group>"; };
+		E78605D024229B8500CC2D28 /* BugsnagEventFromKSCrashReportTest.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; name = BugsnagEventFromKSCrashReportTest.m; path = ../iOS/BugsnagTests/BugsnagEventFromKSCrashReportTest.m; sourceTree = "<group>"; };
+		E78605D124229B8500CC2D28 /* BugsnagStateEventTest.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; name = BugsnagStateEventTest.m; path = ../iOS/BugsnagTests/BugsnagStateEventTest.m; sourceTree = "<group>"; };
+		E78605D224229B8500CC2D28 /* BSGOutOfMemoryWatchdogTests.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; name = BSGOutOfMemoryWatchdogTests.m; path = ../iOS/BugsnagTests/BSGOutOfMemoryWatchdogTests.m; sourceTree = "<group>"; };
+		E78605D424229B8500CC2D28 /* RegisterErrorDataTest.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; name = RegisterErrorDataTest.m; path = ../iOS/BugsnagTests/RegisterErrorDataTest.m; sourceTree = "<group>"; };
+		E78605DB24229B9600CC2D28 /* BugsnagTestConstants.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = BugsnagTestConstants.h; sourceTree = "<group>"; };
 		E790C41F2432314A006FFB26 /* BugsnagClientMirrorTest.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; path = BugsnagClientMirrorTest.m; sourceTree = "<group>"; };
 		E790C426243354FD006FFB26 /* BugsnagClientInternal.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; name = BugsnagClientInternal.h; path = ../Source/BugsnagClientInternal.h; sourceTree = "<group>"; };
 		E790C46224349CE1006FFB26 /* BugsnagStackframe.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; name = BugsnagStackframe.m; path = ../Source/BugsnagStackframe.m; sourceTree = "<group>"; };
@@ -541,6 +560,13 @@
 				E7A9E5A7243B365400D99F8A /* Plugins */,
 				E7A9E5A9243B365E00D99F8A /* Storage */,
 				8A87352B1C6D3B1600EDBD5B /* BSG_KSCrashReportWriter.h */,
+				E786059324229A5400CC2D28 /* BugsnagStateEvent.h */,
+				E786059224229A5400CC2D28 /* BugsnagStateEvent.m */,
+				E72AE1F8241A4E7500ED8972 /* BugsnagPluginClient.h */,
+				E72AE1F7241A4E7500ED8972 /* BugsnagPluginClient.m */,
+				00D7AC9B23E97F8100FBE4A7 /* BugsnagEvent.h */,
+				00D7AC9A23E97F8100FBE4A7 /* BugsnagEvent.m */,
+				8A3C591123968B3600B344AA /* BugsnagPlugin.h */,
 				8A6C6FB02257884C00E8EF24 /* BSGOutOfMemoryWatchdog.h */,
 				8A6C6FAF2257884C00E8EF24 /* BSGOutOfMemoryWatchdog.m */,
 				8A627CD71EC3B75200F7C04E /* BSGSerialization.h */,
@@ -573,6 +599,15 @@
 				8AB65FC622DC739D001200AB /* BSGConfigurationBuilderTests.m */,
 				8AD1E3F823EDDD3F0044F919 /* BSGConnectivityTest.m */,
 				E790C4A22434CB6A006FFB26 /* BugsnagAppTest.m */,
+				E78605DB24229B9600CC2D28 /* BugsnagTestConstants.h */,
+				E78605D224229B8500CC2D28 /* BSGOutOfMemoryWatchdogTests.m */,
+				E78605D024229B8500CC2D28 /* BugsnagEventFromKSCrashReportTest.m */,
+				E78605D124229B8500CC2D28 /* BugsnagStateEventTest.m */,
+				E78605D424229B8500CC2D28 /* RegisterErrorDataTest.m */,
+				E78605C724229B4600CC2D28 /* BugsnagMetadataTests.m */,
+				E78605CA24229B4600CC2D28 /* BugsnagPluginTest.m */,
+				E78605C924229B4600CC2D28 /* BugsnagSessionTrackerStopTest.m */,
+				E78605C824229B4600CC2D28 /* BugsnagTests.m */,
 				00F9393123FC168F008C7073 /* BugsnagBaseUnitTest.h */,
 				00F9393223FC168F008C7073 /* BugsnagBaseUnitTest.m */,
 				8A2C8FE01C6BC38200846019 /* BugsnagBreadcrumbsTest.m */,
@@ -837,6 +872,7 @@
 			children = (
 				8A2C8FC51C6BC2C800846019 /* BugsnagMetadata.h */,
 				8A2C8FC61C6BC2C800846019 /* BugsnagMetadata.m */,
+				E744771B245860B700DFC4E8 /* BugsnagMetadataInternal.h */,
 				009DF96A2432872D000A8363 /* BugsnagMetadataStore.h */,
 			);
 			name = Metadata;
@@ -877,9 +913,6 @@
 		E7A9E5A7243B365400D99F8A /* Plugins */ = {
 			isa = PBXGroup;
 			children = (
-				8A3C591123968B3600B344AA /* BugsnagPlugin.h */,
-				E72AE1F8241A4E7500ED8972 /* BugsnagPluginClient.h */,
-				E72AE1F7241A4E7500ED8972 /* BugsnagPluginClient.m */,
 			);
 			name = Plugins;
 			sourceTree = "<group>";
@@ -932,9 +965,9 @@
 			isa = PBXHeadersBuildPhase;
 			buildActionMask = 2147483647;
 			files = (
-				E7565F81245082940041768E /* BugsnagErrorTypes.h in Headers */,
 				E79148481FD82B36003EFEBF /* BugsnagUser.h in Headers */,
 				E79148461FD82B36003EFEBF /* BugsnagSession.h in Headers */,
+				E7565F81245082940041768E /* BugsnagErrorTypes.h in Headers */,
 				E77AFF10244A18B10082B8BB /* BugsnagEndpointConfiguration.h in Headers */,
 				E790C47C24349CE2006FFB26 /* BugsnagThread.h in Headers */,
 				E790C47A24349CE2006FFB26 /* BugsnagStackframe.h in Headers */,
@@ -958,6 +991,7 @@
 				E79E6BB51F4E3850002B35F9 /* BSG_KSDynamicLinker.h in Headers */,
 				E79E6BBF1F4E3850002B35F9 /* BSG_KSMach.h in Headers */,
 				E79E6BBA1F4E3850002B35F9 /* BSG_KSJSONCodecObjC.h in Headers */,
+				E786059524229A5400CC2D28 /* BugsnagStateEvent.h in Headers */,
 				E791484A1FD82B36003EFEBF /* BugsnagSessionFileStore.h in Headers */,
 				E79E6BBC1F4E3850002B35F9 /* BSG_KSLogger.h in Headers */,
 				8A2C8FD11C6BC2C800846019 /* BugsnagCollections.h in Headers */,
@@ -984,6 +1018,7 @@
 				8AB65FC422DC7390001200AB /* BSGConfigurationBuilder.h in Headers */,
 				E79E6B981F4E3850002B35F9 /* BSG_KSCrashState.h in Headers */,
 				E79148541FD82B36003EFEBF /* BugsnagSessionTrackingApiClient.h in Headers */,
+				E744771C245860B700DFC4E8 /* BugsnagMetadataInternal.h in Headers */,
 				E79E6B9C1F4E3850002B35F9 /* BSG_KSSystemInfo.h in Headers */,
 				8A2C8FD71C6BC2C800846019 /* BugsnagMetadata.h in Headers */,
 				E79E6B021F4E3847002B35F9 /* BugsnagCrashSentry.h in Headers */,
@@ -1180,6 +1215,7 @@
 				E79E6BA81F4E3850002B35F9 /* BSG_KSCrashSentry_NSException.m in Sources */,
 				E79E6B901F4E3850002B35F9 /* BSG_KSCrashReport.c in Sources */,
 				8A2C8FD81C6BC2C800846019 /* BugsnagMetadata.m in Sources */,
+				E786059424229A5400CC2D28 /* BugsnagStateEvent.m in Sources */,
 				E79E6BA51F4E3850002B35F9 /* BSG_KSCrashSentry_MachException.c in Sources */,
 				E79E6BB41F4E3850002B35F9 /* BSG_KSDynamicLinker.c in Sources */,
 				E79E6B031F4E3847002B35F9 /* BugsnagCrashSentry.m in Sources */,
@@ -1204,6 +1240,7 @@
 				E7CE78CC1FD94E77001D07E0 /* KSSystemInfo_Tests.m in Sources */,
 				E7A9E56924361B6300D99F8A /* BugsnagAppTest.m in Sources */,
 				E71DB9DD24470FCF00D0161E /* BugsnagMetadataRedactionTest.m in Sources */,
+				E78605CC24229B4600CC2D28 /* BugsnagTests.m in Sources */,
 				4B775FD422CBE02F004839C5 /* BugsnagCollectionsBSGDictInsertIfNotNilTest.m in Sources */,
 				E7CE78C91FD94E77001D07E0 /* KSSignalInfo_Tests.m in Sources */,
 				E71DB9DA24470FCF00D0161E /* BugsnagPluginTest.m in Sources */,
@@ -1217,6 +1254,7 @@
 				E7CE78CF1FD94E77001D07E0 /* NSError+SimpleConstructor_Tests.m in Sources */,
 				E7CE78BF1FD94E77001D07E0 /* KSCrashSentry_Signal_Tests.m in Sources */,
 				8A530CC922FDD74300F0C108 /* KSCrashIdentifierTests.m in Sources */,
+				E78605DA24229B8500CC2D28 /* RegisterErrorDataTest.m in Sources */,
 				4B406C1822CAD96400464D1D /* BugsnagCollectionsBSGDictMergeTest.m in Sources */,
 				E73D443C243E192F001686F5 /* BugsnagErrorTest.m in Sources */,
 				00D7ACA423E9854C00FBE4A7 /* BugsnagEventTests.m in Sources */,
@@ -1230,10 +1268,12 @@
 				8A2C8FEA1C6BC38900846019 /* BugsnagBreadcrumbsTest.m in Sources */,
 				E7CE78BB1FD94E77001D07E0 /* KSCrashReportConverter_Tests.m in Sources */,
 				E71DB9DB24470FCF00D0161E /* BugsnagSessionTrackerStopTest.m in Sources */,
+				E78605D624229B8500CC2D28 /* BugsnagEventFromKSCrashReportTest.m in Sources */,
 				4B406C1922CAD96400464D1D /* BugsnagCollectionsBSGDictSetSafeObjectTest.m in Sources */,
 				8A2C8FEC1C6BC38900846019 /* BugsnagSinkTests.m in Sources */,
 				8AD9FA891E086351002859A7 /* BugsnagConfigurationTests.m in Sources */,
 				8AD1E3FA23EDDD4F0044F919 /* BSGConnectivityTest.m in Sources */,
+				E78605D824229B8500CC2D28 /* BSGOutOfMemoryWatchdogTests.m in Sources */,
 				E7CE78C41FD94E77001D07E0 /* KSJSONCodec_Tests.m in Sources */,
 				E7CE78C01FD94E77001D07E0 /* KSCrashSentry_Tests.m in Sources */,
 				E7A5679D245B0511009BE2F1 /* BugsnagClientPayloadInfoTest.m in Sources */,
@@ -1247,10 +1287,10 @@
 				E7CE78C11FD94E77001D07E0 /* KSCrashState_Tests.m in Sources */,
 				E7529FA0243CAE35006B4932 /* BugsnagThreadTest.m in Sources */,
 				E71DB9DE24470FCF00D0161E /* BugsnagClientTests.m in Sources */,
-				E71DB9DC24470FCF00D0161E /* BugsnagTests.m in Sources */,
 				E7AB4B9E2423E184004F015A /* BugsnagOnBreadcrumbTest.m in Sources */,
 				E7CE78C31FD94E77001D07E0 /* KSFileUtils_Tests.m in Sources */,
 				E7CE78BC1FD94E77001D07E0 /* KSCrashReportStore_Tests.m in Sources */,
+				E78605D724229B8500CC2D28 /* BugsnagStateEventTest.m in Sources */,
 				E79148611FD82BB7003EFEBF /* BugsnagSessionTrackerTest.m in Sources */,
 				E79148591FD82BAE003EFEBF /* BugsnagSessionTest.m in Sources */,
 				E728378D245184B600EE2B7D /* BugsnagOnCrashTest.m in Sources */,

--- a/Source/BugsnagClient.h
+++ b/Source/BugsnagClient.h
@@ -32,7 +32,7 @@
 
 @class BugsnagSessionTracker;
 
-@interface BugsnagClient : NSObject <BugsnagMetadataDelegate, BugsnagMetadataStore>
+@interface BugsnagClient : NSObject<BugsnagMetadataStore>
 
 - (instancetype _Nonnull)initWithConfiguration:(BugsnagConfiguration *_Nonnull)configuration;
 

--- a/Source/BugsnagClient.m
+++ b/Source/BugsnagClient.m
@@ -400,6 +400,9 @@ NSString *_lastOrientation = nil;
         [self metadataChanged:self.state];
 
         // add observers for future metadata changes
+        // weakSelf is used as the BugsnagClient will always be instantiated
+        // for the entire lifecycle of an application, and there is therefore
+        // no need to check for strong self
         __weak __typeof__(self) weakSelf = self;
         [self addObserverUsingBlock:^(BugsnagStateEvent *event) {
             [weakSelf metadataChanged:event.data];

--- a/Source/BugsnagClient.m
+++ b/Source/BugsnagClient.m
@@ -400,8 +400,9 @@ NSString *_lastOrientation = nil;
         [self metadataChanged:self.state];
 
         // add observers for future metadata changes
-        [self registerStateObserverWithBlock:^(BugsnagStateEvent *event) {
-            [self metadataChanged:event.data];
+        __weak __typeof__(self) weakSelf = self;
+        [self addObserverUsingBlock:^(BugsnagStateEvent *event) {
+            [weakSelf metadataChanged:event.data];
         }];
 
         self.pluginClient = [[BugsnagPluginClient alloc] initWithPlugins:self.configuration.plugins];
@@ -413,14 +414,14 @@ NSString *_lastOrientation = nil;
     return self;
 }
 
-- (void)registerStateObserverWithBlock:(BugsnagObserverBlock _Nonnull)observer {
+- (void)addObserverUsingBlock:(BugsnagObserverBlock _Nonnull)observer {
     [self.stateEventBlocks addObject:[observer copy]];
 
     // additionally listen for metadata updates
-    [self.metadata registerStateObserverWithBlock:observer];
-    [self.configuration.metadata registerStateObserverWithBlock:observer];
-    [self.configuration.config registerStateObserverWithBlock:observer];
-    [self.state registerStateObserverWithBlock:observer];
+    [self.metadata addObserverUsingBlock:observer];
+    [self.configuration.metadata addObserverUsingBlock:observer];
+    [self.configuration.config addObserverUsingBlock:observer];
+    [self.state addObserverUsingBlock:observer];
 }
 
 - (void)notifyObservers:(BugsnagStateEvent *)event {
@@ -1016,8 +1017,6 @@ NSString *const BSGBreadcrumbLoadedMessage = @"Bugsnag loaded";
         } else if (metadata == self.state) {
             BSSerializeJSONDictionary([metadata toDictionary],
                                       &bsg_g_bugsnag_data.stateJSON);
-        } else {
-            bsg_log_debug(@"Unknown metadata dictionary changed");
         }
     }
 }

--- a/Source/BugsnagConfiguration.m
+++ b/Source/BugsnagConfiguration.m
@@ -57,8 +57,6 @@ NSString * const kBugsnagUserEmailAddress = @"BugsnagUserEmailAddress";
 NSString * const kBugsnagUserName = @"BugsnagUserName";
 NSString * const kBugsnagUserUserId = @"BugsnagUserUserId";
 
-typedef void (^BugsnagObserverBlock)(BugsnagStateEvent *_Nonnull event);
-
 @interface Bugsnag ()
 + (BugsnagClient *)client;
 @end
@@ -81,7 +79,6 @@ typedef void (^BugsnagObserverBlock)(BugsnagStateEvent *_Nonnull event);
  */
 @property(nonatomic, readwrite, strong) NSMutableArray *onSessionBlocks;
 @property(nonatomic, readwrite, strong) NSMutableArray *onBreadcrumbBlocks;
-@property(nonatomic, readwrite, strong) BugsnagObserverBlock block;
 @property(nonatomic, readwrite, strong) NSMutableSet *plugins;
 @property(readonly, retain, nullable) NSURL *notifyURL;
 @property(readonly, retain, nullable) NSURL *sessionURL;
@@ -157,7 +154,6 @@ typedef void (^BugsnagObserverBlock)(BugsnagStateEvent *_Nonnull event);
     [copy setUser:self.user.id
         withEmail:self.user.email
           andName:self.user.name];
-    [copy setBlock:self.block];
     return copy;
 }
 
@@ -281,12 +277,6 @@ typedef void (^BugsnagObserverBlock)(BugsnagStateEvent *_Nonnull event);
 
     // Add user info to the metadata
     [self setUserMetadataFromUser:self.user];
-
-    NSMutableDictionary *dict = [NSMutableDictionary new];
-    BSGDictInsertIfNotNil(dict, self.user.id, @"id");
-    BSGDictInsertIfNotNil(dict, self.user.email, @"email");
-    BSGDictInsertIfNotNil(dict, self.user.name, @"name");
-    [self notifyObserver:[[BugsnagStateEvent alloc] initWithName:kStateEventUser data:dict]];
 }
 
 /**
@@ -592,7 +582,6 @@ typedef void (^BugsnagObserverBlock)(BugsnagStateEvent *_Nonnull event);
         [self.config addMetadata:newContext
                          withKey:BSGKeyContext
                        toSection:BSGKeyConfig];
-        [self notifyObserver:[[BugsnagStateEvent alloc] initWithName:kStateEventContext data:newContext]];
     }
 }
 
@@ -654,16 +643,6 @@ typedef void (^BugsnagObserverBlock)(BugsnagStateEvent *_Nonnull event);
 
 - (void)addPlugin:(id<BugsnagPlugin> _Nonnull)plugin {
     [_plugins addObject:plugin];
-}
-
-- (void)notifyObserver:(BugsnagStateEvent *)event {
-    if (self.block != nil) {
-        self.block(event);
-    }
-}
-
-- (void)registerStateObserverWithBlock:(BugsnagObserverBlock _Nonnull)block {
-    self.block = block;
 }
 
 // MARK: - <MetadataStore>

--- a/Source/BugsnagMetadata.h
+++ b/Source/BugsnagMetadata.h
@@ -30,7 +30,3 @@
 @interface BugsnagMetadata : NSObject <BugsnagMetadataStore>
 - (instancetype _Nonnull)initWithDictionary:(NSDictionary *_Nonnull)dict;
 @end
-
-@protocol BugsnagMetadataDelegate <NSObject>
-- (void)metadataChanged:(BugsnagMetadata *_Nonnull)metadata;
-@end

--- a/Source/BugsnagMetadata.m
+++ b/Source/BugsnagMetadata.m
@@ -63,7 +63,7 @@
     }
 }
 
-- (void)registerStateObserverWithBlock:(BugsnagObserverBlock _Nonnull)block {
+- (void)addObserverUsingBlock:(BugsnagObserverBlock _Nonnull)block {
     [self.stateEventBlocks addObject:[block copy]];
 }
 

--- a/Source/BugsnagMetadataInternal.h
+++ b/Source/BugsnagMetadataInternal.h
@@ -1,0 +1,29 @@
+//
+//  BugsnagMetadataInternal.h
+//  Bugsnag
+//
+//  Created by Jamie Lynch on 28/04/2020.
+//  Copyright © 2020 Bugsnag. All rights reserved.
+//
+
+#ifndef BugsnagMetadataInternal_h
+#define BugsnagMetadataInternal_h
+
+#import "BugsnagMetadata.h"
+
+NS_ASSUME_NONNULL_BEGIN
+
+typedef void (^BugsnagMetadataCallback)(BugsnagMetadata *metadata);
+
+@interface BugsnagMetadata ()
+@property(atomic, strong) NSMutableDictionary *dictionary;
+@property NSMutableSet *_Nullable observers;
+
+- (NSDictionary *)toDictionary;
+- (id)deepCopy;
+- (void)addObserver:(BugsnagMetadataCallback)block;
+@end
+
+NS_ASSUME_NONNULL_END
+
+#endif /* BugsnagMetadataInternal_h */

--- a/Source/BugsnagMetadataInternal.h
+++ b/Source/BugsnagMetadataInternal.h
@@ -22,7 +22,7 @@ typedef void (^BugsnagObserverBlock)(BugsnagStateEvent *_Nonnull event);
 
 - (NSDictionary *)toDictionary;
 - (id)deepCopy;
-- (void)registerStateObserverWithBlock:(BugsnagObserverBlock _Nonnull)block;
+- (void)addObserverUsingBlock:(BugsnagObserverBlock _Nonnull)block;
 @end
 
 NS_ASSUME_NONNULL_END

--- a/Source/BugsnagMetadataInternal.h
+++ b/Source/BugsnagMetadataInternal.h
@@ -11,17 +11,18 @@
 
 #import "BugsnagMetadata.h"
 
+@class BugsnagStateEvent;
+
 NS_ASSUME_NONNULL_BEGIN
 
-typedef void (^BugsnagMetadataCallback)(BugsnagMetadata *metadata);
+typedef void (^BugsnagObserverBlock)(BugsnagStateEvent *_Nonnull event);
 
 @interface BugsnagMetadata ()
 @property(atomic, strong) NSMutableDictionary *dictionary;
-@property NSMutableSet *_Nullable observers;
 
 - (NSDictionary *)toDictionary;
 - (id)deepCopy;
-- (void)addObserver:(BugsnagMetadataCallback)block;
+- (void)registerStateObserverWithBlock:(BugsnagObserverBlock _Nonnull)block;
 @end
 
 NS_ASSUME_NONNULL_END

--- a/Source/BugsnagStateEvent.h
+++ b/Source/BugsnagStateEvent.h
@@ -1,0 +1,27 @@
+//
+//  BugsnagStateEvent.h
+//  Bugsnag
+//
+//  Created by Jamie Lynch on 18/03/2020.
+//  Copyright © 2020 Bugsnag. All rights reserved.
+//
+
+#import <Foundation/Foundation.h>
+
+NS_ASSUME_NONNULL_BEGIN
+
+static NSString *const kStateEventContext = @"ContextUpdate";
+static NSString *const kStateEventMetadata = @"MetadataUpdate";
+static NSString *const kStateEventUser = @"UserUpdate";
+
+@interface BugsnagStateEvent : NSObject
+- (instancetype)initWithName:(NSString *)name data:(id)data;
+@property NSString *name;
+@property id data;
+@end
+
+@protocol BugsnagObservable <NSObject>
+@property BugsnagStateEvent *observable;
+@end
+
+NS_ASSUME_NONNULL_END

--- a/Source/BugsnagStateEvent.h
+++ b/Source/BugsnagStateEvent.h
@@ -16,12 +16,8 @@ static NSString *const kStateEventUser = @"UserUpdate";
 
 @interface BugsnagStateEvent : NSObject
 - (instancetype)initWithName:(NSString *)name data:(id)data;
-@property NSString *name;
+@property NSString *type;
 @property id data;
-@end
-
-@protocol BugsnagObservable <NSObject>
-@property BugsnagStateEvent *observable;
 @end
 
 NS_ASSUME_NONNULL_END

--- a/Source/BugsnagStateEvent.m
+++ b/Source/BugsnagStateEvent.m
@@ -1,0 +1,21 @@
+//
+//  BugsnagStateEvent.m
+//  Bugsnag
+//
+//  Created by Jamie Lynch on 18/03/2020.
+//  Copyright © 2020 Bugsnag. All rights reserved.
+//
+
+#import "BugsnagStateEvent.h"
+
+@implementation BugsnagStateEvent
+
+- (instancetype)initWithName:(NSString *)name data:(id)data {
+    if (self = [super init]) {
+        self.name = name;
+        self.data = data;
+    }
+    return self;
+}
+
+@end

--- a/Source/BugsnagStateEvent.m
+++ b/Source/BugsnagStateEvent.m
@@ -12,7 +12,7 @@
 
 - (instancetype)initWithName:(NSString *)name data:(id)data {
     if (self = [super init]) {
-        self.name = name;
+        self.type = name;
         self.data = data;
     }
     return self;

--- a/Tests/BugsnagClientMirrorTest.m
+++ b/Tests/BugsnagClientMirrorTest.m
@@ -98,7 +98,12 @@
             @"collectThreads @16@0:8",
             @"collectDeviceWithState @16@0:8",
             @"extraRuntimeInfo @16@0:8",
-            @"setExtraRuntimeInfo: v24@0:8@16"
+            @"setExtraRuntimeInfo: v24@0:8@16",
+            @"collectDeviceWithState @16@0:8",
+            @"setStateEventBlocks: v24@0:8@16",
+            @"registerStateObserverWithBlock: v24@0:8@?16",
+            @"notifyObservers: v24@0:8@16",
+            @"stateEventBlocks @16@0:8"
     ]];
 
     // the following methods are implemented on Bugsnag but do not need to

--- a/Tests/BugsnagClientMirrorTest.m
+++ b/Tests/BugsnagClientMirrorTest.m
@@ -101,7 +101,7 @@
             @"setExtraRuntimeInfo: v24@0:8@16",
             @"collectDeviceWithState @16@0:8",
             @"setStateEventBlocks: v24@0:8@16",
-            @"registerStateObserverWithBlock: v24@0:8@?16",
+            @"addObserverUsingBlock: v24@0:8@?16",
             @"notifyObservers: v24@0:8@16",
             @"stateEventBlocks @16@0:8"
     ]];

--- a/Tests/BugsnagEventTests.m
+++ b/Tests/BugsnagEventTests.m
@@ -15,6 +15,7 @@
 #import "BugsnagSession.h"
 #import "BugsnagSessionInternal.h"
 #import "BugsnagBaseUnitTest.h"
+#import "BugsnagStateEvent.h"
 #import "BugsnagTestConstants.h"
 #import "BugsnagTestsDummyClass.h"
 

--- a/Tests/BugsnagMetadataTests.m
+++ b/Tests/BugsnagMetadataTests.m
@@ -44,7 +44,7 @@
     metadata = [[BugsnagMetadata alloc] init];
 
     __weak __typeof__(self) weakSelf = self;
-    [metadata addObserver:^(BugsnagMetadata *data) {
+    [metadata registerStateObserverWithBlock:^(BugsnagStateEvent *event) {
         weakSelf.delegateCalled = YES;
     }];
 }
@@ -157,7 +157,7 @@
     // Check delegate method gets called
     delegateCalled = NO;
     __weak __typeof__(self) weakSelf = self;
-    [metadata addObserver:^(BugsnagMetadata *data) {
+    [metadata registerStateObserverWithBlock:^(BugsnagStateEvent *event) {
         weakSelf.delegateCalled = YES;
     }];
     [metadata addMetadata:@{@"key" : @"value"} toSection:@"OtherTab"];
@@ -184,7 +184,7 @@
     // Once more with a delegate
     delegateCalled = NO;
     __weak __typeof__(self) weakSelf = self;
-    [metadata addObserver:^(BugsnagMetadata *data) {
+    [metadata registerStateObserverWithBlock:^(BugsnagStateEvent *event) {
         weakSelf.delegateCalled = YES;
     }];
     [metadata addMetadata:@{dummyObj : @"someValue"} toSection:@"invalidKeyTab"];

--- a/Tests/BugsnagMetadataTests.m
+++ b/Tests/BugsnagMetadataTests.m
@@ -44,7 +44,7 @@
     metadata = [[BugsnagMetadata alloc] init];
 
     __weak __typeof__(self) weakSelf = self;
-    [metadata registerStateObserverWithBlock:^(BugsnagStateEvent *event) {
+    [metadata addObserverUsingBlock:^(BugsnagStateEvent *event) {
         weakSelf.delegateCalled = YES;
     }];
 }
@@ -157,7 +157,7 @@
     // Check delegate method gets called
     delegateCalled = NO;
     __weak __typeof__(self) weakSelf = self;
-    [metadata registerStateObserverWithBlock:^(BugsnagStateEvent *event) {
+    [metadata addObserverUsingBlock:^(BugsnagStateEvent *event) {
         weakSelf.delegateCalled = YES;
     }];
     [metadata addMetadata:@{@"key" : @"value"} toSection:@"OtherTab"];
@@ -184,7 +184,7 @@
     // Once more with a delegate
     delegateCalled = NO;
     __weak __typeof__(self) weakSelf = self;
-    [metadata registerStateObserverWithBlock:^(BugsnagStateEvent *event) {
+    [metadata addObserverUsingBlock:^(BugsnagStateEvent *event) {
         weakSelf.delegateCalled = YES;
     }];
     [metadata addMetadata:@{dummyObj : @"someValue"} toSection:@"invalidKeyTab"];

--- a/Tests/BugsnagStateEventTest.m
+++ b/Tests/BugsnagStateEventTest.m
@@ -16,7 +16,7 @@
 
 @interface BugsnagClient()
 @property BugsnagMetadata *metadata;
-- (void)registerStateObserverWithBlock:(void (^_Nonnull)(BugsnagStateEvent *_Nonnull))event;
+- (void)addObserverUsingBlock:(BugsnagObserverBlock _Nonnull)observer;
 @end
 
 @interface BugsnagStateEventTest : XCTestCase
@@ -30,8 +30,9 @@
     BugsnagConfiguration *config = [[BugsnagConfiguration alloc] initWithApiKey:DUMMY_APIKEY_32CHAR_1];
     self.client = [Bugsnag startWithConfiguration:config];
 
-    [self.client registerStateObserverWithBlock:^(BugsnagStateEvent *event) {
-        self.event = event;
+    __weak __typeof__(self) weakSelf = self;
+    [self.client addObserverUsingBlock:^(BugsnagStateEvent *event) {
+        weakSelf.event = event;
     }];
 }
 
@@ -39,7 +40,7 @@
     [self.client setUser:@"123" withEmail:@"test@example.com" andName:@"Jamie"];
 
     BugsnagStateEvent* obj = self.event;
-    XCTAssertEqualObjects(@"UserUpdate", obj.name);
+    XCTAssertEqualObjects(@"UserUpdate", obj.type);
 
     NSDictionary *dict = obj.data;
     XCTAssertEqualObjects(@"123", dict[@"id"]);
@@ -50,7 +51,7 @@
 - (void)testContextUpdate {
     [self.client setContext:@"Foo"];
     BugsnagStateEvent* obj = self.event;
-    XCTAssertEqualObjects(@"ContextUpdate", obj.name);
+    XCTAssertEqualObjects(@"ContextUpdate", obj.type);
     XCTAssertEqualObjects(@"Foo", obj.data);
 }
 

--- a/iOS/Bugsnag.xcodeproj/project.pbxproj
+++ b/iOS/Bugsnag.xcodeproj/project.pbxproj
@@ -334,6 +334,8 @@
 		E78C1EF81FCC61EA00B976D3 /* BugsnagSessionTrackingPayload.m in Sources */ = {isa = PBXBuildFile; fileRef = E78C1EF51FCC61EA00B976D3 /* BugsnagSessionTrackingPayload.m */; };
 		E78C1EFC1FCC759B00B976D3 /* BugsnagSessionTest.m in Sources */ = {isa = PBXBuildFile; fileRef = E78C1EFB1FCC759B00B976D3 /* BugsnagSessionTest.m */; };
 		E78C1EFE1FCC778700B976D3 /* BugsnagUserTest.m in Sources */ = {isa = PBXBuildFile; fileRef = E78C1EFD1FCC778700B976D3 /* BugsnagUserTest.m */; };
+		E78E8CA824694A020017A314 /* BugsnagMetadata.h in CopyFiles */ = {isa = PBXBuildFile; fileRef = 8A2C8F491C6BBE3C00846019 /* BugsnagMetadata.h */; };
+		E78E8CAA24694A1E0017A314 /* BugsnagMetadata.m in Sources */ = {isa = PBXBuildFile; fileRef = 8A2C8F4A1C6BBE3C00846019 /* BugsnagMetadata.m */; };
 		E790C41E24323102006FFB26 /* BugsnagClientMirrorTest.m in Sources */ = {isa = PBXBuildFile; fileRef = E790C41D24323102006FFB26 /* BugsnagClientMirrorTest.m */; };
 		E790C425243354A8006FFB26 /* BugsnagClientInternal.h in Headers */ = {isa = PBXBuildFile; fileRef = E790C424243354A8006FFB26 /* BugsnagClientInternal.h */; };
 		E790C42A243359F6006FFB26 /* BugsnagClientInternal.h in Sources */ = {isa = PBXBuildFile; fileRef = E790C424243354A8006FFB26 /* BugsnagClientInternal.h */; };
@@ -423,6 +425,7 @@
 			dstPath = "include/${PRODUCT_NAME}";
 			dstSubfolderSpec = 16;
 			files = (
+				E78E8CA824694A020017A314 /* BugsnagMetadata.h in CopyFiles */,
 				E7819BAD2459758300A7EBDD /* BugsnagNotifier.h in CopyFiles */,
 				E7A8EA3A24606A3E00CCBBD1 /* BSGConfigurationBuilder.h in CopyFiles */,
 				E744771A2458608F00DFC4E8 /* BugsnagMetadataInternal.h in CopyFiles */,
@@ -720,7 +723,7 @@
 		E784D25D1FD70E55004B01E1 /* KSString_Tests.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; path = KSString_Tests.m; sourceTree = "<group>"; };
 		E7860568242241E100CC2D28 /* BugsnagStateEvent.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; name = BugsnagStateEvent.h; path = ../Source/BugsnagStateEvent.h; sourceTree = "<group>"; };
 		E7860569242241E100CC2D28 /* BugsnagStateEvent.m */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.objc; name = BugsnagStateEvent.m; path = ../Source/BugsnagStateEvent.m; sourceTree = "<group>"; };
-		E786056C242260AB00CC2D28 /* BugsnagStateEventTest.m */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.objc; path = BugsnagStateEventTest.m; sourceTree = "<group>"; };
+		E786056C242260AB00CC2D28 /* BugsnagStateEventTest.m */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.objc; name = BugsnagStateEventTest.m; path = ../../Tests/BugsnagStateEventTest.m; sourceTree = "<group>"; };
 		E78C1EF01FCC2F1700B976D3 /* BugsnagSessionTrackerTest.m */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.objc; name = BugsnagSessionTrackerTest.m; path = ../Tests/BugsnagSessionTrackerTest.m; sourceTree = SOURCE_ROOT; };
 		E78C1EF21FCC615400B976D3 /* BugsnagSessionTrackingPayloadTest.m */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.objc; name = BugsnagSessionTrackingPayloadTest.m; path = ../Tests/BugsnagSessionTrackingPayloadTest.m; sourceTree = SOURCE_ROOT; };
 		E78C1EF41FCC61EA00B976D3 /* BugsnagSessionTrackingPayload.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; name = BugsnagSessionTrackingPayload.h; path = ../Source/BugsnagSessionTrackingPayload.h; sourceTree = SOURCE_ROOT; };
@@ -912,6 +915,7 @@
 			isa = PBXGroup;
 			children = (
 				8AA661AC23D8C1F50031ECC8 /* BSGConnectivityTest.m */,
+				8A70D9CC2253C484006B696F /* BSGOutOfMemoryWatchdogTests.m */,
 				E790C49A2434C8C8006FFB26 /* BugsnagAppTest.m */,
 				009131BD23F5884E000810D9 /* BugsnagBaseUnitTest.m */,
 				009131BF23F58930000810D9 /* BugsnagBaseUnitTest.h */,
@@ -934,7 +938,6 @@
 				E7819BB6245979B800A7EBDD /* BugsnagNotifierTest.m */,
 				E7AB4B9B2423E16C004F015A /* BugsnagOnBreadcrumbTest.m */,
 				E728378A2451843000EE2B7D /* BugsnagOnCrashTest.m */,
-				8A70D9CC2253C484006B696F /* BSGOutOfMemoryWatchdogTests.m */,
 				E72AE1FF241A57B100ED8972 /* BugsnagPluginTest.m */,
 				E78C1EFB1FCC759B00B976D3 /* BugsnagSessionTest.m */,
 				E78C1EF01FCC2F1700B976D3 /* BugsnagSessionTrackerTest.m */,
@@ -943,7 +946,11 @@
 				8A2C8F8D1C6BBFDD00846019 /* BugsnagSinkTests.m */,
 				E722105B243B69F00083CF15 /* BugsnagStackframeTest.m */,
 				E7D2E66F243B8F8D005A3041 /* BugsnagStacktraceTest.m */,
+				E786056C242260AB00CC2D28 /* BugsnagStateEventTest.m */,
 				000E6E9B23D84DB1009D8194 /* BugsnagTestConstants.h */,
+				00D7ACAC23E9C63000FBE4A7 /* BugsnagTests.m */,
+				00F9393723FC4F63008C7073 /* BugsnagTestsDummyClass.h */,
+				00F9393823FC4F64008C7073 /* BugsnagTestsDummyClass.m */,
 				E7529F9B243CAE02006B4932 /* BugsnagThreadSerializationTest.m */,
 				E7529F9D243CAE0D006B4932 /* BugsnagThreadTest.m */,
 				E78C1EFD1FCC778700B976D3 /* BugsnagUserTest.m */,
@@ -953,11 +960,6 @@
 				000DF29223DB4A6B00A883CE /* Swift Tests */,
 				E70EE0891FD7047D00FA745C /* KSCrash */,
 				E7A8EA602461813700CCBBD1 /* TestsInfo.plist */,
-				00D7ACAC23E9C63000FBE4A7 /* BugsnagTests.m */,
-				00F9393723FC4F63008C7073 /* BugsnagTestsDummyClass.h */,
-				00F9393823FC4F64008C7073 /* BugsnagTestsDummyClass.m */,
-				E72AE1FF241A57B100ED8972 /* BugsnagPluginTest.m */,
-				E786056C242260AB00CC2D28 /* BugsnagStateEventTest.m */,
 			);
 			name = Tests;
 			path = BugsnagTests;
@@ -1640,6 +1642,7 @@
 			isa = PBXSourcesBuildPhase;
 			buildActionMask = 2147483647;
 			files = (
+				E78E8CAA24694A1E0017A314 /* BugsnagMetadata.m in Sources */,
 				E772E4DB24533AF8007C92A4 /* BugsnagPluginClient.m in Sources */,
 				E786056E24226BC800CC2D28 /* BugsnagStateEvent.m in Sources */,
 				E7397E321F83BC320034242A /* BSG_KSCrashC.c in Sources */,

--- a/iOS/Bugsnag.xcodeproj/project.pbxproj
+++ b/iOS/Bugsnag.xcodeproj/project.pbxproj
@@ -203,7 +203,6 @@
 		E7397E2B1F83BC2A0034242A /* BugsnagCollections.m in Sources */ = {isa = PBXBuildFile; fileRef = 8A2C8F421C6BBE3C00846019 /* BugsnagCollections.m */; };
 		E7397E2C1F83BC2A0034242A /* BugsnagConfiguration.m in Sources */ = {isa = PBXBuildFile; fileRef = 8A2C8F441C6BBE3C00846019 /* BugsnagConfiguration.m */; };
 		E7397E2D1F83BC2A0034242A /* BugsnagEvent.m in Sources */ = {isa = PBXBuildFile; fileRef = 8A2C8F461C6BBE3C00846019 /* BugsnagEvent.m */; };
-		E7397E2E1F83BC2A0034242A /* BugsnagMetadata.m in Sources */ = {isa = PBXBuildFile; fileRef = 8A2C8F4A1C6BBE3C00846019 /* BugsnagMetadata.m */; };
 		E7397E2F1F83BC2A0034242A /* BugsnagClient.m in Sources */ = {isa = PBXBuildFile; fileRef = 8A2C8F4C1C6BBE3C00846019 /* BugsnagClient.m */; };
 		E7397E301F83BC2A0034242A /* BugsnagSink.m in Sources */ = {isa = PBXBuildFile; fileRef = 8A2C8F4E1C6BBE3C00846019 /* BugsnagSink.m */; };
 		E7397E311F83BC2A0034242A /* BugsnagHandledState.m in Sources */ = {isa = PBXBuildFile; fileRef = E737DEA11F73AD7400BC7C80 /* BugsnagHandledState.m */; };
@@ -281,13 +280,14 @@
 		E7397EE91F83CFC20034242A /* BugsnagCollections.h in CopyFiles */ = {isa = PBXBuildFile; fileRef = 8A2C8F411C6BBE3C00846019 /* BugsnagCollections.h */; };
 		E7397EEA1F83CFC20034242A /* BugsnagConfiguration.h in CopyFiles */ = {isa = PBXBuildFile; fileRef = 8A2C8F431C6BBE3C00846019 /* BugsnagConfiguration.h */; };
 		E7397EEB1F83CFC20034242A /* BugsnagEvent.h in CopyFiles */ = {isa = PBXBuildFile; fileRef = 8A2C8F451C6BBE3C00846019 /* BugsnagEvent.h */; };
-		E7397EEC1F83CFC20034242A /* BugsnagMetadata.h in CopyFiles */ = {isa = PBXBuildFile; fileRef = 8A2C8F491C6BBE3C00846019 /* BugsnagMetadata.h */; };
 		E7397EED1F83CFC20034242A /* BugsnagClient.h in CopyFiles */ = {isa = PBXBuildFile; fileRef = 8A2C8F4B1C6BBE3C00846019 /* BugsnagClient.h */; };
 		E7397EEE1F83CFC20034242A /* BugsnagSink.h in CopyFiles */ = {isa = PBXBuildFile; fileRef = 8A2C8F4D1C6BBE3C00846019 /* BugsnagSink.h */; };
 		E7397EEF1F83CFC20034242A /* BugsnagHandledState.h in CopyFiles */ = {isa = PBXBuildFile; fileRef = E737DEA01F73AD7400BC7C80 /* BugsnagHandledState.h */; };
 		E73D443A243E1912001686F5 /* BugsnagErrorTest.m in Sources */ = {isa = PBXBuildFile; fileRef = E73D4439243E1912001686F5 /* BugsnagErrorTest.m */; };
 		E7433AD01F4F64D400C082D1 /* libc++.tbd in Frameworks */ = {isa = PBXBuildFile; fileRef = 8A2C8F6F1C6BBE9F00846019 /* libc++.tbd */; };
 		E7433AD11F4F64D900C082D1 /* libz.tbd in Frameworks */ = {isa = PBXBuildFile; fileRef = 8A2C8F6D1C6BBE9A00846019 /* libz.tbd */; };
+		E74477192458601600DFC4E8 /* BugsnagMetadataInternal.h in Headers */ = {isa = PBXBuildFile; fileRef = E74477182458601600DFC4E8 /* BugsnagMetadataInternal.h */; };
+		E744771A2458608F00DFC4E8 /* BugsnagMetadataInternal.h in CopyFiles */ = {isa = PBXBuildFile; fileRef = E74477182458601600DFC4E8 /* BugsnagMetadataInternal.h */; };
 		E748DA781FD02A3F00B14909 /* BugsnagSessionFileStore.h in CopyFiles */ = {isa = PBXBuildFile; fileRef = F42955025DBE1DCEFD928CAA /* BugsnagSessionFileStore.h */; };
 		E74D8E93243B3DF000F2A630 /* ORGANIZATION.md in Resources */ = {isa = PBXBuildFile; fileRef = E74D8E92243B3DF000F2A630 /* ORGANIZATION.md */; };
 		E74EFDC21FD04B9200577D23 /* BugsnagSessionTrackingApiClient.h in CopyFiles */ = {isa = PBXBuildFile; fileRef = F429517A5571A61A897E963D /* BugsnagSessionTrackingApiClient.h */; };
@@ -322,6 +322,11 @@
 		E784D2561FD70B3E004B01E1 /* KSMach_Tests.m in Sources */ = {isa = PBXBuildFile; fileRef = E784D2521FD70AE6004B01E1 /* KSMach_Tests.m */; };
 		E784D25A1FD70C25004B01E1 /* KSJSONCodec_Tests.m in Sources */ = {isa = PBXBuildFile; fileRef = E784D2591FD70C25004B01E1 /* KSJSONCodec_Tests.m */; };
 		E784D25E1FD70E55004B01E1 /* KSString_Tests.m in Sources */ = {isa = PBXBuildFile; fileRef = E784D25D1FD70E55004B01E1 /* KSString_Tests.m */; };
+		E786056A242241E100CC2D28 /* BugsnagStateEvent.h in Headers */ = {isa = PBXBuildFile; fileRef = E7860568242241E100CC2D28 /* BugsnagStateEvent.h */; };
+		E786056B242241E100CC2D28 /* BugsnagStateEvent.m in Sources */ = {isa = PBXBuildFile; fileRef = E7860569242241E100CC2D28 /* BugsnagStateEvent.m */; };
+		E786056D242260AB00CC2D28 /* BugsnagStateEventTest.m in Sources */ = {isa = PBXBuildFile; fileRef = E786056C242260AB00CC2D28 /* BugsnagStateEventTest.m */; };
+		E786056E24226BC800CC2D28 /* BugsnagStateEvent.m in Sources */ = {isa = PBXBuildFile; fileRef = E7860569242241E100CC2D28 /* BugsnagStateEvent.m */; };
+		E786056F24226BDF00CC2D28 /* BugsnagStateEvent.h in CopyFiles */ = {isa = PBXBuildFile; fileRef = E7860568242241E100CC2D28 /* BugsnagStateEvent.h */; };
 		E78C1EF11FCC2F1700B976D3 /* BugsnagSessionTrackerTest.m in Sources */ = {isa = PBXBuildFile; fileRef = E78C1EF01FCC2F1700B976D3 /* BugsnagSessionTrackerTest.m */; };
 		E78C1EF31FCC615400B976D3 /* BugsnagSessionTrackingPayloadTest.m in Sources */ = {isa = PBXBuildFile; fileRef = E78C1EF21FCC615400B976D3 /* BugsnagSessionTrackingPayloadTest.m */; };
 		E78C1EF61FCC61EA00B976D3 /* BugsnagSessionTrackingPayload.h in Headers */ = {isa = PBXBuildFile; fileRef = E78C1EF41FCC61EA00B976D3 /* BugsnagSessionTrackingPayload.h */; };
@@ -420,6 +425,7 @@
 			files = (
 				E7819BAD2459758300A7EBDD /* BugsnagNotifier.h in CopyFiles */,
 				E7A8EA3A24606A3E00CCBBD1 /* BSGConfigurationBuilder.h in CopyFiles */,
+				E744771A2458608F00DFC4E8 /* BugsnagMetadataInternal.h in CopyFiles */,
 				E7565F7C245082580041768E /* BugsnagErrorTypes.h in CopyFiles */,
 				E77AFEF22448A13C0082B8BB /* BugsnagSessionInternal.h in CopyFiles */,
 				E77AFF0C244A18A00082B8BB /* BugsnagEndpointConfiguration.h in CopyFiles */,
@@ -434,6 +440,7 @@
 				E790C46124349A70006FFB26 /* BugsnagThread.h in CopyFiles */,
 				E790C42B24335A2B006FFB26 /* BugsnagClientInternal.h in CopyFiles */,
 				E77526BD242D0B1F0077A42F /* BugsnagBreadcrumbs.h in CopyFiles */,
+				E786056F24226BDF00CC2D28 /* BugsnagStateEvent.h in CopyFiles */,
 				8A3C590923965D9400B344AA /* BugsnagPlugin.h in CopyFiles */,
 				E79148251FD828E6003EFEBF /* BugsnagKeys.h in CopyFiles */,
 				E79148261FD828E6003EFEBF /* BugsnagSessionTracker.h in CopyFiles */,
@@ -497,8 +504,6 @@
 				E7397EE91F83CFC20034242A /* BugsnagCollections.h in CopyFiles */,
 				E7397EEA1F83CFC20034242A /* BugsnagConfiguration.h in CopyFiles */,
 				E7397EEB1F83CFC20034242A /* BugsnagEvent.h in CopyFiles */,
-				E7397EEC1F83CFC20034242A /* BugsnagMetadata.h in CopyFiles */,
-				E7397EEC1F83CFC20034242A /* BugsnagMetadata.h in CopyFiles */,
 				E7397EED1F83CFC20034242A /* BugsnagClient.h in CopyFiles */,
 				E7397EEE1F83CFC20034242A /* BugsnagSink.h in CopyFiles */,
 				E7397EEF1F83CFC20034242A /* BugsnagHandledState.h in CopyFiles */,
@@ -692,6 +697,7 @@
 		E737DEA11F73AD7400BC7C80 /* BugsnagHandledState.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; name = BugsnagHandledState.m; path = ../Source/BugsnagHandledState.m; sourceTree = SOURCE_ROOT; };
 		E7397DC41F83BAC50034242A /* libBugsnagStatic.a */ = {isa = PBXFileReference; explicitFileType = archive.ar; includeInIndex = 0; path = libBugsnagStatic.a; sourceTree = BUILT_PRODUCTS_DIR; };
 		E73D4439243E1912001686F5 /* BugsnagErrorTest.m */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.objc; name = BugsnagErrorTest.m; path = ../../Tests/BugsnagErrorTest.m; sourceTree = "<group>"; };
+		E74477182458601600DFC4E8 /* BugsnagMetadataInternal.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; name = BugsnagMetadataInternal.h; path = ../Source/BugsnagMetadataInternal.h; sourceTree = "<group>"; };
 		E74D8E92243B3DF000F2A630 /* ORGANIZATION.md */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = net.daringfireball.markdown; name = ORGANIZATION.md; path = ../ORGANIZATION.md; sourceTree = "<group>"; };
 		E7529F87243C8DA2006B4932 /* RegisterErrorData.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; name = RegisterErrorData.h; path = ../Source/RegisterErrorData.h; sourceTree = "<group>"; };
 		E7529F88243C8DA2006B4932 /* RegisterErrorData.m */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.objc; name = RegisterErrorData.m; path = ../Source/RegisterErrorData.m; sourceTree = "<group>"; };
@@ -712,6 +718,9 @@
 		E784D2521FD70AE6004B01E1 /* KSMach_Tests.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; name = KSMach_Tests.m; path = ../Tests/KSCrash/KSMach_Tests.m; sourceTree = SOURCE_ROOT; };
 		E784D2591FD70C25004B01E1 /* KSJSONCodec_Tests.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; name = KSJSONCodec_Tests.m; path = ../Tests/KSCrash/KSJSONCodec_Tests.m; sourceTree = SOURCE_ROOT; };
 		E784D25D1FD70E55004B01E1 /* KSString_Tests.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; path = KSString_Tests.m; sourceTree = "<group>"; };
+		E7860568242241E100CC2D28 /* BugsnagStateEvent.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; name = BugsnagStateEvent.h; path = ../Source/BugsnagStateEvent.h; sourceTree = "<group>"; };
+		E7860569242241E100CC2D28 /* BugsnagStateEvent.m */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.objc; name = BugsnagStateEvent.m; path = ../Source/BugsnagStateEvent.m; sourceTree = "<group>"; };
+		E786056C242260AB00CC2D28 /* BugsnagStateEventTest.m */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.objc; path = BugsnagStateEventTest.m; sourceTree = "<group>"; };
 		E78C1EF01FCC2F1700B976D3 /* BugsnagSessionTrackerTest.m */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.objc; name = BugsnagSessionTrackerTest.m; path = ../Tests/BugsnagSessionTrackerTest.m; sourceTree = SOURCE_ROOT; };
 		E78C1EF21FCC615400B976D3 /* BugsnagSessionTrackingPayloadTest.m */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.objc; name = BugsnagSessionTrackingPayloadTest.m; path = ../Tests/BugsnagSessionTrackingPayloadTest.m; sourceTree = SOURCE_ROOT; };
 		E78C1EF41FCC61EA00B976D3 /* BugsnagSessionTrackingPayload.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; name = BugsnagSessionTrackingPayload.h; path = ../Source/BugsnagSessionTrackingPayload.h; sourceTree = SOURCE_ROOT; };
@@ -856,8 +865,6 @@
 				E7A9E58C243B241900D99F8A /* Storage */,
 				8A3B5F252407EC6400CE4A3A /* Private.h */,
 				E7107BD31F4C97F100BB3F98 /* BSG_KSCrashReportWriter.h */,
-				8A70D9C722539C81006B696F /* BSGOutOfMemoryWatchdog.h */,
-				8A70D9C822539C81006B696F /* BSGOutOfMemoryWatchdog.m */,
 				8A627CCF1EC2A5FD00F7C04E /* BSGSerialization.h */,
 				8A627CD11EC2A62900F7C04E /* BSGSerialization.m */,
 				8A2C8F3D1C6BBE3C00846019 /* Bugsnag.h */,
@@ -892,6 +899,11 @@
 				0061D84324067AF70041C068 /* SSKeychain */,
 				E7107BB31F4C97F100BB3F98 /* KSCrash */,
 				8A2C8F321C6BBD7200846019 /* module.modulemap */,
+				8A70D9C722539C81006B696F /* BSGOutOfMemoryWatchdog.h */,
+				8A70D9C822539C81006B696F /* BSGOutOfMemoryWatchdog.m */,
+				8A72A0352396535000328051 /* BugsnagPlugin.h */,
+				E7860568242241E100CC2D28 /* BugsnagStateEvent.h */,
+				E7860569242241E100CC2D28 /* BugsnagStateEvent.m */,
 			);
 			name = Bugsnag;
 			sourceTree = SOURCE_ROOT;
@@ -932,9 +944,6 @@
 				E722105B243B69F00083CF15 /* BugsnagStackframeTest.m */,
 				E7D2E66F243B8F8D005A3041 /* BugsnagStacktraceTest.m */,
 				000E6E9B23D84DB1009D8194 /* BugsnagTestConstants.h */,
-				00D7ACAC23E9C63000FBE4A7 /* BugsnagTests.m */,
-				00F9393723FC4F63008C7073 /* BugsnagTestsDummyClass.h */,
-				00F9393823FC4F64008C7073 /* BugsnagTestsDummyClass.m */,
 				E7529F9B243CAE02006B4932 /* BugsnagThreadSerializationTest.m */,
 				E7529F9D243CAE0D006B4932 /* BugsnagThreadTest.m */,
 				E78C1EFD1FCC778700B976D3 /* BugsnagUserTest.m */,
@@ -944,6 +953,11 @@
 				000DF29223DB4A6B00A883CE /* Swift Tests */,
 				E70EE0891FD7047D00FA745C /* KSCrash */,
 				E7A8EA602461813700CCBBD1 /* TestsInfo.plist */,
+				00D7ACAC23E9C63000FBE4A7 /* BugsnagTests.m */,
+				00F9393723FC4F63008C7073 /* BugsnagTestsDummyClass.h */,
+				00F9393823FC4F64008C7073 /* BugsnagTestsDummyClass.m */,
+				E72AE1FF241A57B100ED8972 /* BugsnagPluginTest.m */,
+				E786056C242260AB00CC2D28 /* BugsnagStateEventTest.m */,
 			);
 			name = Tests;
 			path = BugsnagTests;
@@ -1167,7 +1181,6 @@
 		E7A9E588243B240300D99F8A /* Plugins */ = {
 			isa = PBXGroup;
 			children = (
-				8A72A0352396535000328051 /* BugsnagPlugin.h */,
 				E72AE1F3241A4E4400ED8972 /* BugsnagPluginClient.h */,
 				E72AE1F4241A4E4400ED8972 /* BugsnagPluginClient.m */,
 			);
@@ -1218,6 +1231,7 @@
 			children = (
 				8A2C8F491C6BBE3C00846019 /* BugsnagMetadata.h */,
 				8A2C8F4A1C6BBE3C00846019 /* BugsnagMetadata.m */,
+				E74477182458601600DFC4E8 /* BugsnagMetadataInternal.h */,
 				009DF96824327FA2000A8363 /* BugsnagMetadataStore.h */,
 			);
 			name = Metadata;
@@ -1253,6 +1267,7 @@
 				E7565F7824507F640041768E /* BugsnagErrorTypes.h in Headers */,
 				E72BF77F1FC86A7A004BE82F /* BugsnagUser.h in Headers */,
 				E72BF77A1FC869F7004BE82F /* BugsnagSession.h in Headers */,
+				E74477192458601600DFC4E8 /* BugsnagMetadataInternal.h in Headers */,
 				E77AFF09244A18890082B8BB /* BugsnagEndpointConfiguration.h in Headers */,
 				E790C45824349A28006FFB26 /* BugsnagThread.h in Headers */,
 				E790C453243498BB006FFB26 /* BugsnagStackframe.h in Headers */,
@@ -1334,6 +1349,7 @@
 				8A2C8F5F1C6BBE3C00846019 /* BugsnagSink.h in Headers */,
 				E794E8031F9F743D00A67EE7 /* BugsnagKeys.h in Headers */,
 				E72352B61F55718E00436528 /* BSGConnectivity.h in Headers */,
+				E786056A242241E100CC2D28 /* BugsnagStateEvent.h in Headers */,
 				F4295932E7EC58D1CB806EC9 /* BugsnagFileStore.h in Headers */,
 				F4295C14DCDDF541188CDE66 /* BugsnagSessionFileStore.h in Headers */,
 				F429561943952286B690CFB1 /* BugsnagSessionTrackingApiClient.h in Headers */,
@@ -1535,6 +1551,7 @@
 				E72BF7801FC86A7A004BE82F /* BugsnagUser.m in Sources */,
 				8A2C8F541C6BBE3C00846019 /* BugsnagCollections.m in Sources */,
 				E7107C501F4C97F100BB3F98 /* BSG_KSCrashSentry_MachException.c in Sources */,
+				E786056B242241E100CC2D28 /* BugsnagStateEvent.m in Sources */,
 				E7107C5F1F4C97F100BB3F98 /* BSG_KSDynamicLinker.c in Sources */,
 				E737DEA31F73AD7400BC7C80 /* BugsnagHandledState.m in Sources */,
 				E72962D71F4BBA8B00CEA15D /* BugsnagCrashSentry.m in Sources */,
@@ -1570,6 +1587,7 @@
 				8A2C8F8F1C6BBFDD00846019 /* BugsnagBreadcrumbsTest.m in Sources */,
 				E733A76A1FD7091F003EAA29 /* KSCrashSentry_Tests.m in Sources */,
 				E784D25E1FD70E55004B01E1 /* KSString_Tests.m in Sources */,
+				E786056D242260AB00CC2D28 /* BugsnagStateEventTest.m in Sources */,
 				4B775FCF22CBDEB4004839C5 /* BugsnagCollectionsBSGDictInsertIfNotNilTest.m in Sources */,
 				E72AE200241A57B100ED8972 /* BugsnagPluginTest.m in Sources */,
 				E733A7681FD7091F003EAA29 /* KSCrashSentry_NSException_Tests.m in Sources */,
@@ -1623,6 +1641,7 @@
 			buildActionMask = 2147483647;
 			files = (
 				E772E4DB24533AF8007C92A4 /* BugsnagPluginClient.m in Sources */,
+				E786056E24226BC800CC2D28 /* BugsnagStateEvent.m in Sources */,
 				E7397E321F83BC320034242A /* BSG_KSCrashC.c in Sources */,
 				E7397E331F83BC320034242A /* BSG_KSCrashReport.c in Sources */,
 				E7397E341F83BC320034242A /* BSG_KSCrashState.m in Sources */,
@@ -1683,8 +1702,6 @@
 				E7397E2B1F83BC2A0034242A /* BugsnagCollections.m in Sources */,
 				E7397E2C1F83BC2A0034242A /* BugsnagConfiguration.m in Sources */,
 				E7397E2D1F83BC2A0034242A /* BugsnagEvent.m in Sources */,
-				E7397E2E1F83BC2A0034242A /* BugsnagMetadata.m in Sources */,
-				E7397E2E1F83BC2A0034242A /* BugsnagMetadata.m in Sources */,
 				E7397E2F1F83BC2A0034242A /* BugsnagClient.m in Sources */,
 				E7397E301F83BC2A0034242A /* BugsnagSink.m in Sources */,
 				E790C4462434984B006FFB26 /* BugsnagDevice.m in Sources */,

--- a/iOS/BugsnagTests/BugsnagStateEventTest.m
+++ b/iOS/BugsnagTests/BugsnagStateEventTest.m
@@ -1,0 +1,68 @@
+//
+//  BugsnagStateEventTest.m
+//  Tests
+//
+//  Created by Jamie Lynch on 18/03/2020.
+//  Copyright © 2020 Bugsnag. All rights reserved.
+//
+
+#import <XCTest/XCTest.h>
+
+#import "Bugsnag.h"
+#import "BugsnagConfiguration.h"
+#import "BugsnagTestConstants.h"
+#import "BugsnagStateEvent.h"
+#import "BugsnagMetadataInternal.h"
+
+@interface BugsnagConfiguration()
+@property BugsnagMetadata *metadata;
+- (void)registerStateObserverWithBlock:(void (^_Nonnull)(BugsnagStateEvent *_Nonnull))event;
+@end
+
+@interface BugsnagStateEventTest : XCTestCase
+@property BugsnagConfiguration *config;
+@property BugsnagStateEvent *event;
+@property BugsnagMetadata *observedMetadata;
+@end
+
+@implementation BugsnagStateEventTest
+
+- (void)setUp {
+    self.config = [[BugsnagConfiguration alloc] initWithApiKey:DUMMY_APIKEY_32CHAR_1];
+
+    [self.config registerStateObserverWithBlock:^(BugsnagStateEvent *event) {
+        self.event = event;
+    }];
+
+    __weak __typeof__(self) weakSelf = self;
+    [self.config.metadata addObserver:^(BugsnagMetadata *metadata) {
+        weakSelf.observedMetadata = metadata;
+    }];
+}
+
+- (void)testUserUpdate {
+    [self.config setUser:@"123" withEmail:@"test@example.com" andName:@"Jamie"];
+
+    BugsnagStateEvent* obj = self.event;
+    XCTAssertEqualObjects(@"UserUpdate", obj.name);
+
+    NSDictionary *dict = obj.data;
+    XCTAssertEqualObjects(@"123", dict[@"id"]);
+    XCTAssertEqualObjects(@"Jamie", dict[@"name"]);
+    XCTAssertEqualObjects(@"test@example.com", dict[@"email"]);
+}
+
+- (void)testContextUpdate {
+    [self.config setContext:@"Foo"];
+    BugsnagStateEvent* obj = self.event;
+    XCTAssertEqualObjects(@"ContextUpdate", obj.name);
+    XCTAssertEqualObjects(@"Foo", obj.data);
+}
+
+- (void)testMetadataUpdate {
+    XCTAssertNil(self.observedMetadata);
+    [self.config addMetadata:@"Bar" withKey:@"Foo" toSection:@"test"];
+    XCTAssertEqualObjects(self.config.metadata, self.observedMetadata);
+}
+
+@end

--- a/tvOS/Bugsnag.xcodeproj/project.pbxproj
+++ b/tvOS/Bugsnag.xcodeproj/project.pbxproj
@@ -75,6 +75,7 @@
 		E742DB23243C812E002C4621 /* BugsnagStacktrace.m in Sources */ = {isa = PBXBuildFile; fileRef = E7D2E67A243B8FD2005A3041 /* BugsnagStacktrace.m */; };
 		E7433AD61F4F650C00C082D1 /* libc++.tbd in Frameworks */ = {isa = PBXBuildFile; fileRef = E7433AD51F4F650C00C082D1 /* libc++.tbd */; };
 		E7433AD81F4F651200C082D1 /* libz.tbd in Frameworks */ = {isa = PBXBuildFile; fileRef = E7433AD71F4F651200C082D1 /* libz.tbd */; };
+		E744771E245860CD00DFC4E8 /* BugsnagMetadataInternal.h in Headers */ = {isa = PBXBuildFile; fileRef = E744771D245860CC00DFC4E8 /* BugsnagMetadataInternal.h */; };
 		E7529F92243C8ED4006B4932 /* RegisterErrorData.m in Sources */ = {isa = PBXBuildFile; fileRef = E7529F90243C8ED4006B4932 /* RegisterErrorData.m */; };
 		E7529F93243C8ED4006B4932 /* RegisterErrorData.h in Headers */ = {isa = PBXBuildFile; fileRef = E7529F91243C8ED4006B4932 /* RegisterErrorData.h */; };
 		E7529FA6243CAE6A006B4932 /* BugsnagThreadSerializationTest.m in Sources */ = {isa = PBXBuildFile; fileRef = E7529FA5243CAE6A006B4932 /* BugsnagThreadSerializationTest.m */; };
@@ -170,6 +171,8 @@
 		E7819BB4245975BF00A7EBDD /* BugsnagNotifier.m in Sources */ = {isa = PBXBuildFile; fileRef = E7819BB2245975BF00A7EBDD /* BugsnagNotifier.m */; };
 		E7819BB5245975BF00A7EBDD /* BugsnagNotifier.h in Headers */ = {isa = PBXBuildFile; fileRef = E7819BB3245975BF00A7EBDD /* BugsnagNotifier.h */; };
 		E7819BBB245979E900A7EBDD /* BugsnagNotifierTest.m in Sources */ = {isa = PBXBuildFile; fileRef = E7819BBA245979E900A7EBDD /* BugsnagNotifierTest.m */; };
+		E786059824229A6E00CC2D28 /* BugsnagStateEvent.m in Sources */ = {isa = PBXBuildFile; fileRef = E786059624229A6E00CC2D28 /* BugsnagStateEvent.m */; };
+		E786059924229A6E00CC2D28 /* BugsnagStateEvent.h in Headers */ = {isa = PBXBuildFile; fileRef = E786059724229A6E00CC2D28 /* BugsnagStateEvent.h */; };
 		E790C422243231EA006FFB26 /* BugsnagClientMirrorTest.m in Sources */ = {isa = PBXBuildFile; fileRef = E790C421243231EA006FFB26 /* BugsnagClientMirrorTest.m */; };
 		E790C4292433551D006FFB26 /* BugsnagClientInternal.h in Headers */ = {isa = PBXBuildFile; fileRef = E790C4282433551D006FFB26 /* BugsnagClientInternal.h */; };
 		E790C48C24349D35006FFB26 /* BugsnagApp.h in Headers */ = {isa = PBXBuildFile; fileRef = E790C47E24349D33006FFB26 /* BugsnagApp.h */; settings = {ATTRIBUTES = (Public, ); }; };
@@ -316,6 +319,7 @@
 		E73D443D243E1945001686F5 /* BugsnagErrorTest.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; name = BugsnagErrorTest.m; path = ../../Tests/BugsnagErrorTest.m; sourceTree = "<group>"; };
 		E7433AD51F4F650C00C082D1 /* libc++.tbd */ = {isa = PBXFileReference; lastKnownFileType = "sourcecode.text-based-dylib-definition"; name = "libc++.tbd"; path = "usr/lib/libc++.tbd"; sourceTree = SDKROOT; };
 		E7433AD71F4F651200C082D1 /* libz.tbd */ = {isa = PBXFileReference; lastKnownFileType = "sourcecode.text-based-dylib-definition"; name = libz.tbd; path = usr/lib/libz.tbd; sourceTree = SDKROOT; };
+		E744771D245860CC00DFC4E8 /* BugsnagMetadataInternal.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; name = BugsnagMetadataInternal.h; path = ../Source/BugsnagMetadataInternal.h; sourceTree = "<group>"; };
 		E7529F90243C8ED4006B4932 /* RegisterErrorData.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; name = RegisterErrorData.m; path = ../Source/RegisterErrorData.m; sourceTree = "<group>"; };
 		E7529F91243C8ED4006B4932 /* RegisterErrorData.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; name = RegisterErrorData.h; path = ../Source/RegisterErrorData.h; sourceTree = "<group>"; };
 		E7529FA5243CAE6A006B4932 /* BugsnagThreadSerializationTest.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; name = BugsnagThreadSerializationTest.m; path = ../../iOS/BugsnagTests/BugsnagThreadSerializationTest.m; sourceTree = "<group>"; };
@@ -413,6 +417,8 @@
 		E7819BB2245975BF00A7EBDD /* BugsnagNotifier.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; name = BugsnagNotifier.m; path = ../Source/BugsnagNotifier.m; sourceTree = "<group>"; };
 		E7819BB3245975BF00A7EBDD /* BugsnagNotifier.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; name = BugsnagNotifier.h; path = ../Source/BugsnagNotifier.h; sourceTree = "<group>"; };
 		E7819BBA245979E900A7EBDD /* BugsnagNotifierTest.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; name = BugsnagNotifierTest.m; path = ../../Tests/BugsnagNotifierTest.m; sourceTree = "<group>"; };
+		E786059624229A6E00CC2D28 /* BugsnagStateEvent.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; name = BugsnagStateEvent.m; path = ../Source/BugsnagStateEvent.m; sourceTree = "<group>"; };
+		E786059724229A6E00CC2D28 /* BugsnagStateEvent.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; name = BugsnagStateEvent.h; path = ../Source/BugsnagStateEvent.h; sourceTree = "<group>"; };
 		E790C421243231EA006FFB26 /* BugsnagClientMirrorTest.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; name = BugsnagClientMirrorTest.m; path = ../../Tests/BugsnagClientMirrorTest.m; sourceTree = "<group>"; };
 		E790C4282433551D006FFB26 /* BugsnagClientInternal.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; name = BugsnagClientInternal.h; path = ../Source/BugsnagClientInternal.h; sourceTree = "<group>"; };
 		E790C47E24349D33006FFB26 /* BugsnagApp.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; name = BugsnagApp.h; path = ../Source/BugsnagApp.h; sourceTree = "<group>"; };
@@ -546,6 +552,15 @@
 				E74D8E81243B388E00F2A630 /* Plugins */,
 				E74D8E91243B38E200F2A630 /* Storage */,
 				8AB151251D41366400C9B218 /* BSG_KSCrashReportWriter.h */,
+				E786059724229A6E00CC2D28 /* BugsnagStateEvent.h */,
+				E786059624229A6E00CC2D28 /* BugsnagStateEvent.m */,
+				E72AE1FB241A4ED600ED8972 /* BugsnagPluginClient.h */,
+				E72AE1FC241A4ED600ED8972 /* BugsnagPluginClient.m */,
+				0089B6ED241168CB00D5A7F2 /* BugsnagClient.h */,
+				0089B6EE241168CB00D5A7F2 /* BugsnagClient.m */,
+				00D7AC9F23E97FBD00FBE4A7 /* BugsnagEvent.h */,
+				00D7AC9E23E97FBD00FBE4A7 /* BugsnagEvent.m */,
+				8A3C590F23968B2000B344AA /* BugsnagPlugin.h */,
 				8A6C6FAC2257882400E8EF24 /* BSGOutOfMemoryWatchdog.h */,
 				8A6C6FAB2257882400E8EF24 /* BSGOutOfMemoryWatchdog.m */,
 				8A627CD31EC3B69300F7C04E /* BSGSerialization.h */,
@@ -643,9 +658,6 @@
 		E74D8E81243B388E00F2A630 /* Plugins */ = {
 			isa = PBXGroup;
 			children = (
-				8A3C590F23968B2000B344AA /* BugsnagPlugin.h */,
-				E72AE1FB241A4ED600ED8972 /* BugsnagPluginClient.h */,
-				E72AE1FC241A4ED600ED8972 /* BugsnagPluginClient.m */,
 			);
 			name = Plugins;
 			sourceTree = "<group>";
@@ -687,6 +699,7 @@
 			children = (
 				8AB151301D41366400C9B218 /* BugsnagMetadata.h */,
 				8AB151311D41366400C9B218 /* BugsnagMetadata.m */,
+				E744771D245860CC00DFC4E8 /* BugsnagMetadataInternal.h */,
 				009DF96C2432876C000A8363 /* BugsnagMetadataStore.h */,
 			);
 			name = Metadata;
@@ -714,8 +727,6 @@
 			children = (
 				8AB151261D41366400C9B218 /* Bugsnag.h */,
 				8AB151271D41366400C9B218 /* Bugsnag.m */,
-				0089B6ED241168CB00D5A7F2 /* BugsnagClient.h */,
-				0089B6EE241168CB00D5A7F2 /* BugsnagClient.m */,
 				E790C4282433551D006FFB26 /* BugsnagClientInternal.h */,
 			);
 			name = Client;
@@ -942,9 +953,9 @@
 			isa = PBXHeadersBuildPhase;
 			buildActionMask = 2147483647;
 			files = (
-				E7565F85245082C10041768E /* BugsnagErrorTypes.h in Headers */,
 				E79148791FD82E6D003EFEBF /* BugsnagUser.h in Headers */,
 				E79148771FD82E6D003EFEBF /* BugsnagSession.h in Headers */,
+				E7565F85245082C10041768E /* BugsnagErrorTypes.h in Headers */,
 				E77AFF13244A19260082B8BB /* BugsnagEndpointConfiguration.h in Headers */,
 				E790C49224349D35006FFB26 /* BugsnagThread.h in Headers */,
 				E790C49324349D35006FFB26 /* BugsnagStackframe.h in Headers */,
@@ -969,6 +980,7 @@
 				E76617AA1F4E459C0094CECF /* BSG_KSDynamicLinker.h in Headers */,
 				E76617B41F4E459C0094CECF /* BSG_KSMach.h in Headers */,
 				E76617AF1F4E459C0094CECF /* BSG_KSJSONCodecObjC.h in Headers */,
+				E786059924229A6E00CC2D28 /* BugsnagStateEvent.h in Headers */,
 				E791487B1FD82E6D003EFEBF /* BugsnagSessionFileStore.h in Headers */,
 				E76617B11F4E459C0094CECF /* BSG_KSLogger.h in Headers */,
 				8AD9A4F51D42EE87004E1CC5 /* Bugsnag.h in Headers */,
@@ -994,6 +1006,7 @@
 				E766178F1F4E459C0094CECF /* BSG_KSCrashType.h in Headers */,
 				E766178D1F4E459C0094CECF /* BSG_KSCrashState.h in Headers */,
 				E79148851FD82E6D003EFEBF /* BugsnagSessionTrackingApiClient.h in Headers */,
+				E744771E245860CD00DFC4E8 /* BugsnagMetadataInternal.h in Headers */,
 				E76617911F4E459C0094CECF /* BSG_KSSystemInfo.h in Headers */,
 				8AD9A4FA1D42EE96004E1CC5 /* BugsnagMetadata.h in Headers */,
 				E76616F71F4E45950094CECF /* BugsnagCrashSentry.h in Headers */,
@@ -1189,6 +1202,7 @@
 				E76617AD1F4E459C0094CECF /* BSG_KSJSONCodec.c in Sources */,
 				E790C48E24349D35006FFB26 /* BugsnagThread.m in Sources */,
 				E766179D1F4E459C0094CECF /* BSG_KSCrashSentry_NSException.m in Sources */,
+				E786059824229A6E00CC2D28 /* BugsnagStateEvent.m in Sources */,
 				E76617851F4E459C0094CECF /* BSG_KSCrashReport.c in Sources */,
 				8AD9A5021D42EEB0004E1CC5 /* BugsnagMetadata.m in Sources */,
 				E766179A1F4E459C0094CECF /* BSG_KSCrashSentry_MachException.c in Sources */,

--- a/tvOS/Bugsnag.xcodeproj/project.pbxproj
+++ b/tvOS/Bugsnag.xcodeproj/project.pbxproj
@@ -173,6 +173,7 @@
 		E7819BBB245979E900A7EBDD /* BugsnagNotifierTest.m in Sources */ = {isa = PBXBuildFile; fileRef = E7819BBA245979E900A7EBDD /* BugsnagNotifierTest.m */; };
 		E786059824229A6E00CC2D28 /* BugsnagStateEvent.m in Sources */ = {isa = PBXBuildFile; fileRef = E786059624229A6E00CC2D28 /* BugsnagStateEvent.m */; };
 		E786059924229A6E00CC2D28 /* BugsnagStateEvent.h in Headers */ = {isa = PBXBuildFile; fileRef = E786059724229A6E00CC2D28 /* BugsnagStateEvent.h */; };
+		E78E8CB124694C020017A314 /* BugsnagStateEventTest.m in Sources */ = {isa = PBXBuildFile; fileRef = E78E8CB024694C020017A314 /* BugsnagStateEventTest.m */; };
 		E790C422243231EA006FFB26 /* BugsnagClientMirrorTest.m in Sources */ = {isa = PBXBuildFile; fileRef = E790C421243231EA006FFB26 /* BugsnagClientMirrorTest.m */; };
 		E790C4292433551D006FFB26 /* BugsnagClientInternal.h in Headers */ = {isa = PBXBuildFile; fileRef = E790C4282433551D006FFB26 /* BugsnagClientInternal.h */; };
 		E790C48C24349D35006FFB26 /* BugsnagApp.h in Headers */ = {isa = PBXBuildFile; fileRef = E790C47E24349D33006FFB26 /* BugsnagApp.h */; settings = {ATTRIBUTES = (Public, ); }; };
@@ -419,6 +420,7 @@
 		E7819BBA245979E900A7EBDD /* BugsnagNotifierTest.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; name = BugsnagNotifierTest.m; path = ../../Tests/BugsnagNotifierTest.m; sourceTree = "<group>"; };
 		E786059624229A6E00CC2D28 /* BugsnagStateEvent.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; name = BugsnagStateEvent.m; path = ../Source/BugsnagStateEvent.m; sourceTree = "<group>"; };
 		E786059724229A6E00CC2D28 /* BugsnagStateEvent.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; name = BugsnagStateEvent.h; path = ../Source/BugsnagStateEvent.h; sourceTree = "<group>"; };
+		E78E8CB024694C020017A314 /* BugsnagStateEventTest.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; name = BugsnagStateEventTest.m; path = ../../Tests/BugsnagStateEventTest.m; sourceTree = "<group>"; };
 		E790C421243231EA006FFB26 /* BugsnagClientMirrorTest.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; name = BugsnagClientMirrorTest.m; path = ../../Tests/BugsnagClientMirrorTest.m; sourceTree = "<group>"; };
 		E790C4282433551D006FFB26 /* BugsnagClientInternal.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; name = BugsnagClientInternal.h; path = ../Source/BugsnagClientInternal.h; sourceTree = "<group>"; };
 		E790C47E24349D33006FFB26 /* BugsnagApp.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; name = BugsnagApp.h; path = ../Source/BugsnagApp.h; sourceTree = "<group>"; };
@@ -620,6 +622,7 @@
 				E791488B1FD82E77003EFEBF /* BugsnagSessionTrackingPayloadTest.m */,
 				E71DB9E22447105E00D0161E /* BugsnagSessionTrackerStopTest.m */,
 				8AB1511F1D41361700C9B218 /* BugsnagSinkTests.m */,
+				E78E8CB024694C020017A314 /* BugsnagStateEventTest.m */,
 				E71DB9E02447105D00D0161E /* BugsnagTests.m */,
 				00D7ACA523E98A5D00FBE4A7 /* BugsnagTestConstants.h */,
 				E722105F243B6A220083CF15 /* BugsnagStackframeTest.m */,
@@ -675,8 +678,6 @@
 				E790C48624349D34006FFB26 /* BugsnagDeviceWithState.m */,
 				E790C47F24349D33006FFB26 /* BugsnagError.h */,
 				E790C48724349D34006FFB26 /* BugsnagError.m */,
-				00D7AC9F23E97FBD00FBE4A7 /* BugsnagEvent.h */,
-				00D7AC9E23E97FBD00FBE4A7 /* BugsnagEvent.m */,
 				E7819BB3245975BF00A7EBDD /* BugsnagNotifier.h */,
 				E7819BB2245975BF00A7EBDD /* BugsnagNotifier.m */,
 				E79148641FD82E6A003EFEBF /* BugsnagSession.h */,
@@ -1251,6 +1252,7 @@
 				4B775FD122CBE01F004839C5 /* BugsnagCollectionsBSGDictInsertIfNotNilTest.m in Sources */,
 				E71DB9EA2447105E00D0161E /* BSGConnectivityTest.m in Sources */,
 				E7A9E56F2436366800D99F8A /* BugsnagDeviceTest.m in Sources */,
+				E78E8CB124694C020017A314 /* BugsnagStateEventTest.m in Sources */,
 				E7CE79001FD94F1B001D07E0 /* KSJSONCodec_Tests.m in Sources */,
 				E7CE79051FD94F1B001D07E0 /* KSDynamicLinker_Tests.m in Sources */,
 				E71DB9E92447105E00D0161E /* BugsnagSessionTrackerStopTest.m in Sources */,


### PR DESCRIPTION
## Goal

The React Native layer needs to be informed when the state of the user/context/metadata change on Cocoa, so that it can update the information stored in the JS layer.

This changeset makes the properties observable and allows observers to pass a single block which will be invoked as a callback when any of the properties change.

This loosely follows the Android PR and design: https://github.com/bugsnag/bugsnag-android/pull/827

## Changeset
- Removed `BugsnagMetadataDelegate` in favour of observers
- Updated `BugsnagConfiguration` to allow adding a `BugsnagObserverBlock`, which is invoked whenever a property value changes
- Added `BugsnagStateEvent`, which functions as a data class to contain the event name and data about what changed, structured as per the design document

## Tests

Added unit tests to verify that the observer is called when a value is updated for each stateful property.

Additionally, pre-existing unit tests were added to the macOS.xcodeproj.

Verified in an example app to confirm that `Bugsnag.addMetadata` triggers the observer.