### PR TITLE
Allow setting code bundle id on bugsnag facade

### DIFF
--- a/Source/Bugsnag.m
+++ b/Source/Bugsnag.m
@@ -310,6 +310,13 @@ static BugsnagClient *bsg_g_bugsnag_client = NULL;
     [[self configuration] removeOnSessionBlock:block];
 }
 
+/**
+ * Intended for internal use only - sets the code bundle id for React Native
+ */
++ (void)updateCodeBundleId:(NSString *)codeBundleId {
+    [self configuration].codeBundleId = codeBundleId;
+}
+
 // =============================================================================
 // MARK: - onSend
 // =============================================================================


### PR DESCRIPTION
Allows setting the `codeBundleId` on the `Bugsnag` facade rather than `Configuration`. The `codeBundleId` is set in React Native apps which use CodePush after the native client has initialised, so needs to be set as a stateful value, and therefore belongs on Bugsnag instead.