### PR TITLE
Remove leaveBreadcrumbWithBlock from public api

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,9 @@ Bugsnag Notifiers on other platforms.
 
 ## Enhancements
 
+* Remove `leaveBreadcrumbWithBlock` from public api on `Bugsnag`
+  [#491](https://github.com/bugsnag/bugsnag-cocoa/pull/491)
+
 * `BugsnagNotifier` is now `BugsnagClient`.
   [#480](https://github.com/bugsnag/bugsnag-cocoa/pull/480)
 

--- a/Source/Bugsnag.h
+++ b/Source/Bugsnag.h
@@ -171,15 +171,6 @@ static NSString *_Nonnull const BugsnagSeverityInfo = @"info";
 + (void)leaveBreadcrumbWithMessage:(NSString *_Nonnull)message;
 
 /**
- *  Leave a "breadcrumb" log message with additional information about the
- *  environment at the time the breadcrumb was captured.
- *
- *  @param block configuration block
- */
-+ (void)leaveBreadcrumbWithBlock:
-    (void (^_Nonnull)(BugsnagBreadcrumb *_Nonnull))block;
-
-/**
  *  Leave a "breadcrumb" log message each time a notification with a provided
  *  name is received by the application
  *

--- a/features/fixtures/ios-swift-cocoapods/iOSTestApp/scenarios/DiscardedBreadcrumbTypeScenario.swift
+++ b/features/fixtures/ios-swift-cocoapods/iOSTestApp/scenarios/DiscardedBreadcrumbTypeScenario.swift
@@ -9,14 +9,9 @@ class DiscardedBreadcrumbTypeScenario : Scenario {
     }
 
     override func run() {
-        Bugsnag.leaveBreadcrumb { crumb in
-            crumb.type = .log
-            crumb.message = "Noisy event"
-        }
-        Bugsnag.leaveBreadcrumb { crumb in
-            crumb.type = .process
-            crumb.message = "Important event"
-        }
+        Bugsnag.leaveBreadcrumb("Noisy event", metadata: nil, type: .log)
+        Bugsnag.leaveBreadcrumb("Important event", metadata: nil, type: .process)
+
         Bugsnag.notifyError(MagicError(domain: "com.example",
                                        code: 43,
                                        userInfo: [NSLocalizedDescriptionKey: "incoming!"]))


### PR DESCRIPTION
Removes the `leaveBreadcrumbWithBlock` method from our public API. This is still accessible internally as the implementation for adding breadcrumbs currently relies on this method.