### PR TITLE
Rename onError to onCrashHandler

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -60,7 +60,6 @@ Bugsnag Notifiers on other platforms.
   [#457](https://github.com/bugsnag/bugsnag-cocoa/pull/457)
      
 * Renamed callback functions in the Configuration class:
-  * `onCrashHandler` is now `onError`
   * `beforeSendBlocks` is now `onSendBlocks` (add using `config.add(onSend: { ... })`)
   * `beforeSendSessionBlocks` is now `onSessionBlocks` (add using `config.add(onSession: { ... })`)
 

--- a/Source/BugsnagClient.m
+++ b/Source/BugsnagClient.m
@@ -69,8 +69,8 @@ struct bugsnag_data_t {
     // Contains properties in the Bugsnag payload overridden by the user before
     // it was sent
     char *userOverridesJSON;
-    // User onError handler
-    void (*onError)(const BSG_KSCrashReportWriter *writer);
+    // User onCrash handler
+    void (*onCrash)(const BSG_KSCrashReportWriter *writer);
 };
 
 static struct bugsnag_data_t bsg_g_bugsnag_data;
@@ -118,7 +118,7 @@ void BSSerializeDataCrashHandler(const BSG_KSCrashReportWriter *writer, int type
         }
         if (crashSentinelPath != NULL) {
             // Create a file to indicate that the crash has been handled by
-            // the library. This exists in case the subsequent `onError` handler
+            // the library. This exists in case the subsequent `onCrash` handler
             // crashes or otherwise corrupts the crash report file.
             int fd = open(crashSentinelPath, O_RDWR | O_CREAT, 0644);
             if (fd > -1) {
@@ -127,8 +127,8 @@ void BSSerializeDataCrashHandler(const BSG_KSCrashReportWriter *writer, int type
         }
     }
 
-    if (bsg_g_bugsnag_data.onError) {
-        bsg_g_bugsnag_data.onError(writer);
+    if (bsg_g_bugsnag_data.onCrash) {
+        bsg_g_bugsnag_data.onCrash(writer);
     }
 }
 
@@ -260,7 +260,7 @@ void BSGWriteSessionCrashData(BugsnagSession *session) {
         self.crashSentry = [BugsnagCrashSentry new];
         self.errorReportApiClient = [[BugsnagErrorReportApiClient alloc] initWithConfig:configuration
                                                                               queueName:@"Error API queue"];
-        bsg_g_bugsnag_data.onError = (void (*)(const BSG_KSCrashReportWriter *))self.configuration.onError;
+        bsg_g_bugsnag_data.onCrash = (void (*)(const BSG_KSCrashReportWriter *))self.configuration.onCrashHandler;
 
         static dispatch_once_t once_t;
         dispatch_once(&once_t, ^{

--- a/Source/BugsnagConfiguration.h
+++ b/Source/BugsnagConfiguration.h
@@ -145,7 +145,7 @@ BugsnagBreadcrumbs *breadcrumbs;
 /**
  *  Optional handler invoked when an error or crash occurs
  */
-@property void (*_Nullable onError)
+@property void (*_Nullable onCrashHandler)
     (const BSG_KSCrashReportWriter *_Nonnull writer);
 
 /**

--- a/UPGRADING.md
+++ b/UPGRADING.md
@@ -44,9 +44,6 @@ The exact error is available using the `BSGConfigurationErrorDomain` and
 - config.autoCaptureSessions
 + config.autoTrackSessions
 
-- config.onCrashHandler
-+ config.onError
-
 - config.beforeSendBlocks
 - config.add(beforeSend:)
 + config.onSendBlocks


### PR DESCRIPTION
## Goal

Reverts changes within #471 that renamed `onCrashHandler` to `onError`. As discussed we should retain the old name on Cocoa only and deviate from the notifier spec.

Note that the rename of `BugsnagNotifyBlock` to `BugsnagOnErrorBlock ` has been retained and is not altered in this changeset.