### PR TITLE
Remove unused APIs from BugsnagConfiguration interface

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,9 @@ Bugsnag Notifiers on other platforms.
 
 ## Enhancements
 
+* Remove unused APIs from `BugsnagConfiguration` interface
+  [#496](https://github.com/bugsnag/bugsnag-cocoa/pull/496)
+
 * Remove `leaveBreadcrumbWithBlock` from public api on `Bugsnag`
   [#491](https://github.com/bugsnag/bugsnag-cocoa/pull/491)
 

--- a/Source/Bugsnag.m
+++ b/Source/Bugsnag.m
@@ -33,6 +33,11 @@
 
 static BugsnagClient *bsg_g_bugsnag_client = NULL;
 
+@interface BugsnagConfiguration ()
+@property(readwrite, retain, nullable) BugsnagMetadata *metadata;
+@property(readwrite, retain, nullable) BugsnagMetadata *config;
+@end
+
 @interface Bugsnag ()
 + (BugsnagClient *)client;
 + (BOOL)bugsnagStarted;

--- a/Source/BugsnagClient.m
+++ b/Source/BugsnagClient.m
@@ -213,6 +213,10 @@ void BSGWriteSessionCrashData(BugsnagSession *session) {
 
 @interface BugsnagConfiguration ()
 @property(nonatomic, readwrite, strong) NSMutableSet *plugins;
+@property(readonly, retain, nullable) NSURL *notifyURL;
+@property(readwrite, retain, nullable) BugsnagMetadata *metadata;
+@property(readwrite, retain, nullable) BugsnagMetadata *config;
+@property(readonly, strong, nullable) BugsnagBreadcrumbs *breadcrumbs;
 @end
 
 @implementation BugsnagClient

--- a/Source/BugsnagConfiguration.h
+++ b/Source/BugsnagConfiguration.h
@@ -32,7 +32,6 @@
 #import "BugsnagMetadata.h"
 #import "BugsnagPlugin.h"
 
-@class BugsnagBreadcrumbs;
 @class BugsnagUser;
 
 /**
@@ -67,18 +66,6 @@ typedef bool (^BugsnagOnSendBlock)(BugsnagEvent *_Nonnull event);
  * @param sessionPayload The session about to be delivered
  */
 typedef void(^BugsnagOnSessionBlock)(NSMutableDictionary *_Nonnull sessionPayload);
-
-/**
- *  A handler for modifying data before sending it to Bugsnag
- *
- *  @param rawEventReports The raw event data written at crash time. This
- *                         includes data added in onError.
- *  @param report          The default report payload
- *
- *  @return the report payload intended to be sent or nil to cancel sending
- */
-typedef NSDictionary *_Nullable (^BugsnagBeforeNotifyHook)(
-    NSArray *_Nonnull rawEventReports, NSDictionary *_Nonnull report);
 
 typedef NS_OPTIONS(NSUInteger, BSGErrorType) {
     BSGErrorTypesNone         NS_SWIFT_NAME(None)         = 0,
@@ -128,21 +115,6 @@ typedef NS_OPTIONS(NSUInteger, BSGErrorType) {
 @property(retain, nullable) BugsnagUser *currentUser;
 
 /**
- *  Additional information about the state of the app or environment at the
- *  time the report was generated
- */
-@property(readwrite, retain, nullable) BugsnagMetadata *metadata;
-/**
- *  Meta-information about the state of Bugsnag
- */
-@property(readwrite, retain, nullable) BugsnagMetadata *config;
-/**
- *  Rolling snapshots of user actions leading up to a crash report
- */
-@property(readonly, strong, nullable)
-BugsnagBreadcrumbs *breadcrumbs;
-
-/**
  *  Optional handler invoked when an error or crash occurs
  */
 @property void (*_Nullable onError)
@@ -161,34 +133,9 @@ BugsnagBreadcrumbs *breadcrumbs;
 @property BOOL autoTrackSessions;
 
 /**
- * Whether the app should report out of memory events which terminate the app
- * while the app is in the background. Setting this property has no effect.
- */
-@property BOOL reportBackgroundOOMs
-    __deprecated_msg("This detection option is unreliable and should no longer be used.");
-
-/**
  * The types of breadcrumbs which will be captured. By default, this is all types.
  */
 @property BSGEnabledBreadcrumbType enabledBreadcrumbTypes;
-
-/**
- * Retrieves the endpoint used to notify Bugsnag of errors
- *
- * NOTE: If you want to set this value, you should do so via setEndpointsForNotify:sessions: instead.
- *
- * @see setEndpointsForNotify:sessions:
- */
-@property(readonly, retain, nullable) NSURL *notifyURL;
-
-/**
- * Retrieves the endpoint used to send tracked sessions to Bugsnag
- *
- * NOTE: If you want to set this value, you should do so via setEndpointsForNotify:sessions: instead.
- *
- * @see setEndpointsForNotify:sessions:
- */
-@property(readonly, retain, nullable) NSURL *sessionURL;
 
 @property(retain, nullable) NSString *codeBundleId;
 @property(retain, nullable) NSString *notifierType;
@@ -199,18 +146,6 @@ BugsnagBreadcrumbs *breadcrumbs;
  * messages.
  */
 @property NSUInteger maxBreadcrumbs;
-
-/**
- * Determines whether app sessions should be tracked automatically. By default this value is true.
- * If this value is updated after +[Bugsnag start] is called, only subsequent automatic sessions
- * will be captured.
- */
-@property BOOL shouldAutoCaptureSessions __deprecated_msg("Use autoTrackSessions instead");
-
-/**
- *  YES if uncaught exceptions should be reported automatically
- */
-@property BOOL autoNotify __deprecated_msg("Use autoDetectErrors instead");
 
 /**
  * Whether User information should be persisted to disk between application runs.
@@ -306,16 +241,6 @@ BugsnagBreadcrumbs *breadcrumbs;
  * @param block The block to be removed.
  */
 - (void)removeOnSendBlock:(BugsnagOnSendBlock _Nonnull )block;
-
-/**
- *  Whether reports shoould be sent, based on release stage options
- *
- *  @return YES if reports should be sent based on this configuration
- */
-- (BOOL)shouldSendReports;
-
-- (NSDictionary *_Nonnull)errorApiHeaders;
-- (NSDictionary *_Nonnull)sessionApiHeaders;
 
 - (void)addPlugin:(id<BugsnagPlugin> _Nonnull)plugin;
 

--- a/Source/BugsnagConfiguration.m
+++ b/Source/BugsnagConfiguration.m
@@ -178,7 +178,7 @@ NSString * const kBugsnagUserUserId = @"BugsnagUserUserId";
 // -----------------------------------------------------------------------------
 
 /**
- *  Whether reports shoould be sent, based on release stage options
+ *  Whether reports should be sent, based on release stage options
  *
  *  @return YES if reports should be sent based on this configuration
  */

--- a/Source/BugsnagConfiguration.m
+++ b/Source/BugsnagConfiguration.m
@@ -67,6 +67,24 @@ NSString * const kBugsnagUserUserId = @"BugsnagUserUserId";
  */
 @property(nonatomic, readwrite, strong) NSMutableArray *onSessionBlocks;
 @property(nonatomic, readwrite, strong) NSMutableSet *plugins;
+@property(readonly, retain, nullable) NSURL *notifyURL;
+@property(readonly, retain, nullable) NSURL *sessionURL;
+
+/**
+ *  Additional information about the state of the app or environment at the
+ *  time the report was generated
+ */
+@property(readwrite, retain, nullable) BugsnagMetadata *metadata;
+
+/**
+ *  Meta-information about the state of Bugsnag
+ */
+@property(readwrite, retain, nullable) BugsnagMetadata *config;
+
+/**
+ *  Rolling snapshots of user actions leading up to a crash report
+ */
+@property(readonly, strong, nullable) BugsnagBreadcrumbs *breadcrumbs;
 @end
 
 @implementation BugsnagConfiguration
@@ -159,6 +177,11 @@ NSString * const kBugsnagUserUserId = @"BugsnagUserUserId";
 // MARK: - Instance Methods
 // -----------------------------------------------------------------------------
 
+/**
+ *  Whether reports shoould be sent, based on release stage options
+ *
+ *  @return YES if reports should be sent based on this configuration
+ */
 - (BOOL)shouldSendReports {
     return self.notifyReleaseStages.count == 0 ||
            [self.notifyReleaseStages containsObject:self.releaseStage];

--- a/Source/BugsnagEvent.m
+++ b/Source/BugsnagEvent.m
@@ -229,6 +229,8 @@ static NSString *const DEFAULT_EXCEPTION_TYPE = @"cocoa";
 
 @interface BugsnagConfiguration (BugsnagEvent)
 + (BOOL)isValidApiKey:(NSString *_Nullable)apiKey;
+- (BOOL)shouldSendReports;
+@property(readonly, strong, nullable) BugsnagBreadcrumbs *breadcrumbs;
 @end
 
 @interface BugsnagEvent ()

--- a/Source/BugsnagSessionTracker.m
+++ b/Source/BugsnagSessionTracker.m
@@ -20,6 +20,10 @@ NSTimeInterval const BSGNewSessionBackgroundDuration = 60;
 
 NSString *const BSGSessionUpdateNotification = @"BugsnagSessionChanged";
 
+@interface BugsnagConfiguration ()
+@property(readonly, retain, nullable) NSURL *sessionURL;
+@end
+
 @interface BugsnagSessionTracker ()
 @property (weak, nonatomic) BugsnagConfiguration *config;
 @property (strong, nonatomic) BugsnagSessionFileStore *sessionStore;

--- a/Source/BugsnagSessionTrackingApiClient.m
+++ b/Source/BugsnagSessionTrackingApiClient.m
@@ -13,6 +13,7 @@
 
 @interface BugsnagConfiguration ()
 @property(nonatomic, readwrite, strong) NSMutableArray *onSessionBlocks;
+@property(readonly, retain, nullable) NSURL *sessionURL;
 @end
 
 

--- a/Source/BugsnagSink.m
+++ b/Source/BugsnagSink.m
@@ -41,6 +41,10 @@
 
 @interface BugsnagConfiguration ()
 @property(nonatomic, readwrite, strong) NSMutableArray *onSendBlocks;
+- (NSDictionary *_Nonnull)errorApiHeaders;
+- (NSDictionary *_Nonnull)sessionApiHeaders;
+@property(readonly, retain, nullable) NSURL *sessionURL;
+@property(readonly, retain, nullable) NSURL *notifyURL;
 @end
 
 @implementation BugsnagSink

--- a/Tests/BugsnagBreadcrumbsTest.m
+++ b/Tests/BugsnagBreadcrumbsTest.m
@@ -16,6 +16,10 @@
 @property(nonatomic, strong) BugsnagBreadcrumbs *crumbs;
 @end
 
+@interface BugsnagConfiguration ()
+@property(readonly, strong, nullable) BugsnagBreadcrumbs *breadcrumbs;
+@end
+
 @interface BugsnagBreadcrumbs ()
 @property(nonatomic, readonly, strong) dispatch_queue_t readWriteQueue;
 @end

--- a/Tests/BugsnagConfigurationTests.m
+++ b/Tests/BugsnagConfigurationTests.m
@@ -23,6 +23,11 @@
 @property(nonatomic, readwrite, strong) NSMutableArray *onSendBlocks;
 @property(nonatomic, readwrite, strong) NSMutableArray *onSessionBlocks;
 - (void)deletePersistedUserData;
+- (BOOL)shouldSendReports;
+- (NSDictionary *_Nonnull)errorApiHeaders;
+- (NSDictionary *_Nonnull)sessionApiHeaders;
+@property(readonly, retain, nullable) NSURL *sessionURL;
+@property(readonly, retain, nullable) NSURL *notifyURL;
 @end
 
 @interface BugsnagCrashSentry ()

--- a/Tests/BugsnagTests.m
+++ b/Tests/BugsnagTests.m
@@ -19,6 +19,7 @@
 
 @interface BugsnagConfiguration ()
 @property(nonatomic, readwrite, strong) NSMutableArray *onSendBlocks;
+@property(readwrite, retain, nullable) BugsnagMetadata *metadata;
 @end
 
 @interface BugsnagTests : XCTestCase

--- a/UPGRADING.md
+++ b/UPGRADING.md
@@ -64,6 +64,23 @@ The exact error is available using the `BSGConfigurationErrorDomain` and
 + config.enabledErrorTypes
 ```
 
+#### Removals
+
+```diff
+- BugsnagBeforeNotifyHook
+- config.metadata
+- config.config
+- config.breadcrumbs
+- config.reportBackgroundOOMs
+- config.notifyURL
+- config.sessionURL
+- config.shouldAutoCaptureSessions
+- config.autoNotify
+- config.shouldSendReports
+- config.errorApiHeaders
+- config.sessionApiHeaders
+```
+
 ### `Bugsnag` class
 
 #### Removals

--- a/features/fixtures/ios-swift-cocoapods/iOSTestApp/scenarios/OOMScenario.m
+++ b/features/fixtures/ios-swift-cocoapods/iOSTestApp/scenarios/OOMScenario.m
@@ -5,7 +5,7 @@
 @implementation OOMScenario
 
 - (void)startBugsnag {
-    self.config.shouldAutoCaptureSessions = NO;
+    self.config.autoTrackSessions = NO;
     self.config.releaseStage = @"alpha";
     [self.config addOnSendBlock:^bool(BugsnagEvent * _Nonnull report) {
         NSMutableDictionary *metadata = [report.metadata mutableCopy];


### PR DESCRIPTION
## Goal

Removes/hides unused APIs from the `BugsnagConfiguration` interface. These are either no longer required or were originally part of the internal implementation and mistakenly included in the public header.

## Changeset

The following APIs have been removed/hidden using a [class extension](https://developer.apple.com/library/archive/documentation/Cocoa/Conceptual/ProgrammingWithObjectiveC/CustomizingExistingClasses/CustomizingExistingClasses.html#//apple_ref/doc/uid/TP40011210-CH6-SW6):

```
BugsnagBeforeNotifyHook
BugsnagMetadata and BugsnagConfig
breadcrumbs
reportBackgroundOOMs
notifyURL and sessionURL
shouldAutoCaptureSessions
autoNotify
shouldSendReports
errorApiHeaders
sessionApiHeaders
```

## Tests

Relied on existing test coverage
