### PR TITLE
 Remove notify method variants from public API on Bugsnag

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,9 @@ Bugsnag Notifiers on other platforms.
 
 ## Enhancements
 
+* Remove notify method variants from public api on `Bugsnag`
+  [#497](https://github.com/bugsnag/bugsnag-cocoa/pull/497)
+
 * Remove `leaveBreadcrumbWithBlock` from public api on `Bugsnag`
   [#491](https://github.com/bugsnag/bugsnag-cocoa/pull/491)
 

--- a/Source/Bugsnag.h
+++ b/Source/Bugsnag.h
@@ -101,39 +101,6 @@ static NSString *_Nonnull const BugsnagSeverityInfo = @"info";
 + (void)notifyError:(NSError *_Nonnull)error
               block:(BugsnagOnErrorBlock _Nullable)block;
 
-/** Send a custom or caught exception to Bugsnag.
- *
- * The exception will be sent to Bugsnag in the background allowing your
- * app to continue running.
- *
- * @param exception  The exception.
- *
- * @param metadata   Any additional information you want to send with the
- * report.
- */
-+ (void)notify:(NSException *_Nonnull)exception
-      withData:(NSDictionary *_Nullable)metadata
-    __deprecated_msg("Use notify:block: instead and add the metadata to the "
-                     "report directly.");
-
-/** Send a custom or caught exception to Bugsnag.
- *
- * The exception will be sent to Bugsnag in the background allowing your
- * app to continue running.
- *
- * @param exception  The exception.
- *
- * @param metadata   Any additional information you want to send with the
- * report.
- *
- * @param severity   The severity level (default: BugsnagSeverityWarning)
- */
-+ (void)notify:(NSException *_Nonnull)exception
-      withData:(NSDictionary *_Nullable)metadata
-    atSeverity:(NSString *_Nullable)severity
-    __deprecated_msg("Use notify:block: instead and add the metadata and "
-                     "severity to the report directly.");
-
 /**
  * Intended for use by other clients (React Native/Unity). Calling this method
  * directly from iOS is not supported.

--- a/Source/Bugsnag.m
+++ b/Source/Bugsnag.m
@@ -124,36 +124,6 @@ static BugsnagClient *bsg_g_bugsnag_client = NULL;
     }
 }
 
-+ (void)notify:(NSException *)exception withData:(NSDictionary *)metadata {
-    if ([self bugsnagStarted]) {
-        [[self client]
-                notifyException:exception
-                          block:^(BugsnagEvent *_Nonnull report) {
-                              report.depth += 2;
-                              report.metadata = [metadata
-                                      BSG_mergedInto:[self.client.configuration
-                                              .metadata toDictionary]];
-                          }];
-    }
-}
-
-+ (void)notify:(NSException *)exception
-      withData:(NSDictionary *)metadata
-    atSeverity:(NSString *)severity {
-    if ([self bugsnagStarted]) {
-        [[self client]
-                notifyException:exception
-                     atSeverity:BSGParseSeverity(severity)
-                          block:^(BugsnagEvent *_Nonnull report) {
-                              report.depth += 2;
-                              report.metadata = [metadata
-                                      BSG_mergedInto:[self.client.configuration
-                                              .metadata toDictionary]];
-                              report.severity = BSGParseSeverity(severity);
-                          }];
-    }
-}
-
 + (void)internalClientNotify:(NSException *_Nonnull)exception
                     withData:(NSDictionary *_Nullable)metadata
                        block:(BugsnagOnErrorBlock _Nullable)block {

--- a/Source/BugsnagClient.h
+++ b/Source/BugsnagClient.h
@@ -63,18 +63,6 @@
                   block:(BugsnagOnErrorBlock _Nullable)block;
 
 /**
- *  Notify Bugsnag of an exception
- *
- *  @param exception the exception
- *  @param severity  the severity
- *  @param block     Configuration block for adding additional report
- * information
- */
-- (void)notifyException:(NSException *_Nonnull)exception
-             atSeverity:(BSGSeverity)severity
-                  block:(BugsnagOnErrorBlock _Nullable)block;
-
-/**
  *  Notify Bugsnag of an exception. Only intended for React Native/Unity use.
  *
  *  @param exception the exception

--- a/Source/BugsnagClient.m
+++ b/Source/BugsnagClient.m
@@ -583,17 +583,6 @@ NSString *const BSGBreadcrumbLoadedMessage = @"Bugsnag loaded";
 }
 
 - (void)notifyException:(NSException *)exception
-             atSeverity:(BSGSeverity)severity
-                  block:(void (^)(BugsnagEvent *))block {
-
-    BugsnagHandledState *state = [BugsnagHandledState
-        handledStateWithSeverityReason:UserSpecifiedSeverity
-                              severity:severity
-                             attrValue:nil];
-    [self notify:exception handledState:state block:block];
-}
-
-- (void)notifyException:(NSException *)exception
                   block:(void (^)(BugsnagEvent *))block {
     BugsnagHandledState *state =
         [BugsnagHandledState handledStateWithSeverityReason:HandledException];

--- a/UPGRADING.md
+++ b/UPGRADING.md
@@ -106,6 +106,12 @@ ObjC:
 - [Bugsnag stopSession]
 + [Bugsnag pauseSession]
 
+- [Bugsnag notify:withData:]
++ [Bugsnag notify:block:]
+
+- [Bugsnag notify:withData:severity:]
++ [Bugsnag notify:block:]
+
 Swift:
 
 - Bugsnag.configuration()
@@ -119,6 +125,12 @@ Swift:
 
 - Bugsnag.stopSession()
 + Bugsnag.pauseSession()
+
+- Bugsnag.notify(exception:metadata:)
++ Bugsnag.notify(exception:block:)
+
+- Bugsnag.notify(exception:metadata:severity:)
++ Bugsnag.notify(exception:block:)
 ```
 
 ### `BugsnagMetadata` class


### PR DESCRIPTION
Removes obsolete notify method variants. The `notify` method should only take an NSError/NSException, and an optional callback block which allows the event to be mutated. This removes unnecessary methods from `Bugsnag/BugsnagClient`.
