### PR TITLE
UTC timezone date format

### DIFF
--- a/Source/Bugsnag.m
+++ b/Source/Bugsnag.m
@@ -267,6 +267,7 @@ static BugsnagClient *bsg_g_bugsnag_client = NULL;
     dispatch_once(&onceToken, ^{
       formatter = [NSDateFormatter new];
       formatter.dateFormat = @"yyyy'-'MM'-'dd'T'HH':'mm':'ssZZZ";
+      formatter.timeZone = [NSTimeZone timeZoneForSecondsFromGMT:0];
     });
     return formatter;
 }


### PR DESCRIPTION
In non UTC timezones the tests fail because expectations are set to UTC. I considered improving the tests to have dynamic expectations, but there is no value in using the phone's local timezone for payload dates so I changed it in the SDK itself.

This should mean that we always use UTC for dates that we serialize from now on. No test additions are required because this fixes the tests when running outside of the UK.