### PR TITLE
Remove unused APIs from BugsnagMetadata interface

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,9 @@ Bugsnag Notifiers on other platforms.
 
 ## Enhancements
 
+* Remove unused APIs from `BugsnagMetadata` interface
+[#501](https://github.com/bugsnag/bugsnag-cocoa/pull/501)
+
 * Remove `leaveBreadcrumbWithBlock` from public api on `Bugsnag`
   [#491](https://github.com/bugsnag/bugsnag-cocoa/pull/491)
 

--- a/Source/Bugsnag.m
+++ b/Source/Bugsnag.m
@@ -46,6 +46,10 @@ static BugsnagClient *bsg_g_bugsnag_client = NULL;
 - (void)startListeningForStateChangeNotification:(NSString *_Nonnull)notificationName;
 @end
 
+@interface BugsnagMetadata ()
+- (NSDictionary *_Nonnull)toDictionary;
+@end
+
 @implementation Bugsnag
 
 + (void)startBugsnagWithApiKey:(NSString *)apiKey {

--- a/Source/BugsnagClient.m
+++ b/Source/BugsnagClient.m
@@ -215,6 +215,11 @@ void BSGWriteSessionCrashData(BugsnagSession *session) {
 @property(nonatomic, readwrite, strong) NSMutableSet *plugins;
 @end
 
+@interface BugsnagMetadata ()
+- (NSDictionary *_Nonnull)toDictionary;
+@property(unsafe_unretained) id<BugsnagMetadataDelegate> _Nullable delegate;
+@end
+
 @implementation BugsnagClient
 
 @synthesize configuration;

--- a/Source/BugsnagMetadata.h
+++ b/Source/BugsnagMetadata.h
@@ -26,8 +26,6 @@
 
 #import <Foundation/Foundation.h>
 
-@protocol BugsnagMetadataDelegate;
-
 @interface BugsnagMetadata : NSObject <NSMutableCopying>
 
 - (instancetype _Nonnull)initWithDictionary:(NSMutableDictionary *_Nonnull)dict;
@@ -71,13 +69,9 @@
                            key:(NSString *_Nonnull)key
     NS_SWIFT_NAME(clearMetadata(section:key:));
 
-- (NSDictionary *_Nonnull)toDictionary;
-
 - (void)addAttribute:(NSString *_Nonnull)attributeName
            withValue:(id _Nullable)value
        toTabWithName:(NSString *_Nonnull)sectionName;
-
-@property(unsafe_unretained) id<BugsnagMetadataDelegate> _Nullable delegate;
 
 /**
  * Merge supplied and existing metadata.

--- a/Source/BugsnagMetadata.m
+++ b/Source/BugsnagMetadata.m
@@ -30,6 +30,8 @@
 
 @interface BugsnagMetadata ()
 @property(atomic, strong) NSMutableDictionary *dictionary;
+- (NSDictionary *_Nonnull)toDictionary;
+@property(unsafe_unretained) id<BugsnagMetadataDelegate> _Nullable delegate;
 @end
 
 @implementation BugsnagMetadata

--- a/Tests/BugsnagEventTests.m
+++ b/Tests/BugsnagEventTests.m
@@ -21,6 +21,10 @@
 + (BugsnagConfiguration *)configuration;
 @end
 
+@interface BugsnagMetadata ()
+- (NSDictionary *_Nonnull)toDictionary;
+@end
+
 @interface BugsnagEventTests : BugsnagBaseUnitTest
 @end
 

--- a/Tests/BugsnagMetadataTests.m
+++ b/Tests/BugsnagMetadataTests.m
@@ -18,6 +18,8 @@
 
 @interface BugsnagMetadata ()
 @property(atomic, strong) NSMutableDictionary *dictionary;
+- (NSDictionary *_Nonnull)toDictionary;
+@property(unsafe_unretained) id<BugsnagMetadataDelegate> _Nullable delegate;
 @end
 
 // MARK: - DummyClass

--- a/UPGRADING.md
+++ b/UPGRADING.md
@@ -143,7 +143,14 @@ Swift:
 ```
 
 Note that `BugsnagMetadata.getTab()` previously would create a metadata section if it
-did not exist; the new behaviour in `getMetadata` is to return `nil`. 
+did not exist; the new behaviour in `getMetadata` is to return `nil`.
+
+#### Removals
+
+```diff
+- toDictionary
+- delegate
+```
 
 ### `BugsnagBreadcrumb` class
 


### PR DESCRIPTION
## Goal

Removes/hides unused APIs from the `BugsnagMetadata` interface. These are either no longer required or were originally part of the internal implementation and mistakenly included in the public header.

## Changeset

The following APIs have been removed/hidden using a [class extension](https://developer.apple.com/library/archive/documentation/Cocoa/Conceptual/ProgrammingWithObjectiveC/CustomizingExistingClasses/CustomizingExistingClasses.html#//apple_ref/doc/uid/TP40011210-CH6-SW6):

```
toDictionary
delegate
```

## Tests

Relied on existing test coverage
