### PR TITLE
Rename config.notifierType to config.appType

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,9 @@ Bugsnag Notifiers on other platforms.
 
 ## Enhancements
 
+* Rename `config.notifierType` to `config.appType`
+[#504](https://github.com/bugsnag/bugsnag-cocoa/pull/504)
+
 * Remove unused APIs from `BugsnagMetadata` interface
 [#501](https://github.com/bugsnag/bugsnag-cocoa/pull/501)
 

--- a/Source/BugsnagConfiguration.h
+++ b/Source/BugsnagConfiguration.h
@@ -138,7 +138,7 @@ typedef NS_OPTIONS(NSUInteger, BSGErrorType) {
 @property BSGEnabledBreadcrumbType enabledBreadcrumbTypes;
 
 @property(retain, nullable) NSString *codeBundleId;
-@property(retain, nullable) NSString *notifierType;
+@property(retain, nullable) NSString *appType;
 
 /**
  * The maximum number of breadcrumbs to keep and sent to Bugsnag.

--- a/Source/BugsnagKSCrashSysInfoParser.m
+++ b/Source/BugsnagKSCrashSysInfoParser.m
@@ -103,19 +103,19 @@ NSDictionary *BSGParseAppState(NSDictionary *report, NSString *preferredVersion,
     
     BSGDictSetSafeObject(app, codeBundleId, @"codeBundleId");
     
-    NSString *notifierType;
+    NSString *appType;
 #if TARGET_OS_TV
-    notifierType = @"tvOS";
+    appType = @"tvOS";
 #elif TARGET_IPHONE_SIMULATOR || TARGET_OS_IPHONE
-    notifierType = @"iOS";
+    appType = @"iOS";
 #elif TARGET_OS_MAC
-    notifierType = @"macOS";
+    appType = @"macOS";
 #endif
     
-    if ([Bugsnag configuration].notifierType) {
-        notifierType = [Bugsnag configuration].notifierType;
+    if ([Bugsnag configuration].appType) {
+        appType = [Bugsnag configuration].appType;
     }
-    BSGDictSetSafeObject(app, notifierType, @"type");
+    BSGDictSetSafeObject(app, appType, @"type");
     return app;
 }
 

--- a/UPGRADING.md
+++ b/UPGRADING.md
@@ -59,6 +59,9 @@ The exact error is available using the `BSGConfigurationErrorDomain` and
 
 - config.reportOOMs
 + config.enabledErrorTypes
+
+- config.notifierType
++ config.appType
 ```
 
 #### Removals


### PR DESCRIPTION
Renames `config.notifierType` to `config.appType`, to achieve compliance with the notifier spec.