### PR TITLE
Rename setUser/user interface on Bugsnag and BugsnagConfiguration

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,9 @@ Bugsnag Notifiers on other platforms.
 
 ## Enhancements
 
+* Rename setUser/user interface on `Bugsnag` and `BugsnagConfiguration`
+[#505](https://github.com/bugsnag/bugsnag-cocoa/pull/505)
+
 * Remove unused APIs from `BugsnagMetadata` interface
 [#501](https://github.com/bugsnag/bugsnag-cocoa/pull/501)
 

--- a/Source/Bugsnag.h
+++ b/Source/Bugsnag.h
@@ -316,8 +316,8 @@ static NSString *_Nonnull const BugsnagSeverityInfo = @"info";
  *  @param email  Email address of the user
  */
 + (void)setUser:(NSString *_Nullable)userId
-       withName:(NSString *_Nullable)name
-       andEmail:(NSString *_Nullable)email;
+       withEmail:(NSString *_Nullable)email
+       andName:(NSString *_Nullable)name;
 
 // =============================================================================
 // MARK: - onSend

--- a/Source/Bugsnag.h
+++ b/Source/Bugsnag.h
@@ -299,6 +299,15 @@ static NSString *_Nonnull const BugsnagSeverityInfo = @"info";
 + (void)clearMetadataInSection:(NSString *_Nonnull)sectionName
     NS_SWIFT_NAME(clearMetadata(section:));
 
+// =============================================================================
+// MARK: - User
+// =============================================================================
+
+/**
+ * The current user
+ */
++ (BugsnagUser *_Nonnull)user;
+
 /**
  *  Set user metadata
  *

--- a/Source/Bugsnag.m
+++ b/Source/Bugsnag.m
@@ -282,9 +282,9 @@ static BugsnagClient *bsg_g_bugsnag_client = NULL;
 }
 
 + (void)setUser:(NSString *_Nullable)userId
-       withName:(NSString *_Nullable)name
-       andEmail:(NSString *_Nullable)email {
-    [[self configuration] setUser:userId withName:name andEmail:email];
+      withEmail:(NSString *_Nullable)email
+        andName:(NSString *_Nullable)name {
+    [[self configuration] setUser:userId withEmail:email andName:name];
 }
 
 + (void)addOnSessionBlock:(BugsnagOnSessionBlock _Nonnull)block

--- a/Source/Bugsnag.m
+++ b/Source/Bugsnag.m
@@ -277,6 +277,10 @@ static BugsnagClient *bsg_g_bugsnag_client = NULL;
     [self configuration].context = context;
 }
 
++ (BugsnagUser *)user {
+    return [[self configuration] user];
+}
+
 + (void)setUser:(NSString *_Nullable)userId
        withName:(NSString *_Nullable)name
        andEmail:(NSString *_Nullable)email {

--- a/Source/BugsnagConfiguration.h
+++ b/Source/BugsnagConfiguration.h
@@ -110,11 +110,6 @@ typedef NS_OPTIONS(NSUInteger, BSGErrorType) {
 @property(readwrite, strong, nonnull) NSURLSession *session;
 
 /**
- * The current user
- */
-@property(retain, nullable) BugsnagUser *currentUser;
-
-/**
  *  Optional handler invoked when an error or crash occurs
  */
 @property void (*_Nullable onCrashHandler)
@@ -193,6 +188,15 @@ typedef NS_OPTIONS(NSUInteger, BSGErrorType) {
 
 - (void)setEndpointsForNotify:(NSString *_Nonnull)notify
                      sessions:(NSString *_Nonnull)sessions NS_SWIFT_NAME(setEndpoints(notify:sessions:));
+
+// =============================================================================
+// MARK: - User
+// =============================================================================
+
+/**
+ * The current user
+ */
+@property(readonly, retain, nonnull) BugsnagUser *user;
 
 /**
  *  Set user metadata

--- a/Source/BugsnagConfiguration.h
+++ b/Source/BugsnagConfiguration.h
@@ -206,8 +206,8 @@ typedef NS_OPTIONS(NSUInteger, BSGErrorType) {
  *  @param email  Email address of the user
  */
 - (void)setUser:(NSString *_Nullable)userId
-       withName:(NSString *_Nullable)name
-       andEmail:(NSString *_Nullable)email;
+      withEmail:(NSString *_Nullable)email
+        andName:(NSString *_Nullable)name;
 
 // =============================================================================
 // MARK: - onSession

--- a/Source/BugsnagConfiguration.m
+++ b/Source/BugsnagConfiguration.m
@@ -188,11 +188,10 @@ NSString * const kBugsnagUserUserId = @"BugsnagUserUserId";
            [self.notifyReleaseStages containsObject:self.releaseStage];
 }
 
-- (void)setUser:(NSString *)userId
-       withName:(NSString *)userName
-       andEmail:(NSString *)userEmail
-{
-    _user = [[BugsnagUser alloc] initWithUserId:userId name:userName emailAddress:userEmail];
+- (void)setUser:(NSString *_Nullable)userId
+      withEmail:(NSString *_Nullable)email
+        andName:(NSString *_Nullable)name {
+    _user = [[BugsnagUser alloc] initWithUserId:userId name:name emailAddress:email];
 
     // Persist the user
     if (_persistUser)

--- a/Source/BugsnagConfiguration.m
+++ b/Source/BugsnagConfiguration.m
@@ -153,8 +153,8 @@ NSString * const kBugsnagUserUserId = @"BugsnagUserUserId";
     _persistUser = YES;
     // Only gets persisted user data if there is any, otherwise nil
     // persistUser isn't settable until post-init.
-    _currentUser = [self getPersistedUserData];
-    [self setUserMetadataFromUser:_currentUser];
+    _user = [self getPersistedUserData];
+    [self setUserMetadataFromUser:_user];
     
     #if !DEBUG
         _enabledErrorTypes |= BSGErrorTypesOOMs;
@@ -192,14 +192,14 @@ NSString * const kBugsnagUserUserId = @"BugsnagUserUserId";
        withName:(NSString *)userName
        andEmail:(NSString *)userEmail
 {
-    self.currentUser = [[BugsnagUser alloc] initWithUserId:userId name:userName emailAddress:userEmail];
+    _user = [[BugsnagUser alloc] initWithUserId:userId name:userName emailAddress:userEmail];
 
     // Persist the user
     if (_persistUser)
         [self persistUserData];
     
     // Add user info to the metadata
-    [self setUserMetadataFromUser:self.currentUser];
+    [self setUserMetadataFromUser:self.user];
 }
 
 /**
@@ -300,10 +300,11 @@ NSString * const kBugsnagUserUserId = @"BugsnagUserUserId";
         NSString *name = [BSG_SSKeychain passwordForService:kBugsnagUserName account:kBugsnagUserKeychainAccount];
         NSString *userId = [BSG_SSKeychain passwordForService:kBugsnagUserUserId account:kBugsnagUserKeychainAccount];
 
-        if (email || name || userId)
+        if (email || name || userId) {
             return [[BugsnagUser alloc] initWithUserId:userId name:name emailAddress:email];
-        
-        return nil;
+        } else {
+            return [[BugsnagUser alloc] initWithUserId:nil name:nil emailAddress:nil];
+        }
     }
 }
 
@@ -313,10 +314,10 @@ NSString * const kBugsnagUserUserId = @"BugsnagUserUserId";
  */
 - (void)persistUserData {
     @synchronized(self) {
-        if (_currentUser) {
+        if (_user) {
             // Email
-            if (_currentUser.emailAddress) {
-                [BSG_SSKeychain setPassword:_currentUser.emailAddress
+            if (_user.emailAddress) {
+                [BSG_SSKeychain setPassword:_user.emailAddress
                              forService:kBugsnagUserEmailAddress
                                 account:kBugsnagUserKeychainAccount];
             }
@@ -326,8 +327,8 @@ NSString * const kBugsnagUserUserId = @"BugsnagUserUserId";
             }
 
             // Name
-            if (_currentUser.name) {
-                [BSG_SSKeychain setPassword:_currentUser.name
+            if (_user.name) {
+                [BSG_SSKeychain setPassword:_user.name
                              forService:kBugsnagUserName
                                 account:kBugsnagUserKeychainAccount];
             }
@@ -337,8 +338,8 @@ NSString * const kBugsnagUserUserId = @"BugsnagUserUserId";
             }
             
             // UserId
-            if (_currentUser.userId) {
-                [BSG_SSKeychain setPassword:_currentUser.userId
+            if (_user.userId) {
+                [BSG_SSKeychain setPassword:_user.userId
                              forService:kBugsnagUserUserId
                                 account:kBugsnagUserKeychainAccount];
             }

--- a/Source/BugsnagSessionTracker.m
+++ b/Source/BugsnagSessionTracker.m
@@ -108,7 +108,7 @@ NSString *const BSGSessionUpdateNotification = @"BugsnagSessionChanged";
 
     self.currentSession = [[BugsnagSession alloc] initWithId:[[NSUUID UUID] UUIDString]
                                                    startDate:[NSDate date]
-                                                        user:self.config.currentUser
+                                                        user:self.config.user
                                                 autoCaptured:isAutoCaptured];
 
     [self.sessionStore write:self.currentSession];

--- a/Tests/BugsnagConfigurationTests.m
+++ b/Tests/BugsnagConfigurationTests.m
@@ -423,7 +423,10 @@
 //    XCTAssertNil([bsg_SSKeychain passwordForService:kBugsnagUserUserId account:kBugsnagUserKeychainAccount]);
 
     BugsnagConfiguration *config2 = [[BugsnagConfiguration alloc] initWithApiKey:DUMMY_APIKEY_32CHAR_1];
-    XCTAssertNil(config2.currentUser);
+    XCTAssertNotNil(config2.user);
+    XCTAssertNil(config2.user.userId);
+    XCTAssertNil(config2.user.name);
+    XCTAssertNil(config2.user.emailAddress);
 }
 
 /**
@@ -469,7 +472,7 @@
     [config setUser:nil withName:nil andEmail:nil];
 
     // currentUser should have been set
-    XCTAssertNotNil(config.currentUser);
+    XCTAssertNotNil(config.user);
 
     // But there hould be no persisted data
 //    XCTAssertNil([bsg_SSKeychain passwordForService:kBugsnagUserEmailAddress account:kBugsnagUserKeychainAccount]);
@@ -606,9 +609,9 @@
     
     [config setUser:@"123" withName:@"foo" andEmail:@"test@example.com"];
     
-    XCTAssertEqualObjects(@"123", config.currentUser.userId);
-    XCTAssertEqualObjects(@"foo", config.currentUser.name);
-    XCTAssertEqualObjects(@"test@example.com", config.currentUser.emailAddress);
+    XCTAssertEqualObjects(@"123", config.user.userId);
+    XCTAssertEqualObjects(@"foo", config.user.name);
+    XCTAssertEqualObjects(@"test@example.com", config.user.emailAddress);
 }
 
 - (void)testApiKeySetter {

--- a/Tests/BugsnagConfigurationTests.m
+++ b/Tests/BugsnagConfigurationTests.m
@@ -388,7 +388,7 @@
 //    XCTAssertNil([bsg_SSKeychain passwordForService:kBugsnagUserUserId account:kBugsnagUserKeychainAccount]);
     
     // user should be persisted by default
-    [config setUser:userId withName:name andEmail:email];
+    [config setUser:userId withEmail:email andName:name];
     
     // Check values manually
 //    XCTAssertEqualObjects([bsg_SSKeychain passwordForService:kBugsnagUserEmailAddress account:kBugsnagUserKeychainAccount], email);
@@ -446,16 +446,16 @@
 //    XCTAssertNil([bsg_SSKeychain passwordForService:kBugsnagUserName account:kBugsnagUserKeychainAccount]);
 //    XCTAssertNil([bsg_SSKeychain passwordForService:kBugsnagUserUserId account:kBugsnagUserKeychainAccount]);
 
-    [config setUser:userId withName:nil andEmail:nil];
+    [config setUser:userId withEmail:nil andName:nil];
 //    XCTAssertNil([bsg_SSKeychain passwordForService:kBugsnagUserEmailAddress account:kBugsnagUserKeychainAccount]);
 //    XCTAssertNil([bsg_SSKeychain passwordForService:kBugsnagUserName account:kBugsnagUserKeychainAccount]);
 //    XCTAssertEqualObjects([bsg_SSKeychain passwordForService:kBugsnagUserUserId account:kBugsnagUserKeychainAccount], userId);
-    [config setUser:nil withName:name andEmail:nil];
+    [config setUser:nil withEmail:email andName:nil];
 //    XCTAssertNil([bsg_SSKeychain passwordForService:kBugsnagUserEmailAddress account:kBugsnagUserKeychainAccount]);
 //    XCTAssertEqualObjects([bsg_SSKeychain passwordForService:kBugsnagUserName account:kBugsnagUserKeychainAccount], name);
 //    XCTAssertNil([bsg_SSKeychain passwordForService:kBugsnagUserUserId account:kBugsnagUserKeychainAccount]);
 
-    [config setUser:nil withName:nil andEmail:email];
+    [config setUser:nil withEmail:nil andName:name];
 //    XCTAssertEqualObjects([bsg_SSKeychain passwordForService:kBugsnagUserEmailAddress account:kBugsnagUserKeychainAccount], email);
 //    XCTAssertNil([bsg_SSKeychain passwordForService:kBugsnagUserName account:kBugsnagUserKeychainAccount]);
 //    XCTAssertNil([bsg_SSKeychain passwordForService:kBugsnagUserUserId account:kBugsnagUserKeychainAccount]);
@@ -469,7 +469,7 @@
     XCTAssertTrue(config.persistUser);
     [config deletePersistedUserData];
 
-    [config setUser:nil withName:nil andEmail:nil];
+    [config setUser:nil withEmail:nil andName:nil];
 
     // currentUser should have been set
     XCTAssertNotNil(config.user);
@@ -498,7 +498,7 @@
 //    XCTAssertNil([bsg_SSKeychain passwordForService:kBugsnagUserUserId account:kBugsnagUserKeychainAccount]);
     
     // Persist user data
-    [config setUser:userId withName:name andEmail:email];
+    [config setUser:userId withEmail:email andName:name];
 
     // Check that retrieving persisted user data also sets configuration metadata
     // Check persistence between invocations (when values have been set)
@@ -531,7 +531,7 @@
 //    XCTAssertNil([[config2 metadata] getMetadata:BSGKeyUser key:BSGKeyName]);
 //    XCTAssertNil([[config2 metadata] getMetadata:BSGKeyUser key:BSGKeyEmail]);
     
-    [config2 setUser:userId withName:name andEmail:email];
+    [config2 setUser:userId withEmail:email andName:name];
 //    XCTAssertEqualObjects([config2.metadata getMetadata:BSGKeyUser key:BSGKeyEmail], email);
 //    XCTAssertEqualObjects([config2.metadata getMetadata:BSGKeyUser key:BSGKeyName], name);
 //    XCTAssertEqualObjects([config2.metadata getMetadata:BSGKeyUser key:BSGKeyId], userId);
@@ -607,7 +607,7 @@
 - (void)testUser {
     BugsnagConfiguration *config = [[BugsnagConfiguration alloc] initWithApiKey:DUMMY_APIKEY_32CHAR_1];
     
-    [config setUser:@"123" withName:@"foo" andEmail:@"test@example.com"];
+    [config setUser:@"123" withEmail:@"test@example.com" andName:@"foo"];
     
     XCTAssertEqualObjects(@"123", config.user.userId);
     XCTAssertEqualObjects(@"foo", config.user.name);

--- a/Tests/BugsnagSessionTrackerTest.m
+++ b/Tests/BugsnagSessionTrackerTest.m
@@ -45,7 +45,7 @@
 }
 
 - (void)testStartNewSessionWithUser {
-    [self.configuration setUser:@"123" withName:@"Bill" andEmail:nil];
+    [self.configuration setUser:@"123" withEmail:nil andName:@"Bill"];
     XCTAssertNil(self.sessionTracker.runningSession);
     [self.sessionTracker startNewSession];
     BugsnagSession *session = self.sessionTracker.runningSession;
@@ -74,7 +74,7 @@
 }
 
 - (void)testStartNewAutoCapturedSessionWithUser {
-    [self.configuration setUser:@"123" withName:@"Bill" andEmail:@"bill@example.com"];
+    [self.configuration setUser:@"123" withEmail:@"bill@example.com" andName:@"Bill"];
     XCTAssertNil(self.sessionTracker.runningSession);
     [self.sessionTracker startNewSessionIfAutoCaptureEnabled];
     BugsnagSession *session = self.sessionTracker.runningSession;

--- a/UPGRADING.md
+++ b/UPGRADING.md
@@ -59,6 +59,9 @@ The exact error is available using the `BSGConfigurationErrorDomain` and
 
 - config.reportOOMs
 + config.enabledErrorTypes
+
+- config.currentUser
++ config.user
 ```
 
 #### Removals
@@ -109,7 +112,7 @@ Bugsnag.getMetadata("section" key:"key")
 ObjC:
 
 - [Bugsnag configuration]
-+ [Bugsnag setUser:withName:andEmail:]
++ [Bugsnag setUser:withEmail:andName:]
 
 - [Bugsnag addAttribute:WithValuetoTabWithName:]
 + [Bugsnag addMetadataToSection:key:value:]
@@ -129,7 +132,7 @@ ObjC:
 Swift:
 
 - Bugsnag.configuration()
-+ Bugsnag.setUser(_:name:email:)
++ Bugsnag.setUser(_:email:name:)
 
 - Bugsnag.addAttribute(attributeName:withValue:toTabWithName:)
 + Bugsnag.addMetadata(_:key:value:)

--- a/features/fixtures/ios-swift-cocoapods/iOSTestApp/scenarios/AutoSessionWithUserScenario.m
+++ b/features/fixtures/ios-swift-cocoapods/iOSTestApp/scenarios/AutoSessionWithUserScenario.m
@@ -11,7 +11,7 @@
 @implementation AutoSessionWithUserScenario
 
 - (void)startBugsnag {
-    [self.config setUser:@"123" withName:@"Joe Bloggs" andEmail:@"joe@example.com"];
+    [self.config setUser:@"123" withEmail:@"joe@example.com" andName:@"Joe Bloggs"];
     [super startBugsnag];
 }
 

--- a/features/fixtures/ios-swift-cocoapods/iOSTestApp/scenarios/ManualSessionScenario.m
+++ b/features/fixtures/ios-swift-cocoapods/iOSTestApp/scenarios/ManualSessionScenario.m
@@ -16,7 +16,7 @@
     self.config.autoTrackSessions = NO;
     self.config.persistUser = NO;
     [self.config deletePersistedUserData];
-    [self.config setCurrentUser:nil];
+    [self.config setUser:nil withEmail:nil andName:nil];
     [super startBugsnag];
 }
 

--- a/features/fixtures/ios-swift-cocoapods/iOSTestApp/scenarios/ManualSessionWithUserScenario.m
+++ b/features/fixtures/ios-swift-cocoapods/iOSTestApp/scenarios/ManualSessionWithUserScenario.m
@@ -11,7 +11,7 @@
 @implementation ManualSessionWithUserScenario
 
 - (void)startBugsnag {
-    [self.config setUser:@"123" withName:@"Joe Bloggs" andEmail:@"joe@example.com"];
+    [self.config setUser:@"123" withEmail:@"joe@example.com" andName:@"Joe Bloggs"];
     self.config.autoTrackSessions = NO;
     [super startBugsnag];
 }

--- a/features/fixtures/ios-swift-cocoapods/iOSTestApp/scenarios/UserDisabledScenario.swift
+++ b/features/fixtures/ios-swift-cocoapods/iOSTestApp/scenarios/UserDisabledScenario.swift
@@ -16,7 +16,7 @@ internal class UserDisabledScenario: Scenario {
     }
 
     override func run() {
-        Bugsnag.setUser(nil, withName: nil, andEmail: nil)
+        Bugsnag.setUser(nil, withEmail: nil, andName: nil)
         let error = NSError(domain: "UserDisabledScenario", code: 100, userInfo: nil)
         Bugsnag.notifyError(error)
     }

--- a/features/fixtures/ios-swift-cocoapods/iOSTestApp/scenarios/UserEmailScenario.swift
+++ b/features/fixtures/ios-swift-cocoapods/iOSTestApp/scenarios/UserEmailScenario.swift
@@ -16,7 +16,7 @@ internal class UserEmailScenario: Scenario {
     }
 
     override func run() {
-        Bugsnag.setUser(nil, withName: nil, andEmail: "user@example.com")
+        Bugsnag.setUser(nil, withEmail: "user@example.com", andName: nil)
         let error = NSError(domain: "UserEmailScenario", code: 100, userInfo: nil)
         Bugsnag.notifyError(error)
     }

--- a/features/fixtures/ios-swift-cocoapods/iOSTestApp/scenarios/UserEnabledScenario.swift
+++ b/features/fixtures/ios-swift-cocoapods/iOSTestApp/scenarios/UserEnabledScenario.swift
@@ -17,7 +17,7 @@ internal class UserEnabledScenario: Scenario {
     }
 
     override func run() {
-        Bugsnag.setUser("123", withName: "Joe Bloggs", andEmail: "user@example.com")
+        Bugsnag.setUser("123", withEmail: "user@example.com", andName: "Joe Bloggs")
         let error = NSError(domain: "UserEnabledScenario", code: 100, userInfo: nil)
         Bugsnag.notifyError(error)
     }

--- a/features/fixtures/ios-swift-cocoapods/iOSTestApp/scenarios/UserIdScenario.swift
+++ b/features/fixtures/ios-swift-cocoapods/iOSTestApp/scenarios/UserIdScenario.swift
@@ -17,7 +17,7 @@ internal class UserIdScenario: Scenario {
     }
 
     override func run() {
-        Bugsnag.setUser("abc", withName: nil, andEmail: nil)
+        Bugsnag.setUser("abc", withEmail: nil, andName: nil)
         let error = NSError(domain: "UserIdScenario", code: 100, userInfo: nil)
         Bugsnag.notifyError(error)
     }

--- a/features/fixtures/ios-swift-cocoapods/iOSTestApp/scenarios/UserPersistenceScenarios.m
+++ b/features/fixtures/ios-swift-cocoapods/iOSTestApp/scenarios/UserPersistenceScenarios.m
@@ -16,7 +16,7 @@
 
 - (void)startBugsnag {
     self.config.persistUser = YES;
-    [self.config setUser:@"foo" withName:@"bar" andEmail:@"baz@grok.com"];
+    [self.config setUser:@"foo" withEmail:@"baz@grok.com" andName:@"bar"];
     [super startBugsnag];
 }
 
@@ -35,7 +35,7 @@
 
 - (void)startBugsnag {
     self.config.persistUser = NO;
-    [self.config setUser:@"john" withName:@"paul" andEmail:@"george@ringo.com"];
+    [self.config setUser:@"john" withEmail:@"george@ringo.com" andName:@"paul"];
     [super startBugsnag];
 }
 


### PR DESCRIPTION
- Rearranges the parameter order on the `setUser` method to match the notifier spec
- Renames `config.currentUser` to readonly `config.user` to match the notifier spec
- Update `config.user` to be readonly and non-null