### PR TITLE
Remove unused APIs from BugsnagSession interface

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,9 @@ Bugsnag Notifiers on other platforms.
 
 ## Enhancements
 
+* Remove unused APIs from `BugsnagSession` interface
+[#506](https://github.com/bugsnag/bugsnag-cocoa/pull/506)
+
 * Remove unused APIs from `BugsnagMetadata` interface
 [#501](https://github.com/bugsnag/bugsnag-cocoa/pull/501)
 

--- a/Source/BugsnagClient.m
+++ b/Source/BugsnagClient.m
@@ -85,6 +85,11 @@ static NSUInteger handledCount;
 static NSUInteger unhandledCount;
 static bool hasRecordedSessions;
 
+@interface BugsnagSession ()
+@property NSUInteger unhandledCount;
+@property NSUInteger handledCount;
+@end
+
 /**
  *  Handler executed when the application crashes. Writes information about the
  *  current application state using the crash report writer.

--- a/Source/BugsnagEvent.m
+++ b/Source/BugsnagEvent.m
@@ -239,6 +239,11 @@ static NSString *const DEFAULT_EXCEPTION_TYPE = @"cocoa";
 @property(readonly, strong, nullable) BugsnagBreadcrumbs *breadcrumbs;
 @end
 
+@interface BugsnagSession ()
+@property NSUInteger unhandledCount;
+@property NSUInteger handledCount;
+@end
+
 @interface BugsnagEvent ()
 
 /**

--- a/Source/BugsnagSession.h
+++ b/Source/BugsnagSession.h
@@ -25,26 +25,8 @@
                        handledCount:(NSUInteger)handledCount
                      unhandledCount:(NSUInteger)unhandledCount;
 
-/**
- * Representation used in report payloads
- */
-- (NSDictionary *_Nonnull)toJson;
-
-/**
- * Full representation of a session suitable for creating an identical session
- * using initWithDictionary
- */
-- (NSDictionary *_Nonnull)toDictionary;
-- (void)stop;
-- (void)resume;
-
 @property(readonly) NSString *_Nonnull sessionId;
 @property(readonly) NSDate *_Nonnull startedAt;
 @property(readonly) BugsnagUser *_Nullable user;
-@property(readonly) BOOL autoCaptured;
-@property(readonly, getter=isStopped) BOOL stopped;
-
-@property NSUInteger unhandledCount;
-@property NSUInteger handledCount;
 
 @end

--- a/Source/BugsnagSession.m
+++ b/Source/BugsnagSession.m
@@ -18,6 +18,22 @@ static NSString *const kBugsnagUser = @"user";
 
 @interface BugsnagSession ()
 @property(readwrite, getter=isStopped) BOOL stopped;
+@property(readonly) BOOL autoCaptured;
+@property NSUInteger unhandledCount;
+@property NSUInteger handledCount;
+
+/**
+ * Representation used in report payloads
+ */
+- (NSDictionary *_Nonnull)toJson;
+
+/**
+ * Full representation of a session suitable for creating an identical session
+ * using initWithDictionary
+ */
+- (NSDictionary *_Nonnull)toDictionary;
+- (void)stop;
+- (void)resume;
 @end
 
 @implementation BugsnagSession

--- a/Source/BugsnagSessionFileStore.m
+++ b/Source/BugsnagSessionFileStore.m
@@ -8,6 +8,10 @@
 
 static NSString *const kSessionStoreSuffix = @"-Session-";
 
+@interface BugsnagSession ()
+- (NSDictionary *)toJson;
+@end
+
 @implementation BugsnagSessionFileStore
 
 + (BugsnagSessionFileStore *)storeWithPath:(NSString *)path {

--- a/Source/BugsnagSessionTracker.m
+++ b/Source/BugsnagSessionTracker.m
@@ -20,6 +20,16 @@ NSTimeInterval const BSGNewSessionBackgroundDuration = 60;
 
 NSString *const BSGSessionUpdateNotification = @"BugsnagSessionChanged";
 
+@interface BugsnagSession ()
+
+@property(readwrite, getter=isStopped) BOOL stopped;
+@property NSUInteger unhandledCount;
+@property NSUInteger handledCount;
+- (NSDictionary *_Nonnull)toDictionary;
+- (void)stop;
+- (void)resume;
+@end
+
 @interface BugsnagConfiguration ()
 @property(readonly, retain, nullable) NSURL *sessionURL;
 @end

--- a/Source/BugsnagSessionTrackingPayload.m
+++ b/Source/BugsnagSessionTrackingPayload.m
@@ -15,6 +15,10 @@
 #import "BugsnagKSCrashSysInfoParser.h"
 #import "Private.h"
 
+@interface BugsnagSession ()
+- (NSDictionary *)toJson;
+@end
+
 @interface Bugsnag ()
 + (BugsnagClient *)client;
 @end

--- a/Tests/BugsnagEventTests.m
+++ b/Tests/BugsnagEventTests.m
@@ -17,6 +17,11 @@
 #import "BugsnagTestConstants.h"
 #import "BugsnagTestsDummyClass.h"
 
+@interface BugsnagSession ()
+@property NSUInteger unhandledCount;
+@property NSUInteger handledCount;
+@end
+
 @interface Bugsnag ()
 + (BugsnagConfiguration *)configuration;
 @end

--- a/Tests/BugsnagSessionTest.m
+++ b/Tests/BugsnagSessionTest.m
@@ -11,6 +11,13 @@
 #import "BugsnagSession.h"
 #import "BSG_RFC3339DateTool.h"
 
+@interface BugsnagSession ()
+@property NSUInteger unhandledCount;
+@property NSUInteger handledCount;
+- (NSDictionary *_Nonnull)toJson;
+- (NSDictionary *_Nonnull)toDictionary;
+@end
+
 @interface BugsnagSessionTest : XCTestCase
 @end
 

--- a/Tests/BugsnagSessionTrackerStopTest.m
+++ b/Tests/BugsnagSessionTrackerStopTest.m
@@ -10,6 +10,11 @@
 #import "BugsnagSessionTracker.h"
 #import "BugsnagTestConstants.h"
 
+@interface BugsnagSession ()
+@property NSUInteger unhandledCount;
+@property NSUInteger handledCount;
+@end
+
 @interface BugsnagSessionTrackerStopTest : XCTestCase
 @property BugsnagConfiguration *configuration;
 @property BugsnagSessionTracker *tracker;

--- a/Tests/BugsnagSessionTrackerTest.m
+++ b/Tests/BugsnagSessionTrackerTest.m
@@ -14,6 +14,12 @@
 #import "BugsnagSessionTrackingApiClient.h"
 #import "BugsnagTestConstants.h"
 
+@interface BugsnagSession ()
+@property NSUInteger unhandledCount;
+@property NSUInteger handledCount;
+@property(readonly) BOOL autoCaptured;
+@end
+
 @interface BugsnagConfiguration ()
 - (void)deletePersistedUserData;
 @end

--- a/UPGRADING.md
+++ b/UPGRADING.md
@@ -205,3 +205,18 @@ of the removed `addAttribute`:
 - BugsnagCrashReport.addAttribute(_:withValue:toTabWithName:)
 + BugsnagEvent.addMetadata(sectionName:key:value:)
 ```
+
+### `BugsnagSession` class
+
+#### Removals
+
+```diff
+- toJson
+- toDictionary
+- stop
+- resume
+- autoCaptured
+- handledCount
+- unhandledCount
+- stopped
+```


### PR DESCRIPTION
## Goal

Removes/hides unused APIs from the `BugsnagSession` interface. These are either no longer required or were originally part of the internal implementation and mistakenly included in the public header.

## Changeset

The following APIs have been removed/hidden using a [class extension](https://developer.apple.com/library/archive/documentation/Cocoa/Conceptual/ProgrammingWithObjectiveC/CustomizingExistingClasses/CustomizingExistingClasses.html#//apple_ref/doc/uid/TP40011210-CH6-SW6):

```
toJson
toDictionary
stop
resume
autoCaptured
handledCount
unhandledCount
stopped
```

## Tests

Updated existing test coverage to avoid using deprecated APIs.
