### PR TITLE
Revert breaking changes to breadcrumb serialisation

### DIFF
--- a/Source/BugsnagBreadcrumb.m
+++ b/Source/BugsnagBreadcrumb.m
@@ -95,10 +95,12 @@ BSGBreadcrumbType BSGBreadcrumbTypeFromString(NSString *value) {
                 metadata[[key copy]] = [_metadata[key] copy];
             }
             return @{
-                 BSGKeyMessage : [_message copy],
-                 BSGKeyTimestamp : timestamp,
-                 BSGKeyType : BSGBreadcrumbTypeValue(_type),
-                 BSGKeyMetadata : metadata
+                // Note: The Bugsnag Error Reporting API specifies that the breadcrumb "message"
+                // field should be delivered in as a "name" field.  This comment notes that variance.
+                BSGKeyName : [_message copy],
+                BSGKeyTimestamp : timestamp,
+                BSGKeyType : BSGBreadcrumbTypeValue(_type),
+                BSGKeyMetadata : metadata
             };
         }
         return nil;

--- a/Tests/BugsnagBreadcrumbsTest.m
+++ b/Tests/BugsnagBreadcrumbsTest.m
@@ -126,9 +126,9 @@ BSGBreadcrumbType BSGBreadcrumbTypeFromString(NSString *value);
         XCTAssertTrue([[formatter dateFromString:item[@"timestamp"]]
                        isKindOfClass:[NSDate class]]);
     }
-    XCTAssertEqualObjects(value[0][@"message"], @"Launch app");
-    XCTAssertEqualObjects(value[1][@"message"], @"Tap button");
-    XCTAssertEqualObjects(value[2][@"message"], @"Close tutorial");
+    XCTAssertEqualObjects(value[0][@"name"], @"Launch app");
+    XCTAssertEqualObjects(value[1][@"name"], @"Tap button");
+    XCTAssertEqualObjects(value[2][@"name"], @"Close tutorial");
 }
 
 - (void)testStateType {
@@ -141,7 +141,7 @@ BSGBreadcrumbType BSGBreadcrumbTypeFromString(NSString *value);
     awaitBreadcrumbSync(self.crumbs);
     NSArray *value = [crumbs arrayValue];
     XCTAssertEqualObjects(value[0][@"metaData"][@"direction"], @"right");
-    XCTAssertEqualObjects(value[0][@"message"], @"Rotated Menu");
+    XCTAssertEqualObjects(value[0][@"name"], @"Rotated Menu");
     XCTAssertEqualObjects(value[0][@"type"], @"state");
 }
 
@@ -150,13 +150,13 @@ BSGBreadcrumbType BSGBreadcrumbTypeFromString(NSString *value);
     NSArray *value = [NSJSONSerialization JSONObjectWithData:crumbs options:0 error:nil];
     XCTAssertEqual(value.count, 3);
     XCTAssertEqualObjects(value[0][@"type"], @"manual");
-    XCTAssertEqualObjects(value[0][@"message"], @"Launch app");
+    XCTAssertEqualObjects(value[0][@"name"], @"Launch app");
     XCTAssertNotNil(value[0][@"timestamp"]);
     XCTAssertEqualObjects(value[1][@"type"], @"manual");
-    XCTAssertEqualObjects(value[1][@"message"], @"Tap button");
+    XCTAssertEqualObjects(value[1][@"name"], @"Tap button");
     XCTAssertNotNil(value[1][@"timestamp"]);
     XCTAssertEqualObjects(value[2][@"type"], @"manual");
-    XCTAssertEqualObjects(value[2][@"message"], @"Close tutorial");
+    XCTAssertEqualObjects(value[2][@"name"], @"Close tutorial");
     XCTAssertNotNil(value[2][@"timestamp"]);
 }
 
@@ -170,7 +170,7 @@ BSGBreadcrumbType BSGBreadcrumbTypeFromString(NSString *value);
     NSArray *value = [NSJSONSerialization JSONObjectWithData:crumbs options:0 error:nil];
     XCTAssertEqual(value.count, 4);
     XCTAssertEqualObjects(value[3][@"type"], @"state");
-    XCTAssertEqualObjects(value[3][@"message"], @"Initiate sequence");
+    XCTAssertEqualObjects(value[3][@"name"], @"Initiate sequence");
     XCTAssertEqualObjects(value[3][@"metaData"][@"captain"], @"Bob");
     XCTAssertNotNil(value[3][@"timestamp"]);
 }
@@ -231,7 +231,7 @@ BSGBreadcrumbType BSGBreadcrumbTypeFromString(NSString *value);
     NSArray *value = [self.crumbs arrayValue];
     XCTAssertEqual(1, value.count);
     XCTAssertEqualObjects(value[0][@"type"], @"manual");
-    XCTAssertEqualObjects(value[0][@"message"], @"this is a test");
+    XCTAssertEqualObjects(value[0][@"name"], @"this is a test");
 }
 
 /**
@@ -338,7 +338,7 @@ BSGBreadcrumbType BSGBreadcrumbTypeFromString(NSString *value);
     XCTAssertEqual(Bugsnag.client.configuration.breadcrumbs.count, 8);
 
     XCTAssertEqualObjects(bc0[@"type"], @"state");
-    XCTAssertEqualObjects(bc0[@"message"], @"Bugsnag loaded");
+    XCTAssertEqualObjects(bc0[@"name"], @"Bugsnag loaded");
     XCTAssertEqual([bc0[@"metaData"] count], 0);
 
     XCTAssertEqual([bc1[@"metaData"] count], 1);
@@ -350,25 +350,25 @@ BSGBreadcrumbType BSGBreadcrumbTypeFromString(NSString *value);
     XCTAssertEqual([bc4[@"metaData"] count], 2);
     XCTAssertEqual([bc6[@"metaData"] count], 2);
     
-    XCTAssertEqualObjects(bc1[@"message"], @"manual message");
+    XCTAssertEqualObjects(bc1[@"name"], @"manual message");
     XCTAssertEqualObjects(bc1[@"type"], @"manual");
 
-    XCTAssertEqualObjects(bc2[@"message"], @"log message");
+    XCTAssertEqualObjects(bc2[@"name"], @"log message");
     XCTAssertEqualObjects(bc2[@"type"], @"log");
 
-    XCTAssertEqualObjects(bc3[@"message"], @"navigation message");
+    XCTAssertEqualObjects(bc3[@"name"], @"navigation message");
     XCTAssertEqualObjects(bc3[@"type"], @"navigation");
 
-    XCTAssertEqualObjects(bc4[@"message"], @"process message");
+    XCTAssertEqualObjects(bc4[@"name"], @"process message");
     XCTAssertEqualObjects(bc4[@"type"], @"process");
 
-    XCTAssertEqualObjects(bc5[@"message"], @"request message");
+    XCTAssertEqualObjects(bc5[@"name"], @"request message");
     XCTAssertEqualObjects(bc5[@"type"], @"request");
 
-    XCTAssertEqualObjects(bc6[@"message"], @"state message");
+    XCTAssertEqualObjects(bc6[@"name"], @"state message");
     XCTAssertEqualObjects(bc6[@"type"], @"state");
 
-    XCTAssertEqualObjects(bc7[@"message"], @"user message");
+    XCTAssertEqualObjects(bc7[@"name"], @"user message");
     XCTAssertEqualObjects(bc7[@"type"], @"user");
 }
 
@@ -387,8 +387,8 @@ BSGBreadcrumbType BSGBreadcrumbTypeFromString(NSString *value);
     NSDictionary *bc1 = [Bugsnag.client.configuration.breadcrumbs arrayValue][1];
     NSDictionary *bc2 = [Bugsnag.client.configuration.breadcrumbs arrayValue][2];
 
-    XCTAssertEqualObjects(bc1[@"message"], @"message1");
-    XCTAssertEqualObjects(bc2[@"message"], @"message2");
+    XCTAssertEqualObjects(bc1[@"name"], @"message1");
+    XCTAssertEqualObjects(bc2[@"name"], @"message2");
     
     XCTAssertEqual([bc1[@"metaData"] count], 0);
     XCTAssertEqual([bc2[@"metaData"] count], 0);

--- a/Tests/BugsnagSinkTests.m
+++ b/Tests/BugsnagSinkTests.m
@@ -138,7 +138,7 @@
     [self.processedData[@"events"] firstObject][@"breadcrumbs"];
     XCTAssertEqual(2, breadcrumbs.count);
     for (int i = 0; i < breadcrumbs.count; i++) {
-        XCTAssertEqualObjects(expected[i][@"message"], breadcrumbs[i][@"message"]);
+        XCTAssertEqualObjects(expected[i][@"name"], breadcrumbs[i][@"message"]);
         XCTAssertEqualObjects(expected[i][@"type"], breadcrumbs[i][@"type"]);
         XCTAssertEqualObjects(expected[i][@"timestamp"], breadcrumbs[i][@"timestamp"]);
         XCTAssertEqualObjects(expected[i][@"metadata"], breadcrumbs[i][@"metadata"]);

--- a/features/steps/ios_steps.rb
+++ b/features/steps/ios_steps.rb
@@ -102,7 +102,7 @@ Then("the event breadcrumbs contain {string} with type {string}") do |string, ty
   crumbs = read_key_path(find_request(0)[:body], "events.0.breadcrumbs")
   assert_not_equal(0, crumbs.length, "There are no breadcrumbs on this event")
   match = crumbs.detect do |crumb|
-    crumb["message"] == string && crumb["type"] == type
+    crumb["name"] == string && crumb["type"] == type
   end
   assert_not_nil(match, "No crumb matches the provided message and type")
 end
@@ -111,7 +111,7 @@ Then("the event breadcrumbs contain {string}") do |string|
   crumbs = read_key_path(find_request(0)[:body], "events.0.breadcrumbs")
   assert_not_equal(0, crumbs.length, "There are no breadcrumbs on this event")
   match = crumbs.detect do |crumb|
-    crumb["message"] == string
+    crumb["name"] == string
   end
   assert_not_nil(match, "No crumb matches the provided message")
 end


### PR DESCRIPTION
## Goal

<!-- What is the intent of this change? -->
A global search-and-replace of "name" by "message" in the breadcrumb portions of code (to bring the cocoa notifier in line with other notifiers) failed to take account of the Bugsnag error reporting API, which expects a "name"-keyed field.  This PR partially reverts that change.
<!--
Fixes #
Related to #
-->

## Design

<!-- How does this change work? Why was this approach to the goal used? -->

## Changeset

Single line fix with hintful comment, multiple tests needed changed.

<!-- List what was added, removed, or changed.  Pitch this at a level 
     appropriate to the scope of the change: new  classes, changed architecture,
     minor typo, etc.  If appropriate include a list of changed files: 

         $ git diff --name-status HEAD~1 | cat
-->

## Tests

Unit and CI modified, unit all passed, breadcrumbs.feature passed locally

<!-- How was this change tested? What manual and automated tests were
     run/added? -->

## Review

### Outstanding Questions

<!-- Are there any parts of the design or the implementation which seem
     less than ideal and that could require additional discussion?
     List here: -->

<!-- Preflight checks. Have I:

* Added a changelog entry?
* Checked the scope to ensure the commits are only related to the goal above?

-->

- This pull request is ready for:
  - [ ] Initial review of the intended approach, not yet feature complete
  - [ ] Structural review of the classes, functions, and properties modified
  - [x] Final review

<!-- What do you need from a reviewer to get this changeset
     ready for release -->

- [ ] The correct target branch has been selected (`master` for fixes, `next` for
  features)
- [ ] Consistency across platforms for structures or concepts added or modified
- [ ] Consistency between the changeset and the goal stated above
- [ ] Internal consistency with the rest of the library - is there any overlap between existing interfaces and any which have been added?
- [ ] Usage friction - is the proposed change in usage cumbersome or complicated?
- [ ] Performance and complexity - are there any cases of unexpected O(n^3) when iterating, recursing, flat mapping, etc?
- [ ] Concurrency concerns - if components are accessed asynchronously, what issues will arise
- [ ] Thoroughness of added tests and any missing edge cases
- [ ] Idiomatic use of the language
