### PR TITLE
Allow addition/removal of OnBreadcrumb callbacks

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -17,6 +17,9 @@ Bugsnag Notifiers on other platforms.
 * Remove unused APIs on `BugsnagEvent` interface
   [#498](https://github.com/bugsnag/bugsnag-cocoa/pull/498)
 
+* Allow addition/removal of `OnBreadcrumb` callbacks
+[#508](https://github.com/bugsnag/bugsnag-cocoa/pull/508)
+
 * Remove unused APIs from `BugsnagMetadata` interface
 [#501](https://github.com/bugsnag/bugsnag-cocoa/pull/501)
 

--- a/OSX/Bugsnag.xcodeproj/project.pbxproj
+++ b/OSX/Bugsnag.xcodeproj/project.pbxproj
@@ -162,6 +162,7 @@
 		E79E6BDA1F4E3850002B35F9 /* BSG_RFC3339DateTool.m in Sources */ = {isa = PBXBuildFile; fileRef = E79E6B6E1F4E3850002B35F9 /* BSG_RFC3339DateTool.m */; };
 		E79E6BDB1F4E3850002B35F9 /* BSG_KSCrashReportFilter.h in Headers */ = {isa = PBXBuildFile; fileRef = E79E6B711F4E3850002B35F9 /* BSG_KSCrashReportFilter.h */; };
 		E79E6BDC1F4E3850002B35F9 /* BSG_KSCrashReportFilterCompletion.h in Headers */ = {isa = PBXBuildFile; fileRef = E79E6B721F4E3850002B35F9 /* BSG_KSCrashReportFilterCompletion.h */; };
+		E7AB4B9E2423E184004F015A /* BugsnagOnBreadcrumbTest.m in Sources */ = {isa = PBXBuildFile; fileRef = E7AB4B9D2423E184004F015A /* BugsnagOnBreadcrumbTest.m */; };
 		E7CE78BB1FD94E77001D07E0 /* KSCrashReportConverter_Tests.m in Sources */ = {isa = PBXBuildFile; fileRef = E7CE78991FD94E60001D07E0 /* KSCrashReportConverter_Tests.m */; };
 		E7CE78BC1FD94E77001D07E0 /* KSCrashReportStore_Tests.m in Sources */ = {isa = PBXBuildFile; fileRef = E7CE78951FD94E5F001D07E0 /* KSCrashReportStore_Tests.m */; };
 		E7CE78BE1FD94E77001D07E0 /* KSCrashSentry_NSException_Tests.m in Sources */ = {isa = PBXBuildFile; fileRef = E7CE78911FD94E5F001D07E0 /* KSCrashSentry_NSException_Tests.m */; };
@@ -359,6 +360,7 @@
 		E79E6B6E1F4E3850002B35F9 /* BSG_RFC3339DateTool.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; name = BSG_RFC3339DateTool.m; path = ../Source/KSCrash/Source/KSCrash/Recording/Tools/BSG_RFC3339DateTool.m; sourceTree = SOURCE_ROOT; };
 		E79E6B711F4E3850002B35F9 /* BSG_KSCrashReportFilter.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; name = BSG_KSCrashReportFilter.h; path = ../Source/KSCrash/Source/KSCrash/Reporting/Filters/BSG_KSCrashReportFilter.h; sourceTree = SOURCE_ROOT; };
 		E79E6B721F4E3850002B35F9 /* BSG_KSCrashReportFilterCompletion.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; name = BSG_KSCrashReportFilterCompletion.h; path = ../Source/KSCrash/Source/KSCrash/Reporting/Filters/BSG_KSCrashReportFilterCompletion.h; sourceTree = SOURCE_ROOT; };
+		E7AB4B9D2423E184004F015A /* BugsnagOnBreadcrumbTest.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; path = BugsnagOnBreadcrumbTest.m; sourceTree = "<group>"; };
 		E7CE78871FD94E5F001D07E0 /* KSMach_Tests.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; path = KSMach_Tests.m; sourceTree = "<group>"; };
 		E7CE78881FD94E5F001D07E0 /* NSError+SimpleConstructor_Tests.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; path = "NSError+SimpleConstructor_Tests.m"; sourceTree = "<group>"; };
 		E7CE78891FD94E5F001D07E0 /* KSFileUtils_Tests.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; path = KSFileUtils_Tests.m; sourceTree = "<group>"; };
@@ -503,6 +505,7 @@
 		8A2C8FAF1C6BC1F700846019 /* Tests */ = {
 			isa = PBXGroup;
 			children = (
+				E7AB4B9D2423E184004F015A /* BugsnagOnBreadcrumbTest.m */,
 				00F9393B23FD2D9B008C7073 /* BugsnagTestsDummyClass.h */,
 				00F9393A23FD2D9B008C7073 /* BugsnagTestsDummyClass.m */,
 				00F9393123FC168F008C7073 /* BugsnagBaseUnitTest.h */,
@@ -999,6 +1002,7 @@
 				E762E9F91F73F7F300E82B43 /* BugsnagHandledStateTest.m in Sources */,
 				E7CE78C51FD94E77001D07E0 /* KSLogger_Tests.m in Sources */,
 				E7CE78C11FD94E77001D07E0 /* KSCrashState_Tests.m in Sources */,
+				E7AB4B9E2423E184004F015A /* BugsnagOnBreadcrumbTest.m in Sources */,
 				E7CE78C31FD94E77001D07E0 /* KSFileUtils_Tests.m in Sources */,
 				E7CE78BC1FD94E77001D07E0 /* KSCrashReportStore_Tests.m in Sources */,
 				E79148611FD82BB7003EFEBF /* BugsnagSessionTrackerTest.m in Sources */,

--- a/Source/Bugsnag.h
+++ b/Source/Bugsnag.h
@@ -338,4 +338,23 @@ static NSString *_Nonnull const BugsnagSeverityInfo = @"info";
  */
 + (void)removeOnSendBlock:(BugsnagOnSendBlock _Nonnull)block;
 
+// =============================================================================
+// MARK: - onBreadcrumb
+// =============================================================================
+
+/**
+ *  Add a callback to be invoked when a breadcrumb is captured by Bugsnag, to
+ *  change the breadcrumb contents as needed
+ *
+ *  @param block A block which returns YES if the breadcrumb should be captured
+ */
++ (void)addOnBreadcrumbBlock:(BugsnagOnBreadcrumbBlock _Nonnull)block;
+
+/**
+ * Remove the callback that would be invoked when a breadcrumb is captured.
+ *
+ * @param block The block to be removed.
+ */
++ (void)removeOnBreadcrumbBlock:(BugsnagOnBreadcrumbBlock _Nonnull)block;
+
 @end

--- a/Source/Bugsnag.m
+++ b/Source/Bugsnag.m
@@ -323,6 +323,19 @@ static BugsnagClient *bsg_g_bugsnag_client = NULL;
     [[self configuration] removeOnSendBlock:block];
 }
 
+// =============================================================================
+// MARK: - OnBreadcrumb
+// =============================================================================
+
++ (void)addOnBreadcrumbBlock:(BugsnagOnBreadcrumbBlock _Nonnull)block {
+    [[self configuration] addOnBreadcrumbBlock:block];
+}
+
+
++ (void)removeOnBreadcrumbBlock:(BugsnagOnBreadcrumbBlock _Nonnull)block {
+    [[self configuration] removeOnBreadcrumbBlock:block];
+}
+
 @end
 
 //

--- a/Source/BugsnagConfiguration.h
+++ b/Source/BugsnagConfiguration.h
@@ -61,6 +61,13 @@ typedef void (^BugsnagOnErrorBlock)(BugsnagEvent *_Nonnull event);
 typedef bool (^BugsnagOnSendBlock)(BugsnagEvent *_Nonnull event);
 
 /**
+ *  A configuration block for modifying a captured breadcrumb
+ *
+ *  @param breadcrumb The breadcrumb
+ */
+typedef BOOL (^BugsnagOnBreadcrumbBlock)(BugsnagBreadcrumb *_Nonnull breadcrumb);
+
+/**
  * A configuration block for modifying a session. Intended for internal usage only.
  *
  * @param sessionPayload The session about to be delivered
@@ -247,6 +254,25 @@ typedef NS_OPTIONS(NSUInteger, BSGErrorType) {
 - (void)removeOnSendBlock:(BugsnagOnSendBlock _Nonnull )block;
 
 - (void)addPlugin:(id<BugsnagPlugin> _Nonnull)plugin;
+
+// =============================================================================
+// MARK: - onBreadcrumb
+// =============================================================================
+
+/**
+ *  Add a callback to be invoked when a breadcrumb is captured by Bugsnag, to
+ *  change the breadcrumb contents as needed
+ *
+ *  @param block A block which returns YES if the breadcrumb should be captured
+ */
+- (void)addOnBreadcrumbBlock:(BugsnagOnBreadcrumbBlock _Nonnull)block;
+
+/**
+ * Remove the callback that would be invoked when a breadcrumb is captured.
+ *
+ * @param block The block to be removed.
+ */
+- (void)removeOnBreadcrumbBlock:(BugsnagOnBreadcrumbBlock _Nonnull)block;
 
 /**
  * Should the specified type of breadcrumb be recorded?

--- a/Source/BugsnagConfiguration.m
+++ b/Source/BugsnagConfiguration.m
@@ -67,6 +67,7 @@ NSString * const kBugsnagUserUserId = @"BugsnagUserUserId";
  *  Hooks for modifying sessions before they are sent to Bugsnag. Intended for internal use only by React Native/Unity.
  */
 @property(nonatomic, readwrite, strong) NSMutableArray *onSessionBlocks;
+@property(nonatomic, readwrite, strong) NSMutableArray *onBreadcrumbBlocks;
 @property(nonatomic, readwrite, strong) NSMutableSet *plugins;
 @property(readonly, retain, nullable) NSURL *notifyURL;
 @property(readonly, retain, nullable) NSURL *sessionURL;
@@ -138,6 +139,7 @@ NSString * const kBugsnagUserUserId = @"BugsnagUserUserId";
     _notifyURL = [NSURL URLWithString:BSGDefaultNotifyUrl];
     _onSendBlocks = [NSMutableArray new];
     _onSessionBlocks = [NSMutableArray new];
+    _onBreadcrumbBlocks = [NSMutableArray new];
     _plugins = [NSMutableSet new];
     _notifyReleaseStages = nil;
     _breadcrumbs = [BugsnagBreadcrumbs new];
@@ -235,6 +237,18 @@ NSString * const kBugsnagUserUserId = @"BugsnagUserUserId";
 
 - (void)removeOnSessionBlock:(BugsnagOnSessionBlock)block {
     [(NSMutableArray *)self.onSessionBlocks removeObject:block];
+}
+
+// =============================================================================
+// MARK: - onBreadcrumbBlock
+// =============================================================================
+
+- (void)addOnBreadcrumbBlock:(BugsnagOnBreadcrumbBlock _Nonnull)block {
+    [(NSMutableArray *)self.onBreadcrumbBlocks addObject:[block copy]];
+}
+
+- (void)removeOnBreadcrumbBlock:(BugsnagOnBreadcrumbBlock _Nonnull)block {
+    [(NSMutableArray *)self.onBreadcrumbBlocks removeObject:block];
 }
 
 - (NSDictionary *)errorApiHeaders {

--- a/Tests/BugsnagOnBreadcrumbTest.m
+++ b/Tests/BugsnagOnBreadcrumbTest.m
@@ -1,0 +1,195 @@
+//
+//  BugsnagOnBreadcrumbTest.m
+//  Tests
+//
+//  Created by Jamie Lynch on 19/03/2020.
+//  Copyright © 2020 Bugsnag. All rights reserved.
+//
+
+#import <XCTest/XCTest.h>
+
+#import "Bugsnag.h"
+#import "BugsnagConfiguration.h"
+#import "BugsnagTestConstants.h"
+#import "BugsnagBreadcrumbs.h"
+
+@interface BugsnagConfiguration ()
+@property NSMutableArray *onBreadcrumbBlocks;
+@property BugsnagBreadcrumbs *breadcrumbs;
+@end
+
+@interface BugsnagBreadcrumbs ()
+@property(nonatomic, readwrite, strong) NSMutableArray *breadcrumbs;
+@end
+
+@interface BugsnagOnBreadcrumbTest : XCTestCase
+@end
+
+@implementation BugsnagOnBreadcrumbTest
+
+
+/**
+ * Test that onBreadcrumb blocks get called once added
+ */
+- (void)testAddOnBreadcrumbBlock {
+
+    // Setup
+    __block XCTestExpectation *expectation = [self expectationWithDescription:@"Remove On Breadcrumb Block"];
+    BugsnagConfiguration *config = [[BugsnagConfiguration alloc] initWithApiKey:DUMMY_APIKEY_32CHAR_1];
+    [config setEndpointsForNotify:@"http://notreal.bugsnag.com" sessions:@"http://notreal.bugsnag.com"];
+    XCTAssertEqual([[config onBreadcrumbBlocks] count], 0);
+    BugsnagOnBreadcrumbBlock crumbBlock = ^(BugsnagBreadcrumb * _Nonnull crumb) {
+        // We expect the breadcrumb block to be called
+        [expectation fulfill];
+        return YES;
+    };
+    [config addOnBreadcrumbBlock:crumbBlock];
+    XCTAssertEqual([[config onBreadcrumbBlocks] count], 1);
+
+    // Call onbreadcrumb blocks
+    [Bugsnag startBugsnagWithConfiguration:config];
+    [Bugsnag leaveBreadcrumbWithMessage:@"Hello"];
+    [self waitForExpectationsWithTimeout:5.0 handler:nil];
+}
+
+/**
+ * Test that onBreadcrumb blocks do not get called once they've been removed
+ */
+- (void)testRemoveOnBreadcrumbBlock {
+    // Setup
+    // We expect NOT to be called
+    __block XCTestExpectation *calledExpectation = [self expectationWithDescription:@"Remove On Breadcrumb Block"];
+    calledExpectation.inverted = YES;
+
+    BugsnagConfiguration *config = [[BugsnagConfiguration alloc] initWithApiKey:DUMMY_APIKEY_32CHAR_1];
+    [config setEndpointsForNotify:@"http://notreal.bugsnag.com" sessions:@"http://notreal.bugsnag.com"];
+    XCTAssertEqual([[config onBreadcrumbBlocks] count], 0);
+    BugsnagOnBreadcrumbBlock crumbBlock = ^(BugsnagBreadcrumb * _Nonnull crumb) {
+        [calledExpectation fulfill];
+        return YES;
+    };
+
+    // It's there (and from other tests we know it gets called) and then it's not there
+    [config addOnBreadcrumbBlock:crumbBlock];
+    XCTAssertEqual([[config onBreadcrumbBlocks] count], 1);
+    [config removeOnBreadcrumbBlock:crumbBlock];
+    XCTAssertEqual([[config onBreadcrumbBlocks] count], 0);
+
+    [Bugsnag startBugsnagWithConfiguration:config];
+    [Bugsnag leaveBreadcrumbWithMessage:@"Hello"];
+
+    // Wait a second NOT to be called
+    [self waitForExpectationsWithTimeout:1.0 handler:nil];
+}
+/**
+ * Test that an onBreadcrumb block is called after being added, then NOT called after being removed.
+ * This test could be expanded to verify the behaviour when multiple blocks are added.
+ */
+- (void)testAddOnBreadcrumbBlockThenRemove {
+
+    __block int called = 0; // A counter
+
+    // Setup
+    __block XCTestExpectation *expectation1 = [self expectationWithDescription:@"Remove On Breadcrumb Block 1"];
+    __block XCTestExpectation *expectation2 = [self expectationWithDescription:@"Remove On Breadcrumb Block 2"];
+    expectation2.inverted = YES;
+
+    BugsnagConfiguration *config = [[BugsnagConfiguration alloc] initWithApiKey:DUMMY_APIKEY_32CHAR_1];
+    [config setEndpointsForNotify:@"http://notreal.bugsnag.com" sessions:@"http://notreal.bugsnag.com"];
+    XCTAssertEqual([[config onBreadcrumbBlocks] count], 0);
+
+    BugsnagOnBreadcrumbBlock crumbBlock = ^(BugsnagBreadcrumb * _Nonnull crumb) {
+        switch (called) {
+        case 0:
+            [expectation1 fulfill];
+            break;
+        case 1:
+            [expectation2 fulfill];
+            break;
+        }
+        return YES;
+    };
+
+    [config addOnBreadcrumbBlock:crumbBlock];
+    XCTAssertEqual([[config onBreadcrumbBlocks] count], 1);
+
+    // Call onbreadcrumb blocks
+    [Bugsnag startBugsnagWithConfiguration:config];
+    [Bugsnag leaveBreadcrumbWithMessage:@"Hello"];
+    [self waitForExpectations:@[expectation1] timeout:1.0];
+
+    // Check it's NOT called once the block's deleted
+    called++;
+    [config removeOnBreadcrumbBlock:crumbBlock];
+    [Bugsnag leaveBreadcrumbWithMessage:@"Hello"];
+    [self waitForExpectations:@[expectation2] timeout:1.0];
+}
+
+/**
+ * Make sure slightly invalid removals and duplicate additions don't break things
+ */
+- (void)testRemoveNonexistentOnBreadcrumbBlocks {
+    BugsnagConfiguration *config = [[BugsnagConfiguration alloc] initWithApiKey:DUMMY_APIKEY_32CHAR_1];
+    XCTAssertEqual([[config onBreadcrumbBlocks] count], 0);
+    BugsnagOnBreadcrumbBlock crumbBlock1 = ^(BugsnagBreadcrumb * _Nonnull crumb) {
+        return YES;
+    };
+    BugsnagOnBreadcrumbBlock crumbBlock2 = ^(BugsnagBreadcrumb * _Nonnull crumb) {
+        return YES;
+    };
+
+    [config addOnBreadcrumbBlock:crumbBlock1];
+    XCTAssertEqual([[config onBreadcrumbBlocks] count], 1);
+    [config removeOnBreadcrumbBlock:crumbBlock2];
+    XCTAssertEqual([[config onBreadcrumbBlocks] count], 1);
+    [config removeOnBreadcrumbBlock:crumbBlock1];
+    XCTAssertEqual([[config onBreadcrumbBlocks] count], 0);
+    [config removeOnBreadcrumbBlock:crumbBlock2];
+    XCTAssertEqual([[config onBreadcrumbBlocks] count], 0);
+    [config removeOnBreadcrumbBlock:crumbBlock1];
+    XCTAssertEqual([[config onBreadcrumbBlocks] count], 0);
+
+    [config addOnBreadcrumbBlock:crumbBlock1];
+    XCTAssertEqual([[config onBreadcrumbBlocks] count], 1);
+    [config addOnBreadcrumbBlock:crumbBlock1];
+    XCTAssertEqual([[config onBreadcrumbBlocks] count], 2);
+    [config addOnBreadcrumbBlock:crumbBlock1];
+    XCTAssertEqual([[config onBreadcrumbBlocks] count], 3);
+}
+
+/**
+ * Test that onBreadcrumb blocks mutate a crumb
+ */
+- (void)testAddOnBreadcrumbMutation {
+    BugsnagConfiguration *config = [[BugsnagConfiguration alloc] initWithApiKey:DUMMY_APIKEY_32CHAR_1];
+    [config setEndpointsForNotify:@"http://notreal.bugsnag.com" sessions:@"http://notreal.bugsnag.com"];
+    [config addOnBreadcrumbBlock:^(BugsnagBreadcrumb * _Nonnull crumb) {
+        crumb.message = @"Foo";
+        return YES;
+    }];
+
+    // Call onbreadcrumb blocks
+    [Bugsnag startBugsnagWithConfiguration:config];
+    XCTAssertEqual([[config onBreadcrumbBlocks] count], 1);
+    BugsnagBreadcrumb *crumb = [[config breadcrumbs].breadcrumbs firstObject];
+    XCTAssertEqualObjects(@"Foo", crumb.message);
+}
+
+/**
+ * Test that onBreadcrumb blocks can discard crumbs
+ */
+- (void)testAddOnBreadcrumbRejection {
+    BugsnagConfiguration *config = [[BugsnagConfiguration alloc] initWithApiKey:DUMMY_APIKEY_32CHAR_1];
+    [config setEndpointsForNotify:@"http://notreal.bugsnag.com" sessions:@"http://notreal.bugsnag.com"];
+    [config addOnBreadcrumbBlock:^(BugsnagBreadcrumb * _Nonnull crumb) {
+        return NO;
+    }];
+
+    // Call onbreadcrumb blocks
+    [Bugsnag startBugsnagWithConfiguration:config];
+    XCTAssertEqual([[config breadcrumbs].breadcrumbs count], 0);
+    [Bugsnag leaveBreadcrumbWithMessage:@"Hello"];
+    XCTAssertEqual([[config breadcrumbs].breadcrumbs count], 0);
+}
+
+@end

--- a/UPGRADING.md
+++ b/UPGRADING.md
@@ -33,6 +33,9 @@ The exact error is available using the `BSGConfigurationErrorDomain` and
 
 + config.persistUserData()
 + config.deletePersistedUserData()
+
++ config.add(onBreadcrumb:)
++ config.remove(onBreadcrumb:)
 ```
 
 #### Renames

--- a/features/fixtures/ios-swift-cocoapods/iOSTestApp/scenarios/HandledErrorOverrideScenario.swift
+++ b/features/fixtures/ios-swift-cocoapods/iOSTestApp/scenarios/HandledErrorOverrideScenario.swift
@@ -22,7 +22,7 @@ class HandledErrorOverrideScenario: Scenario {
         Bugsnag.notifyError(error) { report in
             report.errorMessage = "Foo"
             report.errorClass = "Bar"
-            var depth: Int = report.value(forKey: "depth") as! Int
+            let depth: Int = report.value(forKey: "depth") as! Int
             report.setValue(depth + 2, forKey: "depth")
             report.metadata["account"] = [
                 "items": [400,200]

--- a/features/fixtures/ios-swift-cocoapods/iOSTestApp/scenarios/ModifyBreadcrumbScenario.swift
+++ b/features/fixtures/ios-swift-cocoapods/iOSTestApp/scenarios/ModifyBreadcrumbScenario.swift
@@ -5,14 +5,15 @@ class ModifyBreadcrumbScenario: Scenario {
 
     override func startBugsnag() {
         self.config.autoTrackSessions = false;
-        self.config.add { (event) -> Bool in
+
+        self.config.add(onSend: { event in
             event.breadcrumbs?.forEach({ crumb in
                 if crumb.message == "Cache cleared" {
                     crumb.message = "Cache locked"
                 }
             })
-            return true;
-        }
+            return true
+        })
         super.startBugsnag()
     }
 

--- a/iOS/Bugsnag.xcodeproj/project.pbxproj
+++ b/iOS/Bugsnag.xcodeproj/project.pbxproj
@@ -304,6 +304,7 @@
 		E79148291FD828E6003EFEBF /* BugsnagUser.h in CopyFiles */ = {isa = PBXBuildFile; fileRef = E72BF77D1FC86A7A004BE82F /* BugsnagUser.h */; };
 		E791482A1FD828E6003EFEBF /* BugsnagKSCrashSysInfoParser.h in CopyFiles */ = {isa = PBXBuildFile; fileRef = E7EB06721FCDAF2000C076A6 /* BugsnagKSCrashSysInfoParser.h */; };
 		E794E8031F9F743D00A67EE7 /* BugsnagKeys.h in Headers */ = {isa = PBXBuildFile; fileRef = E794E8021F9F743D00A67EE7 /* BugsnagKeys.h */; };
+		E7AB4B9C2423E16C004F015A /* BugsnagOnBreadcrumbTest.m in Sources */ = {isa = PBXBuildFile; fileRef = E7AB4B9B2423E16C004F015A /* BugsnagOnBreadcrumbTest.m */; };
 		E7B3291A1FD707EC0098FC47 /* KSCrashReportConverter_Tests.m in Sources */ = {isa = PBXBuildFile; fileRef = E7B329171FD707EC0098FC47 /* KSCrashReportConverter_Tests.m */; };
 		E7B970311FD702DA00590C27 /* KSLogger_Tests.m in Sources */ = {isa = PBXBuildFile; fileRef = E7B970301FD702DA00590C27 /* KSLogger_Tests.m */; };
 		E7B970341FD7031500590C27 /* XCTestCase+KSCrash.m in Sources */ = {isa = PBXBuildFile; fileRef = E7B970331FD7031500590C27 /* XCTestCase+KSCrash.m */; };
@@ -615,6 +616,7 @@
 		E78C1EFD1FCC778700B976D3 /* BugsnagUserTest.m */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.objc; name = BugsnagUserTest.m; path = ../Tests/BugsnagUserTest.m; sourceTree = SOURCE_ROOT; };
 		E794E8021F9F743D00A67EE7 /* BugsnagKeys.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; name = BugsnagKeys.h; path = ../Source/BugsnagKeys.h; sourceTree = SOURCE_ROOT; };
 		E79FEBE61F4CB1320048FAD6 /* Foundation.framework */ = {isa = PBXFileReference; lastKnownFileType = wrapper.framework; name = Foundation.framework; path = System/Library/Frameworks/Foundation.framework; sourceTree = SDKROOT; };
+		E7AB4B9B2423E16C004F015A /* BugsnagOnBreadcrumbTest.m */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.objc; name = BugsnagOnBreadcrumbTest.m; path = ../../Tests/BugsnagOnBreadcrumbTest.m; sourceTree = "<group>"; };
 		E7B329171FD707EC0098FC47 /* KSCrashReportConverter_Tests.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; name = KSCrashReportConverter_Tests.m; path = ../Tests/KSCrash/KSCrashReportConverter_Tests.m; sourceTree = SOURCE_ROOT; };
 		E7B970301FD702DA00590C27 /* KSLogger_Tests.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; name = KSLogger_Tests.m; path = ../Tests/KSCrash/KSLogger_Tests.m; sourceTree = SOURCE_ROOT; };
 		E7B970321FD7031500590C27 /* XCTestCase+KSCrash.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; name = "XCTestCase+KSCrash.h"; path = "../Tests/KSCrash/XCTestCase+KSCrash.h"; sourceTree = SOURCE_ROOT; };
@@ -818,6 +820,7 @@
 				00F9393723FC4F63008C7073 /* BugsnagTestsDummyClass.h */,
 				00F9393823FC4F64008C7073 /* BugsnagTestsDummyClass.m */,
 				E72AE1FF241A57B100ED8972 /* BugsnagPluginTest.m */,
+				E7AB4B9B2423E16C004F015A /* BugsnagOnBreadcrumbTest.m */,
 			);
 			name = Tests;
 			path = BugsnagTests;
@@ -1303,6 +1306,7 @@
 				000E6E9E23D8690F009D8194 /* BugsnagSwiftConfigurationTests.swift in Sources */,
 				E70EE07E1FD703D600FA745C /* NSError+SimpleConstructor_Tests.m in Sources */,
 				E70EE0931FD706C700FA745C /* KSFileUtils_Tests.m in Sources */,
+				E7AB4B9C2423E16C004F015A /* BugsnagOnBreadcrumbTest.m in Sources */,
 				E70EE08E1FD705A700FA745C /* KSSignalInfo_Tests.m in Sources */,
 				E733A76B1FD7091F003EAA29 /* KSCrashSentry_Signal_Tests.m in Sources */,
 				E784D2561FD70B3E004B01E1 /* KSMach_Tests.m in Sources */,

--- a/tvOS/Bugsnag.xcodeproj/project.pbxproj
+++ b/tvOS/Bugsnag.xcodeproj/project.pbxproj
@@ -143,6 +143,7 @@
 		E76617D11F4E459C0094CECF /* BSG_KSCrashReportFilterCompletion.h in Headers */ = {isa = PBXBuildFile; fileRef = E76617671F4E459C0094CECF /* BSG_KSCrashReportFilterCompletion.h */; };
 		E77526C4242D0E3A0077A42F /* BugsnagBreadcrumbs.m in Sources */ = {isa = PBXBuildFile; fileRef = E77526C2242D0E3A0077A42F /* BugsnagBreadcrumbs.m */; };
 		E77526C5242D0E3A0077A42F /* BugsnagBreadcrumbs.h in Headers */ = {isa = PBXBuildFile; fileRef = E77526C3242D0E3A0077A42F /* BugsnagBreadcrumbs.h */; };
+		E77526C7242E694C0077A42F /* BugsnagOnBreadcrumbTest.m in Sources */ = {isa = PBXBuildFile; fileRef = E77526C6242E694C0077A42F /* BugsnagOnBreadcrumbTest.m */; };
 		E79148771FD82E6D003EFEBF /* BugsnagSession.h in Headers */ = {isa = PBXBuildFile; fileRef = E79148641FD82E6A003EFEBF /* BugsnagSession.h */; };
 		E79148781FD82E6D003EFEBF /* BugsnagKSCrashSysInfoParser.h in Headers */ = {isa = PBXBuildFile; fileRef = E79148651FD82E6A003EFEBF /* BugsnagKSCrashSysInfoParser.h */; };
 		E79148791FD82E6D003EFEBF /* BugsnagUser.h in Headers */ = {isa = PBXBuildFile; fileRef = E79148661FD82E6A003EFEBF /* BugsnagUser.h */; };
@@ -343,6 +344,7 @@
 		E76617671F4E459C0094CECF /* BSG_KSCrashReportFilterCompletion.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; name = BSG_KSCrashReportFilterCompletion.h; path = ../Source/KSCrash/Source/KSCrash/Reporting/Filters/BSG_KSCrashReportFilterCompletion.h; sourceTree = SOURCE_ROOT; };
 		E77526C2242D0E3A0077A42F /* BugsnagBreadcrumbs.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; name = BugsnagBreadcrumbs.m; path = ../Source/BugsnagBreadcrumbs.m; sourceTree = "<group>"; };
 		E77526C3242D0E3A0077A42F /* BugsnagBreadcrumbs.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; name = BugsnagBreadcrumbs.h; path = ../Source/BugsnagBreadcrumbs.h; sourceTree = "<group>"; };
+		E77526C6242E694C0077A42F /* BugsnagOnBreadcrumbTest.m */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.objc; name = BugsnagOnBreadcrumbTest.m; path = ../Tests/BugsnagOnBreadcrumbTest.m; sourceTree = "<group>"; };
 		E79148641FD82E6A003EFEBF /* BugsnagSession.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; name = BugsnagSession.h; path = ../Source/BugsnagSession.h; sourceTree = "<group>"; };
 		E79148651FD82E6A003EFEBF /* BugsnagKSCrashSysInfoParser.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; name = BugsnagKSCrashSysInfoParser.h; path = ../Source/BugsnagKSCrashSysInfoParser.h; sourceTree = "<group>"; };
 		E79148661FD82E6A003EFEBF /* BugsnagUser.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; name = BugsnagUser.h; path = ../Source/BugsnagUser.h; sourceTree = "<group>"; };
@@ -426,6 +428,7 @@
 		8A8D511A1D41343500D33797 = {
 			isa = PBXGroup;
 			children = (
+				E77526C6242E694C0077A42F /* BugsnagOnBreadcrumbTest.m */,
 				8A8D51261D41343500D33797 /* tvOS */,
 				8AB151131D41356800C9B218 /* Tests */,
 				8A8D51251D41343500D33797 /* Products */,
@@ -983,6 +986,7 @@
 			isa = PBXSourcesBuildPhase;
 			buildActionMask = 2147483647;
 			files = (
+				E77526C7242E694C0077A42F /* BugsnagOnBreadcrumbTest.m in Sources */,
 				8ACF0F74201812AD00173809 /* BugsnagSinkTests.m in Sources */,
 				4B3CD2BD22C5676800DBFF33 /* BugsnagThreadTest.m in Sources */,
 				00D7ACA723E98A5D00FBE4A7 /* BugsnagEventTests.m in Sources */,


### PR DESCRIPTION
## Goal

Provides a method for adding/removing callbacks which can mutate every `Breadcrumb` before it is added to the application. This matches the notifier specification.

## Changeset

- Added `addOnBreadcrumbBlock` and `removeOnBreadcrumbBlock` to `Bugsnag` and `BugsnagConfiguration`
- Stored `OnBreadcrumb` callbacks in `BugsnagBreadcrumbs`
- Executed callbacks before adding a breadcrumb and discarded the crumb if false is returned from any callback

## Tests

Added new test coverage for adding/removing callbacks, and verifying that the callback discards/mutates breadcrumbs.