### PR TITLE
Remove unused APIs from Bugsnag interface

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,9 @@ Bugsnag Notifiers on other platforms.
 
 ## Enhancements
 
+* Remove unused APIs from `Bugsnag` interface
+[#514](https://github.com/bugsnag/bugsnag-cocoa/pull/514)
+
 * Enforce that `config.maxBreadcrumbs` must be between 0-100
 [#511](https://github.com/bugsnag/bugsnag-cocoa/pull/511)
 

--- a/Source/BSGOutOfMemoryWatchdog.m
+++ b/Source/BSGOutOfMemoryWatchdog.m
@@ -23,6 +23,10 @@
 @property(nonatomic, strong, readwrite) NSDictionary *lastBootCachedFileInfo;
 @end
 
+@interface Bugsnag ()
++ (NSDateFormatter *_Nonnull)payloadDateFormatter;
+@end
+
 @implementation BSGOutOfMemoryWatchdog
 
 - (instancetype)init {

--- a/Source/Bugsnag.h
+++ b/Source/Bugsnag.h
@@ -155,16 +155,6 @@
                            andType:(BSGBreadcrumbType)type
     NS_SWIFT_NAME(leaveBreadcrumb(_:metadata:type:));
 
-/**
- * Set the maximum number of breadcrumbs to keep and sent to Bugsnag.
- * By default, we'll keep and send the 20 most recent breadcrumb log
- * messages.
- *
- * @param capacity max number of breadcrumb log messages to send
- */
-+ (void)setBreadcrumbCapacity:(NSUInteger)capacity
-        __deprecated_msg("Use [BugsnagConfiguration setMaxBreadcrumbs:] instead");
-
 // =============================================================================
 // MARK: - Session
 // =============================================================================

--- a/Source/Bugsnag.h
+++ b/Source/Bugsnag.h
@@ -264,8 +264,6 @@
                        withKey:(NSString *_Nonnull)key
     NS_SWIFT_NAME(clearMetadata(section:key:));
 
-+ (NSDateFormatter *_Nonnull)payloadDateFormatter;
-
 /**
  * Replicates BugsnagConfiguration.context
  *

--- a/Source/Bugsnag.h
+++ b/Source/Bugsnag.h
@@ -29,10 +29,6 @@
 #import "BugsnagMetadata.h"
 #import "BugsnagPlugin.h"
 
-static NSString *_Nonnull const BugsnagSeverityError = @"error";
-static NSString *_Nonnull const BugsnagSeverityWarning = @"warning";
-static NSString *_Nonnull const BugsnagSeverityInfo = @"info";
-
 @interface Bugsnag : NSObject
 
 /** Start listening for crashes.
@@ -158,11 +154,6 @@ static NSString *_Nonnull const BugsnagSeverityInfo = @"info";
                           metadata:(NSDictionary *_Nullable)metadata
                            andType:(BSGBreadcrumbType)type
     NS_SWIFT_NAME(leaveBreadcrumb(_:metadata:type:));
-
-/**
- * Clear any breadcrumbs that have been left so far.
- */
-+ (void)clearBreadcrumbs;
 
 /**
  * Set the maximum number of breadcrumbs to keep and sent to Bugsnag.

--- a/Source/Bugsnag.m
+++ b/Source/Bugsnag.m
@@ -222,12 +222,6 @@ static BugsnagClient *bsg_g_bugsnag_client = NULL;
     }
 }
 
-+ (void)clearBreadcrumbs {
-    if ([self bugsnagStarted]) {
-        [self.client clearBreadcrumbs];
-    }
-}
-
 + (void)startSession {
     if ([self bugsnagStarted]) {
         [self.client startSession];

--- a/Source/Bugsnag.m
+++ b/Source/Bugsnag.m
@@ -216,12 +216,6 @@ static BugsnagClient *bsg_g_bugsnag_client = NULL;
     }
 }
 
-+ (void)setBreadcrumbCapacity:(NSUInteger)capacity {
-    if ([self bugsnagStarted]) {
-        [self.client.configuration setMaxBreadcrumbs:capacity];
-    }
-}
-
 + (void)startSession {
     if ([self bugsnagStarted]) {
         [self.client startSession];

--- a/Source/BugsnagBreadcrumb.m
+++ b/Source/BugsnagBreadcrumb.m
@@ -70,6 +70,10 @@ BSGBreadcrumbType BSGBreadcrumbTypeFromString(NSString *value) {
     }
 }
 
+@interface Bugsnag ()
++ (NSDateFormatter *_Nonnull)payloadDateFormatter;
+@end
+
 @implementation BugsnagBreadcrumb
 
 - (instancetype)init {

--- a/Source/BugsnagBreadcrumbs.h
+++ b/Source/BugsnagBreadcrumbs.h
@@ -37,11 +37,6 @@
 - (void)addBreadcrumbWithBlock:
     (void (^_Nonnull)(BugsnagBreadcrumb *_Nonnull))block;
 
-/**
- * Clear all stored breadcrumbs.
- */
-- (void)clearBreadcrumbs;
-
 /** Breadcrumb object for a particular index or nil */
 - (BugsnagBreadcrumb *_Nullable)objectAtIndexedSubscript:(NSUInteger)index;
 

--- a/Source/BugsnagBreadcrumbs.m
+++ b/Source/BugsnagBreadcrumbs.m
@@ -136,12 +136,6 @@ NSUInteger BreadcrumbsDefaultCapacity = 25;
     }
 }
 
-- (void)clearBreadcrumbs {
-    dispatch_barrier_sync(self.readWriteQueue, ^{
-      [self.breadcrumbs removeAllObjects];
-    });
-}
-
 - (NSUInteger)count {
     return self.breadcrumbs.count;
 }
@@ -183,9 +177,7 @@ NSUInteger BreadcrumbsDefaultCapacity = 25;
 }
 
 - (void)resizeToFitCapacity:(NSUInteger)capacity {
-    if (capacity == 0) {
-        [self clearBreadcrumbs];
-    } else if ([self count] > capacity) {
+    if ([self count] > capacity) {
         dispatch_barrier_sync(self.readWriteQueue, ^{
           [self.breadcrumbs
               removeObjectsInRange:NSMakeRange(0, self.count - capacity)];

--- a/Source/BugsnagClient.h
+++ b/Source/BugsnagClient.h
@@ -92,11 +92,6 @@
     (void (^_Nonnull)(BugsnagBreadcrumb *_Nonnull))block;
 
 /**
- * Clear all stored breadcrumbs.
- */
-- (void)clearBreadcrumbs;
-
-/**
  * Enable or disable crash reporting based on configuration state
  */
 - (void)updateCrashDetectionSettings;

--- a/Source/BugsnagClient.m
+++ b/Source/BugsnagClient.m
@@ -811,11 +811,6 @@ NSString *const BSGBreadcrumbLoadedMessage = @"Bugsnag loaded";
     [self serializeBreadcrumbs];
 }
 
-- (void)clearBreadcrumbs {
-    [self.configuration.breadcrumbs clearBreadcrumbs];
-    [self serializeBreadcrumbs];
-}
-
 - (void)serializeBreadcrumbs {
     BugsnagBreadcrumbs *crumbs = self.configuration.breadcrumbs;
     NSArray *arrayValue = crumbs.count == 0 ? nil : [crumbs arrayValue];

--- a/Source/BugsnagClient.m
+++ b/Source/BugsnagClient.m
@@ -283,6 +283,10 @@ void BSGWriteSessionCrashData(BugsnagSession *session) {
 @property(unsafe_unretained) id<BugsnagMetadataDelegate> _Nullable delegate;
 @end
 
+@interface Bugsnag ()
++ (NSDateFormatter *_Nonnull)payloadDateFormatter;
+@end
+
 @implementation BugsnagClient
 
 #if TARGET_IPHONE_SIMULATOR || TARGET_OS_IPHONE

--- a/Tests/BugsnagBreadcrumbsTest.m
+++ b/Tests/BugsnagBreadcrumbsTest.m
@@ -88,13 +88,6 @@ BSGBreadcrumbType BSGBreadcrumbTypeFromString(NSString *value);
     XCTAssertEqual(100, self.crumbs.capacity);
 }
 
-- (void)testClearBreadcrumbs {
-    [self.crumbs clearBreadcrumbs];
-    awaitBreadcrumbSync(self.crumbs);
-    XCTAssertTrue(self.crumbs.count == 0);
-    XCTAssertNil(self.crumbs[0]);
-}
-
 - (void)testEmptyCapacity {
     self.crumbs.capacity = 0;
     [self.crumbs addBreadcrumb:@"Clear notifications"];
@@ -176,8 +169,7 @@ BSGBreadcrumbType BSGBreadcrumbTypeFromString(NSString *value);
 }
 
 - (void)testDefaultDiscardByType {
-    [self.crumbs clearBreadcrumbs];
-    awaitBreadcrumbSync(self.crumbs);
+    self.crumbs = [BugsnagBreadcrumbs new];
     [self.crumbs addBreadcrumbWithBlock:^(BugsnagBreadcrumb *_Nonnull crumb) {
         crumb.type = BSGBreadcrumbTypeState;
         crumb.message = @"state";
@@ -223,8 +215,7 @@ BSGBreadcrumbType BSGBreadcrumbTypeFromString(NSString *value);
 }
 
 - (void)testAlwaysAllowManual {
-    [self.crumbs clearBreadcrumbs];
-    awaitBreadcrumbSync(self.crumbs);
+    self.crumbs = [BugsnagBreadcrumbs new];
     self.crumbs.enabledBreadcrumbTypes = 0;
     [self.crumbs addBreadcrumb:@"this is a test"];
     awaitBreadcrumbSync(self.crumbs);
@@ -239,8 +230,7 @@ BSGBreadcrumbType BSGBreadcrumbTypeFromString(NSString *value);
  * private and assumes filtering is already configured.
  */
 - (void)testDiscardByTypeDoesNotApply {
-    [self.crumbs clearBreadcrumbs];
-    awaitBreadcrumbSync(self.crumbs);
+    self.crumbs = [BugsnagBreadcrumbs new];
     self.crumbs.enabledBreadcrumbTypes = BSGEnabledBreadcrumbTypeProcess;
     // Don't discard this
     [self.crumbs addBreadcrumbWithBlock:^(BugsnagBreadcrumb *_Nonnull crumb) {

--- a/UPGRADING.md
+++ b/UPGRADING.md
@@ -100,6 +100,9 @@ The exact error is available using the `BSGConfigurationErrorDomain` and
 - Bugsnag.setBreadcrumbCapacity(40)
   let config = try BugsnagConfiguration("YOUR API KEY HERE")
 + config.setMaxBreadcrumbs(40)
+
+- Bugsnag.payloadDateFormatter()
+- Bugsnag.clearBreadcrumbs()
 ```
 
 #### Additions

--- a/UPGRADING.md
+++ b/UPGRADING.md
@@ -103,6 +103,10 @@ The exact error is available using the `BSGConfigurationErrorDomain` and
 
 - Bugsnag.payloadDateFormatter()
 - Bugsnag.clearBreadcrumbs()
+
+- BugsnagSeverityError
+- BugsnagSeverityWarning
+- BugsnagSeverityInfo
 ```
 
 #### Additions


### PR DESCRIPTION
## Goal

Removes/hides unused APIs from the `Bugsnag` interface. These are either no longer required or were originally part of the internal implementation and mistakenly included in the public header.

## Changeset

The following APIs have been removed/hidden using a [class extension](https://developer.apple.com/library/archive/documentation/Cocoa/Conceptual/ProgrammingWithObjectiveC/CustomizingExistingClasses/CustomizingExistingClasses.html#//apple_ref/doc/uid/TP40011210-CH6-SW6):

```
- clearBreadcrumbs
- setBreadcrumbCapacity
- payloadFormatter
```

## Tests

Updated existing test coverage to avoid using deprecated APIs.
