### PR TITLE
Remove unused APIs from BugsnagClient interface

### DIFF
--- a/OSX/Bugsnag.xcodeproj/project.pbxproj
+++ b/OSX/Bugsnag.xcodeproj/project.pbxproj
@@ -61,6 +61,7 @@
 		E762E9FD1F73F80200E82B43 /* BugsnagHandledState.m in Sources */ = {isa = PBXBuildFile; fileRef = E762E9FB1F73F80200E82B43 /* BugsnagHandledState.m */; };
 		E77526C0242D0E180077A42F /* BugsnagBreadcrumbs.m in Sources */ = {isa = PBXBuildFile; fileRef = E77526BE242D0E180077A42F /* BugsnagBreadcrumbs.m */; };
 		E77526C1242D0E180077A42F /* BugsnagBreadcrumbs.h in Headers */ = {isa = PBXBuildFile; fileRef = E77526BF242D0E180077A42F /* BugsnagBreadcrumbs.h */; };
+		E790C427243354FD006FFB26 /* BugsnagClientInternal.h in Headers */ = {isa = PBXBuildFile; fileRef = E790C426243354FD006FFB26 /* BugsnagClientInternal.h */; };
 		E79148461FD82B36003EFEBF /* BugsnagSession.h in Headers */ = {isa = PBXBuildFile; fileRef = E79148331FD82B34003EFEBF /* BugsnagSession.h */; };
 		E79148471FD82B36003EFEBF /* BugsnagKSCrashSysInfoParser.h in Headers */ = {isa = PBXBuildFile; fileRef = E79148341FD82B34003EFEBF /* BugsnagKSCrashSysInfoParser.h */; };
 		E79148481FD82B36003EFEBF /* BugsnagUser.h in Headers */ = {isa = PBXBuildFile; fileRef = E79148351FD82B34003EFEBF /* BugsnagUser.h */; };
@@ -257,6 +258,7 @@
 		E762E9FB1F73F80200E82B43 /* BugsnagHandledState.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; name = BugsnagHandledState.m; path = ../Source/BugsnagHandledState.m; sourceTree = SOURCE_ROOT; };
 		E77526BE242D0E180077A42F /* BugsnagBreadcrumbs.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; name = BugsnagBreadcrumbs.m; path = ../Source/BugsnagBreadcrumbs.m; sourceTree = "<group>"; };
 		E77526BF242D0E180077A42F /* BugsnagBreadcrumbs.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; name = BugsnagBreadcrumbs.h; path = ../Source/BugsnagBreadcrumbs.h; sourceTree = "<group>"; };
+		E790C426243354FD006FFB26 /* BugsnagClientInternal.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; name = BugsnagClientInternal.h; path = ../Source/BugsnagClientInternal.h; sourceTree = "<group>"; };
 		E791482B1FD82B0C003EFEBF /* BugsnagSessionTrackerTest.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; path = BugsnagSessionTrackerTest.m; sourceTree = "<group>"; };
 		E791482C1FD82B0C003EFEBF /* BugsnagSessionTrackingPayloadTest.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; path = BugsnagSessionTrackingPayloadTest.m; sourceTree = "<group>"; };
 		E791482D1FD82B0C003EFEBF /* BugsnagSessionTest.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; path = BugsnagSessionTest.m; sourceTree = "<group>"; };
@@ -453,6 +455,7 @@
 				E791483D1FD82B35003EFEBF /* BugsnagApiClient.m */,
 				0089B6EA2411682000D5A7F2 /* BugsnagClient.h */,
 				0089B6E92411682000D5A7F2 /* BugsnagClient.m */,
+				E790C426243354FD006FFB26 /* BugsnagClientInternal.h */,
 				E79148401FD82B35003EFEBF /* BugsnagFileStore.h */,
 				E79148451FD82B36003EFEBF /* BugsnagFileStore.m */,
 				E79148341FD82B34003EFEBF /* BugsnagKSCrashSysInfoParser.h */,
@@ -760,6 +763,7 @@
 				E79E6B9E1F4E3850002B35F9 /* BSG_KSSystemInfoC.h in Headers */,
 				E79E6BC71F4E3850002B35F9 /* BSG_KSObjCApple.h in Headers */,
 				E79E6BCB1F4E3850002B35F9 /* BSG_KSSignalInfo.h in Headers */,
+				E790C427243354FD006FFB26 /* BugsnagClientInternal.h in Headers */,
 				E79E6BA61F4E3850002B35F9 /* BSG_KSCrashSentry_MachException.h in Headers */,
 				8A627CD91EC3B75200F7C04E /* BSGSerialization.h in Headers */,
 				E79E6BAE1F4E3850002B35F9 /* BSG_KSArchSpecific.h in Headers */,

--- a/Source/Bugsnag.h
+++ b/Source/Bugsnag.h
@@ -160,11 +160,6 @@ static NSString *_Nonnull const BugsnagSeverityInfo = @"info";
     NS_SWIFT_NAME(leaveBreadcrumb(_:metadata:type:));
 
 /**
- * Clear any breadcrumbs that have been left so far.
- */
-+ (void)clearBreadcrumbs;
-
-/**
  * Set the maximum number of breadcrumbs to keep and sent to Bugsnag.
  * By default, we'll keep and send the 20 most recent breadcrumb log
  * messages.

--- a/Source/Bugsnag.m
+++ b/Source/Bugsnag.m
@@ -28,6 +28,7 @@
 #import "BSG_KSCrash.h"
 #import "BugsnagLogger.h"
 #import "BugsnagClient.h"
+#import "BugsnagClientInternal.h"
 #import "BugsnagKeys.h"
 #import "BugsnagPlugin.h"
 #import "BugsnagHandledState.h"
@@ -92,7 +93,7 @@ static BugsnagClient *bsg_g_bugsnag_client = NULL;
 
 + (BOOL)appDidCrashLastLaunch {
     if ([self bugsnagStarted]) {
-        return [self.client appCrashedLastLaunch];
+        return [self.client appDidCrashLastLaunch];
     }
     return NO;
 }
@@ -219,12 +220,6 @@ static BugsnagClient *bsg_g_bugsnag_client = NULL;
 + (void)setBreadcrumbCapacity:(NSUInteger)capacity {
     if ([self bugsnagStarted]) {
         [self.client.configuration setMaxBreadcrumbs:capacity];
-    }
-}
-
-+ (void)clearBreadcrumbs {
-    if ([self bugsnagStarted]) {
-        [self.client clearBreadcrumbs];
     }
 }
 

--- a/Source/BugsnagClient.h
+++ b/Source/BugsnagClient.h
@@ -29,28 +29,20 @@
 #import "BugsnagConfiguration.h"
 #import "BugsnagMetadata.h"
 
-@class BugsnagSessionTracker;
-
 @interface BugsnagClient : NSObject <BugsnagMetadataDelegate>
 
-@property(nonatomic, readwrite, retain)
-    BugsnagConfiguration *_Nullable configuration;
-@property(nonatomic, readwrite, strong) BugsnagMetadata *_Nonnull state;
-@property(nonatomic, readwrite, strong) NSDictionary *_Nonnull details;
-@property(nonatomic, readwrite, strong) NSLock *_Nonnull metadataLock;
-@property(nonatomic, readonly, strong) BugsnagSessionTracker *_Nonnull sessionTracker;
-
-@property(readonly) BOOL started;
-
-- (instancetype _Nonnull)initWithConfiguration:
-    (BugsnagConfiguration *_Nonnull)configuration;
-- (void)start;
+- (instancetype _Nonnull)initWithConfiguration:(BugsnagConfiguration *_Nonnull)configuration;
 
 - (void)startSession;
+
 - (void)pauseSession;
+
 - (BOOL)resumeSession;
 
-- (BOOL)appCrashedLastLaunch;
+/**
+ * @return YES if Bugsnag has been started and the previous launch crashed
+ */
+- (BOOL)appDidCrashLastLaunch;
 
 /**
  *  Notify Bugsnag of an exception
@@ -89,15 +81,6 @@
  *  @param block configuration block
  */
 - (void)addBreadcrumbWithBlock:
-    (void (^_Nonnull)(BugsnagBreadcrumb *_Nonnull))block;
+        (void (^ _Nonnull)(BugsnagBreadcrumb *_Nonnull))block;
 
-/**
- * Clear all stored breadcrumbs.
- */
-- (void)clearBreadcrumbs;
-
-/**
- * Enable or disable crash reporting based on configuration state
- */
-- (void)updateCrashDetectionSettings;
 @end

--- a/Source/BugsnagClient.m
+++ b/Source/BugsnagClient.m
@@ -25,6 +25,7 @@
 //
 
 #import "BugsnagClient.h"
+#import "BugsnagClientInternal.h"
 #import "BSGConnectivity.h"
 #import "Bugsnag.h"
 #import "Private.h"
@@ -254,10 +255,9 @@ void BSGWriteSessionCrashData(BugsnagSession *session) {
 @interface BugsnagClient ()
 @property(nonatomic, strong) BugsnagCrashSentry *crashSentry;
 @property(nonatomic, strong) BugsnagErrorReportApiClient *errorReportApiClient;
-@property(nonatomic, strong, readwrite) BugsnagSessionTracker *sessionTracker;
 @property (nonatomic, strong) BSGOutOfMemoryWatchdog *oomWatchdog;
 @property (nonatomic, strong) BugsnagPluginClient *pluginClient;
-@property (nonatomic) BOOL appCrashedLastLaunch;
+@property (nonatomic) BOOL appDidCrashLastLaunch;
 #if TARGET_IPHONE_SIMULATOR || TARGET_OS_IPHONE
 // The previous device orientation - iOS only
 @property (nonatomic, strong) NSString *lastOrientation;
@@ -534,7 +534,7 @@ NSString *const BSGBreadcrumbLoadedMessage = @"Bugsnag loaded";
             unlink(crashSentinelPath);
         }
     }
-    self.appCrashedLastLaunch = handledCrashLastLaunch || [self.oomWatchdog didOOMLastLaunch];
+    self.appDidCrashLastLaunch = handledCrashLastLaunch || [self.oomWatchdog didOOMLastLaunch];
     // Ignore potential false positive OOM if previous session crashed and was
     // reported. There are two checks in place:
     // 1. crashState->crashedLastLaunch: Accurate unless the crash callback crashes
@@ -544,7 +544,7 @@ NSString *const BSGBreadcrumbLoadedMessage = @"Bugsnag loaded";
         [self notifyOutOfMemoryEvent];
     }
 #else
-    self.appCrashedLastLaunch = crashState->crashedLastLaunch;
+    self.appDidCrashLastLaunch = crashState->crashedLastLaunch;
 #endif
 }
 

--- a/Source/BugsnagClientInternal.h
+++ b/Source/BugsnagClientInternal.h
@@ -1,0 +1,31 @@
+//
+//  BugsnagClientInternal.h
+//  Bugsnag
+//
+//  Created by Jamie Lynch on 31/03/2020.
+//  Copyright © 2020 Bugsnag. All rights reserved.
+//
+
+#import <Foundation/Foundation.h>
+
+#import "BugsnagClient.h"
+
+@class BugsnagClient;
+@class BugsnagSessionTracker;
+@class BugsnagConfiguration;
+@class BugsnagMetadata;
+
+@interface BugsnagClient ()
+
+@property(nonatomic, readwrite, retain) BugsnagConfiguration *_Nullable configuration;
+@property(nonatomic, readwrite, strong) BugsnagMetadata *_Nonnull state;
+@property(nonatomic, readwrite, strong) NSDictionary *_Nonnull details;
+@property(nonatomic, readwrite, strong) NSLock *_Nonnull metadataLock;
+@property(nonatomic, readwrite, strong) BugsnagSessionTracker *_Nonnull sessionTracker;
+@property(readonly) BOOL started;
+
+- (void)start;
+
+- (void)updateCrashDetectionSettings;
+@end
+

--- a/Source/BugsnagConfiguration.m
+++ b/Source/BugsnagConfiguration.m
@@ -27,6 +27,7 @@
 #import "BugsnagConfiguration.h"
 #import "Bugsnag.h"
 #import "BugsnagClient.h"
+#import "BugsnagClientInternal.h"
 #import "BugsnagKeys.h"
 #import "BSG_RFC3339DateTool.h"
 #import "BugsnagUser.h"
@@ -50,10 +51,6 @@ NSString * const kBugsnagUserUserId = @"BugsnagUserUserId";
 
 @interface Bugsnag ()
 + (BugsnagClient *)client;
-@end
-
-@interface BugsnagClient ()
-@property BugsnagSessionTracker *sessionTracker;
 @end
 
 @interface BugsnagConfiguration ()

--- a/Source/BugsnagSessionTrackingPayload.m
+++ b/Source/BugsnagSessionTrackingPayload.m
@@ -9,6 +9,7 @@
 #import "BugsnagSessionTrackingPayload.h"
 #import "BugsnagCollections.h"
 #import "BugsnagClient.h"
+#import "BugsnagClientInternal.h"
 #import "Bugsnag.h"
 #import "BugsnagKeys.h"
 #import "BSG_KSSystemInfo.h"

--- a/Source/BugsnagSink.m
+++ b/Source/BugsnagSink.m
@@ -29,6 +29,7 @@
 #import "BugsnagLogger.h"
 #import "BugsnagCollections.h"
 #import "BugsnagClient.h"
+#import "BugsnagClientInternal.h"
 #import "BugsnagKeys.h"
 #import "BSG_KSSystemInfo.h"
 #import "Private.h"

--- a/Tests/BugsnagBreadcrumbsTest.m
+++ b/Tests/BugsnagBreadcrumbsTest.m
@@ -8,6 +8,7 @@
 
 #import "Bugsnag.h"
 #import "BugsnagClient.h"
+#import "BugsnagClientInternal.h"
 #import "BugsnagBreadcrumb.h"
 #import "BugsnagBreadcrumbs.h"
 #import "BugsnagTestConstants.h"

--- a/Tests/BugsnagClientTests.m
+++ b/Tests/BugsnagClientTests.m
@@ -9,6 +9,7 @@
 #import "Bugsnag.h"
 #import "BugsnagBreadcrumbs.h"
 #import "BugsnagClient.h"
+#import "BugsnagClientInternal.h"
 #import "BugsnagTestConstants.h"
 #import "BugsnagKeys.h"
 #import <XCTest/XCTest.h>

--- a/iOS/Bugsnag.xcodeproj/project.pbxproj
+++ b/iOS/Bugsnag.xcodeproj/project.pbxproj
@@ -298,6 +298,9 @@
 		E78C1EF81FCC61EA00B976D3 /* BugsnagSessionTrackingPayload.m in Sources */ = {isa = PBXBuildFile; fileRef = E78C1EF51FCC61EA00B976D3 /* BugsnagSessionTrackingPayload.m */; };
 		E78C1EFC1FCC759B00B976D3 /* BugsnagSessionTest.m in Sources */ = {isa = PBXBuildFile; fileRef = E78C1EFB1FCC759B00B976D3 /* BugsnagSessionTest.m */; };
 		E78C1EFE1FCC778700B976D3 /* BugsnagUserTest.m in Sources */ = {isa = PBXBuildFile; fileRef = E78C1EFD1FCC778700B976D3 /* BugsnagUserTest.m */; };
+		E790C425243354A8006FFB26 /* BugsnagClientInternal.h in Headers */ = {isa = PBXBuildFile; fileRef = E790C424243354A8006FFB26 /* BugsnagClientInternal.h */; };
+		E790C42A243359F6006FFB26 /* BugsnagClientInternal.h in Sources */ = {isa = PBXBuildFile; fileRef = E790C424243354A8006FFB26 /* BugsnagClientInternal.h */; };
+		E790C42B24335A2B006FFB26 /* BugsnagClientInternal.h in CopyFiles */ = {isa = PBXBuildFile; fileRef = E790C424243354A8006FFB26 /* BugsnagClientInternal.h */; };
 		E79148251FD828E6003EFEBF /* BugsnagKeys.h in CopyFiles */ = {isa = PBXBuildFile; fileRef = E794E8021F9F743D00A67EE7 /* BugsnagKeys.h */; };
 		E79148261FD828E6003EFEBF /* BugsnagSessionTracker.h in CopyFiles */ = {isa = PBXBuildFile; fileRef = E72BF7731FC867E4004BE82F /* BugsnagSessionTracker.h */; };
 		E79148271FD828E6003EFEBF /* BugsnagSession.h in CopyFiles */ = {isa = PBXBuildFile; fileRef = E72BF7781FC869F7004BE82F /* BugsnagSession.h */; };
@@ -350,6 +353,7 @@
 			dstPath = "include/${PRODUCT_NAME}";
 			dstSubfolderSpec = 16;
 			files = (
+				E790C42B24335A2B006FFB26 /* BugsnagClientInternal.h in CopyFiles */,
 				E77526BD242D0B1F0077A42F /* BugsnagBreadcrumbs.h in CopyFiles */,
 				8A3C590923965D9400B344AA /* BugsnagPlugin.h in CopyFiles */,
 				E79148251FD828E6003EFEBF /* BugsnagKeys.h in CopyFiles */,
@@ -616,6 +620,7 @@
 		E78C1EF51FCC61EA00B976D3 /* BugsnagSessionTrackingPayload.m */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.objc; name = BugsnagSessionTrackingPayload.m; path = ../Source/BugsnagSessionTrackingPayload.m; sourceTree = SOURCE_ROOT; };
 		E78C1EFB1FCC759B00B976D3 /* BugsnagSessionTest.m */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.objc; name = BugsnagSessionTest.m; path = ../Tests/BugsnagSessionTest.m; sourceTree = SOURCE_ROOT; };
 		E78C1EFD1FCC778700B976D3 /* BugsnagUserTest.m */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.objc; name = BugsnagUserTest.m; path = ../Tests/BugsnagUserTest.m; sourceTree = SOURCE_ROOT; };
+		E790C424243354A8006FFB26 /* BugsnagClientInternal.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; name = BugsnagClientInternal.h; path = ../Source/BugsnagClientInternal.h; sourceTree = "<group>"; };
 		E794E8021F9F743D00A67EE7 /* BugsnagKeys.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; name = BugsnagKeys.h; path = ../Source/BugsnagKeys.h; sourceTree = SOURCE_ROOT; };
 		E79FEBE61F4CB1320048FAD6 /* Foundation.framework */ = {isa = PBXFileReference; lastKnownFileType = wrapper.framework; name = Foundation.framework; path = System/Library/Frameworks/Foundation.framework; sourceTree = SDKROOT; };
 		E7AB4B9B2423E16C004F015A /* BugsnagOnBreadcrumbTest.m */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.objc; name = BugsnagOnBreadcrumbTest.m; path = ../../Tests/BugsnagOnBreadcrumbTest.m; sourceTree = "<group>"; };
@@ -740,6 +745,7 @@
 				E77526B9242D0AE50077A42F /* BugsnagBreadcrumbs.m */,
 				8A2C8F4B1C6BBE3C00846019 /* BugsnagClient.h */,
 				8A2C8F4C1C6BBE3C00846019 /* BugsnagClient.m */,
+				E790C424243354A8006FFB26 /* BugsnagClientInternal.h */,
 				8A2C8F411C6BBE3C00846019 /* BugsnagCollections.h */,
 				8A2C8F421C6BBE3C00846019 /* BugsnagCollections.m */,
 				8A2C8F431C6BBE3C00846019 /* BugsnagConfiguration.h */,
@@ -790,10 +796,6 @@
 		8A2C8F261C6BBD2300846019 /* Tests */ = {
 			isa = PBXGroup;
 			children = (
-				000DF29323DB4B4900A883CE /* TestConstants.m */,
-				00F9393723FC4F63008C7073 /* BugsnagTestsDummyClass.h */,
-				00F9393823FC4F64008C7073 /* BugsnagTestsDummyClass.m */,
-				00D7ACAC23E9C63000FBE4A7 /* BugsnagTests.m */,
 				009131BD23F5884E000810D9 /* BugsnagBaseUnitTest.m */,
 				009131BF23F58930000810D9 /* BugsnagBaseUnitTest.h */,
 				8A2C8F8B1C6BBFDD00846019 /* BugsnagBreadcrumbsTest.m */,
@@ -807,7 +809,6 @@
 				E77316E11F73B46600A14F06 /* BugsnagHandledStateTest.m */,
 				F429554A50F3ABE60537F70E /* BugsnagKSCrashSysInfoParserTest.m */,
 				009131BB23F46279000810D9 /* BugsnagMetadataTests.m */,
-				E72AE1FF241A57B100ED8972 /* BugsnagPluginTest.m */,
 				E78C1EFB1FCC759B00B976D3 /* BugsnagSessionTest.m */,
 				E78C1EF01FCC2F1700B976D3 /* BugsnagSessionTrackerTest.m */,
 				E78C1EF21FCC615400B976D3 /* BugsnagSessionTrackingPayloadTest.m */,
@@ -1033,6 +1034,7 @@
 			files = (
 				E7107C411F4C97F100BB3F98 /* BSG_KSCrashReportWriter.h in Headers */,
 				8A70D9C922539C81006B696F /* BSGOutOfMemoryWatchdog.h in Headers */,
+				E790C425243354A8006FFB26 /* BugsnagClientInternal.h in Headers */,
 				8A2C8F4F1C6BBE3C00846019 /* Bugsnag.h in Headers */,
 				8A2C8F5B1C6BBE3C00846019 /* BugsnagMetadata.h in Headers */,
 				8A2C8F551C6BBE3C00846019 /* BugsnagConfiguration.h in Headers */,
@@ -1340,7 +1342,6 @@
 				E733A76F1FD709B7003EAA29 /* KSCrashReportStore_Tests.m in Sources */,
 				E70EE0781FD7039E00FA745C /* RFC3339DateTool_Tests.m in Sources */,
 				8A530CC422FDD51F00F0C108 /* KSCrashIdentifierTests.m in Sources */,
-				000DF29423DB4B4900A883CE /* TestConstants.m in Sources */,
 				0089B70324221EDE00D5A7F2 /* BugsnagClientTests.m in Sources */,
 				8A4E733F1DC13281001F7CC8 /* BugsnagConfigurationTests.m in Sources */,
 				E784D25A1FD70C25004B01E1 /* KSJSONCodec_Tests.m in Sources */,
@@ -1396,6 +1397,7 @@
 				E7397E181F83BC2A0034242A /* BSG_KSCrashReportStore.m in Sources */,
 				E7397E191F83BC2A0034242A /* BSG_KSSystemInfo.m in Sources */,
 				E7397E1A1F83BC2A0034242A /* BSG_KSCrashSentry_CPPException.mm in Sources */,
+				E790C42A243359F6006FFB26 /* BugsnagClientInternal.h in Sources */,
 				E7397E1C1F83BC2A0034242A /* BSG_KSCrashSentry_NSException.m in Sources */,
 				E7397E1D1F83BC2A0034242A /* BSG_KSCrashCallCompletion.m in Sources */,
 				E7397E1E1F83BC2A0034242A /* BSG_KSJSONCodecObjC.m in Sources */,

--- a/tvOS/Bugsnag.xcodeproj/project.pbxproj
+++ b/tvOS/Bugsnag.xcodeproj/project.pbxproj
@@ -144,6 +144,7 @@
 		E77526C4242D0E3A0077A42F /* BugsnagBreadcrumbs.m in Sources */ = {isa = PBXBuildFile; fileRef = E77526C2242D0E3A0077A42F /* BugsnagBreadcrumbs.m */; };
 		E77526C5242D0E3A0077A42F /* BugsnagBreadcrumbs.h in Headers */ = {isa = PBXBuildFile; fileRef = E77526C3242D0E3A0077A42F /* BugsnagBreadcrumbs.h */; };
 		E77526C7242E694C0077A42F /* BugsnagOnBreadcrumbTest.m in Sources */ = {isa = PBXBuildFile; fileRef = E77526C6242E694C0077A42F /* BugsnagOnBreadcrumbTest.m */; };
+		E790C4292433551D006FFB26 /* BugsnagClientInternal.h in Headers */ = {isa = PBXBuildFile; fileRef = E790C4282433551D006FFB26 /* BugsnagClientInternal.h */; };
 		E79148771FD82E6D003EFEBF /* BugsnagSession.h in Headers */ = {isa = PBXBuildFile; fileRef = E79148641FD82E6A003EFEBF /* BugsnagSession.h */; };
 		E79148781FD82E6D003EFEBF /* BugsnagKSCrashSysInfoParser.h in Headers */ = {isa = PBXBuildFile; fileRef = E79148651FD82E6A003EFEBF /* BugsnagKSCrashSysInfoParser.h */; };
 		E79148791FD82E6D003EFEBF /* BugsnagUser.h in Headers */ = {isa = PBXBuildFile; fileRef = E79148661FD82E6A003EFEBF /* BugsnagUser.h */; };
@@ -345,6 +346,7 @@
 		E77526C2242D0E3A0077A42F /* BugsnagBreadcrumbs.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; name = BugsnagBreadcrumbs.m; path = ../Source/BugsnagBreadcrumbs.m; sourceTree = "<group>"; };
 		E77526C3242D0E3A0077A42F /* BugsnagBreadcrumbs.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; name = BugsnagBreadcrumbs.h; path = ../Source/BugsnagBreadcrumbs.h; sourceTree = "<group>"; };
 		E77526C6242E694C0077A42F /* BugsnagOnBreadcrumbTest.m */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.objc; name = BugsnagOnBreadcrumbTest.m; path = ../Tests/BugsnagOnBreadcrumbTest.m; sourceTree = "<group>"; };
+		E790C4282433551D006FFB26 /* BugsnagClientInternal.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; name = BugsnagClientInternal.h; path = ../Source/BugsnagClientInternal.h; sourceTree = "<group>"; };
 		E79148641FD82E6A003EFEBF /* BugsnagSession.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; name = BugsnagSession.h; path = ../Source/BugsnagSession.h; sourceTree = "<group>"; };
 		E79148651FD82E6A003EFEBF /* BugsnagKSCrashSysInfoParser.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; name = BugsnagKSCrashSysInfoParser.h; path = ../Source/BugsnagKSCrashSysInfoParser.h; sourceTree = "<group>"; };
 		E79148661FD82E6A003EFEBF /* BugsnagUser.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; name = BugsnagUser.h; path = ../Source/BugsnagUser.h; sourceTree = "<group>"; };
@@ -449,6 +451,7 @@
 		8A8D51261D41343500D33797 /* tvOS */ = {
 			isa = PBXGroup;
 			children = (
+				E790C4282433551D006FFB26 /* BugsnagClientInternal.h */,
 				E77526C3242D0E3A0077A42F /* BugsnagBreadcrumbs.h */,
 				E77526C2242D0E3A0077A42F /* BugsnagBreadcrumbs.m */,
 				E72AE1FB241A4ED600ED8972 /* BugsnagPluginClient.h */,
@@ -775,6 +778,7 @@
 				E76617931F4E459C0094CECF /* BSG_KSSystemInfoC.h in Headers */,
 				E76617BC1F4E459C0094CECF /* BSG_KSObjCApple.h in Headers */,
 				E76617C01F4E459C0094CECF /* BSG_KSSignalInfo.h in Headers */,
+				E790C4292433551D006FFB26 /* BugsnagClientInternal.h in Headers */,
 				E766179B1F4E459C0094CECF /* BSG_KSCrashSentry_MachException.h in Headers */,
 				8A627CD51EC3B69300F7C04E /* BSGSerialization.h in Headers */,
 				E76617A31F4E459C0094CECF /* BSG_KSArchSpecific.h in Headers */,


### PR DESCRIPTION
## Goal

Removes/hides unused APIs from the `BugsnagClient` interface. These are either no longer required or were originally part of the internal implementation and mistakenly included.

This is in preparation of making `BugsnagClient` publicly accessible, which will be addressed in another PR.

## Changeset

- Unused APIs have been removed/hidden using a [class extension](https://developer.apple.com/library/archive/documentation/Cocoa/Conceptual/ProgrammingWithObjectiveC/CustomizingExistingClasses/CustomizingExistingClasses.html#//apple_ref/doc/uid/TP40011210-CH6-SW6), in the `BugsnagClientInternal` header
- `appCrashedLastLaunch` renamed to `appDidCrashLastLaunch`
- `clearBreadcrumbs` removed from `Bugsnag` interface

## Tests

Updated existing test coverage to avoid using deprecated APIs.
