### PR TITLE
Implement Bugsnag APIs on BugsnagClient

### DIFF
--- a/Source/BugsnagClient.h
+++ b/Source/BugsnagClient.h
@@ -33,26 +33,43 @@
 
 - (instancetype _Nonnull)initWithConfiguration:(BugsnagConfiguration *_Nonnull)configuration;
 
-- (void)startSession;
+// =============================================================================
+// MARK: - Notify
+// =============================================================================
 
-- (void)pauseSession;
-
-- (BOOL)resumeSession;
-
-/**
- * @return YES if Bugsnag has been started and the previous launch crashed
- */
-- (BOOL)appDidCrashLastLaunch;
-
-/**
- *  Notify Bugsnag of an exception
+/** Send a custom or caught exception to Bugsnag.
  *
- *  @param exception the exception
- *  @param block     Configuration block for adding additional report
- * information
+ * The exception will be sent to Bugsnag in the background allowing your
+ * app to continue running.
+ *
+ * @param exception  The exception.
  */
-- (void)notifyException:(NSException *_Nonnull)exception
-                  block:(BugsnagOnErrorBlock _Nullable)block;
+- (void)notify:(NSException *_Nonnull)exception;
+
+/**
+ *  Send a custom or caught exception to Bugsnag
+ *
+ *  @param exception The exception
+ *  @param block     A block for optionally configuring the error report
+ */
+- (void)notify:(NSException *_Nonnull)exception
+         block:(BugsnagOnErrorBlock _Nullable)block;
+
+/**
+ *  Send an error to Bugsnag
+ *
+ *  @param error The error
+ */
+- (void)notifyError:(NSError *_Nonnull)error;
+
+/**
+ *  Send an error to Bugsnag
+ *
+ *  @param error The error
+ *  @param block A block for optionally configuring the error report
+ */
+- (void)notifyError:(NSError *_Nonnull)error
+              block:(BugsnagOnErrorBlock _Nullable)block;
 
 /**
  *  Notify Bugsnag of an exception. Only intended for React Native/Unity use.
@@ -66,21 +83,245 @@
                     withData:(NSDictionary *_Nullable)metadata
                        block:(BugsnagOnErrorBlock _Nullable)block;
 
-/**
- *  Notify Bugsnag of an error
- *
- *  @param error the error
- *  @param block Configuration block for adding additional report information
- */
-- (void)notifyError:(NSError *_Nonnull)error
-              block:(BugsnagOnErrorBlock _Nullable)block;
+// =============================================================================
+// MARK: - Breadcrumbs
+// =============================================================================
 
 /**
- *  Add a breadcrumb
+ * Leave a "breadcrumb" log message, representing an action that occurred
+ * in your app, to aid with debugging.
  *
- *  @param block configuration block
+ * @param message  the log message to leave
  */
-- (void)addBreadcrumbWithBlock:
-    (void (^_Nonnull)(BugsnagBreadcrumb *_Nonnull))block;
+- (void)leaveBreadcrumbWithMessage:(NSString *_Nonnull)message;
+
+/**
+ *  Leave a "breadcrumb" log message each time a notification with a provided
+ *  name is received by the application
+ *
+ *  @param notificationName name of the notification to capture
+ */
+- (void)leaveBreadcrumbForNotificationName:(NSString *_Nonnull)notificationName;
+
+/**
+ * Leave a "breadcrumb" log message, representing an action that occurred
+ * in your app, to aid with debugging, along with additional metadata and
+ * a type.
+ *
+ * @param message The log message to leave.
+ * @param metadata Additional metadata included with the breadcrumb.
+ * @param type A BSGBreadcrumbTypeValue denoting the type of breadcrumb.
+ */
+- (void)leaveBreadcrumbWithMessage:(NSString *_Nonnull)message
+                          metadata:(NSDictionary *_Nullable)metadata
+                           andType:(BSGBreadcrumbType)type
+NS_SWIFT_NAME(leaveBreadcrumb(_:metadata:type:));
+
+// =============================================================================
+// MARK: - Session
+// =============================================================================
+
+/**
+ * Starts tracking a new session.
+ *
+ * By default, sessions are automatically started when the application enters the foreground.
+ * If you wish to manually call startSession at
+ * the appropriate time in your application instead, the default behaviour can be disabled via
+ * autoTrackSessions.
+ *
+ * Any errors which occur in an active session count towards your application's
+ * stability score. You can prevent errors from counting towards your stability
+ * score by calling pauseSession and resumeSession at the appropriate
+ * time in your application.
+ *
+ * @see pauseSession:
+ * @see resumeSession:
+ */
+- (void)startSession;
+
+/**
+ * Stops tracking a session.
+ *
+ * When a session is stopped, errors will not count towards your application's
+ * stability score. This can be advantageous if you do not wish these calculations to
+ * include a certain type of error, for example, a crash in a background service.
+ * You should disable automatic session tracking via autoTrackSessions if you call this method.
+ *
+ * A stopped session can be resumed by calling resumeSession,
+ * which will make any subsequent errors count towards your application's
+ * stability score. Alternatively, an entirely new session can be created by calling startSession.
+ *
+ * @see startSession:
+ * @see resumeSession:
+ */
+- (void)pauseSession;
+
+/**
+ * Resumes a session which has previously been stopped, or starts a new session if none exists.
+ *
+ * If a session has already been resumed or started and has not been stopped, calling this
+ * method will have no effect. You should disable automatic session tracking via
+ * autoTrackSessions if you call this method.
+ *
+ * It's important to note that sessions are stored in memory for the lifetime of the
+ * application process and are not persisted on disk. Therefore calling this method on app
+ * startup would start a new session, rather than continuing any previous session.
+ *
+ * You should call this at the appropriate time in your application when you wish to
+ * resume a previously started session. Any subsequent errors which occur in your application
+ * will be reported to Bugsnag and will count towards your application's stability score.
+ *
+ * @see startSession:
+ * @see pauseSession:
+ *
+ * @return true if a previous session was resumed, false if a new session was started.
+ */
+- (BOOL)resumeSession;
+
+/**
+* Return the metadata for a specific named section
+*
+* @param section The name of the section
+* @returns The mutable dictionary representing the metaadata section, if it
+*          exists, or nil if not.
+*/
+- (NSMutableDictionary *_Nullable)getMetadata:(NSString *_Nonnull)section
+NS_SWIFT_NAME(getMetadata(_:));
+
+/**
+* Return the metadata for a key in a specific named section
+*
+* @param section The name of the section
+* @param key The key
+* @returns The value of the keyed value if it exists or nil.
+*/
+- (id _Nullable )getMetadata:(NSString *_Nonnull)section key:(NSString *_Nonnull)key
+NS_SWIFT_NAME(getMetadata(_:key:));
+
+// =============================================================================
+// MARK: - onSession
+// =============================================================================
+
+/**
+* Add a callback that would be invoked before a session is sent to Bugsnag.
+*
+* @param block The block to be added.
+*/
+- (void)addOnSessionBlock:(BugsnagOnSessionBlock _Nonnull)block;
+
+/**
+ * Remove a callback that would be invoked before a session is sent to Bugsnag.
+ *
+ * @param block The block to be removed.
+ */
+- (void)removeOnSessionBlock:(BugsnagOnSessionBlock _Nonnull )block;
+
+// =============================================================================
+// MARK: - Other methods
+// =============================================================================
+
+/** Add custom data to send to Bugsnag with every exception. If value is nil,
+ *  delete the current value for attributeName
+ *
+ * See also [Bugsnag configuration].metaData;
+ *
+ * @param key      The name of the data.
+ *
+ * @param value    Its value.
+ *
+ * @param section  The tab to show it on on the Bugsnag dashboard.
+ */
+- (void)addMetadataToSection:(NSString *_Nonnull)section
+                         key:(NSString *_Nonnull)key
+                       value:(id _Nullable)value
+NS_SWIFT_NAME(addMetadata(_:key:value:));
+
+/**
+ * Remove a key/value from a named matadata section.  If either the section or the
+ * key do not exist no action will occur.
+ *
+ * @param sectionName The name of the section containing the value
+ * @param key The key to remove
+ */
+- (void)clearMetadataInSection:(NSString *_Nonnull)sectionName
+                       withKey:(NSString *_Nonnull)key
+NS_SWIFT_NAME(clearMetadata(section:key:));
+
+/**
+ * Replicates BugsnagConfiguration.context
+ *
+ * @param context A general summary of what was happening in the application
+ */
+- (void)setContext:(NSString *_Nullable)context;
+
+/** Remove custom data from Bugsnag reports.
+ *
+ * @param sectionName        The section to clear.
+ */
+- (void)clearMetadataInSection:(NSString *_Nonnull)sectionName
+NS_SWIFT_NAME(clearMetadata(section:));
+
+/**
+ * @return YES if Bugsnag has been started and the previous launch crashed
+ */
+- (BOOL)appDidCrashLastLaunch;
+
+// =============================================================================
+// MARK: - User
+// =============================================================================
+
+/**
+ * The current user
+ */
+- (BugsnagUser *_Nonnull)user;
+
+/**
+ *  Set user metadata
+ *
+ *  @param userId ID of the user
+ *  @param name   Name of the user
+ *  @param email  Email address of the user
+ */
+- (void)setUser:(NSString *_Nullable)userId
+      withEmail:(NSString *_Nullable)email
+        andName:(NSString *_Nullable)name;
+
+// =============================================================================
+// MARK: - onSend
+// =============================================================================
+
+/**
+ *  Add a callback to be invoked before a report is sent to Bugsnag, to
+ *  change the report contents as needed
+ *
+ *  @param block A block which returns YES if the report should be sent
+ */
+- (void)addOnSendBlock:(BugsnagOnSendBlock _Nonnull)block;
+
+/**
+ * Remove an onSend callback, if it exists
+ *
+ * @param block The block to remove
+ */
+- (void)removeOnSendBlock:(BugsnagOnSendBlock _Nonnull)block;
+
+// =============================================================================
+// MARK: - onBreadcrumb
+// =============================================================================
+
+/**
+ *  Add a callback to be invoked when a breadcrumb is captured by Bugsnag, to
+ *  change the breadcrumb contents as needed
+ *
+ *  @param block A block which returns YES if the breadcrumb should be captured
+ */
+- (void)addOnBreadcrumbBlock:(BugsnagOnBreadcrumbBlock _Nonnull)block;
+
+/**
+ * Remove the callback that would be invoked when a breadcrumb is captured.
+ *
+ * @param block The block to be removed.
+ */
+- (void)removeOnBreadcrumbBlock:(BugsnagOnBreadcrumbBlock _Nonnull)block;
 
 @end

--- a/Source/BugsnagClient.m
+++ b/Source/BugsnagClient.m
@@ -641,7 +641,119 @@ NSString *const BSGBreadcrumbLoadedMessage = @"Bugsnag loaded";
     }];
 }
 
+// =============================================================================
+// MARK: - Breadcrumbs
+// =============================================================================
+
+- (void)leaveBreadcrumbWithMessage:(NSString *_Nonnull)message {
+    [self addBreadcrumbWithBlock:^(BugsnagBreadcrumb *breadcrumb) {
+        breadcrumb.message = message;
+    }];
+}
+
+- (void)leaveBreadcrumbForNotificationName:(NSString *_Nonnull)notificationName {
+    [self startListeningForStateChangeNotification:notificationName];
+}
+
+- (void)leaveBreadcrumbWithMessage:(NSString *_Nonnull)message
+                          metadata:(NSDictionary *_Nullable)metadata
+                           andType:(BSGBreadcrumbType)type {
+    [self addBreadcrumbWithBlock:^(BugsnagBreadcrumb *_Nonnull crumbs) {
+        crumbs.message = message;
+        crumbs.metadata = metadata;
+        crumbs.type = type;
+    }];
+}
+
+// =============================================================================
+// MARK: - User
+// =============================================================================
+
+- (BugsnagUser *_Nonnull)user {
+    return [self.configuration user];
+}
+
+- (void)setUser:(NSString *_Nullable)userId
+      withEmail:(NSString *_Nullable)email
+        andName:(NSString *_Nullable)name {
+    [self.configuration setUser:userId withEmail:email andName:name];
+}
+
+// =============================================================================
+// MARK: - onSession
+// =============================================================================
+
+- (void)addOnSessionBlock:(BugsnagOnSessionBlock _Nonnull)block {
+    [self.configuration addOnSessionBlock:block];
+}
+
+- (void)removeOnSessionBlock:(BugsnagOnSessionBlock _Nonnull )block {
+    [self.configuration removeOnSessionBlock:block];
+}
+
+// =============================================================================
+// MARK: - onSend
+// =============================================================================
+
+- (void)addOnSendBlock:(BugsnagOnSendBlock _Nonnull)block {
+    [self.configuration addOnSendBlock:block];
+}
+
+- (void)removeOnSendBlock:(BugsnagOnSendBlock _Nonnull)block {
+    [self.configuration removeOnSendBlock:block];
+}
+
+// =============================================================================
+// MARK: - onBreadcrumb
+// =============================================================================
+
+- (void)addOnBreadcrumbBlock:(BugsnagOnBreadcrumbBlock _Nonnull)block {
+    [self.configuration addOnBreadcrumbBlock:block];
+}
+
+- (void)removeOnBreadcrumbBlock:(BugsnagOnBreadcrumbBlock _Nonnull)block {
+    [self.configuration removeOnBreadcrumbBlock:block];
+}
+
+// =============================================================================
+// MARK: - Other methods
+// =============================================================================
+
+- (NSMutableDictionary *_Nullable)getMetadata:(NSString *_Nonnull)section {
+    return [[self.configuration metadata] getMetadata:section];
+}
+
+- (id _Nullable )getMetadata:(NSString *_Nonnull)section key:(NSString *_Nonnull)key {
+    return [[self.configuration metadata] getMetadata:section key:key];
+}
+
+- (void)addMetadataToSection:(NSString *_Nonnull)section
+                         key:(NSString *_Nonnull)key
+                       value:(id _Nullable)value {
+    [self.configuration.metadata addAttribute:key
+                                    withValue:value
+                                toTabWithName:section];
+}
+
+- (void)clearMetadataInSection:(NSString *_Nonnull)sectionName
+                       withKey:(NSString *_Nonnull)key {
+    [self.configuration.metadata clearMetadataInSection:sectionName
+                                                    key:key];
+}
+
+- (void)setContext:(NSString *_Nullable)context {
+    self.configuration.context = context;
+}
+
+- (void)clearMetadataInSection:(NSString *_Nonnull)section {
+    [self.configuration.metadata clearMetadataInSection:section];
+}
+
 // MARK: - Notify
+
+- (void)notifyError:(NSError *_Nonnull)error {
+    [self notifyError:error block:nil];
+}
 
 - (void)notifyError:(NSError *)error
               block:(void (^)(BugsnagEvent *))block {
@@ -672,8 +784,11 @@ NSString *const BSGBreadcrumbLoadedMessage = @"Bugsnag loaded";
                }];
 }
 
-- (void)notifyException:(NSException *)exception
-                  block:(void (^)(BugsnagEvent *))block {
+- (void)notify:(NSException *_Nonnull)exception {
+    [self notify:exception block:nil];
+}
+
+- (void)notify:(NSException *)exception block:(void (^)(BugsnagEvent *))block {
     BugsnagHandledState *state =
         [BugsnagHandledState handledStateWithSeverityReason:HandledException];
     [self notify:exception handledState:state block:block];


### PR DESCRIPTION
## Goal

The `Bugsnag` class should implement a facade on a `BugsnagClient` object. This changeset implements methods which were missing from `BugsnagClient`. It also moves any implementation from `Bugsnag.m` to `BugsnagClient`, in preparation of making the class public.

## Changeset

- Altered `Bugsnag.m` to forward the method call onto `BugsnagClient` after checking a client has been initialised
- Added matching methods from `Bugsnag` to `BugsnagClient`, and added existing documentation for methods such as `startSession` which were not documented on `BugsnagClient`

## Tests

Relied on existing test coverage