### PR TITLE
Make `BugsnagClient` a public interface

### DIFF
--- a/Bugsnag.podspec.json
+++ b/Bugsnag.podspec.json
@@ -30,6 +30,6 @@
   "requires_arc": true,
   "public_header_files": [
     "Source/BSG_KSCrashReportWriter.h",
-    "Source/Bugsnag{,Metadata,Configuration,Breadcrumb,Event,Plugin}.h"
+    "Source/Bugsnag{,Metadata,Configuration,Breadcrumb,Event,Plugin,Client}.h"
   ]
 }

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,9 @@ Bugsnag Notifiers on other platforms.
 
 ## Enhancements
 
+* Make `BugsnagClient` a public interface
+[#517](https://github.com/bugsnag/bugsnag-cocoa/pull/517)
+
 * Remove unused APIs from `Bugsnag` interface
 [#514](https://github.com/bugsnag/bugsnag-cocoa/pull/514)
 

--- a/OSX/Bugsnag.xcodeproj/project.pbxproj
+++ b/OSX/Bugsnag.xcodeproj/project.pbxproj
@@ -12,7 +12,7 @@
 		0061D83B2405B23A0041C068 /* LICENSE in Resources */ = {isa = PBXBuildFile; fileRef = 0061D8382405B23A0041C068 /* LICENSE */; };
 		0061D83C2405B23A0041C068 /* BSG_SSKeychain.h in Headers */ = {isa = PBXBuildFile; fileRef = 0061D8392405B23A0041C068 /* BSG_SSKeychain.h */; };
 		0089B6EB2411682000D5A7F2 /* BugsnagClient.m in Sources */ = {isa = PBXBuildFile; fileRef = 0089B6E92411682000D5A7F2 /* BugsnagClient.m */; };
-		0089B6EC2411682000D5A7F2 /* BugsnagClient.h in Headers */ = {isa = PBXBuildFile; fileRef = 0089B6EA2411682000D5A7F2 /* BugsnagClient.h */; };
+		0089B6EC2411682000D5A7F2 /* BugsnagClient.h in Headers */ = {isa = PBXBuildFile; fileRef = 0089B6EA2411682000D5A7F2 /* BugsnagClient.h */; settings = {ATTRIBUTES = (Public, ); }; };
 		00D7AC9C23E97F8100FBE4A7 /* BugsnagEvent.m in Sources */ = {isa = PBXBuildFile; fileRef = 00D7AC9A23E97F8100FBE4A7 /* BugsnagEvent.m */; };
 		00D7AC9D23E97F8100FBE4A7 /* BugsnagEvent.h in Headers */ = {isa = PBXBuildFile; fileRef = 00D7AC9B23E97F8100FBE4A7 /* BugsnagEvent.h */; settings = {ATTRIBUTES = (Public, ); }; };
 		00D7ACA423E9854C00FBE4A7 /* BugsnagEventTests.m in Sources */ = {isa = PBXBuildFile; fileRef = 00D7ACA223E984B300FBE4A7 /* BugsnagEventTests.m */; };
@@ -62,6 +62,7 @@
 		E77526C0242D0E180077A42F /* BugsnagBreadcrumbs.m in Sources */ = {isa = PBXBuildFile; fileRef = E77526BE242D0E180077A42F /* BugsnagBreadcrumbs.m */; };
 		E77526C1242D0E180077A42F /* BugsnagBreadcrumbs.h in Headers */ = {isa = PBXBuildFile; fileRef = E77526BF242D0E180077A42F /* BugsnagBreadcrumbs.h */; };
 		E790C427243354FD006FFB26 /* BugsnagClientInternal.h in Headers */ = {isa = PBXBuildFile; fileRef = E790C426243354FD006FFB26 /* BugsnagClientInternal.h */; };
+		E790C42324324528006FFB26 /* BugsnagClientMirrorTest.m in Sources */ = {isa = PBXBuildFile; fileRef = E790C41F2432314A006FFB26 /* BugsnagClientMirrorTest.m */; };
 		E79148461FD82B36003EFEBF /* BugsnagSession.h in Headers */ = {isa = PBXBuildFile; fileRef = E79148331FD82B34003EFEBF /* BugsnagSession.h */; };
 		E79148471FD82B36003EFEBF /* BugsnagKSCrashSysInfoParser.h in Headers */ = {isa = PBXBuildFile; fileRef = E79148341FD82B34003EFEBF /* BugsnagKSCrashSysInfoParser.h */; };
 		E79148481FD82B36003EFEBF /* BugsnagUser.h in Headers */ = {isa = PBXBuildFile; fileRef = E79148351FD82B34003EFEBF /* BugsnagUser.h */; };
@@ -259,6 +260,7 @@
 		E77526BE242D0E180077A42F /* BugsnagBreadcrumbs.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; name = BugsnagBreadcrumbs.m; path = ../Source/BugsnagBreadcrumbs.m; sourceTree = "<group>"; };
 		E77526BF242D0E180077A42F /* BugsnagBreadcrumbs.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; name = BugsnagBreadcrumbs.h; path = ../Source/BugsnagBreadcrumbs.h; sourceTree = "<group>"; };
 		E790C426243354FD006FFB26 /* BugsnagClientInternal.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; name = BugsnagClientInternal.h; path = ../Source/BugsnagClientInternal.h; sourceTree = "<group>"; };
+		E790C41F2432314A006FFB26 /* BugsnagClientMirrorTest.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; path = BugsnagClientMirrorTest.m; sourceTree = "<group>"; };
 		E791482B1FD82B0C003EFEBF /* BugsnagSessionTrackerTest.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; path = BugsnagSessionTrackerTest.m; sourceTree = "<group>"; };
 		E791482C1FD82B0C003EFEBF /* BugsnagSessionTrackingPayloadTest.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; path = BugsnagSessionTrackingPayloadTest.m; sourceTree = "<group>"; };
 		E791482D1FD82B0C003EFEBF /* BugsnagSessionTest.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; path = BugsnagSessionTest.m; sourceTree = "<group>"; };
@@ -508,6 +510,7 @@
 		8A2C8FAF1C6BC1F700846019 /* Tests */ = {
 			isa = PBXGroup;
 			children = (
+				E790C41F2432314A006FFB26 /* BugsnagClientMirrorTest.m */,
 				E7AB4B9D2423E184004F015A /* BugsnagOnBreadcrumbTest.m */,
 				00F9393B23FD2D9B008C7073 /* BugsnagTestsDummyClass.h */,
 				00F9393A23FD2D9B008C7073 /* BugsnagTestsDummyClass.m */,
@@ -733,6 +736,7 @@
 			isa = PBXHeadersBuildPhase;
 			buildActionMask = 2147483647;
 			files = (
+				0089B6EC2411682000D5A7F2 /* BugsnagClient.h in Headers */,
 				E79E6BB91F4E3850002B35F9 /* BSG_KSJSONCodec.h in Headers */,
 				8A6C6FB22257884C00E8EF24 /* BSGOutOfMemoryWatchdog.h in Headers */,
 				00D7AC9D23E97F8100FBE4A7 /* BugsnagEvent.h in Headers */,
@@ -783,7 +787,6 @@
 				E79148511FD82B36003EFEBF /* BugsnagApiClient.h in Headers */,
 				E79E6BDB1F4E3850002B35F9 /* BSG_KSCrashReportFilter.h in Headers */,
 				E72AE1FA241A4E7500ED8972 /* BugsnagPluginClient.h in Headers */,
-				0089B6EC2411682000D5A7F2 /* BugsnagClient.h in Headers */,
 				E79E6BA11F4E3850002B35F9 /* BSG_KSCrashSentry_CPPException.h in Headers */,
 				E79E6B041F4E3847002B35F9 /* BugsnagErrorReportApiClient.h in Headers */,
 				8A530CB822FDC38300F0C108 /* BSG_KSCrashIdentifier.h in Headers */,
@@ -988,6 +991,7 @@
 				4B406C1822CAD96400464D1D /* BugsnagCollectionsBSGDictMergeTest.m in Sources */,
 				00D7ACA423E9854C00FBE4A7 /* BugsnagEventTests.m in Sources */,
 				E7CE78CB1FD94E77001D07E0 /* KSSysCtl_Tests.m in Sources */,
+				E790C42324324528006FFB26 /* BugsnagClientMirrorTest.m in Sources */,
 				E7CE78D01FD94E77001D07E0 /* RFC3339DateTool_Tests.m in Sources */,
 				E79148621FD82BB7003EFEBF /* BugsnagSessionTrackingPayloadTest.m in Sources */,
 				E79148631FD82BB7003EFEBF /* BugsnagUserTest.m in Sources */,

--- a/Source/Bugsnag.h
+++ b/Source/Bugsnag.h
@@ -28,6 +28,7 @@
 #import "BugsnagConfiguration.h"
 #import "BugsnagMetadata.h"
 #import "BugsnagPlugin.h"
+#import "BugsnagClient.h"
 
 @interface Bugsnag : NSObject
 
@@ -40,7 +41,7 @@
  *
  * @param apiKey  The API key from your Bugsnag dashboard.
  */
-+ (void)startBugsnagWithApiKey:(NSString *_Nonnull)apiKey;
++ (BugsnagClient *_Nonnull)startBugsnagWithApiKey:(NSString *_Nonnull)apiKey;
 
 /** Start listening for crashes.
  *
@@ -51,8 +52,7 @@
  *
  * @param configuration  The configuration to use.
  */
-+ (void)startBugsnagWithConfiguration:
-    (BugsnagConfiguration *_Nonnull)configuration;
++ (BugsnagClient *_Nonnull)startBugsnagWithConfiguration:(BugsnagConfiguration *_Nonnull)configuration;
 
 /**
  * @return YES if Bugsnag has been started and the previous launch crashed

--- a/Source/Bugsnag.m
+++ b/Source/Bugsnag.m
@@ -64,16 +64,17 @@ static BugsnagClient *bsg_g_bugsnag_client = NULL;
 
 @implementation Bugsnag
 
-+ (void)startBugsnagWithApiKey:(NSString *)apiKey {
++ (BugsnagClient *_Nonnull)startBugsnagWithApiKey:(NSString *)apiKey {
     BugsnagConfiguration *configuration = [[BugsnagConfiguration alloc] initWithApiKey:apiKey];
-    [self startBugsnagWithConfiguration:configuration];
+    return [self startBugsnagWithConfiguration:configuration];
 }
 
-+ (void)startBugsnagWithConfiguration:(BugsnagConfiguration *)configuration {
++ (BugsnagClient *_Nonnull)startBugsnagWithConfiguration:(BugsnagConfiguration *)configuration {
     @synchronized(self) {
         bsg_g_bugsnag_client =
                 [[BugsnagClient alloc] initWithConfiguration:configuration];
         [bsg_g_bugsnag_client start];
+        return bsg_g_bugsnag_client;
     }
 }
 

--- a/Tests/BugsnagClientMirrorTest.m
+++ b/Tests/BugsnagClientMirrorTest.m
@@ -7,20 +7,144 @@
 //
 
 #import <XCTest/XCTest.h>
+#import <objc/runtime.h>
+#import <Bugsnag/Bugsnag.h>
 
 @interface BugsnagClientMirrorTest : XCTestCase
-
+@property NSSet *bugsnagWhitelist;
+@property NSSet *clientWhitelist;
 @end
 
+/**
+ * Verifies that methods on the Bugsnag and BugsnagClient class remain in sync.
+ *
+ * This class relies on introspection using the Objective-C runtime which gets the name
+ * of all methods implemented in each class. As Objective-C doesn't seem to have a way of
+ * only gathering methods implemented in a header file, the whitelists need to be updated
+ * whenever a method signature changes within the Bugsnag/BugsnagClient class.
+ */
 @implementation BugsnagClientMirrorTest
 
 - (void)setUp {
-    // Put setup code here. This method is called before the invocation of each test method in the class.
+    // the following methods are implemented on BugsnagClient but do not need to
+    // be mirrored on the Bugsnag facade
+    self.bugsnagWhitelist = [NSSet setWithArray:@[
+            @"notify:handledState:block: v40@0:8@16@24@?32",
+            @"setAppDidCrashLastLaunch: v20@0:8B16",
+            @"started B16@0:8",
+            @"start v16@0:8",
+            @"initWithConfiguration: @24@0:8@16",
+            @"watchLifecycleEvents: v24@0:8@16",
+            @"flushPendingReports v16@0:8",
+            @"setupConnectivityListener v16@0:8",
+            @"setSessionTracker: v24@0:8@16",
+            @"addTerminationObserver: v24@0:8@16",
+            @"setLastOrientation: v24@0:8@16",
+            @"metadataLock @16@0:8",
+            @"oomWatchdog @16@0:8",
+            @"initializeNotificationNameMap v16@0:8",
+            @"notifyOutOfMemoryEvent v16@0:8",
+            @"willEnterBackground: v24@0:8@16",
+            @"willEnterForeground: v24@0:8@16",
+            @"errorReportApiClient @16@0:8",
+            @"setConfiguration: v24@0:8@16",
+            @"orientationChanged: v24@0:8@16",
+            @"setMetadataLock: v24@0:8@16",
+            @"sendBreadcrumbForMenuItemNotification: v24@0:8@16",
+            @"setState: v24@0:8@16",
+            @"setOomWatchdog: v24@0:8@16",
+            @"automaticBreadcrumbControlEvents @16@0:8",
+            @"crashSentry @16@0:8",
+            @"computeDidCrashLastLaunch v16@0:8",
+            @"details @16@0:8",
+            @"updateAutomaticBreadcrumbDetectionSettings v16@0:8",
+            @"automaticBreadcrumbStateEvents @16@0:8",
+            @"sessionTracker @16@0:8",
+            @"addAutoBreadcrumbOfType:withMessage:andMetadata: v40@0:8Q16@24@32",
+            @"automaticBreadcrumbTableItemEvents @16@0:8",
+            @"updateCrashDetectionSettings v16@0:8",
+            @"sendBreadcrumbForControlNotification: v24@0:8@16",
+            @"dealloc v16@0:8",
+            @"lastOrientation @16@0:8",
+            @"setCrashSentry: v24@0:8@16",
+            @"state @16@0:8",
+            @"sendBreadcrumbForTableViewNotification: v24@0:8@16",
+            @"pluginClient @16@0:8",
+            @"setDetails: v24@0:8@16",
+            @"setErrorReportApiClient: v24@0:8@16",
+            @"metadataChanged: v24@0:8@16",
+            @"automaticBreadcrumbMenuItemEvents @16@0:8",
+            @"serializeBreadcrumbs v16@0:8",
+            @"addBreadcrumbWithBlock: v24@0:8@?16",
+            @"unsubscribeFromNotifications: v24@0:8@16",
+            @"setPluginClient: v24@0:8@16",
+            @"lowMemoryWarning: v24@0:8@16",
+            @"setAppCrashedLastLaunch: v20@0:8B16",
+            @".cxx_destruct v16@0:8",
+            @"startListeningForStateChangeNotification: v24@0:8@16",
+            @"sendBreadcrumbForNotification: v24@0:8@16",
+            @"batteryChanged: v24@0:8@16",
+            @"started c16@0:8",
+            @"setAppDidCrashLastLaunch: v20@0:8c16"
+    ]];
+
+    // the following methods are implemented on Bugsnag but do not need to
+    // be mirrored on BugsnagClient
+    self.clientWhitelist = [NSSet setWithArray:@[
+            @"startBugsnagWithApiKey: @24@0:8@16",
+            @"startBugsnagWithConfiguration: @24@0:8@16",
+            @"payloadDateFormatter @16@0:8",
+            @"updateCodeBundleId: v24@0:8@16",
+            @"instance @16@0:8",
+            @"client @16@0:8",
+            @"bugsnagStarted B16@0:8",
+            @"bugsnagStarted c16@0:8",
+            @"leaveBreadcrumbWithBlock: v24@0:8@?16"
+    ]];
 }
 
-- (void)testExample {
-    // This is an example of a functional test case.
-    // Use XCTAssert and related functions to verify your tests produce the correct results.
+- (void)testBugsnagHasClientMethods {
+    NSMutableSet *bugsnagMethods = [self methodNamesForClass:object_getClass([Bugsnag class])];
+    NSMutableSet *clientMethods = [self methodNamesForClass:[BugsnagClient class]];
+
+    // remove all methods implemented on Bugsnag from Client.
+    // any leftover methods have not been implemented on the Bugsnag facade.
+    [clientMethods minusSet:bugsnagMethods];
+    [clientMethods minusSet:self.bugsnagWhitelist];
+
+    if ([clientMethods count] > 0) {
+        XCTFail(@"Missing the following methods on Bugsnag %@", clientMethods);
+    }
+}
+
+- (void)testClientHasBugsnagMethods {
+    NSMutableSet *bugsnagMethods = [self methodNamesForClass:object_getClass([Bugsnag class])];
+    NSMutableSet *clientMethods = [self methodNamesForClass:[BugsnagClient class]];
+
+    // remove all methods implemented on Client from Bugsnag.
+    // any leftover methods have not been implemented on the Client object.
+    [bugsnagMethods minusSet:clientMethods];
+    [bugsnagMethods minusSet:self.clientWhitelist];
+
+    if ([bugsnagMethods count] > 0) {
+        XCTFail(@"Missing the following methods on Client %@", bugsnagMethods);
+    }
+}
+
+- (NSMutableSet<NSString *> *)methodNamesForClass:(Class)clz {
+    unsigned int count = 0;
+    Method *methods = class_copyMethodList(clz, &count);
+    NSMutableArray *data = [NSMutableArray new];
+
+    for (unsigned int k = 0; k < count; k++) {
+        Method method = methods[k];
+
+        const char *name = sel_getName(method_getName(method));
+        const char *encoding = method_getTypeEncoding(method);
+        [data addObject:[NSString stringWithFormat:@"%s %s", name, encoding]];
+    }
+    free(methods);
+    return [NSMutableSet setWithArray:data];
 }
 
 @end

--- a/Tests/BugsnagClientMirrorTest.m
+++ b/Tests/BugsnagClientMirrorTest.m
@@ -1,0 +1,26 @@
+//
+//  BugsnagClientMirrorTest.m
+//  Tests
+//
+//  Created by Jamie Lynch on 30/03/2020.
+//  Copyright © 2020 Bugsnag. All rights reserved.
+//
+
+#import <XCTest/XCTest.h>
+
+@interface BugsnagClientMirrorTest : XCTestCase
+
+@end
+
+@implementation BugsnagClientMirrorTest
+
+- (void)setUp {
+    // Put setup code here. This method is called before the invocation of each test method in the class.
+}
+
+- (void)testExample {
+    // This is an example of a functional test case.
+    // Use XCTAssert and related functions to verify your tests produce the correct results.
+}
+
+@end

--- a/UPGRADING.md
+++ b/UPGRADING.md
@@ -122,6 +122,8 @@ Bugsnag.getMetadata("section" key:"key")
 [Bugsnag getMetadata:@"section" key:@"key"];
 ```
 
+`startBugsnagWithApiKey` and `startBugsnagWithConfiguration` now return a `BugsnagClient`.
+
 #### Renames
 
 ```diff

--- a/iOS/Bugsnag.xcodeproj/project.pbxproj
+++ b/iOS/Bugsnag.xcodeproj/project.pbxproj
@@ -301,6 +301,7 @@
 		E790C425243354A8006FFB26 /* BugsnagClientInternal.h in Headers */ = {isa = PBXBuildFile; fileRef = E790C424243354A8006FFB26 /* BugsnagClientInternal.h */; };
 		E790C42A243359F6006FFB26 /* BugsnagClientInternal.h in Sources */ = {isa = PBXBuildFile; fileRef = E790C424243354A8006FFB26 /* BugsnagClientInternal.h */; };
 		E790C42B24335A2B006FFB26 /* BugsnagClientInternal.h in CopyFiles */ = {isa = PBXBuildFile; fileRef = E790C424243354A8006FFB26 /* BugsnagClientInternal.h */; };
+		E790C41E24323102006FFB26 /* BugsnagClientMirrorTest.m in Sources */ = {isa = PBXBuildFile; fileRef = E790C41D24323102006FFB26 /* BugsnagClientMirrorTest.m */; };
 		E79148251FD828E6003EFEBF /* BugsnagKeys.h in CopyFiles */ = {isa = PBXBuildFile; fileRef = E794E8021F9F743D00A67EE7 /* BugsnagKeys.h */; };
 		E79148261FD828E6003EFEBF /* BugsnagSessionTracker.h in CopyFiles */ = {isa = PBXBuildFile; fileRef = E72BF7731FC867E4004BE82F /* BugsnagSessionTracker.h */; };
 		E79148271FD828E6003EFEBF /* BugsnagSession.h in CopyFiles */ = {isa = PBXBuildFile; fileRef = E72BF7781FC869F7004BE82F /* BugsnagSession.h */; };
@@ -312,7 +313,7 @@
 		E7B3291A1FD707EC0098FC47 /* KSCrashReportConverter_Tests.m in Sources */ = {isa = PBXBuildFile; fileRef = E7B329171FD707EC0098FC47 /* KSCrashReportConverter_Tests.m */; };
 		E7B970311FD702DA00590C27 /* KSLogger_Tests.m in Sources */ = {isa = PBXBuildFile; fileRef = E7B970301FD702DA00590C27 /* KSLogger_Tests.m */; };
 		E7B970341FD7031500590C27 /* XCTestCase+KSCrash.m in Sources */ = {isa = PBXBuildFile; fileRef = E7B970331FD7031500590C27 /* XCTestCase+KSCrash.m */; };
-		E7DC009A1FC5C4F6004AB8DF /* BugsnagClient.h in Headers */ = {isa = PBXBuildFile; fileRef = 8A2C8F4B1C6BBE3C00846019 /* BugsnagClient.h */; };
+		E7DC009A1FC5C4F6004AB8DF /* BugsnagClient.h in Headers */ = {isa = PBXBuildFile; fileRef = 8A2C8F4B1C6BBE3C00846019 /* BugsnagClient.h */; settings = {ATTRIBUTES = (Public, ); }; };
 		E7DC009B1FC5C4F6004AB8DF /* BugsnagCollections.h in Headers */ = {isa = PBXBuildFile; fileRef = 8A2C8F411C6BBE3C00846019 /* BugsnagCollections.h */; };
 		E7E08C531FCF1F05000C14C9 /* BugsnagFileStore.h in CopyFiles */ = {isa = PBXBuildFile; fileRef = F42953E7E61199381E0405CC /* BugsnagFileStore.h */; };
 		E7EB06741FCDAF2000C076A6 /* BugsnagKSCrashSysInfoParser.h in Headers */ = {isa = PBXBuildFile; fileRef = E7EB06721FCDAF2000C076A6 /* BugsnagKSCrashSysInfoParser.h */; };
@@ -621,6 +622,7 @@
 		E78C1EFB1FCC759B00B976D3 /* BugsnagSessionTest.m */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.objc; name = BugsnagSessionTest.m; path = ../Tests/BugsnagSessionTest.m; sourceTree = SOURCE_ROOT; };
 		E78C1EFD1FCC778700B976D3 /* BugsnagUserTest.m */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.objc; name = BugsnagUserTest.m; path = ../Tests/BugsnagUserTest.m; sourceTree = SOURCE_ROOT; };
 		E790C424243354A8006FFB26 /* BugsnagClientInternal.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; name = BugsnagClientInternal.h; path = ../Source/BugsnagClientInternal.h; sourceTree = "<group>"; };
+		E790C41D24323102006FFB26 /* BugsnagClientMirrorTest.m */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.objc; name = BugsnagClientMirrorTest.m; path = ../../Tests/BugsnagClientMirrorTest.m; sourceTree = "<group>"; };
 		E794E8021F9F743D00A67EE7 /* BugsnagKeys.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; name = BugsnagKeys.h; path = ../Source/BugsnagKeys.h; sourceTree = SOURCE_ROOT; };
 		E79FEBE61F4CB1320048FAD6 /* Foundation.framework */ = {isa = PBXFileReference; lastKnownFileType = wrapper.framework; name = Foundation.framework; path = System/Library/Frameworks/Foundation.framework; sourceTree = SDKROOT; };
 		E7AB4B9B2423E16C004F015A /* BugsnagOnBreadcrumbTest.m */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.objc; name = BugsnagOnBreadcrumbTest.m; path = ../../Tests/BugsnagOnBreadcrumbTest.m; sourceTree = "<group>"; };
@@ -830,6 +832,7 @@
 				00F9393823FC4F64008C7073 /* BugsnagTestsDummyClass.m */,
 				E72AE1FF241A57B100ED8972 /* BugsnagPluginTest.m */,
 				E7AB4B9B2423E16C004F015A /* BugsnagOnBreadcrumbTest.m */,
+				E790C41D24323102006FFB26 /* BugsnagClientMirrorTest.m */,
 			);
 			name = Tests;
 			path = BugsnagTests;
@@ -1032,6 +1035,7 @@
 			isa = PBXHeadersBuildPhase;
 			buildActionMask = 2147483647;
 			files = (
+				E7DC009A1FC5C4F6004AB8DF /* BugsnagClient.h in Headers */,
 				E7107C411F4C97F100BB3F98 /* BSG_KSCrashReportWriter.h in Headers */,
 				8A70D9C922539C81006B696F /* BSGOutOfMemoryWatchdog.h in Headers */,
 				E790C425243354A8006FFB26 /* BugsnagClientInternal.h in Headers */,
@@ -1093,7 +1097,6 @@
 				E7107C541F4C97F100BB3F98 /* BSG_KSCrashSentry_Private.h in Headers */,
 				0061D84B24067AF80041C068 /* BSG_SSKeychain.h in Headers */,
 				E7EB06741FCDAF2000C076A6 /* BugsnagKSCrashSysInfoParser.h in Headers */,
-				E7DC009A1FC5C4F6004AB8DF /* BugsnagClient.h in Headers */,
 				E737DEA21F73AD7400BC7C80 /* BugsnagHandledState.h in Headers */,
 				E7107C351F4C97F100BB3F98 /* BSG_KSCrashAdvanced.h in Headers */,
 				E7107C711F4C97F100BB3F98 /* BSG_KSObjC.h in Headers */,
@@ -1332,6 +1335,7 @@
 				E78C1EFC1FCC759B00B976D3 /* BugsnagSessionTest.m in Sources */,
 				E78C1EFE1FCC778700B976D3 /* BugsnagUserTest.m in Sources */,
 				8A2C8F911C6BBFDD00846019 /* BugsnagSinkTests.m in Sources */,
+				E790C41E24323102006FFB26 /* BugsnagClientMirrorTest.m in Sources */,
 				E784D2551FD70B3B004B01E1 /* KSCrashState_Tests.m in Sources */,
 				00D7ACAD23E9C63000FBE4A7 /* BugsnagTests.m in Sources */,
 				8A2C8F901C6BBFDD00846019 /* BugsnagEventTests.m in Sources */,

--- a/tvOS/Bugsnag.xcodeproj/project.pbxproj
+++ b/tvOS/Bugsnag.xcodeproj/project.pbxproj
@@ -11,7 +11,7 @@
 		0061D8402405B6370041C068 /* BSG_SSKeychain.h in Headers */ = {isa = PBXBuildFile; fileRef = 0061D83D2405B6370041C068 /* BSG_SSKeychain.h */; };
 		0061D8412405B6370041C068 /* BSG_SSKeychain.m in Sources */ = {isa = PBXBuildFile; fileRef = 0061D83E2405B6370041C068 /* BSG_SSKeychain.m */; };
 		0061D8422405B6370041C068 /* LICENSE in Resources */ = {isa = PBXBuildFile; fileRef = 0061D83F2405B6370041C068 /* LICENSE */; };
-		0089B6EF241168CC00D5A7F2 /* BugsnagClient.h in Headers */ = {isa = PBXBuildFile; fileRef = 0089B6ED241168CB00D5A7F2 /* BugsnagClient.h */; };
+		0089B6EF241168CC00D5A7F2 /* BugsnagClient.h in Headers */ = {isa = PBXBuildFile; fileRef = 0089B6ED241168CB00D5A7F2 /* BugsnagClient.h */; settings = {ATTRIBUTES = (Public, ); }; };
 		0089B6F0241168CC00D5A7F2 /* BugsnagClient.m in Sources */ = {isa = PBXBuildFile; fileRef = 0089B6EE241168CB00D5A7F2 /* BugsnagClient.m */; };
 		00D7ACA023E97FBD00FBE4A7 /* BugsnagEvent.m in Sources */ = {isa = PBXBuildFile; fileRef = 00D7AC9E23E97FBD00FBE4A7 /* BugsnagEvent.m */; };
 		00D7ACA123E97FBD00FBE4A7 /* BugsnagEvent.h in Headers */ = {isa = PBXBuildFile; fileRef = 00D7AC9F23E97FBD00FBE4A7 /* BugsnagEvent.h */; settings = {ATTRIBUTES = (Public, ); }; };
@@ -145,6 +145,7 @@
 		E77526C5242D0E3A0077A42F /* BugsnagBreadcrumbs.h in Headers */ = {isa = PBXBuildFile; fileRef = E77526C3242D0E3A0077A42F /* BugsnagBreadcrumbs.h */; };
 		E77526C7242E694C0077A42F /* BugsnagOnBreadcrumbTest.m in Sources */ = {isa = PBXBuildFile; fileRef = E77526C6242E694C0077A42F /* BugsnagOnBreadcrumbTest.m */; };
 		E790C4292433551D006FFB26 /* BugsnagClientInternal.h in Headers */ = {isa = PBXBuildFile; fileRef = E790C4282433551D006FFB26 /* BugsnagClientInternal.h */; };
+		E790C422243231EA006FFB26 /* BugsnagClientMirrorTest.m in Sources */ = {isa = PBXBuildFile; fileRef = E790C421243231EA006FFB26 /* BugsnagClientMirrorTest.m */; };
 		E79148771FD82E6D003EFEBF /* BugsnagSession.h in Headers */ = {isa = PBXBuildFile; fileRef = E79148641FD82E6A003EFEBF /* BugsnagSession.h */; };
 		E79148781FD82E6D003EFEBF /* BugsnagKSCrashSysInfoParser.h in Headers */ = {isa = PBXBuildFile; fileRef = E79148651FD82E6A003EFEBF /* BugsnagKSCrashSysInfoParser.h */; };
 		E79148791FD82E6D003EFEBF /* BugsnagUser.h in Headers */ = {isa = PBXBuildFile; fileRef = E79148661FD82E6A003EFEBF /* BugsnagUser.h */; };
@@ -347,6 +348,7 @@
 		E77526C3242D0E3A0077A42F /* BugsnagBreadcrumbs.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; name = BugsnagBreadcrumbs.h; path = ../Source/BugsnagBreadcrumbs.h; sourceTree = "<group>"; };
 		E77526C6242E694C0077A42F /* BugsnagOnBreadcrumbTest.m */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.objc; name = BugsnagOnBreadcrumbTest.m; path = ../Tests/BugsnagOnBreadcrumbTest.m; sourceTree = "<group>"; };
 		E790C4282433551D006FFB26 /* BugsnagClientInternal.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; name = BugsnagClientInternal.h; path = ../Source/BugsnagClientInternal.h; sourceTree = "<group>"; };
+		E790C421243231EA006FFB26 /* BugsnagClientMirrorTest.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; name = BugsnagClientMirrorTest.m; path = ../../Tests/BugsnagClientMirrorTest.m; sourceTree = "<group>"; };
 		E79148641FD82E6A003EFEBF /* BugsnagSession.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; name = BugsnagSession.h; path = ../Source/BugsnagSession.h; sourceTree = "<group>"; };
 		E79148651FD82E6A003EFEBF /* BugsnagKSCrashSysInfoParser.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; name = BugsnagKSCrashSysInfoParser.h; path = ../Source/BugsnagKSCrashSysInfoParser.h; sourceTree = "<group>"; };
 		E79148661FD82E6A003EFEBF /* BugsnagUser.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; name = BugsnagUser.h; path = ../Source/BugsnagUser.h; sourceTree = "<group>"; };
@@ -516,6 +518,7 @@
 		8AB151131D41356800C9B218 /* Tests */ = {
 			isa = PBXGroup;
 			children = (
+				E790C421243231EA006FFB26 /* BugsnagClientMirrorTest.m */,
 				00F9393D23FD2DDB008C7073 /* BugsnagTestsDummyClass.h */,
 				00F9393E23FD2DDB008C7073 /* BugsnagTestsDummyClass.m */,
 				00F9393423FC16DA008C7073 /* BugsnagBaseUnitTest.h */,
@@ -748,6 +751,7 @@
 			isa = PBXHeadersBuildPhase;
 			buildActionMask = 2147483647;
 			files = (
+				0089B6EF241168CC00D5A7F2 /* BugsnagClient.h in Headers */,
 				E76617AE1F4E459C0094CECF /* BSG_KSJSONCodec.h in Headers */,
 				8A6C6FAE2257882400E8EF24 /* BSGOutOfMemoryWatchdog.h in Headers */,
 				E79148781FD82E6D003EFEBF /* BugsnagKSCrashSysInfoParser.h in Headers */,
@@ -798,7 +802,6 @@
 				E79148821FD82E6D003EFEBF /* BugsnagApiClient.h in Headers */,
 				E76617D01F4E459C0094CECF /* BSG_KSCrashReportFilter.h in Headers */,
 				E72AE1FD241A4ED600ED8972 /* BugsnagPluginClient.h in Headers */,
-				0089B6EF241168CC00D5A7F2 /* BugsnagClient.h in Headers */,
 				E76617961F4E459C0094CECF /* BSG_KSCrashSentry_CPPException.h in Headers */,
 				E76616F91F4E45950094CECF /* BugsnagErrorReportApiClient.h in Headers */,
 				8A530CBD22FDC39300F0C108 /* BSG_KSCrashIdentifier.h in Headers */,
@@ -997,6 +1000,7 @@
 				E7CE78F21FD94F1B001D07E0 /* KSMach_Tests.m in Sources */,
 				E7CE79071FD94F1B001D07E0 /* KSSysCtl_Tests.m in Sources */,
 				E7CE78F71FD94F1B001D07E0 /* KSCrashSentry_Signal_Tests.m in Sources */,
+				E790C422243231EA006FFB26 /* BugsnagClientMirrorTest.m in Sources */,
 				E7CE78FE1FD94F1B001D07E0 /* KSSignalInfo_Tests.m in Sources */,
 				00D7ACAB23E98A9A00FBE4A7 /* BugsnagEventFromKSCrashReportTest.m in Sources */,
 				E7CE78FC1FD94F1B001D07E0 /* KSCrashSentry_NSException_Tests.m in Sources */,


### PR DESCRIPTION
## Goal

Makes the `BugsnagClient` a public interface which users can interact with, and adds test coverage to ensure that its methods remain in sync with `Bugsnag`.

Relies on #516 which has not been merged yet.

## Changeset

- Makes `BugsnagClient` a public interface
- `startBugsnagWithApiKey` and `startBugsnagWithConfiguration` now return a `BugsnagClient`

## Tests

Added an introspective unit test which uses the Objective-C runtime APIs to get the names of all methods implemented in `Bugsnag` and `BugsnagClient`.

Due to restrictions in these APIs this includes non-public methods as well, so whenever a non-public method signature changes in one of these classes, it will be necessary to update the whitelist to pass the test.
