### PR TITLE
Rename add/remove block methods for swift

### DIFF
--- a/Source/Bugsnag.h
+++ b/Source/Bugsnag.h
@@ -236,20 +236,6 @@
 + (id _Nullable )getMetadata:(NSString *_Nonnull)section key:(NSString *_Nonnull)key
     NS_SWIFT_NAME(getMetadata(_:key:));
 
-/**
-* Add a callback that would be invoked before a session is sent to Bugsnag.
-*
-* @param block The block to be added.
-*/
-+ (void)addOnSessionBlock:(BugsnagOnSessionBlock _Nonnull)block;
-
-/**
- * Remove a callback that would be invoked before a session is sent to Bugsnag.
- *
- * @param block The block to be removed.
- */
-+ (void)removeOnSessionBlock:(BugsnagOnSessionBlock _Nonnull )block;
-
 // =============================================================================
 // MARK: - Other methods
 // =============================================================================
@@ -299,6 +285,26 @@
        andName:(NSString *_Nullable)name;
 
 // =============================================================================
+// MARK: - onSession
+// =============================================================================
+
+/**
+ *  Add a callback to be invoked before a session is sent to Bugsnag.
+ *
+ *  @param block A block which can modify the session
+ */
++ (void)addOnSessionBlock:(BugsnagOnSessionBlock _Nonnull)block
+    NS_SWIFT_NAME(addOnSession(block:));
+
+/**
+ * Remove a callback that would be invoked before a session is sent to Bugsnag.
+ *
+ * @param block The block to be removed.
+ */
++ (void)removeOnSessionBlock:(BugsnagOnSessionBlock _Nonnull)block
+    NS_SWIFT_NAME(removeOnSession(block:));;
+
+// =============================================================================
 // MARK: - onSend
 // =============================================================================
 
@@ -308,14 +314,16 @@
  *
  *  @param block A block which returns YES if the report should be sent
  */
-+ (void)addOnSendBlock:(BugsnagOnSendBlock _Nonnull)block;
++ (void)addOnSendBlock:(BugsnagOnSendBlock _Nonnull)block
+    NS_SWIFT_NAME(addOnSend(block:));
 
 /**
- * Remove an onSend callback, if it exists
+ * Remove the callback that would be invoked before an event is sent.
  *
- * @param block The block to remove
+ * @param block The block to be removed.
  */
-+ (void)removeOnSendBlock:(BugsnagOnSendBlock _Nonnull)block;
++ (void)removeOnSendBlock:(BugsnagOnSendBlock _Nonnull)block
+    NS_SWIFT_NAME(removeOnSend(block:));
 
 // =============================================================================
 // MARK: - onBreadcrumb
@@ -327,13 +335,15 @@
  *
  *  @param block A block which returns YES if the breadcrumb should be captured
  */
-+ (void)addOnBreadcrumbBlock:(BugsnagOnBreadcrumbBlock _Nonnull)block;
++ (void)addOnBreadcrumbBlock:(BugsnagOnBreadcrumbBlock _Nonnull)block
+    NS_SWIFT_NAME(addOnBreadcrumb(block:));
 
 /**
  * Remove the callback that would be invoked when a breadcrumb is captured.
  *
  * @param block The block to be removed.
  */
-+ (void)removeOnBreadcrumbBlock:(BugsnagOnBreadcrumbBlock _Nonnull)block;
++ (void)removeOnBreadcrumbBlock:(BugsnagOnBreadcrumbBlock _Nonnull)block
+    NS_SWIFT_NAME(removeOnBreadcrumb(block:));
 
 @end

--- a/Source/BugsnagConfiguration.h
+++ b/Source/BugsnagConfiguration.h
@@ -226,14 +226,16 @@ typedef NS_OPTIONS(NSUInteger, BSGErrorType) {
  *
  *  @param block A block which can modify the session
  */
-- (void)addOnSessionBlock:(BugsnagOnSessionBlock _Nonnull)block;
+- (void)addOnSessionBlock:(BugsnagOnSessionBlock _Nonnull)block
+    NS_SWIFT_NAME(addOnSession(block:));
 
 /**
  * Remove a callback that would be invoked before a session is sent to Bugsnag.
  *
  * @param block The block to be removed.
  */
-- (void)removeOnSessionBlock:(BugsnagOnSessionBlock _Nonnull )block;
+- (void)removeOnSessionBlock:(BugsnagOnSessionBlock _Nonnull)block
+    NS_SWIFT_NAME(removeOnSession(block:));;
 
 // =============================================================================
 // MARK: - onSend
@@ -245,16 +247,16 @@ typedef NS_OPTIONS(NSUInteger, BSGErrorType) {
  *
  *  @param block A block which returns YES if the report should be sent
  */
-- (void)addOnSendBlock:(BugsnagOnSendBlock _Nonnull)block;
+- (void)addOnSendBlock:(BugsnagOnSendBlock _Nonnull)block
+    NS_SWIFT_NAME(addOnSend(block:));
 
 /**
  * Remove the callback that would be invoked before an event is sent.
  *
  * @param block The block to be removed.
  */
-- (void)removeOnSendBlock:(BugsnagOnSendBlock _Nonnull )block;
-
-- (void)addPlugin:(id<BugsnagPlugin> _Nonnull)plugin;
+- (void)removeOnSendBlock:(BugsnagOnSendBlock _Nonnull)block
+    NS_SWIFT_NAME(removeOnSend(block:));
 
 // =============================================================================
 // MARK: - onBreadcrumb
@@ -266,14 +268,18 @@ typedef NS_OPTIONS(NSUInteger, BSGErrorType) {
  *
  *  @param block A block which returns YES if the breadcrumb should be captured
  */
-- (void)addOnBreadcrumbBlock:(BugsnagOnBreadcrumbBlock _Nonnull)block;
+- (void)addOnBreadcrumbBlock:(BugsnagOnBreadcrumbBlock _Nonnull)block
+    NS_SWIFT_NAME(addOnBreadcrumb(block:));
 
 /**
  * Remove the callback that would be invoked when a breadcrumb is captured.
  *
  * @param block The block to be removed.
  */
-- (void)removeOnBreadcrumbBlock:(BugsnagOnBreadcrumbBlock _Nonnull)block;
+- (void)removeOnBreadcrumbBlock:(BugsnagOnBreadcrumbBlock _Nonnull)block
+    NS_SWIFT_NAME(removeOnBreadcrumb(block:));
+
+- (void)addPlugin:(id<BugsnagPlugin> _Nonnull)plugin;
 
 /**
  * Should the specified type of breadcrumb be recorded?

--- a/UPGRADING.md
+++ b/UPGRADING.md
@@ -34,8 +34,8 @@ The exact error is available using the `BSGConfigurationErrorDomain` and
 + config.persistUserData()
 + config.deletePersistedUserData()
 
-+ config.add(onBreadcrumb:)
-+ config.remove(onBreadcrumb:)
++ config.addOnBreadcrumb(block:)
++ config.removeOnBreadcrumb(block:)
 ```
 
 #### Renames
@@ -50,12 +50,12 @@ The exact error is available using the `BSGConfigurationErrorDomain` and
 - config.beforeSendBlocks
 - config.add(beforeSend:)
 + config.onSendBlocks
-+ config.add(onSend:)
++ config.addOnSend(block:)
 
 - config.beforeSessionBlocks
 - config.add(beforeSession:)
 + config.onSessionBlocks
-+ config.add(onSession:)
++ config.addOnSession(block:)
 
 - config.automaticallyCollectBreadcrumbs
 + config.enabledBreadcrumbTypes

--- a/features/fixtures/ios-swift-cocoapods/iOSTestApp/scenarios/ModifyBreadcrumbScenario.swift
+++ b/features/fixtures/ios-swift-cocoapods/iOSTestApp/scenarios/ModifyBreadcrumbScenario.swift
@@ -6,7 +6,7 @@ class ModifyBreadcrumbScenario: Scenario {
     override func startBugsnag() {
         self.config.autoTrackSessions = false;
 
-        self.config.add(onSend: { event in
+        self.config.addOnSend(block: { event in
             event.breadcrumbs?.forEach({ crumb in
                 if crumb.message == "Cache cleared" {
                     crumb.message = "Cache locked"


### PR DESCRIPTION
## Goal

Adds Swift names for the add/remove block methods. This avoids a potential source of ambiguity with the previous methods, which would look like the following:

```swift
// compiles
configuration.add(onSend: { event in
    true
})
// does not compile, complains about ambiguous method names
configuration.add { event in
    true
}
```

The trailing block syntax can be used by mandating a different name with the `NS_SWIFT_NAME` macro, looking like the following:

```
self.config.addOnSend { event in
    true
}
```

## Changeset

Renamed the add/remove block methods using `NS_SWIFT_NAME`

## Tests
Ensured the new syntax compiles in the swift example app.
