### PR TITLE
Add classes for structured Event data

### DIFF
--- a/Bugsnag.podspec.json
+++ b/Bugsnag.podspec.json
@@ -30,6 +30,6 @@
   "requires_arc": true,
   "public_header_files": [
     "Source/BSG_KSCrashReportWriter.h",
-    "Source/Bugsnag{,Metadata,Configuration,Breadcrumb,Event,Plugin,Client}.h"
+    "Source/Bugsnag{,Metadata,Configuration,Breadcrumb,Event,App,AppWithState,Device,DeviceWithState,Error,Stackframe,Thread,Plugin,Client}.h"
   ]
 }

--- a/Bugsnag.podspec.json
+++ b/Bugsnag.podspec.json
@@ -30,6 +30,19 @@
   "requires_arc": true,
   "public_header_files": [
     "Source/BSG_KSCrashReportWriter.h",
-    "Source/Bugsnag{,Metadata,Configuration,Breadcrumb,Event,App,AppWithState,Device,DeviceWithState,Error,Stackframe,Thread,Plugin,Client}.h"
+    "Source/Bugsnag.h",
+    "Source/BugsnagApp.h",
+    "Source/BugsnagAppWithState.h",
+    "Source/BugsnagBreadcrumb.h",
+    "Source/BugsnagClient.h",
+    "Source/BugsnagConfiguration.h",
+    "Source/BugsnagDevice.h",
+    "Source/BugsnagDeviceWithState.h",
+    "Source/BugsnagError.h",
+    "Source/BugsnagEvent.h",
+    "Source/BugsnagMetadata.h",
+    "Source/BugsnagPlugin.h",
+    "Source/BugsnagStackframe.h",
+    "Source/BugsnagThread.h"
   ]
 }

--- a/OSX/Bugsnag.xcodeproj/project.pbxproj
+++ b/OSX/Bugsnag.xcodeproj/project.pbxproj
@@ -61,8 +61,22 @@
 		E762E9FD1F73F80200E82B43 /* BugsnagHandledState.m in Sources */ = {isa = PBXBuildFile; fileRef = E762E9FB1F73F80200E82B43 /* BugsnagHandledState.m */; };
 		E77526C0242D0E180077A42F /* BugsnagBreadcrumbs.m in Sources */ = {isa = PBXBuildFile; fileRef = E77526BE242D0E180077A42F /* BugsnagBreadcrumbs.m */; };
 		E77526C1242D0E180077A42F /* BugsnagBreadcrumbs.h in Headers */ = {isa = PBXBuildFile; fileRef = E77526BF242D0E180077A42F /* BugsnagBreadcrumbs.h */; };
-		E790C427243354FD006FFB26 /* BugsnagClientInternal.h in Headers */ = {isa = PBXBuildFile; fileRef = E790C426243354FD006FFB26 /* BugsnagClientInternal.h */; };
 		E790C42324324528006FFB26 /* BugsnagClientMirrorTest.m in Sources */ = {isa = PBXBuildFile; fileRef = E790C41F2432314A006FFB26 /* BugsnagClientMirrorTest.m */; };
+		E790C427243354FD006FFB26 /* BugsnagClientInternal.h in Headers */ = {isa = PBXBuildFile; fileRef = E790C426243354FD006FFB26 /* BugsnagClientInternal.h */; };
+		E790C47024349CE2006FFB26 /* BugsnagStackframe.m in Sources */ = {isa = PBXBuildFile; fileRef = E790C46224349CE1006FFB26 /* BugsnagStackframe.m */; };
+		E790C47124349CE2006FFB26 /* BugsnagDeviceWithState.m in Sources */ = {isa = PBXBuildFile; fileRef = E790C46324349CE1006FFB26 /* BugsnagDeviceWithState.m */; };
+		E790C47224349CE2006FFB26 /* BugsnagError.m in Sources */ = {isa = PBXBuildFile; fileRef = E790C46424349CE1006FFB26 /* BugsnagError.m */; };
+		E790C47324349CE2006FFB26 /* BugsnagApp.h in Headers */ = {isa = PBXBuildFile; fileRef = E790C46524349CE1006FFB26 /* BugsnagApp.h */; settings = {ATTRIBUTES = (Public, ); }; };
+		E790C47424349CE2006FFB26 /* BugsnagDeviceWithState.h in Headers */ = {isa = PBXBuildFile; fileRef = E790C46624349CE1006FFB26 /* BugsnagDeviceWithState.h */; settings = {ATTRIBUTES = (Public, ); }; };
+		E790C47524349CE2006FFB26 /* BugsnagAppWithState.h in Headers */ = {isa = PBXBuildFile; fileRef = E790C46724349CE2006FFB26 /* BugsnagAppWithState.h */; settings = {ATTRIBUTES = (Public, ); }; };
+		E790C47624349CE2006FFB26 /* BugsnagError.h in Headers */ = {isa = PBXBuildFile; fileRef = E790C46824349CE2006FFB26 /* BugsnagError.h */; settings = {ATTRIBUTES = (Public, ); }; };
+		E790C47724349CE2006FFB26 /* BugsnagApp.m in Sources */ = {isa = PBXBuildFile; fileRef = E790C46924349CE2006FFB26 /* BugsnagApp.m */; };
+		E790C47824349CE2006FFB26 /* BugsnagDevice.h in Headers */ = {isa = PBXBuildFile; fileRef = E790C46A24349CE2006FFB26 /* BugsnagDevice.h */; settings = {ATTRIBUTES = (Public, ); }; };
+		E790C47924349CE2006FFB26 /* BugsnagDevice.m in Sources */ = {isa = PBXBuildFile; fileRef = E790C46B24349CE2006FFB26 /* BugsnagDevice.m */; };
+		E790C47A24349CE2006FFB26 /* BugsnagStackframe.h in Headers */ = {isa = PBXBuildFile; fileRef = E790C46C24349CE2006FFB26 /* BugsnagStackframe.h */; settings = {ATTRIBUTES = (Public, ); }; };
+		E790C47B24349CE2006FFB26 /* BugsnagAppWithState.m in Sources */ = {isa = PBXBuildFile; fileRef = E790C46D24349CE2006FFB26 /* BugsnagAppWithState.m */; };
+		E790C47C24349CE2006FFB26 /* BugsnagThread.h in Headers */ = {isa = PBXBuildFile; fileRef = E790C46E24349CE2006FFB26 /* BugsnagThread.h */; settings = {ATTRIBUTES = (Public, ); }; };
+		E790C47D24349CE2006FFB26 /* BugsnagThread.m in Sources */ = {isa = PBXBuildFile; fileRef = E790C46F24349CE2006FFB26 /* BugsnagThread.m */; };
 		E79148461FD82B36003EFEBF /* BugsnagSession.h in Headers */ = {isa = PBXBuildFile; fileRef = E79148331FD82B34003EFEBF /* BugsnagSession.h */; };
 		E79148471FD82B36003EFEBF /* BugsnagKSCrashSysInfoParser.h in Headers */ = {isa = PBXBuildFile; fileRef = E79148341FD82B34003EFEBF /* BugsnagKSCrashSysInfoParser.h */; };
 		E79148481FD82B36003EFEBF /* BugsnagUser.h in Headers */ = {isa = PBXBuildFile; fileRef = E79148351FD82B34003EFEBF /* BugsnagUser.h */; };
@@ -259,8 +273,22 @@
 		E762E9FB1F73F80200E82B43 /* BugsnagHandledState.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; name = BugsnagHandledState.m; path = ../Source/BugsnagHandledState.m; sourceTree = SOURCE_ROOT; };
 		E77526BE242D0E180077A42F /* BugsnagBreadcrumbs.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; name = BugsnagBreadcrumbs.m; path = ../Source/BugsnagBreadcrumbs.m; sourceTree = "<group>"; };
 		E77526BF242D0E180077A42F /* BugsnagBreadcrumbs.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; name = BugsnagBreadcrumbs.h; path = ../Source/BugsnagBreadcrumbs.h; sourceTree = "<group>"; };
-		E790C426243354FD006FFB26 /* BugsnagClientInternal.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; name = BugsnagClientInternal.h; path = ../Source/BugsnagClientInternal.h; sourceTree = "<group>"; };
 		E790C41F2432314A006FFB26 /* BugsnagClientMirrorTest.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; path = BugsnagClientMirrorTest.m; sourceTree = "<group>"; };
+		E790C426243354FD006FFB26 /* BugsnagClientInternal.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; name = BugsnagClientInternal.h; path = ../Source/BugsnagClientInternal.h; sourceTree = "<group>"; };
+		E790C46224349CE1006FFB26 /* BugsnagStackframe.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; name = BugsnagStackframe.m; path = ../Source/BugsnagStackframe.m; sourceTree = "<group>"; };
+		E790C46324349CE1006FFB26 /* BugsnagDeviceWithState.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; name = BugsnagDeviceWithState.m; path = ../Source/BugsnagDeviceWithState.m; sourceTree = "<group>"; };
+		E790C46424349CE1006FFB26 /* BugsnagError.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; name = BugsnagError.m; path = ../Source/BugsnagError.m; sourceTree = "<group>"; };
+		E790C46524349CE1006FFB26 /* BugsnagApp.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; name = BugsnagApp.h; path = ../Source/BugsnagApp.h; sourceTree = "<group>"; };
+		E790C46624349CE1006FFB26 /* BugsnagDeviceWithState.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; name = BugsnagDeviceWithState.h; path = ../Source/BugsnagDeviceWithState.h; sourceTree = "<group>"; };
+		E790C46724349CE2006FFB26 /* BugsnagAppWithState.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; name = BugsnagAppWithState.h; path = ../Source/BugsnagAppWithState.h; sourceTree = "<group>"; };
+		E790C46824349CE2006FFB26 /* BugsnagError.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; name = BugsnagError.h; path = ../Source/BugsnagError.h; sourceTree = "<group>"; };
+		E790C46924349CE2006FFB26 /* BugsnagApp.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; name = BugsnagApp.m; path = ../Source/BugsnagApp.m; sourceTree = "<group>"; };
+		E790C46A24349CE2006FFB26 /* BugsnagDevice.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; name = BugsnagDevice.h; path = ../Source/BugsnagDevice.h; sourceTree = "<group>"; };
+		E790C46B24349CE2006FFB26 /* BugsnagDevice.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; name = BugsnagDevice.m; path = ../Source/BugsnagDevice.m; sourceTree = "<group>"; };
+		E790C46C24349CE2006FFB26 /* BugsnagStackframe.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; name = BugsnagStackframe.h; path = ../Source/BugsnagStackframe.h; sourceTree = "<group>"; };
+		E790C46D24349CE2006FFB26 /* BugsnagAppWithState.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; name = BugsnagAppWithState.m; path = ../Source/BugsnagAppWithState.m; sourceTree = "<group>"; };
+		E790C46E24349CE2006FFB26 /* BugsnagThread.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; name = BugsnagThread.h; path = ../Source/BugsnagThread.h; sourceTree = "<group>"; };
+		E790C46F24349CE2006FFB26 /* BugsnagThread.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; name = BugsnagThread.m; path = ../Source/BugsnagThread.m; sourceTree = "<group>"; };
 		E791482B1FD82B0C003EFEBF /* BugsnagSessionTrackerTest.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; path = BugsnagSessionTrackerTest.m; sourceTree = "<group>"; };
 		E791482C1FD82B0C003EFEBF /* BugsnagSessionTrackingPayloadTest.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; path = BugsnagSessionTrackingPayloadTest.m; sourceTree = "<group>"; };
 		E791482D1FD82B0C003EFEBF /* BugsnagSessionTest.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; path = BugsnagSessionTest.m; sourceTree = "<group>"; };
@@ -444,6 +472,20 @@
 		8A2C8FA31C6BC1F700846019 /* Bugsnag */ = {
 			isa = PBXGroup;
 			children = (
+				E790C46524349CE1006FFB26 /* BugsnagApp.h */,
+				E790C46924349CE2006FFB26 /* BugsnagApp.m */,
+				E790C46724349CE2006FFB26 /* BugsnagAppWithState.h */,
+				E790C46D24349CE2006FFB26 /* BugsnagAppWithState.m */,
+				E790C46A24349CE2006FFB26 /* BugsnagDevice.h */,
+				E790C46B24349CE2006FFB26 /* BugsnagDevice.m */,
+				E790C46624349CE1006FFB26 /* BugsnagDeviceWithState.h */,
+				E790C46324349CE1006FFB26 /* BugsnagDeviceWithState.m */,
+				E790C46824349CE2006FFB26 /* BugsnagError.h */,
+				E790C46424349CE1006FFB26 /* BugsnagError.m */,
+				E790C46C24349CE2006FFB26 /* BugsnagStackframe.h */,
+				E790C46224349CE1006FFB26 /* BugsnagStackframe.m */,
+				E790C46E24349CE2006FFB26 /* BugsnagThread.h */,
+				E790C46F24349CE2006FFB26 /* BugsnagThread.m */,
 				E77526BF242D0E180077A42F /* BugsnagBreadcrumbs.h */,
 				E77526BE242D0E180077A42F /* BugsnagBreadcrumbs.m */,
 				E72AE1F8241A4E7500ED8972 /* BugsnagPluginClient.h */,
@@ -736,6 +778,13 @@
 			isa = PBXHeadersBuildPhase;
 			buildActionMask = 2147483647;
 			files = (
+				E790C47C24349CE2006FFB26 /* BugsnagThread.h in Headers */,
+				E790C47A24349CE2006FFB26 /* BugsnagStackframe.h in Headers */,
+				E790C47624349CE2006FFB26 /* BugsnagError.h in Headers */,
+				E790C47824349CE2006FFB26 /* BugsnagDevice.h in Headers */,
+				E790C47424349CE2006FFB26 /* BugsnagDeviceWithState.h in Headers */,
+				E790C47324349CE2006FFB26 /* BugsnagApp.h in Headers */,
+				E790C47524349CE2006FFB26 /* BugsnagAppWithState.h in Headers */,
 				0089B6EC2411682000D5A7F2 /* BugsnagClient.h in Headers */,
 				E79E6BB91F4E3850002B35F9 /* BSG_KSJSONCodec.h in Headers */,
 				8A6C6FB22257884C00E8EF24 /* BSGOutOfMemoryWatchdog.h in Headers */,
@@ -913,6 +962,7 @@
 			buildActionMask = 2147483647;
 			files = (
 				E79E6BCD1F4E3850002B35F9 /* BSG_KSString.c in Sources */,
+				E790C47924349CE2006FFB26 /* BugsnagDevice.m in Sources */,
 				E79E6BCF1F4E3850002B35F9 /* BSG_KSSysCtl.c in Sources */,
 				8A2C8FD41C6BC2C800846019 /* BugsnagConfiguration.m in Sources */,
 				8A627CDA1EC3B75200F7C04E /* BSGSerialization.m in Sources */,
@@ -930,6 +980,7 @@
 				E79E6B971F4E3850002B35F9 /* BSG_KSCrashState.m in Sources */,
 				8A6C6FB12257884C00E8EF24 /* BSGOutOfMemoryWatchdog.m in Sources */,
 				E79E6BB31F4E3850002B35F9 /* BSG_KSCrashCallCompletion.m in Sources */,
+				E790C47224349CE2006FFB26 /* BugsnagError.m in Sources */,
 				E79E6BA21F4E3850002B35F9 /* BSG_KSCrashSentry_CPPException.mm in Sources */,
 				E79E6BBD1F4E3850002B35F9 /* BSG_KSLogger.m in Sources */,
 				00D7AC9C23E97F8100FBE4A7 /* BugsnagEvent.m in Sources */,
@@ -937,10 +988,14 @@
 				E79E6BC21F4E3850002B35F9 /* BSG_KSMach_x86_32.c in Sources */,
 				8A2C8FD01C6BC2C800846019 /* BugsnagBreadcrumb.m in Sources */,
 				E79E6BBB1F4E3850002B35F9 /* BSG_KSJSONCodecObjC.m in Sources */,
+				E790C47D24349CE2006FFB26 /* BugsnagThread.m in Sources */,
 				E79148561FD82B36003EFEBF /* BugsnagSessionTracker.m in Sources */,
+				E790C47024349CE2006FFB26 /* BugsnagStackframe.m in Sources */,
+				E790C47B24349CE2006FFB26 /* BugsnagAppWithState.m in Sources */,
 				8A2C8FD21C6BC2C800846019 /* BugsnagCollections.m in Sources */,
 				E79E6BC51F4E3850002B35F9 /* BSG_KSObjC.c in Sources */,
 				E79E6BC11F4E3850002B35F9 /* BSG_KSMach_Arm64.c in Sources */,
+				E790C47124349CE2006FFB26 /* BugsnagDeviceWithState.m in Sources */,
 				E79E6BB61F4E3850002B35F9 /* BSG_KSFileUtils.c in Sources */,
 				E791484B1FD82B36003EFEBF /* BugsnagSessionTrackingApiClient.m in Sources */,
 				E791484D1FD82B36003EFEBF /* BugsnagSessionFileStore.m in Sources */,
@@ -951,6 +1006,7 @@
 				E79E6B8B1F4E3850002B35F9 /* BSG_KSCrashC.c in Sources */,
 				E79E6BAF1F4E3850002B35F9 /* BSG_KSBacktrace.c in Sources */,
 				E79E6B941F4E3850002B35F9 /* BSG_KSCrashReportStore.m in Sources */,
+				E790C47724349CE2006FFB26 /* BugsnagApp.m in Sources */,
 				E79E6B9D1F4E3850002B35F9 /* BSG_KSSystemInfo.m in Sources */,
 				E79E6B051F4E3847002B35F9 /* BugsnagErrorReportApiClient.m in Sources */,
 				E79148571FD82B36003EFEBF /* BugsnagSession.m in Sources */,

--- a/Source/Bugsnag.h
+++ b/Source/Bugsnag.h
@@ -29,6 +29,14 @@
 #import "BugsnagMetadata.h"
 #import "BugsnagPlugin.h"
 #import "BugsnagClient.h"
+#import "BugsnagEvent.h"
+#import "BugsnagApp.h"
+#import "BugsnagAppWithState.h"
+#import "BugsnagDevice.h"
+#import "BugsnagDeviceWithState.h"
+#import "BugsnagError.h"
+#import "BugsnagStackframe.h"
+#import "BugsnagThread.h"
 
 @interface Bugsnag : NSObject
 

--- a/Source/BugsnagApp.h
+++ b/Source/BugsnagApp.h
@@ -1,0 +1,17 @@
+//
+//  BugsnagApp.h
+//  Bugsnag
+//
+//  Created by Jamie Lynch on 01/04/2020.
+//  Copyright © 2020 Bugsnag. All rights reserved.
+//
+
+#import <Foundation/Foundation.h>
+
+NS_ASSUME_NONNULL_BEGIN
+
+@interface BugsnagApp : NSObject
+
+@end
+
+NS_ASSUME_NONNULL_END

--- a/Source/BugsnagApp.h
+++ b/Source/BugsnagApp.h
@@ -10,6 +10,10 @@
 
 NS_ASSUME_NONNULL_BEGIN
 
+/**
+ * Stateless information set by the notifier about your app can be found on this class. These values
+ * can be accessed and amended if necessary.
+ */
 @interface BugsnagApp : NSObject
 
 @end

--- a/Source/BugsnagApp.m
+++ b/Source/BugsnagApp.m
@@ -1,0 +1,13 @@
+//
+//  BugsnagApp.m
+//  Bugsnag
+//
+//  Created by Jamie Lynch on 01/04/2020.
+//  Copyright © 2020 Bugsnag. All rights reserved.
+//
+
+#import "BugsnagApp.h"
+
+@implementation BugsnagApp
+
+@end

--- a/Source/BugsnagAppWithState.h
+++ b/Source/BugsnagAppWithState.h
@@ -12,6 +12,10 @@
 
 NS_ASSUME_NONNULL_BEGIN
 
+/**
+ * Stateful information set by the notifier about your app can be found on this class. These values
+ * can be accessed and amended if necessary.
+ */
 @interface BugsnagAppWithState : BugsnagApp
 
 @end

--- a/Source/BugsnagAppWithState.h
+++ b/Source/BugsnagAppWithState.h
@@ -1,0 +1,19 @@
+//
+//  BugsnagAppWithState.h
+//  Bugsnag
+//
+//  Created by Jamie Lynch on 01/04/2020.
+//  Copyright © 2020 Bugsnag. All rights reserved.
+//
+
+#import <Foundation/Foundation.h>
+
+#import "BugsnagApp.h"
+
+NS_ASSUME_NONNULL_BEGIN
+
+@interface BugsnagAppWithState : BugsnagApp
+
+@end
+
+NS_ASSUME_NONNULL_END

--- a/Source/BugsnagAppWithState.m
+++ b/Source/BugsnagAppWithState.m
@@ -1,0 +1,13 @@
+//
+//  BugsnagAppWithState.m
+//  Bugsnag
+//
+//  Created by Jamie Lynch on 01/04/2020.
+//  Copyright © 2020 Bugsnag. All rights reserved.
+//
+
+#import "BugsnagAppWithState.h"
+
+@implementation BugsnagAppWithState
+
+@end

--- a/Source/BugsnagDevice.h
+++ b/Source/BugsnagDevice.h
@@ -10,6 +10,10 @@
 
 NS_ASSUME_NONNULL_BEGIN
 
+/**
+ * Stateless information set by the notifier about the device on which the event occurred can be
+ * found on this class. These values can be accessed and amended if necessary.
+ */
 @interface BugsnagDevice : NSObject
 
 @end

--- a/Source/BugsnagDevice.h
+++ b/Source/BugsnagDevice.h
@@ -1,0 +1,17 @@
+//
+//  BugsnagDevice.h
+//  Bugsnag
+//
+//  Created by Jamie Lynch on 01/04/2020.
+//  Copyright © 2020 Bugsnag. All rights reserved.
+//
+
+#import <Foundation/Foundation.h>
+
+NS_ASSUME_NONNULL_BEGIN
+
+@interface BugsnagDevice : NSObject
+
+@end
+
+NS_ASSUME_NONNULL_END

--- a/Source/BugsnagDevice.m
+++ b/Source/BugsnagDevice.m
@@ -1,0 +1,13 @@
+//
+//  BugsnagDevice.m
+//  Bugsnag
+//
+//  Created by Jamie Lynch on 01/04/2020.
+//  Copyright © 2020 Bugsnag. All rights reserved.
+//
+
+#import "BugsnagDevice.h"
+
+@implementation BugsnagDevice
+
+@end

--- a/Source/BugsnagDeviceWithState.h
+++ b/Source/BugsnagDeviceWithState.h
@@ -1,0 +1,19 @@
+//
+//  BugsnagDeviceWithState.h
+//  Bugsnag
+//
+//  Created by Jamie Lynch on 01/04/2020.
+//  Copyright © 2020 Bugsnag. All rights reserved.
+//
+
+#import <Foundation/Foundation.h>
+
+#import "BugsnagDevice.h"
+
+NS_ASSUME_NONNULL_BEGIN
+
+@interface BugsnagDeviceWithState : BugsnagDevice
+
+@end
+
+NS_ASSUME_NONNULL_END

--- a/Source/BugsnagDeviceWithState.h
+++ b/Source/BugsnagDeviceWithState.h
@@ -12,6 +12,10 @@
 
 NS_ASSUME_NONNULL_BEGIN
 
+/**
+ * Stateful information set by the notifier about the device on which the event occurred can be
+ * found on this class. These values can be accessed and amended if necessary.
+ */
 @interface BugsnagDeviceWithState : BugsnagDevice
 
 @end

--- a/Source/BugsnagDeviceWithState.m
+++ b/Source/BugsnagDeviceWithState.m
@@ -1,0 +1,13 @@
+//
+//  BugsnagDeviceWithState.m
+//  Bugsnag
+//
+//  Created by Jamie Lynch on 01/04/2020.
+//  Copyright © 2020 Bugsnag. All rights reserved.
+//
+
+#import "BugsnagDeviceWithState.h"
+
+@implementation BugsnagDeviceWithState
+
+@end

--- a/Source/BugsnagError.h
+++ b/Source/BugsnagError.h
@@ -1,0 +1,17 @@
+//
+//  BugsnagError.h
+//  Bugsnag
+//
+//  Created by Jamie Lynch on 01/04/2020.
+//  Copyright © 2020 Bugsnag. All rights reserved.
+//
+
+#import <Foundation/Foundation.h>
+
+NS_ASSUME_NONNULL_BEGIN
+
+@interface BugsnagError : NSObject
+
+@end
+
+NS_ASSUME_NONNULL_END

--- a/Source/BugsnagError.h
+++ b/Source/BugsnagError.h
@@ -10,6 +10,9 @@
 
 NS_ASSUME_NONNULL_BEGIN
 
+/**
+ * An Error represents information extracted from an NSError, NSException, or other error source.
+ */
 @interface BugsnagError : NSObject
 
 @end

--- a/Source/BugsnagError.m
+++ b/Source/BugsnagError.m
@@ -1,0 +1,13 @@
+//
+//  BugsnagError.m
+//  Bugsnag
+//
+//  Created by Jamie Lynch on 01/04/2020.
+//  Copyright © 2020 Bugsnag. All rights reserved.
+//
+
+#import "BugsnagError.h"
+
+@implementation BugsnagError
+
+@end

--- a/Source/BugsnagStackframe.h
+++ b/Source/BugsnagStackframe.h
@@ -10,6 +10,9 @@
 
 NS_ASSUME_NONNULL_BEGIN
 
+/**
+ * Represents a single stackframe from a stacktrace.
+ */
 @interface BugsnagStackframe : NSObject
 
 @end

--- a/Source/BugsnagStackframe.h
+++ b/Source/BugsnagStackframe.h
@@ -1,0 +1,17 @@
+//
+//  BugsnagStackframe.h
+//  Bugsnag
+//
+//  Created by Jamie Lynch on 01/04/2020.
+//  Copyright © 2020 Bugsnag. All rights reserved.
+//
+
+#import <Foundation/Foundation.h>
+
+NS_ASSUME_NONNULL_BEGIN
+
+@interface BugsnagStackframe : NSObject
+
+@end
+
+NS_ASSUME_NONNULL_END

--- a/Source/BugsnagStackframe.m
+++ b/Source/BugsnagStackframe.m
@@ -1,0 +1,13 @@
+//
+//  BugsnagStackframe.m
+//  Bugsnag
+//
+//  Created by Jamie Lynch on 01/04/2020.
+//  Copyright © 2020 Bugsnag. All rights reserved.
+//
+
+#import "BugsnagStackframe.h"
+
+@implementation BugsnagStackframe
+
+@end

--- a/Source/BugsnagThread.h
+++ b/Source/BugsnagThread.h
@@ -1,0 +1,17 @@
+//
+//  BugsnagThread.h
+//  Bugsnag
+//
+//  Created by Jamie Lynch on 01/04/2020.
+//  Copyright © 2020 Bugsnag. All rights reserved.
+//
+
+#import <Foundation/Foundation.h>
+
+NS_ASSUME_NONNULL_BEGIN
+
+@interface BugsnagThread : NSObject
+
+@end
+
+NS_ASSUME_NONNULL_END

--- a/Source/BugsnagThread.h
+++ b/Source/BugsnagThread.h
@@ -10,6 +10,9 @@
 
 NS_ASSUME_NONNULL_BEGIN
 
+/**
+ * A representation of thread information recorded as part of a BugsnagEvent.
+ */
 @interface BugsnagThread : NSObject
 
 @end

--- a/Source/BugsnagThread.m
+++ b/Source/BugsnagThread.m
@@ -1,0 +1,13 @@
+//
+//  BugsnagThread.m
+//  Bugsnag
+//
+//  Created by Jamie Lynch on 01/04/2020.
+//  Copyright © 2020 Bugsnag. All rights reserved.
+//
+
+#import "BugsnagThread.h"
+
+@implementation BugsnagThread
+
+@end

--- a/iOS/Bugsnag.xcodeproj/project.pbxproj
+++ b/iOS/Bugsnag.xcodeproj/project.pbxproj
@@ -298,10 +298,38 @@
 		E78C1EF81FCC61EA00B976D3 /* BugsnagSessionTrackingPayload.m in Sources */ = {isa = PBXBuildFile; fileRef = E78C1EF51FCC61EA00B976D3 /* BugsnagSessionTrackingPayload.m */; };
 		E78C1EFC1FCC759B00B976D3 /* BugsnagSessionTest.m in Sources */ = {isa = PBXBuildFile; fileRef = E78C1EFB1FCC759B00B976D3 /* BugsnagSessionTest.m */; };
 		E78C1EFE1FCC778700B976D3 /* BugsnagUserTest.m in Sources */ = {isa = PBXBuildFile; fileRef = E78C1EFD1FCC778700B976D3 /* BugsnagUserTest.m */; };
+		E790C41E24323102006FFB26 /* BugsnagClientMirrorTest.m in Sources */ = {isa = PBXBuildFile; fileRef = E790C41D24323102006FFB26 /* BugsnagClientMirrorTest.m */; };
 		E790C425243354A8006FFB26 /* BugsnagClientInternal.h in Headers */ = {isa = PBXBuildFile; fileRef = E790C424243354A8006FFB26 /* BugsnagClientInternal.h */; };
 		E790C42A243359F6006FFB26 /* BugsnagClientInternal.h in Sources */ = {isa = PBXBuildFile; fileRef = E790C424243354A8006FFB26 /* BugsnagClientInternal.h */; };
 		E790C42B24335A2B006FFB26 /* BugsnagClientInternal.h in CopyFiles */ = {isa = PBXBuildFile; fileRef = E790C424243354A8006FFB26 /* BugsnagClientInternal.h */; };
-		E790C41E24323102006FFB26 /* BugsnagClientMirrorTest.m in Sources */ = {isa = PBXBuildFile; fileRef = E790C41D24323102006FFB26 /* BugsnagClientMirrorTest.m */; };
+		E790C43A24349817006FFB26 /* BugsnagApp.h in Headers */ = {isa = PBXBuildFile; fileRef = E790C43824349817006FFB26 /* BugsnagApp.h */; settings = {ATTRIBUTES = (Public, ); }; };
+		E790C43B24349817006FFB26 /* BugsnagApp.m in Sources */ = {isa = PBXBuildFile; fileRef = E790C43924349817006FFB26 /* BugsnagApp.m */; };
+		E790C43C24349817006FFB26 /* BugsnagApp.m in Sources */ = {isa = PBXBuildFile; fileRef = E790C43924349817006FFB26 /* BugsnagApp.m */; };
+		E790C43F24349831006FFB26 /* BugsnagAppWithState.h in Headers */ = {isa = PBXBuildFile; fileRef = E790C43D24349831006FFB26 /* BugsnagAppWithState.h */; settings = {ATTRIBUTES = (Public, ); }; };
+		E790C44024349831006FFB26 /* BugsnagAppWithState.m in Sources */ = {isa = PBXBuildFile; fileRef = E790C43E24349831006FFB26 /* BugsnagAppWithState.m */; };
+		E790C44124349831006FFB26 /* BugsnagAppWithState.m in Sources */ = {isa = PBXBuildFile; fileRef = E790C43E24349831006FFB26 /* BugsnagAppWithState.m */; };
+		E790C4442434984B006FFB26 /* BugsnagDevice.h in Headers */ = {isa = PBXBuildFile; fileRef = E790C4422434984B006FFB26 /* BugsnagDevice.h */; settings = {ATTRIBUTES = (Public, ); }; };
+		E790C4452434984B006FFB26 /* BugsnagDevice.m in Sources */ = {isa = PBXBuildFile; fileRef = E790C4432434984B006FFB26 /* BugsnagDevice.m */; };
+		E790C4462434984B006FFB26 /* BugsnagDevice.m in Sources */ = {isa = PBXBuildFile; fileRef = E790C4432434984B006FFB26 /* BugsnagDevice.m */; };
+		E790C4492434985D006FFB26 /* BugsnagDeviceWithState.h in Headers */ = {isa = PBXBuildFile; fileRef = E790C4472434985D006FFB26 /* BugsnagDeviceWithState.h */; settings = {ATTRIBUTES = (Public, ); }; };
+		E790C44A2434985D006FFB26 /* BugsnagDeviceWithState.m in Sources */ = {isa = PBXBuildFile; fileRef = E790C4482434985D006FFB26 /* BugsnagDeviceWithState.m */; };
+		E790C44B2434985D006FFB26 /* BugsnagDeviceWithState.m in Sources */ = {isa = PBXBuildFile; fileRef = E790C4482434985D006FFB26 /* BugsnagDeviceWithState.m */; };
+		E790C44E24349898006FFB26 /* BugsnagError.h in Headers */ = {isa = PBXBuildFile; fileRef = E790C44C24349898006FFB26 /* BugsnagError.h */; settings = {ATTRIBUTES = (Public, ); }; };
+		E790C44F24349898006FFB26 /* BugsnagError.m in Sources */ = {isa = PBXBuildFile; fileRef = E790C44D24349898006FFB26 /* BugsnagError.m */; };
+		E790C45024349898006FFB26 /* BugsnagError.m in Sources */ = {isa = PBXBuildFile; fileRef = E790C44D24349898006FFB26 /* BugsnagError.m */; };
+		E790C453243498BB006FFB26 /* BugsnagStackframe.h in Headers */ = {isa = PBXBuildFile; fileRef = E790C451243498BB006FFB26 /* BugsnagStackframe.h */; settings = {ATTRIBUTES = (Public, ); }; };
+		E790C454243498BB006FFB26 /* BugsnagStackframe.m in Sources */ = {isa = PBXBuildFile; fileRef = E790C452243498BB006FFB26 /* BugsnagStackframe.m */; };
+		E790C455243498BB006FFB26 /* BugsnagStackframe.m in Sources */ = {isa = PBXBuildFile; fileRef = E790C452243498BB006FFB26 /* BugsnagStackframe.m */; };
+		E790C45824349A28006FFB26 /* BugsnagThread.h in Headers */ = {isa = PBXBuildFile; fileRef = E790C45624349A28006FFB26 /* BugsnagThread.h */; settings = {ATTRIBUTES = (Public, ); }; };
+		E790C45924349A28006FFB26 /* BugsnagThread.m in Sources */ = {isa = PBXBuildFile; fileRef = E790C45724349A28006FFB26 /* BugsnagThread.m */; };
+		E790C45A24349A28006FFB26 /* BugsnagThread.m in Sources */ = {isa = PBXBuildFile; fileRef = E790C45724349A28006FFB26 /* BugsnagThread.m */; };
+		E790C45B24349A70006FFB26 /* BugsnagApp.h in CopyFiles */ = {isa = PBXBuildFile; fileRef = E790C43824349817006FFB26 /* BugsnagApp.h */; };
+		E790C45C24349A70006FFB26 /* BugsnagAppWithState.h in CopyFiles */ = {isa = PBXBuildFile; fileRef = E790C43D24349831006FFB26 /* BugsnagAppWithState.h */; };
+		E790C45D24349A70006FFB26 /* BugsnagDevice.h in CopyFiles */ = {isa = PBXBuildFile; fileRef = E790C4422434984B006FFB26 /* BugsnagDevice.h */; };
+		E790C45E24349A70006FFB26 /* BugsnagDeviceWithState.h in CopyFiles */ = {isa = PBXBuildFile; fileRef = E790C4472434985D006FFB26 /* BugsnagDeviceWithState.h */; };
+		E790C45F24349A70006FFB26 /* BugsnagError.h in CopyFiles */ = {isa = PBXBuildFile; fileRef = E790C44C24349898006FFB26 /* BugsnagError.h */; };
+		E790C46024349A70006FFB26 /* BugsnagStackframe.h in CopyFiles */ = {isa = PBXBuildFile; fileRef = E790C451243498BB006FFB26 /* BugsnagStackframe.h */; };
+		E790C46124349A70006FFB26 /* BugsnagThread.h in CopyFiles */ = {isa = PBXBuildFile; fileRef = E790C45624349A28006FFB26 /* BugsnagThread.h */; };
 		E79148251FD828E6003EFEBF /* BugsnagKeys.h in CopyFiles */ = {isa = PBXBuildFile; fileRef = E794E8021F9F743D00A67EE7 /* BugsnagKeys.h */; };
 		E79148261FD828E6003EFEBF /* BugsnagSessionTracker.h in CopyFiles */ = {isa = PBXBuildFile; fileRef = E72BF7731FC867E4004BE82F /* BugsnagSessionTracker.h */; };
 		E79148271FD828E6003EFEBF /* BugsnagSession.h in CopyFiles */ = {isa = PBXBuildFile; fileRef = E72BF7781FC869F7004BE82F /* BugsnagSession.h */; };
@@ -354,6 +382,13 @@
 			dstPath = "include/${PRODUCT_NAME}";
 			dstSubfolderSpec = 16;
 			files = (
+				E790C45B24349A70006FFB26 /* BugsnagApp.h in CopyFiles */,
+				E790C45C24349A70006FFB26 /* BugsnagAppWithState.h in CopyFiles */,
+				E790C45D24349A70006FFB26 /* BugsnagDevice.h in CopyFiles */,
+				E790C45E24349A70006FFB26 /* BugsnagDeviceWithState.h in CopyFiles */,
+				E790C45F24349A70006FFB26 /* BugsnagError.h in CopyFiles */,
+				E790C46024349A70006FFB26 /* BugsnagStackframe.h in CopyFiles */,
+				E790C46124349A70006FFB26 /* BugsnagThread.h in CopyFiles */,
 				E790C42B24335A2B006FFB26 /* BugsnagClientInternal.h in CopyFiles */,
 				E77526BD242D0B1F0077A42F /* BugsnagBreadcrumbs.h in CopyFiles */,
 				8A3C590923965D9400B344AA /* BugsnagPlugin.h in CopyFiles */,
@@ -621,8 +656,22 @@
 		E78C1EF51FCC61EA00B976D3 /* BugsnagSessionTrackingPayload.m */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.objc; name = BugsnagSessionTrackingPayload.m; path = ../Source/BugsnagSessionTrackingPayload.m; sourceTree = SOURCE_ROOT; };
 		E78C1EFB1FCC759B00B976D3 /* BugsnagSessionTest.m */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.objc; name = BugsnagSessionTest.m; path = ../Tests/BugsnagSessionTest.m; sourceTree = SOURCE_ROOT; };
 		E78C1EFD1FCC778700B976D3 /* BugsnagUserTest.m */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.objc; name = BugsnagUserTest.m; path = ../Tests/BugsnagUserTest.m; sourceTree = SOURCE_ROOT; };
-		E790C424243354A8006FFB26 /* BugsnagClientInternal.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; name = BugsnagClientInternal.h; path = ../Source/BugsnagClientInternal.h; sourceTree = "<group>"; };
 		E790C41D24323102006FFB26 /* BugsnagClientMirrorTest.m */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.objc; name = BugsnagClientMirrorTest.m; path = ../../Tests/BugsnagClientMirrorTest.m; sourceTree = "<group>"; };
+		E790C424243354A8006FFB26 /* BugsnagClientInternal.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; name = BugsnagClientInternal.h; path = ../Source/BugsnagClientInternal.h; sourceTree = "<group>"; };
+		E790C43824349817006FFB26 /* BugsnagApp.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; name = BugsnagApp.h; path = ../Source/BugsnagApp.h; sourceTree = "<group>"; };
+		E790C43924349817006FFB26 /* BugsnagApp.m */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.objc; name = BugsnagApp.m; path = ../Source/BugsnagApp.m; sourceTree = "<group>"; };
+		E790C43D24349831006FFB26 /* BugsnagAppWithState.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; name = BugsnagAppWithState.h; path = ../Source/BugsnagAppWithState.h; sourceTree = "<group>"; };
+		E790C43E24349831006FFB26 /* BugsnagAppWithState.m */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.objc; name = BugsnagAppWithState.m; path = ../Source/BugsnagAppWithState.m; sourceTree = "<group>"; };
+		E790C4422434984B006FFB26 /* BugsnagDevice.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; name = BugsnagDevice.h; path = ../Source/BugsnagDevice.h; sourceTree = "<group>"; };
+		E790C4432434984B006FFB26 /* BugsnagDevice.m */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.objc; name = BugsnagDevice.m; path = ../Source/BugsnagDevice.m; sourceTree = "<group>"; };
+		E790C4472434985D006FFB26 /* BugsnagDeviceWithState.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; name = BugsnagDeviceWithState.h; path = ../Source/BugsnagDeviceWithState.h; sourceTree = "<group>"; };
+		E790C4482434985D006FFB26 /* BugsnagDeviceWithState.m */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.objc; name = BugsnagDeviceWithState.m; path = ../Source/BugsnagDeviceWithState.m; sourceTree = "<group>"; };
+		E790C44C24349898006FFB26 /* BugsnagError.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; name = BugsnagError.h; path = ../Source/BugsnagError.h; sourceTree = "<group>"; };
+		E790C44D24349898006FFB26 /* BugsnagError.m */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.objc; name = BugsnagError.m; path = ../Source/BugsnagError.m; sourceTree = "<group>"; };
+		E790C451243498BB006FFB26 /* BugsnagStackframe.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; name = BugsnagStackframe.h; path = ../Source/BugsnagStackframe.h; sourceTree = "<group>"; };
+		E790C452243498BB006FFB26 /* BugsnagStackframe.m */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.objc; name = BugsnagStackframe.m; path = ../Source/BugsnagStackframe.m; sourceTree = "<group>"; };
+		E790C45624349A28006FFB26 /* BugsnagThread.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; name = BugsnagThread.h; path = ../Source/BugsnagThread.h; sourceTree = "<group>"; };
+		E790C45724349A28006FFB26 /* BugsnagThread.m */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.objc; name = BugsnagThread.m; path = ../Source/BugsnagThread.m; sourceTree = "<group>"; };
 		E794E8021F9F743D00A67EE7 /* BugsnagKeys.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; name = BugsnagKeys.h; path = ../Source/BugsnagKeys.h; sourceTree = SOURCE_ROOT; };
 		E79FEBE61F4CB1320048FAD6 /* Foundation.framework */ = {isa = PBXFileReference; lastKnownFileType = wrapper.framework; name = Foundation.framework; path = System/Library/Frameworks/Foundation.framework; sourceTree = SDKROOT; };
 		E7AB4B9B2423E16C004F015A /* BugsnagOnBreadcrumbTest.m */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.objc; name = BugsnagOnBreadcrumbTest.m; path = ../../Tests/BugsnagOnBreadcrumbTest.m; sourceTree = "<group>"; };
@@ -754,6 +803,20 @@
 				8A2C8F441C6BBE3C00846019 /* BugsnagConfiguration.m */,
 				8A2C8F451C6BBE3C00846019 /* BugsnagEvent.h */,
 				8A2C8F461C6BBE3C00846019 /* BugsnagEvent.m */,
+				E790C43824349817006FFB26 /* BugsnagApp.h */,
+				E790C43924349817006FFB26 /* BugsnagApp.m */,
+				E790C43D24349831006FFB26 /* BugsnagAppWithState.h */,
+				E790C43E24349831006FFB26 /* BugsnagAppWithState.m */,
+				E790C4422434984B006FFB26 /* BugsnagDevice.h */,
+				E790C4432434984B006FFB26 /* BugsnagDevice.m */,
+				E790C4472434985D006FFB26 /* BugsnagDeviceWithState.h */,
+				E790C4482434985D006FFB26 /* BugsnagDeviceWithState.m */,
+				E790C44C24349898006FFB26 /* BugsnagError.h */,
+				E790C44D24349898006FFB26 /* BugsnagError.m */,
+				E790C451243498BB006FFB26 /* BugsnagStackframe.h */,
+				E790C452243498BB006FFB26 /* BugsnagStackframe.m */,
+				E790C45624349A28006FFB26 /* BugsnagThread.h */,
+				E790C45724349A28006FFB26 /* BugsnagThread.m */,
 				E72962D01F4BBA8A00CEA15D /* BugsnagCrashSentry.h */,
 				E72962D11F4BBA8A00CEA15D /* BugsnagCrashSentry.m */,
 				E72962D21F4BBA8B00CEA15D /* BugsnagErrorReportApiClient.h */,
@@ -1035,7 +1098,12 @@
 			isa = PBXHeadersBuildPhase;
 			buildActionMask = 2147483647;
 			files = (
+				E790C45824349A28006FFB26 /* BugsnagThread.h in Headers */,
+				E790C453243498BB006FFB26 /* BugsnagStackframe.h in Headers */,
+				E790C44E24349898006FFB26 /* BugsnagError.h in Headers */,
 				E7DC009A1FC5C4F6004AB8DF /* BugsnagClient.h in Headers */,
+				E790C4492434985D006FFB26 /* BugsnagDeviceWithState.h in Headers */,
+				E790C43F24349831006FFB26 /* BugsnagAppWithState.h in Headers */,
 				E7107C411F4C97F100BB3F98 /* BSG_KSCrashReportWriter.h in Headers */,
 				8A70D9C922539C81006B696F /* BSGOutOfMemoryWatchdog.h in Headers */,
 				E790C425243354A8006FFB26 /* BugsnagClientInternal.h in Headers */,
@@ -1043,6 +1111,8 @@
 				8A2C8F5B1C6BBE3C00846019 /* BugsnagMetadata.h in Headers */,
 				8A2C8F551C6BBE3C00846019 /* BugsnagConfiguration.h in Headers */,
 				E72BF7751FC867E4004BE82F /* BugsnagSessionTracker.h in Headers */,
+				E790C4442434984B006FFB26 /* BugsnagDevice.h in Headers */,
+				E790C43A24349817006FFB26 /* BugsnagApp.h in Headers */,
 				8A72A0392396590300328051 /* BugsnagPlugin.h in Headers */,
 				8A3B5F272407EC8900CE4A3A /* Private.h in Headers */,
 				8A2C8F511C6BBE3C00846019 /* BugsnagBreadcrumb.h in Headers */,
@@ -1251,6 +1321,7 @@
 				E7107C781F4C97F100BB3F98 /* BSG_KSString.c in Sources */,
 				E7107C7A1F4C97F100BB3F98 /* BSG_KSSysCtl.c in Sources */,
 				8A2C8F561C6BBE3C00846019 /* BugsnagConfiguration.m in Sources */,
+				E790C44A2434985D006FFB26 /* BugsnagDeviceWithState.m in Sources */,
 				8A627CD21EC2A62900F7C04E /* BSGSerialization.m in Sources */,
 				E72BF7761FC867E4004BE82F /* BugsnagSessionTracker.m in Sources */,
 				E7107C551F4C97F100BB3F98 /* BSG_KSCrashSentry_Signal.c in Sources */,
@@ -1267,26 +1338,31 @@
 				8A70D9CA22539C81006B696F /* BSGOutOfMemoryWatchdog.m in Sources */,
 				E7107C5E1F4C97F100BB3F98 /* BSG_KSCrashCallCompletion.m in Sources */,
 				E7107C4D1F4C97F100BB3F98 /* BSG_KSCrashSentry_CPPException.mm in Sources */,
+				E790C4452434984B006FFB26 /* BugsnagDevice.m in Sources */,
 				E7107C681F4C97F100BB3F98 /* BSG_KSLogger.m in Sources */,
 				E78C1EF71FCC61EA00B976D3 /* BugsnagSessionTrackingPayload.m in Sources */,
 				E7107C751F4C97F100BB3F98 /* BSG_KSSignalInfo.c in Sources */,
 				E7107C6D1F4C97F100BB3F98 /* BSG_KSMach_x86_32.c in Sources */,
 				E72352B71F55718E00436528 /* BSGConnectivity.m in Sources */,
 				8A2C8F601C6BBE3C00846019 /* BugsnagSink.m in Sources */,
+				E790C45924349A28006FFB26 /* BugsnagThread.m in Sources */,
 				E7107C661F4C97F100BB3F98 /* BSG_KSJSONCodecObjC.m in Sources */,
 				8A2C8F5C1C6BBE3C00846019 /* BugsnagMetadata.m in Sources */,
 				E7107C701F4C97F100BB3F98 /* BSG_KSObjC.c in Sources */,
 				E7107C6C1F4C97F100BB3F98 /* BSG_KSMach_Arm64.c in Sources */,
+				E790C454243498BB006FFB26 /* BugsnagStackframe.m in Sources */,
 				E7107C611F4C97F100BB3F98 /* BSG_KSFileUtils.c in Sources */,
 				E7107C4A1F4C97F100BB3F98 /* BSG_KSCrashSentry.c in Sources */,
 				E7107C6E1F4C97F100BB3F98 /* BSG_KSMach_x86_64.c in Sources */,
 				E7107C811F4C97F100BB3F98 /* NSError+BSG_SimpleConstructor.m in Sources */,
+				E790C44024349831006FFB26 /* BugsnagAppWithState.m in Sources */,
 				E7107C361F4C97F100BB3F98 /* BSG_KSCrashC.c in Sources */,
 				E7107C5A1F4C97F100BB3F98 /* BSG_KSBacktrace.c in Sources */,
 				E7107C3F1F4C97F100BB3F98 /* BSG_KSCrashReportStore.m in Sources */,
 				E7107C481F4C97F100BB3F98 /* BSG_KSSystemInfo.m in Sources */,
 				E7EB06751FCDAF2000C076A6 /* BugsnagKSCrashSysInfoParser.m in Sources */,
 				8A2C8F521C6BBE3C00846019 /* BugsnagBreadcrumb.m in Sources */,
+				E790C43B24349817006FFB26 /* BugsnagApp.m in Sources */,
 				E72962D91F4BBA8B00CEA15D /* BugsnagErrorReportApiClient.m in Sources */,
 				E7107C631F4C97F100BB3F98 /* BSG_KSJSONCodec.c in Sources */,
 				E7107C531F4C97F100BB3F98 /* BSG_KSCrashSentry_NSException.m in Sources */,
@@ -1302,6 +1378,7 @@
 				E7107C571F4C97F100BB3F98 /* BSG_KSCrashSentry_User.c in Sources */,
 				E7107C851F4C97F100BB3F98 /* BSG_RFC3339DateTool.m in Sources */,
 				F42953297D561ACAB878DEB8 /* BugsnagFileStore.m in Sources */,
+				E790C44F24349898006FFB26 /* BugsnagError.m in Sources */,
 				0061D84924067AF80041C068 /* BSG_SSKeychain.m in Sources */,
 				F4295B2AC95281CBA3A42DCA /* BugsnagSessionFileStore.m in Sources */,
 				F4295C52A30DC98515F2FF02 /* BugsnagSessionTrackingApiClient.m in Sources */,
@@ -1382,16 +1459,20 @@
 				E7397E3B1F83BC320034242A /* BSG_KSDynamicLinker.c in Sources */,
 				E7397E3C1F83BC320034242A /* BSG_KSFileUtils.c in Sources */,
 				E7397E3D1F83BC320034242A /* BSG_KSJSONCodec.c in Sources */,
+				E790C44124349831006FFB26 /* BugsnagAppWithState.m in Sources */,
 				E77526BC242D0AE50077A42F /* BugsnagBreadcrumbs.m in Sources */,
 				E7397E3E1F83BC320034242A /* BSG_KSMach.c in Sources */,
 				E72BF77C1FC869F7004BE82F /* BugsnagSession.m in Sources */,
 				8A70D9CB22539C81006B696F /* BSGOutOfMemoryWatchdog.m in Sources */,
 				E7397E3F1F83BC320034242A /* BSG_KSMach_Arm.c in Sources */,
+				E790C45024349898006FFB26 /* BugsnagError.m in Sources */,
 				E7397E401F83BC320034242A /* BSG_KSMach_Arm64.c in Sources */,
 				E7397E411F83BC320034242A /* BSG_KSMach_x86_32.c in Sources */,
+				E790C43C24349817006FFB26 /* BugsnagApp.m in Sources */,
 				E78C1EF81FCC61EA00B976D3 /* BugsnagSessionTrackingPayload.m in Sources */,
 				E7397E421F83BC320034242A /* BSG_KSMach_x86_64.c in Sources */,
 				E7397E431F83BC320034242A /* BSG_KSObjC.c in Sources */,
+				E790C455243498BB006FFB26 /* BugsnagStackframe.m in Sources */,
 				0061D84A24067AF80041C068 /* BSG_SSKeychain.m in Sources */,
 				E7397E441F83BC320034242A /* BSG_KSSignalInfo.c in Sources */,
 				E7397E451F83BC320034242A /* BSG_KSString.c in Sources */,
@@ -1406,6 +1487,7 @@
 				E7397E1D1F83BC2A0034242A /* BSG_KSCrashCallCompletion.m in Sources */,
 				E7397E1E1F83BC2A0034242A /* BSG_KSJSONCodecObjC.m in Sources */,
 				E7397E1F1F83BC2A0034242A /* BSG_KSLogger.m in Sources */,
+				E790C44B2434985D006FFB26 /* BugsnagDeviceWithState.m in Sources */,
 				E7397E221F83BC2A0034242A /* NSError+BSG_SimpleConstructor.m in Sources */,
 				E7EB06761FCDAF2000C076A6 /* BugsnagKSCrashSysInfoParser.m in Sources */,
 				E7397E231F83BC2A0034242A /* BSG_RFC3339DateTool.m in Sources */,
@@ -1415,6 +1497,7 @@
 				E7397E281F83BC2A0034242A /* BSGSerialization.m in Sources */,
 				E72BF7811FC86A7A004BE82F /* BugsnagUser.m in Sources */,
 				E7397E291F83BC2A0034242A /* Bugsnag.m in Sources */,
+				E790C45A24349A28006FFB26 /* BugsnagThread.m in Sources */,
 				E7397E2A1F83BC2A0034242A /* BugsnagBreadcrumb.m in Sources */,
 				E7397E2B1F83BC2A0034242A /* BugsnagCollections.m in Sources */,
 				E7397E2C1F83BC2A0034242A /* BugsnagConfiguration.m in Sources */,
@@ -1423,6 +1506,7 @@
 				E7397E2E1F83BC2A0034242A /* BugsnagMetadata.m in Sources */,
 				E7397E2F1F83BC2A0034242A /* BugsnagClient.m in Sources */,
 				E7397E301F83BC2A0034242A /* BugsnagSink.m in Sources */,
+				E790C4462434984B006FFB26 /* BugsnagDevice.m in Sources */,
 				E7397E311F83BC2A0034242A /* BugsnagHandledState.m in Sources */,
 				F42954D2337A7CAE1FE9B308 /* BugsnagFileStore.m in Sources */,
 				F4295DB3B395327B82A47A78 /* BugsnagSessionFileStore.m in Sources */,

--- a/tvOS/Bugsnag.xcodeproj/project.pbxproj
+++ b/tvOS/Bugsnag.xcodeproj/project.pbxproj
@@ -144,8 +144,22 @@
 		E77526C4242D0E3A0077A42F /* BugsnagBreadcrumbs.m in Sources */ = {isa = PBXBuildFile; fileRef = E77526C2242D0E3A0077A42F /* BugsnagBreadcrumbs.m */; };
 		E77526C5242D0E3A0077A42F /* BugsnagBreadcrumbs.h in Headers */ = {isa = PBXBuildFile; fileRef = E77526C3242D0E3A0077A42F /* BugsnagBreadcrumbs.h */; };
 		E77526C7242E694C0077A42F /* BugsnagOnBreadcrumbTest.m in Sources */ = {isa = PBXBuildFile; fileRef = E77526C6242E694C0077A42F /* BugsnagOnBreadcrumbTest.m */; };
-		E790C4292433551D006FFB26 /* BugsnagClientInternal.h in Headers */ = {isa = PBXBuildFile; fileRef = E790C4282433551D006FFB26 /* BugsnagClientInternal.h */; };
 		E790C422243231EA006FFB26 /* BugsnagClientMirrorTest.m in Sources */ = {isa = PBXBuildFile; fileRef = E790C421243231EA006FFB26 /* BugsnagClientMirrorTest.m */; };
+		E790C4292433551D006FFB26 /* BugsnagClientInternal.h in Headers */ = {isa = PBXBuildFile; fileRef = E790C4282433551D006FFB26 /* BugsnagClientInternal.h */; };
+		E790C48C24349D35006FFB26 /* BugsnagApp.h in Headers */ = {isa = PBXBuildFile; fileRef = E790C47E24349D33006FFB26 /* BugsnagApp.h */; settings = {ATTRIBUTES = (Public, ); }; };
+		E790C48D24349D35006FFB26 /* BugsnagError.h in Headers */ = {isa = PBXBuildFile; fileRef = E790C47F24349D33006FFB26 /* BugsnagError.h */; settings = {ATTRIBUTES = (Public, ); }; };
+		E790C48E24349D35006FFB26 /* BugsnagThread.m in Sources */ = {isa = PBXBuildFile; fileRef = E790C48024349D33006FFB26 /* BugsnagThread.m */; };
+		E790C48F24349D35006FFB26 /* BugsnagStackframe.m in Sources */ = {isa = PBXBuildFile; fileRef = E790C48124349D34006FFB26 /* BugsnagStackframe.m */; };
+		E790C49024349D35006FFB26 /* BugsnagApp.m in Sources */ = {isa = PBXBuildFile; fileRef = E790C48224349D34006FFB26 /* BugsnagApp.m */; };
+		E790C49124349D35006FFB26 /* BugsnagDevice.h in Headers */ = {isa = PBXBuildFile; fileRef = E790C48324349D34006FFB26 /* BugsnagDevice.h */; settings = {ATTRIBUTES = (Public, ); }; };
+		E790C49224349D35006FFB26 /* BugsnagThread.h in Headers */ = {isa = PBXBuildFile; fileRef = E790C48424349D34006FFB26 /* BugsnagThread.h */; settings = {ATTRIBUTES = (Public, ); }; };
+		E790C49324349D35006FFB26 /* BugsnagStackframe.h in Headers */ = {isa = PBXBuildFile; fileRef = E790C48524349D34006FFB26 /* BugsnagStackframe.h */; settings = {ATTRIBUTES = (Public, ); }; };
+		E790C49424349D35006FFB26 /* BugsnagDeviceWithState.m in Sources */ = {isa = PBXBuildFile; fileRef = E790C48624349D34006FFB26 /* BugsnagDeviceWithState.m */; };
+		E790C49524349D35006FFB26 /* BugsnagError.m in Sources */ = {isa = PBXBuildFile; fileRef = E790C48724349D34006FFB26 /* BugsnagError.m */; };
+		E790C49624349D35006FFB26 /* BugsnagAppWithState.h in Headers */ = {isa = PBXBuildFile; fileRef = E790C48824349D34006FFB26 /* BugsnagAppWithState.h */; settings = {ATTRIBUTES = (Public, ); }; };
+		E790C49724349D35006FFB26 /* BugsnagDeviceWithState.h in Headers */ = {isa = PBXBuildFile; fileRef = E790C48924349D34006FFB26 /* BugsnagDeviceWithState.h */; settings = {ATTRIBUTES = (Public, ); }; };
+		E790C49824349D35006FFB26 /* BugsnagDevice.m in Sources */ = {isa = PBXBuildFile; fileRef = E790C48A24349D34006FFB26 /* BugsnagDevice.m */; };
+		E790C49924349D35006FFB26 /* BugsnagAppWithState.m in Sources */ = {isa = PBXBuildFile; fileRef = E790C48B24349D35006FFB26 /* BugsnagAppWithState.m */; };
 		E79148771FD82E6D003EFEBF /* BugsnagSession.h in Headers */ = {isa = PBXBuildFile; fileRef = E79148641FD82E6A003EFEBF /* BugsnagSession.h */; };
 		E79148781FD82E6D003EFEBF /* BugsnagKSCrashSysInfoParser.h in Headers */ = {isa = PBXBuildFile; fileRef = E79148651FD82E6A003EFEBF /* BugsnagKSCrashSysInfoParser.h */; };
 		E79148791FD82E6D003EFEBF /* BugsnagUser.h in Headers */ = {isa = PBXBuildFile; fileRef = E79148661FD82E6A003EFEBF /* BugsnagUser.h */; };
@@ -347,8 +361,22 @@
 		E77526C2242D0E3A0077A42F /* BugsnagBreadcrumbs.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; name = BugsnagBreadcrumbs.m; path = ../Source/BugsnagBreadcrumbs.m; sourceTree = "<group>"; };
 		E77526C3242D0E3A0077A42F /* BugsnagBreadcrumbs.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; name = BugsnagBreadcrumbs.h; path = ../Source/BugsnagBreadcrumbs.h; sourceTree = "<group>"; };
 		E77526C6242E694C0077A42F /* BugsnagOnBreadcrumbTest.m */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.objc; name = BugsnagOnBreadcrumbTest.m; path = ../Tests/BugsnagOnBreadcrumbTest.m; sourceTree = "<group>"; };
-		E790C4282433551D006FFB26 /* BugsnagClientInternal.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; name = BugsnagClientInternal.h; path = ../Source/BugsnagClientInternal.h; sourceTree = "<group>"; };
 		E790C421243231EA006FFB26 /* BugsnagClientMirrorTest.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; name = BugsnagClientMirrorTest.m; path = ../../Tests/BugsnagClientMirrorTest.m; sourceTree = "<group>"; };
+		E790C4282433551D006FFB26 /* BugsnagClientInternal.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; name = BugsnagClientInternal.h; path = ../Source/BugsnagClientInternal.h; sourceTree = "<group>"; };
+		E790C47E24349D33006FFB26 /* BugsnagApp.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; name = BugsnagApp.h; path = ../Source/BugsnagApp.h; sourceTree = "<group>"; };
+		E790C47F24349D33006FFB26 /* BugsnagError.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; name = BugsnagError.h; path = ../Source/BugsnagError.h; sourceTree = "<group>"; };
+		E790C48024349D33006FFB26 /* BugsnagThread.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; name = BugsnagThread.m; path = ../Source/BugsnagThread.m; sourceTree = "<group>"; };
+		E790C48124349D34006FFB26 /* BugsnagStackframe.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; name = BugsnagStackframe.m; path = ../Source/BugsnagStackframe.m; sourceTree = "<group>"; };
+		E790C48224349D34006FFB26 /* BugsnagApp.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; name = BugsnagApp.m; path = ../Source/BugsnagApp.m; sourceTree = "<group>"; };
+		E790C48324349D34006FFB26 /* BugsnagDevice.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; name = BugsnagDevice.h; path = ../Source/BugsnagDevice.h; sourceTree = "<group>"; };
+		E790C48424349D34006FFB26 /* BugsnagThread.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; name = BugsnagThread.h; path = ../Source/BugsnagThread.h; sourceTree = "<group>"; };
+		E790C48524349D34006FFB26 /* BugsnagStackframe.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; name = BugsnagStackframe.h; path = ../Source/BugsnagStackframe.h; sourceTree = "<group>"; };
+		E790C48624349D34006FFB26 /* BugsnagDeviceWithState.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; name = BugsnagDeviceWithState.m; path = ../Source/BugsnagDeviceWithState.m; sourceTree = "<group>"; };
+		E790C48724349D34006FFB26 /* BugsnagError.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; name = BugsnagError.m; path = ../Source/BugsnagError.m; sourceTree = "<group>"; };
+		E790C48824349D34006FFB26 /* BugsnagAppWithState.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; name = BugsnagAppWithState.h; path = ../Source/BugsnagAppWithState.h; sourceTree = "<group>"; };
+		E790C48924349D34006FFB26 /* BugsnagDeviceWithState.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; name = BugsnagDeviceWithState.h; path = ../Source/BugsnagDeviceWithState.h; sourceTree = "<group>"; };
+		E790C48A24349D34006FFB26 /* BugsnagDevice.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; name = BugsnagDevice.m; path = ../Source/BugsnagDevice.m; sourceTree = "<group>"; };
+		E790C48B24349D35006FFB26 /* BugsnagAppWithState.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; name = BugsnagAppWithState.m; path = ../Source/BugsnagAppWithState.m; sourceTree = "<group>"; };
 		E79148641FD82E6A003EFEBF /* BugsnagSession.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; name = BugsnagSession.h; path = ../Source/BugsnagSession.h; sourceTree = "<group>"; };
 		E79148651FD82E6A003EFEBF /* BugsnagKSCrashSysInfoParser.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; name = BugsnagKSCrashSysInfoParser.h; path = ../Source/BugsnagKSCrashSysInfoParser.h; sourceTree = "<group>"; };
 		E79148661FD82E6A003EFEBF /* BugsnagUser.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; name = BugsnagUser.h; path = ../Source/BugsnagUser.h; sourceTree = "<group>"; };
@@ -453,6 +481,20 @@
 		8A8D51261D41343500D33797 /* tvOS */ = {
 			isa = PBXGroup;
 			children = (
+				E790C47E24349D33006FFB26 /* BugsnagApp.h */,
+				E790C48224349D34006FFB26 /* BugsnagApp.m */,
+				E790C48824349D34006FFB26 /* BugsnagAppWithState.h */,
+				E790C48B24349D35006FFB26 /* BugsnagAppWithState.m */,
+				E790C48324349D34006FFB26 /* BugsnagDevice.h */,
+				E790C48A24349D34006FFB26 /* BugsnagDevice.m */,
+				E790C48924349D34006FFB26 /* BugsnagDeviceWithState.h */,
+				E790C48624349D34006FFB26 /* BugsnagDeviceWithState.m */,
+				E790C47F24349D33006FFB26 /* BugsnagError.h */,
+				E790C48724349D34006FFB26 /* BugsnagError.m */,
+				E790C48524349D34006FFB26 /* BugsnagStackframe.h */,
+				E790C48124349D34006FFB26 /* BugsnagStackframe.m */,
+				E790C48424349D34006FFB26 /* BugsnagThread.h */,
+				E790C48024349D33006FFB26 /* BugsnagThread.m */,
 				E790C4282433551D006FFB26 /* BugsnagClientInternal.h */,
 				E77526C3242D0E3A0077A42F /* BugsnagBreadcrumbs.h */,
 				E77526C2242D0E3A0077A42F /* BugsnagBreadcrumbs.m */,
@@ -751,6 +793,13 @@
 			isa = PBXHeadersBuildPhase;
 			buildActionMask = 2147483647;
 			files = (
+				E790C49224349D35006FFB26 /* BugsnagThread.h in Headers */,
+				E790C49324349D35006FFB26 /* BugsnagStackframe.h in Headers */,
+				E790C48D24349D35006FFB26 /* BugsnagError.h in Headers */,
+				E790C49124349D35006FFB26 /* BugsnagDevice.h in Headers */,
+				E790C49724349D35006FFB26 /* BugsnagDeviceWithState.h in Headers */,
+				E790C48C24349D35006FFB26 /* BugsnagApp.h in Headers */,
+				E790C49624349D35006FFB26 /* BugsnagAppWithState.h in Headers */,
 				0089B6EF241168CC00D5A7F2 /* BugsnagClient.h in Headers */,
 				E76617AE1F4E459C0094CECF /* BSG_KSJSONCodec.h in Headers */,
 				8A6C6FAE2257882400E8EF24 /* BSGOutOfMemoryWatchdog.h in Headers */,
@@ -930,6 +979,7 @@
 				E76617C21F4E459C0094CECF /* BSG_KSString.c in Sources */,
 				E79148871FD82E6D003EFEBF /* BugsnagSessionTracker.m in Sources */,
 				E76617C41F4E459C0094CECF /* BSG_KSSysCtl.c in Sources */,
+				E790C49424349D35006FFB26 /* BugsnagDeviceWithState.m in Sources */,
 				8AD9A5001D42EEA9004E1CC5 /* BugsnagConfiguration.m in Sources */,
 				8A627CD61EC3B69300F7C04E /* BSGSerialization.m in Sources */,
 				E766179F1F4E459C0094CECF /* BSG_KSCrashSentry_Signal.c in Sources */,
@@ -937,6 +987,7 @@
 				E79148881FD82E6D003EFEBF /* BugsnagSession.m in Sources */,
 				E791487C1FD82E6D003EFEBF /* BugsnagSessionTrackingApiClient.m in Sources */,
 				E76617B31F4E459C0094CECF /* BSG_KSMach.c in Sources */,
+				E790C49924349D35006FFB26 /* BugsnagAppWithState.m in Sources */,
 				E766178E1F4E459C0094CECF /* BSG_KSCrashType.c in Sources */,
 				E791487F1FD82E6D003EFEBF /* BugsnagKSCrashSysInfoParser.m in Sources */,
 				E76617B51F4E459C0094CECF /* BSG_KSMach_Arm.c in Sources */,
@@ -950,6 +1001,7 @@
 				00D7ACA023E97FBD00FBE4A7 /* BugsnagEvent.m in Sources */,
 				E76617A81F4E459C0094CECF /* BSG_KSCrashCallCompletion.m in Sources */,
 				E76617971F4E459C0094CECF /* BSG_KSCrashSentry_CPPException.mm in Sources */,
+				E790C48F24349D35006FFB26 /* BugsnagStackframe.m in Sources */,
 				E76617B21F4E459C0094CECF /* BSG_KSLogger.m in Sources */,
 				E79148801FD82E6D003EFEBF /* BugsnagSessionTrackingPayload.m in Sources */,
 				E76617BF1F4E459C0094CECF /* BSG_KSSignalInfo.c in Sources */,
@@ -959,11 +1011,13 @@
 				E76617B01F4E459C0094CECF /* BSG_KSJSONCodecObjC.m in Sources */,
 				8AD9A5041D42EEB0004E1CC5 /* BugsnagSink.m in Sources */,
 				E76617BA1F4E459C0094CECF /* BSG_KSObjC.c in Sources */,
+				E790C49024349D35006FFB26 /* BugsnagApp.m in Sources */,
 				E76617B61F4E459C0094CECF /* BSG_KSMach_Arm64.c in Sources */,
 				E76617AB1F4E459C0094CECF /* BSG_KSFileUtils.c in Sources */,
 				E76617941F4E459C0094CECF /* BSG_KSCrashSentry.c in Sources */,
 				E76617B81F4E459C0094CECF /* BSG_KSMach_x86_64.c in Sources */,
 				E76617CB1F4E459C0094CECF /* NSError+BSG_SimpleConstructor.m in Sources */,
+				E790C49824349D35006FFB26 /* BugsnagDevice.m in Sources */,
 				E79148891FD82E6D003EFEBF /* BugsnagFileStore.m in Sources */,
 				E79148831FD82E6D003EFEBF /* BugsnagUser.m in Sources */,
 				E76617801F4E459C0094CECF /* BSG_KSCrashC.c in Sources */,
@@ -972,6 +1026,7 @@
 				E76617921F4E459C0094CECF /* BSG_KSSystemInfo.m in Sources */,
 				E76616FA1F4E45950094CECF /* BugsnagErrorReportApiClient.m in Sources */,
 				E76617AD1F4E459C0094CECF /* BSG_KSJSONCodec.c in Sources */,
+				E790C48E24349D35006FFB26 /* BugsnagThread.m in Sources */,
 				E766179D1F4E459C0094CECF /* BSG_KSCrashSentry_NSException.m in Sources */,
 				E76617851F4E459C0094CECF /* BSG_KSCrashReport.c in Sources */,
 				8AD9A5021D42EEB0004E1CC5 /* BugsnagMetadata.m in Sources */,
@@ -981,6 +1036,7 @@
 				E762E9F61F73F7A400E82B43 /* BugsnagHandledState.m in Sources */,
 				8AD9A4FD1D42EE99004E1CC5 /* Bugsnag.m in Sources */,
 				E766177E1F4E459C0094CECF /* BSG_KSCrash.m in Sources */,
+				E790C49524349D35006FFB26 /* BugsnagError.m in Sources */,
 				0061D8412405B6370041C068 /* BSG_SSKeychain.m in Sources */,
 				E76617A11F4E459C0094CECF /* BSG_KSCrashSentry_User.c in Sources */,
 				E76617CF1F4E459C0094CECF /* BSG_RFC3339DateTool.m in Sources */,


### PR DESCRIPTION
## Goal

Adds empty source files for classes which will be used to hold structured data in `BugsnagEvent`.

These have been added here as they needed to be added to the iOS/tvOS/macOS xcodeprojs, and the headers need to be publicly visible, imported in the `Bugsnag.h` umbrella header, and added to the podspec.json. Adding them all at once reduces the chance that these steps are forgotten in the individual PRs which will be raised.

## Changeset

- Added the following public classes:

```
App
AppWithState
Device
DeviceWithState
Error
Stacktrace
Thread
```

- Updated `Bugsnag.h` imports so that structured classes are available in the [umbrella header](https://stackoverflow.com/questions/31238761/what-is-an-umbrella-header/31238936)
- Updated podspec so public header files are found by Cocoapods

## Tests

Verified that the iOS project compiles.