### PR TITLE
(fix)NSWorkspace-specific state change notifications now use the corr…

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -213,6 +213,9 @@ Bugsnag Notifiers on other platforms.
 * Increased the detail in handled event breadcrumbs
   [#493](https://github.com/bugsnag/bugsnag-cocoa/pull/493)
   
+* NSWorkspaceScreenSleep/Wake notifications now use the correct notification center.
+  (#525)[https://github.com/bugsnag/bugsnag-cocoa/pull/525]
+  
 ## 5.23.0 (2019-12-10)
 
 This release removes support for reporting 'partial' or 'minimal' crash reports

--- a/Tests/BugsnagClientMirrorTest.m
+++ b/Tests/BugsnagClientMirrorTest.m
@@ -87,7 +87,9 @@
             @"started c16@0:8",
             @"setAppDidCrashLastLaunch: v20@0:8c16",
             @"setMetadata: v24@0:8@16",
-            @"metadata @16@0:8"
+            @"metadata @16@0:8",
+            @"workspaceBreadcrumbStateEvents @16@0:8",
+            @"startListeningForWorkspaceStateChangeNotifications: v24@0:8@16"
     ]];
 
     // the following methods are implemented on Bugsnag but do not need to


### PR DESCRIPTION
## Goal

MacOS was incorrectly listening to a couple of automatic breadcrumb notifications on the default notification center.  This PR corrects that.

<!-- What is the intent of this change? -->

<!--
Fixes #
Related to #
-->

## Design

Extract the notifications in question and (within protective MacOS #if guards) add them to the correct NSWorkspace notification center. 

<!-- How does this change work? Why was this approach to the goal used? -->

## Changeset

`BugsnagClient`.

<!-- List what was added, removed, or changed.  Pitch this at a level 
     appropriate to the scope of the change: new  classes, changed architecture,
     minor typo, etc.  If appropriate include a list of changed files: 

         $ git diff --name-status HEAD~1 | cat
-->

## Tests

Manual testing only.  Additional methods whitelisted in mirror tests.

<!-- How was this change tested? What manual and automated tests were
     run/added? -->

## Review

### Outstanding Questions

<!-- Are there any parts of the design or the implementation which seem
     less than ideal and that could require additional discussion?
     List here: -->

<!-- Preflight checks. Have I:

* Added a changelog entry?
* Checked the scope to ensure the commits are only related to the goal above?

-->

- This pull request is ready for:
  - [ ] Initial review of the intended approach, not yet feature complete
  - [ ] Structural review of the classes, functions, and properties modified
  - [X] Final review

<!-- What do you need from a reviewer to get this changeset
     ready for release -->

- [ ] The correct target branch has been selected (`master` for fixes, `next` for
  features)
- [ ] Consistency across platforms for structures or concepts added or modified
- [ ] Consistency between the changeset and the goal stated above
- [ ] Internal consistency with the rest of the library - is there any overlap between existing interfaces and any which have been added?
- [ ] Usage friction - is the proposed change in usage cumbersome or complicated?
- [ ] Performance and complexity - are there any cases of unexpected O(n^3) when iterating, recursing, flat mapping, etc?
- [ ] Concurrency concerns - if components are accessed asynchronously, what issues will arise
- [ ] Thoroughness of added tests and any missing edge cases
- [ ] Idiomatic use of the language
