### PR TITLE
Update project source code organisation

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -43,6 +43,8 @@ Here’s a bit about our process designing and building the Bugsnag libraries:
 * Our open source libraries span many languages and frameworks so we strive to ensure they are idiomatic on the given platform, but also consistent in terminology between platforms. That way the core concepts are familiar whether you adopt Bugsnag for one platform or many.
 * Finally, one of our goals is to ensure our libraries work reliably, even in crashy, multi-threaded environments. Oftentimes, this requires an intensive engineering design and code review process that adheres to our style and linting guidelines.
 
+For an overview of source code organisation, see [ORGANIZATION.md](ORGANIZATION.md).
+
 ## Building
 
 Each OS version of `Bugsnag` has an Xcode project in a directory named for the

--- a/ORGANIZATION.md
+++ b/ORGANIZATION.md
@@ -1,0 +1,31 @@
+# Organization
+
+Source code is grouped into the following:
+
+## Breadcrumbs
+
+This contains classes related to breadcrumbs. Breadcrumbs are automatically/manually captured 
+
+## Client
+
+This contains classes related to `Client`. This is the main interface through which users will interact with Bugsnag, by leaving breadcrumbs, manually notifying of errors, etc.
+
+## Delivery
+
+Contains classes related to the delivery of payloads to the Bugsnag API.
+
+## Metadata
+
+Contains classes related to `Metadata`, which holds arbitrary metadata added by the user. The `Client` holds the global state of metadata, which is then copied onto each `Event` so that it can be mutated/redacted before reports are delivered to the Bugsnag API.
+
+## Payload
+
+Contains classes which model the payload sent to the Bugsnag API. These are generally structured data which the user can manipulate in callbacks.
+
+## Plugins
+
+Contains code for managing plugins, which can be instantiated and add/modify behaviour tothe notifier.
+
+## Storage
+
+Code for handling storage of error/session payloads when a network connection is not available or a request cannot be delivered. In this case a report is cached on disk so that it can be delivered in future.

--- a/OSX/Bugsnag.xcodeproj/project.pbxproj
+++ b/OSX/Bugsnag.xcodeproj/project.pbxproj
@@ -476,76 +476,32 @@
 		8A2C8FA31C6BC1F700846019 /* Bugsnag */ = {
 			isa = PBXGroup;
 			children = (
-				009DF96A2432872D000A8363 /* BugsnagMetadataStore.h */,
-				E790C46524349CE1006FFB26 /* BugsnagApp.h */,
-				E790C46924349CE2006FFB26 /* BugsnagApp.m */,
-				E790C46724349CE2006FFB26 /* BugsnagAppWithState.h */,
-				E790C46D24349CE2006FFB26 /* BugsnagAppWithState.m */,
-				E790C46A24349CE2006FFB26 /* BugsnagDevice.h */,
-				E790C46B24349CE2006FFB26 /* BugsnagDevice.m */,
-				E790C46624349CE1006FFB26 /* BugsnagDeviceWithState.h */,
-				E790C46324349CE1006FFB26 /* BugsnagDeviceWithState.m */,
-				E790C46824349CE2006FFB26 /* BugsnagError.h */,
-				E790C46424349CE1006FFB26 /* BugsnagError.m */,
-				E790C46C24349CE2006FFB26 /* BugsnagStackframe.h */,
-				E790C46224349CE1006FFB26 /* BugsnagStackframe.m */,
-				E790C46E24349CE2006FFB26 /* BugsnagThread.h */,
-				E790C46F24349CE2006FFB26 /* BugsnagThread.m */,
-				E77526BF242D0E180077A42F /* BugsnagBreadcrumbs.h */,
-				E77526BE242D0E180077A42F /* BugsnagBreadcrumbs.m */,
-				E72AE1F8241A4E7500ED8972 /* BugsnagPluginClient.h */,
-				E72AE1F7241A4E7500ED8972 /* BugsnagPluginClient.m */,
-				00D7AC9B23E97F8100FBE4A7 /* BugsnagEvent.h */,
-				00D7AC9A23E97F8100FBE4A7 /* BugsnagEvent.m */,
-				8A3C591123968B3600B344AA /* BugsnagPlugin.h */,
+				E7A9E59B243B35F400D99F8A /* Breadcrumbs */,
+				E7A9E59A243B35F100D99F8A /* Client */,
+				E7A9E599243B35EF00D99F8A /* Delivery */,
+				E7A9E5A2243B363100D99F8A /* Metadata */,
+				E7A9E5A5243B364600D99F8A /* Payload */,
+				E7A9E5A7243B365400D99F8A /* Plugins */,
+				E7A9E5A9243B365E00D99F8A /* Storage */,
+				8A87352B1C6D3B1600EDBD5B /* BSG_KSCrashReportWriter.h */,
 				8A6C6FB02257884C00E8EF24 /* BSGOutOfMemoryWatchdog.h */,
 				8A6C6FAF2257884C00E8EF24 /* BSGOutOfMemoryWatchdog.m */,
-				E791483E1FD82B35003EFEBF /* BugsnagApiClient.h */,
-				E791483D1FD82B35003EFEBF /* BugsnagApiClient.m */,
-				0089B6EA2411682000D5A7F2 /* BugsnagClient.h */,
-				0089B6E92411682000D5A7F2 /* BugsnagClient.m */,
-				E790C426243354FD006FFB26 /* BugsnagClientInternal.h */,
-				E79148401FD82B35003EFEBF /* BugsnagFileStore.h */,
-				E79148451FD82B36003EFEBF /* BugsnagFileStore.m */,
-				E79148341FD82B34003EFEBF /* BugsnagKSCrashSysInfoParser.h */,
-				E791483B1FD82B35003EFEBF /* BugsnagKSCrashSysInfoParser.m */,
-				E79148331FD82B34003EFEBF /* BugsnagSession.h */,
-				E79148441FD82B36003EFEBF /* BugsnagSession.m */,
-				E79148371FD82B34003EFEBF /* BugsnagSessionFileStore.h */,
-				E791483A1FD82B35003EFEBF /* BugsnagSessionFileStore.m */,
-				E79148391FD82B34003EFEBF /* BugsnagSessionTracker.h */,
-				E79148431FD82B36003EFEBF /* BugsnagSessionTracker.m */,
-				E79148411FD82B35003EFEBF /* BugsnagSessionTrackingApiClient.h */,
-				E79148381FD82B34003EFEBF /* BugsnagSessionTrackingApiClient.m */,
-				E79148361FD82B34003EFEBF /* BugsnagSessionTrackingPayload.h */,
-				E791483C1FD82B35003EFEBF /* BugsnagSessionTrackingPayload.m */,
-				E79148351FD82B34003EFEBF /* BugsnagUser.h */,
-				E791483F1FD82B35003EFEBF /* BugsnagUser.m */,
-				E794E8041F9F746D00A67EE7 /* BugsnagKeys.h */,
-				E762E9FA1F73F80200E82B43 /* BugsnagHandledState.h */,
-				E762E9FB1F73F80200E82B43 /* BugsnagHandledState.m */,
-				E79E6AFC1F4E3847002B35F9 /* BugsnagCrashSentry.h */,
-				E79E6AFD1F4E3847002B35F9 /* BugsnagCrashSentry.m */,
-				E79E6AFE1F4E3847002B35F9 /* BugsnagErrorReportApiClient.h */,
-				E79E6AFF1F4E3847002B35F9 /* BugsnagErrorReportApiClient.m */,
-				E72352BF1F55924A00436528 /* BSGConnectivity.h */,
-				E72352C01F55924A00436528 /* BSGConnectivity.m */,
-				8A87352B1C6D3B1600EDBD5B /* BSG_KSCrashReportWriter.h */,
-				8A2C8FBB1C6BC2C800846019 /* Bugsnag.h */,
-				8A2C8FBC1C6BC2C800846019 /* Bugsnag.m */,
-				8A2C8FBD1C6BC2C800846019 /* BugsnagBreadcrumb.h */,
-				8A2C8FBE1C6BC2C800846019 /* BugsnagBreadcrumb.m */,
-				8A48EF261EAA805D00B70024 /* BugsnagLogger.h */,
+				8A627CD71EC3B75200F7C04E /* BSGSerialization.h */,
+				8A627CD81EC3B75200F7C04E /* BSGSerialization.m */,
 				8A2C8FBF1C6BC2C800846019 /* BugsnagCollections.h */,
 				8A2C8FC01C6BC2C800846019 /* BugsnagCollections.m */,
 				8A2C8FC11C6BC2C800846019 /* BugsnagConfiguration.h */,
-				8A627CD71EC3B75200F7C04E /* BSGSerialization.h */,
-				8A627CD81EC3B75200F7C04E /* BSGSerialization.m */,
 				8A2C8FC21C6BC2C800846019 /* BugsnagConfiguration.m */,
-				8A2C8FC51C6BC2C800846019 /* BugsnagMetadata.h */,
-				8A2C8FC61C6BC2C800846019 /* BugsnagMetadata.m */,
-				8A2C8FCB1C6BC2C800846019 /* BugsnagSink.h */,
-				8A2C8FCC1C6BC2C800846019 /* BugsnagSink.m */,
+				E79E6AFC1F4E3847002B35F9 /* BugsnagCrashSentry.h */,
+				E79E6AFD1F4E3847002B35F9 /* BugsnagCrashSentry.m */,
+				E762E9FA1F73F80200E82B43 /* BugsnagHandledState.h */,
+				E762E9FB1F73F80200E82B43 /* BugsnagHandledState.m */,
+				E794E8041F9F746D00A67EE7 /* BugsnagKeys.h */,
+				E79148341FD82B34003EFEBF /* BugsnagKSCrashSysInfoParser.h */,
+				E791483B1FD82B35003EFEBF /* BugsnagKSCrashSysInfoParser.m */,
+				8A48EF261EAA805D00B70024 /* BugsnagLogger.h */,
+				E79148391FD82B34003EFEBF /* BugsnagSessionTracker.h */,
+				E79148431FD82B36003EFEBF /* BugsnagSessionTracker.m */,
 				8A2C8FA61C6BC1F700846019 /* Info.plist */,
 				8A2C902F1C6BF3AC00846019 /* module.modulemap */,
 				E79E6B081F4E3850002B35F9 /* BSG_KSCrash */,
@@ -746,6 +702,106 @@
 			name = Filters;
 			path = ../Source/KSCrash/Source/KSCrash/Reporting/Filters;
 			sourceTree = SOURCE_ROOT;
+		};
+		E7A9E599243B35EF00D99F8A /* Delivery */ = {
+			isa = PBXGroup;
+			children = (
+				E72352BF1F55924A00436528 /* BSGConnectivity.h */,
+				E72352C01F55924A00436528 /* BSGConnectivity.m */,
+				E791483E1FD82B35003EFEBF /* BugsnagApiClient.h */,
+				E791483D1FD82B35003EFEBF /* BugsnagApiClient.m */,
+				E79E6AFE1F4E3847002B35F9 /* BugsnagErrorReportApiClient.h */,
+				E79E6AFF1F4E3847002B35F9 /* BugsnagErrorReportApiClient.m */,
+				E79148411FD82B35003EFEBF /* BugsnagSessionTrackingApiClient.h */,
+				E79148381FD82B34003EFEBF /* BugsnagSessionTrackingApiClient.m */,
+				8A2C8FCB1C6BC2C800846019 /* BugsnagSink.h */,
+				8A2C8FCC1C6BC2C800846019 /* BugsnagSink.m */,
+			);
+			name = Delivery;
+			sourceTree = "<group>";
+		};
+		E7A9E59A243B35F100D99F8A /* Client */ = {
+			isa = PBXGroup;
+			children = (
+				8A2C8FBB1C6BC2C800846019 /* Bugsnag.h */,
+				8A2C8FBC1C6BC2C800846019 /* Bugsnag.m */,
+				0089B6EA2411682000D5A7F2 /* BugsnagClient.h */,
+				0089B6E92411682000D5A7F2 /* BugsnagClient.m */,
+				E790C426243354FD006FFB26 /* BugsnagClientInternal.h */,
+			);
+			name = Client;
+			sourceTree = "<group>";
+		};
+		E7A9E59B243B35F400D99F8A /* Breadcrumbs */ = {
+			isa = PBXGroup;
+			children = (
+				8A2C8FBD1C6BC2C800846019 /* BugsnagBreadcrumb.h */,
+				8A2C8FBE1C6BC2C800846019 /* BugsnagBreadcrumb.m */,
+				E77526BF242D0E180077A42F /* BugsnagBreadcrumbs.h */,
+				E77526BE242D0E180077A42F /* BugsnagBreadcrumbs.m */,
+			);
+			name = Breadcrumbs;
+			sourceTree = "<group>";
+		};
+		E7A9E5A2243B363100D99F8A /* Metadata */ = {
+			isa = PBXGroup;
+			children = (
+				8A2C8FC51C6BC2C800846019 /* BugsnagMetadata.h */,
+				8A2C8FC61C6BC2C800846019 /* BugsnagMetadata.m */,
+				009DF96A2432872D000A8363 /* BugsnagMetadataStore.h */,
+			);
+			name = Metadata;
+			sourceTree = "<group>";
+		};
+		E7A9E5A5243B364600D99F8A /* Payload */ = {
+			isa = PBXGroup;
+			children = (
+				E790C46524349CE1006FFB26 /* BugsnagApp.h */,
+				E790C46924349CE2006FFB26 /* BugsnagApp.m */,
+				E790C46D24349CE2006FFB26 /* BugsnagAppWithState.m */,
+				E790C46724349CE2006FFB26 /* BugsnagAppWithState.h */,
+				E790C46A24349CE2006FFB26 /* BugsnagDevice.h */,
+				E790C46B24349CE2006FFB26 /* BugsnagDevice.m */,
+				E790C46624349CE1006FFB26 /* BugsnagDeviceWithState.h */,
+				E790C46324349CE1006FFB26 /* BugsnagDeviceWithState.m */,
+				E790C46824349CE2006FFB26 /* BugsnagError.h */,
+				E790C46424349CE1006FFB26 /* BugsnagError.m */,
+				00D7AC9B23E97F8100FBE4A7 /* BugsnagEvent.h */,
+				00D7AC9A23E97F8100FBE4A7 /* BugsnagEvent.m */,
+				E79148331FD82B34003EFEBF /* BugsnagSession.h */,
+				E79148441FD82B36003EFEBF /* BugsnagSession.m */,
+				E79148361FD82B34003EFEBF /* BugsnagSessionTrackingPayload.h */,
+				E791483C1FD82B35003EFEBF /* BugsnagSessionTrackingPayload.m */,
+				E790C46C24349CE2006FFB26 /* BugsnagStackframe.h */,
+				E790C46224349CE1006FFB26 /* BugsnagStackframe.m */,
+				E790C46E24349CE2006FFB26 /* BugsnagThread.h */,
+				E790C46F24349CE2006FFB26 /* BugsnagThread.m */,
+				E79148351FD82B34003EFEBF /* BugsnagUser.h */,
+				E791483F1FD82B35003EFEBF /* BugsnagUser.m */,
+			);
+			name = Payload;
+			sourceTree = "<group>";
+		};
+		E7A9E5A7243B365400D99F8A /* Plugins */ = {
+			isa = PBXGroup;
+			children = (
+				8A3C591123968B3600B344AA /* BugsnagPlugin.h */,
+				E72AE1F8241A4E7500ED8972 /* BugsnagPluginClient.h */,
+				E72AE1F7241A4E7500ED8972 /* BugsnagPluginClient.m */,
+			);
+			name = Plugins;
+			sourceTree = "<group>";
+		};
+		E7A9E5A9243B365E00D99F8A /* Storage */ = {
+			isa = PBXGroup;
+			children = (
+				E79148401FD82B35003EFEBF /* BugsnagFileStore.h */,
+				E79148451FD82B36003EFEBF /* BugsnagFileStore.m */,
+				E79148371FD82B34003EFEBF /* BugsnagSessionFileStore.h */,
+				E791483A1FD82B35003EFEBF /* BugsnagSessionFileStore.m */,
+			);
+			name = Storage;
+			sourceTree = "<group>";
 		};
 		E7CE78861FD94E40001D07E0 /* KSCrash */ = {
 			isa = PBXGroup;

--- a/iOS/Bugsnag.xcodeproj/project.pbxproj
+++ b/iOS/Bugsnag.xcodeproj/project.pbxproj
@@ -282,6 +282,7 @@
 		E7433AD01F4F64D400C082D1 /* libc++.tbd in Frameworks */ = {isa = PBXBuildFile; fileRef = 8A2C8F6F1C6BBE9F00846019 /* libc++.tbd */; };
 		E7433AD11F4F64D900C082D1 /* libz.tbd in Frameworks */ = {isa = PBXBuildFile; fileRef = 8A2C8F6D1C6BBE9A00846019 /* libz.tbd */; };
 		E748DA781FD02A3F00B14909 /* BugsnagSessionFileStore.h in CopyFiles */ = {isa = PBXBuildFile; fileRef = F42955025DBE1DCEFD928CAA /* BugsnagSessionFileStore.h */; };
+		E74D8E93243B3DF000F2A630 /* ORGANIZATION.md in Resources */ = {isa = PBXBuildFile; fileRef = E74D8E92243B3DF000F2A630 /* ORGANIZATION.md */; };
 		E74EFDC21FD04B9200577D23 /* BugsnagSessionTrackingApiClient.h in CopyFiles */ = {isa = PBXBuildFile; fileRef = F429517A5571A61A897E963D /* BugsnagSessionTrackingApiClient.h */; };
 		E77316E31F73E89E00A14F06 /* BugsnagHandledStateTest.m in Sources */ = {isa = PBXBuildFile; fileRef = E77316E11F73B46600A14F06 /* BugsnagHandledStateTest.m */; };
 		E77526BA242D0AE50077A42F /* BugsnagBreadcrumbs.h in Headers */ = {isa = PBXBuildFile; fileRef = E77526B8242D0AE50077A42F /* BugsnagBreadcrumbs.h */; };
@@ -645,6 +646,7 @@
 		E737DEA01F73AD7400BC7C80 /* BugsnagHandledState.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; name = BugsnagHandledState.h; path = ../Source/BugsnagHandledState.h; sourceTree = SOURCE_ROOT; };
 		E737DEA11F73AD7400BC7C80 /* BugsnagHandledState.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; name = BugsnagHandledState.m; path = ../Source/BugsnagHandledState.m; sourceTree = SOURCE_ROOT; };
 		E7397DC41F83BAC50034242A /* libBugsnagStatic.a */ = {isa = PBXFileReference; explicitFileType = archive.ar; includeInIndex = 0; path = libBugsnagStatic.a; sourceTree = BUILT_PRODUCTS_DIR; };
+		E74D8E92243B3DF000F2A630 /* ORGANIZATION.md */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = net.daringfireball.markdown; name = ORGANIZATION.md; path = ../ORGANIZATION.md; sourceTree = "<group>"; };
 		E77316E11F73B46600A14F06 /* BugsnagHandledStateTest.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; name = BugsnagHandledStateTest.m; path = ../Tests/BugsnagHandledStateTest.m; sourceTree = SOURCE_ROOT; };
 		E77526B8242D0AE50077A42F /* BugsnagBreadcrumbs.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; name = BugsnagBreadcrumbs.h; path = ../Source/BugsnagBreadcrumbs.h; sourceTree = "<group>"; };
 		E77526B9242D0AE50077A42F /* BugsnagBreadcrumbs.m */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.objc; name = BugsnagBreadcrumbs.m; path = ../Source/BugsnagBreadcrumbs.m; sourceTree = "<group>"; };
@@ -757,6 +759,7 @@
 		8A2C8F0E1C6BBD2300846019 = {
 			isa = PBXGroup;
 			children = (
+				E74D8E92243B3DF000F2A630 /* ORGANIZATION.md */,
 				000E6EA223D8AC8C009D8194 /* CHANGELOG.md */,
 				000E6EA023D8AC8C009D8194 /* README.md */,
 				000E6E9F23D8AC8C009D8194 /* UPGRADING.md */,
@@ -1350,6 +1353,7 @@
 				000E6EA523D8AC8C009D8194 /* VERSION in Resources */,
 				000E6EA423D8AC8C009D8194 /* README.md in Resources */,
 				000E6EA323D8AC8C009D8194 /* UPGRADING.md in Resources */,
+				E74D8E93243B3DF000F2A630 /* ORGANIZATION.md in Resources */,
 				000E6EA623D8AC8C009D8194 /* CHANGELOG.md in Resources */,
 				0061D84724067AF80041C068 /* LICENSE in Resources */,
 			);

--- a/iOS/Bugsnag.xcodeproj/project.pbxproj
+++ b/iOS/Bugsnag.xcodeproj/project.pbxproj
@@ -782,81 +782,37 @@
 		8A2C8F1A1C6BBD2300846019 /* Bugsnag */ = {
 			isa = PBXGroup;
 			children = (
+				E7A9E598243B246600D99F8A /* Breadcrumbs */,
+				E7A9E587243B23FF00D99F8A /* Client */,
+				E7A9E593243B245800D99F8A /* Delivery */,
+				E7A9E58F243B242300D99F8A /* Metadata */,
+				E7A9E589243B240500D99F8A /* Payload */,
+				E7A9E588243B240300D99F8A /* Plugins */,
+				E7A9E58C243B241900D99F8A /* Storage */,
 				8A3B5F252407EC6400CE4A3A /* Private.h */,
 				E7107BD31F4C97F100BB3F98 /* BSG_KSCrashReportWriter.h */,
-				E72352B41F55718E00436528 /* BSGConnectivity.h */,
-				E72352B51F55718E00436528 /* BSGConnectivity.m */,
+				8A70D9C722539C81006B696F /* BSGOutOfMemoryWatchdog.h */,
+				8A70D9C822539C81006B696F /* BSGOutOfMemoryWatchdog.m */,
 				8A627CCF1EC2A5FD00F7C04E /* BSGSerialization.h */,
 				8A627CD11EC2A62900F7C04E /* BSGSerialization.m */,
-				8A2C8F3D1C6BBE3C00846019 /* Bugsnag.h */,
-				8A2C8F3E1C6BBE3C00846019 /* Bugsnag.m */,
-				F42950F4A741305B77E95389 /* BugsnagApiClient.h */,
-				F4295E2778677786239F2B28 /* BugsnagApiClient.m */,
-				8A2C8F3F1C6BBE3C00846019 /* BugsnagBreadcrumb.h */,
-				8A2C8F401C6BBE3C00846019 /* BugsnagBreadcrumb.m */,
-				E77526B8242D0AE50077A42F /* BugsnagBreadcrumbs.h */,
-				E77526B9242D0AE50077A42F /* BugsnagBreadcrumbs.m */,
-				8A2C8F4B1C6BBE3C00846019 /* BugsnagClient.h */,
-				8A2C8F4C1C6BBE3C00846019 /* BugsnagClient.m */,
-				E790C424243354A8006FFB26 /* BugsnagClientInternal.h */,
 				8A2C8F411C6BBE3C00846019 /* BugsnagCollections.h */,
 				8A2C8F421C6BBE3C00846019 /* BugsnagCollections.m */,
 				8A2C8F431C6BBE3C00846019 /* BugsnagConfiguration.h */,
 				8A2C8F441C6BBE3C00846019 /* BugsnagConfiguration.m */,
-				8A2C8F451C6BBE3C00846019 /* BugsnagEvent.h */,
-				8A2C8F461C6BBE3C00846019 /* BugsnagEvent.m */,
-				E790C43824349817006FFB26 /* BugsnagApp.h */,
-				E790C43924349817006FFB26 /* BugsnagApp.m */,
-				E790C43D24349831006FFB26 /* BugsnagAppWithState.h */,
-				E790C43E24349831006FFB26 /* BugsnagAppWithState.m */,
-				E790C4422434984B006FFB26 /* BugsnagDevice.h */,
-				E790C4432434984B006FFB26 /* BugsnagDevice.m */,
-				E790C4472434985D006FFB26 /* BugsnagDeviceWithState.h */,
-				E790C4482434985D006FFB26 /* BugsnagDeviceWithState.m */,
-				E790C44C24349898006FFB26 /* BugsnagError.h */,
-				E790C44D24349898006FFB26 /* BugsnagError.m */,
-				E790C451243498BB006FFB26 /* BugsnagStackframe.h */,
-				E790C452243498BB006FFB26 /* BugsnagStackframe.m */,
-				E790C45624349A28006FFB26 /* BugsnagThread.h */,
-				E790C45724349A28006FFB26 /* BugsnagThread.m */,
 				E72962D01F4BBA8A00CEA15D /* BugsnagCrashSentry.h */,
 				E72962D11F4BBA8A00CEA15D /* BugsnagCrashSentry.m */,
-				E72962D21F4BBA8B00CEA15D /* BugsnagErrorReportApiClient.h */,
-				E72962D31F4BBA8B00CEA15D /* BugsnagErrorReportApiClient.m */,
-				F42953E7E61199381E0405CC /* BugsnagFileStore.h */,
-				F42958B2E67C338E3086EAC2 /* BugsnagFileStore.m */,
 				E737DEA01F73AD7400BC7C80 /* BugsnagHandledState.h */,
 				E737DEA11F73AD7400BC7C80 /* BugsnagHandledState.m */,
 				E794E8021F9F743D00A67EE7 /* BugsnagKeys.h */,
 				E7EB06721FCDAF2000C076A6 /* BugsnagKSCrashSysInfoParser.h */,
 				E7EB06731FCDAF2000C076A6 /* BugsnagKSCrashSysInfoParser.m */,
 				8A381D491EAA49A700AF8429 /* BugsnagLogger.h */,
-				8A2C8F491C6BBE3C00846019 /* BugsnagMetadata.h */,
-				8A2C8F4A1C6BBE3C00846019 /* BugsnagMetadata.m */,
-				009DF96824327FA2000A8363 /* BugsnagMetadataStore.h */,
-				8A72A0352396535000328051 /* BugsnagPlugin.h */,
-				E72AE1F3241A4E4400ED8972 /* BugsnagPluginClient.h */,
-				E72AE1F4241A4E4400ED8972 /* BugsnagPluginClient.m */,
-				E72BF7781FC869F7004BE82F /* BugsnagSession.h */,
-				E72BF7791FC869F7004BE82F /* BugsnagSession.m */,
-				F42955025DBE1DCEFD928CAA /* BugsnagSessionFileStore.h */,
-				F42954ACC6FFDDE3C8471495 /* BugsnagSessionFileStore.m */,
 				E72BF7731FC867E4004BE82F /* BugsnagSessionTracker.h */,
 				E72BF7741FC867E4004BE82F /* BugsnagSessionTracker.m */,
-				F429517A5571A61A897E963D /* BugsnagSessionTrackingApiClient.h */,
-				F4295FBD23F478FC6216A006 /* BugsnagSessionTrackingApiClient.m */,
-				E78C1EF41FCC61EA00B976D3 /* BugsnagSessionTrackingPayload.h */,
-				E78C1EF51FCC61EA00B976D3 /* BugsnagSessionTrackingPayload.m */,
-				8A2C8F4D1C6BBE3C00846019 /* BugsnagSink.h */,
-				8A2C8F4E1C6BBE3C00846019 /* BugsnagSink.m */,
-				E72BF77D1FC86A7A004BE82F /* BugsnagUser.h */,
-				E72BF77E1FC86A7A004BE82F /* BugsnagUser.m */,
 				8A2C8F1D1C6BBD2300846019 /* Info.plist */,
 				0061D84324067AF70041C068 /* SSKeychain */,
 				E7107BB31F4C97F100BB3F98 /* KSCrash */,
 				8A2C8F321C6BBD7200846019 /* module.modulemap */,
-				8A70D9C722539C81006B696F /* BSGOutOfMemoryWatchdog.h */,
-				8A70D9C822539C81006B696F /* BSGOutOfMemoryWatchdog.m */,
 			);
 			name = Bugsnag;
 			sourceTree = SOURCE_ROOT;
@@ -1092,6 +1048,106 @@
 				E7107C1D1F4C97F100BB3F98 /* BSG_KSCrashReportFilterCompletion.h */,
 			);
 			path = Filters;
+			sourceTree = "<group>";
+		};
+		E7A9E587243B23FF00D99F8A /* Client */ = {
+			isa = PBXGroup;
+			children = (
+				8A2C8F3D1C6BBE3C00846019 /* Bugsnag.h */,
+				8A2C8F3E1C6BBE3C00846019 /* Bugsnag.m */,
+				8A2C8F4B1C6BBE3C00846019 /* BugsnagClient.h */,
+				8A2C8F4C1C6BBE3C00846019 /* BugsnagClient.m */,
+				E790C424243354A8006FFB26 /* BugsnagClientInternal.h */,
+			);
+			name = Client;
+			sourceTree = "<group>";
+		};
+		E7A9E588243B240300D99F8A /* Plugins */ = {
+			isa = PBXGroup;
+			children = (
+				8A72A0352396535000328051 /* BugsnagPlugin.h */,
+				E72AE1F3241A4E4400ED8972 /* BugsnagPluginClient.h */,
+				E72AE1F4241A4E4400ED8972 /* BugsnagPluginClient.m */,
+			);
+			name = Plugins;
+			sourceTree = "<group>";
+		};
+		E7A9E589243B240500D99F8A /* Payload */ = {
+			isa = PBXGroup;
+			children = (
+				8A2C8F451C6BBE3C00846019 /* BugsnagEvent.h */,
+				8A2C8F461C6BBE3C00846019 /* BugsnagEvent.m */,
+				E790C43824349817006FFB26 /* BugsnagApp.h */,
+				E790C43924349817006FFB26 /* BugsnagApp.m */,
+				E790C43D24349831006FFB26 /* BugsnagAppWithState.h */,
+				E790C43E24349831006FFB26 /* BugsnagAppWithState.m */,
+				E790C4422434984B006FFB26 /* BugsnagDevice.h */,
+				E790C4432434984B006FFB26 /* BugsnagDevice.m */,
+				E790C4472434985D006FFB26 /* BugsnagDeviceWithState.h */,
+				E790C4482434985D006FFB26 /* BugsnagDeviceWithState.m */,
+				E790C44C24349898006FFB26 /* BugsnagError.h */,
+				E790C44D24349898006FFB26 /* BugsnagError.m */,
+				E72BF7781FC869F7004BE82F /* BugsnagSession.h */,
+				E72BF7791FC869F7004BE82F /* BugsnagSession.m */,
+				E78C1EF41FCC61EA00B976D3 /* BugsnagSessionTrackingPayload.h */,
+				E78C1EF51FCC61EA00B976D3 /* BugsnagSessionTrackingPayload.m */,
+				E790C451243498BB006FFB26 /* BugsnagStackframe.h */,
+				E790C452243498BB006FFB26 /* BugsnagStackframe.m */,
+				E790C45624349A28006FFB26 /* BugsnagThread.h */,
+				E790C45724349A28006FFB26 /* BugsnagThread.m */,
+				E72BF77D1FC86A7A004BE82F /* BugsnagUser.h */,
+				E72BF77E1FC86A7A004BE82F /* BugsnagUser.m */,
+			);
+			name = Payload;
+			sourceTree = "<group>";
+		};
+		E7A9E58C243B241900D99F8A /* Storage */ = {
+			isa = PBXGroup;
+			children = (
+				F42953E7E61199381E0405CC /* BugsnagFileStore.h */,
+				F42958B2E67C338E3086EAC2 /* BugsnagFileStore.m */,
+				F42955025DBE1DCEFD928CAA /* BugsnagSessionFileStore.h */,
+				F42954ACC6FFDDE3C8471495 /* BugsnagSessionFileStore.m */,
+			);
+			name = Storage;
+			sourceTree = "<group>";
+		};
+		E7A9E58F243B242300D99F8A /* Metadata */ = {
+			isa = PBXGroup;
+			children = (
+				8A2C8F491C6BBE3C00846019 /* BugsnagMetadata.h */,
+				8A2C8F4A1C6BBE3C00846019 /* BugsnagMetadata.m */,
+				009DF96824327FA2000A8363 /* BugsnagMetadataStore.h */,
+			);
+			name = Metadata;
+			sourceTree = "<group>";
+		};
+		E7A9E593243B245800D99F8A /* Delivery */ = {
+			isa = PBXGroup;
+			children = (
+				E72352B41F55718E00436528 /* BSGConnectivity.h */,
+				E72352B51F55718E00436528 /* BSGConnectivity.m */,
+				F42950F4A741305B77E95389 /* BugsnagApiClient.h */,
+				F4295E2778677786239F2B28 /* BugsnagApiClient.m */,
+				E72962D21F4BBA8B00CEA15D /* BugsnagErrorReportApiClient.h */,
+				E72962D31F4BBA8B00CEA15D /* BugsnagErrorReportApiClient.m */,
+				F429517A5571A61A897E963D /* BugsnagSessionTrackingApiClient.h */,
+				F4295FBD23F478FC6216A006 /* BugsnagSessionTrackingApiClient.m */,
+				8A2C8F4D1C6BBE3C00846019 /* BugsnagSink.h */,
+				8A2C8F4E1C6BBE3C00846019 /* BugsnagSink.m */,
+			);
+			name = Delivery;
+			sourceTree = "<group>";
+		};
+		E7A9E598243B246600D99F8A /* Breadcrumbs */ = {
+			isa = PBXGroup;
+			children = (
+				8A2C8F3F1C6BBE3C00846019 /* BugsnagBreadcrumb.h */,
+				8A2C8F401C6BBE3C00846019 /* BugsnagBreadcrumb.m */,
+				E77526B8242D0AE50077A42F /* BugsnagBreadcrumbs.h */,
+				E77526B9242D0AE50077A42F /* BugsnagBreadcrumbs.m */,
+			);
+			name = Breadcrumbs;
 			sourceTree = "<group>";
 		};
 /* End PBXGroup section */

--- a/tvOS/Bugsnag.xcodeproj/project.pbxproj
+++ b/tvOS/Bugsnag.xcodeproj/project.pbxproj
@@ -361,7 +361,7 @@
 		E76617671F4E459C0094CECF /* BSG_KSCrashReportFilterCompletion.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; name = BSG_KSCrashReportFilterCompletion.h; path = ../Source/KSCrash/Source/KSCrash/Reporting/Filters/BSG_KSCrashReportFilterCompletion.h; sourceTree = SOURCE_ROOT; };
 		E77526C2242D0E3A0077A42F /* BugsnagBreadcrumbs.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; name = BugsnagBreadcrumbs.m; path = ../Source/BugsnagBreadcrumbs.m; sourceTree = "<group>"; };
 		E77526C3242D0E3A0077A42F /* BugsnagBreadcrumbs.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; name = BugsnagBreadcrumbs.h; path = ../Source/BugsnagBreadcrumbs.h; sourceTree = "<group>"; };
-		E77526C6242E694C0077A42F /* BugsnagOnBreadcrumbTest.m */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.objc; name = BugsnagOnBreadcrumbTest.m; path = ../Tests/BugsnagOnBreadcrumbTest.m; sourceTree = "<group>"; };
+		E77526C6242E694C0077A42F /* BugsnagOnBreadcrumbTest.m */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.objc; name = BugsnagOnBreadcrumbTest.m; path = ../../Tests/BugsnagOnBreadcrumbTest.m; sourceTree = "<group>"; };
 		E790C421243231EA006FFB26 /* BugsnagClientMirrorTest.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; name = BugsnagClientMirrorTest.m; path = ../../Tests/BugsnagClientMirrorTest.m; sourceTree = "<group>"; };
 		E790C4282433551D006FFB26 /* BugsnagClientInternal.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; name = BugsnagClientInternal.h; path = ../Source/BugsnagClientInternal.h; sourceTree = "<group>"; };
 		E790C47E24349D33006FFB26 /* BugsnagApp.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; name = BugsnagApp.h; path = ../Source/BugsnagApp.h; sourceTree = "<group>"; };
@@ -462,8 +462,6 @@
 		8A8D511A1D41343500D33797 = {
 			isa = PBXGroup;
 			children = (
-				009DF96C2432876C000A8363 /* BugsnagMetadataStore.h */,
-				E77526C6242E694C0077A42F /* BugsnagOnBreadcrumbTest.m */,
 				8A8D51261D41343500D33797 /* tvOS */,
 				8AB151131D41356800C9B218 /* Tests */,
 				8A8D51251D41343500D33797 /* Products */,
@@ -484,75 +482,32 @@
 		8A8D51261D41343500D33797 /* tvOS */ = {
 			isa = PBXGroup;
 			children = (
-				E790C47E24349D33006FFB26 /* BugsnagApp.h */,
-				E790C48224349D34006FFB26 /* BugsnagApp.m */,
-				E790C48824349D34006FFB26 /* BugsnagAppWithState.h */,
-				E790C48B24349D35006FFB26 /* BugsnagAppWithState.m */,
-				E790C48324349D34006FFB26 /* BugsnagDevice.h */,
-				E790C48A24349D34006FFB26 /* BugsnagDevice.m */,
-				E790C48924349D34006FFB26 /* BugsnagDeviceWithState.h */,
-				E790C48624349D34006FFB26 /* BugsnagDeviceWithState.m */,
-				E790C47F24349D33006FFB26 /* BugsnagError.h */,
-				E790C48724349D34006FFB26 /* BugsnagError.m */,
-				E790C48524349D34006FFB26 /* BugsnagStackframe.h */,
-				E790C48124349D34006FFB26 /* BugsnagStackframe.m */,
-				E790C48424349D34006FFB26 /* BugsnagThread.h */,
-				E790C48024349D33006FFB26 /* BugsnagThread.m */,
-				E790C4282433551D006FFB26 /* BugsnagClientInternal.h */,
-				E77526C3242D0E3A0077A42F /* BugsnagBreadcrumbs.h */,
-				E77526C2242D0E3A0077A42F /* BugsnagBreadcrumbs.m */,
-				E72AE1FB241A4ED600ED8972 /* BugsnagPluginClient.h */,
-				E72AE1FC241A4ED600ED8972 /* BugsnagPluginClient.m */,
-				0089B6ED241168CB00D5A7F2 /* BugsnagClient.h */,
-				0089B6EE241168CB00D5A7F2 /* BugsnagClient.m */,
-				00D7AC9F23E97FBD00FBE4A7 /* BugsnagEvent.h */,
-				00D7AC9E23E97FBD00FBE4A7 /* BugsnagEvent.m */,
-				8A3C590F23968B2000B344AA /* BugsnagPlugin.h */,
+				E74D8E8C243B38AE00F2A630 /* Breadcrumbs */,
+				E74D8E88243B38A100F2A630 /* Client */,
+				E74D8E85243B389800F2A630 /* Delivery */,
+				E74D8E83243B389300F2A630 /* Metadata */,
+				E74D8E82243B389000F2A630 /* Payload */,
+				E74D8E81243B388E00F2A630 /* Plugins */,
+				E74D8E91243B38E200F2A630 /* Storage */,
+				8AB151251D41366400C9B218 /* BSG_KSCrashReportWriter.h */,
 				8A6C6FAC2257882400E8EF24 /* BSGOutOfMemoryWatchdog.h */,
 				8A6C6FAB2257882400E8EF24 /* BSGOutOfMemoryWatchdog.m */,
-				E791486F1FD82E6C003EFEBF /* BugsnagApiClient.h */,
-				E791486E1FD82E6B003EFEBF /* BugsnagApiClient.m */,
-				E79148711FD82E6C003EFEBF /* BugsnagFileStore.h */,
-				E79148761FD82E6C003EFEBF /* BugsnagFileStore.m */,
-				E79148651FD82E6A003EFEBF /* BugsnagKSCrashSysInfoParser.h */,
-				E791486C1FD82E6B003EFEBF /* BugsnagKSCrashSysInfoParser.m */,
-				E79148641FD82E6A003EFEBF /* BugsnagSession.h */,
-				E79148751FD82E6C003EFEBF /* BugsnagSession.m */,
-				E79148681FD82E6B003EFEBF /* BugsnagSessionFileStore.h */,
-				E791486B1FD82E6B003EFEBF /* BugsnagSessionFileStore.m */,
-				E791486A1FD82E6B003EFEBF /* BugsnagSessionTracker.h */,
-				E79148741FD82E6C003EFEBF /* BugsnagSessionTracker.m */,
-				E79148721FD82E6C003EFEBF /* BugsnagSessionTrackingApiClient.h */,
-				E79148691FD82E6B003EFEBF /* BugsnagSessionTrackingApiClient.m */,
-				E79148671FD82E6A003EFEBF /* BugsnagSessionTrackingPayload.h */,
-				E791486D1FD82E6B003EFEBF /* BugsnagSessionTrackingPayload.m */,
-				E79148661FD82E6A003EFEBF /* BugsnagUser.h */,
-				E79148701FD82E6C003EFEBF /* BugsnagUser.m */,
-				E794E8061F9F748100A67EE7 /* BugsnagKeys.h */,
-				E762E9F21F73F6DE00E82B43 /* BugsnagHandledState.h */,
-				E762E9F31F73F6DE00E82B43 /* BugsnagHandledState.m */,
-				E76616F11F4E45950094CECF /* BugsnagCrashSentry.h */,
-				E76616F21F4E45950094CECF /* BugsnagCrashSentry.m */,
-				E76616F31F4E45950094CECF /* BugsnagErrorReportApiClient.h */,
-				E76616F41F4E45950094CECF /* BugsnagErrorReportApiClient.m */,
-				E72352BB1F55923700436528 /* BSGConnectivity.h */,
-				E72352BC1F55923700436528 /* BSGConnectivity.m */,
-				8AB151251D41366400C9B218 /* BSG_KSCrashReportWriter.h */,
-				8AB151261D41366400C9B218 /* Bugsnag.h */,
-				8AB151271D41366400C9B218 /* Bugsnag.m */,
-				8AB151281D41366400C9B218 /* BugsnagBreadcrumb.h */,
-				8AB151291D41366400C9B218 /* BugsnagBreadcrumb.m */,
 				8A627CD31EC3B69300F7C04E /* BSGSerialization.h */,
 				8A627CD41EC3B69300F7C04E /* BSGSerialization.m */,
 				8AB1512A1D41366400C9B218 /* BugsnagCollections.h */,
 				8AB1512B1D41366400C9B218 /* BugsnagCollections.m */,
-				8A48EF281EAA824100B70024 /* BugsnagLogger.h */,
 				8AB1512C1D41366400C9B218 /* BugsnagConfiguration.h */,
 				8AB1512D1D41366400C9B218 /* BugsnagConfiguration.m */,
-				8AB151301D41366400C9B218 /* BugsnagMetadata.h */,
-				8AB151311D41366400C9B218 /* BugsnagMetadata.m */,
-				8AB151341D41366400C9B218 /* BugsnagSink.h */,
-				8AB151351D41366400C9B218 /* BugsnagSink.m */,
+				E76616F11F4E45950094CECF /* BugsnagCrashSentry.h */,
+				E76616F21F4E45950094CECF /* BugsnagCrashSentry.m */,
+				E762E9F21F73F6DE00E82B43 /* BugsnagHandledState.h */,
+				E762E9F31F73F6DE00E82B43 /* BugsnagHandledState.m */,
+				E794E8061F9F748100A67EE7 /* BugsnagKeys.h */,
+				E79148651FD82E6A003EFEBF /* BugsnagKSCrashSysInfoParser.h */,
+				E791486C1FD82E6B003EFEBF /* BugsnagKSCrashSysInfoParser.m */,
+				8A48EF281EAA824100B70024 /* BugsnagLogger.h */,
+				E791486A1FD82E6B003EFEBF /* BugsnagSessionTracker.h */,
+				E79148741FD82E6C003EFEBF /* BugsnagSessionTracker.m */,
 				8A8D51291D41343500D33797 /* Info.plist */,
 				004A41E623FEDF9E0092DF97 /* SSKeychain */,
 				E76616FD1F4E459C0094CECF /* BSG_KSCrash */,
@@ -563,33 +518,34 @@
 		8AB151131D41356800C9B218 /* Tests */ = {
 			isa = PBXGroup;
 			children = (
+				E7CE78D71FD94EF1001D07E0 /* KSCrash */,
+				4B3CD2B722C5676700DBFF33 /* BSGOutOfMemoryWatchdogTests.m */,
 				E790C4A02434CB5B006FFB26 /* BugsnagAppTest.m */,
-				E790C421243231EA006FFB26 /* BugsnagClientMirrorTest.m */,
-				00F9393D23FD2DDB008C7073 /* BugsnagTestsDummyClass.h */,
-				00F9393E23FD2DDB008C7073 /* BugsnagTestsDummyClass.m */,
 				00F9393423FC16DA008C7073 /* BugsnagBaseUnitTest.h */,
 				00F9393523FC16DA008C7073 /* BugsnagBaseUnitTest.m */,
-				00D7ACA923E98A9A00FBE4A7 /* BugsnagEventFromKSCrashReportTest.m */,
-				00D7ACA823E98A9A00FBE4A7 /* TestConstants.m */,
-				00D7ACA623E98A5D00FBE4A7 /* BugsnagEventTests.m */,
-				00D7ACA523E98A5D00FBE4A7 /* BugsnagTestConstants.h */,
-				E7CE78D71FD94EF1001D07E0 /* KSCrash */,
+				8AB1511D1D41361700C9B218 /* BugsnagBreadcrumbsTest.m */,
+				E790C421243231EA006FFB26 /* BugsnagClientMirrorTest.m */,
 				4B406C1322CAD94100464D1D /* BugsnagCollectionsBSGDictMergeTest.m */,
 				4B406C1222CAD94100464D1D /* BugsnagCollectionsBSGDictSetSafeObjectTest.m */,
 				4B775FD022CBE01F004839C5 /* BugsnagCollectionsBSGDictInsertIfNotNilTest.m */,
+				8AD9FA8B1E0863A1002859A7 /* BugsnagConfigurationTests.m */,
+				00D7ACA623E98A5D00FBE4A7 /* BugsnagEventTests.m */,
+				00D7ACA923E98A9A00FBE4A7 /* BugsnagEventFromKSCrashReportTest.m */,
+				E762E9EE1F73F6CF00E82B43 /* BugsnagHandledStateTest.m */,
+				E77526C6242E694C0077A42F /* BugsnagOnBreadcrumbTest.m */,
+				00D7ACA523E98A5D00FBE4A7 /* BugsnagTestConstants.h */,
 				E791488C1FD82E77003EFEBF /* BugsnagSessionTest.m */,
 				E791488A1FD82E77003EFEBF /* BugsnagSessionTrackerTest.m */,
 				E791488B1FD82E77003EFEBF /* BugsnagSessionTrackingPayloadTest.m */,
-				E791488D1FD82E77003EFEBF /* BugsnagUserTest.m */,
-				E762E9EE1F73F6CF00E82B43 /* BugsnagHandledStateTest.m */,
-				8AD9FA8B1E0863A1002859A7 /* BugsnagConfigurationTests.m */,
-				8AB1511D1D41361700C9B218 /* BugsnagBreadcrumbsTest.m */,
 				8AB1511F1D41361700C9B218 /* BugsnagSinkTests.m */,
-				8AB151201D41361700C9B218 /* report.json */,
-				8AB151161D41356800C9B218 /* TestsInfo.plist */,
-				4B3CD2B722C5676700DBFF33 /* BSGOutOfMemoryWatchdogTests.m */,
+				E791488D1FD82E77003EFEBF /* BugsnagUserTest.m */,
+				00F9393D23FD2DDB008C7073 /* BugsnagTestsDummyClass.h */,
+				00F9393E23FD2DDB008C7073 /* BugsnagTestsDummyClass.m */,
 				4B3CD2B922C5676700DBFF33 /* BugsnagThreadTest.m */,
 				4B3CD2BA22C5676800DBFF33 /* RegisterErrorDataTest.m */,
+				00D7ACA823E98A9A00FBE4A7 /* TestConstants.m */,
+				8AB151201D41361700C9B218 /* report.json */,
+				8AB151161D41356800C9B218 /* TestsInfo.plist */,
 			);
 			path = Tests;
 			sourceTree = "<group>";
@@ -610,6 +566,106 @@
 				E7433AD51F4F650C00C082D1 /* libc++.tbd */,
 			);
 			name = Frameworks;
+			sourceTree = "<group>";
+		};
+		E74D8E81243B388E00F2A630 /* Plugins */ = {
+			isa = PBXGroup;
+			children = (
+				8A3C590F23968B2000B344AA /* BugsnagPlugin.h */,
+				E72AE1FB241A4ED600ED8972 /* BugsnagPluginClient.h */,
+				E72AE1FC241A4ED600ED8972 /* BugsnagPluginClient.m */,
+			);
+			name = Plugins;
+			sourceTree = "<group>";
+		};
+		E74D8E82243B389000F2A630 /* Payload */ = {
+			isa = PBXGroup;
+			children = (
+				E790C47E24349D33006FFB26 /* BugsnagApp.h */,
+				E790C48224349D34006FFB26 /* BugsnagApp.m */,
+				E790C48824349D34006FFB26 /* BugsnagAppWithState.h */,
+				E790C48B24349D35006FFB26 /* BugsnagAppWithState.m */,
+				E790C48324349D34006FFB26 /* BugsnagDevice.h */,
+				E790C48A24349D34006FFB26 /* BugsnagDevice.m */,
+				E790C48924349D34006FFB26 /* BugsnagDeviceWithState.h */,
+				E790C48624349D34006FFB26 /* BugsnagDeviceWithState.m */,
+				E790C47F24349D33006FFB26 /* BugsnagError.h */,
+				E790C48724349D34006FFB26 /* BugsnagError.m */,
+				00D7AC9F23E97FBD00FBE4A7 /* BugsnagEvent.h */,
+				00D7AC9E23E97FBD00FBE4A7 /* BugsnagEvent.m */,
+				E79148641FD82E6A003EFEBF /* BugsnagSession.h */,
+				E79148751FD82E6C003EFEBF /* BugsnagSession.m */,
+				E79148671FD82E6A003EFEBF /* BugsnagSessionTrackingPayload.h */,
+				E791486D1FD82E6B003EFEBF /* BugsnagSessionTrackingPayload.m */,
+				E790C48524349D34006FFB26 /* BugsnagStackframe.h */,
+				E790C48124349D34006FFB26 /* BugsnagStackframe.m */,
+				E790C48424349D34006FFB26 /* BugsnagThread.h */,
+				E790C48024349D33006FFB26 /* BugsnagThread.m */,
+				E79148661FD82E6A003EFEBF /* BugsnagUser.h */,
+				E79148701FD82E6C003EFEBF /* BugsnagUser.m */,
+			);
+			name = Payload;
+			sourceTree = "<group>";
+		};
+		E74D8E83243B389300F2A630 /* Metadata */ = {
+			isa = PBXGroup;
+			children = (
+				8AB151301D41366400C9B218 /* BugsnagMetadata.h */,
+				8AB151311D41366400C9B218 /* BugsnagMetadata.m */,
+				009DF96C2432876C000A8363 /* BugsnagMetadataStore.h */,
+			);
+			name = Metadata;
+			sourceTree = "<group>";
+		};
+		E74D8E85243B389800F2A630 /* Delivery */ = {
+			isa = PBXGroup;
+			children = (
+				E72352BB1F55923700436528 /* BSGConnectivity.h */,
+				E72352BC1F55923700436528 /* BSGConnectivity.m */,
+				E791486F1FD82E6C003EFEBF /* BugsnagApiClient.h */,
+				E791486E1FD82E6B003EFEBF /* BugsnagApiClient.m */,
+				E76616F31F4E45950094CECF /* BugsnagErrorReportApiClient.h */,
+				E76616F41F4E45950094CECF /* BugsnagErrorReportApiClient.m */,
+				E79148721FD82E6C003EFEBF /* BugsnagSessionTrackingApiClient.h */,
+				E79148691FD82E6B003EFEBF /* BugsnagSessionTrackingApiClient.m */,
+				8AB151341D41366400C9B218 /* BugsnagSink.h */,
+				8AB151351D41366400C9B218 /* BugsnagSink.m */,
+			);
+			name = Delivery;
+			sourceTree = "<group>";
+		};
+		E74D8E88243B38A100F2A630 /* Client */ = {
+			isa = PBXGroup;
+			children = (
+				8AB151261D41366400C9B218 /* Bugsnag.h */,
+				8AB151271D41366400C9B218 /* Bugsnag.m */,
+				0089B6ED241168CB00D5A7F2 /* BugsnagClient.h */,
+				0089B6EE241168CB00D5A7F2 /* BugsnagClient.m */,
+				E790C4282433551D006FFB26 /* BugsnagClientInternal.h */,
+			);
+			name = Client;
+			sourceTree = "<group>";
+		};
+		E74D8E8C243B38AE00F2A630 /* Breadcrumbs */ = {
+			isa = PBXGroup;
+			children = (
+				8AB151281D41366400C9B218 /* BugsnagBreadcrumb.h */,
+				8AB151291D41366400C9B218 /* BugsnagBreadcrumb.m */,
+				E77526C3242D0E3A0077A42F /* BugsnagBreadcrumbs.h */,
+				E77526C2242D0E3A0077A42F /* BugsnagBreadcrumbs.m */,
+			);
+			name = Breadcrumbs;
+			sourceTree = "<group>";
+		};
+		E74D8E91243B38E200F2A630 /* Storage */ = {
+			isa = PBXGroup;
+			children = (
+				E79148711FD82E6C003EFEBF /* BugsnagFileStore.h */,
+				E79148761FD82E6C003EFEBF /* BugsnagFileStore.m */,
+				E79148681FD82E6B003EFEBF /* BugsnagSessionFileStore.h */,
+				E791486B1FD82E6B003EFEBF /* BugsnagSessionFileStore.m */,
+			);
+			name = Storage;
 			sourceTree = "<group>";
 		};
 		E76616FD1F4E459C0094CECF /* BSG_KSCrash */ = {


### PR DESCRIPTION
Updates the source code organisation to use groups in the iOS project.

This makes the files a bit easier to browse as they previously wouldn't fit on the screen. Logical ordering should also make it easier to find the necessary file.

A brief amount of documentation on how the files have been grouped has also been added.