### PR TITLE
(fix) Automatic session reporting now correctly records a new session…

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,10 @@ Changelog
 * Added several additional event fields (`codeBundleId`, `osName`, `modelNumber`, 
   `locale`) that were missing from the OOM reports.
   [#444](https://github.com/bugsnag/bugsnag-cocoa/pull/444)
+  
+* Bugsnag now correctly records a new session if it is returning to the foreground 
+  after more than 60 seconds in the background.
+  [#529](https://github.com/bugsnag/bugsnag-cocoa/pull/529)
 
 ## 5.23.0 (2019-12-10)
 

--- a/Source/BugsnagNotifier.m
+++ b/Source/BugsnagNotifier.m
@@ -471,7 +471,7 @@ NSString *const kAppWillTerminate = @"App Will Terminate";
 
     #if TARGET_OS_TV || TARGET_IPHONE_SIMULATOR || TARGET_OS_IPHONE
     foregroundName = UIApplicationWillEnterForegroundNotification;
-    backgroundName = UIApplicationWillEnterForegroundNotification;
+    backgroundName = UIApplicationDidEnterBackgroundNotification;
     #elif TARGET_OS_MAC
     foregroundName = NSApplicationWillBecomeActiveNotification;
     backgroundName = NSApplicationDidFinishLaunchingNotification;

--- a/features/fixtures/ios-swift-cocoapods/iOSTestApp.xcodeproj/project.pbxproj
+++ b/features/fixtures/ios-swift-cocoapods/iOSTestApp.xcodeproj/project.pbxproj
@@ -7,6 +7,7 @@
 	objects = {
 
 /* Begin PBXBuildFile section */
+		001E5502243B8FDA0009E31D /* AutoCaptureRunScenario.m in Sources */ = {isa = PBXBuildFile; fileRef = 001E5501243B8FDA0009E31D /* AutoCaptureRunScenario.m */; };
 		8A14F0F52282D4AE00337B05 /* ReportBackgroundOOMsEnabledScenario.m in Sources */ = {isa = PBXBuildFile; fileRef = 8A14F0F02282D4AD00337B05 /* ReportBackgroundOOMsEnabledScenario.m */; };
 		8A14F0F62282D4AE00337B05 /* ReportOOMsDisabledScenario.m in Sources */ = {isa = PBXBuildFile; fileRef = 8A14F0F22282D4AD00337B05 /* ReportOOMsDisabledScenario.m */; };
 		8A14F0F72282D4AE00337B05 /* ReportOOMsDisabledReportBackgroundOOMsEnabledScenario.m in Sources */ = {isa = PBXBuildFile; fileRef = 8A14F0F32282D4AE00337B05 /* ReportOOMsDisabledReportBackgroundOOMsEnabledScenario.m */; };
@@ -70,6 +71,8 @@
 /* End PBXBuildFile section */
 
 /* Begin PBXFileReference section */
+		001E5500243B7D290009E31D /* AutoCaptureRunScenario.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; path = AutoCaptureRunScenario.h; sourceTree = "<group>"; };
+		001E5501243B8FDA0009E31D /* AutoCaptureRunScenario.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; path = AutoCaptureRunScenario.m; sourceTree = "<group>"; };
 		4994F05E0421A0B037DD2CC5 /* Pods_iOSTestApp.framework */ = {isa = PBXFileReference; explicitFileType = wrapper.framework; includeInIndex = 0; path = Pods_iOSTestApp.framework; sourceTree = BUILT_PRODUCTS_DIR; };
 		8A14F0EF2282D4AD00337B05 /* ReportOOMsDisabledReportBackgroundOOMsEnabledScenario.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = ReportOOMsDisabledReportBackgroundOOMsEnabledScenario.h; sourceTree = "<group>"; };
 		8A14F0F02282D4AD00337B05 /* ReportBackgroundOOMsEnabledScenario.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; path = ReportBackgroundOOMsEnabledScenario.m; sourceTree = "<group>"; };
@@ -338,6 +341,8 @@
 				8A72A0372396574F00328051 /* CustomPluginNotifierDescriptionScenario.m */,
 				8AA05A2D23BE700C00C7AD00 /* ManyConcurrentNotifyNoBackgroundThreads.h */,
 				8AA05A2E23BE700C00C7AD00 /* ManyConcurrentNotifyNoBackgroundThreads.m */,
+				001E5501243B8FDA0009E31D /* AutoCaptureRunScenario.m */,
+				001E5500243B7D290009E31D /* AutoCaptureRunScenario.h */,
 			);
 			path = scenarios;
 			sourceTree = "<group>";
@@ -488,6 +493,7 @@
 				8A22FC66225B598500CA8895 /* OOMScenario.m in Sources */,
 				F42953498545B853CC0B635E /* NullPointerScenario.m in Sources */,
 				8A840FBA21AF5C450041DBFA /* SwiftAssertion.swift in Sources */,
+				001E5502243B8FDA0009E31D /* AutoCaptureRunScenario.m in Sources */,
 				F429538D8941382EC2C857CE /* AsyncSafeThreadScenario.m in Sources */,
 				F42955869D33EE0E510B9651 /* ReadGarbagePointerScenario.m in Sources */,
 				8AEFC73420F8D1BB00A78779 /* ManualSessionWithUserScenario.m in Sources */,

--- a/features/fixtures/ios-swift-cocoapods/iOSTestApp/scenarios/AutoCaptureRunScenario.h
+++ b/features/fixtures/ios-swift-cocoapods/iOSTestApp/scenarios/AutoCaptureRunScenario.h
@@ -1,0 +1,18 @@
+//
+//  AutoCaptureRunScenario.h
+//  iOSTestApp
+//
+//  Created by Robin Macharg on 06/04/2020.
+//  Copyright © 2020 Bugsnag. All rights reserved.
+//
+
+#ifndef AutoCaptureRunScenario_h
+#define AutoCaptureRunScenario_h
+
+#import "Scenario.h"
+
+@interface AutoCaptureRunScenario : Scenario
+
+@end
+
+#endif /* AutoCaptureRunScenario_h */

--- a/features/fixtures/ios-swift-cocoapods/iOSTestApp/scenarios/AutoCaptureRunScenario.m
+++ b/features/fixtures/ios-swift-cocoapods/iOSTestApp/scenarios/AutoCaptureRunScenario.m
@@ -1,0 +1,20 @@
+//
+//  AutoCaptureRunScenario.m
+//  iOSTestApp
+//
+//  Created by Robin Macharg on 06/04/2020.
+//  Copyright © 2020 Bugsnag. All rights reserved.
+//
+
+#import "AutoCaptureRunScenario.h"
+
+@implementation AutoCaptureRunScenario
+
+- (void)startBugsnag {
+    self.config.shouldAutoCaptureSessions = YES;
+    [super startBugsnag];
+}
+
+- (void)run {}
+
+@end

--- a/features/scripts/foreground_ios_app.sh
+++ b/features/scripts/foreground_ios_app.sh
@@ -1,0 +1,8 @@
+#!/usr/bin/env bash
+
+# Bring a previously running app to the foreground
+
+xcrun simctl launch "$iOS_Simulator" com.bugsnag.iOSTestApp \
+        "EVENT_TYPE=AutoCaptureRunScenario" \
+        "BUGSNAG_API_KEY=$BUGSNAG_API_KEY" \
+        "MOCK_API_PATH=http://localhost:$MOCK_API_PORT"

--- a/features/session_tracking.feature
+++ b/features/session_tracking.feature
@@ -146,3 +146,20 @@ Scenario: Encountering handled and unhandled events during a session
     And the payload field "events.2.session.id" of request 2 equals the payload field "sessions.0.id" of request 0
     And the payload field "events.0.session.id" of request 2 does not equal the payload field "sessions.1.id" of request 0
 
+Scenario: Backgrounding an app for more than a minute causes a new session to start on re-foregrounding it
+    Given I set environment variable "BUGSNAG_API_KEY" to "a35a2a72bd230ac0aa0f52715bbdc6aa"
+    When I run "AutoCaptureRunScenario"
+    And I wait for 1 request
+    Then request 0 is valid for the session tracking API
+    And the payload field "sessions" is an array with 1 element for request 0
+    
+    Then I put the app in the background
+    And I wait for 70 seconds
+    
+    Then I bring the app to the foreground
+    # cummulative
+    And I wait for 2 requests
+    Then request 1 is valid for the session tracking API
+    And the payload field "sessions" is an array with 1 element for request 1
+    And the payload field "sessions.0.id" of request 0 does not equal the payload field "sessions.0.id" of request 1
+    

--- a/features/steps/ios_steps.rb
+++ b/features/steps/ios_steps.rb
@@ -51,6 +51,12 @@ When("I put the app in the background") do
   }
 end
 
+When("I bring the app to the foreground") do
+  steps %Q{
+    When I run the script "features/scripts/foreground_ios_app.sh" synchronously
+  }
+end
+
 Then("each event in the payload for request {int} matches one of:") do |request_index, table|
   # Checks string equality of event fields against values
   events = read_key_path(find_request(request_index)[:body], "events")


### PR DESCRIPTION
… if returning to the foreground after more than 60 seconds

## Goal

#521 highlighted a copy-and-paste error in the event listening code that meant that apps returning to the foreground after more than 60 seconds were not correctly reporting that as the start of a new session.  This PR fixes that.

<!-- What is the intent of this change? -->

<!--
Fixes #
Related to #
-->

## Design

<!-- How does this change work? Why was this approach to the goal used? -->

A single wrong notification name in `BugsnagNotifier` needed corrected.

## Tests

An end-to-end test has been added that ensures that after an appropriate sequence of foreground/background changes an app reports two sessions with differing ids.

## Review

### Outstanding Questions

<!-- Are there any parts of the design or the implementation which seem
     less than ideal and that could require additional discussion?
     List here: -->

<!-- Preflight checks. Have I:

* Added a changelog entry?
* Checked the scope to ensure the commits are only related to the goal above?

-->

- This pull request is ready for:
  - [ ] Initial review of the intended approach, not yet feature complete
  - [ ] Structural review of the classes, functions, and properties modified
  - [X] Final review

<!-- What do you need from a reviewer to get this changeset
     ready for release -->

- [ ] The correct target branch has been selected (`master` for fixes, `next` for
  features)
- [ ] Consistency across platforms for structures or concepts added or modified
- [ ] Consistency between the changeset and the goal stated above
- [ ] Internal consistency with the rest of the library - is there any overlap between existing interfaces and any which have been added?
- [ ] Usage friction - is the proposed change in usage cumbersome or complicated?
- [ ] Performance and complexity - are there any cases of unexpected O(n^3) when iterating, recursing, flat mapping, etc?
- [ ] Concurrency concerns - if components are accessed asynchronously, what issues will arise
- [X] Thoroughness of added tests and any missing edge cases
- [ ] Idiomatic use of the language
