### PR TITLE
Move RegisterErrorData class to separate source file

### DIFF
--- a/OSX/Bugsnag.xcodeproj/project.pbxproj
+++ b/OSX/Bugsnag.xcodeproj/project.pbxproj
@@ -57,6 +57,8 @@
 		E72AE1FA241A4E7500ED8972 /* BugsnagPluginClient.h in Headers */ = {isa = PBXBuildFile; fileRef = E72AE1F8241A4E7500ED8972 /* BugsnagPluginClient.h */; };
 		E7433AD21F4F64EF00C082D1 /* libz.tbd in Frameworks */ = {isa = PBXBuildFile; fileRef = 8A2C8FF11C6BC3A800846019 /* libz.tbd */; };
 		E7433AD31F4F64F400C082D1 /* libc++.tbd in Frameworks */ = {isa = PBXBuildFile; fileRef = 8A2C8FF31C6BC3AE00846019 /* libc++.tbd */; };
+		E7529F8E243C8EBF006B4932 /* RegisterErrorData.h in Headers */ = {isa = PBXBuildFile; fileRef = E7529F8C243C8EBF006B4932 /* RegisterErrorData.h */; };
+		E7529F8F243C8EBF006B4932 /* RegisterErrorData.m in Sources */ = {isa = PBXBuildFile; fileRef = E7529F8D243C8EBF006B4932 /* RegisterErrorData.m */; };
 		E762E9F91F73F7F300E82B43 /* BugsnagHandledStateTest.m in Sources */ = {isa = PBXBuildFile; fileRef = E762E9F71F73F7E900E82B43 /* BugsnagHandledStateTest.m */; };
 		E762E9FC1F73F80200E82B43 /* BugsnagHandledState.h in Headers */ = {isa = PBXBuildFile; fileRef = E762E9FA1F73F80200E82B43 /* BugsnagHandledState.h */; };
 		E762E9FD1F73F80200E82B43 /* BugsnagHandledState.m in Sources */ = {isa = PBXBuildFile; fileRef = E762E9FB1F73F80200E82B43 /* BugsnagHandledState.m */; };
@@ -270,6 +272,8 @@
 		E72352C01F55924A00436528 /* BSGConnectivity.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; name = BSGConnectivity.m; path = ../Source/BSGConnectivity.m; sourceTree = SOURCE_ROOT; };
 		E72AE1F7241A4E7500ED8972 /* BugsnagPluginClient.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; name = BugsnagPluginClient.m; path = ../Source/BugsnagPluginClient.m; sourceTree = "<group>"; };
 		E72AE1F8241A4E7500ED8972 /* BugsnagPluginClient.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; name = BugsnagPluginClient.h; path = ../Source/BugsnagPluginClient.h; sourceTree = "<group>"; };
+		E7529F8C243C8EBF006B4932 /* RegisterErrorData.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; name = RegisterErrorData.h; path = ../Source/RegisterErrorData.h; sourceTree = "<group>"; };
+		E7529F8D243C8EBF006B4932 /* RegisterErrorData.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; name = RegisterErrorData.m; path = ../Source/RegisterErrorData.m; sourceTree = "<group>"; };
 		E762E9F71F73F7E900E82B43 /* BugsnagHandledStateTest.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; name = BugsnagHandledStateTest.m; path = ../Tests/BugsnagHandledStateTest.m; sourceTree = SOURCE_ROOT; };
 		E762E9FA1F73F80200E82B43 /* BugsnagHandledState.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; name = BugsnagHandledState.h; path = ../Source/BugsnagHandledState.h; sourceTree = SOURCE_ROOT; };
 		E762E9FB1F73F80200E82B43 /* BugsnagHandledState.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; name = BugsnagHandledState.m; path = ../Source/BugsnagHandledState.m; sourceTree = SOURCE_ROOT; };
@@ -498,6 +502,8 @@
 				8A48EF261EAA805D00B70024 /* BugsnagLogger.h */,
 				E79148391FD82B34003EFEBF /* BugsnagSessionTracker.h */,
 				E79148431FD82B36003EFEBF /* BugsnagSessionTracker.m */,
+				E7529F8C243C8EBF006B4932 /* RegisterErrorData.h */,
+				E7529F8D243C8EBF006B4932 /* RegisterErrorData.m */,
 				8A2C8FA61C6BC1F700846019 /* Info.plist */,
 				8A2C902F1C6BF3AC00846019 /* module.modulemap */,
 				E79E6B081F4E3850002B35F9 /* BSG_KSCrash */,
@@ -875,6 +881,7 @@
 				E79E6BC71F4E3850002B35F9 /* BSG_KSObjCApple.h in Headers */,
 				E79E6BCB1F4E3850002B35F9 /* BSG_KSSignalInfo.h in Headers */,
 				E790C427243354FD006FFB26 /* BugsnagClientInternal.h in Headers */,
+				E7529F8E243C8EBF006B4932 /* RegisterErrorData.h in Headers */,
 				E79E6BA61F4E3850002B35F9 /* BSG_KSCrashSentry_MachException.h in Headers */,
 				8A627CD91EC3B75200F7C04E /* BSGSerialization.h in Headers */,
 				E79E6BAE1F4E3850002B35F9 /* BSG_KSArchSpecific.h in Headers */,
@@ -1048,6 +1055,7 @@
 				E79E6BBB1F4E3850002B35F9 /* BSG_KSJSONCodecObjC.m in Sources */,
 				E790C47D24349CE2006FFB26 /* BugsnagThread.m in Sources */,
 				E79148561FD82B36003EFEBF /* BugsnagSessionTracker.m in Sources */,
+				E7529F8F243C8EBF006B4932 /* RegisterErrorData.m in Sources */,
 				E790C47024349CE2006FFB26 /* BugsnagStackframe.m in Sources */,
 				E790C47B24349CE2006FFB26 /* BugsnagAppWithState.m in Sources */,
 				8A2C8FD21C6BC2C800846019 /* BugsnagCollections.m in Sources */,

--- a/Source/BugsnagEvent.m
+++ b/Source/BugsnagEvent.m
@@ -25,6 +25,7 @@
 #import "BugsnagKeys.h"
 #import "BugsnagDeviceWithState.h"
 #import "BugsnagClient.h"
+#import "RegisterErrorData.h"
 
 static NSString *const DEFAULT_EXCEPTION_TYPE = @"cocoa";
 
@@ -43,14 +44,6 @@ NSDictionary *_Nonnull BSGParseDeviceMetadata(NSDictionary *_Nonnull event);
 + (instancetype _Nullable)breadcrumbWithBlock:
         (BSGBreadcrumbConfiguration _Nonnull)block;
 + (instancetype _Nullable)breadcrumbFromDict:(NSDictionary *_Nonnull)dict;
-@end
-
-@interface RegisterErrorData : NSObject
-@property (nonatomic, strong) NSString *errorClass;
-@property (nonatomic, strong) NSString *errorMessage;
-+ (instancetype)errorDataFromThreads:(NSArray *)threads;
-- (instancetype)initWithClass:(NSString *_Nonnull)errorClass
-                      message:(NSString *_Nonnull)errorMessage NS_DESIGNATED_INITIALIZER;
 @end
 
 @interface BugsnagConfiguration (BugsnagEvent)
@@ -760,77 +753,6 @@ NSDictionary *BSGParseCustomException(NSDictionary *report,
                        withKey:(NSString *_Nonnull)key
 {
     [self.metadata clearMetadataFromSection:sectionName withKey:key];
-}
-
-@end
-
-@implementation RegisterErrorData
-+ (instancetype)errorDataFromThreads:(NSArray *)threads {
-    for (NSDictionary *thread in threads) {
-        if (![thread[@"crashed"] boolValue]) {
-            continue;
-        }
-        NSDictionary *notableAddresses = thread[@"notable_addresses"];
-        NSMutableArray *interestingValues = [NSMutableArray new];
-        NSString *reservedWord = nil;
-
-        for (NSString *key in notableAddresses) {
-            NSDictionary *data = notableAddresses[key];
-            if (![@"string" isEqualToString:data[BSGKeyType]]) {
-                continue;
-            }
-            NSString *contentValue = data[@"value"];
-
-#pragma clang diagnostic push
-#pragma ide diagnostic ignored "OCDFAInspection"
-            if (contentValue == nil || ![contentValue isKindOfClass:[NSString class]]) {
-                continue;
-            }
-#pragma clang diagnostic pop
-
-            if ([self isReservedWord:contentValue]) {
-                reservedWord = contentValue;
-            } else if ([[contentValue componentsSeparatedByString:@"/"] count] <= 2) {
-                // must be a string that isn't a reserved word and isn't a filepath
-                [interestingValues addObject:contentValue];
-            }
-        }
-
-        [interestingValues sortUsingSelector:@selector(localizedCaseInsensitiveCompare:)];
-
-        NSString *message = [interestingValues componentsJoinedByString:@" | "];
-        return [[RegisterErrorData alloc] initWithClass:reservedWord
-                                                message:message];
-    }
-    return nil;
-}
-
-/**
- * Determines whether a string is a "reserved word" that identifies it as a known value.
- *
- * For fatalError, preconditionFailure, and assertionFailure, "fatal error" will be in one of the registers.
- *
- * For assert, "assertion failed" will be in one of the registers.
- */
-+ (BOOL)isReservedWord:(NSString *)contentValue {
-    return [@"assertion failed" caseInsensitiveCompare:contentValue] == NSOrderedSame
-    || [@"fatal error" caseInsensitiveCompare:contentValue] == NSOrderedSame
-    || [@"precondition failed" caseInsensitiveCompare:contentValue] == NSOrderedSame;
-}
-
-- (instancetype)init {
-    return [self initWithClass:@"Unknown" message:@"<unset>"];
-}
-
-- (instancetype)initWithClass:(NSString *)errorClass message:(NSString *)errorMessage {
-    if (errorClass.length == 0) {
-        return nil;
-    }
-    if (self = [super init]) {
-        _errorClass = errorClass;
-        _errorMessage = errorMessage;
-    }
-    return self;
 }
 
 @end

--- a/Source/RegisterErrorData.h
+++ b/Source/RegisterErrorData.h
@@ -8,6 +8,11 @@
 
 #import <Foundation/Foundation.h>
 
+/**
+ * Inspects data from the register captured by the KSCrash report for
+ * useful information that can be added to the error class/message. For
+ * example, this can enhance the error message set for Swift's fatalError().
+ */
 @interface RegisterErrorData : NSObject
 @property (nonatomic, strong) NSString *_Nullable errorClass;
 @property (nonatomic, strong) NSString *_Nullable errorMessage;

--- a/Source/RegisterErrorData.h
+++ b/Source/RegisterErrorData.h
@@ -1,0 +1,17 @@
+//
+//  RegisterErrorData.h
+//  Bugsnag
+//
+//  Created by Jamie Lynch on 07/04/2020.
+//  Copyright © 2020 Bugsnag. All rights reserved.
+//
+
+#import <Foundation/Foundation.h>
+
+@interface RegisterErrorData : NSObject
+@property (nonatomic, strong) NSString *_Nullable errorClass;
+@property (nonatomic, strong) NSString *_Nullable errorMessage;
++ (instancetype _Nonnull )errorDataFromThreads:(NSArray *_Nullable)threads;
+- (instancetype _Nonnull )initWithClass:(NSString *_Nonnull)errorClass
+                      message:(NSString *_Nonnull)errorMessage NS_DESIGNATED_INITIALIZER;
+@end

--- a/Source/RegisterErrorData.m
+++ b/Source/RegisterErrorData.m
@@ -1,0 +1,81 @@
+//
+//  RegisterErrorData.m
+//  Bugsnag
+//
+//  Created by Jamie Lynch on 07/04/2020.
+//  Copyright © 2020 Bugsnag. All rights reserved.
+//
+
+#import "RegisterErrorData.h"
+#import "BugsnagKeys.h"
+
+@implementation RegisterErrorData
++ (instancetype)errorDataFromThreads:(NSArray *)threads {
+    for (NSDictionary *thread in threads) {
+        if (![thread[@"crashed"] boolValue]) {
+            continue;
+        }
+        NSDictionary *notableAddresses = thread[@"notable_addresses"];
+        NSMutableArray *interestingValues = [NSMutableArray new];
+        NSString *reservedWord = nil;
+
+        for (NSString *key in notableAddresses) {
+            NSDictionary *data = notableAddresses[key];
+            if (![@"string" isEqualToString:data[BSGKeyType]]) {
+                continue;
+            }
+            NSString *contentValue = data[@"value"];
+
+#pragma clang diagnostic push
+#pragma ide diagnostic ignored "OCDFAInspection"
+            if (contentValue == nil || ![contentValue isKindOfClass:[NSString class]]) {
+                continue;
+            }
+#pragma clang diagnostic pop
+
+            if ([self isReservedWord:contentValue]) {
+                reservedWord = contentValue;
+            } else if ([[contentValue componentsSeparatedByString:@"/"] count] <= 2) {
+                // must be a string that isn't a reserved word and isn't a filepath
+                [interestingValues addObject:contentValue];
+            }
+        }
+
+        [interestingValues sortUsingSelector:@selector(localizedCaseInsensitiveCompare:)];
+
+        NSString *message = [interestingValues componentsJoinedByString:@" | "];
+        return [[RegisterErrorData alloc] initWithClass:reservedWord
+                                                message:message];
+    }
+    return nil;
+}
+
+/**
+ * Determines whether a string is a "reserved word" that identifies it as a known value.
+ *
+ * For fatalError, preconditionFailure, and assertionFailure, "fatal error" will be in one of the registers.
+ *
+ * For assert, "assertion failed" will be in one of the registers.
+ */
++ (BOOL)isReservedWord:(NSString *)contentValue {
+    return [@"assertion failed" caseInsensitiveCompare:contentValue] == NSOrderedSame
+    || [@"fatal error" caseInsensitiveCompare:contentValue] == NSOrderedSame
+    || [@"precondition failed" caseInsensitiveCompare:contentValue] == NSOrderedSame;
+}
+
+- (instancetype)init {
+    return [self initWithClass:@"Unknown" message:@"<unset>"];
+}
+
+- (instancetype)initWithClass:(NSString *)errorClass message:(NSString *)errorMessage {
+    if (errorClass.length == 0) {
+        return nil;
+    }
+    if (self = [super init]) {
+        _errorClass = errorClass;
+        _errorMessage = errorMessage;
+    }
+    return self;
+}
+
+@end

--- a/iOS/Bugsnag.xcodeproj/project.pbxproj
+++ b/iOS/Bugsnag.xcodeproj/project.pbxproj
@@ -284,6 +284,10 @@
 		E748DA781FD02A3F00B14909 /* BugsnagSessionFileStore.h in CopyFiles */ = {isa = PBXBuildFile; fileRef = F42955025DBE1DCEFD928CAA /* BugsnagSessionFileStore.h */; };
 		E74D8E93243B3DF000F2A630 /* ORGANIZATION.md in Resources */ = {isa = PBXBuildFile; fileRef = E74D8E92243B3DF000F2A630 /* ORGANIZATION.md */; };
 		E74EFDC21FD04B9200577D23 /* BugsnagSessionTrackingApiClient.h in CopyFiles */ = {isa = PBXBuildFile; fileRef = F429517A5571A61A897E963D /* BugsnagSessionTrackingApiClient.h */; };
+		E7529F89243C8DA2006B4932 /* RegisterErrorData.h in Headers */ = {isa = PBXBuildFile; fileRef = E7529F87243C8DA2006B4932 /* RegisterErrorData.h */; };
+		E7529F8A243C8DA2006B4932 /* RegisterErrorData.m in Sources */ = {isa = PBXBuildFile; fileRef = E7529F88243C8DA2006B4932 /* RegisterErrorData.m */; };
+		E7529F8B243C8DA2006B4932 /* RegisterErrorData.m in Sources */ = {isa = PBXBuildFile; fileRef = E7529F88243C8DA2006B4932 /* RegisterErrorData.m */; };
+		E7529F94243C8EF2006B4932 /* RegisterErrorData.h in CopyFiles */ = {isa = PBXBuildFile; fileRef = E7529F87243C8DA2006B4932 /* RegisterErrorData.h */; };
 		E77316E31F73E89E00A14F06 /* BugsnagHandledStateTest.m in Sources */ = {isa = PBXBuildFile; fileRef = E77316E11F73B46600A14F06 /* BugsnagHandledStateTest.m */; };
 		E77526BA242D0AE50077A42F /* BugsnagBreadcrumbs.h in Headers */ = {isa = PBXBuildFile; fileRef = E77526B8242D0AE50077A42F /* BugsnagBreadcrumbs.h */; };
 		E77526BB242D0AE50077A42F /* BugsnagBreadcrumbs.m in Sources */ = {isa = PBXBuildFile; fileRef = E77526B9242D0AE50077A42F /* BugsnagBreadcrumbs.m */; };
@@ -381,6 +385,7 @@
 			dstPath = "include/${PRODUCT_NAME}";
 			dstSubfolderSpec = 16;
 			files = (
+				E7529F94243C8EF2006B4932 /* RegisterErrorData.h in CopyFiles */,
 				E790C45B24349A70006FFB26 /* BugsnagApp.h in CopyFiles */,
 				E790C45C24349A70006FFB26 /* BugsnagAppWithState.h in CopyFiles */,
 				E790C45D24349A70006FFB26 /* BugsnagDevice.h in CopyFiles */,
@@ -643,6 +648,8 @@
 		E737DEA11F73AD7400BC7C80 /* BugsnagHandledState.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; name = BugsnagHandledState.m; path = ../Source/BugsnagHandledState.m; sourceTree = SOURCE_ROOT; };
 		E7397DC41F83BAC50034242A /* libBugsnagStatic.a */ = {isa = PBXFileReference; explicitFileType = archive.ar; includeInIndex = 0; path = libBugsnagStatic.a; sourceTree = BUILT_PRODUCTS_DIR; };
 		E74D8E92243B3DF000F2A630 /* ORGANIZATION.md */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = net.daringfireball.markdown; name = ORGANIZATION.md; path = ../ORGANIZATION.md; sourceTree = "<group>"; };
+		E7529F87243C8DA2006B4932 /* RegisterErrorData.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; name = RegisterErrorData.h; path = ../Source/RegisterErrorData.h; sourceTree = "<group>"; };
+		E7529F88243C8DA2006B4932 /* RegisterErrorData.m */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.objc; name = RegisterErrorData.m; path = ../Source/RegisterErrorData.m; sourceTree = "<group>"; };
 		E77316E11F73B46600A14F06 /* BugsnagHandledStateTest.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; name = BugsnagHandledStateTest.m; path = ../Tests/BugsnagHandledStateTest.m; sourceTree = SOURCE_ROOT; };
 		E77526B8242D0AE50077A42F /* BugsnagBreadcrumbs.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; name = BugsnagBreadcrumbs.h; path = ../Source/BugsnagBreadcrumbs.h; sourceTree = "<group>"; };
 		E77526B9242D0AE50077A42F /* BugsnagBreadcrumbs.m */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.objc; name = BugsnagBreadcrumbs.m; path = ../Source/BugsnagBreadcrumbs.m; sourceTree = "<group>"; };
@@ -805,6 +812,8 @@
 				8A381D491EAA49A700AF8429 /* BugsnagLogger.h */,
 				E72BF7731FC867E4004BE82F /* BugsnagSessionTracker.h */,
 				E72BF7741FC867E4004BE82F /* BugsnagSessionTracker.m */,
+				E7529F87243C8DA2006B4932 /* RegisterErrorData.h */,
+				E7529F88243C8DA2006B4932 /* RegisterErrorData.m */,
 				8A2C8F1D1C6BBD2300846019 /* Info.plist */,
 				0061D84324067AF70041C068 /* SSKeychain */,
 				E7107BB31F4C97F100BB3F98 /* KSCrash */,
@@ -1235,6 +1244,7 @@
 				F4295932E7EC58D1CB806EC9 /* BugsnagFileStore.h in Headers */,
 				F4295C14DCDDF541188CDE66 /* BugsnagSessionFileStore.h in Headers */,
 				F429561943952286B690CFB1 /* BugsnagSessionTrackingApiClient.h in Headers */,
+				E7529F89243C8DA2006B4932 /* RegisterErrorData.h in Headers */,
 				F429522FC5D3D54364D51F3F /* BugsnagApiClient.h in Headers */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
@@ -1404,6 +1414,7 @@
 				8A2C8F601C6BBE3C00846019 /* BugsnagSink.m in Sources */,
 				E790C45924349A28006FFB26 /* BugsnagThread.m in Sources */,
 				E7107C661F4C97F100BB3F98 /* BSG_KSJSONCodecObjC.m in Sources */,
+				E7529F8A243C8DA2006B4932 /* RegisterErrorData.m in Sources */,
 				8A2C8F5C1C6BBE3C00846019 /* BugsnagMetadata.m in Sources */,
 				E7107C701F4C97F100BB3F98 /* BSG_KSObjC.c in Sources */,
 				E7107C6C1F4C97F100BB3F98 /* BSG_KSMach_Arm64.c in Sources */,
@@ -1565,6 +1576,7 @@
 				E790C4462434984B006FFB26 /* BugsnagDevice.m in Sources */,
 				E7397E311F83BC2A0034242A /* BugsnagHandledState.m in Sources */,
 				F42954D2337A7CAE1FE9B308 /* BugsnagFileStore.m in Sources */,
+				E7529F8B243C8DA2006B4932 /* RegisterErrorData.m in Sources */,
 				F4295DB3B395327B82A47A78 /* BugsnagSessionFileStore.m in Sources */,
 				F42954D219B725C18DA1084F /* BugsnagSessionTrackingApiClient.m in Sources */,
 				F4295BB0741ED030D0CD002C /* BugsnagApiClient.m in Sources */,

--- a/tvOS/Bugsnag.xcodeproj/project.pbxproj
+++ b/tvOS/Bugsnag.xcodeproj/project.pbxproj
@@ -60,6 +60,8 @@
 		E72AE1FE241A4ED600ED8972 /* BugsnagPluginClient.m in Sources */ = {isa = PBXBuildFile; fileRef = E72AE1FC241A4ED600ED8972 /* BugsnagPluginClient.m */; };
 		E7433AD61F4F650C00C082D1 /* libc++.tbd in Frameworks */ = {isa = PBXBuildFile; fileRef = E7433AD51F4F650C00C082D1 /* libc++.tbd */; };
 		E7433AD81F4F651200C082D1 /* libz.tbd in Frameworks */ = {isa = PBXBuildFile; fileRef = E7433AD71F4F651200C082D1 /* libz.tbd */; };
+		E7529F92243C8ED4006B4932 /* RegisterErrorData.m in Sources */ = {isa = PBXBuildFile; fileRef = E7529F90243C8ED4006B4932 /* RegisterErrorData.m */; };
+		E7529F93243C8ED4006B4932 /* RegisterErrorData.h in Headers */ = {isa = PBXBuildFile; fileRef = E7529F91243C8ED4006B4932 /* RegisterErrorData.h */; };
 		E762E9F01F73F6CF00E82B43 /* BugsnagHandledStateTest.m in Sources */ = {isa = PBXBuildFile; fileRef = E762E9EE1F73F6CF00E82B43 /* BugsnagHandledStateTest.m */; };
 		E762E9F51F73F7A100E82B43 /* BugsnagHandledState.h in Headers */ = {isa = PBXBuildFile; fileRef = E762E9F21F73F6DE00E82B43 /* BugsnagHandledState.h */; };
 		E762E9F61F73F7A400E82B43 /* BugsnagHandledState.m in Sources */ = {isa = PBXBuildFile; fileRef = E762E9F31F73F6DE00E82B43 /* BugsnagHandledState.m */; };
@@ -275,6 +277,8 @@
 		E72AE1FC241A4ED600ED8972 /* BugsnagPluginClient.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; name = BugsnagPluginClient.m; path = ../Source/BugsnagPluginClient.m; sourceTree = "<group>"; };
 		E7433AD51F4F650C00C082D1 /* libc++.tbd */ = {isa = PBXFileReference; lastKnownFileType = "sourcecode.text-based-dylib-definition"; name = "libc++.tbd"; path = "usr/lib/libc++.tbd"; sourceTree = SDKROOT; };
 		E7433AD71F4F651200C082D1 /* libz.tbd */ = {isa = PBXFileReference; lastKnownFileType = "sourcecode.text-based-dylib-definition"; name = libz.tbd; path = usr/lib/libz.tbd; sourceTree = SDKROOT; };
+		E7529F90243C8ED4006B4932 /* RegisterErrorData.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; name = RegisterErrorData.m; path = ../Source/RegisterErrorData.m; sourceTree = "<group>"; };
+		E7529F91243C8ED4006B4932 /* RegisterErrorData.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; name = RegisterErrorData.h; path = ../Source/RegisterErrorData.h; sourceTree = "<group>"; };
 		E762E9EE1F73F6CF00E82B43 /* BugsnagHandledStateTest.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; name = BugsnagHandledStateTest.m; path = ../Tests/BugsnagHandledStateTest.m; sourceTree = SOURCE_ROOT; };
 		E762E9F21F73F6DE00E82B43 /* BugsnagHandledState.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; name = BugsnagHandledState.h; path = ../Source/BugsnagHandledState.h; sourceTree = SOURCE_ROOT; };
 		E762E9F31F73F6DE00E82B43 /* BugsnagHandledState.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; name = BugsnagHandledState.m; path = ../Source/BugsnagHandledState.m; sourceTree = SOURCE_ROOT; };
@@ -504,6 +508,8 @@
 				8A48EF281EAA824100B70024 /* BugsnagLogger.h */,
 				E791486A1FD82E6B003EFEBF /* BugsnagSessionTracker.h */,
 				E79148741FD82E6C003EFEBF /* BugsnagSessionTracker.m */,
+				E7529F91243C8ED4006B4932 /* RegisterErrorData.h */,
+				E7529F90243C8ED4006B4932 /* RegisterErrorData.m */,
 				8A8D51291D41343500D33797 /* Info.plist */,
 				004A41E623FEDF9E0092DF97 /* SSKeychain */,
 				E76616FD1F4E459C0094CECF /* BSG_KSCrash */,
@@ -887,6 +893,7 @@
 				E76617BC1F4E459C0094CECF /* BSG_KSObjCApple.h in Headers */,
 				E76617C01F4E459C0094CECF /* BSG_KSSignalInfo.h in Headers */,
 				E790C4292433551D006FFB26 /* BugsnagClientInternal.h in Headers */,
+				E7529F93243C8ED4006B4932 /* RegisterErrorData.h in Headers */,
 				E766179B1F4E459C0094CECF /* BSG_KSCrashSentry_MachException.h in Headers */,
 				8A627CD51EC3B69300F7C04E /* BSGSerialization.h in Headers */,
 				E76617A31F4E459C0094CECF /* BSG_KSArchSpecific.h in Headers */,
@@ -1060,6 +1067,7 @@
 				E76617B21F4E459C0094CECF /* BSG_KSLogger.m in Sources */,
 				E79148801FD82E6D003EFEBF /* BugsnagSessionTrackingPayload.m in Sources */,
 				E76617BF1F4E459C0094CECF /* BSG_KSSignalInfo.c in Sources */,
+				E7529F92243C8ED4006B4932 /* RegisterErrorData.m in Sources */,
 				E76617B71F4E459C0094CECF /* BSG_KSMach_x86_32.c in Sources */,
 				E791487E1FD82E6D003EFEBF /* BugsnagSessionFileStore.m in Sources */,
 				8AD9A4FF1D42EEA0004E1CC5 /* BugsnagCollections.m in Sources */,


### PR DESCRIPTION
Moves the `RegisterErrorData` class to a separate source file, which has been added as a non-public file to the iOS/OSX/macOS projects.

Previously this lived in `BugsnagEvent` and the class has been lifted out as-is. This should reduce the line count of `BugsnagEvent` and make the file easier to read.