### PR TITLE
Make all callbacks return boolean values

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,9 @@ Bugsnag Notifiers on other platforms.
 
 ## Enhancements
 
+* Make all callbacks return boolean values
+  [#534](https://github.com/bugsnag/bugsnag-cocoa/pull/534)
+
 * Create structured `BugsnagThread` class
   [#532](https://github.com/bugsnag/bugsnag-cocoa/pull/532)
 

--- a/Source/BugsnagConfiguration.h
+++ b/Source/BugsnagConfiguration.h
@@ -59,7 +59,7 @@ typedef void (^BugsnagOnErrorBlock)(BugsnagEvent *_Nonnull event);
  *
  *  @return YES if the event should be sent
  */
-typedef bool (^BugsnagOnSendBlock)(BugsnagEvent *_Nonnull event);
+typedef BOOL (^BugsnagOnSendBlock)(BugsnagEvent *_Nonnull event);
 
 /**
  *  A configuration block for modifying a captured breadcrumb
@@ -73,7 +73,7 @@ typedef BOOL (^BugsnagOnBreadcrumbBlock)(BugsnagBreadcrumb *_Nonnull breadcrumb)
  *
  * @param sessionPayload The session about to be delivered
  */
-typedef void(^BugsnagOnSessionBlock)(NSMutableDictionary *_Nonnull sessionPayload);
+typedef void (^BugsnagOnSessionBlock)(NSMutableDictionary *_Nonnull sessionPayload);
 
 typedef NS_OPTIONS(NSUInteger, BSGErrorType) {
     BSGErrorTypesNone         NS_SWIFT_NAME(None)         = 0,

--- a/Source/BugsnagConfiguration.h
+++ b/Source/BugsnagConfiguration.h
@@ -73,7 +73,7 @@ typedef BOOL (^BugsnagOnBreadcrumbBlock)(BugsnagBreadcrumb *_Nonnull breadcrumb)
  *
  * @param sessionPayload The session about to be delivered
  */
-typedef void (^BugsnagOnSessionBlock)(NSMutableDictionary *_Nonnull sessionPayload);
+typedef BOOL (^BugsnagOnSessionBlock)(NSMutableDictionary *_Nonnull sessionPayload);
 
 typedef NS_OPTIONS(NSUInteger, BSGErrorType) {
     BSGErrorTypesNone         NS_SWIFT_NAME(None)         = 0,

--- a/Source/BugsnagSessionTracker.m
+++ b/Source/BugsnagSessionTracker.m
@@ -117,21 +117,20 @@ NSString *const BSGSessionUpdateNotification = @"BugsnagSessionChanged";
         return;
     }
 
-    BugsnagSession *newSession = [[BugsnagSession alloc] initWithId:[[NSUUID UUID] UUIDString]
-                                                          startDate:[NSDate date]
-                                                               user:self.config.user
-                                                       autoCaptured:isAutoCaptured];
     // TODO JL: refactor to pass as structured data into callback
-    BugsnagSessionTrackingPayload *payload = [[BugsnagSessionTrackingPayload alloc] initWithSessions:@[]
-                                                                                              config:self.config];
-    NSMutableDictionary *data = [payload toJson];
-    for (BugsnagOnSessionBlock cb in self.config.onSessionBlocks) {
-        if (!cb(data)) {
+    BugsnagSessionTrackingPayload *sessions = [[BugsnagSessionTrackingPayload alloc] initWithSessions:@[]
+                                                                                               config:self.config];
+    NSMutableDictionary *sessionsJson = [sessions toJson];
+    for (BugsnagOnSessionBlock onSessionBlock in self.config.onSessionBlocks) {
+        if (!onSessionBlock(sessionsJson)) {
             return;
         }
     }
 
-    self.currentSession = newSession;
+    self.currentSession = [[BugsnagSession alloc] initWithId:[[NSUUID UUID] UUIDString]
+                                                   startDate:[NSDate date]
+                                                        user:self.config.user
+                                                autoCaptured:isAutoCaptured];
     [self.sessionStore write:self.currentSession];
 
     if (self.callback) {

--- a/Source/BugsnagSessionTrackingApiClient.m
+++ b/Source/BugsnagSessionTrackingApiClient.m
@@ -49,10 +49,6 @@
         NSUInteger sessionCount = payload.sessions.count;
         NSMutableDictionary *data = [payload toJson];
 
-        for (BugsnagOnSessionBlock cb in self.config.onSessionBlocks) {
-            cb(data);
-        }
-
         if (sessionCount > 0) {
             NSDictionary *HTTPHeaders = @{
                                           @"Bugsnag-Payload-Version": @"1.0",

--- a/Tests/BugsnagBaseUnitTest.m
+++ b/Tests/BugsnagBaseUnitTest.m
@@ -44,7 +44,7 @@
     [configuration setPersistUser:willPersistUser];
     
     if (willNotify) {
-        [configuration addOnSendBlock:^bool(BugsnagEvent * _Nonnull event) { return false; }];
+        [configuration addOnSendBlock:^BOOL(BugsnagEvent * _Nonnull event) { return false; }];
     }
     [Bugsnag startBugsnagWithConfiguration:configuration];
 }

--- a/Tests/BugsnagBreadcrumbsTest.m
+++ b/Tests/BugsnagBreadcrumbsTest.m
@@ -302,7 +302,7 @@ BSGBreadcrumbType BSGBreadcrumbTypeFromString(NSString *value);
 - (void)testCallbackFreeConstructors2 {
     // Prevent sending events
     BugsnagConfiguration *configuration = [[BugsnagConfiguration alloc] initWithApiKey:DUMMY_APIKEY_32CHAR_1];
-    [configuration addOnSendBlock:^bool(BugsnagEvent * _Nonnull event) { return false; }];
+    [configuration addOnSendBlock:^BOOL(BugsnagEvent * _Nonnull event) { return false; }];
     [Bugsnag startBugsnagWithConfiguration:configuration];
 
     NSDictionary *md1 = @{ @"x" : @"y"};
@@ -369,7 +369,7 @@ BSGBreadcrumbType BSGBreadcrumbTypeFromString(NSString *value);
 - (void)testCallbackFreeConstructors3 {
     // Prevent sending events
     BugsnagConfiguration *configuration = [[BugsnagConfiguration alloc] initWithApiKey:DUMMY_APIKEY_32CHAR_1];
-    [configuration addOnSendBlock:^bool(BugsnagEvent * _Nonnull event) { return false; }];
+    [configuration addOnSendBlock:^BOOL(BugsnagEvent * _Nonnull event) { return false; }];
     [Bugsnag startBugsnagWithConfiguration:configuration];
 
     [Bugsnag leaveBreadcrumbWithMessage:@"message1"];

--- a/Tests/BugsnagClientTests.m
+++ b/Tests/BugsnagClientTests.m
@@ -47,7 +47,7 @@ NSString *BSGFormatSeverity(BSGSeverity severity);
 -(void)setUpBugsnagWillCallNotify:(bool)willNotify {
     BugsnagConfiguration *configuration = [[BugsnagConfiguration alloc] initWithApiKey:DUMMY_APIKEY_32CHAR_1];
     if (willNotify) {
-        [configuration addOnSendBlock:^bool(BugsnagEvent * _Nonnull event) { return false; }];
+        [configuration addOnSendBlock:^BOOL(BugsnagEvent * _Nonnull event) { return false; }];
     }
     [Bugsnag startBugsnagWithConfiguration:configuration];
 }

--- a/Tests/BugsnagConfigurationTests.m
+++ b/Tests/BugsnagConfigurationTests.m
@@ -108,9 +108,10 @@
     BugsnagConfiguration *config = [[BugsnagConfiguration alloc] initWithApiKey:DUMMY_APIKEY_32CHAR_1];
     [config setEndpointsForNotify:@"http://notreal.bugsnag.com" sessions:@"http://notreal.bugsnag.com"];
     XCTAssertEqual([[config onSessionBlocks] count], 0);
-    BugsnagOnSessionBlock sessionBlock = ^(NSMutableDictionary * _Nonnull sessionPayload) {
+    BugsnagOnSessionBlock sessionBlock = ^BOOL(NSMutableDictionary * _Nonnull sessionPayload) {
         // We expect the session block to be called
         [expectation fulfill];
+        return true;
     };
     [config addOnSessionBlock:sessionBlock];
     XCTAssertEqual([[config onSessionBlocks] count], 1);
@@ -132,8 +133,9 @@
     BugsnagConfiguration *config = [[BugsnagConfiguration alloc] initWithApiKey:DUMMY_APIKEY_32CHAR_1];
     [config setEndpointsForNotify:@"http://notreal.bugsnag.com" sessions:@"http://notreal.bugsnag.com"];
     XCTAssertEqual([[config onSessionBlocks] count], 0);
-    BugsnagOnSessionBlock sessionBlock = ^(NSMutableDictionary * _Nonnull sessionPayload) {
+    BugsnagOnSessionBlock sessionBlock = ^BOOL(NSMutableDictionary * _Nonnull sessionPayload) {
         [calledExpectation fulfill];
+        return true;
     };
     
     // It's there (and from other tests we know it gets called) and then it's not there
@@ -166,7 +168,7 @@
     [config setEndpointsForNotify:@"http://notreal.bugsnag.com" sessions:@"http://notreal.bugsnag.com"];
     XCTAssertEqual([[config onSessionBlocks] count], 0);
     
-    BugsnagOnSessionBlock sessionBlock = ^(NSMutableDictionary * _Nonnull sessionPayload) {
+    BugsnagOnSessionBlock sessionBlock = ^BOOL(NSMutableDictionary * _Nonnull sessionPayload) {
         switch (called) {
         case 0:
             [expectation1 fulfill];
@@ -183,6 +185,7 @@
             [expectation4 fulfill];
             break;
         }
+        return true;
     };
     
     [config addOnSessionBlock:sessionBlock];
@@ -219,8 +222,8 @@
 - (void)testRemoveNonexistentOnSessionBlocks {
     BugsnagConfiguration *config = [[BugsnagConfiguration alloc] initWithApiKey:DUMMY_APIKEY_32CHAR_1];
     XCTAssertEqual([[config onSessionBlocks] count], 0);
-    BugsnagOnSessionBlock sessionBlock1 = ^(NSMutableDictionary * _Nonnull sessionPayload) {};
-    BugsnagOnSessionBlock sessionBlock2 = ^(NSMutableDictionary * _Nonnull sessionPayload) {};
+    BugsnagOnSessionBlock sessionBlock1 = ^BOOL(NSMutableDictionary * _Nonnull sessionPayload) { return true; };
+    BugsnagOnSessionBlock sessionBlock2 = ^BOOL(NSMutableDictionary * _Nonnull sessionPayload) { return true; };
     
     [config addOnSessionBlock:sessionBlock1];
     XCTAssertEqual([[config onSessionBlocks] count], 1);

--- a/Tests/BugsnagConfigurationTests.m
+++ b/Tests/BugsnagConfigurationTests.m
@@ -731,7 +731,7 @@
     BugsnagConfiguration *configuration = [[BugsnagConfiguration alloc] initWithApiKey:DUMMY_APIKEY_32CHAR_1];
     XCTAssertEqual([[configuration onSendBlocks] count], 0);
     
-    BugsnagOnSendBlock block = ^bool(BugsnagEvent * _Nonnull event) { return false; };
+    BugsnagOnSendBlock block = ^BOOL(BugsnagEvent * _Nonnull event) { return false; };
     
     [configuration addOnSendBlock:block];
     [Bugsnag startBugsnagWithConfiguration:configuration];
@@ -750,8 +750,8 @@
     BugsnagConfiguration *configuration = [[BugsnagConfiguration alloc] initWithApiKey:DUMMY_APIKEY_32CHAR_1];
     XCTAssertEqual([[configuration onSendBlocks] count], 0);
     
-    BugsnagOnSendBlock block1 = ^bool(BugsnagEvent * _Nonnull event) { return false; };
-    BugsnagOnSendBlock block2 = ^bool(BugsnagEvent * _Nonnull event) { return false; };
+    BugsnagOnSendBlock block1 = ^BOOL(BugsnagEvent * _Nonnull event) { return false; };
+    BugsnagOnSendBlock block2 = ^BOOL(BugsnagEvent * _Nonnull event) { return false; };
     
     // Add more than one
     [configuration addOnSendBlock:block1];
@@ -772,8 +772,8 @@
     [config setContext:@"context1"];
     [config setAppType:@"The most amazing app, a brilliant app, the app to end all apps"];
     [config setPersistUser:YES];
-    BugsnagOnSendBlock onSendBlock1 = ^bool(BugsnagEvent * _Nonnull event) { return true; };
-    BugsnagOnSendBlock onSendBlock2 = ^bool(BugsnagEvent * _Nonnull event) { return true; };
+    BugsnagOnSendBlock onSendBlock1 = ^BOOL(BugsnagEvent * _Nonnull event) { return true; };
+    BugsnagOnSendBlock onSendBlock2 = ^BOOL(BugsnagEvent * _Nonnull event) { return true; };
 
     NSArray *sendBlocks = @[ onSendBlock1, onSendBlock2 ];
     [config setOnSendBlocks:[sendBlocks mutableCopy]]; // Mutable arg required

--- a/Tests/BugsnagSessionTrackerTest.m
+++ b/Tests/BugsnagSessionTrackerTest.m
@@ -24,6 +24,10 @@
 - (void)deletePersistedUserData;
 @end
 
+@interface BugsnagSessionTracker ()
+@property (strong, readwrite) BugsnagSession *currentSession;
+@end
+
 @interface BugsnagSessionTrackerTest : XCTestCase
 @property BugsnagConfiguration *configuration;
 @property BugsnagSessionTracker *sessionTracker;
@@ -138,5 +142,32 @@
     XCTAssertEqual(1, session.handledCount);
     XCTAssertEqual(1, session.unhandledCount);
 }
+
+- (void)testOnSendBlockFalse {
+    self.configuration = [[BugsnagConfiguration alloc] initWithApiKey:DUMMY_APIKEY_32CHAR_1];
+    [self.configuration addOnSessionBlock:^BOOL(NSMutableDictionary *sessionPayload) {
+        return NO;
+    }];
+    self.sessionTracker = [[BugsnagSessionTracker alloc] initWithConfig:self.configuration
+                                                     postRecordCallback:nil];
+    [self.sessionTracker startNewSession];
+    XCTAssertNil(self.sessionTracker.currentSession);
+}
+
+- (void)testOnSendBlockTrue {
+    __block XCTestExpectation *expectation = [self expectationWithDescription:@"Session block is invoked"];
+
+    self.configuration = [[BugsnagConfiguration alloc] initWithApiKey:DUMMY_APIKEY_32CHAR_1];
+    [self.configuration addOnSessionBlock:^BOOL(NSMutableDictionary *sessionPayload) {
+        [expectation fulfill];
+        return YES;
+    }];
+    self.sessionTracker = [[BugsnagSessionTracker alloc] initWithConfig:self.configuration
+                                                     postRecordCallback:nil];
+    [self.sessionTracker startNewSession];
+    [self waitForExpectations:@[expectation] timeout:2];
+    XCTAssertNotNil(self.sessionTracker.currentSession);
+}
+
 
 @end

--- a/Tests/BugsnagTests.m
+++ b/Tests/BugsnagTests.m
@@ -249,7 +249,7 @@
     // non-sending bugsnag
     [configuration addOnSendBlock:^BOOL(BugsnagEvent * _Nonnull event) { return false; }];
 
-    BugsnagOnSessionBlock sessionBlock = ^(NSMutableDictionary * _Nonnull sessionPayload) {
+    BugsnagOnSessionBlock sessionBlock = ^BOOL(NSMutableDictionary * _Nonnull sessionPayload) {
         switch (called) {
         case 0:
             [expectation1 fulfill];
@@ -258,6 +258,7 @@
             [expectation2 fulfill];
             break;
         }
+        return true;
     };
 
     [configuration addOnSessionBlock:sessionBlock];
@@ -289,7 +290,7 @@
     // non-sending bugsnag
     [configuration addOnSendBlock:^BOOL(BugsnagEvent * _Nonnull event) { return false; }];
 
-    BugsnagOnSessionBlock sessionBlock = ^(NSMutableDictionary * _Nonnull sessionPayload) {
+    BugsnagOnSessionBlock sessionBlock = ^BOOL(NSMutableDictionary * _Nonnull sessionPayload) {
         switch (called) {
         case 0:
             [expectation1 fulfill];
@@ -298,6 +299,7 @@
             [expectation2 fulfill];
             break;
         }
+        return true;
     };
 
     // NOTE: Due to test conditions the state of the Bugsnag/client class is indeterminate.

--- a/Tests/BugsnagTests.m
+++ b/Tests/BugsnagTests.m
@@ -44,7 +44,7 @@
 -(void)setUpBugsnagWillCallNotify:(bool)willNotify {
     BugsnagConfiguration *configuration = [[BugsnagConfiguration alloc] initWithApiKey:DUMMY_APIKEY_32CHAR_1];
     if (willNotify) {
-        [configuration addOnSendBlock:^bool(BugsnagEvent * _Nonnull event) { return false; }];
+        [configuration addOnSendBlock:^BOOL(BugsnagEvent * _Nonnull event) { return false; }];
     }
     [Bugsnag startBugsnagWithConfiguration:configuration];
 }
@@ -147,7 +147,7 @@
  */
 -(void)testBugsnagPauseSession {
     BugsnagConfiguration *configuration = [[BugsnagConfiguration alloc] initWithApiKey:DUMMY_APIKEY_32CHAR_1];
-    [configuration addOnSendBlock:^bool(BugsnagEvent * _Nonnull event) { return false; }];
+    [configuration addOnSendBlock:^BOOL(BugsnagEvent * _Nonnull event) { return false; }];
 
     [Bugsnag startBugsnagWithConfiguration:configuration];
 
@@ -164,7 +164,7 @@
     
     BugsnagConfiguration *configuration = [[BugsnagConfiguration alloc] initWithApiKey:DUMMY_APIKEY_32CHAR_1];
     [configuration setContext:@"firstContext"];
-    [configuration addOnSendBlock:^bool(BugsnagEvent * _Nonnull event) { return false; }];
+    [configuration addOnSendBlock:^BOOL(BugsnagEvent * _Nonnull event) { return false; }];
     
     [Bugsnag startBugsnagWithConfiguration:configuration];
 
@@ -247,7 +247,7 @@
     BugsnagConfiguration *configuration = [[BugsnagConfiguration alloc] initWithApiKey:DUMMY_APIKEY_32CHAR_1];
 
     // non-sending bugsnag
-    [configuration addOnSendBlock:^bool(BugsnagEvent * _Nonnull event) { return false; }];
+    [configuration addOnSendBlock:^BOOL(BugsnagEvent * _Nonnull event) { return false; }];
 
     BugsnagOnSessionBlock sessionBlock = ^(NSMutableDictionary * _Nonnull sessionPayload) {
         switch (called) {
@@ -287,7 +287,7 @@
     configuration.autoTrackSessions = NO;
     
     // non-sending bugsnag
-    [configuration addOnSendBlock:^bool(BugsnagEvent * _Nonnull event) { return false; }];
+    [configuration addOnSendBlock:^BOOL(BugsnagEvent * _Nonnull event) { return false; }];
 
     BugsnagOnSessionBlock sessionBlock = ^(NSMutableDictionary * _Nonnull sessionPayload) {
         switch (called) {
@@ -348,7 +348,7 @@
     expectation6.inverted = YES;
 
     // Two blocks that will get called (or not) when we notify()
-    BugsnagOnSendBlock block1 = ^bool(BugsnagEvent * _Nonnull event)
+    BugsnagOnSendBlock block1 = ^BOOL(BugsnagEvent * _Nonnull event)
     {
         switch (called) {
             case 0:
@@ -372,7 +372,7 @@
         return false;
     };
 
-    BugsnagOnSendBlock block2 = ^bool(BugsnagEvent * _Nonnull event)
+    BugsnagOnSendBlock block2 = ^BOOL(BugsnagEvent * _Nonnull event)
     {
         switch (called) {
             case 0:

--- a/features/fixtures/ios-swift-cocoapods/iOSTestApp/scenarios/OOMScenario.m
+++ b/features/fixtures/ios-swift-cocoapods/iOSTestApp/scenarios/OOMScenario.m
@@ -6,7 +6,7 @@
 - (void)startBugsnag {
     self.config.autoTrackSessions = NO;
     self.config.releaseStage = @"alpha";
-    [self.config addOnSendBlock:^bool(BugsnagEvent * _Nonnull event) {
+    [self.config addOnSendBlock:^BOOL(BugsnagEvent * _Nonnull event) {
         [event addMetadata:@{ @"shape": @"line" } toSection:@"extra"];
         return YES;
     }];


### PR DESCRIPTION
## Goal

Updates the `OnSendBlock` and `OnSessionBlock` callbacks to return boolean values which control whether the event/session is sent or not.

## Changeset
- Updated return type of blocks to `BOOL` for both callback types
- Moved `OnSessionBlock` callbacks into the `SessionTracker`. If a callback returns false, the new session is discarded and the original session (if any) is used

Note: the session callback is effectively passed an empty dictionary as its parameter for now, which has been noted as a TODO comment. Future work has been scheduled which will alter the parameter to take a structured class with session information instead.


## Tests
Added new unit tests to verify the behaviour for session blocks.
