### PR TITLE
Make errorReportingThread readonly

### DIFF
--- a/Source/BugsnagThread.h
+++ b/Source/BugsnagThread.h
@@ -33,7 +33,7 @@ typedef NS_OPTIONS(NSUInteger, BSGThreadType) {
 /**
  * Whether this thread was the thread that triggered the captured error
  */
-@property BOOL errorReportingThread;
+@property(readonly) BOOL errorReportingThread;
 
 /**
  * Sets a representation of this thread's stacktrace

--- a/Source/BugsnagThread.m
+++ b/Source/BugsnagThread.m
@@ -27,7 +27,7 @@
 
 - (instancetype)initWithThread:(NSDictionary *)thread binaryImages:(NSArray *)binaryImages {
     if (self = [super init]) {
-        self.errorReportingThread = [thread[@"crashed"] boolValue];
+        _errorReportingThread = [thread[@"crashed"] boolValue];
         self.id = [thread[@"index"] stringValue];
         self.type = BSGThreadTypeCocoa;
 


### PR DESCRIPTION
Makes the `errorReportingThread` property readonly. This prevents a user from setting the value to `true` on more than one thread, while allowing them to read the value in a callback.