### PR TITLE
Add redactedKeys for removing sensitive values from metadata

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,9 @@ Bugsnag Notifiers on other platforms.
 
 ## Enhancements
 
+* Add `redactedKeys` for removing sensitive values from metadata
+  [#540](https://github.com/bugsnag/bugsnag-cocoa/pull/540)
+
 * Create structured `BugsnagThread` class
   [#532](https://github.com/bugsnag/bugsnag-cocoa/pull/532)
 

--- a/OSX/Bugsnag.xcodeproj/project.pbxproj
+++ b/OSX/Bugsnag.xcodeproj/project.pbxproj
@@ -51,6 +51,12 @@
 		8A87352C1C6D3B1600EDBD5B /* BSG_KSCrashReportWriter.h in Headers */ = {isa = PBXBuildFile; fileRef = 8A87352B1C6D3B1600EDBD5B /* BSG_KSCrashReportWriter.h */; settings = {ATTRIBUTES = (Public, ); }; };
 		8AD1E3FA23EDDD4F0044F919 /* BSGConnectivityTest.m in Sources */ = {isa = PBXBuildFile; fileRef = 8AD1E3F823EDDD3F0044F919 /* BSGConnectivityTest.m */; };
 		8AD9FA891E086351002859A7 /* BugsnagConfigurationTests.m in Sources */ = {isa = PBXBuildFile; fileRef = 8AD9FA851E0862DC002859A7 /* BugsnagConfigurationTests.m */; };
+		E71DB9DA24470FCF00D0161E /* BugsnagPluginTest.m in Sources */ = {isa = PBXBuildFile; fileRef = E71DB9D424470FCE00D0161E /* BugsnagPluginTest.m */; };
+		E71DB9DB24470FCF00D0161E /* BugsnagSessionTrackerStopTest.m in Sources */ = {isa = PBXBuildFile; fileRef = E71DB9D524470FCF00D0161E /* BugsnagSessionTrackerStopTest.m */; };
+		E71DB9DC24470FCF00D0161E /* BugsnagTests.m in Sources */ = {isa = PBXBuildFile; fileRef = E71DB9D724470FCF00D0161E /* BugsnagTests.m */; };
+		E71DB9DD24470FCF00D0161E /* BugsnagMetadataRedactionTest.m in Sources */ = {isa = PBXBuildFile; fileRef = E71DB9D824470FCF00D0161E /* BugsnagMetadataRedactionTest.m */; };
+		E71DB9DE24470FCF00D0161E /* BugsnagClientTests.m in Sources */ = {isa = PBXBuildFile; fileRef = E71DB9D924470FCF00D0161E /* BugsnagClientTests.m */; };
+		E71DB9DF2447100000D0161E /* BugsnagMetadataTests.m in Sources */ = {isa = PBXBuildFile; fileRef = E71DB9D224470F5900D0161E /* BugsnagMetadataTests.m */; };
 		E722105E243B6A0F0083CF15 /* BugsnagStackframeTest.m in Sources */ = {isa = PBXBuildFile; fileRef = E722105D243B6A0E0083CF15 /* BugsnagStackframeTest.m */; };
 		E72352C11F55924A00436528 /* BSGConnectivity.h in Headers */ = {isa = PBXBuildFile; fileRef = E72352BF1F55924A00436528 /* BSGConnectivity.h */; };
 		E72352C21F55924A00436528 /* BSGConnectivity.m in Sources */ = {isa = PBXBuildFile; fileRef = E72352C01F55924A00436528 /* BSGConnectivity.m */; };
@@ -274,6 +280,13 @@
 		8A87352B1C6D3B1600EDBD5B /* BSG_KSCrashReportWriter.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; name = BSG_KSCrashReportWriter.h; path = ../Source/BSG_KSCrashReportWriter.h; sourceTree = SOURCE_ROOT; };
 		8AD1E3F823EDDD3F0044F919 /* BSGConnectivityTest.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; path = BSGConnectivityTest.m; sourceTree = "<group>"; };
 		8AD9FA851E0862DC002859A7 /* BugsnagConfigurationTests.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; name = BugsnagConfigurationTests.m; path = ../Tests/BugsnagConfigurationTests.m; sourceTree = SOURCE_ROOT; };
+		E71DB9D224470F5900D0161E /* BugsnagMetadataTests.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; path = BugsnagMetadataTests.m; sourceTree = "<group>"; };
+		E71DB9D424470FCE00D0161E /* BugsnagPluginTest.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; path = BugsnagPluginTest.m; sourceTree = "<group>"; };
+		E71DB9D524470FCF00D0161E /* BugsnagSessionTrackerStopTest.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; path = BugsnagSessionTrackerStopTest.m; sourceTree = "<group>"; };
+		E71DB9D624470FCF00D0161E /* BugsnagTestConstants.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = BugsnagTestConstants.h; sourceTree = "<group>"; };
+		E71DB9D724470FCF00D0161E /* BugsnagTests.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; path = BugsnagTests.m; sourceTree = "<group>"; };
+		E71DB9D824470FCF00D0161E /* BugsnagMetadataRedactionTest.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; path = BugsnagMetadataRedactionTest.m; sourceTree = "<group>"; };
+		E71DB9D924470FCF00D0161E /* BugsnagClientTests.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; path = BugsnagClientTests.m; sourceTree = "<group>"; };
 		E722105D243B6A0E0083CF15 /* BugsnagStackframeTest.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; path = BugsnagStackframeTest.m; sourceTree = "<group>"; };
 		E72352BF1F55924A00436528 /* BSGConnectivity.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; name = BSGConnectivity.h; path = ../Source/BSGConnectivity.h; sourceTree = SOURCE_ROOT; };
 		E72352C01F55924A00436528 /* BSGConnectivity.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; name = BSGConnectivity.m; path = ../Source/BSGConnectivity.m; sourceTree = SOURCE_ROOT; };
@@ -535,6 +548,7 @@
 				00F9393223FC168F008C7073 /* BugsnagBaseUnitTest.m */,
 				8A2C8FE01C6BC38200846019 /* BugsnagBreadcrumbsTest.m */,
 				E790C41F2432314A006FFB26 /* BugsnagClientMirrorTest.m */,
+				E71DB9D924470FCF00D0161E /* BugsnagClientTests.m */,
 				4B406C1622CAD96400464D1D /* BugsnagCollectionsBSGDictMergeTest.m */,
 				4B406C1722CAD96400464D1D /* BugsnagCollectionsBSGDictSetSafeObjectTest.m */,
 				4B775FD222CBE02A004839C5 /* BugsnagCollectionsBSGDictInsertIfNotNilTest.m */,
@@ -542,29 +556,19 @@
 				E7A9E56C2436365300D99F8A /* BugsnagDeviceTest.m */,
 				00D7ACA223E984B300FBE4A7 /* BugsnagEventTests.m */,
 				E762E9F71F73F7E900E82B43 /* BugsnagHandledStateTest.m */,
+				E71DB9D824470FCF00D0161E /* BugsnagMetadataRedactionTest.m */,
+				E71DB9D224470F5900D0161E /* BugsnagMetadataTests.m */,
 				E7AB4B9D2423E184004F015A /* BugsnagOnBreadcrumbTest.m */,
+				E71DB9D424470FCE00D0161E /* BugsnagPluginTest.m */,
 				E791482D1FD82B0C003EFEBF /* BugsnagSessionTest.m */,
 				E791482B1FD82B0C003EFEBF /* BugsnagSessionTrackerTest.m */,
+				E71DB9D524470FCF00D0161E /* BugsnagSessionTrackerStopTest.m */,
 				E791482C1FD82B0C003EFEBF /* BugsnagSessionTrackingPayloadTest.m */,
 				8A2C8FE21C6BC38200846019 /* BugsnagSinkTests.m */,
-				00F9393B23FD2D9B008C7073 /* BugsnagTestsDummyClass.h */,
-				00F9393A23FD2D9B008C7073 /* BugsnagTestsDummyClass.m */,
-				E791482E1FD82B0C003EFEBF /* BugsnagUserTest.m */,
 				E7D2E675243B8FB6005A3041 /* BugsnagStacktraceTest.m */,
 				E722105D243B6A0E0083CF15 /* BugsnagStackframeTest.m */,
-				00F9393B23FD2D9B008C7073 /* BugsnagTestsDummyClass.h */,
-				00F9393A23FD2D9B008C7073 /* BugsnagTestsDummyClass.m */,
-				E7529FA1243CAE3F006B4932 /* BugsnagThreadSerializationTest.m */,
-				E7529F9F243CAE34006B4932 /* BugsnagThreadTest.m */,
-				E791482E1FD82B0C003EFEBF /* BugsnagUserTest.m */,
-				E791482E1FD82B0C003EFEBF /* BugsnagUserTest.m */,
-				00F9393B23FD2D9B008C7073 /* BugsnagTestsDummyClass.h */,
-				00F9393A23FD2D9B008C7073 /* BugsnagTestsDummyClass.m */,
-				E7529FA1243CAE3F006B4932 /* BugsnagThreadSerializationTest.m */,
-				E7529F9F243CAE34006B4932 /* BugsnagThreadTest.m */,
-				E791482E1FD82B0C003EFEBF /* BugsnagUserTest.m */,
-				E7D2E675243B8FB6005A3041 /* BugsnagStacktraceTest.m */,
-				E722105D243B6A0E0083CF15 /* BugsnagStackframeTest.m */,
+				E71DB9D724470FCF00D0161E /* BugsnagTests.m */,
+				E71DB9D624470FCF00D0161E /* BugsnagTestConstants.h */,
 				00F9393B23FD2D9B008C7073 /* BugsnagTestsDummyClass.h */,
 				00F9393A23FD2D9B008C7073 /* BugsnagTestsDummyClass.m */,
 				E7529FA1243CAE3F006B4932 /* BugsnagThreadSerializationTest.m */,
@@ -1138,11 +1142,14 @@
 			files = (
 				E7CE78CC1FD94E77001D07E0 /* KSSystemInfo_Tests.m in Sources */,
 				E7A9E56924361B6300D99F8A /* BugsnagAppTest.m in Sources */,
+				E71DB9DD24470FCF00D0161E /* BugsnagMetadataRedactionTest.m in Sources */,
 				4B775FD422CBE02F004839C5 /* BugsnagCollectionsBSGDictInsertIfNotNilTest.m in Sources */,
 				E7CE78C91FD94E77001D07E0 /* KSSignalInfo_Tests.m in Sources */,
+				E71DB9DA24470FCF00D0161E /* BugsnagPluginTest.m in Sources */,
 				E7CE78C61FD94E77001D07E0 /* KSMach_Tests.m in Sources */,
 				00F9393C23FD2D9B008C7073 /* BugsnagTestsDummyClass.m in Sources */,
 				E7D2E676243B8FB6005A3041 /* BugsnagStacktraceTest.m in Sources */,
+				E71DB9DF2447100000D0161E /* BugsnagMetadataTests.m in Sources */,
 				E7CE78D61FD94E9E001D07E0 /* FileBasedTestCase.m in Sources */,
 				E7CE78D51FD94E93001D07E0 /* XCTestCase+KSCrash.m in Sources */,
 				E7CE78CF1FD94E77001D07E0 /* NSError+SimpleConstructor_Tests.m in Sources */,
@@ -1158,6 +1165,7 @@
 				E79148631FD82BB7003EFEBF /* BugsnagUserTest.m in Sources */,
 				8A2C8FEA1C6BC38900846019 /* BugsnagBreadcrumbsTest.m in Sources */,
 				E7CE78BB1FD94E77001D07E0 /* KSCrashReportConverter_Tests.m in Sources */,
+				E71DB9DB24470FCF00D0161E /* BugsnagSessionTrackerStopTest.m in Sources */,
 				4B406C1922CAD96400464D1D /* BugsnagCollectionsBSGDictSetSafeObjectTest.m in Sources */,
 				8A2C8FEC1C6BC38900846019 /* BugsnagSinkTests.m in Sources */,
 				8AD9FA891E086351002859A7 /* BugsnagConfigurationTests.m in Sources */,
@@ -1173,6 +1181,8 @@
 				E7CE78C51FD94E77001D07E0 /* KSLogger_Tests.m in Sources */,
 				E7CE78C11FD94E77001D07E0 /* KSCrashState_Tests.m in Sources */,
 				E7529FA0243CAE35006B4932 /* BugsnagThreadTest.m in Sources */,
+				E71DB9DE24470FCF00D0161E /* BugsnagClientTests.m in Sources */,
+				E71DB9DC24470FCF00D0161E /* BugsnagTests.m in Sources */,
 				E7AB4B9E2423E184004F015A /* BugsnagOnBreadcrumbTest.m in Sources */,
 				E7CE78C31FD94E77001D07E0 /* KSFileUtils_Tests.m in Sources */,
 				E7CE78BC1FD94E77001D07E0 /* KSCrashReportStore_Tests.m in Sources */,

--- a/Source/BugsnagConfiguration.h
+++ b/Source/BugsnagConfiguration.h
@@ -107,6 +107,17 @@ typedef NS_OPTIONS(NSUInteger, BSGErrorType) {
  *  Release stages which are allowed to notify Bugsnag
  */
 @property(readwrite, retain, nullable) NSArray *enabledReleaseStages;
+
+/**
+ * Sets which values should be removed from any Metadata objects before
+ * sending them to Bugsnag. Use this if you want to ensure you don't send
+ * sensitive data such as passwords, and credit card numbers to our
+ * servers. Any keys which contain these strings will be filtered.
+ *
+ * By default, redactedKeys is set to "password"
+ */
+@property(readwrite, retain, nullable) NSArray<NSString *> *redactedKeys;
+
 /**
  *  A general summary of what was occuring in the application
  */

--- a/Source/BugsnagConfiguration.h
+++ b/Source/BugsnagConfiguration.h
@@ -112,9 +112,10 @@ typedef NS_OPTIONS(NSUInteger, BSGErrorType) {
  * Sets which values should be removed from any Metadata objects before
  * sending them to Bugsnag. Use this if you want to ensure you don't send
  * sensitive data such as passwords, and credit card numbers to our
- * servers. Any keys which contain these strings will be filtered.
+ * servers. Any keys which contain a match will be filtered.
  *
- * By default, redactedKeys is set to "password"
+ * By default, redactedKeys is set to ["password"]. Both string literals and regex
+ * values can be supplied to this property.
  */
 @property(readwrite, retain, nullable) NSArray<NSString *> *redactedKeys;
 

--- a/Source/BugsnagConfiguration.h
+++ b/Source/BugsnagConfiguration.h
@@ -117,7 +117,7 @@ typedef NS_OPTIONS(NSUInteger, BSGErrorType) {
  * By default, redactedKeys is set to ["password"]. Both string literals and regex
  * values can be supplied to this property.
  */
-@property(readwrite, retain, nullable) NSArray<NSString *> *redactedKeys;
+@property(readwrite, retain, nullable) NSArray<id> *redactedKeys;
 
 /**
  *  A general summary of what was occuring in the application

--- a/Source/BugsnagConfiguration.m
+++ b/Source/BugsnagConfiguration.m
@@ -121,6 +121,7 @@ NSString * const kBugsnagUserUserId = @"BugsnagUserUserId";
     [copy setEnabledBreadcrumbTypes:self.enabledBreadcrumbTypes];
     [copy setEnabledErrorTypes:self.enabledErrorTypes];
     [copy setEnabledReleaseStages:self.enabledReleaseStages];
+    [copy setRedactedKeys:self.redactedKeys];
     [copy setMaxBreadcrumbs:self.maxBreadcrumbs];
     [copy setMetadata: [[BugsnagMetadata alloc] initWithDictionary:[[self.metadata toDictionary] mutableCopy]]];
     [copy setEndpointsForNotify:self.notifyURL.absoluteString
@@ -191,6 +192,7 @@ NSString * const kBugsnagUserUserId = @"BugsnagUserUserId";
     _onBreadcrumbBlocks = [NSMutableArray new];
     _plugins = [NSMutableSet new];
     _enabledReleaseStages = nil;
+    _redactedKeys = @[@"password"];
     _breadcrumbs = [BugsnagBreadcrumbs new];
     _autoTrackSessions = YES;
     // Default to recording all error types

--- a/Source/BugsnagKeys.h
+++ b/Source/BugsnagKeys.h
@@ -86,7 +86,7 @@ static NSString *const BSGKeyUnhandled = @"unhandled";
 static NSString *const BSGKeyAttributes = @"attributes";
 static NSString *const BSGKeyAction = @"action";
 static NSString *const BSGKeySession = @"session";
-
+static NSString *const BSGKeyRedaction = @"[REDACTED]";
 
 static NSString *const BSGKeyExecutableName = @"CFBundleExecutable";
 static NSString *const BSGKeyHwModel = @"hw.model";

--- a/Source/BugsnagSink.m
+++ b/Source/BugsnagSink.m
@@ -43,6 +43,7 @@
 @interface BugsnagEvent ()
 - (NSDictionary *_Nonnull)toJson;
 - (BOOL)shouldBeSent;
+@property NSArray *redactedKeys;
 @end
 
 @interface BugsnagConfiguration ()
@@ -120,19 +121,19 @@
                  onCompletion:onCompletion];
 }
 
-
 // Generates the payload for notifying Bugsnag
-- (NSDictionary *)getBodyFromReports:(NSArray *)reports {
+- (NSDictionary *)getBodyFromReports:(NSArray *)events {
     NSMutableDictionary *data = [[NSMutableDictionary alloc] init];
     BSGDictSetSafeObject(data, [Bugsnag client].details, BSGKeyNotifier);
     BSGDictSetSafeObject(data, [Bugsnag client].configuration.apiKey, BSGKeyApiKey);
     BSGDictSetSafeObject(data, @"4.0", @"payloadVersion");
 
     NSMutableArray *formatted =
-            [[NSMutableArray alloc] initWithCapacity:[reports count]];
+            [[NSMutableArray alloc] initWithCapacity:[events count]];
 
-    for (BugsnagEvent *report in reports) {
-        BSGArrayAddSafeObject(formatted, [report toJson]);
+    for (BugsnagEvent *event in events) {
+        event.redactedKeys = [Bugsnag configuration].redactedKeys;
+        BSGArrayAddSafeObject(formatted, [event toJson]);
     }
 
     BSGDictSetSafeObject(data, formatted, BSGKeyEvents);

--- a/Source/BugsnagSink.m
+++ b/Source/BugsnagSink.m
@@ -105,7 +105,7 @@
         return;
     }
 
-    NSDictionary *reportData = [self getBodyFromReports:bugsnagReports];
+    NSDictionary *reportData = [self getBodyFromEvents:bugsnagReports];
 
     if (reportData == nil) {
         if (onCompletion) {
@@ -122,7 +122,7 @@
 }
 
 // Generates the payload for notifying Bugsnag
-- (NSDictionary *)getBodyFromReports:(NSArray *)events {
+- (NSDictionary *)getBodyFromEvents:(NSArray *)events {
     NSMutableDictionary *data = [[NSMutableDictionary alloc] init];
     BSGDictSetSafeObject(data, [Bugsnag client].details, BSGKeyNotifier);
     BSGDictSetSafeObject(data, [Bugsnag client].configuration.apiKey, BSGKeyApiKey);

--- a/Tests/BugsnagConfigurationTests.m
+++ b/Tests/BugsnagConfigurationTests.m
@@ -643,6 +643,12 @@
     XCTAssertEqualObjects(@"test@example.com", config.user.emailAddress);
 }
 
+- (void)testDefaultRedactedKeys {
+    BugsnagConfiguration *config = [[BugsnagConfiguration alloc] initWithApiKey:DUMMY_APIKEY_32CHAR_1];
+    XCTAssertEqual(1, [config.redactedKeys count]);
+    XCTAssertEqualObjects(@"password", config.redactedKeys[0]);
+}
+
 - (void)testApiKeySetter {
     BugsnagConfiguration *config = [[BugsnagConfiguration alloc] initWithApiKey:DUMMY_APIKEY_32CHAR_1];
     XCTAssertTrue([config.apiKey isEqualToString:DUMMY_APIKEY_32CHAR_1]);
@@ -783,6 +789,9 @@
     XCTAssertNotEqual(config, clone);
     
     // Change values
+
+    // Redacted keys
+    XCTAssertEqualObjects(config.redactedKeys, clone.redactedKeys);
     
     // Object
     [clone setUser:@"Cthulu" withEmail:@"hp@lovecraft.com" andName:@"Howard"];

--- a/Tests/BugsnagMetadataRedactionTest.m
+++ b/Tests/BugsnagMetadataRedactionTest.m
@@ -99,4 +99,23 @@
     }];
 }
 
+- (void)testRegexRedaction {
+    BugsnagEvent *event = [self generateEventWithMetadata:@{
+            @"password": @"hunter2",
+            @"somekey9": @"2fa0",
+            @"somekey": @"ba09"
+    }];
+    // disallow any numeric characters
+    NSRegularExpression *regex = [NSRegularExpression regularExpressionWithPattern:@"[0-9]" options:0 error:nil];
+    event.redactedKeys = @[@"password", regex];
+
+    NSDictionary *payload = [event toJson];
+    NSDictionary *section = payload[@"metaData"][@"custom"];
+    XCTAssertNotNil(section);
+    XCTAssertEqualObjects(@"[REDACTED]", section[@"password"]);
+    XCTAssertEqualObjects(@"[REDACTED]", section[@"somekey9"]);
+    XCTAssertEqualObjects(@"ba09", section[@"somekey"]);
+}
+
+
 @end

--- a/Tests/BugsnagSinkTests.m
+++ b/Tests/BugsnagSinkTests.m
@@ -20,7 +20,7 @@
 @end
 
 @interface BugsnagSink ()
-- (NSDictionary *)getBodyFromReports:(NSArray *)events;
+- (NSDictionary *)getBodyFromEvents:(NSArray *)events;
 @end
 
 @implementation BugsnagSinkTests
@@ -47,7 +47,7 @@
     [Bugsnag startBugsnagWithConfiguration:config];
     BugsnagEvent *report =
     [[BugsnagEvent alloc] initWithKSReport:self.rawReportData];
-    self.processedData = [[BugsnagSink new] getBodyFromReports:@[ report ]];
+    self.processedData = [[BugsnagSink new] getBodyFromEvents:@[report]];
 }
 
 - (void)tearDown {
@@ -312,7 +312,7 @@
                                      handledState:state
                                           session:nil];
     
-    NSDictionary *data = [[BugsnagSink new] getBodyFromReports:@[ report ]];
+    NSDictionary *data = [[BugsnagSink new] getBodyFromEvents:@[report]];
     return [data[@"events"] firstObject];
 }
 
@@ -396,7 +396,7 @@
                                           session:nil];
     report.severity = BSGSeverityInfo;
     
-    NSDictionary *data = [[BugsnagSink new] getBodyFromReports:@[ report ]];
+    NSDictionary *data = [[BugsnagSink new] getBodyFromEvents:@[report]];
     NSDictionary *payload = [data[@"events"] firstObject];
     
     XCTAssertEqualObjects(@"info", payload[@"severity"]);

--- a/Tests/BugsnagSinkTests.m
+++ b/Tests/BugsnagSinkTests.m
@@ -20,7 +20,7 @@
 @end
 
 @interface BugsnagSink ()
-- (NSDictionary *)getBodyFromReports:(NSArray *)reports;
+- (NSDictionary *)getBodyFromReports:(NSArray *)events;
 @end
 
 @implementation BugsnagSinkTests

--- a/UPGRADING.md
+++ b/UPGRADING.md
@@ -36,6 +36,8 @@ The exact error is available using the `BSGConfigurationErrorDomain` and
 
 + config.addOnBreadcrumb(block:)
 + config.removeOnBreadcrumb(block:)
+
++ config.redactedKeys
 ```
 
 #### Renames

--- a/iOS/Bugsnag.xcodeproj/project.pbxproj
+++ b/iOS/Bugsnag.xcodeproj/project.pbxproj
@@ -148,6 +148,7 @@
 		E7107C851F4C97F100BB3F98 /* BSG_RFC3339DateTool.m in Sources */ = {isa = PBXBuildFile; fileRef = E7107C191F4C97F100BB3F98 /* BSG_RFC3339DateTool.m */; };
 		E7107C861F4C97F100BB3F98 /* BSG_KSCrashReportFilter.h in Headers */ = {isa = PBXBuildFile; fileRef = E7107C1C1F4C97F100BB3F98 /* BSG_KSCrashReportFilter.h */; };
 		E7107C871F4C97F100BB3F98 /* BSG_KSCrashReportFilterCompletion.h in Headers */ = {isa = PBXBuildFile; fileRef = E7107C1D1F4C97F100BB3F98 /* BSG_KSCrashReportFilterCompletion.h */; };
+		E71DB9D124470F4100D0161E /* BugsnagMetadataRedactionTest.m in Sources */ = {isa = PBXBuildFile; fileRef = E71DB9D024470F4100D0161E /* BugsnagMetadataRedactionTest.m */; };
 		E71FF7591FD55CE50099C9DD /* BugsnagApiClient.h in CopyFiles */ = {isa = PBXBuildFile; fileRef = F42950F4A741305B77E95389 /* BugsnagApiClient.h */; };
 		E722105C243B69F00083CF15 /* BugsnagStackframeTest.m in Sources */ = {isa = PBXBuildFile; fileRef = E722105B243B69F00083CF15 /* BugsnagStackframeTest.m */; };
 		E72352B61F55718E00436528 /* BSGConnectivity.h in Headers */ = {isa = PBXBuildFile; fileRef = E72352B41F55718E00436528 /* BSGConnectivity.h */; };
@@ -632,6 +633,7 @@
 		E7107C191F4C97F100BB3F98 /* BSG_RFC3339DateTool.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; name = BSG_RFC3339DateTool.m; path = ../Source/KSCrash/Source/KSCrash/Recording/Tools/BSG_RFC3339DateTool.m; sourceTree = SOURCE_ROOT; };
 		E7107C1C1F4C97F100BB3F98 /* BSG_KSCrashReportFilter.h */ = {isa = PBXFileReference; explicitFileType = sourcecode.c.h; fileEncoding = 4; name = BSG_KSCrashReportFilter.h; path = ../Source/KSCrash/Source/KSCrash/Reporting/Filters/BSG_KSCrashReportFilter.h; sourceTree = SOURCE_ROOT; };
 		E7107C1D1F4C97F100BB3F98 /* BSG_KSCrashReportFilterCompletion.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; name = BSG_KSCrashReportFilterCompletion.h; path = ../Source/KSCrash/Source/KSCrash/Reporting/Filters/BSG_KSCrashReportFilterCompletion.h; sourceTree = SOURCE_ROOT; };
+		E71DB9D024470F4100D0161E /* BugsnagMetadataRedactionTest.m */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.objc; name = BugsnagMetadataRedactionTest.m; path = ../../Tests/BugsnagMetadataRedactionTest.m; sourceTree = "<group>"; };
 		E722105B243B69F00083CF15 /* BugsnagStackframeTest.m */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.objc; name = BugsnagStackframeTest.m; path = ../../Tests/BugsnagStackframeTest.m; sourceTree = "<group>"; };
 		E72352B41F55718E00436528 /* BSGConnectivity.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; name = BSGConnectivity.h; path = ../Source/BSGConnectivity.h; sourceTree = SOURCE_ROOT; };
 		E72352B51F55718E00436528 /* BSGConnectivity.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; name = BSGConnectivity.m; path = ../Source/BSGConnectivity.m; sourceTree = SOURCE_ROOT; };
@@ -702,8 +704,6 @@
 		E7D2E669243B8F48005A3041 /* BugsnagStacktrace.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; name = BugsnagStacktrace.h; path = ../Source/BugsnagStacktrace.h; sourceTree = "<group>"; };
 		E7D2E66A243B8F48005A3041 /* BugsnagStacktrace.m */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.objc; name = BugsnagStacktrace.m; path = ../Source/BugsnagStacktrace.m; sourceTree = "<group>"; };
 		E7D2E66F243B8F8D005A3041 /* BugsnagStacktraceTest.m */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.objc; name = BugsnagStacktraceTest.m; path = ../../Tests/BugsnagStacktraceTest.m; sourceTree = "<group>"; };
-		E7EB06721FCDAF2000C076A6 /* BugsnagKSCrashSysInfoParser.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; name = BugsnagKSCrashSysInfoParser.h; path = ../Source/BugsnagKSCrashSysInfoParser.h; sourceTree = "<group>"; };
-		E7EB06731FCDAF2000C076A6 /* BugsnagKSCrashSysInfoParser.m */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.objc; name = BugsnagKSCrashSysInfoParser.m; path = ../Source/BugsnagKSCrashSysInfoParser.m; sourceTree = "<group>"; };
 		E7EC040C1F4CC6A000C2E9D5 /* libc++.1.dylib */ = {isa = PBXFileReference; lastKnownFileType = "compiled.mach-o.dylib"; name = "libc++.1.dylib"; path = "../../../../../usr/lib/libc++.1.dylib"; sourceTree = "<group>"; };
 		E7EC040D1F4CC6A000C2E9D5 /* libz.1.dylib */ = {isa = PBXFileReference; lastKnownFileType = "compiled.mach-o.dylib"; name = libz.1.dylib; path = ../../../../../usr/lib/libz.1.dylib; sourceTree = "<group>"; };
 		E7EC04101F4CC82800C2E9D5 /* libstdc++.6.0.9.dylib */ = {isa = PBXFileReference; lastKnownFileType = "compiled.mach-o.dylib"; name = "libstdc++.6.0.9.dylib"; path = "../../../../../usr/lib/libstdc++.6.0.9.dylib"; sourceTree = "<group>"; };
@@ -866,6 +866,7 @@
 				8A2C8F8C1C6BBFDD00846019 /* BugsnagEventTests.m */,
 				4B47970922A9AE1F00FF9C2E /* BugsnagEventFromKSCrashReportTest.m */,
 				E77316E11F73B46600A14F06 /* BugsnagHandledStateTest.m */,
+				E71DB9D024470F4100D0161E /* BugsnagMetadataRedactionTest.m */,
 				009131BB23F46279000810D9 /* BugsnagMetadataTests.m */,
 				E7AB4B9B2423E16C004F015A /* BugsnagOnBreadcrumbTest.m */,
 				E72AE1FF241A57B100ED8972 /* BugsnagPluginTest.m */,
@@ -882,7 +883,6 @@
 				00F9393823FC4F64008C7073 /* BugsnagTestsDummyClass.m */,
 				E7529F9B243CAE02006B4932 /* BugsnagThreadSerializationTest.m */,
 				E7529F9D243CAE0D006B4932 /* BugsnagThreadTest.m */,
-				F429551527EAE3AFE1F605FE /* BugsnagThreadTest.m */,
 				E78C1EFD1FCC778700B976D3 /* BugsnagUserTest.m */,
 				F42954B7D892334E7551F0F3 /* RegisterErrorDataTest.m */,
 				000E6E9C23D8690E009D8194 /* Tests-Bridging-Header.h */,
@@ -1162,8 +1162,6 @@
 				F4295E2778677786239F2B28 /* BugsnagApiClient.m */,
 				E72962D21F4BBA8B00CEA15D /* BugsnagErrorReportApiClient.h */,
 				E72962D31F4BBA8B00CEA15D /* BugsnagErrorReportApiClient.m */,
-				8A2C8F4D1C6BBE3C00846019 /* BugsnagSink.h */,
-				8A2C8F4E1C6BBE3C00846019 /* BugsnagSink.m */,
 			);
 			name = Delivery;
 			sourceTree = "<group>";
@@ -1521,6 +1519,7 @@
 				E733A76F1FD709B7003EAA29 /* KSCrashReportStore_Tests.m in Sources */,
 				E70EE0781FD7039E00FA745C /* RFC3339DateTool_Tests.m in Sources */,
 				8A530CC422FDD51F00F0C108 /* KSCrashIdentifierTests.m in Sources */,
+				E71DB9D124470F4100D0161E /* BugsnagMetadataRedactionTest.m in Sources */,
 				0089B70324221EDE00D5A7F2 /* BugsnagClientTests.m in Sources */,
 				8A4E733F1DC13281001F7CC8 /* BugsnagConfigurationTests.m in Sources */,
 				E784D25A1FD70C25004B01E1 /* KSJSONCodec_Tests.m in Sources */,

--- a/tvOS/Bugsnag.xcodeproj/project.pbxproj
+++ b/tvOS/Bugsnag.xcodeproj/project.pbxproj
@@ -53,6 +53,13 @@
 		8AD9A5041D42EEB0004E1CC5 /* BugsnagSink.m in Sources */ = {isa = PBXBuildFile; fileRef = 8AB151351D41366400C9B218 /* BugsnagSink.m */; };
 		8AD9A5051D42EEE9004E1CC5 /* BSG_KSCrashReportWriter.h in Headers */ = {isa = PBXBuildFile; fileRef = 8AB151251D41366400C9B218 /* BSG_KSCrashReportWriter.h */; settings = {ATTRIBUTES = (Public, ); }; };
 		8AD9FA8D1E0863A1002859A7 /* BugsnagConfigurationTests.m in Sources */ = {isa = PBXBuildFile; fileRef = 8AD9FA8B1E0863A1002859A7 /* BugsnagConfigurationTests.m */; };
+		E71DB9E72447105E00D0161E /* BugsnagTests.m in Sources */ = {isa = PBXBuildFile; fileRef = E71DB9E02447105D00D0161E /* BugsnagTests.m */; };
+		E71DB9E82447105E00D0161E /* BugsnagMetadataRedactionTest.m in Sources */ = {isa = PBXBuildFile; fileRef = E71DB9E12447105E00D0161E /* BugsnagMetadataRedactionTest.m */; };
+		E71DB9E92447105E00D0161E /* BugsnagSessionTrackerStopTest.m in Sources */ = {isa = PBXBuildFile; fileRef = E71DB9E22447105E00D0161E /* BugsnagSessionTrackerStopTest.m */; };
+		E71DB9EA2447105E00D0161E /* BSGConnectivityTest.m in Sources */ = {isa = PBXBuildFile; fileRef = E71DB9E32447105E00D0161E /* BSGConnectivityTest.m */; };
+		E71DB9EB2447105E00D0161E /* BugsnagClientTests.m in Sources */ = {isa = PBXBuildFile; fileRef = E71DB9E42447105E00D0161E /* BugsnagClientTests.m */; };
+		E71DB9EC2447105E00D0161E /* BugsnagPluginTest.m in Sources */ = {isa = PBXBuildFile; fileRef = E71DB9E52447105E00D0161E /* BugsnagPluginTest.m */; };
+		E71DB9ED2447105E00D0161E /* BugsnagMetadataTests.m in Sources */ = {isa = PBXBuildFile; fileRef = E71DB9E62447105E00D0161E /* BugsnagMetadataTests.m */; };
 		E7221060243B6A220083CF15 /* BugsnagStackframeTest.m in Sources */ = {isa = PBXBuildFile; fileRef = E722105F243B6A220083CF15 /* BugsnagStackframeTest.m */; };
 		E72352BA1F55922F00436528 /* SystemConfiguration.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = E72352B91F55922F00436528 /* SystemConfiguration.framework */; };
 		E72352BD1F55923700436528 /* BSGConnectivity.h in Headers */ = {isa = PBXBuildFile; fileRef = E72352BB1F55923700436528 /* BSGConnectivity.h */; };
@@ -275,6 +282,13 @@
 		8AB151341D41366400C9B218 /* BugsnagSink.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; name = BugsnagSink.h; path = ../Source/BugsnagSink.h; sourceTree = "<group>"; };
 		8AB151351D41366400C9B218 /* BugsnagSink.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; name = BugsnagSink.m; path = ../Source/BugsnagSink.m; sourceTree = "<group>"; };
 		8AD9FA8B1E0863A1002859A7 /* BugsnagConfigurationTests.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; name = BugsnagConfigurationTests.m; path = ../Tests/BugsnagConfigurationTests.m; sourceTree = SOURCE_ROOT; };
+		E71DB9E02447105D00D0161E /* BugsnagTests.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; name = BugsnagTests.m; path = ../../Tests/BugsnagTests.m; sourceTree = "<group>"; };
+		E71DB9E12447105E00D0161E /* BugsnagMetadataRedactionTest.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; name = BugsnagMetadataRedactionTest.m; path = ../../Tests/BugsnagMetadataRedactionTest.m; sourceTree = "<group>"; };
+		E71DB9E22447105E00D0161E /* BugsnagSessionTrackerStopTest.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; name = BugsnagSessionTrackerStopTest.m; path = ../../Tests/BugsnagSessionTrackerStopTest.m; sourceTree = "<group>"; };
+		E71DB9E32447105E00D0161E /* BSGConnectivityTest.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; name = BSGConnectivityTest.m; path = ../../Tests/BSGConnectivityTest.m; sourceTree = "<group>"; };
+		E71DB9E42447105E00D0161E /* BugsnagClientTests.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; name = BugsnagClientTests.m; path = ../../Tests/BugsnagClientTests.m; sourceTree = "<group>"; };
+		E71DB9E52447105E00D0161E /* BugsnagPluginTest.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; name = BugsnagPluginTest.m; path = ../../Tests/BugsnagPluginTest.m; sourceTree = "<group>"; };
+		E71DB9E62447105E00D0161E /* BugsnagMetadataTests.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; name = BugsnagMetadataTests.m; path = ../../Tests/BugsnagMetadataTests.m; sourceTree = "<group>"; };
 		E722105F243B6A220083CF15 /* BugsnagStackframeTest.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; name = BugsnagStackframeTest.m; path = ../../Tests/BugsnagStackframeTest.m; sourceTree = "<group>"; };
 		E72352B91F55922F00436528 /* SystemConfiguration.framework */ = {isa = PBXFileReference; lastKnownFileType = wrapper.framework; name = SystemConfiguration.framework; path = System/Library/Frameworks/SystemConfiguration.framework; sourceTree = SDKROOT; };
 		E72352BB1F55923700436528 /* BSGConnectivity.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; name = BSGConnectivity.h; path = ../Source/BSGConnectivity.h; sourceTree = "<group>"; };
@@ -506,8 +520,6 @@
 				8A6C6FAB2257882400E8EF24 /* BSGOutOfMemoryWatchdog.m */,
 				8A627CD31EC3B69300F7C04E /* BSGSerialization.h */,
 				8A627CD41EC3B69300F7C04E /* BSGSerialization.m */,
-				E7D2E679243B8FD2005A3041 /* BugsnagStacktrace.h */,
-				E7D2E67A243B8FD2005A3041 /* BugsnagStacktrace.m */,
 				8AB1512A1D41366400C9B218 /* BugsnagCollections.h */,
 				8AB1512B1D41366400C9B218 /* BugsnagCollections.m */,
 				8AB1512C1D41366400C9B218 /* BugsnagConfiguration.h */,
@@ -535,8 +547,10 @@
 			isa = PBXGroup;
 			children = (
 				E7CE78D71FD94EF1001D07E0 /* KSCrash */,
+				E71DB9E32447105E00D0161E /* BSGConnectivityTest.m */,
 				4B3CD2B722C5676700DBFF33 /* BSGOutOfMemoryWatchdogTests.m */,
 				E790C4A02434CB5B006FFB26 /* BugsnagAppTest.m */,
+				E71DB9E42447105E00D0161E /* BugsnagClientTests.m */,
 				E7A9E56E2436366800D99F8A /* BugsnagDeviceTest.m */,
 				00F9393423FC16DA008C7073 /* BugsnagBaseUnitTest.h */,
 				00F9393523FC16DA008C7073 /* BugsnagBaseUnitTest.m */,
@@ -549,17 +563,19 @@
 				00D7ACA623E98A5D00FBE4A7 /* BugsnagEventTests.m */,
 				00D7ACA923E98A9A00FBE4A7 /* BugsnagEventFromKSCrashReportTest.m */,
 				E762E9EE1F73F6CF00E82B43 /* BugsnagHandledStateTest.m */,
+				E71DB9E12447105E00D0161E /* BugsnagMetadataRedactionTest.m */,
+				E71DB9E62447105E00D0161E /* BugsnagMetadataTests.m */,
 				E77526C6242E694C0077A42F /* BugsnagOnBreadcrumbTest.m */,
+				E71DB9E52447105E00D0161E /* BugsnagPluginTest.m */,
 				E791488C1FD82E77003EFEBF /* BugsnagSessionTest.m */,
 				E791488A1FD82E77003EFEBF /* BugsnagSessionTrackerTest.m */,
 				E791488B1FD82E77003EFEBF /* BugsnagSessionTrackingPayloadTest.m */,
+				E71DB9E22447105E00D0161E /* BugsnagSessionTrackerStopTest.m */,
 				8AB1511F1D41361700C9B218 /* BugsnagSinkTests.m */,
+				E71DB9E02447105D00D0161E /* BugsnagTests.m */,
 				00D7ACA523E98A5D00FBE4A7 /* BugsnagTestConstants.h */,
 				E722105F243B6A220083CF15 /* BugsnagStackframeTest.m */,
 				E7D2E677243B8FC8005A3041 /* BugsnagStacktraceTest.m */,
-				E722105F243B6A220083CF15 /* BugsnagStackframeTest.m */,
-				E7D2E677243B8FC8005A3041 /* BugsnagStacktraceTest.m */,
-				E791488D1FD82E77003EFEBF /* BugsnagUserTest.m */,
 				00F9393D23FD2DDB008C7073 /* BugsnagTestsDummyClass.h */,
 				00F9393E23FD2DDB008C7073 /* BugsnagTestsDummyClass.m */,
 				4B3CD2B922C5676700DBFF33 /* BugsnagThreadTest.m */,
@@ -1136,14 +1152,17 @@
 			files = (
 				E77526C7242E694C0077A42F /* BugsnagOnBreadcrumbTest.m in Sources */,
 				E790C4A12434CB5B006FFB26 /* BugsnagAppTest.m in Sources */,
+				E71DB9E82447105E00D0161E /* BugsnagMetadataRedactionTest.m in Sources */,
 				8ACF0F74201812AD00173809 /* BugsnagSinkTests.m in Sources */,
 				E7529FA6243CAE6A006B4932 /* BugsnagThreadSerializationTest.m in Sources */,
 				4B3CD2BD22C5676800DBFF33 /* BugsnagThreadTest.m in Sources */,
+				E71DB9EC2447105E00D0161E /* BugsnagPluginTest.m in Sources */,
 				00D7ACA723E98A5D00FBE4A7 /* BugsnagEventTests.m in Sources */,
 				E7CE78F21FD94F1B001D07E0 /* KSMach_Tests.m in Sources */,
 				E7CE79071FD94F1B001D07E0 /* KSSysCtl_Tests.m in Sources */,
 				E7CE78F71FD94F1B001D07E0 /* KSCrashSentry_Signal_Tests.m in Sources */,
 				E790C422243231EA006FFB26 /* BugsnagClientMirrorTest.m in Sources */,
+				E71DB9ED2447105E00D0161E /* BugsnagMetadataTests.m in Sources */,
 				E7CE78FE1FD94F1B001D07E0 /* KSSignalInfo_Tests.m in Sources */,
 				00D7ACAB23E98A9A00FBE4A7 /* BugsnagEventFromKSCrashReportTest.m in Sources */,
 				E7CE78FC1FD94F1B001D07E0 /* KSCrashSentry_NSException_Tests.m in Sources */,
@@ -1153,10 +1172,13 @@
 				E7221060243B6A220083CF15 /* BugsnagStackframeTest.m in Sources */,
 				E7CE78F31FD94F1B001D07E0 /* NSError+SimpleConstructor_Tests.m in Sources */,
 				4B775FD122CBE01F004839C5 /* BugsnagCollectionsBSGDictInsertIfNotNilTest.m in Sources */,
+				E71DB9EA2447105E00D0161E /* BSGConnectivityTest.m in Sources */,
 				E7A9E56F2436366800D99F8A /* BugsnagDeviceTest.m in Sources */,
 				E7CE79001FD94F1B001D07E0 /* KSJSONCodec_Tests.m in Sources */,
 				E7CE79051FD94F1B001D07E0 /* KSDynamicLinker_Tests.m in Sources */,
+				E71DB9E92447105E00D0161E /* BugsnagSessionTrackerStopTest.m in Sources */,
 				E7CE78F61FD94F1B001D07E0 /* FileBasedTestCase.m in Sources */,
+				E71DB9EB2447105E00D0161E /* BugsnagClientTests.m in Sources */,
 				E7CE79031FD94F1B001D07E0 /* KSCrashReportConverter_Tests.m in Sources */,
 				E79148911FD82E77003EFEBF /* BugsnagUserTest.m in Sources */,
 				E791488E1FD82E77003EFEBF /* BugsnagSessionTrackerTest.m in Sources */,
@@ -1173,6 +1195,7 @@
 				E791488F1FD82E77003EFEBF /* BugsnagSessionTrackingPayloadTest.m in Sources */,
 				8AD9FA8D1E0863A1002859A7 /* BugsnagConfigurationTests.m in Sources */,
 				4B406C1422CAD94100464D1D /* BugsnagCollectionsBSGDictSetSafeObjectTest.m in Sources */,
+				E71DB9E72447105E00D0161E /* BugsnagTests.m in Sources */,
 				E7CE79021FD94F1B001D07E0 /* RFC3339DateTool_Tests.m in Sources */,
 				4B3CD2BE22C5676800DBFF33 /* RegisterErrorDataTest.m in Sources */,
 				E7CE78F91FD94F1B001D07E0 /* KSSystemInfo_Tests.m in Sources */,


### PR DESCRIPTION
## Goal
Adds the `redactedKeys` property to `Configuration` which allows a user to specify sensitive keys. Any sensitive values present in the metadata of `BugsnagEvent` will be replaced by `"[REDACTED]"` when serialized to JSON.

## Changeset
- Added `redactedKeys` property to `Configuration`, which by default is an array of "password"
- Set the `redactedKeys` on each `BugsnagEvent` using the `Configuration` value
- Sanitised the metadata at the point of JSON serialization when 
- `BugsnagEvent` now redacts sensitive values with any key that is considered redacted

## Tests
- Added unit tests to verify the default value of `redactedKeys` and its effect on JSON serialization
- Added tests to macOS/tvOS projects which already existed on the file system but which were not part of the xcodeproj file

