### PR TITLE
Add originalError property to BugsnagEvent

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,9 @@ Bugsnag Notifiers on other platforms.
 
 ## Enhancements
 
+* Add `originalError` property to `BugsnagEvent`
+  [#541](https://github.com/bugsnag/bugsnag-cocoa/pull/541)
+
 * Create structured `BugsnagThread` class
   [#532](https://github.com/bugsnag/bugsnag-cocoa/pull/532)
 

--- a/Source/BugsnagClient.m
+++ b/Source/BugsnagClient.m
@@ -766,6 +766,7 @@ NSString *const BSGBreadcrumbLoadedMessage = @"Bugsnag loaded";
     [self notify:wrapper
     handledState:state
            block:^(BugsnagEvent *_Nonnull event) {
+                event.originalError = error;
                 [event addMetadata:@{
                                         @"code" : @(error.code),
                                         @"domain" : error.domain,
@@ -872,6 +873,7 @@ NSString *const BSGBreadcrumbLoadedMessage = @"Bugsnag loaded";
                                                          metadata:self.metadata
                                                      handledState:handledState
                                                           session:self.sessionTracker.runningSession];
+    event.originalError = exception;
     
     if (block) {
         block(event);

--- a/Source/BugsnagEvent.h
+++ b/Source/BugsnagEvent.h
@@ -138,5 +138,15 @@ initWithErrorName:(NSString *_Nonnull)name
  */
 @property(readonly, nonnull) NSMutableArray<BugsnagThread *> *threads;
 
+/**
+ * The original object that caused the error in your application. This value will only be populated for
+ * non-fatal errors which did not terminate the process, and will contain an NSError or NSException.
+ *
+ * Manipulating this field does not affect the error information reported to the
+ * Bugsnag dashboard. Use event.errors to access and amend the representation of
+ * the error that will be sent.
+ */
+@property(nullable) id originalError;
+
 @end
 

--- a/UPGRADING.md
+++ b/UPGRADING.md
@@ -221,6 +221,7 @@ This is now BugsnagEvent.
 
 ```diff
 + event.unhandled
++ event.originalError
 ```
 
 `event.device` is now a structured class with properties for each value, rather than an `NSDictionary`.


### PR DESCRIPTION
## Goal

Adds the `originalError` property to `BugsnagEvent`, as per the notifier spec.

This property contains the value of either the `NSError` or `NSException` which caused the error, if they are available. Otherwise the value will be nil.

## Changeset

Populated the `originalError` property with the causing `NSException` or `NSError`.
 
## Tests

Manually verified that the properties are populated when calling Bugsnag.notify.
