### PR TITLE
Move endpoint configuration to class

### DIFF
--- a/Bugsnag.podspec.json
+++ b/Bugsnag.podspec.json
@@ -38,6 +38,7 @@
     "Source/BugsnagConfiguration.h",
     "Source/BugsnagDevice.h",
     "Source/BugsnagDeviceWithState.h",
+    "Source/BugsnagEndpointConfiguration.h",
     "Source/BugsnagError.h",
     "Source/BugsnagEvent.h",
     "Source/BugsnagMetadata.h",

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,9 @@ Bugsnag Notifiers on other platforms.
 * Add `redactedKeys` for removing sensitive values from metadata
   [#540](https://github.com/bugsnag/bugsnag-cocoa/pull/540)
 
+* Move endpoint configuration to class
+  [#542](https://github.com/bugsnag/bugsnag-cocoa/pull/542)
+
 * Make all callbacks return boolean values
   [#534](https://github.com/bugsnag/bugsnag-cocoa/pull/534)
 

--- a/OSX/Bugsnag.xcodeproj/project.pbxproj
+++ b/OSX/Bugsnag.xcodeproj/project.pbxproj
@@ -73,6 +73,8 @@
 		E762E9FD1F73F80200E82B43 /* BugsnagHandledState.m in Sources */ = {isa = PBXBuildFile; fileRef = E762E9FB1F73F80200E82B43 /* BugsnagHandledState.m */; };
 		E77526C0242D0E180077A42F /* BugsnagBreadcrumbs.m in Sources */ = {isa = PBXBuildFile; fileRef = E77526BE242D0E180077A42F /* BugsnagBreadcrumbs.m */; };
 		E77526C1242D0E180077A42F /* BugsnagBreadcrumbs.h in Headers */ = {isa = PBXBuildFile; fileRef = E77526BF242D0E180077A42F /* BugsnagBreadcrumbs.h */; };
+		E77AFF0F244A18B10082B8BB /* BugsnagEndpointConfiguration.m in Sources */ = {isa = PBXBuildFile; fileRef = E77AFF0D244A18B10082B8BB /* BugsnagEndpointConfiguration.m */; };
+		E77AFF10244A18B10082B8BB /* BugsnagEndpointConfiguration.h in Headers */ = {isa = PBXBuildFile; fileRef = E77AFF0E244A18B10082B8BB /* BugsnagEndpointConfiguration.h */; settings = {ATTRIBUTES = (Public, ); }; };
 		E790C42324324528006FFB26 /* BugsnagClientMirrorTest.m in Sources */ = {isa = PBXBuildFile; fileRef = E790C41F2432314A006FFB26 /* BugsnagClientMirrorTest.m */; };
 		E790C427243354FD006FFB26 /* BugsnagClientInternal.h in Headers */ = {isa = PBXBuildFile; fileRef = E790C426243354FD006FFB26 /* BugsnagClientInternal.h */; };
 		E790C47024349CE2006FFB26 /* BugsnagStackframe.m in Sources */ = {isa = PBXBuildFile; fileRef = E790C46224349CE1006FFB26 /* BugsnagStackframe.m */; };
@@ -301,6 +303,8 @@
 		E762E9FB1F73F80200E82B43 /* BugsnagHandledState.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; name = BugsnagHandledState.m; path = ../Source/BugsnagHandledState.m; sourceTree = SOURCE_ROOT; };
 		E77526BE242D0E180077A42F /* BugsnagBreadcrumbs.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; name = BugsnagBreadcrumbs.m; path = ../Source/BugsnagBreadcrumbs.m; sourceTree = "<group>"; };
 		E77526BF242D0E180077A42F /* BugsnagBreadcrumbs.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; name = BugsnagBreadcrumbs.h; path = ../Source/BugsnagBreadcrumbs.h; sourceTree = "<group>"; };
+		E77AFF0D244A18B10082B8BB /* BugsnagEndpointConfiguration.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; name = BugsnagEndpointConfiguration.m; path = ../Source/BugsnagEndpointConfiguration.m; sourceTree = "<group>"; };
+		E77AFF0E244A18B10082B8BB /* BugsnagEndpointConfiguration.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; name = BugsnagEndpointConfiguration.h; path = ../Source/BugsnagEndpointConfiguration.h; sourceTree = "<group>"; };
 		E790C41F2432314A006FFB26 /* BugsnagClientMirrorTest.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; path = BugsnagClientMirrorTest.m; sourceTree = "<group>"; };
 		E790C426243354FD006FFB26 /* BugsnagClientInternal.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; name = BugsnagClientInternal.h; path = ../Source/BugsnagClientInternal.h; sourceTree = "<group>"; };
 		E790C46224349CE1006FFB26 /* BugsnagStackframe.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; name = BugsnagStackframe.m; path = ../Source/BugsnagStackframe.m; sourceTree = "<group>"; };
@@ -521,6 +525,8 @@
 				8A2C8FC21C6BC2C800846019 /* BugsnagConfiguration.m */,
 				E79E6AFC1F4E3847002B35F9 /* BugsnagCrashSentry.h */,
 				E79E6AFD1F4E3847002B35F9 /* BugsnagCrashSentry.m */,
+				E77AFF0E244A18B10082B8BB /* BugsnagEndpointConfiguration.h */,
+				E77AFF0D244A18B10082B8BB /* BugsnagEndpointConfiguration.m */,
 				E762E9FA1F73F80200E82B43 /* BugsnagHandledState.h */,
 				E762E9FB1F73F80200E82B43 /* BugsnagHandledState.m */,
 				E794E8041F9F746D00A67EE7 /* BugsnagKeys.h */,
@@ -881,6 +887,7 @@
 			isa = PBXHeadersBuildPhase;
 			buildActionMask = 2147483647;
 			files = (
+				E77AFF10244A18B10082B8BB /* BugsnagEndpointConfiguration.h in Headers */,
 				E790C47C24349CE2006FFB26 /* BugsnagThread.h in Headers */,
 				E790C47A24349CE2006FFB26 /* BugsnagStackframe.h in Headers */,
 				E790C47624349CE2006FFB26 /* BugsnagError.h in Headers */,
@@ -1075,6 +1082,7 @@
 				8A2C8FDE1C6BC2C800846019 /* BugsnagSink.m in Sources */,
 				0089B6EB2411682000D5A7F2 /* BugsnagClient.m in Sources */,
 				E79E6BBE1F4E3850002B35F9 /* BSG_KSMach.c in Sources */,
+				E77AFF0F244A18B10082B8BB /* BugsnagEndpointConfiguration.m in Sources */,
 				E79E6B991F4E3850002B35F9 /* BSG_KSCrashType.c in Sources */,
 				E79E6BC01F4E3850002B35F9 /* BSG_KSMach_Arm.c in Sources */,
 				E79E6B8F1F4E3850002B35F9 /* BSG_KSCrashDoctor.m in Sources */,

--- a/Source/Bugsnag.h
+++ b/Source/Bugsnag.h
@@ -34,6 +34,7 @@
 #import "BugsnagAppWithState.h"
 #import "BugsnagDevice.h"
 #import "BugsnagDeviceWithState.h"
+#import "BugsnagEndpointConfiguration.h"
 #import "BugsnagError.h"
 #import "BugsnagStackframe.h"
 #import "BugsnagThread.h"

--- a/Source/BugsnagConfiguration.h
+++ b/Source/BugsnagConfiguration.h
@@ -34,6 +34,7 @@
 #import "BugsnagMetadataStore.h"
 
 @class BugsnagUser;
+@class BugsnagEndpointConfiguration;
 
 /**
  * BugsnagConfiguration error constants
@@ -204,15 +205,8 @@ typedef NS_OPTIONS(NSUInteger, BSGErrorType) {
  * Please note that it is recommended that you set both endpoints. If the notify endpoint is
  * missing, an assertion will be thrown. If the session endpoint is missing, a warning will be
  * logged and sessions will not be sent automatically.
- *
- * @param notify the notify endpoint
- * @param sessions the sessions endpoint
- *
- * @throws an assertion if the notify endpoint is not a valid URL
  */
-
-- (void)setEndpointsForNotify:(NSString *_Nonnull)notify
-                     sessions:(NSString *_Nonnull)sessions NS_SWIFT_NAME(setEndpoints(notify:sessions:));
+@property(nonnull, nonatomic) BugsnagEndpointConfiguration *endpoints;
 
 // =============================================================================
 // MARK: - User

--- a/Source/BugsnagConfiguration.m
+++ b/Source/BugsnagConfiguration.m
@@ -37,6 +37,7 @@
 #import "BugsnagBreadcrumbs.h"
 #import "BugsnagMetadataStore.h"
 #import "BSGSerialization.h"
+#import "BugsnagEndpointConfiguration.h"
 
 static NSString *const kHeaderApiPayloadVersion = @"Bugsnag-Payload-Version";
 static NSString *const kHeaderApiKey = @"Bugsnag-Api-Key";
@@ -124,8 +125,7 @@ NSString * const kBugsnagUserUserId = @"BugsnagUserUserId";
     [copy setRedactedKeys:self.redactedKeys];
     [copy setMaxBreadcrumbs:self.maxBreadcrumbs];
     [copy setMetadata: [[BugsnagMetadata alloc] initWithDictionary:[[self.metadata toDictionary] mutableCopy]]];
-    [copy setEndpointsForNotify:self.notifyURL.absoluteString
-                       sessions:self.sessionURL.absoluteString];
+    [copy setEndpoints:self.endpoints];
     [copy setOnBreadcrumbBlocks:[self.onBreadcrumbBlocks mutableCopy]];
     [copy setOnCrashHandler:self.onCrashHandler];
     [copy setOnSendBlocks:[self.onSendBlocks mutableCopy]];
@@ -184,6 +184,7 @@ NSString * const kBugsnagUserUserId = @"BugsnagUserUserId";
     _metadata = [[BugsnagMetadata alloc] init];
     _config = [[BugsnagMetadata alloc] init];
     _apiKey = apiKey;
+    _endpoints = [BugsnagEndpointConfiguration new];
     _sessionURL = [NSURL URLWithString:@"https://sessions.bugsnag.com"];
     _autoDetectErrors = YES;
     _notifyURL = [NSURL URLWithString:BSGDefaultNotifyUrl];
@@ -326,9 +327,10 @@ NSString * const kBugsnagUserUserId = @"BugsnagUserUserId";
              };
 }
 
-- (void)setEndpointsForNotify:(NSString *_Nonnull)notify sessions:(NSString *_Nonnull)sessions {
-    _notifyURL = [NSURL URLWithString:notify];
-    _sessionURL = [NSURL URLWithString:sessions];
+- (void)setEndpoints:(BugsnagEndpointConfiguration *)endpoints {
+    _endpoints = endpoints;
+    _notifyURL = [NSURL URLWithString:endpoints.notify];
+    _sessionURL = [NSURL URLWithString:endpoints.sessions];
 
     NSAssert([self isValidUrl:_notifyURL], @"Invalid URL supplied for notify endpoint");
 

--- a/Source/BugsnagEndpointConfiguration.h
+++ b/Source/BugsnagEndpointConfiguration.h
@@ -1,0 +1,34 @@
+//
+//  BugsnagEndpointConfiguration.h
+//  Bugsnag
+//
+//  Created by Jamie Lynch on 15/04/2020.
+//  Copyright © 2020 Bugsnag. All rights reserved.
+//
+
+#import <Foundation/Foundation.h>
+
+NS_ASSUME_NONNULL_BEGIN
+
+/**
+ * Set the endpoints to send data to. By default we'll send error reports to
+ * https://notify.bugsnag.com, and sessions to https://sessions.bugsnag.com, but you can
+ * override this if you are using Bugsnag Enterprise to point to your own Bugsnag endpoints.
+ */
+@interface BugsnagEndpointConfiguration : NSObject
+
+/**
+ * Configures the endpoint to which events should be sent
+ */
+@property NSString *notify;
+
+/**
+ * Configures the endpoint to which sessions should be sent
+ */
+@property NSString *sessions;
+
+- (instancetype)initWithNotify:(NSString *)notify sessions:(NSString *)sessions;
+
+@end
+
+NS_ASSUME_NONNULL_END

--- a/Source/BugsnagEndpointConfiguration.m
+++ b/Source/BugsnagEndpointConfiguration.m
@@ -1,0 +1,28 @@
+//
+//  BugsnagEndpointConfiguration.m
+//  Bugsnag
+//
+//  Created by Jamie Lynch on 15/04/2020.
+//  Copyright © 2020 Bugsnag. All rights reserved.
+//
+
+#import "BugsnagEndpointConfiguration.h"
+
+@implementation BugsnagEndpointConfiguration
+
+- (instancetype)init {
+    if (self = [super init]) {
+        _notify = @"https://notify.bugsnag.com";
+        _sessions = @"https://sessions.bugsnag.com";
+    }
+    return self;
+}
+
+- (instancetype)initWithNotify:(NSString *)notify sessions:(NSString *)sessions {
+    if (self = [super init]) {
+        _notify = notify;
+        _sessions = sessions;
+    }
+    return self;
+}
+@end

--- a/Tests/BugsnagConfigurationTests.m
+++ b/Tests/BugsnagConfigurationTests.m
@@ -72,13 +72,16 @@
     XCTAssertEqualObjects([NSURL URLWithString:@"https://sessions.bugsnag.com"], config.sessionURL);
     
     // Test overriding the session endpoint (use dummy endpoints to avoid hitting production)
-    [config setEndpointsForNotify:@"http://localhost:1234" sessions:@"http://localhost:8000"];
+
+    config.endpoints = [[BugsnagEndpointConfiguration alloc] initWithNotify:@"http://localhost:1234"
+                                                                   sessions:@"http://localhost:8000"];
     XCTAssertEqualObjects([NSURL URLWithString:@"http://localhost:8000"], config.sessionURL);
 }
 
 - (void)testSetEmptySessionsEndpoint {
     BugsnagConfiguration *config = [[BugsnagConfiguration alloc] initWithApiKey:DUMMY_APIKEY_32CHAR_1];
-    [config setEndpointsForNotify:@"http://notify.example.com" sessions:@""];
+    config.endpoints = [[BugsnagEndpointConfiguration alloc] initWithNotify:@"http://notify.example.com"
+                                                                   sessions:@""];
     BugsnagSessionTracker *sessionTracker
             = [[BugsnagSessionTracker alloc] initWithConfig:config postRecordCallback:nil];
 
@@ -89,7 +92,8 @@
 
 - (void)testSetMalformedSessionsEndpoint {
     BugsnagConfiguration *config = [[BugsnagConfiguration alloc] initWithApiKey:DUMMY_APIKEY_32CHAR_1];
-    [config setEndpointsForNotify:@"http://notify.example.com" sessions:@"f"];
+    config.endpoints = [[BugsnagEndpointConfiguration alloc] initWithNotify:@"http://notify.example.com"
+                                                                   sessions:@"f"];
     BugsnagSessionTracker *sessionTracker
             = [[BugsnagSessionTracker alloc] initWithConfig:config postRecordCallback:nil];
 
@@ -106,7 +110,8 @@
     // Setup
     __block XCTestExpectation *expectation = [self expectationWithDescription:@"Remove On Session Block"];
     BugsnagConfiguration *config = [[BugsnagConfiguration alloc] initWithApiKey:DUMMY_APIKEY_32CHAR_1];
-    [config setEndpointsForNotify:@"http://notreal.bugsnag.com" sessions:@"http://notreal.bugsnag.com"];
+    config.endpoints = [[BugsnagEndpointConfiguration alloc] initWithNotify:@"http://notreal.bugsnag.com"
+                                                                   sessions:@"http://notreal.bugsnag.com"];
     XCTAssertEqual([[config onSessionBlocks] count], 0);
     BugsnagOnSessionBlock sessionBlock = ^BOOL(NSMutableDictionary * _Nonnull sessionPayload) {
         // We expect the session block to be called
@@ -131,7 +136,8 @@
     calledExpectation.inverted = YES;
 
     BugsnagConfiguration *config = [[BugsnagConfiguration alloc] initWithApiKey:DUMMY_APIKEY_32CHAR_1];
-    [config setEndpointsForNotify:@"http://notreal.bugsnag.com" sessions:@"http://notreal.bugsnag.com"];
+    config.endpoints = [[BugsnagEndpointConfiguration alloc] initWithNotify:@"http://notreal.bugsnag.com"
+                                                                   sessions:@"http://notreal.bugsnag.com"];
     XCTAssertEqual([[config onSessionBlocks] count], 0);
     BugsnagOnSessionBlock sessionBlock = ^BOOL(NSMutableDictionary * _Nonnull sessionPayload) {
         [calledExpectation fulfill];
@@ -165,7 +171,8 @@
     expectation4.inverted = YES;
 
     BugsnagConfiguration *config = [[BugsnagConfiguration alloc] initWithApiKey:DUMMY_APIKEY_32CHAR_1];
-    [config setEndpointsForNotify:@"http://notreal.bugsnag.com" sessions:@"http://notreal.bugsnag.com"];
+    config.endpoints = [[BugsnagEndpointConfiguration alloc] initWithNotify:@"http://notreal.bugsnag.com"
+                                                                   sessions:@"http://notreal.bugsnag.com"];
     XCTAssertEqual([[config onSessionBlocks] count], 0);
     
     BugsnagOnSessionBlock sessionBlock = ^BOOL(NSMutableDictionary * _Nonnull sessionPayload) {
@@ -306,13 +313,15 @@
     XCTAssertEqualObjects([NSURL URLWithString:@"https://notify.bugsnag.com/"], config.notifyURL);
 
     // Test overriding the notify endpoint (use dummy endpoints to avoid hitting production)
-    [config setEndpointsForNotify:@"http://localhost:1234" sessions:@"http://localhost:8000"];
+    config.endpoints = [[BugsnagEndpointConfiguration alloc] initWithNotify:@"http://localhost:1234"
+                                                                   sessions:@"http://localhost:8000"];
     XCTAssertEqualObjects([NSURL URLWithString:@"http://localhost:1234"], config.notifyURL);
 }
 
 - (void)testSetEndpoints {
     BugsnagConfiguration *config = [[BugsnagConfiguration alloc] initWithApiKey:DUMMY_APIKEY_32CHAR_1];
-    [config setEndpointsForNotify:@"http://notify.example.com" sessions:@"http://sessions.example.com"];
+    config.endpoints = [[BugsnagEndpointConfiguration alloc] initWithNotify:@"http://notify.example.com"
+                                                                   sessions:@"http://sessions.example.com"];
     XCTAssertEqualObjects([NSURL URLWithString:@"http://notify.example.com"], config.notifyURL);
     XCTAssertEqualObjects([NSURL URLWithString:@"http://sessions.example.com"], config.sessionURL);
 }
@@ -323,10 +332,12 @@
     NSString *notify = @"foo";
     notify = nil;
 #if DEBUG
-    XCTAssertThrowsSpecificNamed([config setEndpointsForNotify:notify sessions:@"http://sessions.example.com"],
+    XCTAssertThrowsSpecificNamed([config setEndpoints:[[BugsnagEndpointConfiguration alloc] initWithNotify:notify
+                                                                                                  sessions:@"http://sessions.example.com"]],
             NSException, NSInternalInconsistencyException);
 #else
-    XCTAssertNoThrow([config setEndpointsForNotify:@"" sessions:@"http://sessions.example.com"]);
+    XCTAssertNoThrow([config setEndpoints:[[BugsnagEndpointConfiguration alloc] initWithNotify:@""
+                                                                                                  sessions:@"http://sessions.example.com"]]);
 #endif
 }
 
@@ -334,10 +345,12 @@
 - (void)testSetEmptyNotifyEndpoint {
     BugsnagConfiguration *config = [[BugsnagConfiguration alloc] initWithApiKey:DUMMY_APIKEY_32CHAR_1];
 #if DEBUG
-    XCTAssertThrowsSpecificNamed([config setEndpointsForNotify:@"" sessions:@"http://sessions.example.com"],
+    XCTAssertThrowsSpecificNamed([config setEndpoints:[[BugsnagEndpointConfiguration alloc] initWithNotify:@""
+            sessions:@"http://sessions.example.com"]],
             NSException, NSInternalInconsistencyException);
 #else
-    XCTAssertNoThrow([config setEndpointsForNotify:@"" sessions:@"http://sessions.example.com"]);
+    XCTAssertNoThrow([config setEndpoints:[[BugsnagEndpointConfiguration alloc] initWithNotify:@""
+            sessions:@"http://sessions.example.com"]]);
 #endif
 }
 
@@ -345,10 +358,12 @@
 - (void)testSetMalformedNotifyEndpoint {
     BugsnagConfiguration *config = [[BugsnagConfiguration alloc] initWithApiKey:DUMMY_APIKEY_32CHAR_1];
 #if DEBUG
-    XCTAssertThrowsSpecificNamed([config setEndpointsForNotify:@"http://" sessions:@"http://sessions.example.com"],
+    XCTAssertThrowsSpecificNamed([config setEndpoints:[[BugsnagEndpointConfiguration alloc] initWithNotify:@"http://"
+                                                                                                  sessions:@"http://sessions.example.com"]],
             NSException, NSInternalInconsistencyException);
 #else
-    XCTAssertNoThrow([config setEndpointsForNotify:@"http://" sessions:@"http://sessions.example.com"]);
+    XCTAssertNoThrow([config setEndpoints:[[BugsnagEndpointConfiguration alloc] initWithNotify:@"http://"
+            sessions:@"http://sessions.example.com"]]);
 #endif
 }
 

--- a/Tests/BugsnagOnBreadcrumbTest.m
+++ b/Tests/BugsnagOnBreadcrumbTest.m
@@ -45,7 +45,8 @@
     // Setup
     __block XCTestExpectation *expectation = [self expectationWithDescription:@"Remove On Breadcrumb Block"];
     BugsnagConfiguration *config = [[BugsnagConfiguration alloc] initWithApiKey:DUMMY_APIKEY_32CHAR_1];
-    [config setEndpointsForNotify:@"http://notreal.bugsnag.com" sessions:@"http://notreal.bugsnag.com"];
+    config.endpoints = [[BugsnagEndpointConfiguration alloc] initWithNotify:@"http://notreal.bugsnag.com"
+                                                                   sessions:@"http://notreal.bugsnag.com"];
     XCTAssertEqual([[config onBreadcrumbBlocks] count], 0);
     BugsnagOnBreadcrumbBlock crumbBlock = ^(BugsnagBreadcrumb * _Nonnull crumb) {
         // We expect the breadcrumb block to be called
@@ -71,7 +72,8 @@
     calledExpectation.inverted = YES;
 
     BugsnagConfiguration *config = [[BugsnagConfiguration alloc] initWithApiKey:DUMMY_APIKEY_32CHAR_1];
-    [config setEndpointsForNotify:@"http://notreal.bugsnag.com" sessions:@"http://notreal.bugsnag.com"];
+    config.endpoints = [[BugsnagEndpointConfiguration alloc] initWithNotify:@"http://notreal.bugsnag.com"
+                                                                   sessions:@"http://notreal.bugsnag.com"];
     XCTAssertEqual([[config onBreadcrumbBlocks] count], 0);
     BugsnagOnBreadcrumbBlock crumbBlock = ^(BugsnagBreadcrumb * _Nonnull crumb) {
         [calledExpectation fulfill];
@@ -104,7 +106,8 @@
     expectation2.inverted = YES;
 
     BugsnagConfiguration *config = [[BugsnagConfiguration alloc] initWithApiKey:DUMMY_APIKEY_32CHAR_1];
-    [config setEndpointsForNotify:@"http://notreal.bugsnag.com" sessions:@"http://notreal.bugsnag.com"];
+    config.endpoints = [[BugsnagEndpointConfiguration alloc] initWithNotify:@"http://notreal.bugsnag.com"
+                                                                   sessions:@"http://notreal.bugsnag.com"];
     XCTAssertEqual([[config onBreadcrumbBlocks] count], 0);
 
     BugsnagOnBreadcrumbBlock crumbBlock = ^(BugsnagBreadcrumb * _Nonnull crumb) {
@@ -172,7 +175,8 @@
  */
 - (void)testAddOnBreadcrumbMutation {
     BugsnagConfiguration *config = [[BugsnagConfiguration alloc] initWithApiKey:DUMMY_APIKEY_32CHAR_1];
-    [config setEndpointsForNotify:@"http://notreal.bugsnag.com" sessions:@"http://notreal.bugsnag.com"];
+    config.endpoints = [[BugsnagEndpointConfiguration alloc] initWithNotify:@"http://notreal.bugsnag.com"
+                                                                   sessions:@"http://notreal.bugsnag.com"];
     [config addOnBreadcrumbBlock:^(BugsnagBreadcrumb * _Nonnull crumb) {
         crumb.message = @"Foo";
         return YES;
@@ -190,7 +194,8 @@
  */
 - (void)testAddOnBreadcrumbRejection {
     BugsnagConfiguration *config = [[BugsnagConfiguration alloc] initWithApiKey:DUMMY_APIKEY_32CHAR_1];
-    [config setEndpointsForNotify:@"http://notreal.bugsnag.com" sessions:@"http://notreal.bugsnag.com"];
+    config.endpoints = [[BugsnagEndpointConfiguration alloc] initWithNotify:@"http://notreal.bugsnag.com"
+                                                                   sessions:@"http://notreal.bugsnag.com"];
     [config addOnBreadcrumbBlock:^(BugsnagBreadcrumb * _Nonnull crumb) {
         return NO;
     }];

--- a/Tests/BugsnagSinkTests.m
+++ b/Tests/BugsnagSinkTests.m
@@ -43,7 +43,8 @@
     config.releaseStage = @"MagicalTestingTime";
 
     // set a dummy endpoint, avoid hitting production
-    [config setEndpointsForNotify:@"http://localhost:1234" sessions:@"http://localhost:1234"];
+    config.endpoints = [[BugsnagEndpointConfiguration alloc] initWithNotify:@"http://localhost:1234"
+                                                                   sessions:@"http://localhost:1234"];
     [Bugsnag startBugsnagWithConfiguration:config];
     BugsnagEvent *report =
     [[BugsnagEvent alloc] initWithKSReport:self.rawReportData];

--- a/Tests/BugsnagTests.m
+++ b/Tests/BugsnagTests.m
@@ -332,9 +332,9 @@
     // Prevent sending events
     BugsnagConfiguration *configuration = [[BugsnagConfiguration alloc] initWithApiKey:DUMMY_APIKEY_32CHAR_1];
     // We'll not be able to use the onSend -> false route to fail calls to notify()
-    [configuration setEndpointsForNotify:@"http://not.valid.bugsnag/not/an/endpoint"
-                                sessions:@"http://not.valid.bugsnag/not/an/endpoint"];
-    
+    configuration.endpoints = [[BugsnagEndpointConfiguration alloc] initWithNotify:@"http://not.valid.bugsnag/not/an/endpoint"
+                                                                          sessions:@"http://not.valid.bugsnag/not/an/endpoint"];
+
     // Ensure there's nothing from another test
     XCTAssertEqual([[configuration onSendBlocks] count], 0);
     

--- a/UPGRADING.md
+++ b/UPGRADING.md
@@ -73,6 +73,9 @@ The exact error is available using the `BSGConfigurationErrorDomain` and
 
 - config.notifyReleaseStages
 + config.enabledReleaseStages
+
+- config.setEndpoints(notify: sessions)
++ config.setEndpoints(BugsnagEndpointConfiguration(notify: sessions))
 ```
 
 #### Removals

--- a/features/fixtures/ios-swift-cocoapods/iOSTestApp/AppDelegate.swift
+++ b/features/fixtures/ios-swift-cocoapods/iOSTestApp/AppDelegate.swift
@@ -52,7 +52,7 @@ class AppDelegate: UIResponder, UIApplicationDelegate {
         // also that extra reports aren't erroneously sent in other conditions
         // when OOM reporting is enabled
         config.enabledErrorTypes.insert(.OOMs)
-        config.setEndpoints(notify: mockAPIPath, sessions: mockAPIPath)
+        config.endpoints = BugsnagEndpointConfiguration(notify: mockAPIPath, sessions: mockAPIPath)
         return config
     }
 

--- a/iOS/Bugsnag.xcodeproj/project.pbxproj
+++ b/iOS/Bugsnag.xcodeproj/project.pbxproj
@@ -297,6 +297,10 @@
 		E77526BB242D0AE50077A42F /* BugsnagBreadcrumbs.m in Sources */ = {isa = PBXBuildFile; fileRef = E77526B9242D0AE50077A42F /* BugsnagBreadcrumbs.m */; };
 		E77526BC242D0AE50077A42F /* BugsnagBreadcrumbs.m in Sources */ = {isa = PBXBuildFile; fileRef = E77526B9242D0AE50077A42F /* BugsnagBreadcrumbs.m */; };
 		E77526BD242D0B1F0077A42F /* BugsnagBreadcrumbs.h in CopyFiles */ = {isa = PBXBuildFile; fileRef = E77526B8242D0AE50077A42F /* BugsnagBreadcrumbs.h */; };
+		E77AFF09244A18890082B8BB /* BugsnagEndpointConfiguration.h in Headers */ = {isa = PBXBuildFile; fileRef = E77AFF07244A18890082B8BB /* BugsnagEndpointConfiguration.h */; settings = {ATTRIBUTES = (Public, ); }; };
+		E77AFF0A244A18890082B8BB /* BugsnagEndpointConfiguration.m in Sources */ = {isa = PBXBuildFile; fileRef = E77AFF08244A18890082B8BB /* BugsnagEndpointConfiguration.m */; };
+		E77AFF0B244A18890082B8BB /* BugsnagEndpointConfiguration.m in Sources */ = {isa = PBXBuildFile; fileRef = E77AFF08244A18890082B8BB /* BugsnagEndpointConfiguration.m */; };
+		E77AFF0C244A18A00082B8BB /* BugsnagEndpointConfiguration.h in CopyFiles */ = {isa = PBXBuildFile; fileRef = E77AFF07244A18890082B8BB /* BugsnagEndpointConfiguration.h */; };
 		E784D2551FD70B3B004B01E1 /* KSCrashState_Tests.m in Sources */ = {isa = PBXBuildFile; fileRef = E784D2511FD70AE6004B01E1 /* KSCrashState_Tests.m */; };
 		E784D2561FD70B3E004B01E1 /* KSMach_Tests.m in Sources */ = {isa = PBXBuildFile; fileRef = E784D2521FD70AE6004B01E1 /* KSMach_Tests.m */; };
 		E784D25A1FD70C25004B01E1 /* KSJSONCodec_Tests.m in Sources */ = {isa = PBXBuildFile; fileRef = E784D2591FD70C25004B01E1 /* KSJSONCodec_Tests.m */; };
@@ -393,6 +397,7 @@
 			dstPath = "include/${PRODUCT_NAME}";
 			dstSubfolderSpec = 16;
 			files = (
+				E77AFF0C244A18A00082B8BB /* BugsnagEndpointConfiguration.h in CopyFiles */,
 				E7529F94243C8EF2006B4932 /* RegisterErrorData.h in CopyFiles */,
 				E7D2E66E243B8F62005A3041 /* BugsnagStacktrace.h in CopyFiles */,
 				E790C45B24349A70006FFB26 /* BugsnagApp.h in CopyFiles */,
@@ -666,6 +671,8 @@
 		E77316E11F73B46600A14F06 /* BugsnagHandledStateTest.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; name = BugsnagHandledStateTest.m; path = ../Tests/BugsnagHandledStateTest.m; sourceTree = SOURCE_ROOT; };
 		E77526B8242D0AE50077A42F /* BugsnagBreadcrumbs.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; name = BugsnagBreadcrumbs.h; path = ../Source/BugsnagBreadcrumbs.h; sourceTree = "<group>"; };
 		E77526B9242D0AE50077A42F /* BugsnagBreadcrumbs.m */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.objc; name = BugsnagBreadcrumbs.m; path = ../Source/BugsnagBreadcrumbs.m; sourceTree = "<group>"; };
+		E77AFF07244A18890082B8BB /* BugsnagEndpointConfiguration.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; name = BugsnagEndpointConfiguration.h; path = ../Source/BugsnagEndpointConfiguration.h; sourceTree = "<group>"; };
+		E77AFF08244A18890082B8BB /* BugsnagEndpointConfiguration.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; name = BugsnagEndpointConfiguration.m; path = ../Source/BugsnagEndpointConfiguration.m; sourceTree = "<group>"; };
 		E784D2511FD70AE6004B01E1 /* KSCrashState_Tests.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; name = KSCrashState_Tests.m; path = ../Tests/KSCrash/KSCrashState_Tests.m; sourceTree = SOURCE_ROOT; };
 		E784D2521FD70AE6004B01E1 /* KSMach_Tests.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; name = KSMach_Tests.m; path = ../Tests/KSCrash/KSMach_Tests.m; sourceTree = SOURCE_ROOT; };
 		E784D2591FD70C25004B01E1 /* KSJSONCodec_Tests.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; name = KSJSONCodec_Tests.m; path = ../Tests/KSCrash/KSJSONCodec_Tests.m; sourceTree = SOURCE_ROOT; };
@@ -821,6 +828,8 @@
 				8A2C8F441C6BBE3C00846019 /* BugsnagConfiguration.m */,
 				E72962D01F4BBA8A00CEA15D /* BugsnagCrashSentry.h */,
 				E72962D11F4BBA8A00CEA15D /* BugsnagCrashSentry.m */,
+				E77AFF07244A18890082B8BB /* BugsnagEndpointConfiguration.h */,
+				E77AFF08244A18890082B8BB /* BugsnagEndpointConfiguration.m */,
 				E737DEA01F73AD7400BC7C80 /* BugsnagHandledState.h */,
 				E737DEA11F73AD7400BC7C80 /* BugsnagHandledState.m */,
 				E794E8021F9F743D00A67EE7 /* BugsnagKeys.h */,
@@ -1184,6 +1193,7 @@
 			isa = PBXHeadersBuildPhase;
 			buildActionMask = 2147483647;
 			files = (
+				E77AFF09244A18890082B8BB /* BugsnagEndpointConfiguration.h in Headers */,
 				E790C45824349A28006FFB26 /* BugsnagThread.h in Headers */,
 				E790C453243498BB006FFB26 /* BugsnagStackframe.h in Headers */,
 				E790C44E24349898006FFB26 /* BugsnagError.h in Headers */,
@@ -1416,6 +1426,7 @@
 				E7107C551F4C97F100BB3F98 /* BSG_KSCrashSentry_Signal.c in Sources */,
 				8A2C8F501C6BBE3C00846019 /* Bugsnag.m in Sources */,
 				E7107C691F4C97F100BB3F98 /* BSG_KSMach.c in Sources */,
+				E77AFF0A244A18890082B8BB /* BugsnagEndpointConfiguration.m in Sources */,
 				E7107C441F4C97F100BB3F98 /* BSG_KSCrashType.c in Sources */,
 				E7107C6B1F4C97F100BB3F98 /* BSG_KSMach_Arm.c in Sources */,
 				8A2C8F5E1C6BBE3C00846019 /* BugsnagClient.m in Sources */,
@@ -1591,6 +1602,7 @@
 				E7397E271F83BC2A0034242A /* BSGConnectivity.m in Sources */,
 				E7397E281F83BC2A0034242A /* BSGSerialization.m in Sources */,
 				E72BF7811FC86A7A004BE82F /* BugsnagUser.m in Sources */,
+				E77AFF0B244A18890082B8BB /* BugsnagEndpointConfiguration.m in Sources */,
 				E7397E291F83BC2A0034242A /* Bugsnag.m in Sources */,
 				E790C45A24349A28006FFB26 /* BugsnagThread.m in Sources */,
 				E7397E2A1F83BC2A0034242A /* BugsnagBreadcrumb.m in Sources */,

--- a/tvOS/Bugsnag.xcodeproj/project.pbxproj
+++ b/tvOS/Bugsnag.xcodeproj/project.pbxproj
@@ -157,6 +157,8 @@
 		E77526C4242D0E3A0077A42F /* BugsnagBreadcrumbs.m in Sources */ = {isa = PBXBuildFile; fileRef = E77526C2242D0E3A0077A42F /* BugsnagBreadcrumbs.m */; };
 		E77526C5242D0E3A0077A42F /* BugsnagBreadcrumbs.h in Headers */ = {isa = PBXBuildFile; fileRef = E77526C3242D0E3A0077A42F /* BugsnagBreadcrumbs.h */; };
 		E77526C7242E694C0077A42F /* BugsnagOnBreadcrumbTest.m in Sources */ = {isa = PBXBuildFile; fileRef = E77526C6242E694C0077A42F /* BugsnagOnBreadcrumbTest.m */; };
+		E77AFF13244A19260082B8BB /* BugsnagEndpointConfiguration.h in Headers */ = {isa = PBXBuildFile; fileRef = E77AFF11244A19260082B8BB /* BugsnagEndpointConfiguration.h */; settings = {ATTRIBUTES = (Public, ); }; };
+		E77AFF14244A19260082B8BB /* BugsnagEndpointConfiguration.m in Sources */ = {isa = PBXBuildFile; fileRef = E77AFF12244A19260082B8BB /* BugsnagEndpointConfiguration.m */; };
 		E790C422243231EA006FFB26 /* BugsnagClientMirrorTest.m in Sources */ = {isa = PBXBuildFile; fileRef = E790C421243231EA006FFB26 /* BugsnagClientMirrorTest.m */; };
 		E790C4292433551D006FFB26 /* BugsnagClientInternal.h in Headers */ = {isa = PBXBuildFile; fileRef = E790C4282433551D006FFB26 /* BugsnagClientInternal.h */; };
 		E790C48C24349D35006FFB26 /* BugsnagApp.h in Headers */ = {isa = PBXBuildFile; fileRef = E790C47E24349D33006FFB26 /* BugsnagApp.h */; settings = {ATTRIBUTES = (Public, ); }; };
@@ -386,6 +388,8 @@
 		E77526C2242D0E3A0077A42F /* BugsnagBreadcrumbs.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; name = BugsnagBreadcrumbs.m; path = ../Source/BugsnagBreadcrumbs.m; sourceTree = "<group>"; };
 		E77526C3242D0E3A0077A42F /* BugsnagBreadcrumbs.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; name = BugsnagBreadcrumbs.h; path = ../Source/BugsnagBreadcrumbs.h; sourceTree = "<group>"; };
 		E77526C6242E694C0077A42F /* BugsnagOnBreadcrumbTest.m */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.objc; name = BugsnagOnBreadcrumbTest.m; path = ../../Tests/BugsnagOnBreadcrumbTest.m; sourceTree = "<group>"; };
+		E77AFF11244A19260082B8BB /* BugsnagEndpointConfiguration.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; name = BugsnagEndpointConfiguration.h; path = ../Source/BugsnagEndpointConfiguration.h; sourceTree = "<group>"; };
+		E77AFF12244A19260082B8BB /* BugsnagEndpointConfiguration.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; name = BugsnagEndpointConfiguration.m; path = ../Source/BugsnagEndpointConfiguration.m; sourceTree = "<group>"; };
 		E790C421243231EA006FFB26 /* BugsnagClientMirrorTest.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; name = BugsnagClientMirrorTest.m; path = ../../Tests/BugsnagClientMirrorTest.m; sourceTree = "<group>"; };
 		E790C4282433551D006FFB26 /* BugsnagClientInternal.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; name = BugsnagClientInternal.h; path = ../Source/BugsnagClientInternal.h; sourceTree = "<group>"; };
 		E790C47E24349D33006FFB26 /* BugsnagApp.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; name = BugsnagApp.h; path = ../Source/BugsnagApp.h; sourceTree = "<group>"; };
@@ -526,6 +530,8 @@
 				8AB1512D1D41366400C9B218 /* BugsnagConfiguration.m */,
 				E76616F11F4E45950094CECF /* BugsnagCrashSentry.h */,
 				E76616F21F4E45950094CECF /* BugsnagCrashSentry.m */,
+				E77AFF11244A19260082B8BB /* BugsnagEndpointConfiguration.h */,
+				E77AFF12244A19260082B8BB /* BugsnagEndpointConfiguration.m */,
 				E762E9F21F73F6DE00E82B43 /* BugsnagHandledState.h */,
 				E762E9F31F73F6DE00E82B43 /* BugsnagHandledState.m */,
 				E794E8061F9F748100A67EE7 /* BugsnagKeys.h */,
@@ -891,6 +897,7 @@
 			isa = PBXHeadersBuildPhase;
 			buildActionMask = 2147483647;
 			files = (
+				E77AFF13244A19260082B8BB /* BugsnagEndpointConfiguration.h in Headers */,
 				E790C49224349D35006FFB26 /* BugsnagThread.h in Headers */,
 				E790C49324349D35006FFB26 /* BugsnagStackframe.h in Headers */,
 				E790C48D24349D35006FFB26 /* BugsnagError.h in Headers */,
@@ -1085,6 +1092,7 @@
 				E766179F1F4E459C0094CECF /* BSG_KSCrashSentry_Signal.c in Sources */,
 				0089B6F0241168CC00D5A7F2 /* BugsnagClient.m in Sources */,
 				E79148881FD82E6D003EFEBF /* BugsnagSession.m in Sources */,
+				E77AFF14244A19260082B8BB /* BugsnagEndpointConfiguration.m in Sources */,
 				E791487C1FD82E6D003EFEBF /* BugsnagSessionTrackingApiClient.m in Sources */,
 				E76617B31F4E459C0094CECF /* BSG_KSMach.c in Sources */,
 				E790C49924349D35006FFB26 /* BugsnagAppWithState.m in Sources */,


### PR DESCRIPTION
## Goal

Moves the configuration of the notify + sessions endpoint to a class, to match the notifier spec.

## Changeset

Altered the `setEndpoints` method into a public property of type `BugsnagEndpointConfiguration`. Updated existing test coverage to use new syntax.