### PR TITLE
Remove attachCustomStacktrace from public API

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,9 @@ Bugsnag Notifiers on other platforms.
 
 ## Enhancements
 
+* Remove attachCustomStacktrace from public API
+  [#547](https://github.com/bugsnag/bugsnag-cocoa/pull/547)
+
 * Create structured `BugsnagError` class
   [#533](https://github.com/bugsnag/bugsnag-cocoa/pull/533)
 

--- a/Source/BugsnagEvent.h
+++ b/Source/BugsnagEvent.h
@@ -62,12 +62,6 @@ initWithErrorName:(NSString *_Nonnull)name
      handledState:(BugsnagHandledState *_Nonnull)handledState
           session:(BugsnagSession *_Nullable)session;
 
-/**
- *  Prepend a custom stacktrace with a provided type to the crash report
- */
-- (void)attachCustomStacktrace:(NSArray *_Nonnull)frames
-                      withType:(NSString *_Nonnull)type;
-
 // -----------------------------------------------------------------------------
 // MARK: - Properties
 // -----------------------------------------------------------------------------

--- a/UPGRADING.md
+++ b/UPGRADING.md
@@ -253,6 +253,7 @@ of the removed `addAttribute`:
 - event.depth
 - event.error
 - event.isIncomplete
+- [event attachCustomStacktrace:type:]
 
 ### `BugsnagSession` class
 

--- a/features/fixtures/ios-swift-cocoapods/iOSTestApp.xcodeproj/project.pbxproj
+++ b/features/fixtures/ios-swift-cocoapods/iOSTestApp.xcodeproj/project.pbxproj
@@ -157,6 +157,7 @@
 		E7767F10221C21D90006648C /* StoppedSessionScenario.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = StoppedSessionScenario.swift; sourceTree = "<group>"; };
 		E7767F12221C21E30006648C /* ResumedSessionScenario.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ResumedSessionScenario.swift; sourceTree = "<group>"; };
 		E7767F14221C223C0006648C /* NewSessionScenario.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = NewSessionScenario.swift; sourceTree = "<group>"; };
+		E77AFEF72449C6460082B8BB /* AttachCustomStacktraceHook.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; path = AttachCustomStacktraceHook.h; sourceTree = "<group>"; };
 		EE18B3777C62D7BCA8DDBE30 /* Pods-iOSTestApp.debug.xcconfig */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.xcconfig; name = "Pods-iOSTestApp.debug.xcconfig"; path = "Pods/Target Support Files/Pods-iOSTestApp/Pods-iOSTestApp.debug.xcconfig"; sourceTree = "<group>"; };
 		F42950588CE34967588DF438 /* ObjCExceptionScenario.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = ObjCExceptionScenario.h; sourceTree = "<group>"; };
 		F42950D49A5F24FF7155EEE1 /* NonExistentMethodScenario.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = NonExistentMethodScenario.h; sourceTree = "<group>"; };
@@ -401,6 +402,7 @@
 				0011E6662403D13100ED71CD /* UserPersistenceScenarios.m */,
 				0011E6682403D14400ED71CD /* UserPersistenceScenarios.h */,
 				00507A63242BFE5600EF1B87 /* EnabledBreadcrumbTypesIsNilScenario.swift */,
+				E77AFEF72449C6460082B8BB /* AttachCustomStacktraceHook.h */,
 			);
 			path = scenarios;
 			sourceTree = "<group>";

--- a/features/fixtures/ios-swift-cocoapods/iOSTestApp/iOSTestApp-Bridging-Header.h
+++ b/features/fixtures/ios-swift-cocoapods/iOSTestApp/iOSTestApp-Bridging-Header.h
@@ -4,3 +4,4 @@
 
 #import <Bugsnag/Bugsnag.h>
 #import "Scenario.h"
+#import "AttachCustomStacktraceHook.h"

--- a/features/fixtures/ios-swift-cocoapods/iOSTestApp/scenarios/AttachCustomStacktraceHook.h
+++ b/features/fixtures/ios-swift-cocoapods/iOSTestApp/scenarios/AttachCustomStacktraceHook.h
@@ -1,0 +1,14 @@
+//
+//  AttachCustomStacktraceHook.h
+//  iOSTestApp
+//
+//  Created by Jamie Lynch on 17/04/2020.
+//  Copyright © 2020 Bugsnag. All rights reserved.
+//
+
+#import <Foundation/Foundation.h>
+#import <Bugsnag/Bugsnag.h>
+
+@interface BugsnagEvent ()
+- (void)attachCustomStacktrace:(NSArray *)frames withType:(NSString *)type;
+@end


### PR DESCRIPTION
## Goal

Removes the `attachCustomStacktrace` method from `BugsnagEvent` in favour of editing the `event.errors` property instead.

## Changeset

Removed `attachCustomStacktrace` from public header file for `BugsnagEvent`.

## Tests

Updated existing tests to use `attachCustomStacktrace` as an internal API instead, by exposing it as a class extension in the test fixture.
