### PR TITLE
Move codeBundleId from configuration to non-public client property

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -26,6 +26,9 @@ Bugsnag Notifiers on other platforms.
 * Hide additional methods from public API
   [#552](https://github.com/bugsnag/bugsnag-cocoa/pull/552)
 
+* Move `codeBundleId` from configuration to non-public client property
+  [#548](https://github.com/bugsnag/bugsnag-cocoa/pull/548)
+
 * Add structured app/device fields to `BugsnagSession`
   [#546](https://github.com/bugsnag/bugsnag-cocoa/pull/546)
 

--- a/Source/BSGOutOfMemoryWatchdog.m
+++ b/Source/BSGOutOfMemoryWatchdog.m
@@ -20,6 +20,7 @@
 @property(nonatomic, getter=didOOMLastLaunch) BOOL oomLastLaunch;
 @property(nonatomic, strong, readwrite) NSMutableDictionary *cachedFileInfo;
 @property(nonatomic, strong, readwrite) NSDictionary *lastBootCachedFileInfo;
+@property(nonatomic) NSString *codeBundleId;
 @end
 
 @interface Bugsnag ()
@@ -164,6 +165,16 @@
     [self writeSentinelFile];
 }
 
+- (void)setCodeBundleId:(NSString *)codeBundleId {
+    _codeBundleId = codeBundleId;
+    self.cachedFileInfo[@"app"][@"codeBundleId"] = codeBundleId;
+
+    if ([self isWatching]) {
+        [self writeSentinelFile];
+    }
+}
+
+
 - (BOOL)computeDidOOMLastLaunchWithConfig:(BugsnagConfiguration *)config {
     if ([[NSFileManager defaultManager] fileExistsAtPath:self.sentinelFilePath]) {
         NSDictionary *lastBootInfo = [self readSentinelFile];
@@ -248,7 +259,7 @@
     app[@"version"] = systemInfo[@BSG_KSSystemField_BundleShortVersion] ?: @"";
     app[@"bundleVersion"] = systemInfo[@BSG_KSSystemField_BundleVersion] ?: @"";
     // 'codeBundleId' only (optionally) exists for React Native clients and defaults otherwise to nil
-    app[@"codeBundleId"] = [config codeBundleId];
+    app[@"codeBundleId"] = self.codeBundleId;
 #if BSGOOMAvailable
     UIApplicationState state = [BSG_KSSystemInfo currentAppState];
     app[@"inForeground"] = @([BSG_KSSystemInfo isInForeground:state]);

--- a/Source/Bugsnag.m
+++ b/Source/Bugsnag.m
@@ -59,6 +59,7 @@ static BugsnagClient *bsg_g_bugsnag_client = NULL;
 - (void)internalClientNotify:(NSException *_Nonnull)exception
                     withData:(NSDictionary *_Nullable)metadata
                        block:(BugsnagOnErrorBlock _Nullable)block;
+@property (nonatomic) NSString *codeBundleId;
 @end
 
 @interface BugsnagMetadata ()
@@ -343,7 +344,9 @@ static BugsnagClient *bsg_g_bugsnag_client = NULL;
  * Intended for internal use only - sets the code bundle id for React Native
  */
 + (void)updateCodeBundleId:(NSString *)codeBundleId {
-    self.configuration.codeBundleId = codeBundleId;
+    if ([self bugsnagStarted]) {
+        self.client.codeBundleId = codeBundleId;
+    }
 }
 
 // =============================================================================

--- a/Source/BugsnagApp.m
+++ b/Source/BugsnagApp.m
@@ -29,15 +29,17 @@
 
 + (BugsnagApp *)appWithDictionary:(NSDictionary *)event
                            config:(BugsnagConfiguration *)config
+                     codeBundleId:(NSString *)codeBundleId
 {
     BugsnagApp *app = [BugsnagApp new];
-    [self populateFields:app dictionary:event config:config];
+    [self populateFields:app dictionary:event config:config codeBundleId:codeBundleId];
     return app;
 }
 
 + (void)populateFields:(BugsnagApp *)app
             dictionary:(NSDictionary *)event
                 config:(BugsnagConfiguration *)config
+          codeBundleId:(NSString *)codeBundleId
 {
     NSDictionary *system = event[BSGKeySystem];
     app.id = system[@"CFBundleIdentifier"];
@@ -45,7 +47,7 @@
     app.dsymUuid = system[@"app_uuid"];
     app.version = [event valueForKeyPath:@"user.config.appVersion"] ?: system[@"CFBundleShortVersionString"];
     app.releaseStage = [event valueForKeyPath:@"user.config.releaseStage"] ?: config.releaseStage;
-    app.codeBundleId = config.codeBundleId;
+    app.codeBundleId = codeBundleId;
     app.type = config.appType;
 }
 

--- a/Source/BugsnagAppWithState.m
+++ b/Source/BugsnagAppWithState.m
@@ -14,7 +14,8 @@
 @interface BugsnagApp ()
 + (void)populateFields:(BugsnagApp *)app
             dictionary:(NSDictionary *)event
-                config:(BugsnagConfiguration *)config;
+                config:(BugsnagConfiguration *)config
+          codeBundleId:(NSString *)codeBundleId;
 
 - (NSDictionary *)toDict;
 @end
@@ -36,6 +37,7 @@
 
 + (BugsnagAppWithState *)appWithDictionary:(NSDictionary *)event
                                     config:(BugsnagConfiguration *)config
+                              codeBundleId:(NSString *)codeBundleId
 {
     BugsnagAppWithState *app = [BugsnagAppWithState new];
     NSDictionary *system = event[BSGKeySystem];
@@ -48,7 +50,7 @@
     app.durationInForeground = activeTimeSinceLaunch;
     app.duration = activeTimeSinceLaunch + backgroundTimeSinceLaunch;
     app.inForeground = [stats[@"application_in_foreground"] boolValue];
-    [BugsnagApp populateFields:app dictionary:event config:config];
+    [BugsnagApp populateFields:app dictionary:event config:config codeBundleId:codeBundleId];
     return app;
 }
 

--- a/Source/BugsnagClient.m
+++ b/Source/BugsnagClient.m
@@ -34,6 +34,7 @@
 #import "BugsnagLogger.h"
 #import "BugsnagKeys.h"
 #import "BugsnagSessionTracker.h"
+#import "BugsnagSessionTrackingApiClient.h"
 #import "BugsnagPluginClient.h"
 #import "BSGOutOfMemoryWatchdog.h"
 #import "BSG_RFC3339DateTool.h"
@@ -269,6 +270,7 @@ void BSGWriteSessionCrashData(BugsnagSession *session) {
 @property (nonatomic, strong) BugsnagPluginClient *pluginClient;
 @property (nonatomic) BOOL appDidCrashLastLaunch;
 @property (nonatomic, strong) BugsnagMetadata *metadata;
+@property (nonatomic) NSString *codeBundleId;
 #if TARGET_IPHONE_SIMULATOR || TARGET_OS_IPHONE
 // The previous device orientation - iOS only
 @property (nonatomic, strong) NSString *lastOrientation;
@@ -302,6 +304,14 @@ void BSGWriteSessionCrashData(BugsnagSession *session) {
 @property(unsafe_unretained) id<BugsnagMetadataDelegate> _Nullable delegate;
 - (NSDictionary *_Nonnull)toDictionary;
 - (id)deepCopy;
+@end
+
+@interface BSGOutOfMemoryWatchdog ()
+@property(nonatomic) NSString *codeBundleId;
+@end
+
+@interface BugsnagSessionTracker ()
+@property(nonatomic) NSString *codeBundleId;
 @end
 
 @interface BugsnagUser ()
@@ -582,6 +592,12 @@ NSString *const BSGBreadcrumbLoadedMessage = @"Bugsnag loaded";
 #else
     self.appDidCrashLastLaunch = crashState->crashedLastLaunch;
 #endif
+}
+
+- (void)setCodeBundleId:(NSString *)codeBundleId {
+    _codeBundleId = codeBundleId;
+    self.oomWatchdog.codeBundleId = codeBundleId;
+    self.sessionTracker.codeBundleId = codeBundleId;
 }
 
 /**

--- a/Source/BugsnagConfiguration.h
+++ b/Source/BugsnagConfiguration.h
@@ -195,7 +195,6 @@ typedef NS_OPTIONS(NSUInteger, BSGEnabledErrorType) {
  */
 @property (readwrite, retain, nullable) NSString *bundleVersion;
 
-@property(retain, nullable) NSString *codeBundleId;
 @property(retain, nullable) NSString *appType;
 
 /**

--- a/Source/BugsnagConfiguration.m
+++ b/Source/BugsnagConfiguration.m
@@ -123,7 +123,6 @@ NSString * const kBugsnagUserUserId = @"BugsnagUserUserId";
     [copy setAutoTrackSessions:self.autoTrackSessions];
     [copy setBundleVersion:self.bundleVersion];
     // Skip breadcrumbs - none should have been set
-    [copy setCodeBundleId:self.codeBundleId];
     [copy setConfig:[[BugsnagMetadata alloc] initWithDictionary:[[self.config toDictionary] mutableCopy]]];
     [copy setContext:self.context];
     [copy setEnabledBreadcrumbTypes:self.enabledBreadcrumbTypes];

--- a/Source/BugsnagEvent.m
+++ b/Source/BugsnagEvent.m
@@ -36,7 +36,8 @@ NSDictionary *_Nonnull BSGParseDeviceMetadata(NSDictionary *_Nonnull event);
 
 @interface BugsnagAppWithState ()
 + (BugsnagAppWithState *)appWithDictionary:(NSDictionary *)event
-                                    config:(BugsnagConfiguration *)config;
+                                    config:(BugsnagConfiguration *)config
+                              codeBundleId:(NSString *)codeBundleId;
 - (NSDictionary *)toDict;
 + (BugsnagAppWithState *)appWithOomData:(NSDictionary *)event;
 @end
@@ -49,6 +50,8 @@ NSDictionary *_Nonnull BSGParseDeviceMetadata(NSDictionary *_Nonnull event);
 
 @interface BugsnagUser ()
 - (NSDictionary *)toJson;
+- (instancetype)initWithUserId:(NSString *)userId name:(NSString *)name emailAddress:(NSString *)emailAddress;
+- (instancetype)initWithDictionary:(NSDictionary *)dict;
 @end
 
 @interface BugsnagConfiguration (BugsnagEvent)
@@ -283,6 +286,7 @@ NSDictionary *BSGParseCustomException(NSDictionary *report,
 
 @property NSArray *redactedKeys;
 
+@property(nonatomic) NSString *codeBundleId;
 @end
 
 @implementation BugsnagEvent
@@ -348,7 +352,7 @@ NSDictionary *BSGParseCustomException(NSDictionary *report,
 
             _context = BSGParseContext(report);
             _device = [BugsnagDeviceWithState deviceWithDictionary:report];
-            _app = [BugsnagAppWithState appWithDictionary:report config:config];
+            _app = [BugsnagAppWithState appWithDictionary:report config:config codeBundleId:self.codeBundleId];
             _groupingHash = BSGParseGroupingHash(report);
             _overrides = [report valueForKeyPath:@"user.overrides"];
 

--- a/Source/BugsnagSessionTracker.m
+++ b/Source/BugsnagSessionTracker.m
@@ -39,11 +39,16 @@ NSString *const BSGSessionUpdateNotification = @"BugsnagSessionChanged";
 
 @interface BugsnagApp ()
 + (BugsnagApp *)appWithDictionary:(NSDictionary *)event
-                           config:(BugsnagConfiguration *)config;
+                           config:(BugsnagConfiguration *)config
+                     codeBundleId:(NSString *)codeBundleId;
 @end
 
 @interface BugsnagDevice ()
 + (BugsnagDevice *)deviceWithDictionary:(NSDictionary *)event;
+@end
+
+@interface BugsnagSessionTrackingApiClient ()
+@property (nonatomic) NSString *codeBundleId;
 @end
 
 @interface BugsnagSessionTracker ()
@@ -51,7 +56,7 @@ NSString *const BSGSessionUpdateNotification = @"BugsnagSessionChanged";
 @property (strong, nonatomic) BugsnagSessionFileStore *sessionStore;
 @property (strong, nonatomic) BugsnagSessionTrackingApiClient *apiClient;
 @property (strong, nonatomic) NSDate *backgroundStartTime;
-
+@property (nonatomic) NSString *codeBundleId;
 @property (strong, readwrite) BugsnagSession *currentSession;
 
 /**
@@ -76,6 +81,11 @@ NSString *const BSGSessionUpdateNotification = @"BugsnagSessionChanged";
         _sessionStore = [BugsnagSessionFileStore storeWithPath:storePath];
     }
     return self;
+}
+
+- (void)setCodeBundleId:(NSString *)codeBundleId {
+    _codeBundleId = codeBundleId;
+    _apiClient.codeBundleId = codeBundleId;
 }
 
 #pragma mark - Creating and sending a new session
@@ -129,7 +139,7 @@ NSString *const BSGSessionUpdateNotification = @"BugsnagSessionChanged";
     }
 
     NSDictionary *systemInfo = [BSG_KSSystemInfo systemInfo];
-    BugsnagApp *app = [BugsnagApp appWithDictionary:@{@"system": systemInfo} config:self.config];
+    BugsnagApp *app = [BugsnagApp appWithDictionary:@{@"system": systemInfo} config:self.config codeBundleId:self.codeBundleId];
     BugsnagDevice *device = [BugsnagDevice deviceWithDictionary:@{@"system": systemInfo}];
     BugsnagSession *newSession = [[BugsnagSession alloc] initWithId:[[NSUUID UUID] UUIDString]
                                                           startDate:[NSDate date]

--- a/Source/BugsnagSessionTrackingApiClient.m
+++ b/Source/BugsnagSessionTrackingApiClient.m
@@ -20,7 +20,9 @@
 
 @interface BugsnagSessionTrackingApiClient ()
 @property NSMutableSet *activeIds;
+@property(nonatomic) NSString *codeBundleId;
 @end
+
 
 @implementation BugsnagSessionTrackingApiClient
 
@@ -58,7 +60,10 @@
         BugsnagSession *session = [[BugsnagSession alloc] initWithDictionary:filesWithIds[fileId]];
 
         [self.sendQueue addOperationWithBlock:^{
-            BugsnagSessionTrackingPayload *payload = [[BugsnagSessionTrackingPayload alloc] initWithSessions:@[session] config:[Bugsnag configuration]];
+            BugsnagSessionTrackingPayload *payload = [[BugsnagSessionTrackingPayload alloc]
+                initWithSessions:@[session]
+                          config:[Bugsnag configuration]
+                    codeBundleId:self.codeBundleId];
             NSUInteger sessionCount = payload.sessions.count;
             NSMutableDictionary *data = [payload toJson];
             NSDictionary *HTTPHeaders = @{

--- a/Source/BugsnagSessionTrackingPayload.h
+++ b/Source/BugsnagSessionTrackingPayload.h
@@ -15,7 +15,8 @@
 @interface BugsnagSessionTrackingPayload : NSObject
 
 - (instancetype)initWithSessions:(NSArray<BugsnagSession *> *)sessions
-                          config:(BugsnagConfiguration *)config;
+                          config:(BugsnagConfiguration *)config
+                    codeBundleId:(NSString *)codeBundleId;
 
 - (NSMutableDictionary *)toJson;
 

--- a/Source/BugsnagSessionTrackingPayload.m
+++ b/Source/BugsnagSessionTrackingPayload.m
@@ -32,23 +32,27 @@
 
 @interface BugsnagApp ()
 + (BugsnagApp *)appWithDictionary:(NSDictionary *)event
-                           config:(BugsnagConfiguration *)config;
+                           config:(BugsnagConfiguration *)config
+                     codeBundleId:(NSString *)codeBundleId;
 
 - (NSDictionary *)toDict;
 @end
 
 @interface BugsnagSessionTrackingPayload ()
 @property (nonatomic) BugsnagConfiguration *config;
+@property(nonatomic, copy) NSString *codeBundleId;
 @end
 
 @implementation BugsnagSessionTrackingPayload
 
 - (instancetype)initWithSessions:(NSArray<BugsnagSession *> *)sessions
                           config:(BugsnagConfiguration *)config
+                    codeBundleId:(NSString *)codeBundleId
 {
     if (self = [super init]) {
         _sessions = sessions;
         _config = config;
+        _codeBundleId = codeBundleId;
     }
     return self;
 }

--- a/Source/BugsnagSink.m
+++ b/Source/BugsnagSink.m
@@ -40,11 +40,16 @@
 + (BugsnagClient *)client;
 @end
 
+@interface BugsnagClient ()
+@property (nonatomic) NSString *codeBundleId;
+@end
+
 @interface BugsnagEvent ()
 - (NSDictionary *_Nonnull)toJson;
 - (BOOL)shouldBeSent;
 - (instancetype _Nonnull)initWithKSReport:(NSDictionary *_Nonnull)report;
 @property NSArray *redactedKeys;
+@property (nonatomic) NSString *codeBundleId;
 @end
 
 @interface BugsnagConfiguration ()
@@ -82,6 +87,8 @@
     for (NSString *fileKey in reports) {
         NSDictionary *report = reports[fileKey];
         BugsnagEvent *bugsnagReport = [[BugsnagEvent alloc] initWithKSReport:report];
+        bugsnagReport.codeBundleId = [Bugsnag client].codeBundleId;
+
         if (![bugsnagReport shouldBeSent])
             continue;
         BOOL shouldSend = YES;

--- a/Tests/BugsnagAppTest.m
+++ b/Tests/BugsnagAppTest.m
@@ -13,12 +13,16 @@
 #import "BugsnagTestConstants.h"
 
 @interface BugsnagApp ()
-+ (BugsnagApp *)appWithDictionary:(NSDictionary *)event config:(BugsnagConfiguration *)config;
++ (BugsnagApp *)appWithDictionary:(NSDictionary *)event
+                           config:(BugsnagConfiguration *)config
+                     codeBundleId:(NSString *)codeBundleId;
 - (NSDictionary *)toDict;
 @end
 
 @interface BugsnagAppWithState ()
-+ (BugsnagAppWithState *)appWithDictionary:(NSDictionary *)event config:(BugsnagConfiguration *)config;
++ (BugsnagAppWithState *)appWithDictionary:(NSDictionary *)event
+                                    config:(BugsnagConfiguration *)config
+                              codeBundleId:(NSString *)codeBundleId;
 + (BugsnagAppWithState *)appWithOomData:(NSDictionary *)event;
 - (NSDictionary *)toDict;
 @end
@@ -26,6 +30,7 @@
 @interface BugsnagAppTest : XCTestCase
 @property NSDictionary *data;
 @property BugsnagConfiguration *config;
+@property NSString *codeBundleId;
 @end
 
 @implementation BugsnagAppTest
@@ -56,11 +61,11 @@
 
     self.config = [[BugsnagConfiguration alloc] initWithApiKey:DUMMY_APIKEY_32CHAR_1];
     self.config.appType = @"iOS";
-    self.config.codeBundleId = @"bundle-123";
+    self.codeBundleId = @"bundle-123";
 }
 
 - (void)testApp {
-    BugsnagApp *app = [BugsnagApp appWithDictionary:self.data config:self.config];
+    BugsnagApp *app = [BugsnagApp appWithDictionary:self.data config:self.config codeBundleId:self.codeBundleId];
 
     // verify stateless fields
     XCTAssertEqualObjects(@"1", app.bundleVersion);
@@ -73,7 +78,7 @@
 }
 
 - (void)testAppWithState {
-    BugsnagAppWithState *app = [BugsnagAppWithState appWithDictionary:self.data config:self.config];
+    BugsnagAppWithState *app = [BugsnagAppWithState appWithDictionary:self.data config:self.config codeBundleId:self.codeBundleId];
 
     // verify stateful fields
     XCTAssertEqual(7000, app.duration);
@@ -91,7 +96,7 @@
 }
 
 - (void)testAppToDict {
-    BugsnagApp *app = [BugsnagApp appWithDictionary:self.data config:self.config];
+    BugsnagApp *app = [BugsnagApp appWithDictionary:self.data config:self.config codeBundleId:self.codeBundleId];
     NSDictionary *dict = [app toDict];
 
     // verify stateless fields
@@ -105,7 +110,7 @@
 }
 
 - (void)testAppWithStateToDict {
-    BugsnagAppWithState *app = [BugsnagAppWithState appWithDictionary:self.data config:self.config];
+    BugsnagAppWithState *app = [BugsnagAppWithState appWithDictionary:self.data config:self.config codeBundleId:self.codeBundleId];
     NSDictionary *dict = [app toDict];
 
     // verify stateful fields

--- a/Tests/BugsnagClientMirrorTest.m
+++ b/Tests/BugsnagClientMirrorTest.m
@@ -90,6 +90,8 @@
             @"metadata @16@0:8",
             @"workspaceBreadcrumbStateEvents @16@0:8",
             @"startListeningForWorkspaceStateChangeNotifications: v24@0:8@16",
+            @"codeBundleId @16@0:8",
+            @"setCodeBundleId: v24@0:8@16",
             @"context @16@0:8"
     ]];
 

--- a/Tests/BugsnagSessionTest.m
+++ b/Tests/BugsnagSessionTest.m
@@ -17,7 +17,9 @@
 #import "BugsnagTestConstants.h"
 
 @interface BugsnagApp ()
-+ (BugsnagApp *)appWithDictionary:(NSDictionary *)data config:(BugsnagConfiguration *)config;
++ (BugsnagApp *)appWithDictionary:(NSDictionary *)data
+                           config:(BugsnagConfiguration *)config
+                     codeBundleId:(NSString *)codeBundleId;
 - (NSDictionary *)toDict;
 @end
 
@@ -37,6 +39,10 @@
 @property BugsnagApp *app;
 @property BugsnagDevice *device;
 @property NSDictionary *serializedSession;
+@end
+
+@interface BugsnagUser ()
+- (instancetype)initWithUserId:(NSString *)userId name:(NSString *)name emailAddress:(NSString *)emailAddress;
 @end
 
 @implementation BugsnagSessionTest
@@ -70,8 +76,7 @@
 
     BugsnagConfiguration *config = [[BugsnagConfiguration alloc] initWithApiKey:DUMMY_APIKEY_32CHAR_1];
     config.appType = @"iOS";
-    config.codeBundleId = @"bundle-123";
-    return [BugsnagApp appWithDictionary:appData config:config];
+    return [BugsnagApp appWithDictionary:appData config:config codeBundleId:@"bundle-123"];
 }
 
 - (BugsnagDevice *)generateDevice {

--- a/Tests/BugsnagSessionTrackingPayloadTest.m
+++ b/Tests/BugsnagSessionTrackingPayloadTest.m
@@ -16,7 +16,9 @@
 #import "BugsnagSessionInternal.h"
 
 @interface BugsnagApp ()
-+ (BugsnagApp *)appWithDictionary:(NSDictionary *)data config:(BugsnagConfiguration *)config;
++ (BugsnagApp *)appWithDictionary:(NSDictionary *)data
+                           config:(BugsnagConfiguration *)config
+                     codeBundleId:(NSString *)codeBundleId;
 @end
 
 @interface BugsnagDevice ()
@@ -37,7 +39,7 @@
 
     BugsnagConfiguration *config = [[BugsnagConfiguration alloc] initWithApiKey:DUMMY_APIKEY_32CHAR_1];
     config.releaseStage = @"beta";
-    BugsnagSessionTrackingPayload *data = [[BugsnagSessionTrackingPayload alloc] initWithSessions:@[] config:config];
+    BugsnagSessionTrackingPayload *data = [[BugsnagSessionTrackingPayload alloc] initWithSessions:@[] config:config codeBundleId:nil];
     BugsnagSession *session = [[BugsnagSession alloc] initWithId:@"test"
                                                        startDate:[NSDate date]
                                                             user:nil
@@ -71,8 +73,7 @@
 
     BugsnagConfiguration *config = [[BugsnagConfiguration alloc] initWithApiKey:DUMMY_APIKEY_32CHAR_1];
     config.appType = @"iOS";
-    config.codeBundleId = @"bundle-123";
-    return [BugsnagApp appWithDictionary:appData config:config];
+    return [BugsnagApp appWithDictionary:appData config:config codeBundleId:@"bundle-123"];
 }
 
 - (BugsnagDevice *)generateDevice {

--- a/Tests/BugsnagUserTest.m
+++ b/Tests/BugsnagUserTest.m
@@ -11,9 +11,14 @@
 #import "BugsnagUser.h"
 #import "BugsnagEvent.h"
 
+@interface BugsnagEvent ()
+- (instancetype)initWithKSReport:(NSDictionary *)report;
+@end
+
 @interface BugsnagUser ()
 - (instancetype)initWithDictionary:(NSDictionary *)dict;
 - (NSDictionary *)toJson;
+- (instancetype)initWithUserId:(NSString *)userId name:(NSString *)name emailAddress:(NSString *)emailAddress;
 @end
 
 @interface BugsnagUserTest : XCTestCase

--- a/UPGRADING.md
+++ b/UPGRADING.md
@@ -94,6 +94,7 @@ The exact error is available using the `BSGConfigurationErrorDomain` and
 - config.shouldSendReports
 - config.errorApiHeaders
 - config.sessionApiHeaders
+- config.codeBundleId
 ```
 
 ### `Bugsnag` class

--- a/iOS/BugsnagTests/BSGOutOfMemoryWatchdogTests.m
+++ b/iOS/BugsnagTests/BSGOutOfMemoryWatchdogTests.m
@@ -14,6 +14,7 @@
 
 @interface BugsnagClient (Testing)
 @property (nonatomic, strong) BSGOutOfMemoryWatchdog *oomWatchdog;
+@property (nonatomic) NSString *codeBundleId;
 @end
 
 @interface BSGOutOfMemoryWatchdog (Testing)
@@ -30,7 +31,6 @@
     [super setUp];
     BugsnagConfiguration *config = [[BugsnagConfiguration alloc] initWithApiKey:DUMMY_APIKEY_32CHAR_1];
     config.autoDetectErrors = NO;
-    config.codeBundleId = @"codeBundleIdHere";
     config.releaseStage = @"MagicalTestingTime";
 
     [Bugsnag startBugsnagWithConfiguration:config];
@@ -46,7 +46,11 @@
  * Test that the generated OOM report values exist and are correct (where that can be tested)
  */
 - (void)testOOMFieldsSetCorrectly {
-    NSMutableDictionary *cachedFileInfo = [[[Bugsnag client] oomWatchdog] cachedFileInfo];
+    BugsnagClient *client = [Bugsnag client];
+    BSGOutOfMemoryWatchdog *watchdog = [client oomWatchdog];
+
+    client.codeBundleId = @"codeBundleIdHere";
+    NSMutableDictionary *cachedFileInfo = [watchdog cachedFileInfo];
     XCTAssertNotNil([cachedFileInfo objectForKey:@"app"]);
     XCTAssertNotNil([cachedFileInfo objectForKey:@"device"]);
     
@@ -56,8 +60,8 @@
     XCTAssertNotNil([app objectForKey:@"inForeground"]);
     XCTAssertNotNil([app objectForKey:@"version"]);
     XCTAssertNotNil([app objectForKey:@"name"]);
-    XCTAssertEqual([app valueForKey:@"codeBundleId"], @"codeBundleIdHere");
-    XCTAssertEqual([app valueForKey:@"releaseStage"], @"MagicalTestingTime");
+    XCTAssertEqualObjects([app valueForKey:@"codeBundleId"], @"codeBundleIdHere");
+    XCTAssertEqualObjects([app valueForKey:@"releaseStage"], @"MagicalTestingTime");
     
     NSMutableDictionary *device = [cachedFileInfo objectForKey:@"device"];
     XCTAssertNotNil([device objectForKey:@"osName"]);
@@ -67,7 +71,7 @@
     XCTAssertNotNil([device objectForKey:@"model"]);
     XCTAssertNotNil([device objectForKey:@"simulator"]);
     XCTAssertNotNil([device objectForKey:@"wordSize"]);
-    XCTAssertEqual([device valueForKey:@"locale"], [[NSLocale currentLocale] localeIdentifier]);
+    XCTAssertEqualObjects([device valueForKey:@"locale"], [[NSLocale currentLocale] localeIdentifier]);
 }
 
 @end


### PR DESCRIPTION
## Goal

Removes the `codeBundleId` from the public API and onto `BugsnagClient`. This is because end-users do not need to set the value - it is required only for the React Native implementation, where it is set via JS.

## Changeset
- Removed `codeBundleId` property from `BugsnagConfiguration`
- Updated `Bugsnag` to set `codeBundleId` on `BugsnagClient` rather than `BugsnagConfiguration`
- `BugsnagApp` and `BugsnagAppWithState` now have constructor parameter for `codeBundleId` rather than relying on `BugsnagConfiguration`
- Added custom setter on `BugsnagClient` so that when `codeBundleId` is set, the value is propagated to events + sessions
- Recorded `app.codeBundleId` value when an OOM is detected

## Tests
Updated existing test coverage to supply `codeBundleId` from `Client` rather than `Configuration`
