### PR TITLE
fix: device charging status is now reported as a boolean

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -252,6 +252,11 @@ Bugsnag Notifiers on other platforms.
 * NSWorkspaceScreenSleep/Wake notifications now use the correct notification center.
   (#525)[https://github.com/bugsnag/bugsnag-cocoa/pull/525]
   
+* Device Charging status was being incorrectly reported as a number rather than a boolean.
+  Device charging status is represented as a four-valued enum.  If the device is plugged in it reports 
+  as charging, even if it is at 100%.  Any other values are reported as not charging.
+  (#551)[https://github.com/bugsnag/bugsnag-cocoa/pull/551]
+  
 ## 5.23.0 (2019-12-10)
 
 This release removes support for reporting 'partial' or 'minimal' crash reports

--- a/Source/BugsnagClient.m
+++ b/Source/BugsnagClient.m
@@ -968,13 +968,14 @@ NSString *const BSGBreadcrumbLoadedMessage = @"Bugsnag loaded";
 #elif TARGET_IPHONE_SIMULATOR || TARGET_OS_IPHONE
 - (void)batteryChanged:(NSNotification *)notification {
     NSNumber *batteryLevel = @([UIDevice currentDevice].batteryLevel);
-    NSNumber *charging = @([UIDevice currentDevice].batteryState == UIDeviceBatteryStateCharging);
+    BOOL charging = [UIDevice currentDevice].batteryState == UIDeviceBatteryStateCharging ||
+                    [UIDevice currentDevice].batteryState == UIDeviceBatteryStateFull;
 
     [[self state] addMetadata:batteryLevel
                      withKey:BSGKeyBatteryLevel
                  toSection:BSGKeyDeviceState];
     
-    [[self state] addMetadata:charging
+    [[self state] addMetadata:charging ? @YES : @NO
                      withKey:BSGKeyCharging
                  toSection:BSGKeyDeviceState];
 }


### PR DESCRIPTION
## Goal

Device charging status was incorrectly being reported as a number, rather than a boolean.  This change corrects that.

<!-- What is the intent of this change? -->

<!--
Fixes #
Related to #
-->

## Design

Four values are possible for a device charging status:

```
typedef NS_ENUM(NSInteger, UIDeviceBatteryState) {
    UIDeviceBatteryStateUnknown,
    UIDeviceBatteryStateUnplugged,   // on battery, discharging
    UIDeviceBatteryStateCharging,    // plugged in, less than 100%
    UIDeviceBatteryStateFull,        // plugged in, at 100%
} API_UNAVAILABLE(tvos);              // available in iPhone 3.0
```

This change assumes that `plugged-in == charging` (true) and vice-versa.

<!-- How does this change work? Why was this approach to the goal used? -->

## Changeset

Simple change to `BugsnagClient`.

<!-- List what was added, removed, or changed.  Pitch this at a level 
     appropriate to the scope of the change: new  classes, changed architecture,
     minor typo, etc.  If appropriate include a list of changed files: 

         $ git diff --name-status HEAD~1 | cat
-->

## Tests

Since this is a hardware-specific property it was tested manually, and in the simulator, corroborated appropriately with the Bugsnag dashboard.

<!-- How was this change tested? What manual and automated tests were
     run/added? -->

## Review

### Outstanding Questions

<!-- Are there any parts of the design or the implementation which seem
     less than ideal and that could require additional discussion?
     List here: -->

<!-- Preflight checks. Have I:

* Added a changelog entry?
* Checked the scope to ensure the commits are only related to the goal above?

-->

- This pull request is ready for:
  - [ ] Initial review of the intended approach, not yet feature complete
  - [ ] Structural review of the classes, functions, and properties modified
  - [X] Final review
  - [ ] Release

<!-- What do you need from a reviewer to get this changeset
     ready for release -->

- [ ] The correct target branch has been selected (`master` for fixes, `next` for
  features)
- [ ] If this is intended for release have all of the [pre-release checks](CONTRIBUTING.md) been considered?
- [ ] Consistency across platforms for structures or concepts added or modified
- [ ] Consistency between the changeset and the goal stated above
- [ ] Internal consistency with the rest of the library - is there any overlap between existing interfaces and any which have been added?
- [ ] Usage friction - is the proposed change in usage cumbersome or complicated?
- [ ] Performance and complexity - are there any cases of unexpected O(n^3) when iterating, recursing, flat mapping, etc?
- [ ] Concurrency concerns - if components are accessed asynchronously, what issues will arise
- [ ] Thoroughness of added tests and any missing edge cases
- [ ] Idiomatic use of the language
