### PR TITLE
Make apiKey nullable on BugsnagEvent

### DIFF
--- a/Source/BugsnagEvent.h
+++ b/Source/BugsnagEvent.h
@@ -115,7 +115,7 @@ initWithErrorName:(NSString *_Nonnull)name
  * - Reads default to the BugsnagConfiguration apiKey value unless explicitly set.
  * - Writes are not persisted to BugsnagConfiguration.
  */
-@property(readwrite, copy, nonnull) NSString *apiKey;
+@property(readwrite, copy, nullable) NSString *apiKey;
 
 /**
  *  Device information such as OS name and version


### PR DESCRIPTION
Makes apiKey nullable on the `BugsnagEvent` class only, to match the specification.