### PR TITLE
Add getter for bugsnag.context

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,9 @@ Bugsnag Notifiers on other platforms.
 
 ## Enhancements
 
+* Add getter for `Bugsnag.context`
+  [#554](https://github.com/bugsnag/bugsnag-cocoa/pull/554)
+
 * Add `sendThreads` property to `BugsnagConfiguration`
   [#549](https://github.com/bugsnag/bugsnag-cocoa/pull/549)
 

--- a/Source/Bugsnag.h
+++ b/Source/Bugsnag.h
@@ -217,11 +217,11 @@
 // =============================================================================
 
 /**
- * Replicates BugsnagConfiguration.context
- *
- * @param context A general summary of what was happening in the application
+ * Retrieves the context - a general summary of what was happening in the application
  */
 + (void)setContext:(NSString *_Nullable)context;
+
++ (NSString *_Nullable)getContext;
 
 // =============================================================================
 // MARK: - User

--- a/Source/Bugsnag.h
+++ b/Source/Bugsnag.h
@@ -221,7 +221,10 @@
  */
 + (void)setContext:(NSString *_Nullable)context;
 
-+ (NSString *_Nullable)getContext;
+/**
+ * Retrieves the context - a general summary of what was happening in the application
+ */
++ (NSString *_Nullable)context;
 
 // =============================================================================
 // MARK: - User

--- a/Source/Bugsnag.m
+++ b/Source/Bugsnag.m
@@ -299,7 +299,7 @@ static BugsnagClient *bsg_g_bugsnag_client = NULL;
     }
 }
 
-+ (NSString *_Nullable)getContext {
++ (NSString *_Nullable)context {
     if ([self bugsnagStarted]) {
         return self.client.context;
     }

--- a/Source/Bugsnag.m
+++ b/Source/Bugsnag.m
@@ -299,6 +299,13 @@ static BugsnagClient *bsg_g_bugsnag_client = NULL;
     }
 }
 
++ (NSString *_Nullable)getContext {
+    if ([self bugsnagStarted]) {
+        return self.client.context;
+    }
+    return nil;
+}
+
 + (BugsnagUser *)user {
     return self.client.user;
 }

--- a/Source/BugsnagClient.h
+++ b/Source/BugsnagClient.h
@@ -204,11 +204,9 @@ NS_SWIFT_NAME(leaveBreadcrumb(_:metadata:type:));
 // =============================================================================
 
 /**
- * Replicates BugsnagConfiguration.context
- *
- * @param context A general summary of what was happening in the application
+ * Retrieves the context - a general summary of what was happening in the application
  */
-- (void)setContext:(NSString *_Nullable)context;
+ @property NSString *_Nullable context;
 
 /**
  * @return YES if Bugsnag has been started and the previous launch crashed

--- a/Source/BugsnagClient.m
+++ b/Source/BugsnagClient.m
@@ -748,6 +748,10 @@ NSString *const BSGBreadcrumbLoadedMessage = @"Bugsnag loaded";
     self.configuration.context = context;
 }
 
+- (NSString *)context {
+    return self.configuration.context;
+}
+
 // MARK: - Notify
 
 - (void)notifyError:(NSError *_Nonnull)error {

--- a/Tests/BugsnagClientMirrorTest.m
+++ b/Tests/BugsnagClientMirrorTest.m
@@ -89,7 +89,8 @@
             @"setMetadata: v24@0:8@16",
             @"metadata @16@0:8",
             @"workspaceBreadcrumbStateEvents @16@0:8",
-            @"startListeningForWorkspaceStateChangeNotifications: v24@0:8@16"
+            @"startListeningForWorkspaceStateChangeNotifications: v24@0:8@16",
+            @"context @16@0:8"
     ]];
 
     // the following methods are implemented on Bugsnag but do not need to
@@ -103,7 +104,8 @@
             @"client @16@0:8",
             @"bugsnagStarted B16@0:8",
             @"bugsnagStarted c16@0:8",
-            @"leaveBreadcrumbWithBlock: v24@0:8@?16"
+            @"leaveBreadcrumbWithBlock: v24@0:8@?16",
+            @"getContext @16@0:8"
     ]];
 }
 


### PR DESCRIPTION
## Goal

Adds a getter method for context on `Bugsnag`, and converts `context into a property on `BugsnagClient`. This allows users to read the value if necessary which is a requirement in the spec.