### PR TITLE
Make BugsnagUser properties readonly

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,9 @@ Bugsnag Notifiers on other platforms.
 
 ## Enhancements
 
+* Make `BugsnagUser` properties readonly
+  [#556](https://github.com/bugsnag/bugsnag-cocoa/pull/556)
+
 * Add `sendThreads` property to `BugsnagConfiguration`
   [#549](https://github.com/bugsnag/bugsnag-cocoa/pull/549)
 

--- a/Source/BugsnagUser.h
+++ b/Source/BugsnagUser.h
@@ -15,8 +15,8 @@
 
 - (NSDictionary *)toJson;
 
-@property NSString *userId;
-@property NSString *name;
-@property NSString *emailAddress;
+@property(readonly) NSString *userId;
+@property(readonly) NSString *name;
+@property(readonly) NSString *emailAddress;
 
 @end

--- a/Source/BugsnagUser.m
+++ b/Source/BugsnagUser.m
@@ -23,9 +23,9 @@
 - (instancetype)initWithUserId:(NSString *)userId name:(NSString *)name emailAddress:(NSString *)emailAddress {
     self = [super init];
     if (self) {
-        self.userId = userId;
-        self.name = name;
-        self.emailAddress = emailAddress;
+        _userId = userId;
+        _name = name;
+        _emailAddress = emailAddress;
     }
     return self;
 }

--- a/Tests/BugsnagSessionTest.m
+++ b/Tests/BugsnagSessionTest.m
@@ -125,10 +125,7 @@
 
 - (void)testPayloadSerialization {
     NSDate *now = [NSDate date];
-    BugsnagUser *user = [BugsnagUser new];
-    user.userId = @"123";
-    user.name = @"Joe Bloggs";
-    user.emailAddress = @"joe@example.com";
+    BugsnagUser *user = [[BugsnagUser alloc] initWithUserId:@"123" name:@"Joe Bloggs" emailAddress:@"joe@example.com"];
     BugsnagSession *payload = [[BugsnagSession alloc] initWithId:@"test"
                                                        startDate:now
                                                             user:user

--- a/Tests/BugsnagUserTest.m
+++ b/Tests/BugsnagUserTest.m
@@ -31,11 +31,7 @@
 }
 
 - (void)testPayloadSerialisation {
-    BugsnagUser *payload = [BugsnagUser new];
-    payload.userId = @"test";
-    payload.emailAddress = @"fake@example.com";
-    payload.name = @"Tom Bombadil";
-    
+    BugsnagUser *payload = [[BugsnagUser alloc] initWithUserId:@"test" name:@"Tom Bombadil" emailAddress:@"fake@example.com"];
     NSDictionary *rootNode = [payload toJson];
     XCTAssertNotNil(rootNode);
     XCTAssertEqual(3, [rootNode count]);


### PR DESCRIPTION
## Goal

Makes the properties on `BugsnagUser` readonly, and updates test code to initialise using the new syntax. This is in line with the notifier spec.