### PR TITLE
Make user editable on BugsnagEvent

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,9 @@ Bugsnag Notifiers on other platforms.
 
 ## Enhancements
 
+* Make user editable on `BugsnagEvent`
+  [#557](https://github.com/bugsnag/bugsnag-cocoa/pull/557)
+
 * Add `sendThreads` property to `BugsnagConfiguration`
   [#549](https://github.com/bugsnag/bugsnag-cocoa/pull/549)
 

--- a/Source/BugsnagEvent.h
+++ b/Source/BugsnagEvent.h
@@ -18,6 +18,7 @@
 @class BugsnagMetadata;
 @class BugsnagThread;
 @class BugsnagError;
+@class BugsnagUser;
 
 typedef NS_ENUM(NSUInteger, BSGSeverity) {
     BSGSeverityError,
@@ -129,6 +130,27 @@ initWithErrorName:(NSString *_Nonnull)name
  * the error that will be sent.
  */
 @property(nullable) id originalError;
+
+
+// =============================================================================
+// MARK: - User
+// =============================================================================
+
+/**
+ * The current user
+ */
+@property(readonly, nonatomic, nonnull) BugsnagUser *user;
+
+/**
+ *  Set user metadata
+ *
+ *  @param userId ID of the user
+ *  @param name   Name of the user
+ *  @param email  Email address of the user
+ */
+- (void)setUser:(NSString *_Nullable)userId
+      withEmail:(NSString *_Nullable)email
+        andName:(NSString *_Nullable)name;
 
 @end
 

--- a/Tests/BugsnagUserTest.m
+++ b/Tests/BugsnagUserTest.m
@@ -9,6 +9,7 @@
 #import <XCTest/XCTest.h>
 
 #import "BugsnagUser.h"
+#import "BugsnagEvent.h"
 
 @interface BugsnagUserTest : XCTestCase
 @end
@@ -43,6 +44,21 @@
     XCTAssertEqualObjects(@"test", rootNode[@"id"]);
     XCTAssertEqualObjects(@"fake@example.com", rootNode[@"email"]);
     XCTAssertEqualObjects(@"Tom Bombadil", rootNode[@"name"]);
+}
+
+- (void)testUserEvent {
+    // Setup
+    BugsnagEvent *event = [[BugsnagEvent alloc] initWithKSReport:@{
+            @"user.metaData": @{
+                    @"user": @{
+                            @"id": @"123",
+                            @"name": @"Jane Smith",
+                            @"email": @"jane@example.com",
+                    }
+            }}];
+    XCTAssertEqualObjects(@"123", event.user.userId);
+    XCTAssertEqualObjects(@"Jane Smith", event.user.name);
+    XCTAssertEqualObjects(@"jane@example.com", event.user.emailAddress);
 }
 
 @end

--- a/UPGRADING.md
+++ b/UPGRADING.md
@@ -228,6 +228,8 @@ This is now BugsnagEvent.
 ```diff
 + event.unhandled
 + event.originalError
++ event.user
++ event.setUser
 ```
 
 `event.device` is now a structured class with properties for each value, rather than an `NSDictionary`.


### PR DESCRIPTION
## Goal

Makes user information editable on individual `BugsnagEvent` objects, as per the notifier spec.

## Changeset

- Added a setUser/user method to `BugsnagEvent`
- Updated `BugsnagEvent` serialization to use `BugsnagUser` rather than an `NSDictionary`

## Tests
Added a test to verify `event.user` is populated with user information; existing tests in `BugsnagEventTests` cover JSON serialization
