### PR TITLE
Make BugsnagPlugin take BugsnagClient as param

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,9 @@ Bugsnag Notifiers on other platforms.
 
 ## Enhancements
 
+* Make `BugsnagPlugin` take `BugsnagClient` as param
+  [#558](https://github.com/bugsnag/bugsnag-cocoa/pull/558)
+
 * Add `sendThreads` property to `BugsnagConfiguration`
   [#549](https://github.com/bugsnag/bugsnag-cocoa/pull/549)
 

--- a/Source/BugsnagPlugin.h
+++ b/Source/BugsnagPlugin.h
@@ -2,6 +2,7 @@
 #define BugsnagPlugin_h
 
 @class Bugsnag;
+@class BugsnagClient;
 
 /**
  * Internal interface for adding custom behavior
@@ -14,7 +15,8 @@
  * Loads a plugin with the given Client. When this method is invoked the plugin should
  * activate its behaviour - for example, by capturing an additional source of errors.
 */
-- (void)load;
+- (void)load:(BugsnagClient *)client;
+
 /**
  * Unloads a plugin. When this is invoked the plugin should cease all custom behaviour and
  * restore the application to its unloaded state.

--- a/Source/BugsnagPluginClient.m
+++ b/Source/BugsnagPluginClient.m
@@ -6,9 +6,14 @@
 //  Copyright © 2020 Bugsnag. All rights reserved.
 //
 
+#import "Bugsnag.h"
 #import "BugsnagPluginClient.h"
 #import "BugsnagPlugin.h"
 #import "BugsnagLogger.h"
+
+@interface Bugsnag ()
++ (BugsnagClient *)client;
+@end
 
 @interface BugsnagPluginClient ()
 @property NSSet<id<BugsnagPlugin>> *plugins;
@@ -26,7 +31,7 @@
 - (void)loadPlugins {
     for (id<BugsnagPlugin> plugin in self.plugins) {
         @try {
-            [plugin load];
+            [plugin load:[Bugsnag client]];
         } @catch (NSException *exception) {
             bsg_log_err(@"Failed to load plugin %@, continuing with initialisation.", plugin);
         }

--- a/Tests/BugsnagPluginTest.m
+++ b/Tests/BugsnagPluginTest.m
@@ -24,7 +24,7 @@
 @property XCTestExpectation *expectation;
 @end
 @implementation FakePlugin
-    - (void)load {
+    - (void)load:(BugsnagClient *)client {
         [self.expectation fulfill];
     }
     - (void)unload {}
@@ -34,7 +34,7 @@
 @property XCTestExpectation *expectation;
 @end
 @implementation CrashyPlugin
-    - (void)load {
+    - (void)load:(BugsnagClient *)client {
         [NSException raise:@"WhoopsException" format:@"something went wrong"];
         [self.expectation fulfill];
     }

--- a/features/fixtures/ios-swift-cocoapods/iOSTestApp/scenarios/CustomPluginNotifierDescriptionScenario.m
+++ b/features/fixtures/ios-swift-cocoapods/iOSTestApp/scenarios/CustomPluginNotifierDescriptionScenario.m
@@ -1,9 +1,5 @@
 #import "CustomPluginNotifierDescriptionScenario.h"
-#import <Bugsnag/BugsnagPlugin.h>
-
-@interface Bugsnag()
-+ (id)client;
-@end
+#import <Bugsnag/Bugsnag.h>
 
 @interface DescriptionPlugin : NSObject<BugsnagPlugin>
 
@@ -16,14 +12,13 @@
     return self;
 }
 
-- (void)load {
-    id notifier = [Bugsnag client];
+- (void)load:(BugsnagClient *)client {
     NSDictionary *newDetails = @{
         @"version": @"2.1.0",
         @"name": @"Foo Handler Library",
         @"url": @"https://example.com"
     };
-    [notifier setValue:newDetails forKey:@"details"];
+    [client setValue:newDetails forKey:@"details"];
 }
 
 - (void)unload {}


### PR DESCRIPTION
## Goal

Updates `BugsnagPlugin` to take `BugsnagClient` as a parameter, and fixes tests to use this syntax. This brings the plugin in line with the notifier spec.
