### PR TITLE
Rename BugsnagUser properties

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,9 @@ Bugsnag Notifiers on other platforms.
 
 ## Enhancements
 
+* Rename `BugsnagUser` properties
+  [#560](https://github.com/bugsnag/bugsnag-cocoa/pull/560)
+
 * Make `BugsnagOnErrorBlock` return `BOOL` rather than `void`
   [#555](https://github.com/bugsnag/bugsnag-cocoa/pull/555)
 

--- a/Source/BugsnagConfiguration.m
+++ b/Source/BugsnagConfiguration.m
@@ -141,8 +141,8 @@ NSString * const kBugsnagUserUserId = @"BugsnagUserUserId";
     [copy setReleaseStage:self.releaseStage];
     [copy setSession:[self.session copy]];
     [copy setSendThreads:self.sendThreads];
-    [copy setUser:self.user.userId
-        withEmail:self.user.emailAddress
+    [copy setUser:self.user.id
+        withEmail:self.user.email
           andName:self.user.name];
     
     return copy;
@@ -278,9 +278,9 @@ NSString * const kBugsnagUserUserId = @"BugsnagUserUserId";
  * @param user A BugsnagUser object containing data to be added to the configuration metadata.
  */
 - (void)setUserMetadataFromUser:(BugsnagUser *)user {
-    [self.metadata addMetadata:user.userId       withKey:BSGKeyId    toSection:BSGKeyUser];
+    [self.metadata addMetadata:user.id withKey:BSGKeyId toSection:BSGKeyUser];
     [self.metadata addMetadata:user.name         withKey:BSGKeyName  toSection:BSGKeyUser];
-    [self.metadata addMetadata:user.emailAddress withKey:BSGKeyEmail toSection:BSGKeyUser];
+    [self.metadata addMetadata:user.email withKey:BSGKeyEmail toSection:BSGKeyUser];
 }
 
 // =============================================================================
@@ -399,8 +399,8 @@ NSString * const kBugsnagUserUserId = @"BugsnagUserUserId";
     @synchronized(self) {
         if (_user) {
             // Email
-            if (_user.emailAddress) {
-                [BSG_SSKeychain setPassword:_user.emailAddress
+            if (_user.email) {
+                [BSG_SSKeychain setPassword:_user.email
                              forService:kBugsnagUserEmailAddress
                                 account:kBugsnagUserKeychainAccount];
             }
@@ -421,8 +421,8 @@ NSString * const kBugsnagUserUserId = @"BugsnagUserUserId";
             }
             
             // UserId
-            if (_user.userId) {
-                [BSG_SSKeychain setPassword:_user.userId
+            if (_user.id) {
+                [BSG_SSKeychain setPassword:_user.id
                              forService:kBugsnagUserUserId
                                 account:kBugsnagUserKeychainAccount];
             }

--- a/Source/BugsnagUser.h
+++ b/Source/BugsnagUser.h
@@ -10,8 +10,8 @@
 
 @interface BugsnagUser : NSObject
 
-@property(readonly) NSString *userId;
+@property(readonly) NSString *id;
 @property(readonly) NSString *name;
-@property(readonly) NSString *emailAddress;
+@property(readonly) NSString *email;
 
 @end

--- a/Source/BugsnagUser.m
+++ b/Source/BugsnagUser.m
@@ -13,8 +13,8 @@
 
 - (instancetype)initWithDictionary:(NSDictionary *)dict {
     if (self = [super init]) {
-        _userId = dict[@"id"];
-        _emailAddress = dict[@"email"];
+        _id = dict[@"id"];
+        _email = dict[@"email"];
         _name = dict[@"name"];
     }
     return self;
@@ -23,9 +23,9 @@
 - (instancetype)initWithUserId:(NSString *)userId name:(NSString *)name emailAddress:(NSString *)emailAddress {
     self = [super init];
     if (self) {
-        _userId = userId;
+        _id = userId;
         _name = name;
-        _emailAddress = emailAddress;
+        _email = emailAddress;
     }
     return self;
 }
@@ -36,8 +36,8 @@
 
 - (NSDictionary *)toJson {
     NSMutableDictionary *dict = [NSMutableDictionary new];
-    BSGDictInsertIfNotNil(dict, self.userId, @"id");
-    BSGDictInsertIfNotNil(dict, self.emailAddress, @"email");
+    BSGDictInsertIfNotNil(dict, self.id, @"id");
+    BSGDictInsertIfNotNil(dict, self.email, @"email");
     BSGDictInsertIfNotNil(dict, self.name, @"name");
     return [NSDictionary dictionaryWithDictionary:dict];
 }

--- a/Tests/BugsnagClientTests.m
+++ b/Tests/BugsnagClientTests.m
@@ -134,15 +134,15 @@ NSString *BSGFormatSeverity(BSGSeverity severity);
     XCTAssertEqualObjects([client.metadata getMetadataFromSection:BSGKeyUser withKey:BSGKeyName], @"Jiminy Cricket");
     XCTAssertEqualObjects([client.metadata getMetadataFromSection:BSGKeyUser withKey:BSGKeyEmail], @"jiminy@bugsnag.com");
 
-    XCTAssertEqualObjects([client user].userId, @"Jiminy");
+    XCTAssertEqualObjects([client user].id, @"Jiminy");
     XCTAssertEqualObjects([client user].name, @"Jiminy Cricket");
-    XCTAssertEqualObjects([client user].emailAddress, @"jiminy@bugsnag.com");
+    XCTAssertEqualObjects([client user].email, @"jiminy@bugsnag.com");
     
     [client setUser:nil withEmail:nil andName:@"Jiminy Cricket"];
     
-    XCTAssertNil([client user].userId);
+    XCTAssertNil([client user].id);
     XCTAssertEqualObjects([client user].name, @"Jiminy Cricket");
-    XCTAssertNil([client user].emailAddress);
+    XCTAssertNil([client user].email);
 }
 
 - (void)testMetadataMutability {

--- a/Tests/BugsnagConfigurationTests.m
+++ b/Tests/BugsnagConfigurationTests.m
@@ -441,9 +441,9 @@
 
     BugsnagConfiguration *config2 = [[BugsnagConfiguration alloc] initWithApiKey:DUMMY_APIKEY_32CHAR_1];
     XCTAssertNotNil(config2.user);
-    XCTAssertNil(config2.user.userId);
+    XCTAssertNil(config2.user.id);
     XCTAssertNil(config2.user.name);
-    XCTAssertNil(config2.user.emailAddress);
+    XCTAssertNil(config2.user.email);
 }
 
 /**
@@ -656,9 +656,9 @@
     
     [config setUser:@"123" withEmail:@"test@example.com" andName:@"foo"];
     
-    XCTAssertEqualObjects(@"123", config.user.userId);
+    XCTAssertEqualObjects(@"123", config.user.id);
     XCTAssertEqualObjects(@"foo", config.user.name);
-    XCTAssertEqualObjects(@"test@example.com", config.user.emailAddress);
+    XCTAssertEqualObjects(@"test@example.com", config.user.email);
 }
 
 - (void)testDefaultRedactedKeys {
@@ -822,8 +822,8 @@
 
     // Object
     [clone setUser:@"Cthulu" withEmail:@"hp@lovecraft.com" andName:@"Howard"];
-    XCTAssertEqualObjects(config.user.userId, @"foo");
-    XCTAssertEqualObjects(clone.user.userId, @"Cthulu");
+    XCTAssertEqualObjects(config.user.id, @"foo");
+    XCTAssertEqualObjects(clone.user.id, @"Cthulu");
     
     // String
     [clone setApiKey:DUMMY_APIKEY_32CHAR_2];

--- a/Tests/BugsnagSessionTest.m
+++ b/Tests/BugsnagSessionTest.m
@@ -196,9 +196,9 @@
 
     // user
     XCTAssertNotNil(session.user);
-    XCTAssertEqualObjects(@"123", session.user.userId);
+    XCTAssertEqualObjects(@"123", session.user.id);
     XCTAssertEqualObjects(@"Joe Bloggs", session.user.name);
-    XCTAssertEqualObjects(@"joe@example.com", session.user.emailAddress);
+    XCTAssertEqualObjects(@"joe@example.com", session.user.email);
 
     // app
     BugsnagApp *app = session.app;

--- a/Tests/BugsnagSessionTrackerTest.m
+++ b/Tests/BugsnagSessionTrackerTest.m
@@ -64,8 +64,8 @@
     XCTAssertNotNil(session.id);
     XCTAssertTrue([[NSDate date] timeIntervalSinceDate:session.startedAt] < 1);
     XCTAssertEqual(session.user.name, @"Bill");
-    XCTAssertEqual(session.user.userId, @"123");
-    XCTAssertNil(session.user.emailAddress);
+    XCTAssertEqual(session.user.id, @"123");
+    XCTAssertNil(session.user.email);
     XCTAssertFalse(session.autoCaptured);
 }
 
@@ -79,8 +79,8 @@
     XCTAssertTrue([[NSDate date] timeIntervalSinceDate:session.startedAt] < 1);
     XCTAssertTrue(session.autoCaptured);
     XCTAssertNil(session.user.name);
-    XCTAssertNil(session.user.userId);
-    XCTAssertNil(session.user.emailAddress);
+    XCTAssertNil(session.user.id);
+    XCTAssertNil(session.user.email);
 }
 
 - (void)testStartNewAutoCapturedSessionWithUser {
@@ -93,8 +93,8 @@
     XCTAssertNotNil(session.id);
     XCTAssertTrue([[NSDate date] timeIntervalSinceDate:session.startedAt] < 1);
     XCTAssertEqual(session.user.name, @"Bill");
-    XCTAssertEqual(session.user.userId, @"123");
-    XCTAssertEqual(session.user.emailAddress, @"bill@example.com");
+    XCTAssertEqual(session.user.id, @"123");
+    XCTAssertEqual(session.user.email, @"bill@example.com");
     XCTAssertTrue(session.autoCaptured);
 }
 

--- a/Tests/BugsnagUserTest.m
+++ b/Tests/BugsnagUserTest.m
@@ -19,7 +19,6 @@
 - (instancetype)initWithDictionary:(NSDictionary *)dict;
 - (instancetype)initWithUserId:(NSString *)userId name:(NSString *)name emailAddress:(NSString *)emailAddress;
 - (NSDictionary *)toJson;
-- (instancetype)initWithUserId:(NSString *)userId name:(NSString *)name emailAddress:(NSString *)emailAddress;
 @end
 
 @interface BugsnagEvent ()
@@ -41,8 +40,8 @@
     BugsnagUser *user = [[BugsnagUser alloc] initWithDictionary:dict];
 
     XCTAssertNotNil(user);
-    XCTAssertEqualObjects(user.userId, @"test");
-    XCTAssertEqualObjects(user.emailAddress, @"fake@example.com");
+    XCTAssertEqualObjects(user.id, @"test");
+    XCTAssertEqualObjects(user.email, @"fake@example.com");
     XCTAssertEqualObjects(user.name, @"Tom Bombadil");
 }
 
@@ -67,9 +66,9 @@
                             @"email": @"jane@example.com",
                     }
             }}];
-    XCTAssertEqualObjects(@"123", event.user.userId);
+    XCTAssertEqualObjects(@"123", event.user.id);
     XCTAssertEqualObjects(@"Jane Smith", event.user.name);
-    XCTAssertEqualObjects(@"jane@example.com", event.user.emailAddress);
+    XCTAssertEqualObjects(@"jane@example.com", event.user.email);
 }
 
 @end

--- a/UPGRADING.md
+++ b/UPGRADING.md
@@ -291,3 +291,15 @@ of the removed `addAttribute`:
 - user
 - sessionId
 ```
+
+### `BugsnagUser` class
+
+#### Renames
+
+```diff
+- userId
++ id
+
+- emailAddress
++ email
+```


### PR DESCRIPTION
## Goal

Renames the following `BugsnagUser` properties:

`userId` -> `id`
`emailAddress` -> `email`

This achieves consistency with what the notifier spec mandates.
