### PR TITLE
Add BugsnagErrorTypes for controlling captured errors

### DIFF
--- a/Bugsnag.podspec.json
+++ b/Bugsnag.podspec.json
@@ -40,6 +40,7 @@
     "Source/BugsnagDeviceWithState.h",
     "Source/BugsnagEndpointConfiguration.h",
     "Source/BugsnagError.h",
+    "Source/BugsnagErrorTypes.h",
     "Source/BugsnagEvent.h",
     "Source/BugsnagMetadata.h",
     "Source/BugsnagMetadataStore.h",

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,9 @@ Bugsnag Notifiers on other platforms.
 
 ## Enhancements
 
+* Add `BugsnagErrorTypes` for controlling captured errors
+  [#561](https://github.com/bugsnag/bugsnag-cocoa/pull/561)
+
 * Rename `BugsnagUser` properties
   [#560](https://github.com/bugsnag/bugsnag-cocoa/pull/560)
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,9 +8,6 @@ Bugsnag Notifiers on other platforms.
 
 ## Enhancements
 
-* Add `BugsnagErrorTypes` for controlling captured errors
-  [#561](https://github.com/bugsnag/bugsnag-cocoa/pull/561)
-
 * Rename `BugsnagUser` properties
   [#560](https://github.com/bugsnag/bugsnag-cocoa/pull/560)
 
@@ -212,10 +209,11 @@ Bugsnag Notifiers on other platforms.
 * Add metadata accessor methods to `BugsnagEvent`
   [#465](https://github.com/bugsnag/bugsnag-cocoa/pull/465)
   
-* Added a user-configurable `enabledErrorTypes` bitfield property to `BugsnagConfiguration`.
-  This allows users to choose which types of events are reported.  If automatic crash detection
+* Added a user-configurable `enabledErrorTypes` property to `BugsnagConfiguration`.
+  The `BugsnagErrorTypes` property allows users to choose which types of events are reported.  If automatic crash detection
   is disabled this value is ignored.  User-generated `notify()` events are reported in all cases.
   [#477](https://github.com/bugsnag/bugsnag-cocoa/pull/477)
+  [#561](https://github.com/bugsnag/bugsnag-cocoa/pull/561)
 
 * Internal logging has been unified.  Where before two preprocessor macros were
   required to configure both `Bugsnag` and `KSCrash` portions, now the Bugsnag

--- a/OSX/Bugsnag.xcodeproj/project.pbxproj
+++ b/OSX/Bugsnag.xcodeproj/project.pbxproj
@@ -69,6 +69,8 @@
 		E7529F8F243C8EBF006B4932 /* RegisterErrorData.m in Sources */ = {isa = PBXBuildFile; fileRef = E7529F8D243C8EBF006B4932 /* RegisterErrorData.m */; };
 		E7529FA0243CAE35006B4932 /* BugsnagThreadTest.m in Sources */ = {isa = PBXBuildFile; fileRef = E7529F9F243CAE34006B4932 /* BugsnagThreadTest.m */; };
 		E7529FA2243CAE3F006B4932 /* BugsnagThreadSerializationTest.m in Sources */ = {isa = PBXBuildFile; fileRef = E7529FA1243CAE3F006B4932 /* BugsnagThreadSerializationTest.m */; };
+		E7565F80245082940041768E /* BugsnagErrorTypes.m in Sources */ = {isa = PBXBuildFile; fileRef = E7565F7E245082940041768E /* BugsnagErrorTypes.m */; };
+		E7565F81245082940041768E /* BugsnagErrorTypes.h in Headers */ = {isa = PBXBuildFile; fileRef = E7565F7F245082940041768E /* BugsnagErrorTypes.h */; settings = {ATTRIBUTES = (Public, ); }; };
 		E762E9F91F73F7F300E82B43 /* BugsnagHandledStateTest.m in Sources */ = {isa = PBXBuildFile; fileRef = E762E9F71F73F7E900E82B43 /* BugsnagHandledStateTest.m */; };
 		E762E9FC1F73F80200E82B43 /* BugsnagHandledState.h in Headers */ = {isa = PBXBuildFile; fileRef = E762E9FA1F73F80200E82B43 /* BugsnagHandledState.h */; };
 		E762E9FD1F73F80200E82B43 /* BugsnagHandledState.m in Sources */ = {isa = PBXBuildFile; fileRef = E762E9FB1F73F80200E82B43 /* BugsnagHandledState.m */; };
@@ -296,11 +298,13 @@
 		E72352C01F55924A00436528 /* BSGConnectivity.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; name = BSGConnectivity.m; path = ../Source/BSGConnectivity.m; sourceTree = SOURCE_ROOT; };
 		E72AE1F7241A4E7500ED8972 /* BugsnagPluginClient.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; name = BugsnagPluginClient.m; path = ../Source/BugsnagPluginClient.m; sourceTree = "<group>"; };
 		E72AE1F8241A4E7500ED8972 /* BugsnagPluginClient.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; name = BugsnagPluginClient.h; path = ../Source/BugsnagPluginClient.h; sourceTree = "<group>"; };
+		E73D443B243E192F001686F5 /* BugsnagErrorTest.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; path = BugsnagErrorTest.m; sourceTree = "<group>"; };
 		E7529F8C243C8EBF006B4932 /* RegisterErrorData.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; name = RegisterErrorData.h; path = ../Source/RegisterErrorData.h; sourceTree = "<group>"; };
 		E7529F8D243C8EBF006B4932 /* RegisterErrorData.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; name = RegisterErrorData.m; path = ../Source/RegisterErrorData.m; sourceTree = "<group>"; };
-		E73D443B243E192F001686F5 /* BugsnagErrorTest.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; path = BugsnagErrorTest.m; sourceTree = "<group>"; };
 		E7529F9F243CAE34006B4932 /* BugsnagThreadTest.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; path = BugsnagThreadTest.m; sourceTree = "<group>"; };
 		E7529FA1243CAE3F006B4932 /* BugsnagThreadSerializationTest.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; name = BugsnagThreadSerializationTest.m; path = ../iOS/BugsnagTests/BugsnagThreadSerializationTest.m; sourceTree = "<group>"; };
+		E7565F7E245082940041768E /* BugsnagErrorTypes.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; name = BugsnagErrorTypes.m; path = ../Source/BugsnagErrorTypes.m; sourceTree = "<group>"; };
+		E7565F7F245082940041768E /* BugsnagErrorTypes.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; name = BugsnagErrorTypes.h; path = ../Source/BugsnagErrorTypes.h; sourceTree = "<group>"; };
 		E762E9F71F73F7E900E82B43 /* BugsnagHandledStateTest.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; name = BugsnagHandledStateTest.m; path = ../Tests/BugsnagHandledStateTest.m; sourceTree = SOURCE_ROOT; };
 		E762E9FA1F73F80200E82B43 /* BugsnagHandledState.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; name = BugsnagHandledState.h; path = ../Source/BugsnagHandledState.h; sourceTree = SOURCE_ROOT; };
 		E762E9FB1F73F80200E82B43 /* BugsnagHandledState.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; name = BugsnagHandledState.m; path = ../Source/BugsnagHandledState.m; sourceTree = SOURCE_ROOT; };
@@ -513,6 +517,7 @@
 			children = (
 				E7A9E59B243B35F400D99F8A /* Breadcrumbs */,
 				E7A9E59A243B35F100D99F8A /* Client */,
+				E7565F7D245082690041768E /* Configuration */,
 				E7A9E599243B35EF00D99F8A /* Delivery */,
 				E7A9E5A2243B363100D99F8A /* Metadata */,
 				E7A9E5A5243B364600D99F8A /* Payload */,
@@ -525,12 +530,8 @@
 				8A627CD81EC3B75200F7C04E /* BSGSerialization.m */,
 				8A2C8FBF1C6BC2C800846019 /* BugsnagCollections.h */,
 				8A2C8FC01C6BC2C800846019 /* BugsnagCollections.m */,
-				8A2C8FC11C6BC2C800846019 /* BugsnagConfiguration.h */,
-				8A2C8FC21C6BC2C800846019 /* BugsnagConfiguration.m */,
 				E79E6AFC1F4E3847002B35F9 /* BugsnagCrashSentry.h */,
 				E79E6AFD1F4E3847002B35F9 /* BugsnagCrashSentry.m */,
-				E77AFF0E244A18B10082B8BB /* BugsnagEndpointConfiguration.h */,
-				E77AFF0D244A18B10082B8BB /* BugsnagEndpointConfiguration.m */,
 				E762E9FA1F73F80200E82B43 /* BugsnagHandledState.h */,
 				E762E9FB1F73F80200E82B43 /* BugsnagHandledState.m */,
 				E794E8041F9F746D00A67EE7 /* BugsnagKeys.h */,
@@ -604,6 +605,19 @@
 				8A2C8FEF1C6BC3A200846019 /* SystemConfiguration.framework */,
 			);
 			name = Frameworks;
+			sourceTree = "<group>";
+		};
+		E7565F7D245082690041768E /* Configuration */ = {
+			isa = PBXGroup;
+			children = (
+				8A2C8FC11C6BC2C800846019 /* BugsnagConfiguration.h */,
+				8A2C8FC21C6BC2C800846019 /* BugsnagConfiguration.m */,
+				E77AFF0E244A18B10082B8BB /* BugsnagEndpointConfiguration.h */,
+				E77AFF0D244A18B10082B8BB /* BugsnagEndpointConfiguration.m */,
+				E7565F7F245082940041768E /* BugsnagErrorTypes.h */,
+				E7565F7E245082940041768E /* BugsnagErrorTypes.m */,
+			);
+			name = Configuration;
 			sourceTree = "<group>";
 		};
 		E79E6B081F4E3850002B35F9 /* BSG_KSCrash */ = {
@@ -893,6 +907,7 @@
 			isa = PBXHeadersBuildPhase;
 			buildActionMask = 2147483647;
 			files = (
+				E7565F81245082940041768E /* BugsnagErrorTypes.h in Headers */,
 				E79148481FD82B36003EFEBF /* BugsnagUser.h in Headers */,
 				E79148461FD82B36003EFEBF /* BugsnagSession.h in Headers */,
 				E77AFF10244A18B10082B8BB /* BugsnagEndpointConfiguration.h in Headers */,
@@ -1147,6 +1162,7 @@
 				E79148581FD82B36003EFEBF /* BugsnagFileStore.m in Sources */,
 				E79E6BDA1F4E3850002B35F9 /* BSG_RFC3339DateTool.m in Sources */,
 				E72352C21F55924A00436528 /* BSGConnectivity.m in Sources */,
+				E7565F80245082940041768E /* BugsnagErrorTypes.m in Sources */,
 				8A530CB922FDC38300F0C108 /* BSG_KSCrashIdentifier.m in Sources */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;

--- a/Source/BSGOutOfMemoryWatchdog.m
+++ b/Source/BSGOutOfMemoryWatchdog.m
@@ -13,6 +13,7 @@
 #import "Bugsnag.h"
 #import "BugsnagSessionTracker.h"
 #import "Private.h"
+#import "BugsnagErrorTypes.h"
 
 @interface BSGOutOfMemoryWatchdog ()
 @property(nonatomic, getter=isWatching) BOOL watching;
@@ -199,7 +200,7 @@
             BOOL sameVersions = [lastBootOSVersion isEqualToString:osVersion] &&
                                 [lastBootBundleVersion isEqualToString:bundleVersion] &&
                                 [lastBootAppVersion isEqualToString:appVersion];
-            BOOL shouldReport = (config.enabledErrorTypes & BSGErrorTypesOOMs)
+            BOOL shouldReport = (config.enabledErrorTypes.OOMs)
                 && (lastBootInForeground && lastBootWasActive);
             [self deleteSentinelFile];
             return sameVersions && shouldReport;

--- a/Source/BSGOutOfMemoryWatchdog.m
+++ b/Source/BSGOutOfMemoryWatchdog.m
@@ -200,8 +200,7 @@
             BOOL sameVersions = [lastBootOSVersion isEqualToString:osVersion] &&
                                 [lastBootBundleVersion isEqualToString:bundleVersion] &&
                                 [lastBootAppVersion isEqualToString:appVersion];
-            BOOL shouldReport = (config.enabledErrorTypes.OOMs)
-                && (lastBootInForeground && lastBootWasActive);
+            BOOL shouldReport = (lastBootInForeground && lastBootWasActive);
             [self deleteSentinelFile];
             return sameVersions && shouldReport;
         }

--- a/Source/Bugsnag.h
+++ b/Source/Bugsnag.h
@@ -36,6 +36,7 @@
 #import "BugsnagDeviceWithState.h"
 #import "BugsnagEndpointConfiguration.h"
 #import "BugsnagError.h"
+#import "BugsnagErrorTypes.h"
 #import "BugsnagSession.h"
 #import "BugsnagStackframe.h"
 #import "BugsnagThread.h"

--- a/Source/BugsnagClient.m
+++ b/Source/BugsnagClient.m
@@ -45,6 +45,7 @@
 #import "BSG_KSMach.h"
 #import "BSGSerialization.h"
 #import "Bugsnag.h"
+#import "BugsnagErrorTypes.h"
 
 #if TARGET_IPHONE_SIMULATOR || TARGET_OS_IPHONE
 #import <UIKit/UIKit.h>
@@ -530,8 +531,7 @@ NSString *const BSGBreadcrumbLoadedMessage = @"Bugsnag loaded";
 
     _started = YES;
     // autoDetectErrors disables all unhandled event reporting
-    BOOL configuredToReportOOMs = self.configuration.autoDetectErrors
-        && ([[Bugsnag configuration] enabledErrorTypes] & BSGErrorTypesOOMs);
+    BOOL configuredToReportOOMs = self.configuration.autoDetectErrors && (self.configuration.enabledErrorTypes.OOMs);
     
     // Disable if a debugger is enabled, since the development cycle of starting
     // and restarting an app is also an uncatchable kill
@@ -1097,7 +1097,7 @@ NSString *const BSGBreadcrumbLoadedMessage = @"Bugsnag loaded";
     if (self.configuration.autoDetectErrors) {
         // Enable all crash detection
         bsg_kscrash_setHandlingCrashTypes(BSG_KSCrashTypeAll);
-        if (self.configuration.enabledErrorTypes & BSGErrorTypesOOMs) {
+        if (self.configuration.enabledErrorTypes.OOMs) {
             [self.oomWatchdog enable];
         }
     } else {

--- a/Source/BugsnagClient.m
+++ b/Source/BugsnagClient.m
@@ -531,7 +531,7 @@ NSString *const BSGBreadcrumbLoadedMessage = @"Bugsnag loaded";
 
     _started = YES;
     // autoDetectErrors disables all unhandled event reporting
-    BOOL configuredToReportOOMs = self.configuration.autoDetectErrors && (self.configuration.enabledErrorTypes.OOMs);
+    BOOL configuredToReportOOMs = self.configuration.autoDetectErrors && self.configuration.enabledErrorTypes.ooms;
     
     // Disable if a debugger is enabled, since the development cycle of starting
     // and restarting an app is also an uncatchable kill
@@ -1090,21 +1090,6 @@ NSString *const BSGBreadcrumbLoadedMessage = @"Bugsnag loaded";
             breadcrumb.type = breadcrumbType;
             breadcrumb.message = message;
         }];
-    }
-}
-
-- (void)updateCrashDetectionSettings {
-    if (self.configuration.autoDetectErrors) {
-        // Enable all crash detection
-        bsg_kscrash_setHandlingCrashTypes(BSG_KSCrashTypeAll);
-        if (self.configuration.enabledErrorTypes.OOMs) {
-            [self.oomWatchdog enable];
-        }
-    } else {
-        // Only enable support for notify()-based reports
-        bsg_kscrash_setHandlingCrashTypes(BSG_KSCrashTypeUserReported);
-        // autoDetectErrors gates all unhandled report detection
-        [self.oomWatchdog disable];
     }
 }
 

--- a/Source/BugsnagClientInternal.h
+++ b/Source/BugsnagClientInternal.h
@@ -25,7 +25,5 @@
 @property(readonly) BOOL started;
 
 - (void)start;
-
-- (void)updateCrashDetectionSettings;
 @end
 

--- a/Source/BugsnagConfiguration.h
+++ b/Source/BugsnagConfiguration.h
@@ -35,6 +35,7 @@
 
 @class BugsnagUser;
 @class BugsnagEndpointConfiguration;
+@class BugsnagErrorTypes;
 
 /**
  * Controls whether Bugsnag should capture and serialize the state of all threads at the time
@@ -97,15 +98,6 @@ typedef BOOL (^BugsnagOnBreadcrumbBlock)(BugsnagBreadcrumb *_Nonnull breadcrumb)
  * @param session The session about to be delivered
  */
 typedef BOOL (^BugsnagOnSessionBlock)(BugsnagSession *_Nonnull session);
-
-typedef NS_OPTIONS(NSUInteger, BSGEnabledErrorType) {
-    BSGErrorTypesNone         NS_SWIFT_NAME(None)         = 0,
-    BSGErrorTypesOOMs         NS_SWIFT_NAME(OOMs)         = 1 << 0,
-    BSGErrorTypesNSExceptions NS_SWIFT_NAME(NSExceptions) = 1 << 1,
-    BSGErrorTypesSignals      NS_SWIFT_NAME(Signals)      = 1 << 2,
-    BSGErrorTypesCPP          NS_SWIFT_NAME(CPP)          = 1 << 3,
-    BSGErrorTypesMach         NS_SWIFT_NAME(Mach)         = 1 << 4
-};
 
 // =============================================================================
 // MARK: - BugsnagConfiguration
@@ -216,11 +208,10 @@ typedef NS_OPTIONS(NSUInteger, BSGEnabledErrorType) {
 // -----------------------------------------------------------------------------
 
 /**
- * A bitfield defining the types of error that are reported.
- * Passed down to KSCrash in BugsnagCrashSentry.
- * Defaults to all-true
+ * A class defining the types of error that are reported. By default,
+ * all properties are true.
  */
-@property BSGEnabledErrorType enabledErrorTypes;
+@property BugsnagErrorTypes *_Nonnull enabledErrorTypes;
 
 /**
  * Required declaration to suppress a superclass designated-initializer error

--- a/Source/BugsnagConfiguration.m
+++ b/Source/BugsnagConfiguration.m
@@ -38,6 +38,7 @@
 #import "BugsnagMetadataStore.h"
 #import "BSGSerialization.h"
 #import "BugsnagEndpointConfiguration.h"
+#import "BugsnagErrorTypes.h"
 
 static NSString *const kHeaderApiPayloadVersion = @"Bugsnag-Payload-Version";
 static NSString *const kHeaderApiKey = @"Bugsnag-Api-Key";
@@ -206,10 +207,7 @@ NSString * const kBugsnagUserUserId = @"BugsnagUserUserId";
     _autoTrackSessions = YES;
     _sendThreads = BSGThreadSendPolicyAlways;
     // Default to recording all error types
-    _enabledErrorTypes = BSGErrorTypesCPP
-                       | BSGErrorTypesMach
-                       | BSGErrorTypesSignals
-                       | BSGErrorTypesNSExceptions;
+    _enabledErrorTypes = [BugsnagErrorTypes new];
 
     // Enabling OOM detection only happens in release builds, to avoid triggering
     // the heuristic when killing/restarting an app in Xcode or similar.
@@ -218,9 +216,9 @@ NSString * const kBugsnagUserUserId = @"BugsnagUserUserId";
     // persistUser isn't settable until post-init.
     _user = [self getPersistedUserData];
     [self setUserMetadataFromUser:_user];
-    
+
     #if !DEBUG
-        _enabledErrorTypes |= BSGErrorTypesOOMs;
+        _enabledErrorTypes.OOMs = true;
     #endif
 
     if ([NSURLSession class]) {

--- a/Source/BugsnagConfiguration.m
+++ b/Source/BugsnagConfiguration.m
@@ -217,10 +217,6 @@ NSString * const kBugsnagUserUserId = @"BugsnagUserUserId";
     _user = [self getPersistedUserData];
     [self setUserMetadataFromUser:_user];
 
-    #if !DEBUG
-        _enabledErrorTypes.OOMs = true;
-    #endif
-
     if ([NSURLSession class]) {
         _session = [NSURLSession
             sessionWithConfiguration:[NSURLSessionConfiguration
@@ -517,22 +513,6 @@ NSString * const kBugsnagUserUserId = @"BugsnagUserUserId";
 }
 
 // MARK: -
-
-@synthesize autoDetectErrors = _autoDetectErrors;
-
-- (BOOL)autoDetectErrors {
-    return _autoDetectErrors;
-}
-
-- (void)setAutoDetectErrors:(BOOL)autoDetectErrors {
-    if (autoDetectErrors == _autoDetectErrors) {
-        return;
-    }
-    [self willChangeValueForKey:NSStringFromSelector(@selector(autoDetectErrors))];
-    _autoDetectErrors = autoDetectErrors;
-    [[Bugsnag client] updateCrashDetectionSettings];
-    [self didChangeValueForKey:NSStringFromSelector(@selector(autoDetectErrors))];
-}
 
 - (BOOL)autoNotify {
     return self.autoDetectErrors;

--- a/Source/BugsnagConfiguration.m
+++ b/Source/BugsnagConfiguration.m
@@ -514,16 +514,6 @@ NSString * const kBugsnagUserUserId = @"BugsnagUserUserId";
 
 // MARK: -
 
-- (BOOL)autoNotify {
-    return self.autoDetectErrors;
-}
-
-- (void)setAutoNotify:(BOOL)autoNotify {
-    self.autoDetectErrors = autoNotify;
-}
-
-// MARK: -
-
 @synthesize enabledReleaseStages = _enabledReleaseStages;
 
 - (NSArray *)enabledReleaseStages {

--- a/Source/BugsnagCrashSentry.m
+++ b/Source/BugsnagCrashSentry.m
@@ -14,6 +14,7 @@
 #import "BugsnagSink.h"
 #import "BugsnagConfiguration.h"
 #import "Bugsnag.h"
+#import "BugsnagErrorTypes.h"
 
 NSUInteger const BSG_MAX_STORED_REPORTS = 12;
 
@@ -39,9 +40,8 @@ NSUInteger const BSG_MAX_STORED_REPORTS = 12;
     // If Bugsnag is autodetecting errors then the types of event detected is configurable
     // (otherwise it's just the user reported events)
     if (config.autoDetectErrors) {
-        BSGEnabledErrorType errorTypes = [config enabledErrorTypes];
         // Translate the relevant BSGErrorTypes bitfield into the equivalent BSG_KSCrashType one
-        crashTypes = crashTypes | [self mapKSToBSGCrashTypes:errorTypes];
+        crashTypes = crashTypes | [self mapKSToBSGCrashTypes:config.enabledErrorTypes];
     }
     
     bsg_kscrash_setHandlingCrashTypes(crashTypes);
@@ -58,17 +58,15 @@ NSUInteger const BSG_MAX_STORED_REPORTS = 12;
  * OOMs are dealt with exclusively in the Bugsnag layer so omitted from consideration here.
  * User reported events should always be included and so also not dealt with here.
  *
- * @param bsgCrashMask The BSGErrorType bitfield
+ * @param errorTypes The enabled error types
  * @returns A BSG_KSCrashType equivalent (with the above caveats) to the input
  */
-- (BSG_KSCrashType)mapKSToBSGCrashTypes:(BSGEnabledErrorType)bsgCrashMask
+- (BSG_KSCrashType)mapKSToBSGCrashTypes:(BugsnagErrorTypes *)errorTypes
 {
-    BSG_KSCrashType crashType;
-    crashType = (bsgCrashMask & BSGErrorTypesNSExceptions ? BSG_KSCrashTypeNSException   : 0)
-              | (bsgCrashMask & BSGErrorTypesCPP          ? BSG_KSCrashTypeCPPException  : 0)
-              | (bsgCrashMask & BSGErrorTypesSignals      ? BSG_KSCrashTypeSignal        : 0)
-              | (bsgCrashMask & BSGErrorTypesMach         ? BSG_KSCrashTypeMachException : 0);
-    return crashType;
+    return (BSG_KSCrashType) ((errorTypes.NSExceptions ? BSG_KSCrashTypeNSException : 0)
+                    | (errorTypes.C ? BSG_KSCrashTypeCPPException : 0)
+                    | (errorTypes.signals ? BSG_KSCrashTypeSignal : 0)
+                    | (errorTypes.mach ? BSG_KSCrashTypeMachException : 0));
 }
 
 - (void)reportUserException:(NSString *)reportName

--- a/Source/BugsnagCrashSentry.m
+++ b/Source/BugsnagCrashSentry.m
@@ -63,10 +63,10 @@ NSUInteger const BSG_MAX_STORED_REPORTS = 12;
  */
 - (BSG_KSCrashType)mapKSToBSGCrashTypes:(BugsnagErrorTypes *)errorTypes
 {
-    return (BSG_KSCrashType) ((errorTypes.NSExceptions ? BSG_KSCrashTypeNSException : 0)
-                    | (errorTypes.C ? BSG_KSCrashTypeCPPException : 0)
+    return (BSG_KSCrashType) ((errorTypes.unhandledExceptions ? BSG_KSCrashTypeNSException : 0)
+                    | (errorTypes.cppExceptions ? BSG_KSCrashTypeCPPException : 0)
                     | (errorTypes.signals ? BSG_KSCrashTypeSignal : 0)
-                    | (errorTypes.mach ? BSG_KSCrashTypeMachException : 0));
+                    | (errorTypes.machExceptions ? BSG_KSCrashTypeMachException : 0));
 }
 
 - (void)reportUserException:(NSString *)reportName

--- a/Source/BugsnagErrorTypes.h
+++ b/Source/BugsnagErrorTypes.h
@@ -15,14 +15,14 @@
  *
  * This flag is true by default.
  */
-@property BOOL OOMs;
+@property BOOL ooms;
 
 /**
  * Determines whether NSExceptions should be reported to bugsnag.
  *
  * This flag is true by default.
  */
-@property BOOL NSExceptions;
+@property BOOL unhandledExceptions;
 
 /**
  * Determines whether signals should be reported to bugsnag.
@@ -36,14 +36,14 @@
  *
  * This flag is true by default.
  */
-@property BOOL C;
+@property BOOL cppExceptions;
 
 /**
  * Determines whether Mach Exceptions should be reported to bugsnag.
  *
  * This flag is true by default.
  */
-@property BOOL mach;
+@property BOOL machExceptions;
 
 @end
 

--- a/Source/BugsnagErrorTypes.h
+++ b/Source/BugsnagErrorTypes.h
@@ -1,0 +1,49 @@
+//
+//  BugsnagErrorTypes.h
+//  Bugsnag
+//
+//  Created by Jamie Lynch on 22/04/2020.
+//  Copyright © 2020 Bugsnag. All rights reserved.
+//
+
+#import <Foundation/Foundation.h>
+
+@interface BugsnagErrorTypes : NSObject
+
+/**
+ * Determines whether Out of Memory events should be reported to bugsnag.
+ *
+ * This flag is true by default.
+ */
+@property BOOL OOMs;
+
+/**
+ * Determines whether NSExceptions should be reported to bugsnag.
+ *
+ * This flag is true by default.
+ */
+@property BOOL NSExceptions;
+
+/**
+ * Determines whether signals should be reported to bugsnag.
+ *
+ * This flag is true by default.
+ */
+@property BOOL signals;
+
+/**
+ * Determines whether C errors should be reported to bugsnag.
+ *
+ * This flag is true by default.
+ */
+@property BOOL C;
+
+/**
+ * Determines whether Mach Exceptions should be reported to bugsnag.
+ *
+ * This flag is true by default.
+ */
+@property BOOL mach;
+
+@end
+

--- a/Source/BugsnagErrorTypes.m
+++ b/Source/BugsnagErrorTypes.m
@@ -1,0 +1,29 @@
+//
+//  BugsnagErrorTypes.m
+//  Bugsnag
+//
+//  Created by Jamie Lynch on 22/04/2020.
+//  Copyright © 2020 Bugsnag. All rights reserved.
+//
+
+#import "BugsnagErrorTypes.h"
+
+@implementation BugsnagErrorTypes
+
+- (instancetype)init {
+    if (self = [super init]) {
+        _NSExceptions = true;
+        _signals = true;
+        _C = true;
+        _mach = true;
+
+#if DEBUG
+        _OOMs = false;
+#else
+        _OOMs = true;
+#endif
+    }
+    return self;
+}
+
+@end

--- a/Source/BugsnagErrorTypes.m
+++ b/Source/BugsnagErrorTypes.m
@@ -20,7 +20,7 @@
 #if DEBUG
         _ooms = false;
 #else
-        _OOMs = true;
+        _ooms = true;
 #endif
     }
     return self;

--- a/Source/BugsnagErrorTypes.m
+++ b/Source/BugsnagErrorTypes.m
@@ -12,13 +12,13 @@
 
 - (instancetype)init {
     if (self = [super init]) {
-        _NSExceptions = true;
+        _unhandledExceptions = true;
         _signals = true;
-        _C = true;
-        _mach = true;
+        _cppExceptions = true;
+        _machExceptions = true;
 
 #if DEBUG
-        _OOMs = false;
+        _ooms = false;
 #else
         _OOMs = true;
 #endif

--- a/Tests/BugsnagConfigurationTests.m
+++ b/Tests/BugsnagConfigurationTests.m
@@ -637,7 +637,7 @@
 - (void)testDefaultReportOOMs {
     BugsnagConfiguration *config = [[BugsnagConfiguration alloc] initWithApiKey:DUMMY_APIKEY_32CHAR_1];
 #if DEBUG
-    XCTAssertFalse(config.enabledErrorTypes.OOMs);
+    XCTAssertFalse(config.enabledErrorTypes.ooms);
 #else
     XCTAssertTrue(config.enabledErrorTypes.OOMs);
 #endif
@@ -699,25 +699,25 @@
     
     // Test all are set by default
     // See config init for details.  OOMs are disabled in debug.
-    config.enabledErrorTypes.OOMs = true;
+    config.enabledErrorTypes.ooms = true;
 
-    XCTAssertTrue(config.enabledErrorTypes.OOMs);
+    XCTAssertTrue(config.enabledErrorTypes.ooms);
     XCTAssertTrue(config.enabledErrorTypes.signals);
-    XCTAssertTrue(config.enabledErrorTypes.C);
-    XCTAssertTrue(config.enabledErrorTypes.NSExceptions);
-    XCTAssertTrue(config.enabledErrorTypes.mach);
+    XCTAssertTrue(config.enabledErrorTypes.cppExceptions);
+    XCTAssertTrue(config.enabledErrorTypes.unhandledExceptions);
+    XCTAssertTrue(config.enabledErrorTypes.machExceptions);
     
     // Test that we can set it
-    config.enabledErrorTypes.OOMs = false;
+    config.enabledErrorTypes.ooms = false;
     config.enabledErrorTypes.signals = false;
-    config.enabledErrorTypes.C = false;
-    config.enabledErrorTypes.NSExceptions = false;
-    config.enabledErrorTypes.mach = false;
-    XCTAssertFalse(config.enabledErrorTypes.OOMs);
+    config.enabledErrorTypes.cppExceptions = false;
+    config.enabledErrorTypes.unhandledExceptions = false;
+    config.enabledErrorTypes.machExceptions = false;
+    XCTAssertFalse(config.enabledErrorTypes.ooms);
     XCTAssertFalse(config.enabledErrorTypes.signals);
-    XCTAssertFalse(config.enabledErrorTypes.C);
-    XCTAssertFalse(config.enabledErrorTypes.NSExceptions);
-    XCTAssertFalse(config.enabledErrorTypes.mach);
+    XCTAssertFalse(config.enabledErrorTypes.cppExceptions);
+    XCTAssertFalse(config.enabledErrorTypes.unhandledExceptions);
+    XCTAssertFalse(config.enabledErrorTypes.machExceptions);
 }
 
 /**
@@ -739,19 +739,19 @@
     
     // Check partial sets
     BugsnagErrorTypes *errorTypes = [BugsnagErrorTypes new];
-    errorTypes.OOMs = false;
+    errorTypes.ooms = false;
     errorTypes.signals = false;
-    errorTypes.mach = false;
+    errorTypes.machExceptions = false;
     crashTypes = BSG_KSCrashTypeNSException | BSG_KSCrashTypeCPPException;
     XCTAssertEqual((NSUInteger)crashTypes, [sentry mapKSToBSGCrashTypes:errorTypes]);
 
     errorTypes.signals = true;
-    errorTypes.C = false;
+    errorTypes.cppExceptions = false;
     crashTypes = BSG_KSCrashTypeNSException | BSG_KSCrashTypeSignal;
     XCTAssertEqual((NSUInteger)crashTypes, [sentry mapKSToBSGCrashTypes:errorTypes]);
 
-    errorTypes.C = true;
-    errorTypes.NSExceptions = false;
+    errorTypes.cppExceptions = true;
+    errorTypes.unhandledExceptions = false;
     crashTypes = BSG_KSCrashTypeCPPException | BSG_KSCrashTypeSignal;
     XCTAssertEqual((NSUInteger)crashTypes, [sentry mapKSToBSGCrashTypes:errorTypes]);
 }

--- a/Tests/BugsnagConfigurationTests.m
+++ b/Tests/BugsnagConfigurationTests.m
@@ -639,7 +639,7 @@
 #if DEBUG
     XCTAssertFalse(config.enabledErrorTypes.ooms);
 #else
-    XCTAssertTrue(config.enabledErrorTypes.OOMs);
+    XCTAssertTrue(config.enabledErrorTypes.ooms);
 #endif
 }
 

--- a/features/fixtures/ios-swift-cocoapods/iOSTestApp/AppDelegate.swift
+++ b/features/fixtures/ios-swift-cocoapods/iOSTestApp/AppDelegate.swift
@@ -51,7 +51,7 @@ class AppDelegate: UIResponder, UIApplicationDelegate {
         // Enabling by default to check not only the OOM reporting tests but
         // also that extra reports aren't erroneously sent in other conditions
         // when OOM reporting is enabled
-        config.enabledErrorTypes.insert(.OOMs)
+        config.enabledErrorTypes.ooms = true
         config.endpoints = BugsnagEndpointConfiguration(notify: mockAPIPath, sessions: mockAPIPath)
         return config
     }

--- a/features/fixtures/ios-swift-cocoapods/iOSTestApp/scenarios/EnabledErrorTypesCxxScenario.mm
+++ b/features/fixtures/ios-swift-cocoapods/iOSTestApp/scenarios/EnabledErrorTypesCxxScenario.mm
@@ -16,11 +16,9 @@ const char *disabled_cxx_reporting_kaboom_exception::what() const throw() {
 @implementation EnabledErrorTypesCxxScenario
 
 - (void)startBugsnag {
-    self.config.enabledErrorTypes = BSGErrorTypesMach 
-                                  | BSGErrorTypesNSExceptions 
-                                  | BSGErrorTypesSignals 
-                                /*| BSGErrorTypesCPP*/ 
-                                  | BSGErrorTypesOOMs;
+    BugsnagErrorTypes *errorTypes = [BugsnagErrorTypes new];
+    errorTypes.C = false;
+    self.config.enabledErrorTypes = errorTypes;
     self.config.autoTrackSessions = NO;
     [super startBugsnag];
 }

--- a/features/fixtures/ios-swift-cocoapods/iOSTestApp/scenarios/EnabledErrorTypesCxxScenario.mm
+++ b/features/fixtures/ios-swift-cocoapods/iOSTestApp/scenarios/EnabledErrorTypesCxxScenario.mm
@@ -17,7 +17,7 @@ const char *disabled_cxx_reporting_kaboom_exception::what() const throw() {
 
 - (void)startBugsnag {
     BugsnagErrorTypes *errorTypes = [BugsnagErrorTypes new];
-    errorTypes.C = false;
+    errorTypes.cppExceptions = false;
     self.config.enabledErrorTypes = errorTypes;
     self.config.autoTrackSessions = NO;
     [super startBugsnag];

--- a/features/fixtures/ios-swift-cocoapods/iOSTestApp/scenarios/EnabledErrorTypesScenario.m
+++ b/features/fixtures/ios-swift-cocoapods/iOSTestApp/scenarios/EnabledErrorTypesScenario.m
@@ -19,7 +19,13 @@
 @implementation DisableAllExceptManualExceptionsAndCrashScenario
 
 - (void)startBugsnag {
-    self.config.enabledErrorTypes = BSGErrorTypesNone;
+    BugsnagErrorTypes *errorTypes = [BugsnagErrorTypes new];
+    errorTypes.C = false;
+    errorTypes.mach = false;
+    errorTypes.NSExceptions = false;
+    errorTypes.signals = false;
+    errorTypes.OOMs = false;
+    self.config.enabledErrorTypes = errorTypes;
     self.config.autoTrackSessions = YES;
     [super startBugsnag];
 }
@@ -44,7 +50,13 @@
 @implementation DisableAllExceptManualExceptionsSendManualAndCrashScenario
 
 - (void)startBugsnag {
-    self.config.enabledErrorTypes = BSGErrorTypesNone;
+    BugsnagErrorTypes *errorTypes = [BugsnagErrorTypes new];
+    errorTypes.C = false;
+    errorTypes.mach = false;
+    errorTypes.NSExceptions = false;
+    errorTypes.signals = false;
+    errorTypes.OOMs = false;
+    self.config.enabledErrorTypes = errorTypes;
     self.config.autoTrackSessions = NO;
     [super startBugsnag];
 }
@@ -67,12 +79,9 @@
 @implementation DisableNSExceptionScenario
 
 - (void)startBugsnag {
-    self.config.enabledErrorTypes = BSGErrorTypesNone
-                                  | BSGErrorTypesMach
-                               /* | BSGErrorTypesNSExceptions */
-                                  | BSGErrorTypesSignals
-                                  | BSGErrorTypesCPP
-                                  | BSGErrorTypesOOMs;
+    BugsnagErrorTypes *errorTypes = [BugsnagErrorTypes new];
+    errorTypes.NSExceptions = false;
+    self.config.enabledErrorTypes = errorTypes;
     self.config.autoTrackSessions = NO;
     [super startBugsnag];
 }
@@ -96,12 +105,9 @@
 @implementation DisableMachExceptionScenario
 
 - (void)startBugsnag {
-    self.config.enabledErrorTypes = BSGErrorTypesNone
-                               /* | BSGErrorTypesMach */
-                                  | BSGErrorTypesNSExceptions
-                                  | BSGErrorTypesSignals
-                                  | BSGErrorTypesCPP
-                                  | BSGErrorTypesOOMs;
+    BugsnagErrorTypes *errorTypes = [BugsnagErrorTypes new];
+    errorTypes.mach = false;
+    self.config.enabledErrorTypes = errorTypes;
     self.config.autoTrackSessions = NO;
     [super startBugsnag];
 }
@@ -122,13 +128,9 @@
 @implementation DisableSignalsExceptionScenario
 
 - (void)startBugsnag {
-    self.config.enabledErrorTypes = BSGErrorTypesNone
-                                  | BSGErrorTypesMach
-                                  | BSGErrorTypesNSExceptions
-                               /* | BSGErrorTypesSignals */
-                                  | BSGErrorTypesCPP
-                               // OOMs are disabled since they raise a false positive 
-                               /* | BSGErrorTypesOOMs */ ;
+    BugsnagErrorTypes *errorTypes = [BugsnagErrorTypes new];
+    errorTypes.signals = false;
+    self.config.enabledErrorTypes = errorTypes;
     self.config.autoTrackSessions = NO;
     [super startBugsnag];
 }

--- a/features/fixtures/ios-swift-cocoapods/iOSTestApp/scenarios/EnabledErrorTypesScenario.m
+++ b/features/fixtures/ios-swift-cocoapods/iOSTestApp/scenarios/EnabledErrorTypesScenario.m
@@ -20,11 +20,11 @@
 
 - (void)startBugsnag {
     BugsnagErrorTypes *errorTypes = [BugsnagErrorTypes new];
-    errorTypes.C = false;
-    errorTypes.mach = false;
-    errorTypes.NSExceptions = false;
+    errorTypes.cppExceptions = false;
+    errorTypes.machExceptions = false;
+    errorTypes.unhandledExceptions = false;
     errorTypes.signals = false;
-    errorTypes.OOMs = false;
+    errorTypes.ooms = false;
     self.config.enabledErrorTypes = errorTypes;
     self.config.autoTrackSessions = YES;
     [super startBugsnag];
@@ -51,11 +51,11 @@
 
 - (void)startBugsnag {
     BugsnagErrorTypes *errorTypes = [BugsnagErrorTypes new];
-    errorTypes.C = false;
-    errorTypes.mach = false;
-    errorTypes.NSExceptions = false;
+    errorTypes.cppExceptions = false;
+    errorTypes.machExceptions = false;
+    errorTypes.unhandledExceptions = false;
     errorTypes.signals = false;
-    errorTypes.OOMs = false;
+    errorTypes.ooms = false;
     self.config.enabledErrorTypes = errorTypes;
     self.config.autoTrackSessions = NO;
     [super startBugsnag];
@@ -80,7 +80,7 @@
 
 - (void)startBugsnag {
     BugsnagErrorTypes *errorTypes = [BugsnagErrorTypes new];
-    errorTypes.NSExceptions = false;
+    errorTypes.unhandledExceptions = false;
     self.config.enabledErrorTypes = errorTypes;
     self.config.autoTrackSessions = NO;
     [super startBugsnag];
@@ -106,7 +106,7 @@
 
 - (void)startBugsnag {
     BugsnagErrorTypes *errorTypes = [BugsnagErrorTypes new];
-    errorTypes.mach = false;
+    errorTypes.machExceptions = false;
     self.config.enabledErrorTypes = errorTypes;
     self.config.autoTrackSessions = NO;
     [super startBugsnag];

--- a/features/fixtures/ios-swift-cocoapods/iOSTestApp/scenarios/ReportOOMsDisabledReportBackgroundOOMsEnabledScenario.m
+++ b/features/fixtures/ios-swift-cocoapods/iOSTestApp/scenarios/ReportOOMsDisabledReportBackgroundOOMsEnabledScenario.m
@@ -5,7 +5,7 @@
 
 - (void)startBugsnag {
     self.config.autoTrackSessions = NO;
-    self.config.enabledErrorTypes.OOMs = false;
+    self.config.enabledErrorTypes.ooms = false;
     [super startBugsnag];
 }
 

--- a/features/fixtures/ios-swift-cocoapods/iOSTestApp/scenarios/ReportOOMsDisabledReportBackgroundOOMsEnabledScenario.m
+++ b/features/fixtures/ios-swift-cocoapods/iOSTestApp/scenarios/ReportOOMsDisabledReportBackgroundOOMsEnabledScenario.m
@@ -5,7 +5,7 @@
 
 - (void)startBugsnag {
     self.config.autoTrackSessions = NO;
-    self.config.enabledErrorTypes &= ~BSGErrorTypesOOMs; // OOM == 0
+    self.config.enabledErrorTypes.OOMs = false;
     [super startBugsnag];
 }
 

--- a/features/fixtures/ios-swift-cocoapods/iOSTestApp/scenarios/ReportOOMsDisabledScenario.m
+++ b/features/fixtures/ios-swift-cocoapods/iOSTestApp/scenarios/ReportOOMsDisabledScenario.m
@@ -6,7 +6,7 @@
 
 - (void)startBugsnag {
     self.config.autoTrackSessions = NO;
-    self.config.enabledErrorTypes.OOMs = false;
+    self.config.enabledErrorTypes.ooms = false;
     [super startBugsnag];
 }
 

--- a/features/fixtures/ios-swift-cocoapods/iOSTestApp/scenarios/ReportOOMsDisabledScenario.m
+++ b/features/fixtures/ios-swift-cocoapods/iOSTestApp/scenarios/ReportOOMsDisabledScenario.m
@@ -6,7 +6,7 @@
 
 - (void)startBugsnag {
     self.config.autoTrackSessions = NO;
-    self.config.enabledErrorTypes &= ~BSGErrorTypesOOMs; // OOM == 0
+    self.config.enabledErrorTypes.OOMs = false;
     [super startBugsnag];
 }
 

--- a/iOS/Bugsnag.xcodeproj/project.pbxproj
+++ b/iOS/Bugsnag.xcodeproj/project.pbxproj
@@ -293,6 +293,10 @@
 		E7529F94243C8EF2006B4932 /* RegisterErrorData.h in CopyFiles */ = {isa = PBXBuildFile; fileRef = E7529F87243C8DA2006B4932 /* RegisterErrorData.h */; };
 		E7529F9C243CAE02006B4932 /* BugsnagThreadSerializationTest.m in Sources */ = {isa = PBXBuildFile; fileRef = E7529F9B243CAE02006B4932 /* BugsnagThreadSerializationTest.m */; };
 		E7529F9E243CAE0D006B4932 /* BugsnagThreadTest.m in Sources */ = {isa = PBXBuildFile; fileRef = E7529F9D243CAE0D006B4932 /* BugsnagThreadTest.m */; };
+		E7565F7824507F640041768E /* BugsnagErrorTypes.h in Headers */ = {isa = PBXBuildFile; fileRef = E7565F7624507F640041768E /* BugsnagErrorTypes.h */; settings = {ATTRIBUTES = (Public, ); }; };
+		E7565F7924507F640041768E /* BugsnagErrorTypes.m in Sources */ = {isa = PBXBuildFile; fileRef = E7565F7724507F640041768E /* BugsnagErrorTypes.m */; };
+		E7565F7A24507F640041768E /* BugsnagErrorTypes.m in Sources */ = {isa = PBXBuildFile; fileRef = E7565F7724507F640041768E /* BugsnagErrorTypes.m */; };
+		E7565F7C245082580041768E /* BugsnagErrorTypes.h in CopyFiles */ = {isa = PBXBuildFile; fileRef = E7565F7624507F640041768E /* BugsnagErrorTypes.h */; };
 		E77316E31F73E89E00A14F06 /* BugsnagHandledStateTest.m in Sources */ = {isa = PBXBuildFile; fileRef = E77316E11F73B46600A14F06 /* BugsnagHandledStateTest.m */; };
 		E77526BA242D0AE50077A42F /* BugsnagBreadcrumbs.h in Headers */ = {isa = PBXBuildFile; fileRef = E77526B8242D0AE50077A42F /* BugsnagBreadcrumbs.h */; };
 		E77526BB242D0AE50077A42F /* BugsnagBreadcrumbs.m in Sources */ = {isa = PBXBuildFile; fileRef = E77526B9242D0AE50077A42F /* BugsnagBreadcrumbs.m */; };
@@ -400,6 +404,7 @@
 			dstPath = "include/${PRODUCT_NAME}";
 			dstSubfolderSpec = 16;
 			files = (
+				E7565F7C245082580041768E /* BugsnagErrorTypes.h in CopyFiles */,
 				E77AFEF22448A13C0082B8BB /* BugsnagSessionInternal.h in CopyFiles */,
 				E77AFF0C244A18A00082B8BB /* BugsnagEndpointConfiguration.h in CopyFiles */,
 				E7529F94243C8EF2006B4932 /* RegisterErrorData.h in CopyFiles */,
@@ -673,6 +678,8 @@
 		E7529F88243C8DA2006B4932 /* RegisterErrorData.m */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.objc; name = RegisterErrorData.m; path = ../Source/RegisterErrorData.m; sourceTree = "<group>"; };
 		E7529F9B243CAE02006B4932 /* BugsnagThreadSerializationTest.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; path = BugsnagThreadSerializationTest.m; sourceTree = "<group>"; };
 		E7529F9D243CAE0D006B4932 /* BugsnagThreadTest.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; name = BugsnagThreadTest.m; path = ../../Tests/BugsnagThreadTest.m; sourceTree = "<group>"; };
+		E7565F7624507F640041768E /* BugsnagErrorTypes.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; name = BugsnagErrorTypes.h; path = ../Source/BugsnagErrorTypes.h; sourceTree = "<group>"; };
+		E7565F7724507F640041768E /* BugsnagErrorTypes.m */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.objc; name = BugsnagErrorTypes.m; path = ../Source/BugsnagErrorTypes.m; sourceTree = "<group>"; };
 		E77316E11F73B46600A14F06 /* BugsnagHandledStateTest.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; name = BugsnagHandledStateTest.m; path = ../Tests/BugsnagHandledStateTest.m; sourceTree = SOURCE_ROOT; };
 		E77526B8242D0AE50077A42F /* BugsnagBreadcrumbs.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; name = BugsnagBreadcrumbs.h; path = ../Source/BugsnagBreadcrumbs.h; sourceTree = "<group>"; };
 		E77526B9242D0AE50077A42F /* BugsnagBreadcrumbs.m */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.objc; name = BugsnagBreadcrumbs.m; path = ../Source/BugsnagBreadcrumbs.m; sourceTree = "<group>"; };
@@ -817,6 +824,7 @@
 			children = (
 				E7A9E598243B246600D99F8A /* Breadcrumbs */,
 				E7A9E587243B23FF00D99F8A /* Client */,
+				E7565F7B245082100041768E /* Configuration */,
 				E7A9E593243B245800D99F8A /* Delivery */,
 				E7A9E58F243B242300D99F8A /* Metadata */,
 				E7A9E589243B240500D99F8A /* Payload */,
@@ -830,12 +838,8 @@
 				8A627CD11EC2A62900F7C04E /* BSGSerialization.m */,
 				8A2C8F411C6BBE3C00846019 /* BugsnagCollections.h */,
 				8A2C8F421C6BBE3C00846019 /* BugsnagCollections.m */,
-				8A2C8F431C6BBE3C00846019 /* BugsnagConfiguration.h */,
-				8A2C8F441C6BBE3C00846019 /* BugsnagConfiguration.m */,
 				E72962D01F4BBA8A00CEA15D /* BugsnagCrashSentry.h */,
 				E72962D11F4BBA8A00CEA15D /* BugsnagCrashSentry.m */,
-				E77AFF07244A18890082B8BB /* BugsnagEndpointConfiguration.h */,
-				E77AFF08244A18890082B8BB /* BugsnagEndpointConfiguration.m */,
 				E737DEA01F73AD7400BC7C80 /* BugsnagHandledState.h */,
 				E737DEA11F73AD7400BC7C80 /* BugsnagHandledState.m */,
 				E794E8021F9F743D00A67EE7 /* BugsnagKeys.h */,
@@ -1101,6 +1105,19 @@
 			path = Filters;
 			sourceTree = "<group>";
 		};
+		E7565F7B245082100041768E /* Configuration */ = {
+			isa = PBXGroup;
+			children = (
+				8A2C8F431C6BBE3C00846019 /* BugsnagConfiguration.h */,
+				8A2C8F441C6BBE3C00846019 /* BugsnagConfiguration.m */,
+				E77AFF07244A18890082B8BB /* BugsnagEndpointConfiguration.h */,
+				E77AFF08244A18890082B8BB /* BugsnagEndpointConfiguration.m */,
+				E7565F7624507F640041768E /* BugsnagErrorTypes.h */,
+				E7565F7724507F640041768E /* BugsnagErrorTypes.m */,
+			);
+			name = Configuration;
+			sourceTree = "<group>";
+		};
 		E7A9E587243B23FF00D99F8A /* Client */ = {
 			isa = PBXGroup;
 			children = (
@@ -1201,6 +1218,7 @@
 			isa = PBXHeadersBuildPhase;
 			buildActionMask = 2147483647;
 			files = (
+				E7565F7824507F640041768E /* BugsnagErrorTypes.h in Headers */,
 				E72BF77F1FC86A7A004BE82F /* BugsnagUser.h in Headers */,
 				E72BF77A1FC869F7004BE82F /* BugsnagSession.h in Headers */,
 				E77AFF09244A18890082B8BB /* BugsnagEndpointConfiguration.h in Headers */,
@@ -1493,6 +1511,7 @@
 				F4295B2AC95281CBA3A42DCA /* BugsnagSessionFileStore.m in Sources */,
 				F4295C52A30DC98515F2FF02 /* BugsnagSessionTrackingApiClient.m in Sources */,
 				F4295168CDC7A77A832C9475 /* BugsnagApiClient.m in Sources */,
+				E7565F7924507F640041768E /* BugsnagErrorTypes.m in Sources */,
 				8A530CC122FDC3AF00F0C108 /* BSG_KSCrashIdentifier.m in Sources */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
@@ -1570,6 +1589,7 @@
 				E72BF7771FC867E4004BE82F /* BugsnagSessionTracker.m in Sources */,
 				E7D2E66D243B8F48005A3041 /* BugsnagStacktrace.m in Sources */,
 				E7397E371F83BC320034242A /* BSG_KSCrashSentry_MachException.c in Sources */,
+				E7565F7A24507F640041768E /* BugsnagErrorTypes.m in Sources */,
 				E7397E381F83BC320034242A /* BSG_KSCrashSentry_Signal.c in Sources */,
 				E7397E391F83BC320034242A /* BSG_KSCrashSentry_User.c in Sources */,
 				E7397E3A1F83BC320034242A /* BSG_KSBacktrace.c in Sources */,

--- a/tvOS/Bugsnag.xcodeproj/project.pbxproj
+++ b/tvOS/Bugsnag.xcodeproj/project.pbxproj
@@ -74,6 +74,8 @@
 		E7529F92243C8ED4006B4932 /* RegisterErrorData.m in Sources */ = {isa = PBXBuildFile; fileRef = E7529F90243C8ED4006B4932 /* RegisterErrorData.m */; };
 		E7529F93243C8ED4006B4932 /* RegisterErrorData.h in Headers */ = {isa = PBXBuildFile; fileRef = E7529F91243C8ED4006B4932 /* RegisterErrorData.h */; };
 		E7529FA6243CAE6A006B4932 /* BugsnagThreadSerializationTest.m in Sources */ = {isa = PBXBuildFile; fileRef = E7529FA5243CAE6A006B4932 /* BugsnagThreadSerializationTest.m */; };
+		E7565F85245082C10041768E /* BugsnagErrorTypes.h in Headers */ = {isa = PBXBuildFile; fileRef = E7565F83245082C10041768E /* BugsnagErrorTypes.h */; settings = {ATTRIBUTES = (Public, ); }; };
+		E7565F86245082C10041768E /* BugsnagErrorTypes.m in Sources */ = {isa = PBXBuildFile; fileRef = E7565F84245082C10041768E /* BugsnagErrorTypes.m */; };
 		E762E9F01F73F6CF00E82B43 /* BugsnagHandledStateTest.m in Sources */ = {isa = PBXBuildFile; fileRef = E762E9EE1F73F6CF00E82B43 /* BugsnagHandledStateTest.m */; };
 		E762E9F51F73F7A100E82B43 /* BugsnagHandledState.h in Headers */ = {isa = PBXBuildFile; fileRef = E762E9F21F73F6DE00E82B43 /* BugsnagHandledState.h */; };
 		E762E9F61F73F7A400E82B43 /* BugsnagHandledState.m in Sources */ = {isa = PBXBuildFile; fileRef = E762E9F31F73F6DE00E82B43 /* BugsnagHandledState.m */; };
@@ -305,6 +307,8 @@
 		E7529F90243C8ED4006B4932 /* RegisterErrorData.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; name = RegisterErrorData.m; path = ../Source/RegisterErrorData.m; sourceTree = "<group>"; };
 		E7529F91243C8ED4006B4932 /* RegisterErrorData.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; name = RegisterErrorData.h; path = ../Source/RegisterErrorData.h; sourceTree = "<group>"; };
 		E7529FA5243CAE6A006B4932 /* BugsnagThreadSerializationTest.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; name = BugsnagThreadSerializationTest.m; path = ../../iOS/BugsnagTests/BugsnagThreadSerializationTest.m; sourceTree = "<group>"; };
+		E7565F83245082C10041768E /* BugsnagErrorTypes.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; name = BugsnagErrorTypes.h; path = ../Source/BugsnagErrorTypes.h; sourceTree = "<group>"; };
+		E7565F84245082C10041768E /* BugsnagErrorTypes.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; name = BugsnagErrorTypes.m; path = ../Source/BugsnagErrorTypes.m; sourceTree = "<group>"; };
 		E762E9EE1F73F6CF00E82B43 /* BugsnagHandledStateTest.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; name = BugsnagHandledStateTest.m; path = ../Tests/BugsnagHandledStateTest.m; sourceTree = SOURCE_ROOT; };
 		E762E9F21F73F6DE00E82B43 /* BugsnagHandledState.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; name = BugsnagHandledState.h; path = ../Source/BugsnagHandledState.h; sourceTree = SOURCE_ROOT; };
 		E762E9F31F73F6DE00E82B43 /* BugsnagHandledState.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; name = BugsnagHandledState.m; path = ../Source/BugsnagHandledState.m; sourceTree = SOURCE_ROOT; };
@@ -518,6 +522,7 @@
 			children = (
 				E74D8E8C243B38AE00F2A630 /* Breadcrumbs */,
 				E74D8E88243B38A100F2A630 /* Client */,
+				E7565F82245082A90041768E /* Configuration */,
 				E74D8E85243B389800F2A630 /* Delivery */,
 				E74D8E83243B389300F2A630 /* Metadata */,
 				E74D8E82243B389000F2A630 /* Payload */,
@@ -530,12 +535,8 @@
 				8A627CD41EC3B69300F7C04E /* BSGSerialization.m */,
 				8AB1512A1D41366400C9B218 /* BugsnagCollections.h */,
 				8AB1512B1D41366400C9B218 /* BugsnagCollections.m */,
-				8AB1512C1D41366400C9B218 /* BugsnagConfiguration.h */,
-				8AB1512D1D41366400C9B218 /* BugsnagConfiguration.m */,
 				E76616F11F4E45950094CECF /* BugsnagCrashSentry.h */,
 				E76616F21F4E45950094CECF /* BugsnagCrashSentry.m */,
-				E77AFF11244A19260082B8BB /* BugsnagEndpointConfiguration.h */,
-				E77AFF12244A19260082B8BB /* BugsnagEndpointConfiguration.m */,
 				E762E9F21F73F6DE00E82B43 /* BugsnagHandledState.h */,
 				E762E9F31F73F6DE00E82B43 /* BugsnagHandledState.m */,
 				E794E8061F9F748100A67EE7 /* BugsnagKeys.h */,
@@ -717,6 +718,19 @@
 				E791486B1FD82E6B003EFEBF /* BugsnagSessionFileStore.m */,
 			);
 			name = Storage;
+			sourceTree = "<group>";
+		};
+		E7565F82245082A90041768E /* Configuration */ = {
+			isa = PBXGroup;
+			children = (
+				8AB1512C1D41366400C9B218 /* BugsnagConfiguration.h */,
+				8AB1512D1D41366400C9B218 /* BugsnagConfiguration.m */,
+				E77AFF11244A19260082B8BB /* BugsnagEndpointConfiguration.h */,
+				E77AFF12244A19260082B8BB /* BugsnagEndpointConfiguration.m */,
+				E7565F83245082C10041768E /* BugsnagErrorTypes.h */,
+				E7565F84245082C10041768E /* BugsnagErrorTypes.m */,
+			);
+			name = Configuration;
 			sourceTree = "<group>";
 		};
 		E76616FD1F4E459C0094CECF /* BSG_KSCrash */ = {
@@ -903,6 +917,7 @@
 			isa = PBXHeadersBuildPhase;
 			buildActionMask = 2147483647;
 			files = (
+				E7565F85245082C10041768E /* BugsnagErrorTypes.h in Headers */,
 				E79148791FD82E6D003EFEBF /* BugsnagUser.h in Headers */,
 				E79148771FD82E6D003EFEBF /* BugsnagSession.h in Headers */,
 				E77AFF13244A19260082B8BB /* BugsnagEndpointConfiguration.h in Headers */,
@@ -1157,6 +1172,7 @@
 				E76617A11F4E459C0094CECF /* BSG_KSCrashSentry_User.c in Sources */,
 				E76617CF1F4E459C0094CECF /* BSG_RFC3339DateTool.m in Sources */,
 				E72352BE1F55923700436528 /* BSGConnectivity.m in Sources */,
+				E7565F86245082C10041768E /* BugsnagErrorTypes.m in Sources */,
 				8A530CBC22FDC39300F0C108 /* BSG_KSCrashIdentifier.m in Sources */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;


### PR DESCRIPTION
## Goal

Adds the `BugsnagErrorTypes` class which controls which errors are captured by Bugsnag. By default, all error types are captured. This replaces the bitmask which was used in the previous implementation.

## Changeset

- Created "Configuration" group in XCode which logically groups configuration source files together
- Added publicly visible `BugsnagErrorTypes` class
- Made existing implementation use new syntax

## Tests

Updated existing test coverage to use new syntax.
