### PR TITLE
Rename OnSend to OnSendError

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,9 @@ Bugsnag Notifiers on other platforms.
 
 ## Enhancements
 
+* Rename `OnSend` to `OnSendError`
+  [#562](https://github.com/bugsnag/bugsnag-cocoa/pull/562)
+
 * Rename `BugsnagUser` properties
   [#560](https://github.com/bugsnag/bugsnag-cocoa/pull/560)
 

--- a/Source/Bugsnag.h
+++ b/Source/Bugsnag.h
@@ -256,7 +256,7 @@
  * @param block The block to be removed.
  */
 + (void)removeOnSessionBlock:(BugsnagOnSessionBlock _Nonnull)block
-    NS_SWIFT_NAME(removeOnSession(block:));;
+    NS_SWIFT_NAME(removeOnSession(block:));
 
 // =============================================================================
 // MARK: - onSend
@@ -268,16 +268,16 @@
  *
  *  @param block A block which returns YES if the report should be sent
  */
-+ (void)addOnSendBlock:(BugsnagOnSendBlock _Nonnull)block
-    NS_SWIFT_NAME(addOnSend(block:));
++ (void)addOnSendErrorBlock:(BugsnagOnSendErrorBlock _Nonnull)block
+    NS_SWIFT_NAME(addOnSendError(block:));
 
 /**
  * Remove the callback that would be invoked before an event is sent.
  *
  * @param block The block to be removed.
  */
-+ (void)removeOnSendBlock:(BugsnagOnSendBlock _Nonnull)block
-    NS_SWIFT_NAME(removeOnSend(block:));
++ (void)removeOnSendErrorBlock:(BugsnagOnSendErrorBlock _Nonnull)block
+    NS_SWIFT_NAME(removeOnSendError(block:));
 
 // =============================================================================
 // MARK: - onBreadcrumb

--- a/Source/Bugsnag.m
+++ b/Source/Bugsnag.m
@@ -357,17 +357,17 @@ static BugsnagClient *bsg_g_bugsnag_client = NULL;
 // MARK: - onSend
 // =============================================================================
 
-+ (void)addOnSendBlock:(BugsnagOnSendBlock _Nonnull)block
++ (void)addOnSendErrorBlock:(BugsnagOnSendErrorBlock _Nonnull)block
 {
     if ([self bugsnagStarted]) {
-        [self.client addOnSendBlock:block];
+        [self.client addOnSendErrorBlock:block];
     }
 }
 
-+ (void)removeOnSendBlock:(BugsnagOnSendBlock _Nonnull)block
++ (void)removeOnSendErrorBlock:(BugsnagOnSendErrorBlock _Nonnull)block
 {
     if ([self bugsnagStarted]) {
-        [self.client removeOnSendBlock:block];
+        [self.client removeOnSendErrorBlock:block];
     }
 }
 

--- a/Source/BugsnagClient.h
+++ b/Source/BugsnagClient.h
@@ -178,14 +178,16 @@ NS_SWIFT_NAME(leaveBreadcrumb(_:metadata:type:));
 *
 * @param block The block to be added.
 */
-- (void)addOnSessionBlock:(BugsnagOnSessionBlock _Nonnull)block;
+- (void)addOnSessionBlock:(BugsnagOnSessionBlock _Nonnull)block
+    NS_SWIFT_NAME(addOnSession(block:));
 
 /**
  * Remove a callback that would be invoked before a session is sent to Bugsnag.
  *
  * @param block The block to be removed.
  */
-- (void)removeOnSessionBlock:(BugsnagOnSessionBlock _Nonnull )block;
+- (void)removeOnSessionBlock:(BugsnagOnSessionBlock _Nonnull )block
+    NS_SWIFT_NAME(removeOnSession(block:));
 
 // =============================================================================
 // MARK: - Other methods
@@ -231,14 +233,16 @@ NS_SWIFT_NAME(leaveBreadcrumb(_:metadata:type:));
  *
  *  @param block A block which returns YES if the report should be sent
  */
-- (void)addOnSendBlock:(BugsnagOnSendBlock _Nonnull)block;
+- (void)addOnSendErrorBlock:(BugsnagOnSendErrorBlock _Nonnull)block
+    NS_SWIFT_NAME(addOnSendError(block:));
 
 /**
  * Remove an onSend callback, if it exists
  *
  * @param block The block to remove
  */
-- (void)removeOnSendBlock:(BugsnagOnSendBlock _Nonnull)block;
+- (void)removeOnSendErrorBlock:(BugsnagOnSendErrorBlock _Nonnull)block
+    NS_SWIFT_NAME(removeOnSendError(block:));
 
 // =============================================================================
 // MARK: - onBreadcrumb
@@ -250,13 +254,15 @@ NS_SWIFT_NAME(leaveBreadcrumb(_:metadata:type:));
  *
  *  @param block A block which returns YES if the breadcrumb should be captured
  */
-- (void)addOnBreadcrumbBlock:(BugsnagOnBreadcrumbBlock _Nonnull)block;
+- (void)addOnBreadcrumbBlock:(BugsnagOnBreadcrumbBlock _Nonnull)block
+    NS_SWIFT_NAME(addOnBreadcrumb(block:));
 
 /**
  * Remove the callback that would be invoked when a breadcrumb is captured.
  *
  * @param block The block to be removed.
  */
-- (void)removeOnBreadcrumbBlock:(BugsnagOnBreadcrumbBlock _Nonnull)block;
+- (void)removeOnBreadcrumbBlock:(BugsnagOnBreadcrumbBlock _Nonnull)block
+    NS_SWIFT_NAME(removeOnBreadcrumb(block:));
 
 @end

--- a/Source/BugsnagClient.m
+++ b/Source/BugsnagClient.m
@@ -748,12 +748,12 @@ NSString *const BSGBreadcrumbLoadedMessage = @"Bugsnag loaded";
 // MARK: - onSend
 // =============================================================================
 
-- (void)addOnSendBlock:(BugsnagOnSendBlock _Nonnull)block {
-    [self.configuration addOnSendBlock:block];
+- (void)addOnSendErrorBlock:(BugsnagOnSendErrorBlock _Nonnull)block {
+    [self.configuration addOnSendErrorBlock:block];
 }
 
-- (void)removeOnSendBlock:(BugsnagOnSendBlock _Nonnull)block {
-    [self.configuration removeOnSendBlock:block];
+- (void)removeOnSendErrorBlock:(BugsnagOnSendErrorBlock _Nonnull)block {
+    [self.configuration removeOnSendErrorBlock:block];
 }
 
 // =============================================================================

--- a/Source/BugsnagConfiguration.h
+++ b/Source/BugsnagConfiguration.h
@@ -75,14 +75,14 @@ typedef BOOL (^BugsnagOnErrorBlock)(BugsnagEvent *_Nonnull event);
 /**
  *  A handler for modifying data before sending it to Bugsnag.
  *
- * onSendBlocks will be invoked on a dedicated
+ * onSendErrorBlocks will be invoked on a dedicated
  * background queue, which will be different from the queue where the block was originally added.
  *
  *  @param event The event report.
  *
  *  @return YES if the event should be sent
  */
-typedef BOOL (^BugsnagOnSendBlock)(BugsnagEvent *_Nonnull event);
+typedef BOOL (^BugsnagOnSendErrorBlock)(BugsnagEvent *_Nonnull event);
 
 /**
  *  A configuration block for modifying a captured breadcrumb
@@ -283,7 +283,7 @@ typedef NS_OPTIONS(NSUInteger, BSGEnabledErrorType) {
  * @param block The block to be removed.
  */
 - (void)removeOnSessionBlock:(BugsnagOnSessionBlock _Nonnull)block
-    NS_SWIFT_NAME(removeOnSession(block:));;
+    NS_SWIFT_NAME(removeOnSession(block:));
 
 // =============================================================================
 // MARK: - onSend
@@ -295,16 +295,16 @@ typedef NS_OPTIONS(NSUInteger, BSGEnabledErrorType) {
  *
  *  @param block A block which returns YES if the report should be sent
  */
-- (void)addOnSendBlock:(BugsnagOnSendBlock _Nonnull)block
-    NS_SWIFT_NAME(addOnSend(block:));
+- (void)addOnSendErrorBlock:(BugsnagOnSendErrorBlock _Nonnull)block
+    NS_SWIFT_NAME(addOnSendError(block:));
 
 /**
  * Remove the callback that would be invoked before an event is sent.
  *
  * @param block The block to be removed.
  */
-- (void)removeOnSendBlock:(BugsnagOnSendBlock _Nonnull)block
-    NS_SWIFT_NAME(removeOnSend(block:));
+- (void)removeOnSendErrorBlock:(BugsnagOnSendErrorBlock _Nonnull)block
+    NS_SWIFT_NAME(removeOnSendError(block:));
 
 // =============================================================================
 // MARK: - onBreadcrumb

--- a/Source/BugsnagConfiguration.m
+++ b/Source/BugsnagConfiguration.m
@@ -287,11 +287,11 @@ NSString * const kBugsnagUserUserId = @"BugsnagUserUserId";
 // MARK: - onSendBlock
 // =============================================================================
 
-- (void)addOnSendBlock:(BugsnagOnSendBlock)block {
+- (void)addOnSendErrorBlock:(BugsnagOnSendErrorBlock _Nonnull)block {
     [(NSMutableArray *)self.onSendBlocks addObject:[block copy]];
 }
 
-- (void)removeOnSendBlock:(BugsnagOnSendBlock _Nonnull )block
+- (void)removeOnSendErrorBlock:(BugsnagOnSendErrorBlock _Nonnull )block
 {
     [(NSMutableArray *)self.onSendBlocks removeObject:block];
 }

--- a/Source/BugsnagSink.m
+++ b/Source/BugsnagSink.m
@@ -92,7 +92,7 @@
         if (![bugsnagReport shouldBeSent])
             continue;
         BOOL shouldSend = YES;
-        for (BugsnagOnSendBlock block in configuration.onSendBlocks) {
+        for (BugsnagOnSendErrorBlock block in configuration.onSendBlocks) {
             @try {
                 shouldSend = block(bugsnagReport);
                 if (!shouldSend)

--- a/Tests/BugsnagBaseUnitTest.m
+++ b/Tests/BugsnagBaseUnitTest.m
@@ -44,7 +44,9 @@
     [configuration setPersistUser:willPersistUser];
     
     if (willNotify) {
-        [configuration addOnSendBlock:^BOOL(BugsnagEvent * _Nonnull event) { return false; }];
+        [configuration addOnSendErrorBlock:^BOOL(BugsnagEvent *_Nonnull event) {
+            return false;
+        }];
     }
     [Bugsnag startBugsnagWithConfiguration:configuration];
 }

--- a/Tests/BugsnagBreadcrumbsTest.m
+++ b/Tests/BugsnagBreadcrumbsTest.m
@@ -302,7 +302,9 @@ BSGBreadcrumbType BSGBreadcrumbTypeFromString(NSString *value);
 - (void)testCallbackFreeConstructors2 {
     // Prevent sending events
     BugsnagConfiguration *configuration = [[BugsnagConfiguration alloc] initWithApiKey:DUMMY_APIKEY_32CHAR_1];
-    [configuration addOnSendBlock:^BOOL(BugsnagEvent * _Nonnull event) { return false; }];
+    [configuration addOnSendErrorBlock:^BOOL(BugsnagEvent *_Nonnull event) {
+        return false;
+    }];
     [Bugsnag startBugsnagWithConfiguration:configuration];
 
     NSDictionary *md1 = @{ @"x" : @"y"};
@@ -369,7 +371,9 @@ BSGBreadcrumbType BSGBreadcrumbTypeFromString(NSString *value);
 - (void)testCallbackFreeConstructors3 {
     // Prevent sending events
     BugsnagConfiguration *configuration = [[BugsnagConfiguration alloc] initWithApiKey:DUMMY_APIKEY_32CHAR_1];
-    [configuration addOnSendBlock:^BOOL(BugsnagEvent * _Nonnull event) { return false; }];
+    [configuration addOnSendErrorBlock:^BOOL(BugsnagEvent *_Nonnull event) {
+        return false;
+    }];
     [Bugsnag startBugsnagWithConfiguration:configuration];
 
     [Bugsnag leaveBreadcrumbWithMessage:@"message1"];

--- a/Tests/BugsnagClientTests.m
+++ b/Tests/BugsnagClientTests.m
@@ -47,7 +47,9 @@ NSString *BSGFormatSeverity(BSGSeverity severity);
 -(void)setUpBugsnagWillCallNotify:(bool)willNotify {
     BugsnagConfiguration *configuration = [[BugsnagConfiguration alloc] initWithApiKey:DUMMY_APIKEY_32CHAR_1];
     if (willNotify) {
-        [configuration addOnSendBlock:^BOOL(BugsnagEvent * _Nonnull event) { return false; }];
+        [configuration addOnSendErrorBlock:^BOOL(BugsnagEvent *_Nonnull event) {
+            return false;
+        }];
     }
     [Bugsnag startBugsnagWithConfiguration:configuration];
 }

--- a/Tests/BugsnagConfigurationTests.m
+++ b/Tests/BugsnagConfigurationTests.m
@@ -755,14 +755,14 @@
     BugsnagConfiguration *configuration = [[BugsnagConfiguration alloc] initWithApiKey:DUMMY_APIKEY_32CHAR_1];
     XCTAssertEqual([[configuration onSendBlocks] count], 0);
     
-    BugsnagOnSendBlock block = ^BOOL(BugsnagEvent * _Nonnull event) { return false; };
-    
-    [configuration addOnSendBlock:block];
+    BugsnagOnSendErrorBlock block = ^BOOL(BugsnagEvent * _Nonnull event) { return false; };
+
+    [configuration addOnSendErrorBlock:block];
     [Bugsnag startBugsnagWithConfiguration:configuration];
     
     XCTAssertEqual([[configuration onSendBlocks] count], 1);
-    
-    [configuration removeOnSendBlock:block];
+
+    [configuration removeOnSendErrorBlock:block];
     XCTAssertEqual([[configuration onSendBlocks] count], 0);
 }
 
@@ -774,12 +774,12 @@
     BugsnagConfiguration *configuration = [[BugsnagConfiguration alloc] initWithApiKey:DUMMY_APIKEY_32CHAR_1];
     XCTAssertEqual([[configuration onSendBlocks] count], 0);
     
-    BugsnagOnSendBlock block1 = ^BOOL(BugsnagEvent * _Nonnull event) { return false; };
-    BugsnagOnSendBlock block2 = ^BOOL(BugsnagEvent * _Nonnull event) { return false; };
+    BugsnagOnSendErrorBlock block1 = ^BOOL(BugsnagEvent * _Nonnull event) { return false; };
+    BugsnagOnSendErrorBlock block2 = ^BOOL(BugsnagEvent * _Nonnull event) { return false; };
     
     // Add more than one
-    [configuration addOnSendBlock:block1];
-    [configuration addOnSendBlock:block2];
+    [configuration addOnSendErrorBlock:block1];
+    [configuration addOnSendErrorBlock:block2];
     
     [Bugsnag startBugsnagWithConfiguration:configuration];
     
@@ -802,8 +802,8 @@
     [config setAppType:@"The most amazing app, a brilliant app, the app to end all apps"];
     [config setPersistUser:YES];
     [config setSendThreads:BSGThreadSendPolicyUnhandledOnly];
-    BugsnagOnSendBlock onSendBlock1 = ^BOOL(BugsnagEvent * _Nonnull event) { return true; };
-    BugsnagOnSendBlock onSendBlock2 = ^BOOL(BugsnagEvent * _Nonnull event) { return true; };
+    BugsnagOnSendErrorBlock onSendBlock1 = ^BOOL(BugsnagEvent * _Nonnull event) { return true; };
+    BugsnagOnSendErrorBlock onSendBlock2 = ^BOOL(BugsnagEvent * _Nonnull event) { return true; };
 
     NSArray *sendBlocks = @[ onSendBlock1, onSendBlock2 ];
     [config setOnSendBlocks:[sendBlocks mutableCopy]]; // Mutable arg required

--- a/Tests/BugsnagTests.m
+++ b/Tests/BugsnagTests.m
@@ -44,7 +44,9 @@
 -(void)setUpBugsnagWillCallNotify:(bool)willNotify {
     BugsnagConfiguration *configuration = [[BugsnagConfiguration alloc] initWithApiKey:DUMMY_APIKEY_32CHAR_1];
     if (willNotify) {
-        [configuration addOnSendBlock:^BOOL(BugsnagEvent * _Nonnull event) { return false; }];
+        [configuration addOnSendErrorBlock:^BOOL(BugsnagEvent *_Nonnull event) {
+            return false;
+        }];
     }
     [Bugsnag startBugsnagWithConfiguration:configuration];
 }
@@ -147,7 +149,9 @@
  */
 -(void)testBugsnagPauseSession {
     BugsnagConfiguration *configuration = [[BugsnagConfiguration alloc] initWithApiKey:DUMMY_APIKEY_32CHAR_1];
-    [configuration addOnSendBlock:^BOOL(BugsnagEvent * _Nonnull event) { return false; }];
+    [configuration addOnSendErrorBlock:^BOOL(BugsnagEvent *_Nonnull event) {
+        return false;
+    }];
 
     [Bugsnag startBugsnagWithConfiguration:configuration];
 
@@ -164,7 +168,9 @@
     
     BugsnagConfiguration *configuration = [[BugsnagConfiguration alloc] initWithApiKey:DUMMY_APIKEY_32CHAR_1];
     [configuration setContext:@"firstContext"];
-    [configuration addOnSendBlock:^BOOL(BugsnagEvent * _Nonnull event) { return false; }];
+    [configuration addOnSendErrorBlock:^BOOL(BugsnagEvent *_Nonnull event) {
+        return false;
+    }];
     
     [Bugsnag startBugsnagWithConfiguration:configuration];
 
@@ -249,7 +255,9 @@
     BugsnagConfiguration *configuration = [[BugsnagConfiguration alloc] initWithApiKey:DUMMY_APIKEY_32CHAR_1];
 
     // non-sending bugsnag
-    [configuration addOnSendBlock:^BOOL(BugsnagEvent * _Nonnull event) { return false; }];
+    [configuration addOnSendErrorBlock:^BOOL(BugsnagEvent *_Nonnull event) {
+        return false;
+    }];
 
     BugsnagOnSessionBlock sessionBlock = ^BOOL(BugsnagSession * _Nonnull sessionPayload) {
         switch (called) {
@@ -290,7 +298,9 @@
     configuration.autoTrackSessions = NO;
     
     // non-sending bugsnag
-    [configuration addOnSendBlock:^BOOL(BugsnagEvent * _Nonnull event) { return false; }];
+    [configuration addOnSendErrorBlock:^BOOL(BugsnagEvent *_Nonnull event) {
+        return false;
+    }];
 
     BugsnagOnSessionBlock sessionBlock = ^BOOL(BugsnagSession * _Nonnull sessionPayload) {
         switch (called) {
@@ -352,7 +362,7 @@
     expectation6.inverted = YES;
 
     // Two blocks that will get called (or not) when we notify()
-    BugsnagOnSendBlock block1 = ^BOOL(BugsnagEvent * _Nonnull event)
+    BugsnagOnSendErrorBlock block1 = ^BOOL(BugsnagEvent * _Nonnull event)
     {
         switch (called) {
             case 0:
@@ -376,7 +386,7 @@
         return false;
     };
 
-    BugsnagOnSendBlock block2 = ^BOOL(BugsnagEvent * _Nonnull event)
+    BugsnagOnSendErrorBlock block2 = ^BOOL(BugsnagEvent * _Nonnull event)
     {
         switch (called) {
             case 0:
@@ -403,9 +413,9 @@
     // Can't check for block behaviour before start(), so we don't
     
     [Bugsnag startBugsnagWithConfiguration:configuration];
-    
-    [Bugsnag addOnSendBlock:block1];
-    [Bugsnag addOnSendBlock:block2];
+
+    [Bugsnag addOnSendErrorBlock:block1];
+    [Bugsnag addOnSendErrorBlock:block2];
 
     // Both added?
     XCTAssertEqual([[[Bugsnag configuration] onSendBlocks] count], 2);
@@ -415,8 +425,8 @@
     
     // Both called?
     [self waitForExpectations:@[expectation1, expectation2] timeout:10.0];
-    
-    [Bugsnag removeOnSendBlock:block2];
+
+    [Bugsnag removeOnSendErrorBlock:block2];
     XCTAssertEqual([[[Bugsnag configuration] onSendBlocks] count], 1);
     called++;
     XCTAssertEqual(called, 1);  

--- a/UPGRADING.md
+++ b/UPGRADING.md
@@ -53,7 +53,7 @@ The exact error is available using the `BSGConfigurationErrorDomain` and
 - config.beforeSendBlocks
 - config.add(beforeSend:)
 + config.onSendBlocks
-+ config.addOnSend(block:)
++ config.addOnSendError(block:)
 
 - config.beforeSessionBlocks
 - config.add(beforeSession:)

--- a/features/fixtures/ios-swift-cocoapods/iOSTestApp/scenarios/ModifyBreadcrumbScenario.swift
+++ b/features/fixtures/ios-swift-cocoapods/iOSTestApp/scenarios/ModifyBreadcrumbScenario.swift
@@ -6,7 +6,7 @@ class ModifyBreadcrumbScenario: Scenario {
     override func startBugsnag() {
         self.config.autoTrackSessions = false;
 
-        self.config.addOnSend(block: { event in
+        self.config.addOnSendError(block: { event in
             event.breadcrumbs?.forEach({ crumb in
                 if crumb.message == "Cache cleared" {
                     crumb.message = "Cache locked"

--- a/features/fixtures/ios-swift-cocoapods/iOSTestApp/scenarios/OOMScenario.m
+++ b/features/fixtures/ios-swift-cocoapods/iOSTestApp/scenarios/OOMScenario.m
@@ -6,7 +6,7 @@
 - (void)startBugsnag {
     self.config.autoTrackSessions = NO;
     self.config.releaseStage = @"alpha";
-    [self.config addOnSendBlock:^BOOL(BugsnagEvent * _Nonnull event) {
+    [self.config addOnSendErrorBlock:^BOOL(BugsnagEvent * _Nonnull event) {
         [event addMetadata:@{ @"shape": @"line" } toSection:@"extra"];
         return YES;
     }];


### PR DESCRIPTION
Renames `OnSend` to `OnSendError`, as requested for consistency with the notifier spec.

Additionally, this adds missing `NS_SWIFT_NAME` macros to `BugsnagClient`, so that the method signatures are the same across `Bugsnag` and `BugsnagClient`.