### PR TITLE
Add onCrashHandler data to BugsnagEvent metadata

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,9 @@ Bugsnag Notifiers on other platforms.
 
 ## Enhancements
 
+* Add `onCrashHandler` data to `BugsnagEvent` metadata
+  [#564](https://github.com/bugsnag/bugsnag-cocoa/pull/564)
+
 * Rename `BugsnagUser` properties
   [#560](https://github.com/bugsnag/bugsnag-cocoa/pull/560)
 

--- a/OSX/Bugsnag.xcodeproj/project.pbxproj
+++ b/OSX/Bugsnag.xcodeproj/project.pbxproj
@@ -60,6 +60,7 @@
 		E722105E243B6A0F0083CF15 /* BugsnagStackframeTest.m in Sources */ = {isa = PBXBuildFile; fileRef = E722105D243B6A0E0083CF15 /* BugsnagStackframeTest.m */; };
 		E72352C11F55924A00436528 /* BSGConnectivity.h in Headers */ = {isa = PBXBuildFile; fileRef = E72352BF1F55924A00436528 /* BSGConnectivity.h */; };
 		E72352C21F55924A00436528 /* BSGConnectivity.m in Sources */ = {isa = PBXBuildFile; fileRef = E72352C01F55924A00436528 /* BSGConnectivity.m */; };
+		E728378D245184B600EE2B7D /* BugsnagOnCrashTest.m in Sources */ = {isa = PBXBuildFile; fileRef = E728378C245184B600EE2B7D /* BugsnagOnCrashTest.m */; };
 		E72AE1F9241A4E7500ED8972 /* BugsnagPluginClient.m in Sources */ = {isa = PBXBuildFile; fileRef = E72AE1F7241A4E7500ED8972 /* BugsnagPluginClient.m */; };
 		E72AE1FA241A4E7500ED8972 /* BugsnagPluginClient.h in Headers */ = {isa = PBXBuildFile; fileRef = E72AE1F8241A4E7500ED8972 /* BugsnagPluginClient.h */; };
 		E73D443C243E192F001686F5 /* BugsnagErrorTest.m in Sources */ = {isa = PBXBuildFile; fileRef = E73D443B243E192F001686F5 /* BugsnagErrorTest.m */; };
@@ -294,11 +295,12 @@
 		E722105D243B6A0E0083CF15 /* BugsnagStackframeTest.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; path = BugsnagStackframeTest.m; sourceTree = "<group>"; };
 		E72352BF1F55924A00436528 /* BSGConnectivity.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; name = BSGConnectivity.h; path = ../Source/BSGConnectivity.h; sourceTree = SOURCE_ROOT; };
 		E72352C01F55924A00436528 /* BSGConnectivity.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; name = BSGConnectivity.m; path = ../Source/BSGConnectivity.m; sourceTree = SOURCE_ROOT; };
+		E728378C245184B600EE2B7D /* BugsnagOnCrashTest.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; path = BugsnagOnCrashTest.m; sourceTree = "<group>"; };
 		E72AE1F7241A4E7500ED8972 /* BugsnagPluginClient.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; name = BugsnagPluginClient.m; path = ../Source/BugsnagPluginClient.m; sourceTree = "<group>"; };
 		E72AE1F8241A4E7500ED8972 /* BugsnagPluginClient.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; name = BugsnagPluginClient.h; path = ../Source/BugsnagPluginClient.h; sourceTree = "<group>"; };
+		E73D443B243E192F001686F5 /* BugsnagErrorTest.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; path = BugsnagErrorTest.m; sourceTree = "<group>"; };
 		E7529F8C243C8EBF006B4932 /* RegisterErrorData.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; name = RegisterErrorData.h; path = ../Source/RegisterErrorData.h; sourceTree = "<group>"; };
 		E7529F8D243C8EBF006B4932 /* RegisterErrorData.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; name = RegisterErrorData.m; path = ../Source/RegisterErrorData.m; sourceTree = "<group>"; };
-		E73D443B243E192F001686F5 /* BugsnagErrorTest.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; path = BugsnagErrorTest.m; sourceTree = "<group>"; };
 		E7529F9F243CAE34006B4932 /* BugsnagThreadTest.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; path = BugsnagThreadTest.m; sourceTree = "<group>"; };
 		E7529FA1243CAE3F006B4932 /* BugsnagThreadSerializationTest.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; name = BugsnagThreadSerializationTest.m; path = ../iOS/BugsnagTests/BugsnagThreadSerializationTest.m; sourceTree = "<group>"; };
 		E762E9F71F73F7E900E82B43 /* BugsnagHandledStateTest.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; name = BugsnagHandledStateTest.m; path = ../Tests/BugsnagHandledStateTest.m; sourceTree = SOURCE_ROOT; };
@@ -552,6 +554,7 @@
 		8A2C8FAF1C6BC1F700846019 /* Tests */ = {
 			isa = PBXGroup;
 			children = (
+				E728378C245184B600EE2B7D /* BugsnagOnCrashTest.m */,
 				8AD1E3F823EDDD3F0044F919 /* BSGConnectivityTest.m */,
 				E790C4A22434CB6A006FFB26 /* BugsnagAppTest.m */,
 				00F9393123FC168F008C7073 /* BugsnagBaseUnitTest.h */,
@@ -1204,6 +1207,7 @@
 				E7CE78BC1FD94E77001D07E0 /* KSCrashReportStore_Tests.m in Sources */,
 				E79148611FD82BB7003EFEBF /* BugsnagSessionTrackerTest.m in Sources */,
 				E79148591FD82BAE003EFEBF /* BugsnagSessionTest.m in Sources */,
+				E728378D245184B600EE2B7D /* BugsnagOnCrashTest.m in Sources */,
 				E7A9E56D2436365300D99F8A /* BugsnagDeviceTest.m in Sources */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;

--- a/Source/BugsnagEvent.m
+++ b/Source/BugsnagEvent.m
@@ -409,7 +409,7 @@ NSDictionary *BSGParseCustomException(NSDictionary *report,
 
             NSMutableDictionary *userAtCrash = [self parseOnCrashData:report];
             if (userAtCrash != nil) {
-                [_metadata addMetadata:userAtCrash toSection:@BSG_KSCrashField_OnCrash];
+                [_metadata addMetadata:userAtCrash toSection:@BSG_KSCrashField_OnCrashMetadataSectionName];
             }
         }
         _user = [self parseUser:[_metadata toDictionary]];

--- a/Source/BugsnagEvent.m
+++ b/Source/BugsnagEvent.m
@@ -27,6 +27,7 @@
 #import "RegisterErrorData.h"
 #import "BugsnagSessionInternal.h"
 #import "BugsnagUser.h"
+#import "BSG_KSCrashReportFields.h"
 
 static NSString *const DEFAULT_EXCEPTION_TYPE = @"cocoa";
 
@@ -405,10 +406,34 @@ NSDictionary *BSGParseCustomException(NSDictionary *report,
                                              attrValue:_errors[0].errorClass];
             }
             _severity = _handledState.currentSeverity;
+
+            NSMutableDictionary *userAtCrash = [self parseOnCrashData:report];
+            if (userAtCrash != nil) {
+                [_metadata addMetadata:userAtCrash toSection:@BSG_KSCrashField_OnCrash];
+            }
         }
         _user = [self parseUser:[_metadata toDictionary]];
     }
     return self;
+}
+
+- (NSMutableDictionary *)parseOnCrashData:(NSDictionary *)report {
+    NSMutableDictionary *userAtCrash = [report[@"user"] mutableCopy];
+    // avoid adding internal information to user-defined metadata
+    NSArray *blacklistedKeys = @[
+            @BSG_KSCrashField_Overrides,
+            @BSG_KSCrashField_HandledState,
+            @BSG_KSCrashField_Metadata,
+            @BSG_KSCrashField_State,
+            @BSG_KSCrashField_Config,
+            @BSG_KSCrashField_DiscardDepth,
+            @"startedAt",
+            @"unhandledCount",
+            @"handledCount",
+            @"id",
+    ];
+    [userAtCrash removeObjectsForKeys:blacklistedKeys];
+    return userAtCrash;
 }
 
 /**

--- a/Source/KSCrash/Source/KSCrash/Recording/BSG_KSCrashReport.c
+++ b/Source/KSCrash/Source/KSCrash/Recording/BSG_KSCrashReport.c
@@ -1628,6 +1628,10 @@ void bsg_kscrashreport_writeStandardReport(
         writer->endContainer(writer);
 
         if (crashContext->config.onCrashNotify != NULL) {
+
+            // NOTE: The blacklist for BSG_KSCrashField_UserAtCrash children in BugsnagEvent.m
+            // should be updated when adding new fields here
+
             // Write handled exception report info
             writer->beginObject(writer, BSG_KSCrashField_UserAtCrash);
             if (crashContext->crash.crashType == BSG_KSCrashTypeUserReported) {

--- a/Source/KSCrash/Source/KSCrash/Recording/BSG_KSCrashReportFields.h
+++ b/Source/KSCrash/Source/KSCrash/Recording/BSG_KSCrashReportFields.h
@@ -174,7 +174,7 @@
 #define BSG_KSCrashField_Threads "threads"
 #define BSG_KSCrashField_User "user"
 #define BSG_KSCrashField_UserAtCrash "user_atcrash"
-#define BSG_KSCrashField_OnCrash "onCrash"
+#define BSG_KSCrashField_OnCrashMetadataSectionName "onCrash"
 
 #pragma mark Incomplete
 #define BSG_KSCrashField_Incomplete "incomplete"

--- a/Source/KSCrash/Source/KSCrash/Recording/BSG_KSCrashReportFields.h
+++ b/Source/KSCrash/Source/KSCrash/Recording/BSG_KSCrashReportFields.h
@@ -174,6 +174,7 @@
 #define BSG_KSCrashField_Threads "threads"
 #define BSG_KSCrashField_User "user"
 #define BSG_KSCrashField_UserAtCrash "user_atcrash"
+#define BSG_KSCrashField_OnCrash "onCrash"
 
 #pragma mark Incomplete
 #define BSG_KSCrashField_Incomplete "incomplete"

--- a/Tests/BugsnagOnCrashTest.m
+++ b/Tests/BugsnagOnCrashTest.m
@@ -1,0 +1,99 @@
+//
+//  BugsnagOnCrashTest.m
+//  Tests
+//
+//  Created by Jamie Lynch on 23/04/2020.
+//  Copyright © 2020 Bugsnag. All rights reserved.
+//
+
+#import <XCTest/XCTest.h>
+
+#import <Bugsnag/Bugsnag.h>
+
+@interface BugsnagEvent ()
+- (instancetype)initWithKSReport:(NSDictionary *)report;
+@end
+
+@interface BugsnagOnCrashTest : XCTestCase
+
+@end
+
+@implementation BugsnagOnCrashTest
+
+- (void)testEmptyData {
+    BugsnagEvent *event = [[BugsnagEvent alloc] initWithKSReport:@{}];
+    XCTAssertNil([event getMetadataFromSection:@"onCrash"]);
+}
+
+- (void)testOnCrashData {
+    BugsnagEvent *event = [[BugsnagEvent alloc] initWithKSReport:@{
+            @"user": @{
+                    @"name": @"Joe Bloggs"
+            }
+    }];
+    NSMutableDictionary *data = [event getMetadataFromSection:@"onCrash"];
+    XCTAssertNotNil(data);
+    XCTAssertEqual(1, [data count]);
+    XCTAssertEqualObjects(@"Joe Bloggs", data[@"name"]);
+}
+
+/**
+ * Verifies that fields stored in same section under different keys are
+ * _not_ added to the metadata
+ */
+- (void)testBlacklistedFields {
+    BugsnagEvent *event = [[BugsnagEvent alloc] initWithKSReport:@{
+            @"user": @{
+                    @"name": @"Joe Bloggs",
+                    @"overrides": @{
+                            @"test": @"test_val"
+                    },
+                    @"handledState": @{
+                            @"test": @"test_val"
+                    },
+                    @"metaData": @{
+                            @"test": @"test_val"
+                    },
+                    @"state": @{
+                            @"test": @"test_val"
+                    },
+                    @"config": @{
+                            @"test": @"test_val"
+                    },
+                    @"depth": @2,
+                    @"id": @"E7E3A6E8-D1FE-426D-B7BB-B247C957A109",
+                    @"startedAt": @"2020-04-23T09:01:04Z",
+                    @"handledCount": @0,
+                    @"unhandledCount": @1,
+            }
+    }];
+    NSMutableDictionary *data = [event getMetadataFromSection:@"onCrash"];
+    XCTAssertNotNil(data);
+    XCTAssertEqual(1, [data count]);
+    XCTAssertEqualObjects(@"Joe Bloggs", data[@"name"]);
+}
+
+/**
+ * Assert that data added via onCrashHandler has higher precedence than
+ * that added to metadata (as it was added more recently)
+ */
+- (void)testMergePrecedence {
+    BugsnagEvent *event = [[BugsnagEvent alloc] initWithKSReport:@{
+            @"user": @{
+                    @"name": @"Joe Bloggs",
+                    @"metaData": @{
+                            @"onCrash": @{
+                                    @"name": @"Beryl Merryweather",
+                                    @"age": @76
+                            }
+                    }
+            }
+    }];
+    NSMutableDictionary *data = [event getMetadataFromSection:@"onCrash"];
+    XCTAssertNotNil(data);
+    XCTAssertEqual(2, [data count]);
+    XCTAssertEqualObjects(@"Joe Bloggs", data[@"name"]);
+    XCTAssertEqualObjects(@76, data[@"age"]);
+}
+
+@end

--- a/iOS/Bugsnag.xcodeproj/project.pbxproj
+++ b/iOS/Bugsnag.xcodeproj/project.pbxproj
@@ -153,6 +153,7 @@
 		E722105C243B69F00083CF15 /* BugsnagStackframeTest.m in Sources */ = {isa = PBXBuildFile; fileRef = E722105B243B69F00083CF15 /* BugsnagStackframeTest.m */; };
 		E72352B61F55718E00436528 /* BSGConnectivity.h in Headers */ = {isa = PBXBuildFile; fileRef = E72352B41F55718E00436528 /* BSGConnectivity.h */; };
 		E72352B71F55718E00436528 /* BSGConnectivity.m in Sources */ = {isa = PBXBuildFile; fileRef = E72352B51F55718E00436528 /* BSGConnectivity.m */; };
+		E728378B2451843000EE2B7D /* BugsnagOnCrashTest.m in Sources */ = {isa = PBXBuildFile; fileRef = E728378A2451843000EE2B7D /* BugsnagOnCrashTest.m */; };
 		E72962D61F4BBA8B00CEA15D /* BugsnagCrashSentry.h in Headers */ = {isa = PBXBuildFile; fileRef = E72962D01F4BBA8A00CEA15D /* BugsnagCrashSentry.h */; };
 		E72962D71F4BBA8B00CEA15D /* BugsnagCrashSentry.m in Sources */ = {isa = PBXBuildFile; fileRef = E72962D11F4BBA8A00CEA15D /* BugsnagCrashSentry.m */; };
 		E72962D81F4BBA8B00CEA15D /* BugsnagErrorReportApiClient.h in Headers */ = {isa = PBXBuildFile; fileRef = E72962D21F4BBA8B00CEA15D /* BugsnagErrorReportApiClient.h */; };
@@ -646,6 +647,7 @@
 		E722105B243B69F00083CF15 /* BugsnagStackframeTest.m */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.objc; name = BugsnagStackframeTest.m; path = ../../Tests/BugsnagStackframeTest.m; sourceTree = "<group>"; };
 		E72352B41F55718E00436528 /* BSGConnectivity.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; name = BSGConnectivity.h; path = ../Source/BSGConnectivity.h; sourceTree = SOURCE_ROOT; };
 		E72352B51F55718E00436528 /* BSGConnectivity.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; name = BSGConnectivity.m; path = ../Source/BSGConnectivity.m; sourceTree = SOURCE_ROOT; };
+		E728378A2451843000EE2B7D /* BugsnagOnCrashTest.m */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.objc; name = BugsnagOnCrashTest.m; path = ../../Tests/BugsnagOnCrashTest.m; sourceTree = "<group>"; };
 		E72962D01F4BBA8A00CEA15D /* BugsnagCrashSentry.h */ = {isa = PBXFileReference; explicitFileType = sourcecode.c.h; fileEncoding = 4; name = BugsnagCrashSentry.h; path = ../Source/BugsnagCrashSentry.h; sourceTree = SOURCE_ROOT; };
 		E72962D11F4BBA8A00CEA15D /* BugsnagCrashSentry.m */ = {isa = PBXFileReference; explicitFileType = sourcecode.c.objc; fileEncoding = 4; name = BugsnagCrashSentry.m; path = ../Source/BugsnagCrashSentry.m; sourceTree = SOURCE_ROOT; };
 		E72962D21F4BBA8B00CEA15D /* BugsnagErrorReportApiClient.h */ = {isa = PBXFileReference; explicitFileType = sourcecode.c.h; fileEncoding = 4; name = BugsnagErrorReportApiClient.h; path = ../Source/BugsnagErrorReportApiClient.h; sourceTree = SOURCE_ROOT; };
@@ -885,6 +887,7 @@
 				E71DB9D024470F4100D0161E /* BugsnagMetadataRedactionTest.m */,
 				009131BB23F46279000810D9 /* BugsnagMetadataTests.m */,
 				E7AB4B9B2423E16C004F015A /* BugsnagOnBreadcrumbTest.m */,
+				E728378A2451843000EE2B7D /* BugsnagOnCrashTest.m */,
 				E72AE1FF241A57B100ED8972 /* BugsnagPluginTest.m */,
 				E78C1EFB1FCC759B00B976D3 /* BugsnagSessionTest.m */,
 				E78C1EF01FCC2F1700B976D3 /* BugsnagSessionTrackerTest.m */,
@@ -1541,6 +1544,7 @@
 				E70EE0781FD7039E00FA745C /* RFC3339DateTool_Tests.m in Sources */,
 				8A530CC422FDD51F00F0C108 /* KSCrashIdentifierTests.m in Sources */,
 				E71DB9D124470F4100D0161E /* BugsnagMetadataRedactionTest.m in Sources */,
+				E728378B2451843000EE2B7D /* BugsnagOnCrashTest.m in Sources */,
 				0089B70324221EDE00D5A7F2 /* BugsnagClientTests.m in Sources */,
 				8A4E733F1DC13281001F7CC8 /* BugsnagConfigurationTests.m in Sources */,
 				E784D25A1FD70C25004B01E1 /* KSJSONCodec_Tests.m in Sources */,

--- a/tvOS/Bugsnag.xcodeproj/project.pbxproj
+++ b/tvOS/Bugsnag.xcodeproj/project.pbxproj
@@ -64,6 +64,7 @@
 		E72352BA1F55922F00436528 /* SystemConfiguration.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = E72352B91F55922F00436528 /* SystemConfiguration.framework */; };
 		E72352BD1F55923700436528 /* BSGConnectivity.h in Headers */ = {isa = PBXBuildFile; fileRef = E72352BB1F55923700436528 /* BSGConnectivity.h */; };
 		E72352BE1F55923700436528 /* BSGConnectivity.m in Sources */ = {isa = PBXBuildFile; fileRef = E72352BC1F55923700436528 /* BSGConnectivity.m */; };
+		E728378F245184C900EE2B7D /* BugsnagOnCrashTest.m in Sources */ = {isa = PBXBuildFile; fileRef = E728378E245184C800EE2B7D /* BugsnagOnCrashTest.m */; };
 		E72AE1FD241A4ED600ED8972 /* BugsnagPluginClient.h in Headers */ = {isa = PBXBuildFile; fileRef = E72AE1FB241A4ED600ED8972 /* BugsnagPluginClient.h */; };
 		E72AE1FE241A4ED600ED8972 /* BugsnagPluginClient.m in Sources */ = {isa = PBXBuildFile; fileRef = E72AE1FC241A4ED600ED8972 /* BugsnagPluginClient.m */; };
 		E73D443E243E1945001686F5 /* BugsnagErrorTest.m in Sources */ = {isa = PBXBuildFile; fileRef = E73D443D243E1945001686F5 /* BugsnagErrorTest.m */; };
@@ -297,6 +298,7 @@
 		E72352B91F55922F00436528 /* SystemConfiguration.framework */ = {isa = PBXFileReference; lastKnownFileType = wrapper.framework; name = SystemConfiguration.framework; path = System/Library/Frameworks/SystemConfiguration.framework; sourceTree = SDKROOT; };
 		E72352BB1F55923700436528 /* BSGConnectivity.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; name = BSGConnectivity.h; path = ../Source/BSGConnectivity.h; sourceTree = "<group>"; };
 		E72352BC1F55923700436528 /* BSGConnectivity.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; name = BSGConnectivity.m; path = ../Source/BSGConnectivity.m; sourceTree = "<group>"; };
+		E728378E245184C800EE2B7D /* BugsnagOnCrashTest.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; name = BugsnagOnCrashTest.m; path = ../../Tests/BugsnagOnCrashTest.m; sourceTree = "<group>"; };
 		E72AE1FB241A4ED600ED8972 /* BugsnagPluginClient.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; name = BugsnagPluginClient.h; path = ../Source/BugsnagPluginClient.h; sourceTree = "<group>"; };
 		E72AE1FC241A4ED600ED8972 /* BugsnagPluginClient.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; name = BugsnagPluginClient.m; path = ../Source/BugsnagPluginClient.m; sourceTree = "<group>"; };
 		E73D443D243E1945001686F5 /* BugsnagErrorTest.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; name = BugsnagErrorTest.m; path = ../../Tests/BugsnagErrorTest.m; sourceTree = "<group>"; };
@@ -577,6 +579,7 @@
 				E71DB9E12447105E00D0161E /* BugsnagMetadataRedactionTest.m */,
 				E71DB9E62447105E00D0161E /* BugsnagMetadataTests.m */,
 				E77526C6242E694C0077A42F /* BugsnagOnBreadcrumbTest.m */,
+				E728378E245184C800EE2B7D /* BugsnagOnCrashTest.m */,
 				E71DB9E52447105E00D0161E /* BugsnagPluginTest.m */,
 				E791488C1FD82E77003EFEBF /* BugsnagSessionTest.m */,
 				E791488A1FD82E77003EFEBF /* BugsnagSessionTrackerTest.m */,
@@ -1175,6 +1178,7 @@
 				00D7ACA723E98A5D00FBE4A7 /* BugsnagEventTests.m in Sources */,
 				E7CE78F21FD94F1B001D07E0 /* KSMach_Tests.m in Sources */,
 				E7CE79071FD94F1B001D07E0 /* KSSysCtl_Tests.m in Sources */,
+				E728378F245184C900EE2B7D /* BugsnagOnCrashTest.m in Sources */,
 				E7CE78F71FD94F1B001D07E0 /* KSCrashSentry_Signal_Tests.m in Sources */,
 				E790C422243231EA006FFB26 /* BugsnagClientMirrorTest.m in Sources */,
 				E71DB9ED2447105E00D0161E /* BugsnagMetadataTests.m in Sources */,


### PR DESCRIPTION
## Goal

Data which is added in the [onCrashHandler](https://docs.bugsnag.com/platforms/ios/configuration-options/#oncrashhandler) is now added to error reports in an `onCrash` metadata tab. This provides a replacement for the previous API which allowed for these values to be inspected (but not reported) in the now removed `rawData` parameter.

<img width="703" alt="Screenshot 2020-04-23 at 10 14 38" src="https://user-images.githubusercontent.com/11800640/80082426-4895b180-854c-11ea-99f3-cd0bc6e877c1.png">

## Changeset

- Read `user` information when constructing a `BugsnagEvent` from a KSCrash report
- Removed other keys which can be serialized into the `user` object that are not user-added data
- Added any remaining information to an `onCrash` metadata tab

## Tests

Added a unit test to verify behaviour of `onCrash` data parsing. Manually tested `onCrashHandler` functionality in an example app and verified the value was sent to the dashboard.
