### PR TITLE
Rename Bugsnag start methods

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,9 @@ Bugsnag Notifiers on other platforms.
 
 ## Enhancements
 
+* Rename `Bugsnag` start methods
+  [#566](https://github.com/bugsnag/bugsnag-cocoa/pull/566)
+
 * Rename `OnSend` to `OnSendError`
   [#562](https://github.com/bugsnag/bugsnag-cocoa/pull/562)
 

--- a/Source/Bugsnag.h
+++ b/Source/Bugsnag.h
@@ -52,7 +52,7 @@
  *
  * @param apiKey  The API key from your Bugsnag dashboard.
  */
-+ (BugsnagClient *_Nonnull)startBugsnagWithApiKey:(NSString *_Nonnull)apiKey;
++ (BugsnagClient *_Nonnull)startWithApiKey:(NSString *_Nonnull)apiKey;
 
 /** Start listening for crashes.
  *
@@ -63,7 +63,7 @@
  *
  * @param configuration  The configuration to use.
  */
-+ (BugsnagClient *_Nonnull)startBugsnagWithConfiguration:(BugsnagConfiguration *_Nonnull)configuration;
++ (BugsnagClient *_Nonnull)startWithConfiguration:(BugsnagConfiguration *_Nonnull)configuration;
 
 /**
  * @return YES if Bugsnag has been started and the previous launch crashed

--- a/Source/Bugsnag.m
+++ b/Source/Bugsnag.m
@@ -68,12 +68,12 @@ static BugsnagClient *bsg_g_bugsnag_client = NULL;
 
 @implementation Bugsnag
 
-+ (BugsnagClient *_Nonnull)startBugsnagWithApiKey:(NSString *)apiKey {
++ (BugsnagClient *_Nonnull)startWithApiKey:(NSString *_Nonnull)apiKey {
     BugsnagConfiguration *configuration = [[BugsnagConfiguration alloc] initWithApiKey:apiKey];
-    return [self startBugsnagWithConfiguration:configuration];
+    return [self startWithConfiguration:configuration];
 }
 
-+ (BugsnagClient *_Nonnull)startBugsnagWithConfiguration:(BugsnagConfiguration *)configuration {
++ (BugsnagClient *_Nonnull)startWithConfiguration:(BugsnagConfiguration *_Nonnull)configuration {
     @synchronized(self) {
         bsg_g_bugsnag_client =
                 [[BugsnagClient alloc] initWithConfiguration:configuration];

--- a/Source/Private.h
+++ b/Source/Private.h
@@ -25,8 +25,8 @@
 
 /** Get the current Bugsnag configuration.
  *
- * This method returns nil if called before +startBugsnagWithApiKey: or
- * +startBugsnagWithConfiguration:, and otherwise returns the current
+ * This method returns nil if called before +startWithApiKey: or
+ * +startWithConfiguration:, and otherwise returns the current
  * configuration for Bugsnag.
  *
  * @return The configuration, or nil.

--- a/Tests/BugsnagBaseUnitTest.m
+++ b/Tests/BugsnagBaseUnitTest.m
@@ -48,7 +48,7 @@
             return false;
         }];
     }
-    [Bugsnag startBugsnagWithConfiguration:configuration];
+    [Bugsnag startWithConfiguration:configuration];
 }
 
 @end

--- a/Tests/BugsnagBreadcrumbsTest.m
+++ b/Tests/BugsnagBreadcrumbsTest.m
@@ -305,7 +305,7 @@ BSGBreadcrumbType BSGBreadcrumbTypeFromString(NSString *value);
     [configuration addOnSendErrorBlock:^BOOL(BugsnagEvent *_Nonnull event) {
         return false;
     }];
-    [Bugsnag startBugsnagWithConfiguration:configuration];
+    [Bugsnag startWithConfiguration:configuration];
 
     NSDictionary *md1 = @{ @"x" : @"y"};
     NSDictionary *md2 = @{ @"a" : @"b",
@@ -374,7 +374,7 @@ BSGBreadcrumbType BSGBreadcrumbTypeFromString(NSString *value);
     [configuration addOnSendErrorBlock:^BOOL(BugsnagEvent *_Nonnull event) {
         return false;
     }];
-    [Bugsnag startBugsnagWithConfiguration:configuration];
+    [Bugsnag startWithConfiguration:configuration];
 
     [Bugsnag leaveBreadcrumbWithMessage:@"message1"];
     [Bugsnag leaveBreadcrumbWithMessage:@"message2" metadata:nil andType:BSGBreadcrumbTypeUser];

--- a/Tests/BugsnagClientMirrorTest.m
+++ b/Tests/BugsnagClientMirrorTest.m
@@ -98,8 +98,8 @@
     // the following methods are implemented on Bugsnag but do not need to
     // be mirrored on BugsnagClient
     self.clientWhitelist = [NSSet setWithArray:@[
-            @"startBugsnagWithApiKey: @24@0:8@16",
-            @"startBugsnagWithConfiguration: @24@0:8@16",
+            @"startWithApiKey: @24@0:8@16",
+            @"startWithConfiguration: @24@0:8@16",
             @"payloadDateFormatter @16@0:8",
             @"updateCodeBundleId: v24@0:8@16",
             @"instance @16@0:8",

--- a/Tests/BugsnagClientTests.m
+++ b/Tests/BugsnagClientTests.m
@@ -51,7 +51,7 @@ NSString *BSGFormatSeverity(BSGSeverity severity);
             return false;
         }];
     }
-    [Bugsnag startBugsnagWithConfiguration:configuration];
+    [Bugsnag startWithConfiguration:configuration];
 }
 
 /**

--- a/Tests/BugsnagConfigurationTests.m
+++ b/Tests/BugsnagConfigurationTests.m
@@ -122,7 +122,7 @@
     XCTAssertEqual([[config onSessionBlocks] count], 1);
     
     // Call onSession blocks
-    [Bugsnag startBugsnagWithConfiguration:config];
+    [Bugsnag startWithConfiguration:config];
     [self waitForExpectationsWithTimeout:5.0 handler:nil];
 }
 
@@ -150,7 +150,7 @@
     [config removeOnSessionBlock:sessionBlock];
     XCTAssertEqual([[config onSessionBlocks] count], 0);
 
-    [Bugsnag startBugsnagWithConfiguration:config];
+    [Bugsnag startWithConfiguration:config];
 
     // Wait a second NOT to be called
     [self waitForExpectationsWithTimeout:1.0 handler:nil];
@@ -199,7 +199,7 @@
     XCTAssertEqual([[config onSessionBlocks] count], 1);
     
     // Call onSession blocks
-    [Bugsnag startBugsnagWithConfiguration:config];
+    [Bugsnag startWithConfiguration:config];
     [self waitForExpectations:@[expectation1] timeout:1.0];
     
     // Check it's called on new session start
@@ -769,7 +769,7 @@
     BugsnagOnSendErrorBlock block = ^BOOL(BugsnagEvent * _Nonnull event) { return false; };
 
     [configuration addOnSendErrorBlock:block];
-    [Bugsnag startBugsnagWithConfiguration:configuration];
+    [Bugsnag startWithConfiguration:configuration];
     
     XCTAssertEqual([[configuration onSendBlocks] count], 1);
 
@@ -791,8 +791,8 @@
     // Add more than one
     [configuration addOnSendErrorBlock:block1];
     [configuration addOnSendErrorBlock:block2];
-    
-    [Bugsnag startBugsnagWithConfiguration:configuration];
+
+    [Bugsnag startWithConfiguration:configuration];
     
     XCTAssertEqual([[configuration onSendBlocks] count], 2);
 }

--- a/Tests/BugsnagOnBreadcrumbTest.m
+++ b/Tests/BugsnagOnBreadcrumbTest.m
@@ -57,7 +57,7 @@
     XCTAssertEqual([[config onBreadcrumbBlocks] count], 1);
 
     // Call onbreadcrumb blocks
-    [Bugsnag startBugsnagWithConfiguration:config];
+    [Bugsnag startWithConfiguration:config];
     [Bugsnag leaveBreadcrumbWithMessage:@"Hello"];
     [self waitForExpectationsWithTimeout:5.0 handler:nil];
 }
@@ -86,7 +86,7 @@
     [config removeOnBreadcrumbBlock:crumbBlock];
     XCTAssertEqual([[config onBreadcrumbBlocks] count], 0);
 
-    [Bugsnag startBugsnagWithConfiguration:config];
+    [Bugsnag startWithConfiguration:config];
     [Bugsnag leaveBreadcrumbWithMessage:@"Hello"];
 
     // Wait a second NOT to be called
@@ -126,7 +126,7 @@
     XCTAssertEqual([[config onBreadcrumbBlocks] count], 1);
 
     // Call onbreadcrumb blocks
-    [Bugsnag startBugsnagWithConfiguration:config];
+    [Bugsnag startWithConfiguration:config];
     [Bugsnag leaveBreadcrumbWithMessage:@"Hello"];
     [self waitForExpectations:@[expectation1] timeout:1.0];
 
@@ -183,7 +183,7 @@
     }];
 
     // Call onbreadcrumb blocks
-    [Bugsnag startBugsnagWithConfiguration:config];
+    [Bugsnag startWithConfiguration:config];
     XCTAssertEqual([[config onBreadcrumbBlocks] count], 1);
     NSDictionary *crumb = [[[[[Bugsnag client] configuration] breadcrumbs] arrayValue] firstObject];
     XCTAssertEqualObjects(@"Foo", crumb[@"name"]);
@@ -201,7 +201,7 @@
     }];
 
     // Call onbreadcrumb blocks
-    [Bugsnag startBugsnagWithConfiguration:config];
+    [Bugsnag startWithConfiguration:config];
     XCTAssertEqual([[config breadcrumbs].breadcrumbs count], 0);
     [Bugsnag leaveBreadcrumbWithMessage:@"Hello"];
     XCTAssertEqual([[config breadcrumbs].breadcrumbs count], 0);

--- a/Tests/BugsnagPluginTest.m
+++ b/Tests/BugsnagPluginTest.m
@@ -57,7 +57,7 @@
 
     BugsnagConfiguration *config = [[BugsnagConfiguration alloc] initWithApiKey:DUMMY_APIKEY_32CHAR_1];
     [config addPlugin:plugin];
-    [Bugsnag startBugsnagWithConfiguration:config];
+    [Bugsnag startWithConfiguration:config];
     [self waitForExpectations:@[expectation] timeout:3.0];
 }
 
@@ -69,7 +69,7 @@
 
     BugsnagConfiguration *config = [[BugsnagConfiguration alloc] initWithApiKey:DUMMY_APIKEY_32CHAR_1];
     [config addPlugin:plugin];
-    [Bugsnag startBugsnagWithConfiguration:config];
+    [Bugsnag startWithConfiguration:config];
     [self waitForExpectations:@[expectation] timeout:3.0];
 }
 

--- a/Tests/BugsnagSinkTests.m
+++ b/Tests/BugsnagSinkTests.m
@@ -55,7 +55,7 @@
     // set a dummy endpoint, avoid hitting production
     config.endpoints = [[BugsnagEndpointConfiguration alloc] initWithNotify:@"http://localhost:1234"
                                                                    sessions:@"http://localhost:1234"];
-    [Bugsnag startBugsnagWithConfiguration:config];
+    [Bugsnag startWithConfiguration:config];
     BugsnagEvent *report =
     [[BugsnagEvent alloc] initWithKSReport:self.rawReportData];
     self.processedData = [[BugsnagSink new] getBodyFromEvents:@[report]];

--- a/Tests/BugsnagTests.m
+++ b/Tests/BugsnagTests.m
@@ -48,7 +48,7 @@
             return false;
         }];
     }
-    [Bugsnag startBugsnagWithConfiguration:configuration];
+    [Bugsnag startWithConfiguration:configuration];
 }
 
 /**
@@ -153,7 +153,7 @@
         return false;
     }];
 
-    [Bugsnag startBugsnagWithConfiguration:configuration];
+    [Bugsnag startWithConfiguration:configuration];
 
     // For now only test that the method exists
     [Bugsnag pauseSession];
@@ -171,8 +171,8 @@
     [configuration addOnSendErrorBlock:^BOOL(BugsnagEvent *_Nonnull event) {
         return false;
     }];
-    
-    [Bugsnag startBugsnagWithConfiguration:configuration];
+
+    [Bugsnag startWithConfiguration:configuration];
 
     NSException *exception1 = [[NSException alloc] initWithName:@"exception1" reason:@"reason1" userInfo:nil];
 
@@ -273,7 +273,7 @@
 
     [configuration addOnSessionBlock:sessionBlock];
 
-    [Bugsnag startBugsnagWithConfiguration:configuration];
+    [Bugsnag startWithConfiguration:configuration];
     [self waitForExpectations:@[expectation1] timeout:1.0];
     
     [Bugsnag pauseSession];
@@ -317,8 +317,8 @@
     // NOTE: Due to test conditions the state of the Bugsnag/client class is indeterminate.
     //       We *should* be able to test that pre-start() calls to add/removeOnSessionBlock()
     //       do nothing, but actually we can't guarantee this.  For now we don't test this.
-    
-    [Bugsnag startBugsnagWithConfiguration:configuration];
+
+    [Bugsnag startWithConfiguration:configuration];
     [Bugsnag pauseSession];
 
     [Bugsnag addOnSessionBlock:sessionBlock];
@@ -411,8 +411,8 @@
     };
 
     // Can't check for block behaviour before start(), so we don't
-    
-    [Bugsnag startBugsnagWithConfiguration:configuration];
+
+    [Bugsnag startWithConfiguration:configuration];
 
     [Bugsnag addOnSendErrorBlock:block1];
     [Bugsnag addOnSendErrorBlock:block2];

--- a/UPGRADING.md
+++ b/UPGRADING.md
@@ -129,12 +129,18 @@ Bugsnag.getMetadata("section" key:"key")
 [Bugsnag getMetadata:@"section" key:@"key"];
 ```
 
-`startBugsnagWithApiKey` and `startBugsnagWithConfiguration` now return a `BugsnagClient`.
+`startWithApiKey` and `startWithConfiguration` now return a `BugsnagClient`.
 
 #### Renames
 
 ```diff
 ObjC:
+
+- [Bugsnag startBugsnagWithApiKey]
++ [Bugsnag startWithApiKey]
+
+- [Bugsnag startBugsnagWithConfiguration]
++ [Bugsnag startWithConfiguration]
 
 - [Bugsnag configuration]
 + [Bugsnag setUser:withEmail:andName:]
@@ -155,6 +161,11 @@ ObjC:
 + [Bugsnag notify:block:]
 
 Swift:
+- Bugsnag.startBugsnagWith(:apiKey)
++ Bugsnag.startWith(:apiKey)
+
+- Bugsnag.startBugsnagWith(:configuration)
++ Bugsnag.startWith(:configuration)
 
 - Bugsnag.configuration()
 + Bugsnag.setUser(_:email:name:)

--- a/examples/objective-c-ios/Bugsnag Test App/AppDelegate.m
+++ b/examples/objective-c-ios/Bugsnag Test App/AppDelegate.m
@@ -15,7 +15,7 @@
     
     NSString *apiKey = @"<YOUR_APIKEY_HERE>";
     BugsnagConfiguration *config = [[BugsnagConfiguration alloc] initWithApiKey:apiKey];
-    [Bugsnag startBugsnagWithConfiguration:config];
+    [Bugsnag startWithConfiguration:config];
     
     return YES;
 }

--- a/examples/objective-c-ios/Bugsnag Test App/ViewController.m
+++ b/examples/objective-c-ios/Bugsnag Test App/ViewController.m
@@ -67,8 +67,9 @@
         [NSJSONSerialization dataWithJSONObject:actuallyReallyJSON options:0 error:nil];
     }
     @catch (NSException *exception) {
-        [Bugsnag notify:exception block:^(BugsnagEvent * _Nonnull report) {
+        [Bugsnag notify:exception block:^BOOL(BugsnagEvent * _Nonnull report) {
             [report addMetadata:@{@"user": @"Bob Loblaw"} toSection:@"tab"];
+            return true;
         }];
     }
 }

--- a/examples/objective-c-osx/objective-c-osx/AppDelegate.m
+++ b/examples/objective-c-osx/objective-c-osx/AppDelegate.m
@@ -23,7 +23,7 @@ void exceptionHandler(NSException *ex) {
     
     NSString *apiKey = @"<YOUR_APIKEY_HERE>";
     BugsnagConfiguration *config = [[BugsnagConfiguration alloc] initWithApiKey:apiKey];
-    [Bugsnag startBugsnagWithConfiguration:config];
+    [Bugsnag startWithConfiguration:config];
     
 }
 

--- a/examples/swift-ios/bugsnag-example/ViewController.swift
+++ b/examples/swift-ios/bugsnag-example/ViewController.swift
@@ -63,6 +63,7 @@ class ViewController: UITableViewController {
             Bugsnag.notifyError(error) { report in
                 // modify report properties in the (optional) block
                 report.severity = .info
+                return true
             }
         }
     }

--- a/features/fixtures/ios-swift-cocoapods/iOSTestApp/scenarios/Scenario.m
+++ b/features/fixtures/ios-swift-cocoapods/iOSTestApp/scenarios/Scenario.m
@@ -41,7 +41,7 @@
 }
 
 - (void)startBugsnag {
-    [Bugsnag startBugsnagWithConfiguration:self.config];
+    [Bugsnag startWithConfiguration:self.config];
 }
 
 @end

--- a/iOS/BugsnagTests/BSGOutOfMemoryWatchdogTests.m
+++ b/iOS/BugsnagTests/BSGOutOfMemoryWatchdogTests.m
@@ -33,7 +33,7 @@
     config.autoDetectErrors = NO;
     config.releaseStage = @"MagicalTestingTime";
 
-    [Bugsnag startBugsnagWithConfiguration:config];
+    [Bugsnag startWithConfiguration:config];
 }
 
 - (void)testNilPathDoesNotCreateWatchdog {


### PR DESCRIPTION
## Goal

Renames the `startBugsnagWithApiKey` and `startBugsnagWithConfiguration` methods to remove 'Bugsnag' from the name, to make the method names comply more with the notifier spec.

All related usage of these methods has been updated in the codebase. Additionally, the example apps have been updated to return BOOLs in callbacks where they previously were not, which resulted in compilation errors.
