### PR TITLE
Add unhandledRejections to BugsnagErrorTypes

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,9 @@ Bugsnag Notifiers on other platforms.
 
 ## Enhancements
 
+* Add `unhandledRejections` to `BugsnagErrorTypes`
+  [#567](https://github.com/bugsnag/bugsnag-cocoa/pull/567)
+
 * Rename `OnSend` to `OnSendError`
   [#562](https://github.com/bugsnag/bugsnag-cocoa/pull/562)
 

--- a/Source/BugsnagErrorTypes.h
+++ b/Source/BugsnagErrorTypes.h
@@ -45,5 +45,12 @@
  */
 @property BOOL machExceptions;
 
+/**
+ * Sets whether Bugsnag should automatically capture and report unhandled promise rejections.
+ * This only applies to React Native apps.
+ * By default, this value is true.
+ */
+@property BOOL unhandledRejections;
+
 @end
 

--- a/Source/BugsnagErrorTypes.m
+++ b/Source/BugsnagErrorTypes.m
@@ -16,6 +16,7 @@
         _signals = true;
         _cppExceptions = true;
         _machExceptions = true;
+        _unhandledRejections = true;
 
 #if DEBUG
         _ooms = false;

--- a/Tests/BugsnagConfigurationTests.m
+++ b/Tests/BugsnagConfigurationTests.m
@@ -706,17 +706,20 @@
     XCTAssertTrue(config.enabledErrorTypes.cppExceptions);
     XCTAssertTrue(config.enabledErrorTypes.unhandledExceptions);
     XCTAssertTrue(config.enabledErrorTypes.machExceptions);
-    
+    XCTAssertTrue(config.enabledErrorTypes.unhandledRejections);
+
     // Test that we can set it
     config.enabledErrorTypes.ooms = false;
     config.enabledErrorTypes.signals = false;
     config.enabledErrorTypes.cppExceptions = false;
     config.enabledErrorTypes.unhandledExceptions = false;
+    config.enabledErrorTypes.unhandledRejections = false;
     config.enabledErrorTypes.machExceptions = false;
     XCTAssertFalse(config.enabledErrorTypes.ooms);
     XCTAssertFalse(config.enabledErrorTypes.signals);
     XCTAssertFalse(config.enabledErrorTypes.cppExceptions);
     XCTAssertFalse(config.enabledErrorTypes.unhandledExceptions);
+    XCTAssertFalse(config.enabledErrorTypes.unhandledRejections);
     XCTAssertFalse(config.enabledErrorTypes.machExceptions);
 }
 


### PR DESCRIPTION
## Goal

Adds the `unhandledRejections` property to the `BugsnagErrorTypes` class, as specified in the notifier spec. This is required to send the information to the JS layer in React Native, where it will be used to conditionally enable promise rejection detection.
