### PR TITLE
Import Bugsnag headers before reading preprocessor defines

### DIFF
--- a/Source/BSGOutOfMemoryWatchdog.m
+++ b/Source/BSGOutOfMemoryWatchdog.m
@@ -1,3 +1,5 @@
+#import "BSGOutOfMemoryWatchdog.h"
+
 #if (TARGET_OS_TV || TARGET_OS_IPHONE)
 #define BSGOOMAvailable 1
 #else
@@ -7,7 +9,6 @@
 #if BSGOOMAvailable
 #import <UIKit/UIKit.h>
 #endif
-#import "BSGOutOfMemoryWatchdog.h"
 #import "BSG_KSSystemInfo.h"
 #import "BugsnagLogger.h"
 #import "Bugsnag.h"

--- a/Source/BugsnagCrashReport.m
+++ b/Source/BugsnagCrashReport.m
@@ -6,8 +6,9 @@
 //
 //
 
-#if TARGET_OS_MAC || TARGET_OS_TV
-#elif TARGET_IPHONE_SIMULATOR || TARGET_OS_IPHONE
+#import "BugsnagCrashReport.h"
+
+#if TARGET_IPHONE_SIMULATOR || TARGET_OS_IPHONE
 #import <UIKit/UIKit.h>
 #include <sys/utsname.h>
 #endif

--- a/Source/BugsnagNotifier.m
+++ b/Source/BugsnagNotifier.m
@@ -458,8 +458,7 @@ NSString *const kAppWillTerminate = @"App Will Terminate";
     [[NSNotificationCenter defaultCenter] removeObserver:self];
     [self.networkReachable stopWatchingConnectivity];
 
-#if TARGET_OS_TV || TARGET_OS_MAC
-#elif TARGET_IPHONE_SIMULATOR || TARGET_OS_IPHONE
+#if TARGET_IPHONE_SIMULATOR || TARGET_OS_IPHONE
     [UIDevice currentDevice].batteryMonitoringEnabled = NO;
     [[UIDevice currentDevice] endGeneratingDeviceOrientationNotifications];
 #endif

--- a/Source/BugsnagNotifier.m
+++ b/Source/BugsnagNotifier.m
@@ -458,7 +458,8 @@ NSString *const kAppWillTerminate = @"App Will Terminate";
     [[NSNotificationCenter defaultCenter] removeObserver:self];
     [self.networkReachable stopWatchingConnectivity];
 
-#if TARGET_IPHONE_SIMULATOR || TARGET_OS_IPHONE
+#if TARGET_OS_TV
+#elif TARGET_IPHONE_SIMULATOR || TARGET_OS_IPHONE
     [UIDevice currentDevice].batteryMonitoringEnabled = NO;
     [[UIDevice currentDevice] endGeneratingDeviceOrientationNotifications];
 #endif


### PR DESCRIPTION
Summary:
- This change is a little different than https://github.com/bugsnag/bugsnag-react-native/pull/455 in that it just has .m files import their header files first thing.
- Also do not query `TARGET_OS_MAC` first as that is true for `TARGET_IOS_SIMULATOR`.

Test Plan:
- Debugging in Bugsnag for this code.
- I added a compiler error in every `TARGET_OS_IPHONE` conditional and ensured that they all worked. This is how I found the ones found in this diff.

## Goal

Fix building Bugsnag via Bazel

## Design

Ensure class headers are imported first, which brings in Foundation, which brings in TargetConditionals.h. This is typical code structure.

## Changeset

Change the imports of files so that preprocessor macros are defined when read.

## Tests

I added nonsense characters, to ensure that before the change would show that code wrapped in macro was not compiling, and that after the change it was. At runtime I was able to step into the `BSGOutOfMemoryWatchdog` which is usually preprocessor wrapped with `BSGOOMAvailable`, and it wasn't compiling for us.

## Review

### Outstanding Questions


<!-- Preflight checks. Have I:

* Added a changelog entry?
* Checked the scope to ensure the commits are only related to the goal above?

-->

- This pull request is ready for:
  - [ ] Initial review of the intended approach, not yet feature complete
  - [ ] Structural review of the classes, functions, and properties modified
  - [x] Final review
  - [ ] Release

<!-- What do you need from a reviewer to get this changeset
     ready for release -->

- [x] The correct target branch has been selected (`master` for fixes, `next` for
  features)
- [ ] If this is intended for release have all of the [pre-release checks](CONTRIBUTING.md) been considered?
- [ ] Consistency across platforms for structures or concepts added or modified
- [ ] Consistency between the changeset and the goal stated above
- [ ] Internal consistency with the rest of the library - is there any overlap between existing interfaces and any which have been added?
- [ ] Usage friction - is the proposed change in usage cumbersome or complicated?
- [ ] Performance and complexity - are there any cases of unexpected O(n^3) when iterating, recursing, flat mapping, etc?
- [ ] Concurrency concerns - if components are accessed asynchronously, what issues will arise
- [ ] Thoroughness of added tests and any missing edge cases
- [ ] Idiomatic use of the language
