### PR TITLE
Add methods for collecting payload info for react-native

### DIFF
--- a/OSX/Bugsnag.xcodeproj/project.pbxproj
+++ b/OSX/Bugsnag.xcodeproj/project.pbxproj
@@ -195,6 +195,7 @@
 		E79E6BDA1F4E3850002B35F9 /* BSG_RFC3339DateTool.m in Sources */ = {isa = PBXBuildFile; fileRef = E79E6B6E1F4E3850002B35F9 /* BSG_RFC3339DateTool.m */; };
 		E79E6BDB1F4E3850002B35F9 /* BSG_KSCrashReportFilter.h in Headers */ = {isa = PBXBuildFile; fileRef = E79E6B711F4E3850002B35F9 /* BSG_KSCrashReportFilter.h */; };
 		E79E6BDC1F4E3850002B35F9 /* BSG_KSCrashReportFilterCompletion.h in Headers */ = {isa = PBXBuildFile; fileRef = E79E6B721F4E3850002B35F9 /* BSG_KSCrashReportFilterCompletion.h */; };
+		E7A5679D245B0511009BE2F1 /* BugsnagClientPayloadInfoTest.m in Sources */ = {isa = PBXBuildFile; fileRef = E7A5678A245AE7AF009BE2F1 /* BugsnagClientPayloadInfoTest.m */; };
 		E7A9E56924361B6300D99F8A /* BugsnagAppTest.m in Sources */ = {isa = PBXBuildFile; fileRef = E790C4A22434CB6A006FFB26 /* BugsnagAppTest.m */; };
 		E7A9E56D2436365300D99F8A /* BugsnagDeviceTest.m in Sources */ = {isa = PBXBuildFile; fileRef = E7A9E56C2436365300D99F8A /* BugsnagDeviceTest.m */; };
 		E7AB4B9E2423E184004F015A /* BugsnagOnBreadcrumbTest.m in Sources */ = {isa = PBXBuildFile; fileRef = E7AB4B9D2423E184004F015A /* BugsnagOnBreadcrumbTest.m */; };
@@ -433,6 +434,7 @@
 		E79E6B6E1F4E3850002B35F9 /* BSG_RFC3339DateTool.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; name = BSG_RFC3339DateTool.m; path = ../Source/KSCrash/Source/KSCrash/Recording/Tools/BSG_RFC3339DateTool.m; sourceTree = SOURCE_ROOT; };
 		E79E6B711F4E3850002B35F9 /* BSG_KSCrashReportFilter.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; name = BSG_KSCrashReportFilter.h; path = ../Source/KSCrash/Source/KSCrash/Reporting/Filters/BSG_KSCrashReportFilter.h; sourceTree = SOURCE_ROOT; };
 		E79E6B721F4E3850002B35F9 /* BSG_KSCrashReportFilterCompletion.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; name = BSG_KSCrashReportFilterCompletion.h; path = ../Source/KSCrash/Source/KSCrash/Reporting/Filters/BSG_KSCrashReportFilterCompletion.h; sourceTree = SOURCE_ROOT; };
+		E7A5678A245AE7AF009BE2F1 /* BugsnagClientPayloadInfoTest.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; path = BugsnagClientPayloadInfoTest.m; sourceTree = "<group>"; };
 		E7A9E56C2436365300D99F8A /* BugsnagDeviceTest.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; path = BugsnagDeviceTest.m; sourceTree = "<group>"; };
 		E7AB4B9D2423E184004F015A /* BugsnagOnBreadcrumbTest.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; path = BugsnagOnBreadcrumbTest.m; sourceTree = "<group>"; };
 		E7CE78871FD94E5F001D07E0 /* KSMach_Tests.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; path = KSMach_Tests.m; sourceTree = "<group>"; };
@@ -562,6 +564,7 @@
 				00F9393223FC168F008C7073 /* BugsnagBaseUnitTest.m */,
 				8A2C8FE01C6BC38200846019 /* BugsnagBreadcrumbsTest.m */,
 				E790C41F2432314A006FFB26 /* BugsnagClientMirrorTest.m */,
+				E7A5678A245AE7AF009BE2F1 /* BugsnagClientPayloadInfoTest.m */,
 				E71DB9D924470FCF00D0161E /* BugsnagClientTests.m */,
 				4B406C1622CAD96400464D1D /* BugsnagCollectionsBSGDictMergeTest.m */,
 				4B406C1722CAD96400464D1D /* BugsnagCollectionsBSGDictSetSafeObjectTest.m */,
@@ -1207,6 +1210,7 @@
 				8AD1E3FA23EDDD4F0044F919 /* BSGConnectivityTest.m in Sources */,
 				E7CE78C41FD94E77001D07E0 /* KSJSONCodec_Tests.m in Sources */,
 				E7CE78C01FD94E77001D07E0 /* KSCrashSentry_Tests.m in Sources */,
+				E7A5679D245B0511009BE2F1 /* BugsnagClientPayloadInfoTest.m in Sources */,
 				00F9393323FC168F008C7073 /* BugsnagBaseUnitTest.m in Sources */,
 				E7CE78BE1FD94E77001D07E0 /* KSCrashSentry_NSException_Tests.m in Sources */,
 				E7CE78C21FD94E77001D07E0 /* KSDynamicLinker_Tests.m in Sources */,

--- a/Source/BugsnagClient.m
+++ b/Source/BugsnagClient.m
@@ -103,6 +103,14 @@ static bool hasRecordedSessions;
 @property NSUInteger handledCount;
 @end
 
+
+@interface BugsnagAppWithState ()
++ (BugsnagAppWithState *)appWithDictionary:(NSDictionary *)event
+                                    config:(BugsnagConfiguration *)config
+                              codeBundleId:(NSString *)codeBundleId;
+- (NSDictionary *)toDict;
+@end
+
 /**
  *  Handler executed when the application crashes. Writes information about the
  *  current application state using the crash report writer.
@@ -1411,6 +1419,34 @@ NSString *const BSGBreadcrumbLoadedMessage = @"Bugsnag loaded";
                        withKey:(NSString *_Nonnull)key
 {
     [self.metadata clearMetadataFromSection:sectionName withKey:key];
+}
+
+// MARK: - methods used by React Native for collecting payload data
+
+- (NSDictionary *)collectAppWithState {
+    NSDictionary *systemInfo = [BSG_KSSystemInfo systemInfo];
+    BugsnagAppWithState *app = [BugsnagAppWithState appWithDictionary:@{@"system": systemInfo}
+                                                               config:self.configuration
+                                                         codeBundleId:self.codeBundleId];
+    return [app toDict];
+}
+
+- (NSDictionary *)collectDeviceWithState {
+    return @{
+        // TODO implement
+    };
+}
+
+- (NSArray *)collectBreadcrumbs {
+    return @[
+        // TODO implement
+    ];
+}
+
+- (NSArray *)collectThreads {
+    return @[
+        // TODO implement
+    ];
 }
 
 @end

--- a/Source/BugsnagClient.m
+++ b/Source/BugsnagClient.m
@@ -111,6 +111,11 @@ static bool hasRecordedSessions;
 - (NSDictionary *)toDict;
 @end
 
+@interface BugsnagDeviceWithState ()
++ (BugsnagDeviceWithState *)deviceWithDictionary:(NSDictionary *)event;
+- (NSDictionary *)toDictionary;
+@end
+
 /**
  *  Handler executed when the application crashes. Writes information about the
  *  current application state using the crash report writer.
@@ -1432,9 +1437,9 @@ NSString *const BSGBreadcrumbLoadedMessage = @"Bugsnag loaded";
 }
 
 - (NSDictionary *)collectDeviceWithState {
-    return @{
-        // TODO implement
-    };
+    NSDictionary *systemInfo = [BSG_KSSystemInfo systemInfo];
+    BugsnagDeviceWithState *device = [BugsnagDeviceWithState deviceWithDictionary:@{@"system": systemInfo}];
+    return [device toDictionary];
 }
 
 - (NSArray *)collectBreadcrumbs {

--- a/Source/BugsnagDeviceWithState.m
+++ b/Source/BugsnagDeviceWithState.m
@@ -90,7 +90,7 @@ NSNumber *BSGDeviceFreeSpace(NSSearchPathDirectory directory) {
     BugsnagDeviceWithState *device = [BugsnagDeviceWithState new];
     [self populateFields:device dictionary:event];
     device.orientation = [event valueForKeyPath:@"user.state.deviceState.orientation"];
-    device.freeMemory = [event valueForKeyPath:@"system.memory.free"];
+    device.freeMemory = [event valueForKeyPath:@"system.memory.free"] ?: [event valueForKeyPath:@"system.memory.usable"];
     device.freeDisk = BSGDeviceFreeSpace(NSCachesDirectory);
 
     NSString *val = [event valueForKeyPath:@"report.timestamp"];

--- a/Tests/BugsnagClientMirrorTest.m
+++ b/Tests/BugsnagClientMirrorTest.m
@@ -92,7 +92,11 @@
             @"startListeningForWorkspaceStateChangeNotifications: v24@0:8@16",
             @"codeBundleId @16@0:8",
             @"setCodeBundleId: v24@0:8@16",
-            @"context @16@0:8"
+            @"context @16@0:8",
+            @"collectAppWithState @16@0:8",
+            @"collectBreadcrumbs @16@0:8",
+            @"collectThreads @16@0:8",
+            @"collectDeviceWithState @16@0:8"
     ]];
 
     // the following methods are implemented on Bugsnag but do not need to

--- a/Tests/BugsnagClientPayloadInfoTest.m
+++ b/Tests/BugsnagClientPayloadInfoTest.m
@@ -1,0 +1,49 @@
+//
+//  BugsnagClientPayloadInfoTest.m
+//  Tests
+//
+//  Created by Jamie Lynch on 30/04/2020.
+//  Copyright © 2020 Bugsnag. All rights reserved.
+//
+
+#import <XCTest/XCTest.h>
+#import "Bugsnag.h"
+#import "BugsnagConfiguration.h"
+#import "BugsnagTestConstants.h"
+
+@interface Bugsnag ()
++ (BugsnagClient *)client;
+@end
+
+@interface BugsnagClient ()
+- (NSDictionary *)collectAppWithState;
+- (NSDictionary *)collectDeviceWithState;
+- (NSArray *)collectBreadcrumbs;
+- (NSArray *)collectThreads;
+@property NSString *codeBundleId;
+@end
+
+@interface BugsnagClientPayloadInfoTest : XCTestCase
+
+@end
+
+@implementation BugsnagClientPayloadInfoTest
+
+- (void)setUp {
+    BugsnagConfiguration *configuration = [[BugsnagConfiguration alloc] initWithApiKey:DUMMY_APIKEY_32CHAR_1];
+    [Bugsnag startWithConfiguration:configuration];
+}
+
+- (void)testAppInfo {
+    BugsnagClient *client = [Bugsnag client];
+    client.codeBundleId = @"f00123";
+    NSDictionary *app = [client collectAppWithState];
+    XCTAssertNotNil(app);
+
+    NSArray *observedKeys = [[app allKeys] sortedArrayUsingSelector:@selector(localizedCaseInsensitiveCompare:)];
+    NSArray *expectedKeys = @[@"bundleVersion", @"codeBundleId", @"dsymUUIDs", @"duration", @"durationInForeground",
+            @"id", @"inForeground", @"releaseStage", @"type", @"version"];
+    XCTAssertEqualObjects(observedKeys, expectedKeys);
+}
+
+@end

--- a/Tests/BugsnagClientPayloadInfoTest.m
+++ b/Tests/BugsnagClientPayloadInfoTest.m
@@ -46,4 +46,20 @@
     XCTAssertEqualObjects(observedKeys, expectedKeys);
 }
 
+- (void)testDeviceInfo {
+    BugsnagClient *client = [Bugsnag client];
+    NSDictionary *device = [client collectDeviceWithState];
+    XCTAssertNotNil(device);
+
+    NSArray *observedKeys = [[device allKeys] sortedArrayUsingSelector:@selector(localizedCaseInsensitiveCompare:)];
+    NSMutableArray *expectedKeys = [@[@"freeDisk", @"freeMemory", @"id", @"jailbroken", @"locale", @"manufacturer",
+            @"model", @"osName", @"osVersion", @"runtimeVersions", @"totalMemory"] mutableCopy];
+
+#if TARGET_IPHONE_SIMULATOR || TARGET_OS_IPHONE
+    [expectedKeys addObject:@"modelNumber"];
+#endif
+
+    XCTAssertEqualObjects(observedKeys, [expectedKeys sortedArrayUsingSelector:@selector(localizedCaseInsensitiveCompare:)]);
+}
+
 @end

--- a/iOS/Bugsnag.xcodeproj/project.pbxproj
+++ b/iOS/Bugsnag.xcodeproj/project.pbxproj
@@ -360,6 +360,7 @@
 		E79148281FD828E6003EFEBF /* BugsnagSessionTrackingPayload.h in CopyFiles */ = {isa = PBXBuildFile; fileRef = E78C1EF41FCC61EA00B976D3 /* BugsnagSessionTrackingPayload.h */; };
 		E79148291FD828E6003EFEBF /* BugsnagUser.h in CopyFiles */ = {isa = PBXBuildFile; fileRef = E72BF77D1FC86A7A004BE82F /* BugsnagUser.h */; };
 		E794E8031F9F743D00A67EE7 /* BugsnagKeys.h in Headers */ = {isa = PBXBuildFile; fileRef = E794E8021F9F743D00A67EE7 /* BugsnagKeys.h */; };
+		E7A56789245AE79C009BE2F1 /* BugsnagClientPayloadInfoTest.m in Sources */ = {isa = PBXBuildFile; fileRef = E7A56788245AE79C009BE2F1 /* BugsnagClientPayloadInfoTest.m */; };
 		E7A9E56B2436363900D99F8A /* BugsnagDeviceTest.m in Sources */ = {isa = PBXBuildFile; fileRef = E7A9E56A2436363900D99F8A /* BugsnagDeviceTest.m */; };
 		E7AB4B9C2423E16C004F015A /* BugsnagOnBreadcrumbTest.m in Sources */ = {isa = PBXBuildFile; fileRef = E7AB4B9B2423E16C004F015A /* BugsnagOnBreadcrumbTest.m */; };
 		E7B3291A1FD707EC0098FC47 /* KSCrashReportConverter_Tests.m in Sources */ = {isa = PBXBuildFile; fileRef = E7B329171FD707EC0098FC47 /* KSCrashReportConverter_Tests.m */; };
@@ -718,6 +719,7 @@
 		E790C49A2434C8C8006FFB26 /* BugsnagAppTest.m */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.objc; name = BugsnagAppTest.m; path = ../../Tests/BugsnagAppTest.m; sourceTree = "<group>"; };
 		E794E8021F9F743D00A67EE7 /* BugsnagKeys.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; name = BugsnagKeys.h; path = ../Source/BugsnagKeys.h; sourceTree = SOURCE_ROOT; };
 		E79FEBE61F4CB1320048FAD6 /* Foundation.framework */ = {isa = PBXFileReference; lastKnownFileType = wrapper.framework; name = Foundation.framework; path = System/Library/Frameworks/Foundation.framework; sourceTree = SDKROOT; };
+		E7A56788245AE79C009BE2F1 /* BugsnagClientPayloadInfoTest.m */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.objc; name = BugsnagClientPayloadInfoTest.m; path = ../../Tests/BugsnagClientPayloadInfoTest.m; sourceTree = "<group>"; };
 		E7A9E56A2436363900D99F8A /* BugsnagDeviceTest.m */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.objc; name = BugsnagDeviceTest.m; path = ../../Tests/BugsnagDeviceTest.m; sourceTree = "<group>"; };
 		E7AB4B9B2423E16C004F015A /* BugsnagOnBreadcrumbTest.m */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.objc; name = BugsnagOnBreadcrumbTest.m; path = ../../Tests/BugsnagOnBreadcrumbTest.m; sourceTree = "<group>"; };
 		E7B329171FD707EC0098FC47 /* KSCrashReportConverter_Tests.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; name = KSCrashReportConverter_Tests.m; path = ../Tests/KSCrash/KSCrashReportConverter_Tests.m; sourceTree = SOURCE_ROOT; };
@@ -880,6 +882,7 @@
 				8A2C8F8B1C6BBFDD00846019 /* BugsnagBreadcrumbsTest.m */,
 				0089B70224221EDE00D5A7F2 /* BugsnagClientTests.m */,
 				E790C41D24323102006FFB26 /* BugsnagClientMirrorTest.m */,
+				E7A56788245AE79C009BE2F1 /* BugsnagClientPayloadInfoTest.m */,
 				4B3B193422CA7B0900475354 /* BugsnagCollectionsBSGDictSetSafeObjectTest.m */,
 				4B775FCE22CBDEB4004839C5 /* BugsnagCollectionsBSGDictInsertIfNotNilTest.m */,
 				4BE6C42522CAD61A0056305D /* BugsnagCollectionsBSGDictMergeTest.m */,
@@ -1553,6 +1556,7 @@
 				E722105C243B69F00083CF15 /* BugsnagStackframeTest.m in Sources */,
 				8A2C8F911C6BBFDD00846019 /* BugsnagSinkTests.m in Sources */,
 				E790C41E24323102006FFB26 /* BugsnagClientMirrorTest.m in Sources */,
+				E7A56789245AE79C009BE2F1 /* BugsnagClientPayloadInfoTest.m in Sources */,
 				E784D2551FD70B3B004B01E1 /* KSCrashState_Tests.m in Sources */,
 				00D7ACAD23E9C63000FBE4A7 /* BugsnagTests.m in Sources */,
 				8A2C8F901C6BBFDD00846019 /* BugsnagEventTests.m in Sources */,

--- a/tvOS/Bugsnag.xcodeproj/project.pbxproj
+++ b/tvOS/Bugsnag.xcodeproj/project.pbxproj
@@ -202,6 +202,7 @@
 		E79148901FD82E77003EFEBF /* BugsnagSessionTest.m in Sources */ = {isa = PBXBuildFile; fileRef = E791488C1FD82E77003EFEBF /* BugsnagSessionTest.m */; };
 		E79148911FD82E77003EFEBF /* BugsnagUserTest.m in Sources */ = {isa = PBXBuildFile; fileRef = E791488D1FD82E77003EFEBF /* BugsnagUserTest.m */; };
 		E794E8071F9F748100A67EE7 /* BugsnagKeys.h in Headers */ = {isa = PBXBuildFile; fileRef = E794E8061F9F748100A67EE7 /* BugsnagKeys.h */; };
+		E7A5678D245AE7C1009BE2F1 /* BugsnagClientPayloadInfoTest.m in Sources */ = {isa = PBXBuildFile; fileRef = E7A5678C245AE7C0009BE2F1 /* BugsnagClientPayloadInfoTest.m */; };
 		E7A9E56F2436366800D99F8A /* BugsnagDeviceTest.m in Sources */ = {isa = PBXBuildFile; fileRef = E7A9E56E2436366800D99F8A /* BugsnagDeviceTest.m */; };
 		E7CE78F21FD94F1B001D07E0 /* KSMach_Tests.m in Sources */ = {isa = PBXBuildFile; fileRef = E7CE78D81FD94F18001D07E0 /* KSMach_Tests.m */; };
 		E7CE78F31FD94F1B001D07E0 /* NSError+SimpleConstructor_Tests.m in Sources */ = {isa = PBXBuildFile; fileRef = E7CE78D91FD94F18001D07E0 /* NSError+SimpleConstructor_Tests.m */; };
@@ -438,6 +439,7 @@
 		E791488C1FD82E77003EFEBF /* BugsnagSessionTest.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; name = BugsnagSessionTest.m; path = ../../Tests/BugsnagSessionTest.m; sourceTree = "<group>"; };
 		E791488D1FD82E77003EFEBF /* BugsnagUserTest.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; name = BugsnagUserTest.m; path = ../../Tests/BugsnagUserTest.m; sourceTree = "<group>"; };
 		E794E8061F9F748100A67EE7 /* BugsnagKeys.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; name = BugsnagKeys.h; path = ../Source/BugsnagKeys.h; sourceTree = "<group>"; };
+		E7A5678C245AE7C0009BE2F1 /* BugsnagClientPayloadInfoTest.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; name = BugsnagClientPayloadInfoTest.m; path = ../../Tests/BugsnagClientPayloadInfoTest.m; sourceTree = "<group>"; };
 		E7A9E56E2436366800D99F8A /* BugsnagDeviceTest.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; name = BugsnagDeviceTest.m; path = ../../Tests/BugsnagDeviceTest.m; sourceTree = "<group>"; };
 		E7CE78D81FD94F18001D07E0 /* KSMach_Tests.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; path = KSMach_Tests.m; sourceTree = "<group>"; };
 		E7CE78D91FD94F18001D07E0 /* NSError+SimpleConstructor_Tests.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; path = "NSError+SimpleConstructor_Tests.m"; sourceTree = "<group>"; };
@@ -569,6 +571,7 @@
 				00F9393523FC16DA008C7073 /* BugsnagBaseUnitTest.m */,
 				8AB1511D1D41361700C9B218 /* BugsnagBreadcrumbsTest.m */,
 				E790C421243231EA006FFB26 /* BugsnagClientMirrorTest.m */,
+				E7A5678C245AE7C0009BE2F1 /* BugsnagClientPayloadInfoTest.m */,
 				4B406C1322CAD94100464D1D /* BugsnagCollectionsBSGDictMergeTest.m */,
 				4B406C1222CAD94100464D1D /* BugsnagCollectionsBSGDictSetSafeObjectTest.m */,
 				4B775FD022CBE01F004839C5 /* BugsnagCollectionsBSGDictInsertIfNotNilTest.m */,
@@ -1219,6 +1222,7 @@
 				E791488E1FD82E77003EFEBF /* BugsnagSessionTrackerTest.m in Sources */,
 				E79148901FD82E77003EFEBF /* BugsnagSessionTest.m in Sources */,
 				8AB151211D41361700C9B218 /* BugsnagBreadcrumbsTest.m in Sources */,
+				E7A5678D245AE7C1009BE2F1 /* BugsnagClientPayloadInfoTest.m in Sources */,
 				E7CE78F81FD94F1B001D07E0 /* KSCrashSentry_Tests.m in Sources */,
 				E7CE78F51FD94F1B001D07E0 /* XCTestCase+KSCrash.m in Sources */,
 				8A530CC622FDD71B00F0C108 /* KSCrashIdentifierTests.m in Sources */,


### PR DESCRIPTION
## Goal

Adds method signatures for the collection of payload info for react-native. In React Native, the JS layer requests app/device/breadcrumb/thread information from the native layer and adds it to JS errors. This adds methods which will be used the `BugsnagReactNative` class to obtain this info.

## Changeset
- Added private methods to `BugsnagClient` for collecting info
- Implemented method for gathering `AppWithState` info
- Added unit test to verify method captures fields correctly (the contents of fields are tested separately in existing coverage)