### PR TITLE
Collect device info for react native payload

### DIFF
--- a/Source/BugsnagClient.m
+++ b/Source/BugsnagClient.m
@@ -111,6 +111,11 @@ static bool hasRecordedSessions;
 - (NSDictionary *)toDict;
 @end
 
+@interface BugsnagDeviceWithState ()
++ (BugsnagDeviceWithState *)deviceWithDictionary:(NSDictionary *)event;
+- (NSDictionary *)toDictionary;
+@end
+
 /**
  *  Handler executed when the application crashes. Writes information about the
  *  current application state using the crash report writer.
@@ -1432,9 +1437,9 @@ NSString *const BSGBreadcrumbLoadedMessage = @"Bugsnag loaded";
 }
 
 - (NSDictionary *)collectDeviceWithState {
-    return @{
-        // TODO implement
-    };
+    NSDictionary *systemInfo = [BSG_KSSystemInfo systemInfo];
+    BugsnagDeviceWithState *device = [BugsnagDeviceWithState deviceWithDictionary:@{@"system": systemInfo}];
+    return [device toDictionary];
 }
 
 - (NSArray *)collectBreadcrumbs {

--- a/Source/BugsnagDeviceWithState.m
+++ b/Source/BugsnagDeviceWithState.m
@@ -90,7 +90,7 @@ NSNumber *BSGDeviceFreeSpace(NSSearchPathDirectory directory) {
     BugsnagDeviceWithState *device = [BugsnagDeviceWithState new];
     [self populateFields:device dictionary:event];
     device.orientation = [event valueForKeyPath:@"user.state.deviceState.orientation"];
-    device.freeMemory = [event valueForKeyPath:@"system.memory.free"];
+    device.freeMemory = [event valueForKeyPath:@"system.memory.free"] ?: [event valueForKeyPath:@"system.memory.usable"];
     device.freeDisk = BSGDeviceFreeSpace(NSCachesDirectory);
 
     NSString *val = [event valueForKeyPath:@"report.timestamp"];

--- a/Tests/BugsnagClientPayloadInfoTest.m
+++ b/Tests/BugsnagClientPayloadInfoTest.m
@@ -46,4 +46,20 @@
     XCTAssertEqualObjects(observedKeys, expectedKeys);
 }
 
+- (void)testDeviceInfo {
+    BugsnagClient *client = [Bugsnag client];
+    NSDictionary *device = [client collectDeviceWithState];
+    XCTAssertNotNil(device);
+
+    NSArray *observedKeys = [[device allKeys] sortedArrayUsingSelector:@selector(localizedCaseInsensitiveCompare:)];
+    NSMutableArray *expectedKeys = [@[@"freeDisk", @"freeMemory", @"id", @"jailbroken", @"locale", @"manufacturer",
+            @"model", @"osName", @"osVersion", @"runtimeVersions", @"totalMemory"] mutableCopy];
+
+#if TARGET_IPHONE_SIMULATOR || TARGET_OS_IPHONE
+    [expectedKeys addObject:@"modelNumber"];
+#endif
+
+    XCTAssertEqualObjects(observedKeys, [expectedKeys sortedArrayUsingSelector:@selector(localizedCaseInsensitiveCompare:)]);
+}
+
 @end


### PR DESCRIPTION
## Goal

Adds method signatures for the collection of payload info for react-native. In React Native, the JS layer requests device information from the native layer and adds it to JS errors. This adds methods which will be used the BugsnagReactNative class to obtain this info.

## Changeset

- Implemented method for gathering `DeviceWithState` info
- Updated `device.freeMemory` to parse the dictionary for `system.memory.usable`, as this value is recorded in a different key compared to when a report is persisted on disk
- Added unit test to verify method captures fields correctly (the contents of fields are tested separately in existing coverage)
