### PR TITLE
Collect breadcrumbs for react-native payload

### DIFF
--- a/Source/BugsnagClient.m
+++ b/Source/BugsnagClient.m
@@ -336,6 +336,10 @@ void BSGWriteSessionCrashData(BugsnagSession *session) {
 + (NSDateFormatter *_Nonnull)payloadDateFormatter;
 @end
 
+@interface BugsnagBreadcrumbs ()
+@property(nonatomic, readwrite, strong) NSMutableArray *breadcrumbs;
+@end
+
 // =============================================================================
 // MARK: - BugsnagClient
 // =============================================================================
@@ -1443,9 +1447,19 @@ NSString *const BSGBreadcrumbLoadedMessage = @"Bugsnag loaded";
 }
 
 - (NSArray *)collectBreadcrumbs {
-    return @[
-        // TODO implement
-    ];
+    NSMutableArray *crumbs = self.configuration.breadcrumbs.breadcrumbs;
+    NSMutableArray *data = [NSMutableArray new];
+
+    for (BugsnagBreadcrumb *crumb in crumbs) {
+        NSMutableDictionary *crumbData = [[crumb objectValue] mutableCopy];
+        // JSON is serialized as 'name', we want as 'message' when passing to RN
+        crumbData[@"message"] = crumbData[@"name"];
+        crumbData[@"name"] = nil;
+        crumbData[@"metadata"] = crumbData[@"metaData"];
+        crumbData[@"metaData"] = nil;
+        [data addObject: crumbData];
+    }
+    return data;
 }
 
 - (NSArray *)collectThreads {

--- a/Tests/BugsnagClientPayloadInfoTest.m
+++ b/Tests/BugsnagClientPayloadInfoTest.m
@@ -62,4 +62,18 @@
     XCTAssertEqualObjects(observedKeys, [expectedKeys sortedArrayUsingSelector:@selector(localizedCaseInsensitiveCompare:)]);
 }
 
+- (void)testBreadcrumbInfo {
+    BugsnagClient *client = [Bugsnag client];
+    [client leaveBreadcrumbWithMessage:@"Hello World"];
+    NSArray *breadcrumbs = [client collectBreadcrumbs];
+    XCTAssertNotNil(breadcrumbs);
+    XCTAssertTrue([breadcrumbs count] > 0);
+
+    for (NSDictionary *crumb in breadcrumbs) {
+        XCTAssertNotNil(crumb[@"message"]);
+        XCTAssertNotNil(crumb[@"type"]);
+        XCTAssertNotNil(crumb[@"timestamp"]);
+    }
+}
+
 @end


### PR DESCRIPTION
## Goal

Adds collection of breadcrumb info method for react-native. In React Native, the JS layer requests breadcrumb information from the native layer and adds it to JS errors.

## Changeset

- Implemented method for gathering `Breadcrumb` info
- Added unit test to verify method captures fields correctly (the contents of fields are tested separately in existing coverage)
