### PR TITLE
Add notifyInternal method to BugsnagClient

### DIFF
--- a/Source/Bugsnag.m
+++ b/Source/Bugsnag.m
@@ -56,9 +56,8 @@ static BugsnagClient *bsg_g_bugsnag_client = NULL;
 @interface BugsnagClient ()
 - (void)startListeningForStateChangeNotification:(NSString *_Nonnull)notificationName;
 - (void)addBreadcrumbWithBlock:(void (^_Nonnull)(BugsnagBreadcrumb *_Nonnull))block;
-- (void)internalClientNotify:(NSException *_Nonnull)exception
-                    withData:(NSDictionary *_Nullable)metadata
-                       block:(BugsnagOnErrorBlock _Nullable)block;
+- (void)notifyInternal:(BugsnagEvent *_Nonnull)event
+                 block:(BugsnagOnErrorBlock)block;
 @property (nonatomic) NSString *codeBundleId;
 @end
 
@@ -156,13 +155,11 @@ static BugsnagClient *bsg_g_bugsnag_client = NULL;
  * Intended for use by other clients (React Native/Unity). Calling this method
  * directly from iOS is not supported.
  */
-+ (void)internalClientNotify:(NSException *_Nonnull)exception
-                    withData:(NSDictionary *_Nullable)metadata
-                       block:(BugsnagOnErrorBlock _Nullable)block {
++ (void)notifyInternal:(BugsnagEvent *_Nonnull)event
+                 block:(BugsnagOnErrorBlock)block {
     if ([self bugsnagStarted]) {
-        [self.client internalClientNotify:exception
-                                   withData:metadata
-                                      block:block];
+        [self.client notifyInternal:event
+                              block:block];
     }
 }
 

--- a/Source/BugsnagClient.m
+++ b/Source/BugsnagClient.m
@@ -59,7 +59,7 @@ NSString *const BSTabCrash = @"crash";
 NSString *const BSAttributeDepth = @"depth";
 NSString *const BSEventLowMemoryWarning = @"lowMemoryWarning";
 
-static NSInteger const BSGNotifierStackFrameCount = 5;
+static NSInteger const BSGNotifierStackFrameCount = 6;
 
 struct bugsnag_data_t {
     // Contains the state of the event (handled/unhandled)
@@ -841,35 +841,6 @@ NSString *const BSGBreadcrumbLoadedMessage = @"Bugsnag loaded";
     [self notify:exception handledState:state block:block];
 }
 
-/**
- *  Notify Bugsnag of an exception. Only intended for React Native/Unity use.
- *
- *  @param exception the exception
- *  @param metadata  the metadata
- *  @param block     Configuration block for adding additional report
- * information
- */
-- (void)internalClientNotify:(NSException *_Nonnull)exception
-                    withData:(NSDictionary *_Nullable)metadata
-                       block:(BugsnagOnErrorBlock _Nullable)block
-{
-    BSGSeverity severity = BSGParseSeverity(metadata[BSGKeySeverity]);
-    NSString *severityReason = metadata[BSGKeySeverityReason];
-    BOOL unhandled = [metadata[BSGKeyUnhandled] boolValue];
-    NSString *logLevel = metadata[BSGKeyLogLevel];
-    NSParameterAssert(severityReason.length > 0);
-
-    SeverityReasonType severityReasonType =
-        [BugsnagHandledState severityReasonFromString:severityReason];
-
-    BugsnagHandledState *state = [[BugsnagHandledState alloc] initWithSeverityReason:severityReasonType
-                                                                            severity:severity
-                                                                           unhandled:unhandled
-                                                                           attrValue:logLevel];
-
-    [self notify:exception handledState:state block:block];
-}
-
 - (void)notifyOutOfMemoryEvent {
     static NSString *const BSGOutOfMemoryErrorClass = @"Out Of Memory";
     static NSString *const BSGOutOfMemoryMessageFormat = @"The app was likely terminated by the operating system while in the %@";
@@ -915,11 +886,6 @@ NSString *const BSGBreadcrumbLoadedMessage = @"Bugsnag loaded";
 {
     NSString *exceptionName = exception.name ?: NSStringFromClass([exception class]);
     NSString *message = exception.reason;
-    if (handledState.unhandled) {
-        [self.sessionTracker handleUnhandledErrorEvent];
-    } else {
-        [self.sessionTracker handleHandledErrorEvent];
-    }
 
     BugsnagEvent *event = [[BugsnagEvent alloc] initWithErrorName:exceptionName
                                                      errorMessage:message
@@ -928,12 +894,29 @@ NSString *const BSGBreadcrumbLoadedMessage = @"Bugsnag loaded";
                                                      handledState:handledState
                                                           session:self.sessionTracker.runningSession];
     event.originalError = exception;
-    
+    [self notifyInternal:event block:block];
+}
+
+/**
+ *  Notify Bugsnag of an exception. Only intended for React Native/Unity use.
+ *
+ *  @param event    the event
+ *  @param block     Configuration block for adding additional report information
+ */
+- (void)notifyInternal:(BugsnagEvent *_Nonnull)event
+                 block:(BugsnagOnErrorBlock)block
+{
     if (block != nil && !block(event)) { // skip notifying if callback false
         return;
     }
-    
-    //    We discard 5 stack frames (including this one) by default,
+
+    if (event.handledState.unhandled) {
+        [self.sessionTracker handleUnhandledErrorEvent];
+    } else {
+        [self.sessionTracker handleHandledErrorEvent];
+    }
+
+    //    We discard 6 stack frames (including this one) by default,
     //    and sum that with the number specified by report.depth:
     //
     //    0 bsg_kscrashsentry_reportUserException
@@ -941,35 +924,42 @@ NSString *const BSGBreadcrumbLoadedMessage = @"Bugsnag loaded";
     //    2 -[BSG_KSCrash
     //    reportUserException:reason:language:lineOfCode:stackTrace:terminateProgram:]
     //    3 -[BugsnagCrashSentry reportUserException:reason:]
-    //    4 -[BugsnagClient notify:message:block:]
+    //    4 -[BugsnagClient notifyInternal:block:]
+    //    5 -[BugsnagClient notify:message:block:]
 
     int depth = (int)(BSGNotifierStackFrameCount + event.depth);
 
     NSString *eventErrorClass = event.errors[0].errorClass ?: NSStringFromClass([NSException class]);
     NSString *eventMessage = event.errors[0].errorMessage ?: @"";
 
+    NSException *exc = nil;
+
+    if ([event.originalError isKindOfClass:[NSException class]]) {
+        exc = event.originalError;
+    }
+
     [self.crashSentry reportUserException:eventErrorClass
                                    reason:eventMessage
-                        originalException:exception
-                             handledState:[handledState toJson]
+                        originalException:exc
+                             handledState:[event.handledState toJson]
                                  appState:[self.state toDictionary]
                         callbackOverrides:event.overrides
                                  metadata:[event.metadata toDictionary]
                                    config:[self.configuration.config toDictionary]
                              discardDepth:depth];
-    
+
     // A basic set of event metadata
     NSMutableDictionary *metadata = [@{
-        BSGKeyErrorClass : eventErrorClass,
-        BSGKeyUnhandled : [[event handledState] unhandled] ? @YES : @NO,
-        BSGKeySeverity : BSGFormatSeverity(event.severity)
+            BSGKeyErrorClass : eventErrorClass,
+            BSGKeyUnhandled : [[event handledState] unhandled] ? @YES : @NO,
+            BSGKeySeverity : BSGFormatSeverity(event.severity)
     } mutableCopy];
-    
+
     // Only include the eventMessage if it contains something
     if (eventMessage && [eventMessage length] > 0) {
         [metadata setValue:eventMessage forKey:BSGKeyName];
     }
-    
+
     [self addAutoBreadcrumbOfType:BSGBreadcrumbTypeError
                       withMessage:eventErrorClass
                       andMetadata:metadata];

--- a/Source/BugsnagEvent.m
+++ b/Source/BugsnagEvent.m
@@ -480,7 +480,13 @@ NSDictionary *BSGParseCustomException(NSDictionary *report,
         }
         self.breadcrumbs = [crumbs copy];
 
-        _handledState = handledState;
+        if (handledState == nil) { // initialise a sensible default to avoid crashing
+            _handledState = [BugsnagHandledState handledStateWithSeverityReason:HandledException
+                                                                       severity:BSGSeverityWarning
+                                                                      attrValue:nil];
+        } else {
+            _handledState = handledState;
+        }
         _severity = handledState.currentSeverity;
         _session = session;
         _threads = [NSMutableArray new];
@@ -813,6 +819,10 @@ NSDictionary *BSGParseCustomException(NSDictionary *report,
                        withKey:(NSString *_Nonnull)key
 {
     [self.metadata clearMetadataFromSection:sectionName withKey:key];
+}
+
+- (void)updateUnhandled:(BOOL)val {
+    self.handledState.unhandled = val;
 }
 
 @end

--- a/Source/BugsnagHandledState.h
+++ b/Source/BugsnagHandledState.h
@@ -42,7 +42,7 @@ NSString *BSGFormatSeverity(BSGSeverity severity);
 
 @interface BugsnagHandledState : NSObject
 
-@property(nonatomic, readonly) BOOL unhandled;
+@property(nonatomic) BOOL unhandled;
 @property(nonatomic, readonly) SeverityReasonType severityReasonType;
 @property(nonatomic, readonly) BSGSeverity originalSeverity;
 @property(nonatomic) BSGSeverity currentSeverity;

--- a/features/fixtures/ios-swift-cocoapods/iOSTestApp/scenarios/AttachCustomStacktraceHook.h
+++ b/features/fixtures/ios-swift-cocoapods/iOSTestApp/scenarios/AttachCustomStacktraceHook.h
@@ -11,4 +11,5 @@
 
 @interface BugsnagEvent ()
 - (void)attachCustomStacktrace:(NSArray *)frames withType:(NSString *)type;
+- (void)updateUnhandled:(BOOL)val;
 @end

--- a/features/fixtures/ios-swift-cocoapods/iOSTestApp/scenarios/BugsnagHooks.h
+++ b/features/fixtures/ios-swift-cocoapods/iOSTestApp/scenarios/BugsnagHooks.h
@@ -10,7 +10,6 @@
 #import <Bugsnag/Bugsnag.h>
 
 @interface Bugsnag ()
-+ (void)internalClientNotify:(NSException *_Nonnull)exception
-                    withData:(NSDictionary *_Nullable)metadata
-                       block:(BugsnagOnErrorBlock _Nullable)block;
++ (void)notifyInternal:(BugsnagEvent *_Nonnull)event
+                 block:(BugsnagOnErrorBlock _Nonnull)block;
 @end

--- a/features/fixtures/ios-swift-cocoapods/iOSTestApp/scenarios/HandledInternalNotifyScenario.swift
+++ b/features/fixtures/ios-swift-cocoapods/iOSTestApp/scenarios/HandledInternalNotifyScenario.swift
@@ -8,18 +8,14 @@ import Bugsnag
         let exception = NSException(name: NSExceptionName("Handled Error!"),
                                     reason: "Internally reported a handled event",
                                     userInfo: nil);
-        let options = [
-            "severity": "warning",
-            "severityReason": "handledException",
-            "unhandled": false
-            ] as [String : Any]
-        Bugsnag.internalClientNotify(exception, withData: options) { report in
+
+        Bugsnag.notify(exception) { (event) -> Bool in
             let frames = [
                 ["method":"foo()", "file":"src/Giraffe.mm", "lineNumber": 200],
                 ["method":"bar()", "file":"parser.js"],
                 ["method":"yes()"]
             ]
-            report.attachCustomStacktrace(frames, withType: "unreal")
+            event.attachCustomStacktrace(frames, withType: "unreal")
             return true
         }
     }

--- a/features/fixtures/ios-swift-cocoapods/iOSTestApp/scenarios/UnhandledInternalNotifyScenario.swift
+++ b/features/fixtures/ios-swift-cocoapods/iOSTestApp/scenarios/UnhandledInternalNotifyScenario.swift
@@ -8,18 +8,16 @@ import Bugsnag
         let exception = NSException(name: NSExceptionName("Unhandled Error?!"),
                                     reason: "Internally reported an unhandled event",
                                     userInfo: nil);
-        let options = [
-            "severity": "info",
-            "severityReason": "userCallbackSetSeverity",
-            "unhandled": true
-            ] as [String : Any]
-        Bugsnag.internalClientNotify(exception, withData: options) { report in
+
+        Bugsnag.notify(exception) { (event) -> Bool in
             let frames = [
                 ["method":"bar()", "file":"foo.js", "lineNumber": 43],
                 ["method":"baz()", "file":"[native code]"],
                 ["method":"is_done()"]
             ]
-            report.attachCustomStacktrace(frames, withType: "fake")
+            event.severity = .info
+            event.updateUnhandled(true)
+            event.attachCustomStacktrace(frames, withType: "fake")
             return true
         }
     }


### PR DESCRIPTION
## Goal

Adds a notifyInternal method to `BugsnagClient`. This allows external notifiers such as React Native to construct their own `BugsnagEvent` and pass it into a notify call ready-made. This follows a similar approach used by the Android notifier on React Native.

## Changeset

- Replaced `internalClientNotify` with `notifyInternal`
- Moved main code used in all `notify` method variants to live inside `notifyInternal`, which consolidates event generation/delivery
- Moved session tracker incrementing to happen _after_ a callback where users can discard the error
- Updated existing mazerunner tests to use `notifyInternal`

