### PR TITLE
Allow enhancing default runtimeVersions info

### DIFF
--- a/Source/Bugsnag.m
+++ b/Source/Bugsnag.m
@@ -58,6 +58,8 @@ static BugsnagClient *bsg_g_bugsnag_client = NULL;
 - (void)addBreadcrumbWithBlock:(void (^_Nonnull)(BugsnagBreadcrumb *_Nonnull))block;
 - (void)notifyInternal:(BugsnagEvent *_Nonnull)event
                  block:(BugsnagOnErrorBlock)block;
+- (void)addRuntimeVersionInfo:(NSString *)info
+                      withKey:(NSString *)key;
 @property (nonatomic) NSString *codeBundleId;
 @end
 
@@ -233,6 +235,13 @@ static BugsnagClient *bsg_g_bugsnag_client = NULL;
       formatter.timeZone = [NSTimeZone timeZoneForSecondsFromGMT:0];
     });
     return formatter;
+}
+
++ (void)addRuntimeVersionInfo:(NSString *)info
+                      withKey:(NSString *)key {
+    if ([self bugsnagStarted]) {
+        [self.client addRuntimeVersionInfo:info withKey:key];
+    }
 }
 
 // =============================================================================

--- a/Source/BugsnagClient.m
+++ b/Source/BugsnagClient.m
@@ -114,6 +114,7 @@ static bool hasRecordedSessions;
 @interface BugsnagDeviceWithState ()
 + (BugsnagDeviceWithState *)deviceWithDictionary:(NSDictionary *)event;
 - (NSDictionary *)toDictionary;
+- (void)appendRuntimeInfo:(NSDictionary *)info;
 @end
 
 /**
@@ -289,6 +290,7 @@ void BSGWriteSessionCrashData(BugsnagSession *session) {
 // The previous device orientation - iOS only
 @property (nonatomic, strong) NSString *lastOrientation;
 #endif
+@property NSMutableDictionary *extraRuntimeInfo;
 @end
 
 @interface BugsnagConfiguration ()
@@ -389,6 +391,7 @@ NSString *_lastOrientation = nil;
                                                                       configuration:configuration];
         }
 
+        self.extraRuntimeInfo = [NSMutableDictionary new];
         self.metadataLock = [[NSLock alloc] init];
         self.configuration.metadata.delegate = self;
         self.configuration.config.delegate = self;
@@ -910,6 +913,7 @@ NSString *const BSGBreadcrumbLoadedMessage = @"Bugsnag loaded";
 - (void)notifyInternal:(BugsnagEvent *_Nonnull)event
                  block:(BugsnagOnErrorBlock)block
 {
+    [event.device appendRuntimeInfo:self.extraRuntimeInfo];
     if (block != nil && !block(event)) { // skip notifying if callback false
         return;
     }
@@ -1433,6 +1437,7 @@ NSString *const BSGBreadcrumbLoadedMessage = @"Bugsnag loaded";
 - (NSDictionary *)collectDeviceWithState {
     NSDictionary *systemInfo = [BSG_KSSystemInfo systemInfo];
     BugsnagDeviceWithState *device = [BugsnagDeviceWithState deviceWithDictionary:@{@"system": systemInfo}];
+    [device appendRuntimeInfo:self.extraRuntimeInfo];
     return [device toDictionary];
 }
 
@@ -1456,6 +1461,15 @@ NSString *const BSGBreadcrumbLoadedMessage = @"Bugsnag loaded";
     return @[
         // TODO implement
     ];
+}
+
+- (void)addRuntimeVersionInfo:(NSString *)info
+                      withKey:(NSString *)key {
+    [self.sessionTracker addRuntimeVersionInfo:info
+                                       withKey:key];
+    if (info != nil && key != nil) {
+        self.extraRuntimeInfo[key] = info;
+    }
 }
 
 @end

--- a/Source/BugsnagDevice.m
+++ b/Source/BugsnagDevice.m
@@ -68,4 +68,11 @@
     BSGDictInsertIfNotNil(dict, self.totalMemory, @"totalMemory");
     return dict;
 }
+
+- (void)appendRuntimeInfo:(NSDictionary *)info {
+    NSMutableDictionary *versions = [self.runtimeVersions mutableCopy];
+    [versions addEntriesFromDictionary:info];
+    self.runtimeVersions = versions;
+}
+
 @end

--- a/Source/BugsnagSessionTracker.h
+++ b/Source/BugsnagSessionTracker.h
@@ -88,4 +88,7 @@ extern NSString *const BSGSessionUpdateNotification;
  */
 @property (nonatomic, strong, readonly) BugsnagSession *runningSession;
 
+- (void)addRuntimeVersionInfo:(NSString *)info
+                      withKey:(NSString *)key;
+
 @end

--- a/Source/BugsnagSessionTracker.m
+++ b/Source/BugsnagSessionTracker.m
@@ -14,6 +14,7 @@
 #import "BugsnagLogger.h"
 #import "BugsnagSessionInternal.h"
 #import "BSG_KSSystemInfo.h"
+#import "BugsnagCollections.h"
 
 /**
  Number of seconds in background required to make a new session
@@ -45,6 +46,7 @@ NSString *const BSGSessionUpdateNotification = @"BugsnagSessionChanged";
 
 @interface BugsnagDevice ()
 + (BugsnagDevice *)deviceWithDictionary:(NSDictionary *)event;
+- (void)appendRuntimeInfo:(NSDictionary *)info;
 @end
 
 @interface BugsnagSessionTrackingApiClient ()
@@ -63,6 +65,8 @@ NSString *const BSGSessionUpdateNotification = @"BugsnagSessionChanged";
  * Called when a session is altered
  */
 @property (nonatomic, strong, readonly) SessionTrackerCallback callback;
+
+@property NSMutableDictionary *extraRuntimeInfo;
 @end
 
 @implementation BugsnagSessionTracker
@@ -79,6 +83,7 @@ NSString *const BSGSessionUpdateNotification = @"BugsnagSessionChanged";
             BSG_KSLOG_ERROR(@"Failed to initialize session store.");
         }
         _sessionStore = [BugsnagSessionFileStore storeWithPath:storePath];
+        _extraRuntimeInfo = [NSMutableDictionary new];
     }
     return self;
 }
@@ -141,6 +146,8 @@ NSString *const BSGSessionUpdateNotification = @"BugsnagSessionChanged";
     NSDictionary *systemInfo = [BSG_KSSystemInfo systemInfo];
     BugsnagApp *app = [BugsnagApp appWithDictionary:@{@"system": systemInfo} config:self.config codeBundleId:self.codeBundleId];
     BugsnagDevice *device = [BugsnagDevice deviceWithDictionary:@{@"system": systemInfo}];
+    [device appendRuntimeInfo:self.extraRuntimeInfo];
+
     BugsnagSession *newSession = [[BugsnagSession alloc] initWithId:[[NSUUID UUID] UUIDString]
                                                           startDate:[NSDate date]
                                                                user:self.config.user
@@ -162,6 +169,13 @@ NSString *const BSGSessionUpdateNotification = @"BugsnagSessionChanged";
     [self postUpdateNotice];
 
     [self.apiClient deliverSessionsInStore:self.sessionStore];
+}
+
+- (void)addRuntimeVersionInfo:(NSString *)info
+                      withKey:(NSString *)key {
+    if (info != nil && key != nil) {
+        self.extraRuntimeInfo[key] = info;
+    }
 }
 
 - (void)registerExistingSession:(NSString *)sessionId

--- a/Tests/BugsnagClientMirrorTest.m
+++ b/Tests/BugsnagClientMirrorTest.m
@@ -96,7 +96,9 @@
             @"collectAppWithState @16@0:8",
             @"collectBreadcrumbs @16@0:8",
             @"collectThreads @16@0:8",
-            @"collectDeviceWithState @16@0:8"
+            @"collectDeviceWithState @16@0:8",
+            @"extraRuntimeInfo @16@0:8",
+            @"setExtraRuntimeInfo: v24@0:8@16"
     ]];
 
     // the following methods are implemented on Bugsnag but do not need to

--- a/Tests/BugsnagDeviceTest.m
+++ b/Tests/BugsnagDeviceTest.m
@@ -18,6 +18,8 @@ NSNumber *BSGDeviceFreeSpace(NSSearchPathDirectory directory);
 + (BugsnagDevice *)deviceWithDictionary:(NSDictionary *)event;
 
 - (NSDictionary *)toDictionary;
+
+- (void)appendRuntimeInfo:(NSDictionary *)info;
 @end
 
 @interface BugsnagDeviceWithState ()
@@ -198,6 +200,19 @@ NSNumber *BSGDeviceFreeSpace(NSSearchPathDirectory directory);
     NSSearchPathDirectory notAccessibleDirectory = NSAdminApplicationDirectory;
     NSNumber *freeBytes = BSGDeviceFreeSpace(notAccessibleDirectory);
     XCTAssertNil(freeBytes, @"expect nil when fails to retrieve free space for the directory");
+}
+
+- (void)testDeviceRuntimeInfoAppended {
+    BugsnagDevice *device = [BugsnagDevice deviceWithDictionary:self.data];
+    XCTAssertEqual(2, [device.runtimeVersions count]);
+    XCTAssertEqualObjects(@"14B25", device.runtimeVersions[@"osBuild"]);
+    XCTAssertEqualObjects(@"10.0.0 (clang-1000.11.45.5)", device.runtimeVersions[@"clangVersion"]);
+
+    [device appendRuntimeInfo:@{@"foo": @"bar"}];
+    XCTAssertEqual(3, [device.runtimeVersions count]);
+    XCTAssertEqualObjects(@"14B25", device.runtimeVersions[@"osBuild"]);
+    XCTAssertEqualObjects(@"10.0.0 (clang-1000.11.45.5)", device.runtimeVersions[@"clangVersion"]);
+    XCTAssertEqualObjects(@"bar", device.runtimeVersions[@"foo"]);
 }
 
 @end


### PR DESCRIPTION
## Goal

Allows for downstream notifiers such as bugsnag-react-native to set the runtime version information recorded for events and sessions. This changeset largely mirrors the Android implementation.

## Changeset

- Created method on `Bugsnag` and `BugsnagClient` for adding runtime version information
- Updated the session tracker + client implementation to hold extra runtime version info when it is added
- Whenever a new session/error is captured, the extra runtime version info is added

## Tests
Verified with a debugger that the object passed to an onSession/onError block contains the appropriate runtime version information.

Note that there is a known issue with the Cocoa implementation where the Event is not fully populated/persisted, so runtimeVersions information will not be sent in the actual payload. This will be addressed by a separate internal ticket.