### PR TITLE
Avoid cast for breadcrumbs/threads/errors on BugsnagEvent

### DIFF
--- a/Source/BugsnagEvent.h
+++ b/Source/BugsnagEvent.h
@@ -47,7 +47,7 @@ typedef NS_ENUM(NSUInteger, BSGSeverity) {
  * at least one error that represents the root cause, with subsequent elements populated
  * from the cause.
  */
-@property(readonly, nonnull) NSMutableArray<BugsnagError *> *errors;
+@property(readwrite, copy, nonnull) NSArray<BugsnagError *> *errors;
 
 /**
  *  Customized hash for grouping this report with other errors
@@ -56,7 +56,7 @@ typedef NS_ENUM(NSUInteger, BSGSeverity) {
 /**
  *  Breadcrumbs from user events leading up to the error
  */
-@property(readwrite, copy, nullable) NSArray <BugsnagBreadcrumb *>*breadcrumbs;
+@property(readwrite, copy, nonnull) NSArray<BugsnagBreadcrumb *> *breadcrumbs;
 
 /**
  * A per-event override for the apiKey.
@@ -84,7 +84,7 @@ typedef NS_ENUM(NSUInteger, BSGSeverity) {
 /**
  * Thread traces for the error that occurred, if collection was enabled.
  */
-@property(readonly, nonnull) NSMutableArray<BugsnagThread *> *threads;
+@property(readwrite, copy, nonnull) NSArray<BugsnagThread *> *threads;
 
 /**
  * The original object that caused the error in your application. This value will only be populated for

--- a/Source/BugsnagEvent.m
+++ b/Source/BugsnagEvent.m
@@ -326,8 +326,8 @@ NSDictionary *BSGParseCustomException(NSDictionary *report,
             _deviceAppHash = [report valueForKeyPath:@"user.state.oom.device.id"];
 
             // no threads or metadata captured for OOMs
-            _threads = [NSMutableArray new];
-            [_errors addObject:[[BugsnagError alloc] initWithEvent:report errorReportingThread:nil]];
+            _threads = @[];
+            _errors = @[[[BugsnagError alloc] initWithEvent:report errorReportingThread:nil]];
             self.metadata = [BugsnagMetadata new];
 
             NSDictionary *sessionData = [report valueForKeyPath:@"user.state.oom.session"];
@@ -394,7 +394,7 @@ NSDictionary *BSGParseCustomException(NSDictionary *report,
                 }
             }
 
-            [_errors addObject:[[BugsnagError alloc] initWithEvent:report errorReportingThread:errorReportingThread]];
+            _errors = @[[[BugsnagError alloc] initWithEvent:report errorReportingThread:errorReportingThread]];
             _customException = BSGParseCustomException(report, [_errors[0].errorClass copy], [_errors[0].errorMessage copy]);
 
             if (!recordedState) { // the event was unhandled.
@@ -457,12 +457,11 @@ NSDictionary *BSGParseCustomException(NSDictionary *report,
                                    session:(BugsnagSession *_Nullable)session
 {
     if (self = [super init]) {
-        _errors = [NSMutableArray new];
         BugsnagError *error = [BugsnagError new];
         error.errorClass = name;
         error.errorMessage = message;
         error.type = BSGErrorTypeCocoa;
-        [_errors addObject:error];
+        _errors = @[error];
 
         _overrides = [NSDictionary new];
         _device = [BugsnagDeviceWithState new];
@@ -483,7 +482,7 @@ NSDictionary *BSGParseCustomException(NSDictionary *report,
         _handledState = handledState;
         _severity = handledState.currentSeverity;
         _session = session;
-        _threads = [NSMutableArray new];
+        _threads = @[];
     }
     return self;
 }

--- a/features/fixtures/ios-swift-cocoapods/iOSTestApp/scenarios/HandledErrorOverrideScenario.swift
+++ b/features/fixtures/ios-swift-cocoapods/iOSTestApp/scenarios/HandledErrorOverrideScenario.swift
@@ -20,7 +20,7 @@ class HandledErrorOverrideScenario: Scenario {
 
     fileprivate func logError(_ error: Error)  {
         Bugsnag.notifyError(error) { report in
-            let error = report.errors[0] as! BugsnagError
+            let error = report.errors[0]
             error.errorMessage = "Foo"
             error.errorClass = "Bar"
             let depth: Int = report.value(forKey: "depth") as! Int

--- a/features/fixtures/ios-swift-cocoapods/iOSTestApp/scenarios/ModifyBreadcrumbInNotify.swift
+++ b/features/fixtures/ios-swift-cocoapods/iOSTestApp/scenarios/ModifyBreadcrumbInNotify.swift
@@ -12,7 +12,7 @@ class ModifyBreadcrumbInNotify: Scenario {
         Bugsnag.leaveBreadcrumb(withMessage: "Cache cleared")
         let error = NSError(domain: "HandledErrorScenario", code: 100, userInfo: nil)
         Bugsnag.notifyError(error) { event in
-            event.breadcrumbs?.forEach({ crumb in
+            event.breadcrumbs.forEach({ crumb in
                 if crumb.message == "Cache cleared" {
                     crumb.message = "Cache locked"
                 }

--- a/features/fixtures/ios-swift-cocoapods/iOSTestApp/scenarios/ModifyBreadcrumbScenario.swift
+++ b/features/fixtures/ios-swift-cocoapods/iOSTestApp/scenarios/ModifyBreadcrumbScenario.swift
@@ -7,7 +7,7 @@ class ModifyBreadcrumbScenario: Scenario {
         self.config.autoTrackSessions = false;
 
         self.config.addOnSendError(block: { event in
-            event.breadcrumbs?.forEach({ crumb in
+            event.breadcrumbs.forEach({ crumb in
                 if crumb.message == "Cache cleared" {
                     crumb.message = "Cache locked"
                 }


### PR DESCRIPTION
## Goal

Makes the `breadcrumbs/errors/threads` properties on `BugsnagEvent` use `NSArray` instead of `NSMutableArray`. In Swift this means that the individual elements will be accessible without requiring a type cast.

Additionally the properties have been made mutable, to allow for users to alter the contents of the event as `NSArray` itself is not mutable.
