### PR TITLE
Fix potential deadlock when generating a crash report

### DIFF
--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -37,6 +37,7 @@ Related to #
 
 * Added a changelog entry?
 * Checked the scope to ensure the commits are only related to the goal above?
+* Added any new headers to the "Copy Files" stage of the static iOS target?
 
 -->
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,14 @@
 Changelog
 =========
 
+## TBD
+
+## Bug Fixes
+
+* Fixed an issue where an app could deadlock during a crash if unfavourable 
+  timing caused DYLD lock contention.
+  [#580](https://github.com/bugsnag/bugsnag-cocoa/pull/580)
+
 ## 5.23.1 (2020-04-08)
 
 ## Bug fixes

--- a/OSX/Bugsnag.xcodeproj/project.pbxproj
+++ b/OSX/Bugsnag.xcodeproj/project.pbxproj
@@ -7,6 +7,8 @@
 	objects = {
 
 /* Begin PBXBuildFile section */
+		0071CB53246074BD00F562B1 /* BSG_KSMachHeaders.m in Sources */ = {isa = PBXBuildFile; fileRef = 0071CB51246074BD00F562B1 /* BSG_KSMachHeaders.m */; };
+		0071CB54246074BD00F562B1 /* BSG_KSMachHeaders.h in Headers */ = {isa = PBXBuildFile; fileRef = 0071CB52246074BD00F562B1 /* BSG_KSMachHeaders.h */; };
 		4B406C1822CAD96400464D1D /* BugsnagCollectionsBSGDictMergeTest.m in Sources */ = {isa = PBXBuildFile; fileRef = 4B406C1622CAD96400464D1D /* BugsnagCollectionsBSGDictMergeTest.m */; };
 		4B406C1922CAD96400464D1D /* BugsnagCollectionsBSGDictSetSafeObjectTest.m in Sources */ = {isa = PBXBuildFile; fileRef = 4B406C1722CAD96400464D1D /* BugsnagCollectionsBSGDictSetSafeObjectTest.m */; };
 		4B775FD422CBE02F004839C5 /* BugsnagCollectionsBSGDictInsertIfNotNilTest.m in Sources */ = {isa = PBXBuildFile; fileRef = 4B775FD222CBE02A004839C5 /* BugsnagCollectionsBSGDictInsertIfNotNilTest.m */; };
@@ -183,6 +185,8 @@
 /* End PBXContainerItemProxy section */
 
 /* Begin PBXFileReference section */
+		0071CB51246074BD00F562B1 /* BSG_KSMachHeaders.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; path = BSG_KSMachHeaders.m; sourceTree = "<group>"; };
+		0071CB52246074BD00F562B1 /* BSG_KSMachHeaders.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = BSG_KSMachHeaders.h; sourceTree = "<group>"; };
 		4B406C1622CAD96400464D1D /* BugsnagCollectionsBSGDictMergeTest.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; path = BugsnagCollectionsBSGDictMergeTest.m; sourceTree = "<group>"; };
 		4B406C1722CAD96400464D1D /* BugsnagCollectionsBSGDictSetSafeObjectTest.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; path = BugsnagCollectionsBSGDictSetSafeObjectTest.m; sourceTree = "<group>"; };
 		4B775FD222CBE02A004839C5 /* BugsnagCollectionsBSGDictInsertIfNotNilTest.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; path = BugsnagCollectionsBSGDictInsertIfNotNilTest.m; sourceTree = "<group>"; };
@@ -582,6 +586,8 @@
 		E79E6B411F4E3850002B35F9 /* Tools */ = {
 			isa = PBXGroup;
 			children = (
+				0071CB52246074BD00F562B1 /* BSG_KSMachHeaders.h */,
+				0071CB51246074BD00F562B1 /* BSG_KSMachHeaders.m */,
 				E79E6B421F4E3850002B35F9 /* BSG_KSArchSpecific.h */,
 				E79E6B431F4E3850002B35F9 /* BSG_KSBacktrace.c */,
 				E79E6B441F4E3850002B35F9 /* BSG_KSBacktrace.h */,
@@ -720,6 +726,7 @@
 				E79E6B9C1F4E3850002B35F9 /* BSG_KSSystemInfo.h in Headers */,
 				8A2C8FD71C6BC2C800846019 /* BugsnagMetaData.h in Headers */,
 				E79E6B021F4E3847002B35F9 /* BugsnagCrashSentry.h in Headers */,
+				0071CB54246074BD00F562B1 /* BSG_KSMachHeaders.h in Headers */,
 				E79E6B911F4E3850002B35F9 /* BSG_KSCrashReport.h in Headers */,
 				8A48EF271EAA805D00B70024 /* BugsnagLogger.h in Headers */,
 				E79E6BCC1F4E3850002B35F9 /* BSG_KSSingleton.h in Headers */,
@@ -895,6 +902,7 @@
 				E79E6BA81F4E3850002B35F9 /* BSG_KSCrashSentry_NSException.m in Sources */,
 				E79E6B901F4E3850002B35F9 /* BSG_KSCrashReport.c in Sources */,
 				8A2C8FD81C6BC2C800846019 /* BugsnagMetaData.m in Sources */,
+				0071CB53246074BD00F562B1 /* BSG_KSMachHeaders.m in Sources */,
 				E79E6BA51F4E3850002B35F9 /* BSG_KSCrashSentry_MachException.c in Sources */,
 				E79E6BB41F4E3850002B35F9 /* BSG_KSDynamicLinker.c in Sources */,
 				E79E6B031F4E3847002B35F9 /* BugsnagCrashSentry.m in Sources */,

--- a/Source/KSCrash/Source/KSCrash/Recording/BSG_KSCrash.m
+++ b/Source/KSCrash/Source/KSCrash/Recording/BSG_KSCrash.m
@@ -51,6 +51,10 @@
 #define BSG_KSCRASH_DefaultReportFilesDirectory @"KSCrashReports"
 #endif
 
+#ifndef BSG_INITIAL_MACH_BINARY_IMAGE_ARRAY_SIZE
+#define BSG_INITIAL_MACH_BINARY_IMAGE_ARRAY_SIZE 100
+#endif
+
 // ============================================================================
 #pragma mark - Constants -
 // ============================================================================
@@ -265,7 +269,7 @@ IMPLEMENT_EXCLUSIVE_SHARED_INSTANCE(BSG_KSCrash)
  * behaviour.
  */
 - (void)listenForLoadedBinaries {
-    bsg_initialise_mach_binary_headers();
+    bsg_initialise_mach_binary_headers(BSG_INITIAL_MACH_BINARY_IMAGE_ARRAY_SIZE);
 
     // Note: Internally, access to DYLD's binary image store is guarded by an OSSpinLock.  We therefore don't need to
     // add additional guards around our access.

--- a/Source/KSCrash/Source/KSCrash/Recording/BSG_KSCrash.m
+++ b/Source/KSCrash/Source/KSCrash/Recording/BSG_KSCrash.m
@@ -52,7 +52,7 @@
 #endif
 
 #ifndef BSG_INITIAL_MACH_BINARY_IMAGE_ARRAY_SIZE
-#define BSG_INITIAL_MACH_BINARY_IMAGE_ARRAY_SIZE 100
+#define BSG_INITIAL_MACH_BINARY_IMAGE_ARRAY_SIZE 400
 #endif
 
 // ============================================================================

--- a/Source/KSCrash/Source/KSCrash/Recording/BSG_KSCrash.m
+++ b/Source/KSCrash/Source/KSCrash/Recording/BSG_KSCrash.m
@@ -24,6 +24,7 @@
 // THE SOFTWARE.
 //
 
+#import <mach-o/dyld.h>
 #import "BSG_KSCrashAdvanced.h"
 
 #import "BSG_KSCrashC.h"
@@ -31,6 +32,7 @@
 #import "BSG_KSJSONCodecObjC.h"
 #import "BSG_KSSingleton.h"
 #import "BSG_KSSystemCapabilities.h"
+#import "BSG_KSMachHeaders.h"
 #import "NSError+BSG_SimpleConstructor.h"
 
 //#define BSG_KSLogger_LocalLevel TRACE
@@ -226,6 +228,9 @@ IMPLEMENT_EXCLUSIVE_SHARED_INSTANCE(BSG_KSCrash)
         return false;
     }
 
+    // Maintain a cache of info about dynamically loaded binary images
+    [self listenForLoadedBinaries];
+    
 #if BSG_KSCRASH_HAS_UIKIT
     NSNotificationCenter *nCenter = [NSNotificationCenter defaultCenter];
     [nCenter addObserver:self
@@ -251,6 +256,18 @@ IMPLEMENT_EXCLUSIVE_SHARED_INSTANCE(BSG_KSCrash)
 #endif
 
     return true;
+}
+
+/**
+ * Set up listeners for un/loaded frameworks.  Maintaining our own list of framework Mach
+ * headers means that we avoid potential deadlock situations where we try and suspend
+ * lock-holding threads prior to loading mach headers as part of our normal event handling
+ * behaviour.
+ */
+- (void)listenForLoadedBinaries {
+    bsg_initialise_mach_binary_headers();
+    _dyld_register_func_for_remove_image(&bsg_mach_binary_image_removed);
+    _dyld_register_func_for_add_image(&bsg_mach_binary_image_added);
 }
 
 - (void)sendAllReportsWithCompletion:

--- a/Source/KSCrash/Source/KSCrash/Recording/BSG_KSCrashReport.c
+++ b/Source/KSCrash/Source/KSCrash/Recording/BSG_KSCrashReport.c
@@ -36,6 +36,7 @@
 #include "BSG_KSObjC.h"
 #include "BSG_KSSignalInfo.h"
 #include "BSG_KSString.h"
+#include "BSG_KSMachHeaders.h"
 
 //#define BSG_kSLogger_LocalLevel TRACE
 #include "BSG_KSLogger.h"
@@ -1084,70 +1085,21 @@ int bsg_kscrw_i_threadIndex(const thread_t thread) {
  *
  * @param key The object key, if needed.
  *
- * @param index Which image to write about.
+ * @param info Cached info about the binary image.
  */
 void bsg_kscrw_i_writeBinaryImage(const BSG_KSCrashReportWriter *const writer,
-                                  const char *const key, const uint32_t index) {
-    const struct mach_header *header = _dyld_get_image_header(index);
-    if (header == NULL) {
-        return;
-    }
-
-    uintptr_t cmdPtr = bsg_ksdlfirstCmdAfterHeader(header);
-    if (cmdPtr == 0) {
-        return;
-    }
-
-    // Look for the TEXT segment to get the image size.
-    // Also look for a UUID command.
-    uint64_t imageSize = 0;
-    uint64_t imageVmAddr = 0;
-    uint8_t *uuid = NULL;
-
-    for (uint32_t iCmd = 0; iCmd < header->ncmds; iCmd++) {
-        struct load_command *loadCmd = (struct load_command *)cmdPtr;
-        switch (loadCmd->cmd) {
-        case LC_SEGMENT: {
-            struct segment_command *segCmd = (struct segment_command *)cmdPtr;
-            if (strcmp(segCmd->segname, SEG_TEXT) == 0) {
-                imageSize = segCmd->vmsize;
-                imageVmAddr = segCmd->vmaddr;
-            }
-            break;
-        }
-        case LC_SEGMENT_64: {
-            struct segment_command_64 *segCmd =
-                (struct segment_command_64 *)cmdPtr;
-            if (strcmp(segCmd->segname, SEG_TEXT) == 0) {
-                imageSize = segCmd->vmsize;
-                imageVmAddr = segCmd->vmaddr;
-            }
-            break;
-        }
-        case LC_UUID: {
-            struct uuid_command *uuidCmd = (struct uuid_command *)cmdPtr;
-            uuid = uuidCmd->uuid;
-            break;
-        }
-        }
-        cmdPtr += loadCmd->cmdsize;
-    }
-
+                                  const char *const key,
+                                  const BSG_Mach_Binary_Image_Info *info)
+{
     writer->beginObject(writer, key);
     {
-        writer->addUIntegerElement(writer, BSG_KSCrashField_ImageAddress,
-                                   (uintptr_t)header);
-        writer->addUIntegerElement(writer, BSG_KSCrashField_ImageVmAddress,
-                                   imageVmAddr);
-        writer->addUIntegerElement(writer, BSG_KSCrashField_ImageSize,
-                                   imageSize);
-        writer->addStringElement(writer, BSG_KSCrashField_Name,
-                                 _dyld_get_image_name(index));
-        writer->addUUIDElement(writer, BSG_KSCrashField_UUID, uuid);
-        writer->addIntegerElement(writer, BSG_KSCrashField_CPUType,
-                                  header->cputype);
-        writer->addIntegerElement(writer, BSG_KSCrashField_CPUSubType,
-                                  header->cpusubtype);
+        writer->addUIntegerElement(writer, BSG_KSCrashField_ImageAddress, (uintptr_t)info->mh);
+        writer->addUIntegerElement(writer, BSG_KSCrashField_ImageVmAddress,          info->imageVmAddr);
+        writer->addUIntegerElement(writer, BSG_KSCrashField_ImageSize,               info->imageSize);
+        writer->addStringElement(writer, BSG_KSCrashField_Name,                      info->name);
+        writer->addUUIDElement(writer, BSG_KSCrashField_UUID,                        info->uuid);
+        writer->addIntegerElement(writer, BSG_KSCrashField_CPUType,                  info->cputype);
+        writer->addIntegerElement(writer, BSG_KSCrashField_CPUSubType,               info->cpusubtype);
     }
     writer->endContainer(writer);
 }
@@ -1159,13 +1111,16 @@ void bsg_kscrw_i_writeBinaryImage(const BSG_KSCrashReportWriter *const writer,
  * @param key The object key, if needed.
  */
 void bsg_kscrw_i_writeBinaryImages(const BSG_KSCrashReportWriter *const writer,
-                                   const char *const key) {
-    const uint32_t imageCount = _dyld_image_count();
+                                   const char *const key)
+{
+    // Get the array of loaded binary images and a count
+    size_t imageCount;
+    BSG_Mach_Binary_Image_Info *info = bsg_mach_header_array(&imageCount);
 
     writer->beginArray(writer, key);
     {
         for (uint32_t iImg = 0; iImg < imageCount; iImg++) {
-            bsg_kscrw_i_writeBinaryImage(writer, NULL, iImg);
+            bsg_kscrw_i_writeBinaryImage(writer, NULL, &info[iImg]);
         }
     }
     writer->endContainer(writer);

--- a/Source/KSCrash/Source/KSCrash/Recording/BSG_KSCrashReport.c
+++ b/Source/KSCrash/Source/KSCrash/Recording/BSG_KSCrashReport.c
@@ -1085,21 +1085,23 @@ int bsg_kscrw_i_threadIndex(const thread_t thread) {
  *
  * @param key The object key, if needed.
  *
- * @param info Cached info about the binary image.
+ * @param index Cached info about the binary image.
  */
 void bsg_kscrw_i_writeBinaryImage(const BSG_KSCrashReportWriter *const writer,
                                   const char *const key,
-                                  const BSG_Mach_Binary_Image_Info *info)
+                                  const uint32_t index)
 {
+    BSG_Mach_Binary_Image_Info info = *bsg_dyld_get_image_info(index);
+    
     writer->beginObject(writer, key);
     {
-        writer->addUIntegerElement(writer, BSG_KSCrashField_ImageAddress, (uintptr_t)info->header);
-        writer->addUIntegerElement(writer, BSG_KSCrashField_ImageVmAddress,          info->imageVmAddr);
-        writer->addUIntegerElement(writer, BSG_KSCrashField_ImageSize,               info->imageSize);
-        writer->addStringElement(writer, BSG_KSCrashField_Name,                      info->name);
-        writer->addUUIDElement(writer, BSG_KSCrashField_UUID,                        info->uuid);
-        writer->addIntegerElement(writer, BSG_KSCrashField_CPUType,                  info->header->cputype);
-        writer->addIntegerElement(writer, BSG_KSCrashField_CPUSubType,               info->header->cpusubtype);
+        writer->addUIntegerElement(writer, BSG_KSCrashField_ImageAddress, (uintptr_t)info.header);
+        writer->addUIntegerElement(writer, BSG_KSCrashField_ImageVmAddress,          info.imageVmAddr);
+        writer->addUIntegerElement(writer, BSG_KSCrashField_ImageSize,               info.imageSize);
+        writer->addStringElement(writer, BSG_KSCrashField_Name,                      info.name);
+        writer->addUUIDElement(writer, BSG_KSCrashField_UUID,                        info.uuid);
+        writer->addIntegerElement(writer, BSG_KSCrashField_CPUType,                  info.header->cputype);
+        writer->addIntegerElement(writer, BSG_KSCrashField_CPUSubType,               info.header->cpusubtype);
     }
     writer->endContainer(writer);
 }
@@ -1114,13 +1116,12 @@ void bsg_kscrw_i_writeBinaryImages(const BSG_KSCrashReportWriter *const writer,
                                    const char *const key)
 {
     const uint32_t imageCount = (uint32_t)bsg_dyld_image_count();
-    
+
     writer->beginArray(writer, key);
     {
-        for (uint32_t i = 0; i < imageCount; i++) {
+        for (uint32_t iImg = 0; iImg < imageCount; iImg++) {
             // Threads are suspended at this point; no need to synchronise/lock
-            BSG_Mach_Binary_Image_Info *info = bsg_dyld_get_image_info(i);
-            bsg_kscrw_i_writeBinaryImage(writer, NULL, info);
+            bsg_kscrw_i_writeBinaryImage(writer, NULL, iImg);
         }
     }
     writer->endContainer(writer);

--- a/Source/KSCrash/Source/KSCrash/Recording/BSG_KSCrashReport.c
+++ b/Source/KSCrash/Source/KSCrash/Recording/BSG_KSCrashReport.c
@@ -1115,7 +1115,7 @@ void bsg_kscrw_i_writeBinaryImage(const BSG_KSCrashReportWriter *const writer,
 void bsg_kscrw_i_writeBinaryImages(const BSG_KSCrashReportWriter *const writer,
                                    const char *const key)
 {
-    const uint32_t imageCount = (uint32_t)bsg_dyld_image_count();
+    const uint32_t imageCount = bsg_dyld_image_count();
 
     writer->beginArray(writer, key);
     {

--- a/Source/KSCrash/Source/KSCrash/Recording/BSG_KSCrashReport.c
+++ b/Source/KSCrash/Source/KSCrash/Recording/BSG_KSCrashReport.c
@@ -1093,13 +1093,13 @@ void bsg_kscrw_i_writeBinaryImage(const BSG_KSCrashReportWriter *const writer,
 {
     writer->beginObject(writer, key);
     {
-        writer->addUIntegerElement(writer, BSG_KSCrashField_ImageAddress, (uintptr_t)info->mh);
+        writer->addUIntegerElement(writer, BSG_KSCrashField_ImageAddress, (uintptr_t)info->header);
         writer->addUIntegerElement(writer, BSG_KSCrashField_ImageVmAddress,          info->imageVmAddr);
         writer->addUIntegerElement(writer, BSG_KSCrashField_ImageSize,               info->imageSize);
         writer->addStringElement(writer, BSG_KSCrashField_Name,                      info->name);
         writer->addUUIDElement(writer, BSG_KSCrashField_UUID,                        info->uuid);
-        writer->addIntegerElement(writer, BSG_KSCrashField_CPUType,                  info->cputype);
-        writer->addIntegerElement(writer, BSG_KSCrashField_CPUSubType,               info->cpusubtype);
+        writer->addIntegerElement(writer, BSG_KSCrashField_CPUType,                  info->header->cputype);
+        writer->addIntegerElement(writer, BSG_KSCrashField_CPUSubType,               info->header->cpusubtype);
     }
     writer->endContainer(writer);
 }

--- a/Source/KSCrash/Source/KSCrash/Recording/BSG_KSCrashReport.c
+++ b/Source/KSCrash/Source/KSCrash/Recording/BSG_KSCrashReport.c
@@ -1113,14 +1113,12 @@ void bsg_kscrw_i_writeBinaryImage(const BSG_KSCrashReportWriter *const writer,
 void bsg_kscrw_i_writeBinaryImages(const BSG_KSCrashReportWriter *const writer,
                                    const char *const key)
 {
-    // Get the array of loaded binary images and a count
-    size_t imageCount;
-    BSG_Mach_Binary_Image_Info *info = bsg_mach_header_array(&imageCount);
-
     writer->beginArray(writer, key);
     {
-        for (uint32_t iImg = 0; iImg < imageCount; iImg++) {
-            bsg_kscrw_i_writeBinaryImage(writer, NULL, &info[iImg]);
+        BSG_Mach_Binary_Images *images = bsg_get_mach_binary_images();
+        for (uint32_t i = 0; i < images->used; i++) {
+            // Threads are suspended at this point; no need to synchronise/lock
+            bsg_kscrw_i_writeBinaryImage(writer, NULL, &(images->contents[i]));
         }
     }
     writer->endContainer(writer);

--- a/Source/KSCrash/Source/KSCrash/Recording/BSG_KSCrashReport.c
+++ b/Source/KSCrash/Source/KSCrash/Recording/BSG_KSCrashReport.c
@@ -1113,12 +1113,14 @@ void bsg_kscrw_i_writeBinaryImage(const BSG_KSCrashReportWriter *const writer,
 void bsg_kscrw_i_writeBinaryImages(const BSG_KSCrashReportWriter *const writer,
                                    const char *const key)
 {
+    const uint32_t imageCount = (uint32_t)bsg_dyld_image_count();
+    
     writer->beginArray(writer, key);
     {
-        BSG_Mach_Binary_Images *images = bsg_get_mach_binary_images();
-        for (uint32_t i = 0; i < images->used; i++) {
+        for (uint32_t i = 0; i < imageCount; i++) {
             // Threads are suspended at this point; no need to synchronise/lock
-            bsg_kscrw_i_writeBinaryImage(writer, NULL, &(images->contents[i]));
+            BSG_Mach_Binary_Image_Info *info = bsg_dyld_get_image_info(i);
+            bsg_kscrw_i_writeBinaryImage(writer, NULL, info);
         }
     }
     writer->endContainer(writer);

--- a/Source/KSCrash/Source/KSCrash/Recording/Tools/BSG_KSDynamicLinker.c
+++ b/Source/KSCrash/Source/KSCrash/Recording/Tools/BSG_KSDynamicLinker.c
@@ -34,7 +34,7 @@
 
 uint32_t bsg_ksdlimageNamed(const char *const imageName, bool exactMatch) {
     if (imageName != NULL) {
-        const size_t imageCount = bsg_dyld_image_count();
+        const uint32_t imageCount = bsg_dyld_image_count();
         
         for (uint32_t iImg = 0; iImg < imageCount; iImg++) {
             const char *name = bsg_dyld_get_image_name(iImg);
@@ -291,7 +291,7 @@ const void *bsg_ksdlgetSymbolAddrInImage(uint32_t imageIdx,
 }
 
 const void *bsg_ksdlgetSymbolAddrInAnyImage(const char *symbolName) {
-    const size_t imageCount = bsg_dyld_image_count();
+    const uint32_t imageCount = bsg_dyld_image_count();
 
     for (uint32_t iImg = 0; iImg < imageCount; iImg++) {
         const void *symbolAddr = bsg_ksdlgetSymbolAddrInImage(iImg, symbolName);

--- a/Source/KSCrash/Source/KSCrash/Recording/Tools/BSG_KSDynamicLinker.c
+++ b/Source/KSCrash/Source/KSCrash/Recording/Tools/BSG_KSDynamicLinker.c
@@ -26,6 +26,7 @@
 
 #include "BSG_KSDynamicLinker.h"
 #include "BSG_KSArchSpecific.h"
+#include "BSG_KSMachHeaders.h"
 
 #include <limits.h>
 #include <mach-o/nlist.h>
@@ -33,10 +34,11 @@
 
 uint32_t bsg_ksdlimageNamed(const char *const imageName, bool exactMatch) {
     if (imageName != NULL) {
-        const uint32_t imageCount = _dyld_image_count();
-
+        BSG_Mach_Binary_Images *images = bsg_get_mach_binary_images();
+        const size_t imageCount = images->used;
+        
         for (uint32_t iImg = 0; iImg < imageCount; iImg++) {
-            const char *name = _dyld_get_image_name(iImg);
+            const char *name = images->contents[iImg].name;
             if (name == NULL) {
                 continue; // name is null if the index is out of range per dyld(3)
             } else if (exactMatch) {
@@ -57,7 +59,8 @@ const uint8_t *bsg_ksdlimageUUID(const char *const imageName, bool exactMatch) {
     if (imageName != NULL) {
         const uint32_t iImg = bsg_ksdlimageNamed(imageName, exactMatch);
         if (iImg != UINT32_MAX) {
-            const struct mach_header *header = _dyld_get_image_header(iImg);
+            BSG_Mach_Binary_Images *images = bsg_get_mach_binary_images();
+            const struct mach_header *header = images->contents[iImg].mh;
             if (header != NULL) {
                 uintptr_t cmdPtr = bsg_ksdlfirstCmdAfterHeader(header);
                 if (cmdPtr != 0) {
@@ -96,15 +99,16 @@ uintptr_t bsg_ksdlfirstCmdAfterHeader(const struct mach_header *const header) {
 }
 
 uint32_t bsg_ksdlimageIndexContainingAddress(const uintptr_t address) {
-    const uint32_t imageCount = _dyld_image_count();
+    BSG_Mach_Binary_Images *images = bsg_get_mach_binary_images();
+    const size_t imageCount = images->used;
     const struct mach_header *header = 0;
 
     for (uint32_t iImg = 0; iImg < imageCount; iImg++) {
-        header = _dyld_get_image_header(iImg);
+        header = images->contents[iImg].mh;
         if (header != NULL) {
             // Look for a segment command with this address within its range.
             uintptr_t addressWSlide =
-                address - (uintptr_t)_dyld_get_image_vmaddr_slide(iImg);
+                address - images->contents[iImg].slide;
             uintptr_t cmdPtr = bsg_ksdlfirstCmdAfterHeader(header);
             if (cmdPtr == 0) {
                 continue;
@@ -115,16 +119,20 @@ uint32_t bsg_ksdlimageIndexContainingAddress(const uintptr_t address) {
                 if (loadCmd->cmd == LC_SEGMENT) {
                     const struct segment_command *segCmd =
                         (struct segment_command *)cmdPtr;
-                    if (addressWSlide >= segCmd->vmaddr &&
-                        addressWSlide < segCmd->vmaddr + segCmd->vmsize) {
-                        return iImg;
+                    if ( strcmp(segCmd->segname, "__TEXT") == 0 ) {
+                        if (addressWSlide >= segCmd->vmaddr &&
+                            addressWSlide < segCmd->vmaddr + segCmd->vmsize) {
+                            return iImg;
+                        }
                     }
                 } else if (loadCmd->cmd == LC_SEGMENT_64) {
                     const struct segment_command_64 *segCmd =
                         (struct segment_command_64 *)cmdPtr;
-                    if (addressWSlide >= segCmd->vmaddr &&
-                        addressWSlide < segCmd->vmaddr + segCmd->vmsize) {
-                        return iImg;
+                    if ( strcmp(segCmd->segname, "__TEXT") == 0 ) {
+                        if (addressWSlide >= segCmd->vmaddr &&
+                            addressWSlide < segCmd->vmaddr + segCmd->vmsize) {
+                            return iImg;
+                        }
                     }
                 }
                 cmdPtr += loadCmd->cmdsize;
@@ -135,7 +143,8 @@ uint32_t bsg_ksdlimageIndexContainingAddress(const uintptr_t address) {
 }
 
 uintptr_t bsg_ksdlsegmentBaseOfImageIndex(const uint32_t idx) {
-    const struct mach_header *header = _dyld_get_image_header(idx);
+    BSG_Mach_Binary_Images *images = bsg_get_mach_binary_images();
+    const struct mach_header *header = images->contents[idx].mh;
     if (header == NULL) {
         return 0;
     }
@@ -176,12 +185,13 @@ bool bsg_ksdldladdr(const uintptr_t address, Dl_info *const info) {
     if (idx == UINT_MAX) {
         return false;
     }
-    const struct mach_header *header = _dyld_get_image_header(idx);
+    BSG_Mach_Binary_Images *images = bsg_get_mach_binary_images();
+    const struct mach_header *header = images->contents[idx].mh;
     if (header == NULL) {
         return false;
     }
     const uintptr_t imageVMAddrSlide =
-        (uintptr_t)_dyld_get_image_vmaddr_slide(idx);
+        images->contents[idx].slide;
     const uintptr_t addressWithSlide = address - imageVMAddrSlide;
     const uintptr_t segmentBase =
         bsg_ksdlsegmentBaseOfImageIndex(idx) + imageVMAddrSlide;
@@ -189,7 +199,7 @@ bool bsg_ksdldladdr(const uintptr_t address, Dl_info *const info) {
         return false;
     }
 
-    info->dli_fname = _dyld_get_image_name(idx);
+    info->dli_fname = images->contents[idx].name;
     info->dli_fbase = (void *)header;
 
     // Find symbol tables and get whichever symbol is closest to the address.
@@ -244,12 +254,13 @@ bool bsg_ksdldladdr(const uintptr_t address, Dl_info *const info) {
 
 const void *bsg_ksdlgetSymbolAddrInImage(uint32_t imageIdx,
                                          const char *symbolName) {
-    const struct mach_header *header = _dyld_get_image_header(imageIdx);
+    BSG_Mach_Binary_Images *images = bsg_get_mach_binary_images();
+    const struct mach_header *header = images->contents[imageIdx].mh;
     if (header == NULL) {
         return NULL;
     }
     const uintptr_t imageVMAddrSlide =
-        (uintptr_t)_dyld_get_image_vmaddr_slide(imageIdx);
+        images->contents[imageIdx].slide;
     const uintptr_t segmentBase =
         bsg_ksdlsegmentBaseOfImageIndex(imageIdx) + imageVMAddrSlide;
     if (segmentBase == 0) {
@@ -290,7 +301,8 @@ const void *bsg_ksdlgetSymbolAddrInImage(uint32_t imageIdx,
 }
 
 const void *bsg_ksdlgetSymbolAddrInAnyImage(const char *symbolName) {
-    const uint32_t imageCount = _dyld_image_count();
+    BSG_Mach_Binary_Images *images = bsg_get_mach_binary_images();
+    const size_t imageCount = images->used;
 
     for (uint32_t iImg = 0; iImg < imageCount; iImg++) {
         const void *symbolAddr = bsg_ksdlgetSymbolAddrInImage(iImg, symbolName);

--- a/Source/KSCrash/Source/KSCrash/Recording/Tools/BSG_KSDynamicLinker.c
+++ b/Source/KSCrash/Source/KSCrash/Recording/Tools/BSG_KSDynamicLinker.c
@@ -97,7 +97,7 @@ uintptr_t bsg_ksdlfirstCmdAfterHeader(const struct mach_header *const header) {
 }
 
 uint32_t bsg_ksdlimageIndexContainingAddress(const uintptr_t address) {
-    const size_t imageCount = bsg_dyld_image_count();
+    const uint32_t imageCount = bsg_dyld_image_count();
     const struct mach_header *header = 0;
 
     for (uint32_t iImg = 0; iImg < imageCount; iImg++) {
@@ -116,20 +116,16 @@ uint32_t bsg_ksdlimageIndexContainingAddress(const uintptr_t address) {
                 if (loadCmd->cmd == LC_SEGMENT) {
                     const struct segment_command *segCmd =
                         (struct segment_command *)cmdPtr;
-                    if ( strcmp(segCmd->segname, "__TEXT") == 0 ) {
-                        if (addressWSlide >= segCmd->vmaddr &&
-                            addressWSlide < segCmd->vmaddr + segCmd->vmsize) {
-                            return iImg;
-                        }
+                    if (addressWSlide >= segCmd->vmaddr &&
+                        addressWSlide < segCmd->vmaddr + segCmd->vmsize) {
+                        return iImg;
                     }
                 } else if (loadCmd->cmd == LC_SEGMENT_64) {
                     const struct segment_command_64 *segCmd =
                         (struct segment_command_64 *)cmdPtr;
-                    if ( strcmp(segCmd->segname, "__TEXT") == 0 ) {
-                        if (addressWSlide >= segCmd->vmaddr &&
-                            addressWSlide < segCmd->vmaddr + segCmd->vmsize) {
-                            return iImg;
-                        }
+                    if (addressWSlide >= segCmd->vmaddr &&
+                        addressWSlide < segCmd->vmaddr + segCmd->vmsize) {
+                        return iImg;
                     }
                 }
                 cmdPtr += loadCmd->cmdsize;
@@ -181,7 +177,6 @@ bool bsg_ksdldladdr(const uintptr_t address, Dl_info *const info) {
     if (idx == UINT_MAX) {
         return false;
     }
-    
     const struct mach_header *header = bsg_dyld_get_image_header(idx);
     if (header == NULL) {
         return false;

--- a/Source/KSCrash/Source/KSCrash/Recording/Tools/BSG_KSMachHeaders.h
+++ b/Source/KSCrash/Source/KSCrash/Recording/Tools/BSG_KSMachHeaders.h
@@ -40,14 +40,23 @@ static BSG_Mach_Binary_Images bsg_mach_binary_images;
 
 /**
  * An OS-version-specific lock, used to synchronise access to the array of binary image info.
+ *
+ * os_unfair_lock is available from specific OS versions onwards:
+ *     https://developer.apple.com/documentation/os/os_unfair_lock
+ *
+ * It deprecates OSSpinLock:
+ *     https://developer.apple.com/library/archive/documentation/System/Conceptual/ManPages_iPhoneOS/man3/spinlock.3.html
  */
 #if defined(__IPHONE_10_0) || defined(__MAC_10_12) || defined(__TVOS_10_0) || defined(__WATCHOS_3_0)
     #import <os/lock.h>
     static os_unfair_lock bsg_mach_binary_images_access_lock = OS_UNFAIR_LOCK_INIT;
+    #define bsg_lock_mach_binary_image_access os_unfair_lock_lock
+    #define bsg_unlock_mach_binary_image_access os_unfair_lock_unlock
 #else
     #import <libkern/OSAtomic.h>
-    #define OS_SPINLOCK_INIT 0
     static OSSpinLock bsg_mach_binary_images_access_lock = OS_SPINLOCK_INIT;
+    #define bsg_lock_mach_binary_image_access OSSpinLockLock
+    #define bsg_unlock_mach_binary_image_access OSSpinLockUnlock
 #endif
 
 /**

--- a/Source/KSCrash/Source/KSCrash/Recording/Tools/BSG_KSMachHeaders.h
+++ b/Source/KSCrash/Source/KSCrash/Recording/Tools/BSG_KSMachHeaders.h
@@ -98,6 +98,6 @@ void bsg_mach_binary_image_removed(const struct mach_header *mh, intptr_t slide)
 /**
  * Create an empty array with initial capacity to hold Mach header info.
  */
-void bsg_initialise_mach_binary_headers(size_t initialSize);
+BSG_Mach_Binary_Images *bsg_initialise_mach_binary_headers(size_t initialSize);
 
 #endif /* BSG_KSMachHeaders_h */

--- a/Source/KSCrash/Source/KSCrash/Recording/Tools/BSG_KSMachHeaders.h
+++ b/Source/KSCrash/Source/KSCrash/Recording/Tools/BSG_KSMachHeaders.h
@@ -11,7 +11,6 @@
 
 #import <mach/machine.h>
 
-
 /**
  * An encapsulation of the Mach header - either 64 or 32 bit, along with some additional information required for
  * detailing a crash report's binary images.
@@ -24,6 +23,7 @@ typedef struct {
     const char* name;
     cpu_type_t cputype;          /* cpu specifier */
     cpu_subtype_t cpusubtype;    /* machine specifier */
+    intptr_t slide;
 } BSG_Mach_Binary_Image_Info;
 
 /**

--- a/Source/KSCrash/Source/KSCrash/Recording/Tools/BSG_KSMachHeaders.h
+++ b/Source/KSCrash/Source/KSCrash/Recording/Tools/BSG_KSMachHeaders.h
@@ -59,10 +59,31 @@ static BSG_Mach_Binary_Images bsg_mach_binary_images;
     #define bsg_unlock_mach_binary_image_access OSSpinLockUnlock
 #endif
 
+// MARK: - Replicate the DYLD API
+
 /**
- * Provide external access to the array of binary image info
+ * Returns the current number of images mapped in by dyld
  */
-BSG_Mach_Binary_Images *bsg_get_mach_binary_images(void);
+size_t bsg_dyld_image_count(void);
+
+/**
+ * Returns a pointer to the mach header of the image indexed by image_index.  If imageIndex
+ * is out of range, NULL is returned.
+ */
+const struct mach_header* bsg_dyld_get_image_header(uint32_t imageIndex);
+
+/**
+ * Returns the virtural memory address slide amount of the image indexed by imageIndex.
+ * If image_index is out of range zero is returned.
+ */
+intptr_t bsg_dyld_get_image_vmaddr_slide(uint32_t imageIndex);
+
+/**
+ * Returns the name of the image indexed by imageIndex.
+ */
+const char* bsg_dyld_get_image_name(uint32_t imageIndex);
+
+BSG_Mach_Binary_Image_Info *bsg_dyld_get_image_info(uint32_t imageIndex); // An additional convenience function
 
 /**
  * Called when a binary image is loaded.

--- a/Source/KSCrash/Source/KSCrash/Recording/Tools/BSG_KSMachHeaders.h
+++ b/Source/KSCrash/Source/KSCrash/Recording/Tools/BSG_KSMachHeaders.h
@@ -38,12 +38,14 @@ typedef struct {
 
 static BSG_Mach_Binary_Images bsg_mach_binary_images;
 
+/**
+ * A lock, used to synchronise access to the array of binary image info.
+ */
 static os_unfair_lock bsg_mach_binary_images_access_lock = OS_UNFAIR_LOCK_INIT;
 
-void bsg_initialize_binary_images_array(BSG_Mach_Binary_Images *array, size_t initialSize);
-void bsg_add_mach_binary_image(BSG_Mach_Binary_Images *array, BSG_Mach_Binary_Image_Info element);
-void bsg_remove_mach_binary_image(BSG_Mach_Binary_Images *array, const char *element_name);
-void bsg_free_binary_images_array(BSG_Mach_Binary_Images *array);
+/**
+ * Provide external access to the array of binary image info
+ */
 BSG_Mach_Binary_Images *bsg_get_mach_binary_images(void);
 
 /**

--- a/Source/KSCrash/Source/KSCrash/Recording/Tools/BSG_KSMachHeaders.h
+++ b/Source/KSCrash/Source/KSCrash/Recording/Tools/BSG_KSMachHeaders.h
@@ -16,13 +16,11 @@
  * detailing a crash report's binary images.
  */
 typedef struct {
-    const struct mach_header *mh;      /* The mach_header - 32 or 64 bit */
+    const struct mach_header *header; /* The mach_header - 32 or 64 bit */
     uint64_t imageVmAddr;
     uint64_t imageSize;
     uint8_t *uuid;
     const char* name;
-    cpu_type_t cputype;          /* cpu specifier */
-    cpu_subtype_t cpusubtype;    /* machine specifier */
     intptr_t slide;
 } BSG_Mach_Binary_Image_Info;
 
@@ -31,8 +29,8 @@ typedef struct {
  * See: https://stackoverflow.com/a/3536261/2431627
  */
 typedef struct {
-    size_t used;
-    size_t size;
+    uint32_t used;
+    uint32_t size;
     BSG_Mach_Binary_Image_Info *contents;
 } BSG_Mach_Binary_Images;
 
@@ -98,6 +96,6 @@ void bsg_mach_binary_image_removed(const struct mach_header *mh, intptr_t slide)
 /**
  * Create an empty array with initial capacity to hold Mach header info.
  */
-BSG_Mach_Binary_Images *bsg_initialise_mach_binary_headers(size_t initialSize);
+BSG_Mach_Binary_Images *bsg_initialise_mach_binary_headers(uint32_t initialSize);
 
 #endif /* BSG_KSMachHeaders_h */

--- a/Source/KSCrash/Source/KSCrash/Recording/Tools/BSG_KSMachHeaders.h
+++ b/Source/KSCrash/Source/KSCrash/Recording/Tools/BSG_KSMachHeaders.h
@@ -1,4 +1,4 @@
-    //
+//
 //  BSG_KSMachHeaders.h
 //  Bugsnag
 //
@@ -61,6 +61,6 @@ void bsg_mach_binary_image_removed(const struct mach_header *mh, intptr_t slide)
 /**
  * Create an empty, mutable NSArray to hold Mach header info
  */
-void bsg_initialise_mach_binary_headers(void);
+void bsg_initialise_mach_binary_headers(size_t initialSize);
 
 #endif /* BSG_KSMachHeaders_h */

--- a/Source/KSCrash/Source/KSCrash/Recording/Tools/BSG_KSMachHeaders.h
+++ b/Source/KSCrash/Source/KSCrash/Recording/Tools/BSG_KSMachHeaders.h
@@ -62,7 +62,7 @@ static BSG_Mach_Binary_Images bsg_mach_binary_images;
 /**
  * Returns the current number of images mapped in by dyld
  */
-size_t bsg_dyld_image_count(void);
+uint32_t bsg_dyld_image_count(void);
 
 /**
  * Returns a pointer to the mach header of the image indexed by image_index.  If imageIndex

--- a/Source/KSCrash/Source/KSCrash/Recording/Tools/BSG_KSMachHeaders.h
+++ b/Source/KSCrash/Source/KSCrash/Recording/Tools/BSG_KSMachHeaders.h
@@ -1,0 +1,68 @@
+    //
+//  BSG_KSMachHeaders.h
+//  Bugsnag
+//
+//  Created by Robin Macharg on 04/05/2020.
+//  Copyright © 2020 Bugsnag. All rights reserved.
+//
+
+#ifndef BSG_KSMachHeaders_h
+#define BSG_KSMachHeaders_h
+
+/**
+ * An encapsulation of the Mach header - either 64 or 32 bit, along with some additional information required for
+ * detailing a crash report's binary images.
+ */
+typedef struct {
+    // Removal of loaded binary images is a relative rarity.  It's simpler to mark an entry than reallocate the array
+    bool deleted;
+    const struct mach_header *mh;      /* The mach_header - 32 or 64 bit */
+    uint64_t imageVmAddr;
+    uint64_t imageSize;
+    uint8_t *uuid;
+    const char* name;
+    cpu_type_t cputype;          /* cpu specifier */
+    cpu_subtype_t cpusubtype;    /* machine specifier */
+} BSG_Mach_Binary_Image_Info;
+
+/**
+ * MARK: - A Dynamic array container
+ * See: https://stackoverflow.com/a/3536261/2431627
+ */
+typedef struct {
+  BSG_Mach_Binary_Image_Info *contents;
+  size_t used;
+  size_t size;
+} BSG_Mach_Binary_Images;
+
+void initializeBinaryImages(BSG_Mach_Binary_Images *array, size_t initialSize);
+void addBinaryImage(BSG_Mach_Binary_Images *array, BSG_Mach_Binary_Image_Info element);
+bool deleteBinaryImage(BSG_Mach_Binary_Images *array, const char *element_name);
+void freeBinaryImages(BSG_Mach_Binary_Images *array);
+
+/**
+ * Returns a C array of structs describing the loaded Mach binaries
+ *
+ * @param count A reference to the length of the array
+ *
+ * @returns A reference to an array of BSG_Mach_Binary_Image_Info structs containing info
+ *          about a loaded Mach binary.
+ */
+BSG_Mach_Binary_Image_Info* bsg_mach_header_array(size_t *count);
+
+/**
+ * Called when a binary image is loaded.
+ */
+void bsg_mach_binary_image_added(const struct mach_header *mh, intptr_t slide);
+
+/**
+ * Called when a binary image is unloaded.
+ */
+void bsg_mach_binary_image_removed(const struct mach_header *mh, intptr_t slide);
+
+/**
+ * Create an empty, mutable NSArray to hold Mach header info
+ */
+void bsg_initialise_mach_binary_headers(void);
+
+#endif /* BSG_KSMachHeaders_h */

--- a/Source/KSCrash/Source/KSCrash/Recording/Tools/BSG_KSMachHeaders.m
+++ b/Source/KSCrash/Source/KSCrash/Recording/Tools/BSG_KSMachHeaders.m
@@ -53,7 +53,7 @@ BSG_Mach_Binary_Image_Info *bsg_dyld_get_image_info(uint32_t imageIndex) {
  */
 void bsg_add_mach_binary_image(BSG_Mach_Binary_Image_Info element) {
     
-    bsg_lock_mach_binary_image_access(&bsg_mach_binary_images_access_lock);
+    BSG_DYLD_CACHE_LOCK
     
     // Expand array if necessary.  We're slightly paranoid here.  An OOM is likely to be indicative of bigger problems
     // but we should still do *our* best not to crash the app.
@@ -69,7 +69,7 @@ void bsg_add_mach_binary_image(BSG_Mach_Binary_Image_Info element) {
         }
         else {
             // Exit early, don't expand the array, don't store the header info and unlock
-            bsg_unlock_mach_binary_image_access(&bsg_mach_binary_images_access_lock);
+            BSG_DYLD_CACHE_UNLOCK
             return;
         }
     }
@@ -77,7 +77,7 @@ void bsg_add_mach_binary_image(BSG_Mach_Binary_Image_Info element) {
     // Store the value, increment the number of used elements
     bsg_mach_binary_images.contents[bsg_mach_binary_images.used++] = element;
     
-    bsg_unlock_mach_binary_image_access(&bsg_mach_binary_images_access_lock);
+    BSG_DYLD_CACHE_UNLOCK
 }
 
 /**
@@ -87,7 +87,7 @@ void bsg_add_mach_binary_image(BSG_Mach_Binary_Image_Info element) {
  */
 void bsg_remove_mach_binary_image(uint64_t imageVmAddr) {
     
-    bsg_lock_mach_binary_image_access(&bsg_mach_binary_images_access_lock);
+    BSG_DYLD_CACHE_LOCK
     
     for (uint32_t i=0; i<bsg_mach_binary_images.used; i++) {
         BSG_Mach_Binary_Image_Info item = bsg_mach_binary_images.contents[i];
@@ -104,7 +104,7 @@ void bsg_remove_mach_binary_image(uint64_t imageVmAddr) {
         }
     }
     
-    bsg_unlock_mach_binary_image_access(&bsg_mach_binary_images_access_lock);
+    BSG_DYLD_CACHE_UNLOCK
 }
 
 BSG_Mach_Binary_Images *bsg_initialise_mach_binary_headers(uint32_t initialSize) {

--- a/Source/KSCrash/Source/KSCrash/Recording/Tools/BSG_KSMachHeaders.m
+++ b/Source/KSCrash/Source/KSCrash/Recording/Tools/BSG_KSMachHeaders.m
@@ -12,8 +12,38 @@
 #import "BSG_KSDynamicLinker.h"
 #import "BSG_KSMachHeaders.h"
 
-BSG_Mach_Binary_Images *bsg_get_mach_binary_images() {
-    return &bsg_mach_binary_images;
+// MARK: - Replicate the DYLD API
+
+size_t bsg_dyld_image_count(void) {
+    return bsg_mach_binary_images.used;
+}
+
+const struct mach_header* bsg_dyld_get_image_header(uint32_t imageIndex) {
+    if (imageIndex < bsg_mach_binary_images.used) {
+        return bsg_mach_binary_images.contents[imageIndex].mh;
+    }
+    return NULL;
+}
+
+intptr_t bsg_dyld_get_image_vmaddr_slide(uint32_t imageIndex) {
+    if (imageIndex < bsg_mach_binary_images.used) {
+        return bsg_mach_binary_images.contents[imageIndex].slide;
+    }
+    return 0;
+}
+
+const char* bsg_dyld_get_image_name(uint32_t imageIndex) {
+    if (imageIndex < bsg_mach_binary_images.used) {
+        return bsg_mach_binary_images.contents[imageIndex].name;
+    }
+    return NULL;
+}
+
+BSG_Mach_Binary_Image_Info *bsg_dyld_get_image_info(uint32_t imageIndex) {
+    if (imageIndex < bsg_mach_binary_images.used) {
+        return &bsg_mach_binary_images.contents[imageIndex];
+    }
+    return NULL;
 }
 
 /**

--- a/Source/KSCrash/Source/KSCrash/Recording/Tools/BSG_KSMachHeaders.m
+++ b/Source/KSCrash/Source/KSCrash/Recording/Tools/BSG_KSMachHeaders.m
@@ -20,7 +20,7 @@ size_t bsg_dyld_image_count(void) {
 
 const struct mach_header* bsg_dyld_get_image_header(uint32_t imageIndex) {
     if (imageIndex < bsg_mach_binary_images.used) {
-        return bsg_mach_binary_images.contents[imageIndex].mh;
+        return bsg_mach_binary_images.contents[imageIndex].header;
     }
     return NULL;
 }
@@ -58,8 +58,8 @@ void bsg_add_mach_binary_image(BSG_Mach_Binary_Image_Info element) {
     // Expand array if necessary.  We're slightly paranoid here.  An OOM is likely to be indicative of bigger problems
     // but we should still do *our* best not to crash the app.
     if (bsg_mach_binary_images.used == bsg_mach_binary_images.size) {
-        size_t newSize = bsg_mach_binary_images.size *= 2;
-        size_t newAllocationSize = newSize * sizeof(BSG_Mach_Binary_Image_Info);
+        uint32_t newSize = bsg_mach_binary_images.size *= 2;
+        uint32_t newAllocationSize = newSize * sizeof(BSG_Mach_Binary_Image_Info);
         errno = 0;
         BSG_Mach_Binary_Image_Info *newAllocation = (BSG_Mach_Binary_Image_Info *)realloc(bsg_mach_binary_images.contents, newAllocationSize);
         
@@ -107,7 +107,7 @@ void bsg_remove_mach_binary_image(uint64_t imageVmAddr) {
     bsg_unlock_mach_binary_image_access(&bsg_mach_binary_images_access_lock);
 }
 
-BSG_Mach_Binary_Images *bsg_initialise_mach_binary_headers(size_t initialSize) {
+BSG_Mach_Binary_Images *bsg_initialise_mach_binary_headers(uint32_t initialSize) {
     bsg_mach_binary_images.contents = (BSG_Mach_Binary_Image_Info *)malloc(initialSize * sizeof(BSG_Mach_Binary_Image_Info));
     bsg_mach_binary_images.used = 0;
     bsg_mach_binary_images.size = initialSize;
@@ -176,9 +176,7 @@ bool bsg_populate_mach_image_info(const struct mach_header *header, intptr_t sli
     }
     
     // Save these values
-    info->mh = header;
-    info->cpusubtype = header->cpusubtype;
-    info->cputype = header->cputype;
+    info->header = header;
     info->imageSize = imageSize;
     info->imageVmAddr = imageVmAddr;
     info->uuid = uuid;

--- a/Source/KSCrash/Source/KSCrash/Recording/Tools/BSG_KSMachHeaders.m
+++ b/Source/KSCrash/Source/KSCrash/Recording/Tools/BSG_KSMachHeaders.m
@@ -107,10 +107,11 @@ void bsg_remove_mach_binary_image(uint64_t imageVmAddr) {
     bsg_unlock_mach_binary_image_access(&bsg_mach_binary_images_access_lock);
 }
 
-void bsg_initialise_mach_binary_headers(size_t initialSize) {
+BSG_Mach_Binary_Images *bsg_initialise_mach_binary_headers(size_t initialSize) {
     bsg_mach_binary_images.contents = (BSG_Mach_Binary_Image_Info *)malloc(initialSize * sizeof(BSG_Mach_Binary_Image_Info));
     bsg_mach_binary_images.used = 0;
     bsg_mach_binary_images.size = initialSize;
+    return &bsg_mach_binary_images;
 }
 
 /**

--- a/Source/KSCrash/Source/KSCrash/Recording/Tools/BSG_KSMachHeaders.m
+++ b/Source/KSCrash/Source/KSCrash/Recording/Tools/BSG_KSMachHeaders.m
@@ -12,15 +12,6 @@
 #import "BSG_KSDynamicLinker.h"
 #import "BSG_KSMachHeaders.h"
 
-// We expect <1000 items
-static const int BSG_INITIAL_MACH_BINARY_IMAGE_ARRAY_SIZE = 100;
-
-void bsg_initialize_binary_images_array(size_t initialSize) {
-    bsg_mach_binary_images.contents = (BSG_Mach_Binary_Image_Info *)malloc(initialSize * sizeof(BSG_Mach_Binary_Image_Info));
-    bsg_mach_binary_images.used = 0;
-    bsg_mach_binary_images.size = initialSize;
-}
-
 BSG_Mach_Binary_Images *bsg_get_mach_binary_images() {
     return &bsg_mach_binary_images;
 }
@@ -73,8 +64,10 @@ void bsg_remove_mach_binary_image(const char *element_name) {
     os_unfair_lock_unlock(&bsg_mach_binary_images_access_lock);
 }
 
-void bsg_initialise_mach_binary_headers() {
-    bsg_initialize_binary_images_array(BSG_INITIAL_MACH_BINARY_IMAGE_ARRAY_SIZE);
+void bsg_initialise_mach_binary_headers(size_t initialSize) {
+    bsg_mach_binary_images.contents = (BSG_Mach_Binary_Image_Info *)malloc(initialSize * sizeof(BSG_Mach_Binary_Image_Info));
+    bsg_mach_binary_images.used = 0;
+    bsg_mach_binary_images.size = initialSize;
 }
 
 /**

--- a/Source/KSCrash/Source/KSCrash/Recording/Tools/BSG_KSMachHeaders.m
+++ b/Source/KSCrash/Source/KSCrash/Recording/Tools/BSG_KSMachHeaders.m
@@ -1,0 +1,211 @@
+//
+//  BSG_KSMachHeaders.m
+//  Bugsnag
+//
+//  Created by Robin Macharg on 04/05/2020.
+//  Copyright © 2020 Bugsnag. All rights reserved.
+//
+
+#import <mach-o/dyld.h>
+#import <dlfcn.h>
+#import <Foundation/Foundation.h>
+#import "BSG_KSCrash.h"
+#import "BSG_KSMachHeaders.h"
+
+static NSMutableDictionary<NSString *, NSValue*> *bsg_mach_binary_images_info;
+static BSG_Mach_Binary_Images bsg_binary_images;
+
+@interface BSG_KSCrash ()
+@end
+
+void initializeBinaryImages(BSG_Mach_Binary_Images *array, size_t initialSize) {
+  array->contents = (BSG_Mach_Binary_Image_Info *)malloc(initialSize * sizeof(BSG_Mach_Binary_Image_Info));
+  array->used = 0;
+  array->size = initialSize;
+}
+
+void addBinaryImage(BSG_Mach_Binary_Images *array, BSG_Mach_Binary_Image_Info element) {
+  // a->used is the number of used entries, because a->array[a->used++] updates a->used only *after* the array has been accessed.
+  // Therefore a->used can go up to a->size
+  if (array->used == array->size) {
+    array->size *= 2;
+    array->contents = (BSG_Mach_Binary_Image_Info *)realloc(array->contents, array->size * sizeof(BSG_Mach_Binary_Image_Info));
+  }
+  array->contents[array->used++] = element;
+}
+
+/**
+ * Binary images can only be loaded at most once.  We can use the (file)name as a key, without needing to compare the
+ * other fields.  Element order is not important; deletion is accomplished by copying the last item into the deleted
+ * position.
+ */
+bool deleteBinaryImage(BSG_Mach_Binary_Images *array, const char *element_name) {
+    for (size_t i=0; i<array->used; i++) {
+        BSG_Mach_Binary_Image_Info item = array->contents[i];
+        if (strcmp(element_name, item.name) == 0) {
+            
+            // !!!!!
+            array->contents[i] = array->contents[array->used--];
+            
+            break;
+        }
+    }
+    
+    return false;
+}
+
+void freeBinaryImages(BSG_Mach_Binary_Images *array) {
+  free(array->contents);
+  array->contents = NULL;
+  array->used = array->size = 0;
+}
+
+void bsg_initialise_mach_binary_headers() {
+    bsg_mach_binary_images_info = [NSMutableDictionary<NSString *, NSValue*> new];
+    initializeBinaryImages(&bsg_binary_images, 100);
+}
+
+uintptr_t bsg_ksdlfirstCmdAfterHeader(const struct mach_header *const header);
+
+/**
+ * Populate a Mach binary image info structure
+ *
+ * @param header The Mach binary image header
+ *
+ * @param info Encapsulated Binary Image info
+ *
+ * @returns a boolean indicating success
+ */
+bool populate_info(const struct mach_header *header, BSG_Mach_Binary_Image_Info *info) {
+    
+    // Early exit conditions; this is not a valid/useful binary image
+    // 1. We can't find a sensible Mach command
+    uintptr_t cmdPtr = bsg_ksdlfirstCmdAfterHeader(header);
+    if (cmdPtr == 0) {
+        return false;
+    }
+
+    // 2. The image doesn't have a name.  Note: running with a debugger attached causes this condition to match.
+    Dl_info DlInfo = (const Dl_info) { 0 };
+    dladdr(header, &DlInfo);
+    const char *image_name = DlInfo.dli_fname;
+    if (!image_name) {
+        return false;
+    }
+    
+    // Look for the TEXT segment to get the image size.
+    // Also look for a UUID command.
+    uint64_t imageSize = 0;
+    uint64_t imageVmAddr = 0;
+    uint8_t *uuid = NULL;
+
+    for (uint32_t iCmd = 0; iCmd < header->ncmds; iCmd++) {
+        struct load_command *loadCmd = (struct load_command *)cmdPtr;
+        switch (loadCmd->cmd) {
+        case LC_SEGMENT: {
+            struct segment_command *segCmd = (struct segment_command *)cmdPtr;
+            if (strcmp(segCmd->segname, SEG_TEXT) == 0) {
+                imageSize = segCmd->vmsize;
+                imageVmAddr = segCmd->vmaddr;
+            }
+            break;
+        }
+        case LC_SEGMENT_64: {
+            struct segment_command_64 *segCmd =
+                (struct segment_command_64 *)cmdPtr;
+            if (strcmp(segCmd->segname, SEG_TEXT) == 0) {
+                imageSize = segCmd->vmsize;
+                imageVmAddr = segCmd->vmaddr;
+            }
+            break;
+        }
+        case LC_UUID: {
+            struct uuid_command *uuidCmd = (struct uuid_command *)cmdPtr;
+            uuid = uuidCmd->uuid;
+            break;
+        }
+        }
+        cmdPtr += loadCmd->cmdsize;
+    }
+    
+    // Save these values
+    info->mh = header;
+    info->cpusubtype = header->cpusubtype;
+    info->cputype = header->cputype;
+    info->imageSize = imageSize;
+    info->imageVmAddr = imageVmAddr;
+    info->uuid = uuid;
+    info->name = image_name;
+    
+    return true;
+}
+
+/**
+ * A callback invoked when dyld loads binary images.  It stores enough relevant info about the
+ * image to populate a crash report later.
+ *
+ * @param header A mach_header structure
+ *
+ * @param slide The VM offset of the binary image
+ */
+void bsg_mach_binary_image_added(const struct mach_header *header, intptr_t slide)
+{
+    BSG_Mach_Binary_Image_Info info = { 0 };
+    if (populate_info(header, &info)) {
+        NSString *key = [NSString stringWithUTF8String:info.name];
+        NSValue *value = [NSValue valueWithBytes:&info
+                                        objCType:@encode(BSG_Mach_Binary_Image_Info)];
+        
+        [bsg_mach_binary_images_info setValue:value forKey:key];
+    }
+}
+
+/**
+ * Called when a binary image is unloaded.
+ */
+void bsg_mach_binary_image_removed(const struct mach_header *header, intptr_t slide)
+{
+    // Convert header and slide into an info struct
+    BSG_Mach_Binary_Image_Info info;
+    if (populate_info(header, &info)) {
+        NSString *key = [NSString stringWithUTF8String:info.name];
+        [bsg_mach_binary_images_info removeObjectForKey:key];
+    }
+}
+
+/**
+ * Returns a C array of structs describing the loaded Mach binaries
+ */
+BSG_Mach_Binary_Image_Info* bsg_mach_header_array(size_t *count) {
+    @synchronized (@"bsg_mach_header_array") {
+    
+        // Pass out the number of binary images
+        *count = [bsg_mach_binary_images_info count] ;
+        
+        // How big is our struct?
+        const size_t mach_header_size = sizeof(BSG_Mach_Binary_Image_Info);
+        
+        // Heap allocate the array of binary image info structs
+        BSG_Mach_Binary_Image_Info *headers = (BSG_Mach_Binary_Image_Info *)calloc(*count, mach_header_size);
+        
+        // Copy the info into an array
+        for (size_t i=0; i<*count; ++i) {
+            
+            // Reconstitute struct from NSValue
+            BSG_Mach_Binary_Image_Info info;
+            
+            [[[bsg_mach_binary_images_info allValues] objectAtIndex:i] getValue:&info];
+
+            headers[i].cpusubtype = info.cpusubtype;
+            headers[i].cputype = info.cputype;
+            headers[i].imageSize = info.imageSize;
+            headers[i].imageVmAddr = info.imageVmAddr;
+            headers[i].uuid = info.uuid;
+            headers[i].mh = info.mh;
+            headers[i].name = info.name;
+        }
+        
+        return headers;
+    }
+}
+

--- a/Source/KSCrash/Source/KSCrash/Recording/Tools/BSG_KSMachHeaders.m
+++ b/Source/KSCrash/Source/KSCrash/Recording/Tools/BSG_KSMachHeaders.m
@@ -14,7 +14,7 @@
 
 // MARK: - Replicate the DYLD API
 
-size_t bsg_dyld_image_count(void) {
+uint32_t bsg_dyld_image_count(void) {
     return bsg_mach_binary_images.used;
 }
 

--- a/Source/KSCrash/Source/KSCrash/Recording/Tools/BSG_KSMachHeaders.m
+++ b/Source/KSCrash/Source/KSCrash/Recording/Tools/BSG_KSMachHeaders.m
@@ -92,7 +92,7 @@ void bsg_initialise_mach_binary_headers(size_t initialSize) {
  *
  * @returns a boolean indicating success
  */
-bool bsg_populate_mach_image_info(const struct mach_header *header, BSG_Mach_Binary_Image_Info *info) {
+bool bsg_populate_mach_image_info(const struct mach_header *header, intptr_t slide, BSG_Mach_Binary_Image_Info *info) {
     
     // Early exit conditions; this is not a valid/useful binary image
     // 1. We can't find a sensible Mach command
@@ -152,6 +152,7 @@ bool bsg_populate_mach_image_info(const struct mach_header *header, BSG_Mach_Bin
     info->imageVmAddr = imageVmAddr;
     info->uuid = uuid;
     info->name = imageName;
+    info->slide = slide;
     
     return true;
 }
@@ -163,12 +164,12 @@ bool bsg_populate_mach_image_info(const struct mach_header *header, BSG_Mach_Bin
  * @param header A mach_header structure
  *
  * @param slide A virtual memory slide amount. The virtual memory slide amount specifies the difference between the
- *              address at which the image was linked and the address at which the image is loaded.  Unused.
+ *              address at which the image was linked and the address at which the image is loaded.
  */
 void bsg_mach_binary_image_added(const struct mach_header *header, intptr_t slide)
 {
     BSG_Mach_Binary_Image_Info info = { 0 };
-    if (bsg_populate_mach_image_info(header, &info)) {
+    if (bsg_populate_mach_image_info(header, slide, &info)) {
         bsg_add_mach_binary_image(info);
     }
 }
@@ -180,7 +181,7 @@ void bsg_mach_binary_image_removed(const struct mach_header *header, intptr_t sl
 {
     // Convert header into an info struct
     BSG_Mach_Binary_Image_Info info = { 0 };
-    if (bsg_populate_mach_image_info(header, &info)) {
+    if (bsg_populate_mach_image_info(header, slide, &info)) {
         bsg_remove_mach_binary_image(info.imageVmAddr);
     }
 }

--- a/Source/KSCrash/Source/KSCrash/Recording/Tools/BSG_KSMachHeaders.m
+++ b/Source/KSCrash/Source/KSCrash/Recording/Tools/BSG_KSMachHeaders.m
@@ -51,7 +51,7 @@ void bsg_add_mach_binary_image(BSG_Mach_Binary_Image_Info element) {
 }
 
 /**
- * Binary images can only be loaded at most once.  We can use the (file)name as a key, without needing to compare the
+ * Binary images can only be loaded at most once.  We can use the VMAddress as a key, without needing to compare the
  * other fields.  Element order is not important; deletion is accomplished by copying the last item into the deleted
  * position.
  */

--- a/Source/KSCrash/Source/KSCrash/Recording/Tools/BSG_KSMachHeaders.m
+++ b/Source/KSCrash/Source/KSCrash/Recording/Tools/BSG_KSMachHeaders.m
@@ -89,7 +89,7 @@ void bsg_remove_mach_binary_image(uint64_t imageVmAddr) {
     
     bsg_lock_mach_binary_image_access(&bsg_mach_binary_images_access_lock);
     
-    for (size_t i=0; i<bsg_mach_binary_images.used; i++) {
+    for (uint32_t i=0; i<bsg_mach_binary_images.used; i++) {
         BSG_Mach_Binary_Image_Info item = bsg_mach_binary_images.contents[i];
         
         if (imageVmAddr == item.imageVmAddr) {

--- a/Tests/KSCrash/KSMachHeader_Tests.m
+++ b/Tests/KSCrash/KSMachHeader_Tests.m
@@ -13,7 +13,7 @@
 // Private methods
 void bsg_initialize_binary_images_array(size_t initialSize);
 void bsg_add_mach_binary_image(BSG_Mach_Binary_Image_Info element);
-void bsg_remove_mach_binary_image(const char *element_name);
+void bsg_remove_mach_binary_image(uint64_t imageVmAddr);
 BSG_Mach_Binary_Images *bsg_get_mach_binary_images(void);
 
 const struct mach_header mh = {
@@ -27,9 +27,9 @@ const struct mach_header mh = {
 };
 
 const BSG_Mach_Binary_Image_Info info1 = {.mh = &mh, .imageVmAddr = 12345, .imageSize = 6789, .uuid = (uint8_t *)123, .name = "header the first", .cputype = 42, .cpusubtype = 27 };
-const BSG_Mach_Binary_Image_Info info2 = {.mh = &mh, .imageVmAddr = 12345, .imageSize = 6789, .uuid = (uint8_t *)123, .name = "header the second", .cputype = 42, .cpusubtype = 27 };
-const BSG_Mach_Binary_Image_Info info3 = {.mh = &mh, .imageVmAddr = 12345, .imageSize = 6789, .uuid = (uint8_t *)123, .name = "header the third", .cputype = 42, .cpusubtype = 27 };
-const BSG_Mach_Binary_Image_Info info4 = {.mh = &mh, .imageVmAddr = 12345, .imageSize = 6789, .uuid = (uint8_t *)123, .name = "header the fourth", .cputype = 42, .cpusubtype = 27 };
+const BSG_Mach_Binary_Image_Info info2 = {.mh = &mh, .imageVmAddr = 23456, .imageSize = 6789, .uuid = (uint8_t *)123, .name = "header the second", .cputype = 42, .cpusubtype = 27 };
+const BSG_Mach_Binary_Image_Info info3 = {.mh = &mh, .imageVmAddr = 34567, .imageSize = 6789, .uuid = (uint8_t *)123, .name = "header the third", .cputype = 42, .cpusubtype = 27 };
+const BSG_Mach_Binary_Image_Info info4 = {.mh = &mh, .imageVmAddr = 45678, .imageSize = 6789, .uuid = (uint8_t *)123, .name = "header the fourth", .cputype = 42, .cpusubtype = 27 };
 
 @interface KSMachHeader_Tests : XCTestCase
 @end
@@ -58,7 +58,7 @@ const BSG_Mach_Binary_Image_Info info4 = {.mh = &mh, .imageVmAddr = 12345, .imag
     XCTAssertEqual(headers->used, 3);
     
     // Delete - third will be copied
-    bsg_remove_mach_binary_image("header the first");
+    bsg_remove_mach_binary_image(12345);
     XCTAssertEqual(headers->size, 4);
     XCTAssertEqual(headers->used, 2);
 
@@ -67,20 +67,20 @@ const BSG_Mach_Binary_Image_Info info4 = {.mh = &mh, .imageVmAddr = 12345, .imag
     XCTAssertEqual(headers->size, 4);
     
     // Nothing happens
-    bsg_remove_mach_binary_image("header the first");
+    bsg_remove_mach_binary_image(12345);
     XCTAssertEqual(headers->size, 4);
     XCTAssertEqual(headers->used, 2);
 
-    bsg_remove_mach_binary_image("header the second");
+    bsg_remove_mach_binary_image(23456);
     XCTAssertEqual(headers->size, 4);
     XCTAssertEqual(headers->used, 1);
     XCTAssertEqual(strcmp(headers->contents[0].name, "header the third"), 0);
     
-    bsg_remove_mach_binary_image("header the third");
+    bsg_remove_mach_binary_image(34567);
     XCTAssertEqual(headers->size, 4);
     XCTAssertEqual(headers->used, 0);
     
-    bsg_remove_mach_binary_image("header the third");
+    bsg_remove_mach_binary_image(34567);
     XCTAssertEqual(headers->size, 4);
     XCTAssertEqual(headers->used, 0);
     
@@ -97,7 +97,7 @@ const BSG_Mach_Binary_Image_Info info4 = {.mh = &mh, .imageVmAddr = 12345, .imag
     XCTAssertEqual(headers->size, 2);
     XCTAssertEqual(headers->used, 1);
 
-    bsg_remove_mach_binary_image("header the first");
+    bsg_remove_mach_binary_image(12345);
     XCTAssertEqual(headers->size, 2);
     XCTAssertEqual(headers->used, 0);
 }
@@ -110,11 +110,11 @@ const BSG_Mach_Binary_Image_Info info4 = {.mh = &mh, .imageVmAddr = 12345, .imag
     XCTAssertEqual(headers->size, 2);
     XCTAssertEqual(headers->used, 2);
 
-    bsg_remove_mach_binary_image("header the second");
+    bsg_remove_mach_binary_image(23456);
     XCTAssertEqual(headers->size, 2);
     XCTAssertEqual(headers->used, 1);
 
-    bsg_remove_mach_binary_image("header the first");
+    bsg_remove_mach_binary_image(12345);
     XCTAssertEqual(headers->size, 2);
     XCTAssertEqual(headers->used, 0);
 }
@@ -130,19 +130,19 @@ const BSG_Mach_Binary_Image_Info info4 = {.mh = &mh, .imageVmAddr = 12345, .imag
     XCTAssertEqual(headers->size, 4);
     XCTAssertEqual(headers->used, 4);
 
-    bsg_remove_mach_binary_image("header the fourth");
+    bsg_remove_mach_binary_image(45678);
     XCTAssertEqual(headers->size, 4);
     XCTAssertEqual(headers->used, 3);
 
-    bsg_remove_mach_binary_image("header the first");
+    bsg_remove_mach_binary_image(12345);
     XCTAssertEqual(headers->size, 4);
     XCTAssertEqual(headers->used, 2);
 
-    bsg_remove_mach_binary_image("header the first");
+    bsg_remove_mach_binary_image(12345);
     XCTAssertEqual(headers->size, 4);
     XCTAssertEqual(headers->used, 2);
 
-    bsg_remove_mach_binary_image("header the third");
+    bsg_remove_mach_binary_image(34567);
     XCTAssertEqual(headers->size, 4);
     XCTAssertEqual(headers->used, 1);
 }

--- a/Tests/KSCrash/KSMachHeader_Tests.m
+++ b/Tests/KSCrash/KSMachHeader_Tests.m
@@ -1,0 +1,111 @@
+//
+//  KSMachHeader_Tests.m
+//  Tests
+//
+//  Created by Robin Macharg on 04/05/2020.
+//  Copyright © 2020 Bugsnag. All rights reserved.
+//
+
+#import <XCTest/XCTest.h>
+#import "BSG_KSMachHeaders.h"
+#import <mach-o/dyld.h>
+
+const struct mach_header mh = {
+    .magic = 1,
+    .cputype = 1,
+    .cpusubtype = 1,
+    .filetype = 1,
+    .ncmds = 1,
+    .sizeofcmds = 1,
+    .flags = 1
+};
+
+const BSG_Mach_Binary_Image_Info info1 = {
+    .mh = &mh,
+    .imageVmAddr = 12345,
+    .imageSize = 6789,
+    .uuid = (uint8_t *)123,
+    .name = "header the first",
+    .cputype = 42,
+    .cpusubtype = 27
+};
+
+const BSG_Mach_Binary_Image_Info info2 = {
+    .mh = &mh,
+    .imageVmAddr = 12345,
+    .imageSize = 6789,
+    .uuid = (uint8_t *)123,
+    .name = "header the second",
+    .cputype = 42,
+    .cpusubtype = 27
+};
+
+const BSG_Mach_Binary_Image_Info info3 = {
+    .mh = &mh,
+    .imageVmAddr = 12345,
+    .imageSize = 6789,
+    .uuid = (uint8_t *)123,
+    .name = "header the third",
+    .cputype = 42,
+    .cpusubtype = 27
+};
+
+@interface KSMachHeader_Tests : XCTestCase
+@end
+
+@implementation KSMachHeader_Tests
+
+- (void)testDynamicArray {
+    BSG_Mach_Binary_Images headers;
+    bsg_initialize_binary_images_array(&headers, 2);
+    XCTAssertEqual(headers.size, 2);
+    XCTAssertEqual(headers.used, 0);
+    
+    // Add
+    bsg_add_mach_binary_image(&headers, info1);
+    XCTAssertEqual(headers.size, 2);
+    XCTAssertEqual(headers.used, 1);
+    
+    bsg_add_mach_binary_image(&headers, info2);
+    XCTAssertEqual(headers.size, 2);
+    XCTAssertEqual(headers.used, 2);
+
+    // Expand - double size
+    bsg_add_mach_binary_image(&headers, info3);
+    XCTAssertEqual(headers.size, 4);
+    XCTAssertEqual(headers.used, 3);
+    
+    // Delete - third will be copied
+    bsg_remove_mach_binary_image(&headers, "header the first");
+    XCTAssertEqual(headers.size, 4);
+    XCTAssertEqual(headers.used, 2);
+
+    XCTAssertEqual(strcmp(headers.contents[0].name, "header the third"), 0);
+    XCTAssertEqual(strcmp(headers.contents[1].name, "header the second"), 0);
+    XCTAssertEqual(headers.size, 4);
+    
+    // Nothing happens
+    bsg_remove_mach_binary_image(&headers, "header the first");
+    XCTAssertEqual(headers.size, 4);
+    XCTAssertEqual(headers.used, 2);
+
+    bsg_remove_mach_binary_image(&headers, "header the second");
+    XCTAssertEqual(headers.size, 4);
+    XCTAssertEqual(headers.used, 1);
+    XCTAssertEqual(strcmp(headers.contents[0].name, "header the third"), 0);
+    
+    bsg_remove_mach_binary_image(&headers, "header the third");
+    XCTAssertEqual(headers.size, 4);
+    XCTAssertEqual(headers.used, 0);
+    
+    bsg_remove_mach_binary_image(&headers, "header the third");
+    XCTAssertEqual(headers.size, 4);
+    XCTAssertEqual(headers.used, 0);
+    
+    // Readd
+    bsg_add_mach_binary_image(&headers, info1);
+    XCTAssertEqual(headers.size, 4);
+    XCTAssertEqual(headers.used, 1);
+}
+
+@end

--- a/Tests/KSCrash/KSMachHeader_Tests.m
+++ b/Tests/KSCrash/KSMachHeader_Tests.m
@@ -18,18 +18,18 @@ BSG_Mach_Binary_Images *bsg_get_mach_binary_images(void);
 
 const struct mach_header mh = {
     .magic = 1,
-    .cputype = 1,
-    .cpusubtype = 1,
+    .cputype = 42,
+    .cpusubtype = 27,
     .filetype = 1,
     .ncmds = 1,
     .sizeofcmds = 1,
     .flags = 1
 };
 
-const BSG_Mach_Binary_Image_Info info1 = {.mh = &mh, .imageVmAddr = 12345, .imageSize = 6789, .uuid = (uint8_t *)123, .name = "header the first",  .cputype = 42, .cpusubtype = 27, .slide = 123 };
-const BSG_Mach_Binary_Image_Info info2 = {.mh = &mh, .imageVmAddr = 23456, .imageSize = 6789, .uuid = (uint8_t *)123, .name = "header the second", .cputype = 42, .cpusubtype = 27, .slide = 1234 };
-const BSG_Mach_Binary_Image_Info info3 = {.mh = &mh, .imageVmAddr = 34567, .imageSize = 6789, .uuid = (uint8_t *)123, .name = "header the third",  .cputype = 42, .cpusubtype = 27, .slide = 12345 };
-const BSG_Mach_Binary_Image_Info info4 = {.mh = &mh, .imageVmAddr = 45678, .imageSize = 6789, .uuid = (uint8_t *)123, .name = "header the fourth", .cputype = 42, .cpusubtype = 27, .slide = 123456 };
+const BSG_Mach_Binary_Image_Info info1 = {.header = &mh, .imageVmAddr = 12345, .imageSize = 6789, .uuid = (uint8_t *)123, .name = "header the first",  .slide = 123 };
+const BSG_Mach_Binary_Image_Info info2 = {.header = &mh, .imageVmAddr = 23456, .imageSize = 6789, .uuid = (uint8_t *)123, .name = "header the second", .slide = 1234 };
+const BSG_Mach_Binary_Image_Info info3 = {.header = &mh, .imageVmAddr = 34567, .imageSize = 6789, .uuid = (uint8_t *)123, .name = "header the third",  .slide = 12345 };
+const BSG_Mach_Binary_Image_Info info4 = {.header = &mh, .imageVmAddr = 45678, .imageSize = 6789, .uuid = (uint8_t *)123, .name = "header the fourth", .slide = 123456 };
 
 @interface KSMachHeader_Tests : XCTestCase
 @end

--- a/Tests/KSCrash/KSMachHeader_Tests.m
+++ b/Tests/KSCrash/KSMachHeader_Tests.m
@@ -11,10 +11,8 @@
 #import <mach-o/dyld.h>
 
 // Private methods
-void bsg_initialize_binary_images_array(size_t initialSize);
 void bsg_add_mach_binary_image(BSG_Mach_Binary_Image_Info element);
 void bsg_remove_mach_binary_image(uint64_t imageVmAddr);
-BSG_Mach_Binary_Images *bsg_get_mach_binary_images(void);
 
 const struct mach_header mh = {
     .magic = 1,

--- a/Tests/KSCrash/KSMachHeader_Tests.m
+++ b/Tests/KSCrash/KSMachHeader_Tests.m
@@ -10,6 +10,12 @@
 #import "BSG_KSMachHeaders.h"
 #import <mach-o/dyld.h>
 
+// Private methods
+void bsg_initialize_binary_images_array(size_t initialSize);
+void bsg_add_mach_binary_image(BSG_Mach_Binary_Image_Info element);
+void bsg_remove_mach_binary_image(const char *element_name);
+BSG_Mach_Binary_Images *bsg_get_mach_binary_images(void);
+
 const struct mach_header mh = {
     .magic = 1,
     .cputype = 1,
@@ -20,35 +26,10 @@ const struct mach_header mh = {
     .flags = 1
 };
 
-const BSG_Mach_Binary_Image_Info info1 = {
-    .mh = &mh,
-    .imageVmAddr = 12345,
-    .imageSize = 6789,
-    .uuid = (uint8_t *)123,
-    .name = "header the first",
-    .cputype = 42,
-    .cpusubtype = 27
-};
-
-const BSG_Mach_Binary_Image_Info info2 = {
-    .mh = &mh,
-    .imageVmAddr = 12345,
-    .imageSize = 6789,
-    .uuid = (uint8_t *)123,
-    .name = "header the second",
-    .cputype = 42,
-    .cpusubtype = 27
-};
-
-const BSG_Mach_Binary_Image_Info info3 = {
-    .mh = &mh,
-    .imageVmAddr = 12345,
-    .imageSize = 6789,
-    .uuid = (uint8_t *)123,
-    .name = "header the third",
-    .cputype = 42,
-    .cpusubtype = 27
-};
+const BSG_Mach_Binary_Image_Info info1 = {.mh = &mh, .imageVmAddr = 12345, .imageSize = 6789, .uuid = (uint8_t *)123, .name = "header the first", .cputype = 42, .cpusubtype = 27 };
+const BSG_Mach_Binary_Image_Info info2 = {.mh = &mh, .imageVmAddr = 12345, .imageSize = 6789, .uuid = (uint8_t *)123, .name = "header the second", .cputype = 42, .cpusubtype = 27 };
+const BSG_Mach_Binary_Image_Info info3 = {.mh = &mh, .imageVmAddr = 12345, .imageSize = 6789, .uuid = (uint8_t *)123, .name = "header the third", .cputype = 42, .cpusubtype = 27 };
+const BSG_Mach_Binary_Image_Info info4 = {.mh = &mh, .imageVmAddr = 12345, .imageSize = 6789, .uuid = (uint8_t *)123, .name = "header the fourth", .cputype = 42, .cpusubtype = 27 };
 
 @interface KSMachHeader_Tests : XCTestCase
 @end
@@ -56,56 +37,114 @@ const BSG_Mach_Binary_Image_Info info3 = {
 @implementation KSMachHeader_Tests
 
 - (void)testDynamicArray {
-    BSG_Mach_Binary_Images headers;
-    bsg_initialize_binary_images_array(&headers, 2);
-    XCTAssertEqual(headers.size, 2);
-    XCTAssertEqual(headers.used, 0);
+
+    bsg_initialize_binary_images_array(2);
+    BSG_Mach_Binary_Images *headers = bsg_get_mach_binary_images();
+    XCTAssertEqual(headers->size, 2);
+    XCTAssertEqual(headers->used, 0);
     
     // Add
-    bsg_add_mach_binary_image(&headers, info1);
-    XCTAssertEqual(headers.size, 2);
-    XCTAssertEqual(headers.used, 1);
+    bsg_add_mach_binary_image(info1);
+    XCTAssertEqual(headers->size, 2);
+    XCTAssertEqual(headers->used, 1);
     
-    bsg_add_mach_binary_image(&headers, info2);
-    XCTAssertEqual(headers.size, 2);
-    XCTAssertEqual(headers.used, 2);
+    bsg_add_mach_binary_image(info2);
+    XCTAssertEqual(headers->size, 2);
+    XCTAssertEqual(headers->used, 2);
 
     // Expand - double size
-    bsg_add_mach_binary_image(&headers, info3);
-    XCTAssertEqual(headers.size, 4);
-    XCTAssertEqual(headers.used, 3);
+    bsg_add_mach_binary_image(info3);
+    XCTAssertEqual(headers->size, 4);
+    XCTAssertEqual(headers->used, 3);
     
     // Delete - third will be copied
-    bsg_remove_mach_binary_image(&headers, "header the first");
-    XCTAssertEqual(headers.size, 4);
-    XCTAssertEqual(headers.used, 2);
+    bsg_remove_mach_binary_image("header the first");
+    XCTAssertEqual(headers->size, 4);
+    XCTAssertEqual(headers->used, 2);
 
-    XCTAssertEqual(strcmp(headers.contents[0].name, "header the third"), 0);
-    XCTAssertEqual(strcmp(headers.contents[1].name, "header the second"), 0);
-    XCTAssertEqual(headers.size, 4);
+    XCTAssertEqual(strcmp(headers->contents[0].name, "header the third"), 0);
+    XCTAssertEqual(strcmp(headers->contents[1].name, "header the second"), 0);
+    XCTAssertEqual(headers->size, 4);
     
     // Nothing happens
-    bsg_remove_mach_binary_image(&headers, "header the first");
-    XCTAssertEqual(headers.size, 4);
-    XCTAssertEqual(headers.used, 2);
+    bsg_remove_mach_binary_image("header the first");
+    XCTAssertEqual(headers->size, 4);
+    XCTAssertEqual(headers->used, 2);
 
-    bsg_remove_mach_binary_image(&headers, "header the second");
-    XCTAssertEqual(headers.size, 4);
-    XCTAssertEqual(headers.used, 1);
-    XCTAssertEqual(strcmp(headers.contents[0].name, "header the third"), 0);
+    bsg_remove_mach_binary_image("header the second");
+    XCTAssertEqual(headers->size, 4);
+    XCTAssertEqual(headers->used, 1);
+    XCTAssertEqual(strcmp(headers->contents[0].name, "header the third"), 0);
     
-    bsg_remove_mach_binary_image(&headers, "header the third");
-    XCTAssertEqual(headers.size, 4);
-    XCTAssertEqual(headers.used, 0);
+    bsg_remove_mach_binary_image("header the third");
+    XCTAssertEqual(headers->size, 4);
+    XCTAssertEqual(headers->used, 0);
     
-    bsg_remove_mach_binary_image(&headers, "header the third");
-    XCTAssertEqual(headers.size, 4);
-    XCTAssertEqual(headers.used, 0);
+    bsg_remove_mach_binary_image("header the third");
+    XCTAssertEqual(headers->size, 4);
+    XCTAssertEqual(headers->used, 0);
     
     // Readd
-    bsg_add_mach_binary_image(&headers, info1);
-    XCTAssertEqual(headers.size, 4);
-    XCTAssertEqual(headers.used, 1);
+    bsg_add_mach_binary_image(info1);
+    XCTAssertEqual(headers->size, 4);
+    XCTAssertEqual(headers->used, 1);
+}
+
+- (void)testRemoveLast1 {
+    bsg_initialize_binary_images_array(2);
+    BSG_Mach_Binary_Images *headers = bsg_get_mach_binary_images();
+    bsg_add_mach_binary_image(info1);
+    XCTAssertEqual(headers->size, 2);
+    XCTAssertEqual(headers->used, 1);
+
+    bsg_remove_mach_binary_image("header the first");
+    XCTAssertEqual(headers->size, 2);
+    XCTAssertEqual(headers->used, 0);
+}
+
+- (void)testRemoveLast2 {
+    bsg_initialize_binary_images_array(2);
+    BSG_Mach_Binary_Images *headers = bsg_get_mach_binary_images();
+    bsg_add_mach_binary_image(info1);
+    bsg_add_mach_binary_image(info2);
+    XCTAssertEqual(headers->size, 2);
+    XCTAssertEqual(headers->used, 2);
+
+    bsg_remove_mach_binary_image("header the second");
+    XCTAssertEqual(headers->size, 2);
+    XCTAssertEqual(headers->used, 1);
+
+    bsg_remove_mach_binary_image("header the first");
+    XCTAssertEqual(headers->size, 2);
+    XCTAssertEqual(headers->used, 0);
+}
+
+- (void)testRemoveLast3 {
+    bsg_initialize_binary_images_array(2);
+    BSG_Mach_Binary_Images *headers = bsg_get_mach_binary_images();
+    
+    bsg_add_mach_binary_image(info1);
+    bsg_add_mach_binary_image(info2);
+    bsg_add_mach_binary_image(info3);
+    bsg_add_mach_binary_image(info4);
+    XCTAssertEqual(headers->size, 4);
+    XCTAssertEqual(headers->used, 4);
+
+    bsg_remove_mach_binary_image("header the fourth");
+    XCTAssertEqual(headers->size, 4);
+    XCTAssertEqual(headers->used, 3);
+
+    bsg_remove_mach_binary_image("header the first");
+    XCTAssertEqual(headers->size, 4);
+    XCTAssertEqual(headers->used, 2);
+
+    bsg_remove_mach_binary_image("header the first");
+    XCTAssertEqual(headers->size, 4);
+    XCTAssertEqual(headers->used, 2);
+
+    bsg_remove_mach_binary_image("header the third");
+    XCTAssertEqual(headers->size, 4);
+    XCTAssertEqual(headers->used, 1);
 }
 
 @end

--- a/Tests/KSCrash/KSMachHeader_Tests.m
+++ b/Tests/KSCrash/KSMachHeader_Tests.m
@@ -38,7 +38,7 @@ const BSG_Mach_Binary_Image_Info info4 = {.mh = &mh, .imageVmAddr = 12345, .imag
 
 - (void)testDynamicArray {
 
-    bsg_initialize_binary_images_array(2);
+    bsg_initialise_mach_binary_headers(2);
     BSG_Mach_Binary_Images *headers = bsg_get_mach_binary_images();
     XCTAssertEqual(headers->size, 2);
     XCTAssertEqual(headers->used, 0);
@@ -91,7 +91,7 @@ const BSG_Mach_Binary_Image_Info info4 = {.mh = &mh, .imageVmAddr = 12345, .imag
 }
 
 - (void)testRemoveLast1 {
-    bsg_initialize_binary_images_array(2);
+    bsg_initialise_mach_binary_headers(2);
     BSG_Mach_Binary_Images *headers = bsg_get_mach_binary_images();
     bsg_add_mach_binary_image(info1);
     XCTAssertEqual(headers->size, 2);
@@ -103,7 +103,7 @@ const BSG_Mach_Binary_Image_Info info4 = {.mh = &mh, .imageVmAddr = 12345, .imag
 }
 
 - (void)testRemoveLast2 {
-    bsg_initialize_binary_images_array(2);
+    bsg_initialise_mach_binary_headers(2);
     BSG_Mach_Binary_Images *headers = bsg_get_mach_binary_images();
     bsg_add_mach_binary_image(info1);
     bsg_add_mach_binary_image(info2);
@@ -120,7 +120,7 @@ const BSG_Mach_Binary_Image_Info info4 = {.mh = &mh, .imageVmAddr = 12345, .imag
 }
 
 - (void)testRemoveLast3 {
-    bsg_initialize_binary_images_array(2);
+    bsg_initialise_mach_binary_headers(2);
     BSG_Mach_Binary_Images *headers = bsg_get_mach_binary_images();
     
     bsg_add_mach_binary_image(info1);

--- a/iOS/Bugsnag.xcodeproj/project.pbxproj
+++ b/iOS/Bugsnag.xcodeproj/project.pbxproj
@@ -7,6 +7,8 @@
 	objects = {
 
 /* Begin PBXBuildFile section */
+		0071CB4B2460213200F562B1 /* BSG_KSMachHeaders.m in Sources */ = {isa = PBXBuildFile; fileRef = 0071CB4A2460213200F562B1 /* BSG_KSMachHeaders.m */; };
+		0071CB4C2460213200F562B1 /* BSG_KSMachHeaders.m in Sources */ = {isa = PBXBuildFile; fileRef = 0071CB4A2460213200F562B1 /* BSG_KSMachHeaders.m */; };
 		4B47970A22A9AE1F00FF9C2E /* BugsnagCrashReportFromKSCrashReportTest.m in Sources */ = {isa = PBXBuildFile; fileRef = 4B47970922A9AE1F00FF9C2E /* BugsnagCrashReportFromKSCrashReportTest.m */; };
 		4B775FCF22CBDEB4004839C5 /* BugsnagCollectionsBSGDictInsertIfNotNilTest.m in Sources */ = {isa = PBXBuildFile; fileRef = 4B775FCE22CBDEB4004839C5 /* BugsnagCollectionsBSGDictInsertIfNotNilTest.m */; };
 		4BE6C42622CAD61A0056305D /* BugsnagCollectionsBSGDictMergeTest.m in Sources */ = {isa = PBXBuildFile; fileRef = 4BE6C42522CAD61A0056305D /* BugsnagCollectionsBSGDictMergeTest.m */; };
@@ -397,6 +399,8 @@
 /* End PBXCopyFilesBuildPhase section */
 
 /* Begin PBXFileReference section */
+		0071CB4A2460213200F562B1 /* BSG_KSMachHeaders.m */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.objc; name = BSG_KSMachHeaders.m; path = Tools/BSG_KSMachHeaders.m; sourceTree = "<group>"; };
+		0071CB4D2460216200F562B1 /* BSG_KSMachHeaders.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; name = BSG_KSMachHeaders.h; path = Tools/BSG_KSMachHeaders.h; sourceTree = "<group>"; };
 		4B3B193422CA7B0900475354 /* BugsnagCollectionsBSGDictSetSafeObjectTest.m */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.objc; name = BugsnagCollectionsBSGDictSetSafeObjectTest.m; path = ../../Tests/BugsnagCollectionsBSGDictSetSafeObjectTest.m; sourceTree = "<group>"; };
 		4B47970922A9AE1F00FF9C2E /* BugsnagCrashReportFromKSCrashReportTest.m */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.objc; path = BugsnagCrashReportFromKSCrashReportTest.m; sourceTree = "<group>"; };
 		4B775FCE22CBDEB4004839C5 /* BugsnagCollectionsBSGDictInsertIfNotNilTest.m */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.objc; name = BugsnagCollectionsBSGDictInsertIfNotNilTest.m; path = ../../Tests/BugsnagCollectionsBSGDictInsertIfNotNilTest.m; sourceTree = "<group>"; };
@@ -833,6 +837,8 @@
 				E7107BDB1F4C97F100BB3F98 /* BSG_KSSystemInfoC.h */,
 				E7107BDC1F4C97F100BB3F98 /* Sentry */,
 				E7107BEC1F4C97F100BB3F98 /* Tools */,
+				0071CB4A2460213200F562B1 /* BSG_KSMachHeaders.m */,
+				0071CB4D2460216200F562B1 /* BSG_KSMachHeaders.h */,
 			);
 			path = Recording;
 			sourceTree = "<group>";
@@ -1170,6 +1176,7 @@
 				E72BF7801FC86A7A004BE82F /* BugsnagUser.m in Sources */,
 				8A2C8F541C6BBE3C00846019 /* BugsnagCollections.m in Sources */,
 				E7107C501F4C97F100BB3F98 /* BSG_KSCrashSentry_MachException.c in Sources */,
+				0071CB4B2460213200F562B1 /* BSG_KSMachHeaders.m in Sources */,
 				E7107C5F1F4C97F100BB3F98 /* BSG_KSDynamicLinker.c in Sources */,
 				E737DEA31F73AD7400BC7C80 /* BugsnagHandledState.m in Sources */,
 				E72962D71F4BBA8B00CEA15D /* BugsnagCrashSentry.m in Sources */,
@@ -1277,6 +1284,7 @@
 				E72BF7811FC86A7A004BE82F /* BugsnagUser.m in Sources */,
 				E7397E291F83BC2A0034242A /* Bugsnag.m in Sources */,
 				E7397E2A1F83BC2A0034242A /* BugsnagBreadcrumb.m in Sources */,
+				0071CB4C2460213200F562B1 /* BSG_KSMachHeaders.m in Sources */,
 				E7397E2B1F83BC2A0034242A /* BugsnagCollections.m in Sources */,
 				E7397E2C1F83BC2A0034242A /* BugsnagConfiguration.m in Sources */,
 				E7397E2D1F83BC2A0034242A /* BugsnagCrashReport.m in Sources */,

--- a/iOS/Bugsnag.xcodeproj/project.pbxproj
+++ b/iOS/Bugsnag.xcodeproj/project.pbxproj
@@ -9,6 +9,8 @@
 /* Begin PBXBuildFile section */
 		0071CB4B2460213200F562B1 /* BSG_KSMachHeaders.m in Sources */ = {isa = PBXBuildFile; fileRef = 0071CB4A2460213200F562B1 /* BSG_KSMachHeaders.m */; };
 		0071CB4C2460213200F562B1 /* BSG_KSMachHeaders.m in Sources */ = {isa = PBXBuildFile; fileRef = 0071CB4A2460213200F562B1 /* BSG_KSMachHeaders.m */; };
+		0071CB4F246025AF00F562B1 /* KSMachHeader_Tests.m in Sources */ = {isa = PBXBuildFile; fileRef = 0071CB4E246025AF00F562B1 /* KSMachHeader_Tests.m */; };
+		0071CB502460705D00F562B1 /* BSG_KSMachHeaders.h in Headers */ = {isa = PBXBuildFile; fileRef = 0071CB4D2460216200F562B1 /* BSG_KSMachHeaders.h */; };
 		4B47970A22A9AE1F00FF9C2E /* BugsnagCrashReportFromKSCrashReportTest.m in Sources */ = {isa = PBXBuildFile; fileRef = 4B47970922A9AE1F00FF9C2E /* BugsnagCrashReportFromKSCrashReportTest.m */; };
 		4B775FCF22CBDEB4004839C5 /* BugsnagCollectionsBSGDictInsertIfNotNilTest.m in Sources */ = {isa = PBXBuildFile; fileRef = 4B775FCE22CBDEB4004839C5 /* BugsnagCollectionsBSGDictInsertIfNotNilTest.m */; };
 		4BE6C42622CAD61A0056305D /* BugsnagCollectionsBSGDictMergeTest.m in Sources */ = {isa = PBXBuildFile; fileRef = 4BE6C42522CAD61A0056305D /* BugsnagCollectionsBSGDictMergeTest.m */; };
@@ -399,8 +401,9 @@
 /* End PBXCopyFilesBuildPhase section */
 
 /* Begin PBXFileReference section */
-		0071CB4A2460213200F562B1 /* BSG_KSMachHeaders.m */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.objc; name = BSG_KSMachHeaders.m; path = Tools/BSG_KSMachHeaders.m; sourceTree = "<group>"; };
-		0071CB4D2460216200F562B1 /* BSG_KSMachHeaders.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; name = BSG_KSMachHeaders.h; path = Tools/BSG_KSMachHeaders.h; sourceTree = "<group>"; };
+		0071CB4A2460213200F562B1 /* BSG_KSMachHeaders.m */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.objc; path = BSG_KSMachHeaders.m; sourceTree = "<group>"; };
+		0071CB4D2460216200F562B1 /* BSG_KSMachHeaders.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; path = BSG_KSMachHeaders.h; sourceTree = "<group>"; };
+		0071CB4E246025AF00F562B1 /* KSMachHeader_Tests.m */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.objc; path = KSMachHeader_Tests.m; sourceTree = "<group>"; };
 		4B3B193422CA7B0900475354 /* BugsnagCollectionsBSGDictSetSafeObjectTest.m */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.objc; name = BugsnagCollectionsBSGDictSetSafeObjectTest.m; path = ../../Tests/BugsnagCollectionsBSGDictSetSafeObjectTest.m; sourceTree = "<group>"; };
 		4B47970922A9AE1F00FF9C2E /* BugsnagCrashReportFromKSCrashReportTest.m */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.objc; path = BugsnagCrashReportFromKSCrashReportTest.m; sourceTree = "<group>"; };
 		4B775FCE22CBDEB4004839C5 /* BugsnagCollectionsBSGDictInsertIfNotNilTest.m */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.objc; name = BugsnagCollectionsBSGDictInsertIfNotNilTest.m; path = ../../Tests/BugsnagCollectionsBSGDictInsertIfNotNilTest.m; sourceTree = "<group>"; };
@@ -775,6 +778,7 @@
 				E7B970321FD7031500590C27 /* XCTestCase+KSCrash.h */,
 				E7B970331FD7031500590C27 /* XCTestCase+KSCrash.m */,
 				E7B970301FD702DA00590C27 /* KSLogger_Tests.m */,
+				0071CB4E246025AF00F562B1 /* KSMachHeader_Tests.m */,
 			);
 			name = KSCrash;
 			path = ../../Tests/KSCrash;
@@ -837,8 +841,6 @@
 				E7107BDB1F4C97F100BB3F98 /* BSG_KSSystemInfoC.h */,
 				E7107BDC1F4C97F100BB3F98 /* Sentry */,
 				E7107BEC1F4C97F100BB3F98 /* Tools */,
-				0071CB4A2460213200F562B1 /* BSG_KSMachHeaders.m */,
-				0071CB4D2460216200F562B1 /* BSG_KSMachHeaders.h */,
 			);
 			path = Recording;
 			sourceTree = "<group>";
@@ -889,6 +891,8 @@
 				E7107C011F4C97F100BB3F98 /* BSG_KSMach_x86_32.c */,
 				E7107C021F4C97F100BB3F98 /* BSG_KSMach_x86_64.c */,
 				E7107C031F4C97F100BB3F98 /* BSG_KSMachApple.h */,
+				0071CB4A2460213200F562B1 /* BSG_KSMachHeaders.m */,
+				0071CB4D2460216200F562B1 /* BSG_KSMachHeaders.h */,
 				E7107C041F4C97F100BB3F98 /* BSG_KSObjC.c */,
 				E7107C051F4C97F100BB3F98 /* BSG_KSObjC.h */,
 				E7107C061F4C97F100BB3F98 /* BSG_KSObjCApple.h */,
@@ -971,6 +975,7 @@
 				E7107C451F4C97F100BB3F98 /* BSG_KSCrashType.h in Headers */,
 				E7107C431F4C97F100BB3F98 /* BSG_KSCrashState.h in Headers */,
 				E7107C471F4C97F100BB3F98 /* BSG_KSSystemInfo.h in Headers */,
+				0071CB502460705D00F562B1 /* BSG_KSMachHeaders.h in Headers */,
 				E72962D61F4BBA8B00CEA15D /* BugsnagCrashSentry.h in Headers */,
 				E7107C3C1F4C97F100BB3F98 /* BSG_KSCrashReport.h in Headers */,
 				8A381D4B1EAA49A700AF8429 /* BugsnagLogger.h in Headers */,
@@ -1225,6 +1230,7 @@
 				E784D25A1FD70C25004B01E1 /* KSJSONCodec_Tests.m in Sources */,
 				E70EE0881FD7047800FA745C /* KSSystemInfo_Tests.m in Sources */,
 				4BE6C42622CAD61A0056305D /* BugsnagCollectionsBSGDictMergeTest.m in Sources */,
+				0071CB4F246025AF00F562B1 /* KSMachHeader_Tests.m in Sources */,
 				E70EE0871FD7047800FA745C /* KSSysCtl_Tests.m in Sources */,
 				E78C1EF31FCC615400B976D3 /* BugsnagSessionTrackingPayloadTest.m in Sources */,
 				E78C1EF11FCC2F1700B976D3 /* BugsnagSessionTrackerTest.m in Sources */,

--- a/iOS/Bugsnag.xcodeproj/project.pbxproj
+++ b/iOS/Bugsnag.xcodeproj/project.pbxproj
@@ -7,6 +7,7 @@
 	objects = {
 
 /* Begin PBXBuildFile section */
+		0003F3C52461B29A00AE0C93 /* BSG_KSMachHeaders.h in CopyFiles */ = {isa = PBXBuildFile; fileRef = 0071CB4D2460216200F562B1 /* BSG_KSMachHeaders.h */; };
 		0071CB4B2460213200F562B1 /* BSG_KSMachHeaders.m in Sources */ = {isa = PBXBuildFile; fileRef = 0071CB4A2460213200F562B1 /* BSG_KSMachHeaders.m */; };
 		0071CB4C2460213200F562B1 /* BSG_KSMachHeaders.m in Sources */ = {isa = PBXBuildFile; fileRef = 0071CB4A2460213200F562B1 /* BSG_KSMachHeaders.m */; };
 		0071CB4F246025AF00F562B1 /* KSMachHeader_Tests.m in Sources */ = {isa = PBXBuildFile; fileRef = 0071CB4E246025AF00F562B1 /* KSMachHeader_Tests.m */; };
@@ -327,6 +328,7 @@
 			dstPath = "include/${PRODUCT_NAME}";
 			dstSubfolderSpec = 16;
 			files = (
+				0003F3C52461B29A00AE0C93 /* BSG_KSMachHeaders.h in CopyFiles */,
 				8A3C590923965D9400B344AA /* BugsnagPlugin.h in CopyFiles */,
 				E79148251FD828E6003EFEBF /* BugsnagKeys.h in CopyFiles */,
 				E79148261FD828E6003EFEBF /* BugsnagSessionTracker.h in CopyFiles */,

--- a/tvOS/Bugsnag.xcodeproj/project.pbxproj
+++ b/tvOS/Bugsnag.xcodeproj/project.pbxproj
@@ -7,6 +7,8 @@
 	objects = {
 
 /* Begin PBXBuildFile section */
+		0071CB572460755500F562B1 /* BSG_KSMachHeaders.m in Sources */ = {isa = PBXBuildFile; fileRef = 0071CB552460755500F562B1 /* BSG_KSMachHeaders.m */; };
+		0071CB582460755500F562B1 /* BSG_KSMachHeaders.h in Headers */ = {isa = PBXBuildFile; fileRef = 0071CB562460755500F562B1 /* BSG_KSMachHeaders.h */; };
 		4B3CD2B622C5625800DBFF33 /* BugsnagKSCrashSysInfoParserTest.m in Sources */ = {isa = PBXBuildFile; fileRef = 4B3CD2B522C5625800DBFF33 /* BugsnagKSCrashSysInfoParserTest.m */; };
 		4B3CD2BB22C5676800DBFF33 /* BSGOutOfMemoryWatchdogTests.m in Sources */ = {isa = PBXBuildFile; fileRef = 4B3CD2B722C5676700DBFF33 /* BSGOutOfMemoryWatchdogTests.m */; };
 		4B3CD2BC22C5676800DBFF33 /* BugsnagCrashReportFromKSCrashReportTest.m in Sources */ = {isa = PBXBuildFile; fileRef = 4B3CD2B822C5676700DBFF33 /* BugsnagCrashReportFromKSCrashReportTest.m */; };
@@ -15,7 +17,6 @@
 		4B406C1422CAD94100464D1D /* BugsnagCollectionsBSGDictSetSafeObjectTest.m in Sources */ = {isa = PBXBuildFile; fileRef = 4B406C1222CAD94100464D1D /* BugsnagCollectionsBSGDictSetSafeObjectTest.m */; };
 		4B406C1522CAD94100464D1D /* BugsnagCollectionsBSGDictMergeTest.m in Sources */ = {isa = PBXBuildFile; fileRef = 4B406C1322CAD94100464D1D /* BugsnagCollectionsBSGDictMergeTest.m */; };
 		4B775FD122CBE01F004839C5 /* BugsnagCollectionsBSGDictInsertIfNotNilTest.m in Sources */ = {isa = PBXBuildFile; fileRef = 4B775FD022CBE01F004839C5 /* BugsnagCollectionsBSGDictInsertIfNotNilTest.m */; };
-		8A12006E221C51550008C9C3 /* BSGFilepathTests.m in Sources */ = {isa = PBXBuildFile; fileRef = 8A12006D221C51550008C9C3 /* BSGFilepathTests.m */; };
 		8A3C591023968B2000B344AA /* BugsnagPlugin.h in Headers */ = {isa = PBXBuildFile; fileRef = 8A3C590F23968B2000B344AA /* BugsnagPlugin.h */; settings = {ATTRIBUTES = (Public, ); }; };
 		8A48EF291EAA824100B70024 /* BugsnagLogger.h in Headers */ = {isa = PBXBuildFile; fileRef = 8A48EF281EAA824100B70024 /* BugsnagLogger.h */; };
 		8A530CBC22FDC39300F0C108 /* BSG_KSCrashIdentifier.m in Sources */ = {isa = PBXBuildFile; fileRef = 8A530CBA22FDC39300F0C108 /* BSG_KSCrashIdentifier.m */; };
@@ -189,6 +190,8 @@
 /* End PBXContainerItemProxy section */
 
 /* Begin PBXFileReference section */
+		0071CB552460755500F562B1 /* BSG_KSMachHeaders.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; path = BSG_KSMachHeaders.m; sourceTree = "<group>"; };
+		0071CB562460755500F562B1 /* BSG_KSMachHeaders.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = BSG_KSMachHeaders.h; sourceTree = "<group>"; };
 		4B3CD2B522C5625800DBFF33 /* BugsnagKSCrashSysInfoParserTest.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; name = BugsnagKSCrashSysInfoParserTest.m; path = ../../iOS/BugsnagTests/BugsnagKSCrashSysInfoParserTest.m; sourceTree = "<group>"; };
 		4B3CD2B722C5676700DBFF33 /* BSGOutOfMemoryWatchdogTests.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; name = BSGOutOfMemoryWatchdogTests.m; path = ../../iOS/BugsnagTests/BSGOutOfMemoryWatchdogTests.m; sourceTree = "<group>"; };
 		4B3CD2B822C5676700DBFF33 /* BugsnagCrashReportFromKSCrashReportTest.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; name = BugsnagCrashReportFromKSCrashReportTest.m; path = ../../iOS/BugsnagTests/BugsnagCrashReportFromKSCrashReportTest.m; sourceTree = "<group>"; };
@@ -197,7 +200,6 @@
 		4B406C1222CAD94100464D1D /* BugsnagCollectionsBSGDictSetSafeObjectTest.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; name = BugsnagCollectionsBSGDictSetSafeObjectTest.m; path = ../../Tests/BugsnagCollectionsBSGDictSetSafeObjectTest.m; sourceTree = "<group>"; };
 		4B406C1322CAD94100464D1D /* BugsnagCollectionsBSGDictMergeTest.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; name = BugsnagCollectionsBSGDictMergeTest.m; path = ../../Tests/BugsnagCollectionsBSGDictMergeTest.m; sourceTree = "<group>"; };
 		4B775FD022CBE01F004839C5 /* BugsnagCollectionsBSGDictInsertIfNotNilTest.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; name = BugsnagCollectionsBSGDictInsertIfNotNilTest.m; path = ../../Tests/BugsnagCollectionsBSGDictInsertIfNotNilTest.m; sourceTree = "<group>"; };
-		8A12006D221C51550008C9C3 /* BSGFilepathTests.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; name = BSGFilepathTests.m; path = ../../Tests/BSGFilepathTests.m; sourceTree = "<group>"; };
 		8A3C590F23968B2000B344AA /* BugsnagPlugin.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; name = BugsnagPlugin.h; path = ../Source/BugsnagPlugin.h; sourceTree = "<group>"; };
 		8A48EF281EAA824100B70024 /* BugsnagLogger.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; name = BugsnagLogger.h; path = ../Source/BugsnagLogger.h; sourceTree = "<group>"; };
 		8A530CBA22FDC39300F0C108 /* BSG_KSCrashIdentifier.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; path = BSG_KSCrashIdentifier.m; sourceTree = "<group>"; };
@@ -598,6 +600,8 @@
 		E76617361F4E459C0094CECF /* Tools */ = {
 			isa = PBXGroup;
 			children = (
+				0071CB562460755500F562B1 /* BSG_KSMachHeaders.h */,
+				0071CB552460755500F562B1 /* BSG_KSMachHeaders.m */,
 				E76617371F4E459C0094CECF /* BSG_KSArchSpecific.h */,
 				E76617381F4E459C0094CECF /* BSG_KSBacktrace.c */,
 				E76617391F4E459C0094CECF /* BSG_KSBacktrace.h */,
@@ -736,6 +740,7 @@
 				E76617911F4E459C0094CECF /* BSG_KSSystemInfo.h in Headers */,
 				8AD9A4FA1D42EE96004E1CC5 /* BugsnagMetaData.h in Headers */,
 				E76616F71F4E45950094CECF /* BugsnagCrashSentry.h in Headers */,
+				0071CB582460755500F562B1 /* BSG_KSMachHeaders.h in Headers */,
 				E76617861F4E459C0094CECF /* BSG_KSCrashReport.h in Headers */,
 				8A48EF291EAA824100B70024 /* BugsnagLogger.h in Headers */,
 				E76617C11F4E459C0094CECF /* BSG_KSSingleton.h in Headers */,
@@ -911,6 +916,7 @@
 				E76616FA1F4E45950094CECF /* BugsnagErrorReportApiClient.m in Sources */,
 				E76617AD1F4E459C0094CECF /* BSG_KSJSONCodec.c in Sources */,
 				E766179D1F4E459C0094CECF /* BSG_KSCrashSentry_NSException.m in Sources */,
+				0071CB572460755500F562B1 /* BSG_KSMachHeaders.m in Sources */,
 				E76617851F4E459C0094CECF /* BSG_KSCrashReport.c in Sources */,
 				8AD9A5021D42EEB0004E1CC5 /* BugsnagMetaData.m in Sources */,
 				E766179A1F4E459C0094CECF /* BSG_KSCrashSentry_MachException.c in Sources */,


### PR DESCRIPTION
[Note: this PR supersedes #577, and incorporates feedback from initial review.] 

## Goal

An [issue](https://github.com/bugsnag/bugsnag-react-native/issues/448) has been identified that can lead to an app deadlocking when reporting a crash.

The sequence of events is:

1. Some program component accesses `dyld` and takes a lock out.
2. A crash is reported.
3. Bugsnag, as part of its normal crash reporting behaviour, suspends all but a few critical threads, including the thread that holds the `dyld` lock.
4. Bugsnag attempts to read the Mach binary images loaded into the app.  This also attempts to take out a lock but is unable to, leading to deadlock.

This PR fixes this issue.

<!-- What is the intent of this change? -->

<!--
Fixes #
Related to #
-->

## Design

There are two main mechanisms by which a program may find out about `dyld` behaviour: by direct querying (e.g. `_dyld_get_image_header()` etc., used by the KSCrash component of Bugsnag prior to this issue) and by callback (`_dyld_register_func_for_add_image()` etc.).  This change modifies the KSCrash component to use callbacks and caches information about loaded binary images for when a crash does occur.  Thus, when threads are suspended and a crash report is generated no additional calls to `dyld` need to be made and deadlock is avoided.

Thread safety is a concern.  Reading [the released dyld source code](https://github.com/opensource-apple/dyld/blob/3f928f32597888c5eac6003b9199d972d49857b5/src/dyld.cpp#L526) implies that access to the internal binary image storage in modern OS releases is mediated by a locking mechanism.  However to date no documented guarantee of this has been found.  For the avoidance of doubt the KSCrash-level `add/remove` callbacks use a legacy-compatible shared lock to ensure synchronisation.  By the time a crash report is being written all other non-KS threads will have been suspended and so no additional locking is required.

Performance is also a concern, especially given that the proposed solution moves processing from post-crash (where users are likely to be less concerned about a couple of lost seconds) to up-front.  The library startup code was crudely timed in the sample iOS app on a real device (iPhone XS), with results as follows:

```objc
    // Placed in AppDelegate
    CFTimeInterval start = CACurrentMediaTime();
    [Bugsnag startBugsnagWithApiKey:@"<API KEY>"];
    CFTimeInterval end = CACurrentMediaTime();
    NSLog(@"Took: %f", end - start);
```

|     | Without fix | With fix  |
|-----|-------------|-----------|
| 1   | 0.010215    | 0.011997  |
| 2   | 0.014457    | 0.011432  |
| 3   | 0.011843    | 0.015702  |
| 4   | 0.014623    | 0.013538  |
| 5   | 0.011528    | 0.01601   |
| 6   | 0.015008    | 0.017804  |
| 7   | 0.01258     | 0.015619  |
| 8   | 0.012356    | 0.012655  |
| 9   | 0.011991    | 0.014726  |
| 10  | 0.012292    | 0.013338  |
| __Avg__ | __0.0126893__   | __0.0142821__ |

i.e. a difference of ~2ms.  This was for 385 binary images.  (Anecdotally, turning on debugging adds ~0.1s to the startup time).


<!-- How does this change work? Why was this approach to the goal used? -->

## Changeset

`dyld` binary image capture was moved from `BSG_KSCrashReport.c` to `BSG_KSCrash.m`.  A file-static dynamic array cache is used.  An additional `.m` file contains functions to ease bridging between Objective C and C.

Bugsnag/KSCrash makes use of `dyld` in two main - but related -  places: `BSG_KSCrashReport.c` writing and `BSG_KSDynamicLinker.c`.  These were modified to use an internal API similar to that presented by `dyld` that accesses the cache of headers.

<!-- List what was added, removed, or changed.  Pitch this at a level 
     appropriate to the scope of the change: new  classes, changed architecture,
     minor typo, etc.  If appropriate include a list of changed files: 

         $ git diff --name-status HEAD~1 | cat
-->

## Tests

- A dynamic C array is used to record loaded binary images.  Its behaviour is tested.
- Manual performance testing has been carried out to ascertain the impact on app startup times of recording binary images.
- The generated `json` reports are have been manually tested.
- Both symbolicated and unsymbolicated crash reports need checked on the dashboard for correctness.

<!-- How was this change tested? What manual and automated tests were
     run/added? -->

## Review

### Outstanding Questions

<!-- Are there any parts of the design or the implementation which seem
     less than ideal and that could require additional discussion?
     List here: -->

<!-- Preflight checks. Have I:

* Added a changelog entry?
* Checked the scope to ensure the commits are only related to the goal above?

-->

- This pull request is ready for:
  - [ ] Initial review of the intended approach, not yet feature complete
  - [ ] Structural review of the classes, functions, and properties modified
  - [X] Final review
  - [ ] Release

<!-- What do you need from a reviewer to get this changeset
     ready for release -->

- [ ] The correct target branch has been selected (`master` for fixes, `next` for
  features)
- [ ] If this is intended for release have all of the [pre-release checks](CONTRIBUTING.md) been considered?
- [ ] Consistency across platforms for structures or concepts added or modified
- [ ] Consistency between the changeset and the goal stated above
- [ ] Internal consistency with the rest of the library - is there any overlap between existing interfaces and any which have been added?
- [ ] Usage friction - is the proposed change in usage cumbersome or complicated?
- [ ] Performance and complexity - are there any cases of unexpected O(n^3) when iterating, recursing, flat mapping, etc?
- [X] Concurrency concerns - if components are accessed asynchronously, what issues will arise
- [ ] Thoroughness of added tests and any missing edge cases
- [X] Idiomatic use of the language
