### PR TITLE
Alter default session background timeout to 30s

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,9 @@ Bugsnag Notifiers on other platforms.
 
 ## Enhancements
 
+* Alter default session background timeout to 30s
+  [#581](https://github.com/bugsnag/bugsnag-cocoa/pull/581)
+
 * Add `unhandledRejections` to `BugsnagErrorTypes`
   [#567](https://github.com/bugsnag/bugsnag-cocoa/pull/567)
 

--- a/Source/BugsnagSessionTracker.m
+++ b/Source/BugsnagSessionTracker.m
@@ -18,7 +18,7 @@
 /**
  Number of seconds in background required to make a new session
  */
-NSTimeInterval const BSGNewSessionBackgroundDuration = 60;
+NSTimeInterval const BSGNewSessionBackgroundDuration = 30;
 
 NSString *const BSGSessionUpdateNotification = @"BugsnagSessionChanged";
 


### PR DESCRIPTION
## Goal

Alters the default timeout for sessions to be 30s from 60s once the app has exited the foreground. If the app is relaunched during this time, the existing session will be reused. If the app is relaunched after this threshold, a new session will be created as these are assumed to be two distinct uses of the application.

Changing this threshold brings the Cocoa notifier into line with the Android notifier and the specification.