### PR TITLE
Load configuration from Plist files

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,9 @@ Bugsnag Notifiers on other platforms.
 * Alter default session background timeout to 30s
   [#581](https://github.com/bugsnag/bugsnag-cocoa/pull/581)
 
+* Support loading configuration from values in `Info.plist`.
+  [#582](https://github.com/bugsnag/bugsnag-cocoa/pull/582)
+
 * Add `unhandledRejections` to `BugsnagErrorTypes`
   [#567](https://github.com/bugsnag/bugsnag-cocoa/pull/567)
 

--- a/OSX/Bugsnag.xcodeproj/project.pbxproj
+++ b/OSX/Bugsnag.xcodeproj/project.pbxproj
@@ -50,6 +50,10 @@
 		8A6C6FB22257884C00E8EF24 /* BSGOutOfMemoryWatchdog.h in Headers */ = {isa = PBXBuildFile; fileRef = 8A6C6FB02257884C00E8EF24 /* BSGOutOfMemoryWatchdog.h */; };
 		8A87352C1C6D3B1600EDBD5B /* BSG_KSCrashReportWriter.h in Headers */ = {isa = PBXBuildFile; fileRef = 8A87352B1C6D3B1600EDBD5B /* BSG_KSCrashReportWriter.h */; settings = {ATTRIBUTES = (Public, ); }; };
 		8AD1E3FA23EDDD4F0044F919 /* BSGConnectivityTest.m in Sources */ = {isa = PBXBuildFile; fileRef = 8AD1E3F823EDDD3F0044F919 /* BSGConnectivityTest.m */; };
+		8AB65FC422DC7390001200AB /* BSGConfigurationBuilder.h in Headers */ = {isa = PBXBuildFile; fileRef = 8AB65FC222DC7390001200AB /* BSGConfigurationBuilder.h */; };
+		8AB65FC522DC7390001200AB /* BSGConfigurationBuilder.m in Sources */ = {isa = PBXBuildFile; fileRef = 8AB65FC322DC7390001200AB /* BSGConfigurationBuilder.m */; };
+		8AB65FC822DC73A7001200AB /* BSGConfigurationBuilderTests.m in Sources */ = {isa = PBXBuildFile; fileRef = 8AB65FC622DC739D001200AB /* BSGConfigurationBuilderTests.m */; };
+		8ACF0F752018136200173809 /* BugsnagCrashReportTests.m in Sources */ = {isa = PBXBuildFile; fileRef = 8A2C8FE11C6BC38200846019 /* BugsnagCrashReportTests.m */; };
 		8AD9FA891E086351002859A7 /* BugsnagConfigurationTests.m in Sources */ = {isa = PBXBuildFile; fileRef = 8AD9FA851E0862DC002859A7 /* BugsnagConfigurationTests.m */; };
 		E71DB9DA24470FCF00D0161E /* BugsnagPluginTest.m in Sources */ = {isa = PBXBuildFile; fileRef = E71DB9D424470FCE00D0161E /* BugsnagPluginTest.m */; };
 		E71DB9DB24470FCF00D0161E /* BugsnagSessionTrackerStopTest.m in Sources */ = {isa = PBXBuildFile; fileRef = E71DB9D524470FCF00D0161E /* BugsnagSessionTrackerStopTest.m */; };
@@ -290,6 +294,9 @@
 		8A6C6FB02257884C00E8EF24 /* BSGOutOfMemoryWatchdog.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; name = BSGOutOfMemoryWatchdog.h; path = ../Source/BSGOutOfMemoryWatchdog.h; sourceTree = "<group>"; };
 		8A87352B1C6D3B1600EDBD5B /* BSG_KSCrashReportWriter.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; name = BSG_KSCrashReportWriter.h; path = ../Source/BSG_KSCrashReportWriter.h; sourceTree = SOURCE_ROOT; };
 		8AD1E3F823EDDD3F0044F919 /* BSGConnectivityTest.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; path = BSGConnectivityTest.m; sourceTree = "<group>"; };
+		8AB65FC222DC7390001200AB /* BSGConfigurationBuilder.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; name = BSGConfigurationBuilder.h; path = ../Source/BSGConfigurationBuilder.h; sourceTree = "<group>"; };
+		8AB65FC322DC7390001200AB /* BSGConfigurationBuilder.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; name = BSGConfigurationBuilder.m; path = ../Source/BSGConfigurationBuilder.m; sourceTree = "<group>"; };
+		8AB65FC622DC739D001200AB /* BSGConfigurationBuilderTests.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; path = BSGConfigurationBuilderTests.m; sourceTree = "<group>"; };
 		8AD9FA851E0862DC002859A7 /* BugsnagConfigurationTests.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; name = BugsnagConfigurationTests.m; path = ../Tests/BugsnagConfigurationTests.m; sourceTree = SOURCE_ROOT; };
 		E71DB9D224470F5900D0161E /* BugsnagMetadataTests.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; path = BugsnagMetadataTests.m; sourceTree = "<group>"; };
 		E71DB9D424470FCE00D0161E /* BugsnagPluginTest.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; path = BugsnagPluginTest.m; sourceTree = "<group>"; };
@@ -534,6 +541,8 @@
 				E7A9E5A7243B365400D99F8A /* Plugins */,
 				E7A9E5A9243B365E00D99F8A /* Storage */,
 				8A87352B1C6D3B1600EDBD5B /* BSG_KSCrashReportWriter.h */,
+				8AB65FC222DC7390001200AB /* BSGConfigurationBuilder.h */,
+				8AB65FC322DC7390001200AB /* BSGConfigurationBuilder.m */,
 				8A6C6FB02257884C00E8EF24 /* BSGOutOfMemoryWatchdog.h */,
 				8A6C6FAF2257884C00E8EF24 /* BSGOutOfMemoryWatchdog.m */,
 				8A627CD71EC3B75200F7C04E /* BSGSerialization.h */,
@@ -572,6 +581,8 @@
 				E790C41F2432314A006FFB26 /* BugsnagClientMirrorTest.m */,
 				E7A5678A245AE7AF009BE2F1 /* BugsnagClientPayloadInfoTest.m */,
 				E71DB9D924470FCF00D0161E /* BugsnagClientTests.m */,
+				8AB65FC622DC739D001200AB /* BSGConfigurationBuilderTests.m */,
+				8A12006B221C50F40008C9C3 /* BSGFilepathTests.m */,
 				4B406C1622CAD96400464D1D /* BugsnagCollectionsBSGDictMergeTest.m */,
 				4B406C1722CAD96400464D1D /* BugsnagCollectionsBSGDictSetSafeObjectTest.m */,
 				4B775FD222CBE02A004839C5 /* BugsnagCollectionsBSGDictInsertIfNotNilTest.m */,
@@ -971,6 +982,7 @@
 				E79E6BB71F4E3850002B35F9 /* BSG_KSFileUtils.h in Headers */,
 				E79E6B951F4E3850002B35F9 /* BSG_KSCrashReportVersion.h in Headers */,
 				E79E6B9A1F4E3850002B35F9 /* BSG_KSCrashType.h in Headers */,
+				8AB65FC422DC7390001200AB /* BSGConfigurationBuilder.h in Headers */,
 				E79E6B981F4E3850002B35F9 /* BSG_KSCrashState.h in Headers */,
 				E79148541FD82B36003EFEBF /* BugsnagSessionTrackingApiClient.h in Headers */,
 				E79E6B9C1F4E3850002B35F9 /* BSG_KSSystemInfo.h in Headers */,
@@ -1155,6 +1167,7 @@
 				E79E6B9F1F4E3850002B35F9 /* BSG_KSCrashSentry.c in Sources */,
 				E79E6BC31F4E3850002B35F9 /* BSG_KSMach_x86_64.c in Sources */,
 				E79E6BD61F4E3850002B35F9 /* NSError+BSG_SimpleConstructor.m in Sources */,
+				8AB65FC522DC7390001200AB /* BSGConfigurationBuilder.m in Sources */,
 				E79E6B8B1F4E3850002B35F9 /* BSG_KSCrashC.c in Sources */,
 				E79E6BAF1F4E3850002B35F9 /* BSG_KSBacktrace.c in Sources */,
 				E79E6B941F4E3850002B35F9 /* BSG_KSCrashReportStore.m in Sources */,
@@ -1198,6 +1211,7 @@
 				00F9393C23FD2D9B008C7073 /* BugsnagTestsDummyClass.m in Sources */,
 				E7D2E676243B8FB6005A3041 /* BugsnagStacktraceTest.m in Sources */,
 				E71DB9DF2447100000D0161E /* BugsnagMetadataTests.m in Sources */,
+				8AB65FC822DC73A7001200AB /* BSGConfigurationBuilderTests.m in Sources */,
 				E7CE78D61FD94E9E001D07E0 /* FileBasedTestCase.m in Sources */,
 				E7CE78D51FD94E93001D07E0 /* XCTestCase+KSCrash.m in Sources */,
 				E7CE78CF1FD94E77001D07E0 /* NSError+SimpleConstructor_Tests.m in Sources */,

--- a/OSX/Bugsnag.xcodeproj/project.pbxproj
+++ b/OSX/Bugsnag.xcodeproj/project.pbxproj
@@ -49,11 +49,10 @@
 		8A6C6FB12257884C00E8EF24 /* BSGOutOfMemoryWatchdog.m in Sources */ = {isa = PBXBuildFile; fileRef = 8A6C6FAF2257884C00E8EF24 /* BSGOutOfMemoryWatchdog.m */; };
 		8A6C6FB22257884C00E8EF24 /* BSGOutOfMemoryWatchdog.h in Headers */ = {isa = PBXBuildFile; fileRef = 8A6C6FB02257884C00E8EF24 /* BSGOutOfMemoryWatchdog.h */; };
 		8A87352C1C6D3B1600EDBD5B /* BSG_KSCrashReportWriter.h in Headers */ = {isa = PBXBuildFile; fileRef = 8A87352B1C6D3B1600EDBD5B /* BSG_KSCrashReportWriter.h */; settings = {ATTRIBUTES = (Public, ); }; };
-		8AD1E3FA23EDDD4F0044F919 /* BSGConnectivityTest.m in Sources */ = {isa = PBXBuildFile; fileRef = 8AD1E3F823EDDD3F0044F919 /* BSGConnectivityTest.m */; };
 		8AB65FC422DC7390001200AB /* BSGConfigurationBuilder.h in Headers */ = {isa = PBXBuildFile; fileRef = 8AB65FC222DC7390001200AB /* BSGConfigurationBuilder.h */; };
 		8AB65FC522DC7390001200AB /* BSGConfigurationBuilder.m in Sources */ = {isa = PBXBuildFile; fileRef = 8AB65FC322DC7390001200AB /* BSGConfigurationBuilder.m */; };
 		8AB65FC822DC73A7001200AB /* BSGConfigurationBuilderTests.m in Sources */ = {isa = PBXBuildFile; fileRef = 8AB65FC622DC739D001200AB /* BSGConfigurationBuilderTests.m */; };
-		8ACF0F752018136200173809 /* BugsnagCrashReportTests.m in Sources */ = {isa = PBXBuildFile; fileRef = 8A2C8FE11C6BC38200846019 /* BugsnagCrashReportTests.m */; };
+		8AD1E3FA23EDDD4F0044F919 /* BSGConnectivityTest.m in Sources */ = {isa = PBXBuildFile; fileRef = 8AD1E3F823EDDD3F0044F919 /* BSGConnectivityTest.m */; };
 		8AD9FA891E086351002859A7 /* BugsnagConfigurationTests.m in Sources */ = {isa = PBXBuildFile; fileRef = 8AD9FA851E0862DC002859A7 /* BugsnagConfigurationTests.m */; };
 		E71DB9DA24470FCF00D0161E /* BugsnagPluginTest.m in Sources */ = {isa = PBXBuildFile; fileRef = E71DB9D424470FCE00D0161E /* BugsnagPluginTest.m */; };
 		E71DB9DB24470FCF00D0161E /* BugsnagSessionTrackerStopTest.m in Sources */ = {isa = PBXBuildFile; fileRef = E71DB9D524470FCF00D0161E /* BugsnagSessionTrackerStopTest.m */; };
@@ -203,6 +202,7 @@
 		E79E6BDB1F4E3850002B35F9 /* BSG_KSCrashReportFilter.h in Headers */ = {isa = PBXBuildFile; fileRef = E79E6B711F4E3850002B35F9 /* BSG_KSCrashReportFilter.h */; };
 		E79E6BDC1F4E3850002B35F9 /* BSG_KSCrashReportFilterCompletion.h in Headers */ = {isa = PBXBuildFile; fileRef = E79E6B721F4E3850002B35F9 /* BSG_KSCrashReportFilterCompletion.h */; };
 		E7A5679D245B0511009BE2F1 /* BugsnagClientPayloadInfoTest.m in Sources */ = {isa = PBXBuildFile; fileRef = E7A5678A245AE7AF009BE2F1 /* BugsnagClientPayloadInfoTest.m */; };
+		E7A8EA65246181AA00CCBBD1 /* TestsInfo.plist in Resources */ = {isa = PBXBuildFile; fileRef = E7A8EA64246181AA00CCBBD1 /* TestsInfo.plist */; };
 		E7A9E56924361B6300D99F8A /* BugsnagAppTest.m in Sources */ = {isa = PBXBuildFile; fileRef = E790C4A22434CB6A006FFB26 /* BugsnagAppTest.m */; };
 		E7A9E56D2436365300D99F8A /* BugsnagDeviceTest.m in Sources */ = {isa = PBXBuildFile; fileRef = E7A9E56C2436365300D99F8A /* BugsnagDeviceTest.m */; };
 		E7AB4B9E2423E184004F015A /* BugsnagOnBreadcrumbTest.m in Sources */ = {isa = PBXBuildFile; fileRef = E7AB4B9D2423E184004F015A /* BugsnagOnBreadcrumbTest.m */; };
@@ -261,7 +261,6 @@
 		8A2C8FA11C6BC1F700846019 /* Bugsnag.framework */ = {isa = PBXFileReference; explicitFileType = wrapper.framework; includeInIndex = 0; path = Bugsnag.framework; sourceTree = BUILT_PRODUCTS_DIR; };
 		8A2C8FA61C6BC1F700846019 /* Info.plist */ = {isa = PBXFileReference; lastKnownFileType = text.plist.xml; path = Info.plist; sourceTree = "<group>"; };
 		8A2C8FAB1C6BC1F700846019 /* Tests.xctest */ = {isa = PBXFileReference; explicitFileType = wrapper.cfbundle; includeInIndex = 0; path = Tests.xctest; sourceTree = BUILT_PRODUCTS_DIR; };
-		8A2C8FB21C6BC1F700846019 /* TestsInfo.plist */ = {isa = PBXFileReference; lastKnownFileType = text.plist; name = TestsInfo.plist; path = ../Tests/TestsInfo.plist; sourceTree = SOURCE_ROOT; };
 		8A2C8FBB1C6BC2C800846019 /* Bugsnag.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; name = Bugsnag.h; path = ../Source/Bugsnag.h; sourceTree = SOURCE_ROOT; };
 		8A2C8FBC1C6BC2C800846019 /* Bugsnag.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; name = Bugsnag.m; path = ../Source/Bugsnag.m; sourceTree = SOURCE_ROOT; };
 		8A2C8FBD1C6BC2C800846019 /* BugsnagBreadcrumb.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; name = BugsnagBreadcrumb.h; path = ../Source/BugsnagBreadcrumb.h; sourceTree = SOURCE_ROOT; };
@@ -293,10 +292,10 @@
 		8A6C6FAF2257884C00E8EF24 /* BSGOutOfMemoryWatchdog.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; name = BSGOutOfMemoryWatchdog.m; path = ../Source/BSGOutOfMemoryWatchdog.m; sourceTree = "<group>"; };
 		8A6C6FB02257884C00E8EF24 /* BSGOutOfMemoryWatchdog.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; name = BSGOutOfMemoryWatchdog.h; path = ../Source/BSGOutOfMemoryWatchdog.h; sourceTree = "<group>"; };
 		8A87352B1C6D3B1600EDBD5B /* BSG_KSCrashReportWriter.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; name = BSG_KSCrashReportWriter.h; path = ../Source/BSG_KSCrashReportWriter.h; sourceTree = SOURCE_ROOT; };
-		8AD1E3F823EDDD3F0044F919 /* BSGConnectivityTest.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; path = BSGConnectivityTest.m; sourceTree = "<group>"; };
 		8AB65FC222DC7390001200AB /* BSGConfigurationBuilder.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; name = BSGConfigurationBuilder.h; path = ../Source/BSGConfigurationBuilder.h; sourceTree = "<group>"; };
 		8AB65FC322DC7390001200AB /* BSGConfigurationBuilder.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; name = BSGConfigurationBuilder.m; path = ../Source/BSGConfigurationBuilder.m; sourceTree = "<group>"; };
 		8AB65FC622DC739D001200AB /* BSGConfigurationBuilderTests.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; path = BSGConfigurationBuilderTests.m; sourceTree = "<group>"; };
+		8AD1E3F823EDDD3F0044F919 /* BSGConnectivityTest.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; path = BSGConnectivityTest.m; sourceTree = "<group>"; };
 		8AD9FA851E0862DC002859A7 /* BugsnagConfigurationTests.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; name = BugsnagConfigurationTests.m; path = ../Tests/BugsnagConfigurationTests.m; sourceTree = SOURCE_ROOT; };
 		E71DB9D224470F5900D0161E /* BugsnagMetadataTests.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; path = BugsnagMetadataTests.m; sourceTree = "<group>"; };
 		E71DB9D424470FCE00D0161E /* BugsnagPluginTest.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; path = BugsnagPluginTest.m; sourceTree = "<group>"; };
@@ -448,6 +447,7 @@
 		E79E6B711F4E3850002B35F9 /* BSG_KSCrashReportFilter.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; name = BSG_KSCrashReportFilter.h; path = ../Source/KSCrash/Source/KSCrash/Reporting/Filters/BSG_KSCrashReportFilter.h; sourceTree = SOURCE_ROOT; };
 		E79E6B721F4E3850002B35F9 /* BSG_KSCrashReportFilterCompletion.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; name = BSG_KSCrashReportFilterCompletion.h; path = ../Source/KSCrash/Source/KSCrash/Reporting/Filters/BSG_KSCrashReportFilterCompletion.h; sourceTree = SOURCE_ROOT; };
 		E7A5678A245AE7AF009BE2F1 /* BugsnagClientPayloadInfoTest.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; path = BugsnagClientPayloadInfoTest.m; sourceTree = "<group>"; };
+		E7A8EA64246181AA00CCBBD1 /* TestsInfo.plist */ = {isa = PBXFileReference; lastKnownFileType = text.plist; path = TestsInfo.plist; sourceTree = SOURCE_ROOT; };
 		E7A9E56C2436365300D99F8A /* BugsnagDeviceTest.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; path = BugsnagDeviceTest.m; sourceTree = "<group>"; };
 		E7AB4B9D2423E184004F015A /* BugsnagOnBreadcrumbTest.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; path = BugsnagOnBreadcrumbTest.m; sourceTree = "<group>"; };
 		E7CE78871FD94E5F001D07E0 /* KSMach_Tests.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; path = KSMach_Tests.m; sourceTree = "<group>"; };
@@ -541,8 +541,6 @@
 				E7A9E5A7243B365400D99F8A /* Plugins */,
 				E7A9E5A9243B365E00D99F8A /* Storage */,
 				8A87352B1C6D3B1600EDBD5B /* BSG_KSCrashReportWriter.h */,
-				8AB65FC222DC7390001200AB /* BSGConfigurationBuilder.h */,
-				8AB65FC322DC7390001200AB /* BSGConfigurationBuilder.m */,
 				8A6C6FB02257884C00E8EF24 /* BSGOutOfMemoryWatchdog.h */,
 				8A6C6FAF2257884C00E8EF24 /* BSGOutOfMemoryWatchdog.m */,
 				8A627CD71EC3B75200F7C04E /* BSGSerialization.h */,
@@ -572,7 +570,7 @@
 		8A2C8FAF1C6BC1F700846019 /* Tests */ = {
 			isa = PBXGroup;
 			children = (
-				E728378C245184B600EE2B7D /* BugsnagOnCrashTest.m */,
+				8AB65FC622DC739D001200AB /* BSGConfigurationBuilderTests.m */,
 				8AD1E3F823EDDD3F0044F919 /* BSGConnectivityTest.m */,
 				E790C4A22434CB6A006FFB26 /* BugsnagAppTest.m */,
 				00F9393123FC168F008C7073 /* BugsnagBaseUnitTest.h */,
@@ -581,8 +579,6 @@
 				E790C41F2432314A006FFB26 /* BugsnagClientMirrorTest.m */,
 				E7A5678A245AE7AF009BE2F1 /* BugsnagClientPayloadInfoTest.m */,
 				E71DB9D924470FCF00D0161E /* BugsnagClientTests.m */,
-				8AB65FC622DC739D001200AB /* BSGConfigurationBuilderTests.m */,
-				8A12006B221C50F40008C9C3 /* BSGFilepathTests.m */,
 				4B406C1622CAD96400464D1D /* BugsnagCollectionsBSGDictMergeTest.m */,
 				4B406C1722CAD96400464D1D /* BugsnagCollectionsBSGDictSetSafeObjectTest.m */,
 				4B775FD222CBE02A004839C5 /* BugsnagCollectionsBSGDictInsertIfNotNilTest.m */,
@@ -595,6 +591,7 @@
 				E71DB9D224470F5900D0161E /* BugsnagMetadataTests.m */,
 				E7819BB8245979D200A7EBDD /* BugsnagNotifierTest.m */,
 				E7AB4B9D2423E184004F015A /* BugsnagOnBreadcrumbTest.m */,
+				E728378C245184B600EE2B7D /* BugsnagOnCrashTest.m */,
 				E71DB9D424470FCE00D0161E /* BugsnagPluginTest.m */,
 				E791482D1FD82B0C003EFEBF /* BugsnagSessionTest.m */,
 				E791482B1FD82B0C003EFEBF /* BugsnagSessionTrackerTest.m */,
@@ -611,8 +608,8 @@
 				E7529F9F243CAE34006B4932 /* BugsnagThreadTest.m */,
 				E791482E1FD82B0C003EFEBF /* BugsnagUserTest.m */,
 				8A2C8FE41C6BC38200846019 /* report.json */,
-				8A2C8FB21C6BC1F700846019 /* TestsInfo.plist */,
 				E7CE78861FD94E40001D07E0 /* KSCrash */,
+				E7A8EA64246181AA00CCBBD1 /* TestsInfo.plist */,
 			);
 			name = Tests;
 			path = ../Tests;
@@ -634,6 +631,8 @@
 		E7565F7D245082690041768E /* Configuration */ = {
 			isa = PBXGroup;
 			children = (
+				8AB65FC222DC7390001200AB /* BSGConfigurationBuilder.h */,
+				8AB65FC322DC7390001200AB /* BSGConfigurationBuilder.m */,
 				8A2C8FC11C6BC2C800846019 /* BugsnagConfiguration.h */,
 				8A2C8FC21C6BC2C800846019 /* BugsnagConfiguration.m */,
 				E77AFF0E244A18B10082B8BB /* BugsnagEndpointConfiguration.h */,
@@ -1112,6 +1111,7 @@
 			isa = PBXResourcesBuildPhase;
 			buildActionMask = 2147483647;
 			files = (
+				E7A8EA65246181AA00CCBBD1 /* TestsInfo.plist in Resources */,
 				8A2C8FEE1C6BC38900846019 /* report.json in Resources */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;

--- a/OSX/Info.plist
+++ b/OSX/Info.plist
@@ -19,7 +19,7 @@
 	<key>CFBundleSignature</key>
 	<string>????</string>
 	<key>CFBundleVersion</key>
-	<string>$(CURRENT_PROJECT_VERSION)</string>
+	<string>1</string>
 	<key>NSHumanReadableCopyright</key>
 	<string>Copyright © 2016 Bugsnag. All rights reserved.</string>
 	<key>NSPrincipalClass</key>

--- a/OSX/Info.plist
+++ b/OSX/Info.plist
@@ -21,7 +21,7 @@
 	<key>CFBundleVersion</key>
 	<string>1</string>
 	<key>NSHumanReadableCopyright</key>
-	<string>Copyright © 2016 Bugsnag. All rights reserved.</string>
+	<string>Copyright © 2020 Bugsnag. All rights reserved.</string>
 	<key>NSPrincipalClass</key>
 	<string></string>
 </dict>

--- a/Source/BSGConfigurationBuilder.h
+++ b/Source/BSGConfigurationBuilder.h
@@ -1,0 +1,16 @@
+#import <Foundation/Foundation.h>
+
+@class BugsnagConfiguration;
+
+@interface BSGConfigurationBuilder : NSObject
+
+/**
+ * Creates a configuration, applying supported options before returning the new
+ * config object. Unsupported options warn.
+ *
+ * @return a new BugsnagConfiguration object or nil if the a valid object could
+ * not be created (including a non-empty API key)
+ */
++ (BugsnagConfiguration *_Nullable)configurationFromOptions:(NSDictionary *_Nullable)options;
+
+@end

--- a/Source/BSGConfigurationBuilder.h
+++ b/Source/BSGConfigurationBuilder.h
@@ -11,6 +11,6 @@
  * @return a new BugsnagConfiguration object or nil if the a valid object could
  * not be created (including a non-empty API key)
  */
-+ (BugsnagConfiguration *_Nullable)configurationFromOptions:(NSDictionary *_Nullable)options;
++ (BugsnagConfiguration *_Nonnull)configurationFromOptions:(NSDictionary *_Nonnull)options;
 
 @end

--- a/Source/BSGConfigurationBuilder.h
+++ b/Source/BSGConfigurationBuilder.h
@@ -6,7 +6,7 @@
 
 /**
  * Creates a configuration, applying supported options before returning the new
- * config object. Unsupported options warn.
+ * config object.
  *
  * @return a new BugsnagConfiguration object or nil if the a valid object could
  * not be created (including a non-empty API key)

--- a/Source/BSGConfigurationBuilder.m
+++ b/Source/BSGConfigurationBuilder.m
@@ -1,0 +1,145 @@
+#import "BSGConfigurationBuilder.h"
+#import "BugsnagConfiguration.h"
+
+NSString *const BSGAutoCollectBreadcrumbsKey = @"autoBreadcrumbs";
+NSString *const BSGAutoCaptureSessionsKey = @"autoSessions";
+
+/**
+ * Validate and set a value on config if the value is of the correct type.
+ * Remove the value from options after successful validation.
+ *
+ * @return config or nil if the value is not of the correct type
+ */
+BugsnagConfiguration *BSGValidateAndSetStringOption(BugsnagConfiguration *config, NSMutableDictionary *options, NSString *key);
+/**
+ * Validate and set a value on config if the value is a boolean.
+ * Remove the value from options after successful validation.
+ *
+ * @return config or nil if the value is a boolean
+ */
+BugsnagConfiguration *BSGValidateAndSetBooleanOption(BugsnagConfiguration *config, NSMutableDictionary *options, NSString *key);
+
+/**
+ * Validate and set notifyReleaseStages on config if the value is an array of
+ * strings.
+ * Remove the value from options after successful validation.
+ *
+ * @return config or nil if the value or contained values are not of the correct
+ * type
+ */
+BugsnagConfiguration *BSGValidateAndSetNotifyReleaseStages(BugsnagConfiguration *config, NSMutableDictionary *options);
+
+/**
+ * Validate and set notifyURL and sessionURL on config if the value is a
+ * dictionary containing exactly two values for keys "notify" and "sessions".
+ * Remove the value from options after successful validation.
+ *
+ * @return config or nil if the value or contained values are not of the correct
+ * type or name, to avoid data leakage to the hosted version from on-premise.
+ */
+BugsnagConfiguration *BSGValidateAndSetEndpoints(BugsnagConfiguration *config, NSMutableDictionary *options);
+
+@implementation BSGConfigurationBuilder
+
++ (BugsnagConfiguration *)configurationFromOptions:(NSDictionary *)options {
+    BugsnagConfiguration *config = [BugsnagConfiguration new];
+    NSMutableDictionary *properties = [options mutableCopy];
+    config = BSGValidateAndSetStringOption(config, properties, NSStringFromSelector(@selector(apiKey)));
+    if (config.apiKey.length == 0) {
+        // The API key is not valid
+        return nil;
+    }
+    config = BSGValidateAndSetBooleanOption(config, properties, NSStringFromSelector(@selector(autoNotify)));
+    config = BSGValidateAndSetBooleanOption(config, properties, BSGAutoCollectBreadcrumbsKey);
+    config = BSGValidateAndSetBooleanOption(config, properties, BSGAutoCaptureSessionsKey);
+    config = BSGValidateAndSetBooleanOption(config, properties, NSStringFromSelector(@selector(reportOOMs)));
+    config = BSGValidateAndSetBooleanOption(config, properties, NSStringFromSelector(@selector(reportBackgroundOOMs)));
+    config = BSGValidateAndSetStringOption(config, properties, NSStringFromSelector(@selector(releaseStage)));
+    config = BSGValidateAndSetNotifyReleaseStages(config, properties);
+    config = BSGValidateAndSetEndpoints(config, properties);
+    if (properties.count > 0) {
+        // The collection contains values unsupported in BugsnagConfiguration
+        return nil;
+    }
+    return config;
+}
+
+@end
+
+static BOOL BSGValueIsBoolean(id object) {
+    return [object isKindOfClass:[NSNumber class]]
+    && CFGetTypeID((__bridge CFTypeRef)object) == CFBooleanGetTypeID();
+}
+
+NSString *BSGTransformOptionToPropertyName(NSString *option) {
+    if ([option isEqualToString:BSGAutoCollectBreadcrumbsKey]) {
+        return NSStringFromSelector(@selector(automaticallyCollectBreadcrumbs));
+    } else if ([option isEqualToString:BSGAutoCaptureSessionsKey]) {
+        return NSStringFromSelector(@selector(shouldAutoCaptureSessions));
+    }
+    return option;
+}
+
+BugsnagConfiguration *BSGValidateAndSetStringOption(BugsnagConfiguration *config, NSMutableDictionary *options, NSString *key) {
+    if ([options[key] isKindOfClass:[NSString class]]) {
+        [config setValue:options[key] forKey:key];
+    } else if (options[key]) {
+        return nil;
+    }
+    [options removeObjectForKey:key];
+    return config;
+}
+
+BugsnagConfiguration *BSGValidateAndSetBooleanOption(BugsnagConfiguration *config, NSMutableDictionary *options, NSString *key) {
+    if (BSGValueIsBoolean(options[key])) {
+        [config setValue:options[key] forKey:BSGTransformOptionToPropertyName(key)];
+    } else if (options[key]) {
+        return nil;
+    }
+    [options removeObjectForKey:key];
+    return config;
+}
+
+BugsnagConfiguration *BSGValidateAndSetNotifyReleaseStages(BugsnagConfiguration *config, NSMutableDictionary *options) {
+    NSString *const notifyReleaseStagesKey = NSStringFromSelector(@selector(notifyReleaseStages));
+    if (options[notifyReleaseStagesKey] && [options[notifyReleaseStagesKey] isKindOfClass:[NSArray class]]) {
+        NSArray *notifyReleaseStages = options[notifyReleaseStagesKey];
+        for (id stage in notifyReleaseStages) {
+            if (![stage isKindOfClass:[NSString class]]) {
+                return nil;
+            }
+        }
+        config.notifyReleaseStages = notifyReleaseStages;
+    } else if (options[notifyReleaseStagesKey]) {
+        return nil;
+    }
+    [options removeObjectForKey:notifyReleaseStagesKey];
+    return config;
+}
+
+BugsnagConfiguration *BSGValidateAndSetEndpoints(BugsnagConfiguration *config, NSMutableDictionary *options) {
+    NSString *const endpointsKey = @"endpoints";
+    NSString *const notifyEndpointKey = @"notify";
+    NSString *const sessionsEndpointKey = @"sessions";
+    if (options[endpointsKey] && [options[endpointsKey] isKindOfClass:[NSDictionary class]]) {
+        NSDictionary *endpoints = options[endpointsKey];
+        if (endpoints.count == 2
+            && [endpoints[notifyEndpointKey] isKindOfClass:[NSString class]]
+            && [endpoints[sessionsEndpointKey] isKindOfClass:[NSString class]]) {
+            NSString *notifyEndpoint = endpoints[notifyEndpointKey];
+            NSString *sessionsEndpoint = endpoints[sessionsEndpointKey];
+            if (notifyEndpoint.length > 0 && sessionsEndpoint.length > 0) {
+                [config setEndpointsForNotify:endpoints[notifyEndpointKey]
+                                     sessions:endpoints[sessionsEndpointKey]];
+            } else {
+                return nil;
+            }
+        } else {
+            return nil;
+        }
+    } else if (options[endpointsKey]) {
+        return nil;
+    }
+    [options removeObjectForKey:endpointsKey];
+    return config;
+}

--- a/Source/BugsnagConfiguration.h
+++ b/Source/BugsnagConfiguration.h
@@ -105,6 +105,14 @@ typedef BOOL (^BugsnagOnSessionBlock)(BugsnagSession *_Nonnull session);
 
 @interface BugsnagConfiguration : NSObject <BugsnagMetadataStore>
 
+/**
+ * Create a new configuration from the main bundle's infoDictionary, using keys nested under
+ * the "bugsnag" key.
+ *
+ * @return a BugsnagConfiguration containing the options set in the plist file
+ */
++ (instancetype _Nonnull)loadConfig;
+
 // -----------------------------------------------------------------------------
 // MARK: - Properties
 // -----------------------------------------------------------------------------

--- a/Tests/BSGConfigurationBuilderTests.m
+++ b/Tests/BSGConfigurationBuilderTests.m
@@ -1,0 +1,494 @@
+#import "BSGConfigurationBuilder.h"
+#import "BugsnagConfiguration.h"
+#import <XCTest/XCTest.h>
+
+@interface BSGConfigurationBuilderTests : XCTestCase
+@end
+
+@implementation BSGConfigurationBuilderTests
+
+- (void)testDecodeEmptyOptions {
+    BugsnagConfiguration *config = [BSGConfigurationBuilder configurationFromOptions:@{}];
+    XCTAssertNil(config);
+}
+
+- (void)testDecodeApiKey {
+    BugsnagConfiguration *config = [BSGConfigurationBuilder
+        configurationFromOptions:@{@"apiKey" : @"foo123"}];
+    XCTAssertEqualObjects(@"foo123", config.apiKey);
+}
+
+- (void)testDecodeDefaultAutoNotify {
+    BugsnagConfiguration *config = [BSGConfigurationBuilder
+        configurationFromOptions:@{@"apiKey" : @"foo123"}];
+    XCTAssertEqualObjects(@"foo123", config.apiKey);
+    XCTAssertTrue(config.autoNotify);
+}
+
+- (void)testDecodeDefaultAutoCaptureSessions {
+    BugsnagConfiguration *config = [BSGConfigurationBuilder
+        configurationFromOptions:@{@"apiKey" : @"foo123"}];
+    XCTAssertEqualObjects(@"foo123", config.apiKey);
+    XCTAssertTrue(config.shouldAutoCaptureSessions);
+}
+
+- (void)testDecodeDefaultAutoCollectBreadcrumbs {
+    BugsnagConfiguration *config = [BSGConfigurationBuilder
+        configurationFromOptions:@{@"apiKey" : @"foo123"}];
+    XCTAssertEqualObjects(@"foo123", config.apiKey);
+    XCTAssertTrue(config.automaticallyCollectBreadcrumbs);
+}
+
+- (void)testDecodeDefaultEndpoints {
+    BugsnagConfiguration *config = [BSGConfigurationBuilder
+        configurationFromOptions:@{@"apiKey" : @"foo123"}];
+    XCTAssertEqualObjects(@"foo123", config.apiKey);
+    XCTAssertEqualObjects([NSURL URLWithString:@"https://notify.bugsnag.com/"],
+                          config.notifyURL);
+    XCTAssertEqualObjects([NSURL URLWithString:@"https://sessions.bugsnag.com"],
+                          config.sessionURL);
+}
+
+- (void)testDecodeDefaultReleaseStage {
+    BugsnagConfiguration *config = [BSGConfigurationBuilder
+        configurationFromOptions:@{@"apiKey" : @"foo123"}];
+    XCTAssertEqualObjects(@"foo123", config.apiKey);
+#if DEBUG
+    XCTAssertEqualObjects(@"development", config.releaseStage);
+#else
+    XCTAssertEqualObjects(@"production", config.releaseStage);
+#endif
+}
+
+- (void)testDecodeDefaultNotifyReleaseStages {
+    BugsnagConfiguration *config = [BSGConfigurationBuilder
+        configurationFromOptions:@{@"apiKey" : @"foo123"}];
+    XCTAssertEqualObjects(@"foo123", config.apiKey);
+    XCTAssertNil(config.notifyReleaseStages);
+}
+
+- (void)testDecodeDefaultReportOOMs {
+    BugsnagConfiguration *config = [BSGConfigurationBuilder
+        configurationFromOptions:@{@"apiKey" : @"foo123"}];
+    XCTAssertEqualObjects(@"foo123", config.apiKey);
+    XCTAssertTrue(config.reportOOMs);
+}
+
+- (void)testDecodeDefaultReportBackgroundOOMs {
+    BugsnagConfiguration *config = [BSGConfigurationBuilder
+        configurationFromOptions:@{@"apiKey" : @"foo123"}];
+    XCTAssertEqualObjects(@"foo123", config.apiKey);
+    XCTAssertFalse(config.reportBackgroundOOMs);
+}
+
+- (void)testDecodeEmptyApiKey {
+    BugsnagConfiguration *config = [BSGConfigurationBuilder
+        configurationFromOptions:@{@"apiKey" : @""}];
+    XCTAssertNil(config);
+}
+
+- (void)testDecodeInvalidTypeApiKey {
+    BugsnagConfiguration *config = [BSGConfigurationBuilder
+        configurationFromOptions:@{@"apiKey" : @[ @"one", @"two" ]}];
+    XCTAssertNil(config);
+}
+
+- (void)testDecodeAutoNotifyWithoutApiKey {
+    BugsnagConfiguration *config = [BSGConfigurationBuilder
+        configurationFromOptions:@{@"autoNotify" : @NO}];
+    XCTAssertNil(config);
+    config = [BSGConfigurationBuilder
+        configurationFromOptions:@{@"autoNotify" : @YES}];
+    XCTAssertNil(config);
+}
+
+- (void)testDecodeAutoNotifyInvalidType {
+    BugsnagConfiguration *config = [BSGConfigurationBuilder configurationFromOptions:@{
+                                                                                          @"autoNotify" : @(67),
+                                                                                          @"apiKey" : @"accfe1383",
+                                                                                          }];
+    XCTAssertNil(config);
+}
+
+- (void)testDecodeAutoNotify {
+    BugsnagConfiguration *config =
+        [BSGConfigurationBuilder configurationFromOptions:@{
+            @"autoNotify" : @NO,
+            @"apiKey" : @"34234136bff"
+        }];
+    XCTAssertNotNil(config);
+    XCTAssertFalse(config.autoNotify);
+    XCTAssertEqualObjects(@"34234136bff", config.apiKey);
+    config = [BSGConfigurationBuilder configurationFromOptions:@{
+        @"autoNotify" : @YES,
+        @"apiKey" : @"83434136bff"
+    }];
+    XCTAssertNotNil(config);
+    XCTAssertTrue(config.autoNotify);
+    XCTAssertEqualObjects(@"83434136bff", config.apiKey);
+}
+
+- (void)testDecodeAutoCaptureSessionsWithoutApiKey {
+    BugsnagConfiguration *config = [BSGConfigurationBuilder
+        configurationFromOptions:@{@"autoSessions" : @NO}];
+    XCTAssertNil(config);
+    config = [BSGConfigurationBuilder
+        configurationFromOptions:@{@"autoSessions" : @YES}];
+    XCTAssertNil(config);
+}
+
+- (void)testDecodeAutoCaptureSessionsInvalidType {
+    BugsnagConfiguration *config = [BSGConfigurationBuilder configurationFromOptions:@{
+                                                                                          @"autoSessions" : @"NO",
+                                                                                          @"apiKey" : @"ac928faeec"
+                                                                                          }];
+    XCTAssertNil(config);
+}
+
+- (void)testDecodeAutoCaptureSessions {
+    BugsnagConfiguration *config =
+        [BSGConfigurationBuilder configurationFromOptions:@{
+            @"autoSessions" : @NO,
+            @"apiKey" : @"2343a136bff"
+        }];
+    XCTAssertNotNil(config);
+    XCTAssertFalse(config.shouldAutoCaptureSessions);
+    XCTAssertEqualObjects(@"2343a136bff", config.apiKey);
+    config = [BSGConfigurationBuilder configurationFromOptions:@{
+        @"autoSessions" : @YES,
+        @"apiKey" : @"2343a136bff"
+    }];
+    XCTAssertNotNil(config);
+    XCTAssertTrue(config.shouldAutoCaptureSessions);
+    XCTAssertEqualObjects(@"2343a136bff", config.apiKey);
+}
+
+- (void)testDecodeAutoCollectBreadcrumbs {
+    BugsnagConfiguration *config =
+        [BSGConfigurationBuilder configurationFromOptions:@{
+            @"autoBreadcrumbs" : @NO,
+            @"apiKey" : @"1343a136bff"
+        }];
+    XCTAssertNotNil(config);
+    XCTAssertFalse(config.automaticallyCollectBreadcrumbs);
+    XCTAssertEqualObjects(@"1343a136bff", config.apiKey);
+    config = [BSGConfigurationBuilder configurationFromOptions:@{
+        @"autoBreadcrumbs" : @YES,
+        @"apiKey" : @"1343a136bff"
+    }];
+    XCTAssertNotNil(config);
+    XCTAssertTrue(config.automaticallyCollectBreadcrumbs);
+    XCTAssertEqualObjects(@"1343a136bff", config.apiKey);
+}
+
+- (void)testDecodeAutoCollectBreadcrumbsInvalidType {
+    BugsnagConfiguration *config =
+        [BSGConfigurationBuilder configurationFromOptions:@{
+            @"autoBreadcrumbs" : @"foo",
+            @"apiKey" : @"5628acc"
+        }];
+    XCTAssertNil(config);
+}
+
+- (void)testDecodeAutoCollectBreadcrumbsWithoutApiKey {
+    BugsnagConfiguration *config = [BSGConfigurationBuilder
+        configurationFromOptions:@{@"autoBreadcrumbs" : @NO}];
+    XCTAssertNil(config);
+    config = [BSGConfigurationBuilder
+        configurationFromOptions:@{@"autoBreadcrumbs" : @YES}];
+    XCTAssertNil(config);
+}
+
+- (void)testDecodeEndpointsInvalidTypes {
+    BugsnagConfiguration *config = [BSGConfigurationBuilder configurationFromOptions:@{
+        @"endpoints" : @"foo",
+        @"apiKey" : @"5628acc"
+    }];
+    XCTAssertNil(config);
+    config = [BSGConfigurationBuilder configurationFromOptions:@{
+        @"endpoints" : @[ @"http://example.com", @"http://foo.example.com" ],
+        @"apiKey" : @"5628acc"
+    }];
+    XCTAssertNil(config);
+    config = [BSGConfigurationBuilder configurationFromOptions:@{
+        @"endpoints" : @{},
+        @"apiKey" : @"5628acc"
+    }];
+    XCTAssertNil(config);
+}
+
+- (void)testDecodeEndpointsUnknownKeys {
+    BugsnagConfiguration *config = [BSGConfigurationBuilder configurationFromOptions:@{
+        @"endpoints" : @{
+            @"notify" : @"https://notify.example.com",
+            @"sessions" : @"https://sessions.example.com",
+            @"florps" : @"https://florps.example.com",
+        },
+        @"apiKey" : @"b128acce"
+    }];
+    XCTAssertNil(config);
+}
+
+- (void)testDecodeEndpointsWithoutApiKey {
+    BugsnagConfiguration *config = [BSGConfigurationBuilder configurationFromOptions:@{
+        @"endpoints" : @{
+            @"notify" : @"https://notify.example.com",
+            @"sessions" : @"https://sessions.example.com"
+        },
+    }];
+    XCTAssertNil(config);
+}
+
+- (void)testDecodeEndpointsOnlyNotifySet {
+    BugsnagConfiguration *config = [BSGConfigurationBuilder configurationFromOptions:@{
+        @"endpoints" : @{
+            @"notify" : @"https://notify.example.com",
+        },
+    }];
+    XCTAssertNil(config);
+}
+
+- (void)testDecodeEndpointsOnlySessionsSet {
+    BugsnagConfiguration *config = [BSGConfigurationBuilder configurationFromOptions:@{
+        @"endpoints" : @{@"sessions" : @"https://sessions.example.com"},
+    }];
+    XCTAssertNil(config);
+}
+
+- (void)testDecodeEndpointsBothSet {
+    BugsnagConfiguration *config =
+        [BSGConfigurationBuilder configurationFromOptions:@{
+            @"endpoints" : @{
+                @"notify" : @"https://notify.example.com",
+                @"sessions" : @"https://sessions.example.com"
+            },
+            @"apiKey" : @"b128acce"
+        }];
+    XCTAssertNotNil(config);
+    XCTAssertEqualObjects(@"b128acce", config.apiKey);
+    XCTAssertEqualObjects([NSURL URLWithString:@"https://notify.example.com"],
+                          config.notifyURL);
+    XCTAssertEqualObjects([NSURL URLWithString:@"https://sessions.example.com"],
+                          config.sessionURL);
+}
+
+- (void)testDecodeReleaseStageWithoutApiKey {
+    BugsnagConfiguration *config = [BSGConfigurationBuilder configurationFromOptions:@{
+        @"releaseStage" : @[ @"three" ],
+    }];
+    XCTAssertNil(config);
+}
+
+- (void)testDecodeReleaseStageInvalidType {
+    BugsnagConfiguration *config = [BSGConfigurationBuilder configurationFromOptions:@{
+        @"releaseStage" : @NO,
+        @"apiKey" : @"ac928faeec"
+    }];
+    XCTAssertNil(config);
+}
+
+- (void)testDecodeReleaseStage {
+    BugsnagConfiguration *config =
+        [BSGConfigurationBuilder configurationFromOptions:@{
+            @"releaseStage" : @"debug",
+            @"apiKey" : @"b128acce"
+        }];
+    XCTAssertNotNil(config);
+    XCTAssertEqualObjects(@"b128acce", config.apiKey);
+    XCTAssertEqualObjects(@"debug", config.releaseStage);
+}
+
+- (void)testDecodeNotifyReleaseStagesInvalidTypes {
+    BugsnagConfiguration *config = [BSGConfigurationBuilder configurationFromOptions:@{
+        @"notifyReleaseStages" : @[ @"beta", @"prod", @300 ],
+        @"apiKey" : @"5628acc"
+    }];
+    XCTAssertNil(config);
+    config = [BSGConfigurationBuilder configurationFromOptions:@{
+        @"notifyReleaseStages" : @{@"name" : @"foo"},
+        @"apiKey" : @"5628acc"
+    }];
+    XCTAssertNil(config);
+    config = [BSGConfigurationBuilder configurationFromOptions:@{
+        @"notifyReleaseStages" : @"fooo",
+        @"apiKey" : @"5628acc"
+    }];
+    XCTAssertNil(config);
+}
+
+- (void)testDecodeNotifyReleaseStagesWithoutApiKey {
+    BugsnagConfiguration *config = [BSGConfigurationBuilder configurationFromOptions:@{
+        @"notifyReleaseStages" : @[ @"beta", @"prod" ],
+    }];
+    XCTAssertNil(config);
+}
+
+- (void)testDecodeNotifyReleaseStages {
+    BugsnagConfiguration *config =
+        [BSGConfigurationBuilder configurationFromOptions:@{
+            @"notifyReleaseStages" : @[ @"beta", @"prod" ],
+            @"apiKey" : @"b128acce"
+        }];
+    XCTAssertNotNil(config);
+    XCTAssertEqualObjects(@"b128acce", config.apiKey);
+    XCTAssertEqual(2, config.notifyReleaseStages.count);
+    XCTAssertTrue([config.notifyReleaseStages containsObject:@"beta"]);
+    XCTAssertTrue([config.notifyReleaseStages containsObject:@"prod"]);
+}
+
+- (void)testDecodeReportOOMsWithoutApiKey {
+    BugsnagConfiguration *config = [BSGConfigurationBuilder configurationFromOptions:@{
+        @"reportOOMs" : @NO,
+    }];
+    XCTAssertNil(config);
+}
+
+- (void)testDecodeReportOOMsInvalidType {
+    BugsnagConfiguration *config = [BSGConfigurationBuilder configurationFromOptions:@{
+        @"reportOOMs" : @[ @300 ],
+        @"apiKey" : @"5628acc"
+    }];
+    XCTAssertNil(config);
+    config = [BSGConfigurationBuilder configurationFromOptions:@{
+        @"reportOOMs" : @{@"type" : @"dessert"},
+        @"apiKey" : @"5628acc"
+    }];
+    XCTAssertNil(config);
+    config = [BSGConfigurationBuilder configurationFromOptions:@{
+        @"reportOOMs" : @"fooooo",
+        @"apiKey" : @"5628acc"
+    }];
+    XCTAssertNil(config);
+}
+
+- (void)testDecodeReportOOMs {
+    BugsnagConfiguration *config =
+        [BSGConfigurationBuilder configurationFromOptions:@{
+            @"reportOOMs" : @YES,
+            @"apiKey" : @"5763651be"
+        }];
+    XCTAssertNotNil(config);
+    XCTAssertEqualObjects(@"5763651be", config.apiKey);
+    XCTAssertTrue(config.reportOOMs);
+    config = [BSGConfigurationBuilder configurationFromOptions:@{
+        @"reportOOMs" : @NO,
+        @"apiKey" : @"a763651be"
+    }];
+    XCTAssertNotNil(config);
+    XCTAssertEqualObjects(@"a763651be", config.apiKey);
+    XCTAssertFalse(config.reportOOMs);
+}
+
+- (void)testDecodeReportBackgroundOOMs {
+    BugsnagConfiguration *config =
+        [BSGConfigurationBuilder configurationFromOptions:@{
+            @"reportBackgroundOOMs" : @YES,
+            @"apiKey" : @"5763651be"
+        }];
+    XCTAssertNotNil(config);
+    XCTAssertEqualObjects(@"5763651be", config.apiKey);
+    XCTAssertTrue(config.reportBackgroundOOMs);
+    config = [BSGConfigurationBuilder configurationFromOptions:@{
+        @"reportBackgroundOOMs" : @NO,
+        @"apiKey" : @"a763651be"
+    }];
+    XCTAssertNotNil(config);
+    XCTAssertEqualObjects(@"a763651be", config.apiKey);
+    XCTAssertFalse(config.reportBackgroundOOMs);
+}
+
+- (void)testDecodeReportBackgroundOOMsWithoutApiKey {
+    BugsnagConfiguration *config = [BSGConfigurationBuilder configurationFromOptions:@{
+        @"reportBackgroundOOMs" : @NO,
+    }];
+    XCTAssertNil(config);
+}
+
+- (void)testDecodeReportBackgroundOOMsInvalidType {
+    BugsnagConfiguration *config = [BSGConfigurationBuilder configurationFromOptions:@{
+        @"reportBackgroundOOMs" : @[ @300 ],
+        @"apiKey" : @"5628acc"
+    }];
+    XCTAssertNil(config);
+    config = [BSGConfigurationBuilder configurationFromOptions:@{
+        @"reportBackgroundOOMs" : @{@"type" : @"dessert"},
+        @"apiKey" : @"5628acc"
+    }];
+    XCTAssertNil(config);
+    config = [BSGConfigurationBuilder configurationFromOptions:@{
+        @"reportBackgroundOOMs" : @"fooooo",
+        @"apiKey" : @"5628acc"
+    }];
+    XCTAssertNil(config);
+}
+
+- (void)testDecodeFullConfig {
+    BugsnagConfiguration *config =
+        [BSGConfigurationBuilder configurationFromOptions:@{
+            @"autoNotify" : @NO,
+            @"autoSessions" : @YES,
+            @"autoBreadcrumbs" : @NO,
+            @"endpoints" : @{
+                @"notify" : @"https://reports.example.co",
+                @"sessions" : @"https://sessions.example.co"
+            },
+            @"reportBackgroundOOMs" : @YES,
+            @"reportOOMs" : @YES,
+            @"releaseStage" : @"beta1",
+            @"notifyReleaseStages" : @[ @"beta2", @"prod" ],
+            @"apiKey" : @"5625251ceff"
+        }];
+    XCTAssertNotNil(config);
+    XCTAssertEqualObjects(@"5625251ceff", config.apiKey);
+    XCTAssertEqualObjects(@"beta1", config.releaseStage);
+    XCTAssertTrue(config.shouldAutoCaptureSessions);
+    XCTAssertTrue(config.reportOOMs);
+    XCTAssertTrue(config.reportBackgroundOOMs);
+    XCTAssertFalse(config.automaticallyCollectBreadcrumbs);
+    XCTAssertFalse(config.autoNotify);
+    XCTAssertEqual(2, config.notifyReleaseStages.count);
+    XCTAssertTrue([config.notifyReleaseStages containsObject:@"beta2"]);
+    XCTAssertTrue([config.notifyReleaseStages containsObject:@"prod"]);
+    XCTAssertEqualObjects([NSURL URLWithString:@"https://reports.example.co"],
+                          config.notifyURL);
+    XCTAssertEqualObjects([NSURL URLWithString:@"https://sessions.example.co"],
+                          config.sessionURL);
+}
+
+- (void)testDecodeFullConfigMinusApiKey {
+    BugsnagConfiguration *config = [BSGConfigurationBuilder configurationFromOptions:@{
+        @"autoNotify" : @NO,
+        @"autoSessions" : @YES,
+        @"autoBreadcrumbs" : @NO,
+        @"endpoints" : @{
+            @"notify" : @"https://reports.example.co",
+            @"sessions" : @"https://sessions.example.co"
+        },
+        @"reportBackgroundOOMs" : @YES,
+        @"reportOOMs" : @YES,
+        @"releaseStage" : @"beta1",
+        @"notifyReleaseStages" : @[ @"beta2", @"prod" ],
+    }];
+    XCTAssertNil(config);
+}
+
+- (void)testDecodeUnknownKeys {
+    BugsnagConfiguration *config = [BSGConfigurationBuilder configurationFromOptions:@{
+        @"giraffes" : @3,
+        @"autoNotify" : @NO,
+        @"autoSessions" : @YES,
+        @"autoBreadcrumbs" : @NO,
+        @"endpoints" : @{
+            @"notify" : @"https://reports.example.co",
+            @"sessions" : @"https://sessions.example.co"
+        },
+        @"reportBackgroundOOMs" : @YES,
+        @"reportOOMs" : @YES,
+        @"releaseStage" : @"beta1",
+        @"notifyReleaseStages" : @[ @"beta2", @"prod" ],
+        @"apiKey" : @"5625251ceff"
+    }];
+    XCTAssertNil(config);
+}
+
+@end

--- a/Tests/BSGConfigurationBuilderTests.m
+++ b/Tests/BSGConfigurationBuilderTests.m
@@ -1,494 +1,245 @@
+#import <XCTest/XCTest.h>
+
 #import "BSGConfigurationBuilder.h"
 #import "BugsnagConfiguration.h"
-#import <XCTest/XCTest.h>
+#import "BugsnagTestConstants.h"
+#import "BugsnagEndpointConfiguration.h"
+#import "BugsnagErrorTypes.h"
 
 @interface BSGConfigurationBuilderTests : XCTestCase
 @end
 
 @implementation BSGConfigurationBuilderTests
 
+// MARK: - rejecting invalid plists
+
+- (void)testDecodeEmptyApiKey {
+    BugsnagConfiguration *config = [BSGConfigurationBuilder
+            configurationFromOptions:@{@"apiKey": @""}];
+    XCTAssertNotNil(config);
+    XCTAssertEqualObjects(@"", config.apiKey);
+}
+
+- (void)testDecodeInvalidTypeApiKey {
+    BugsnagConfiguration *config = [BSGConfigurationBuilder
+            configurationFromOptions:@{@"apiKey": @[@"one", @"two"]}];
+    XCTAssertNotNil(config);
+    XCTAssertEqualObjects(@"", config.apiKey);
+}
+
+- (void)testDecodeWithoutApiKey {
+    BugsnagConfiguration *config = [BSGConfigurationBuilder
+            configurationFromOptions:@{@"autoDetectErrors": @NO}];
+    XCTAssertNotNil(config);
+    XCTAssertEqualObjects(@"", config.apiKey);
+}
+
+- (void)testDecodeUnknownKeys {
+    BugsnagConfiguration *config = [BSGConfigurationBuilder configurationFromOptions:@{
+            @"giraffes": @3,
+            @"apiKey": DUMMY_APIKEY_32CHAR_1
+    }];
+    XCTAssertNotNil(config);
+}
+
 - (void)testDecodeEmptyOptions {
     BugsnagConfiguration *config = [BSGConfigurationBuilder configurationFromOptions:@{}];
-    XCTAssertNil(config);
+    XCTAssertNotNil(config);
+    XCTAssertEqualObjects(@"", config.apiKey);
 }
 
-- (void)testDecodeApiKey {
+// MARK: - config loading
+
+- (void)testDecodeDefaultValues {
     BugsnagConfiguration *config = [BSGConfigurationBuilder
-        configurationFromOptions:@{@"apiKey" : @"foo123"}];
-    XCTAssertEqualObjects(@"foo123", config.apiKey);
+            configurationFromOptions:@{@"apiKey": DUMMY_APIKEY_32CHAR_1}];
+    XCTAssertNotNil(config);
+    XCTAssertEqualObjects(DUMMY_APIKEY_32CHAR_1, config.apiKey);
+    XCTAssertNotNil(config.appType);
+    XCTAssertNil(config.appVersion);
+    XCTAssertTrue(config.autoDetectErrors);
+    XCTAssertTrue(config.autoTrackSessions);
+    XCTAssertEqual(25, config.maxBreadcrumbs);
+    XCTAssertTrue(config.persistUser);
+    XCTAssertEqualObjects(@[@"password"], config.redactedKeys);
+    XCTAssertEqual(BSGThreadSendPolicyAlways, config.sendThreads);
+    XCTAssertEqual(BSGEnabledBreadcrumbTypeAll, config.enabledBreadcrumbTypes);
+    XCTAssertEqualObjects(@"https://notify.bugsnag.com", config.endpoints.notify);
+    XCTAssertEqualObjects(@"https://sessions.bugsnag.com", config.endpoints.sessions);
+
+#if DEBUG
+    XCTAssertEqualObjects(@"development", config.releaseStage);
+    XCTAssertFalse(config.enabledErrorTypes.ooms);
+#else
+    XCTAssertEqualObjects(@"production", config.releaseStage);
+    XCTAssertTrue(config.enabledErrorTypes.ooms);
+#endif
+
+    XCTAssertNil(config.enabledReleaseStages);
+    XCTAssertTrue(config.enabledErrorTypes.unhandledExceptions);
+    XCTAssertTrue(config.enabledErrorTypes.signals);
+    XCTAssertTrue(config.enabledErrorTypes.cppExceptions);
+    XCTAssertTrue(config.enabledErrorTypes.machExceptions);
+    XCTAssertTrue(config.enabledErrorTypes.unhandledRejections);
 }
 
-- (void)testDecodeDefaultAutoNotify {
-    BugsnagConfiguration *config = [BSGConfigurationBuilder
-        configurationFromOptions:@{@"apiKey" : @"foo123"}];
-    XCTAssertEqualObjects(@"foo123", config.apiKey);
-    XCTAssertTrue(config.autoNotify);
+- (void)testDecodeFullConfig {
+    BugsnagConfiguration *config =
+            [BSGConfigurationBuilder configurationFromOptions:@{
+                    @"apiKey": DUMMY_APIKEY_32CHAR_1,
+                    @"appType": @"cocoa-custom",
+                    @"appVersion": @"5.2.33",
+                    @"autoDetectErrors": @NO,
+                    @"autoTrackSessions": @NO,
+                    @"bundleVersion": @"7.22",
+                    @"endpoints": @{
+                            @"notify": @"https://reports.example.co",
+                            @"sessions": @"https://sessions.example.co"
+                    },
+                    @"enabledReleaseStages": @[@"beta2", @"prod"],
+                    @"maxBreadcrumbs": @27,
+                    @"persistUser": @NO,
+                    @"redactedKeys": @[@"foo"],
+                    @"sendThreads": @"never",
+                    @"releaseStage": @"beta1",
+            }];
+    XCTAssertNotNil(config);
+    XCTAssertEqualObjects(DUMMY_APIKEY_32CHAR_1, config.apiKey);
+    XCTAssertEqualObjects(@"cocoa-custom", config.appType);
+    XCTAssertEqualObjects(@"5.2.33", config.appVersion);
+    XCTAssertFalse(config.autoDetectErrors);
+    XCTAssertFalse(config.autoTrackSessions);
+    XCTAssertEqualObjects(@"7.22", config.bundleVersion);
+    XCTAssertEqual(27, config.maxBreadcrumbs);
+    XCTAssertFalse(config.persistUser);
+    XCTAssertEqualObjects(@[@"foo"], config.redactedKeys);
+    XCTAssertEqual(BSGThreadSendPolicyNever, config.sendThreads);
+    XCTAssertEqualObjects(@"beta1", config.releaseStage);
+    XCTAssertEqualObjects(@"https://reports.example.co", config.endpoints.notify);
+    XCTAssertEqualObjects(@"https://sessions.example.co", config.endpoints.sessions);
+
+    NSArray *releaseStages = @[@"beta2", @"prod"];
+    XCTAssertEqualObjects(releaseStages, config.enabledReleaseStages);
+
+#if DEBUG
+    XCTAssertFalse(config.enabledErrorTypes.ooms);
+#else
+    XCTAssertTrue(config.enabledErrorTypes.ooms);
+#endif
+
+    XCTAssertTrue(config.enabledErrorTypes.unhandledExceptions);
+    XCTAssertTrue(config.enabledErrorTypes.signals);
+    XCTAssertTrue(config.enabledErrorTypes.cppExceptions);
+    XCTAssertTrue(config.enabledErrorTypes.machExceptions);
+    XCTAssertTrue(config.enabledErrorTypes.unhandledRejections);
 }
 
-- (void)testDecodeDefaultAutoCaptureSessions {
-    BugsnagConfiguration *config = [BSGConfigurationBuilder
-        configurationFromOptions:@{@"apiKey" : @"foo123"}];
-    XCTAssertEqualObjects(@"foo123", config.apiKey);
-    XCTAssertTrue(config.shouldAutoCaptureSessions);
+// MARK: - invalid config options
+
+- (void)testInvalidConfigOptions {
+    BugsnagConfiguration *config =
+            [BSGConfigurationBuilder configurationFromOptions:@{
+                    @"apiKey": DUMMY_APIKEY_32CHAR_1,
+                    @"appType": @[],
+                    @"appVersion": @99,
+                    @"autoDetectErrors": @67,
+                    @"autoTrackSessions": @"NO",
+                    @"bundleVersion": @{},
+                    @"endpoints": [NSNull null],
+                    @"enabledReleaseStages": @[@"beta2", @"prod"],
+                    @"enabledErrorTypes": @[@"ooms", @"signals"],
+                    @"maxBreadcrumbs": @27,
+                    @"persistUser": @"pomelo",
+                    @"redactedKeys": @[@77],
+                    @"sendThreads": @"nev",
+                    @"releaseStage": @YES,
+            }];
+    XCTAssertNotNil(config); // no exception should be thrown when loading
 }
 
-- (void)testDecodeDefaultAutoCollectBreadcrumbs {
-    BugsnagConfiguration *config = [BSGConfigurationBuilder
-        configurationFromOptions:@{@"apiKey" : @"foo123"}];
-    XCTAssertEqualObjects(@"foo123", config.apiKey);
-    XCTAssertTrue(config.automaticallyCollectBreadcrumbs);
+- (void)testDecodeEnabledReleaseStagesInvalidTypes {
+    BugsnagConfiguration *config = [BSGConfigurationBuilder configurationFromOptions:@{
+            @"enabledReleaseStages": @[@"beta", @"prod", @300],
+            @"apiKey": DUMMY_APIKEY_32CHAR_1
+    }];
+    XCTAssertNotNil(config);
+    XCTAssertNil(config.enabledReleaseStages);
+
+    config = [BSGConfigurationBuilder configurationFromOptions:@{
+            @"enabledReleaseStages": @{@"name": @"foo"},
+            @"apiKey": DUMMY_APIKEY_32CHAR_1
+    }];
+    XCTAssertNotNil(config);
+    XCTAssertNil(config.enabledReleaseStages);
+
+    config = [BSGConfigurationBuilder configurationFromOptions:@{
+            @"enabledReleaseStages": @"fooo",
+            @"apiKey": DUMMY_APIKEY_32CHAR_1
+    }];
+    XCTAssertNotNil(config);
+    XCTAssertNil(config.enabledReleaseStages);
 }
 
-- (void)testDecodeDefaultEndpoints {
-    BugsnagConfiguration *config = [BSGConfigurationBuilder
-        configurationFromOptions:@{@"apiKey" : @"foo123"}];
-    XCTAssertEqualObjects(@"foo123", config.apiKey);
-    XCTAssertEqualObjects([NSURL URLWithString:@"https://notify.bugsnag.com/"],
-                          config.notifyURL);
-    XCTAssertEqualObjects([NSURL URLWithString:@"https://sessions.bugsnag.com"],
-                          config.sessionURL);
+- (void)testDecodeEndpointsInvalidTypes {
+    BugsnagConfiguration *config = [BSGConfigurationBuilder configurationFromOptions:@{
+            @"endpoints": @"foo",
+            @"apiKey": DUMMY_APIKEY_32CHAR_1
+    }];
+    XCTAssertNotNil(config);
+    XCTAssertEqualObjects(@"https://notify.bugsnag.com", config.endpoints.notify);
+    XCTAssertEqualObjects(@"https://sessions.bugsnag.com", config.endpoints.sessions);
+
+    config = [BSGConfigurationBuilder configurationFromOptions:@{
+            @"endpoints": @[@"http://example.com", @"http://foo.example.com"],
+            @"apiKey": DUMMY_APIKEY_32CHAR_1
+    }];
+    XCTAssertNotNil(config);
+    XCTAssertEqualObjects(@"https://notify.bugsnag.com", config.endpoints.notify);
+    XCTAssertEqualObjects(@"https://sessions.bugsnag.com", config.endpoints.sessions);
+
+    config = [BSGConfigurationBuilder configurationFromOptions:@{
+            @"endpoints": @{},
+            @"apiKey": DUMMY_APIKEY_32CHAR_1
+    }];
+    XCTAssertNotNil(config);
+    XCTAssertEqualObjects(@"https://notify.bugsnag.com", config.endpoints.notify);
+    XCTAssertEqualObjects(@"https://sessions.bugsnag.com", config.endpoints.sessions);
 }
 
-- (void)testDecodeDefaultReleaseStage {
-    BugsnagConfiguration *config = [BSGConfigurationBuilder
-        configurationFromOptions:@{@"apiKey" : @"foo123"}];
-    XCTAssertEqualObjects(@"foo123", config.apiKey);
+- (void)testDecodeEndpointsOnlyNotifySet {
+    BugsnagConfiguration *config = [BSGConfigurationBuilder configurationFromOptions:@{
+            @"apiKey": DUMMY_APIKEY_32CHAR_1,
+            @"endpoints": @{
+                    @"notify": @"https://notify.example.com",
+            },
+    }];
+    XCTAssertNotNil(config);
+    XCTAssertEqualObjects(@"https://notify.example.com", config.endpoints.notify);
+    XCTAssertEqualObjects(@"https://sessions.bugsnag.com", config.endpoints.sessions);
+}
+
+- (void)testDecodeEndpointsOnlySessionsSet {
+    BugsnagConfiguration *config = [BSGConfigurationBuilder configurationFromOptions:@{
+            @"apiKey": DUMMY_APIKEY_32CHAR_1,
+            @"endpoints": @{@"sessions": @"https://sessions.example.com"},
+    }];
+    XCTAssertNotNil(config);
+    XCTAssertEqualObjects(@"https://notify.bugsnag.com", config.endpoints.notify);
+    XCTAssertEqualObjects(@"https://sessions.example.com", config.endpoints.sessions);
+}
+
+- (void)testDecodeReleaseStageInvalidType {
+    BugsnagConfiguration *config = [BSGConfigurationBuilder configurationFromOptions:@{
+            @"releaseStage": @NO,
+            @"apiKey": DUMMY_APIKEY_32CHAR_1
+    }];
+    XCTAssertNotNil(config);
+
 #if DEBUG
     XCTAssertEqualObjects(@"development", config.releaseStage);
 #else
     XCTAssertEqualObjects(@"production", config.releaseStage);
 #endif
-}
-
-- (void)testDecodeDefaultNotifyReleaseStages {
-    BugsnagConfiguration *config = [BSGConfigurationBuilder
-        configurationFromOptions:@{@"apiKey" : @"foo123"}];
-    XCTAssertEqualObjects(@"foo123", config.apiKey);
-    XCTAssertNil(config.notifyReleaseStages);
-}
-
-- (void)testDecodeDefaultReportOOMs {
-    BugsnagConfiguration *config = [BSGConfigurationBuilder
-        configurationFromOptions:@{@"apiKey" : @"foo123"}];
-    XCTAssertEqualObjects(@"foo123", config.apiKey);
-    XCTAssertTrue(config.reportOOMs);
-}
-
-- (void)testDecodeDefaultReportBackgroundOOMs {
-    BugsnagConfiguration *config = [BSGConfigurationBuilder
-        configurationFromOptions:@{@"apiKey" : @"foo123"}];
-    XCTAssertEqualObjects(@"foo123", config.apiKey);
-    XCTAssertFalse(config.reportBackgroundOOMs);
-}
-
-- (void)testDecodeEmptyApiKey {
-    BugsnagConfiguration *config = [BSGConfigurationBuilder
-        configurationFromOptions:@{@"apiKey" : @""}];
-    XCTAssertNil(config);
-}
-
-- (void)testDecodeInvalidTypeApiKey {
-    BugsnagConfiguration *config = [BSGConfigurationBuilder
-        configurationFromOptions:@{@"apiKey" : @[ @"one", @"two" ]}];
-    XCTAssertNil(config);
-}
-
-- (void)testDecodeAutoNotifyWithoutApiKey {
-    BugsnagConfiguration *config = [BSGConfigurationBuilder
-        configurationFromOptions:@{@"autoNotify" : @NO}];
-    XCTAssertNil(config);
-    config = [BSGConfigurationBuilder
-        configurationFromOptions:@{@"autoNotify" : @YES}];
-    XCTAssertNil(config);
-}
-
-- (void)testDecodeAutoNotifyInvalidType {
-    BugsnagConfiguration *config = [BSGConfigurationBuilder configurationFromOptions:@{
-                                                                                          @"autoNotify" : @(67),
-                                                                                          @"apiKey" : @"accfe1383",
-                                                                                          }];
-    XCTAssertNil(config);
-}
-
-- (void)testDecodeAutoNotify {
-    BugsnagConfiguration *config =
-        [BSGConfigurationBuilder configurationFromOptions:@{
-            @"autoNotify" : @NO,
-            @"apiKey" : @"34234136bff"
-        }];
-    XCTAssertNotNil(config);
-    XCTAssertFalse(config.autoNotify);
-    XCTAssertEqualObjects(@"34234136bff", config.apiKey);
-    config = [BSGConfigurationBuilder configurationFromOptions:@{
-        @"autoNotify" : @YES,
-        @"apiKey" : @"83434136bff"
-    }];
-    XCTAssertNotNil(config);
-    XCTAssertTrue(config.autoNotify);
-    XCTAssertEqualObjects(@"83434136bff", config.apiKey);
-}
-
-- (void)testDecodeAutoCaptureSessionsWithoutApiKey {
-    BugsnagConfiguration *config = [BSGConfigurationBuilder
-        configurationFromOptions:@{@"autoSessions" : @NO}];
-    XCTAssertNil(config);
-    config = [BSGConfigurationBuilder
-        configurationFromOptions:@{@"autoSessions" : @YES}];
-    XCTAssertNil(config);
-}
-
-- (void)testDecodeAutoCaptureSessionsInvalidType {
-    BugsnagConfiguration *config = [BSGConfigurationBuilder configurationFromOptions:@{
-                                                                                          @"autoSessions" : @"NO",
-                                                                                          @"apiKey" : @"ac928faeec"
-                                                                                          }];
-    XCTAssertNil(config);
-}
-
-- (void)testDecodeAutoCaptureSessions {
-    BugsnagConfiguration *config =
-        [BSGConfigurationBuilder configurationFromOptions:@{
-            @"autoSessions" : @NO,
-            @"apiKey" : @"2343a136bff"
-        }];
-    XCTAssertNotNil(config);
-    XCTAssertFalse(config.shouldAutoCaptureSessions);
-    XCTAssertEqualObjects(@"2343a136bff", config.apiKey);
-    config = [BSGConfigurationBuilder configurationFromOptions:@{
-        @"autoSessions" : @YES,
-        @"apiKey" : @"2343a136bff"
-    }];
-    XCTAssertNotNil(config);
-    XCTAssertTrue(config.shouldAutoCaptureSessions);
-    XCTAssertEqualObjects(@"2343a136bff", config.apiKey);
-}
-
-- (void)testDecodeAutoCollectBreadcrumbs {
-    BugsnagConfiguration *config =
-        [BSGConfigurationBuilder configurationFromOptions:@{
-            @"autoBreadcrumbs" : @NO,
-            @"apiKey" : @"1343a136bff"
-        }];
-    XCTAssertNotNil(config);
-    XCTAssertFalse(config.automaticallyCollectBreadcrumbs);
-    XCTAssertEqualObjects(@"1343a136bff", config.apiKey);
-    config = [BSGConfigurationBuilder configurationFromOptions:@{
-        @"autoBreadcrumbs" : @YES,
-        @"apiKey" : @"1343a136bff"
-    }];
-    XCTAssertNotNil(config);
-    XCTAssertTrue(config.automaticallyCollectBreadcrumbs);
-    XCTAssertEqualObjects(@"1343a136bff", config.apiKey);
-}
-
-- (void)testDecodeAutoCollectBreadcrumbsInvalidType {
-    BugsnagConfiguration *config =
-        [BSGConfigurationBuilder configurationFromOptions:@{
-            @"autoBreadcrumbs" : @"foo",
-            @"apiKey" : @"5628acc"
-        }];
-    XCTAssertNil(config);
-}
-
-- (void)testDecodeAutoCollectBreadcrumbsWithoutApiKey {
-    BugsnagConfiguration *config = [BSGConfigurationBuilder
-        configurationFromOptions:@{@"autoBreadcrumbs" : @NO}];
-    XCTAssertNil(config);
-    config = [BSGConfigurationBuilder
-        configurationFromOptions:@{@"autoBreadcrumbs" : @YES}];
-    XCTAssertNil(config);
-}
-
-- (void)testDecodeEndpointsInvalidTypes {
-    BugsnagConfiguration *config = [BSGConfigurationBuilder configurationFromOptions:@{
-        @"endpoints" : @"foo",
-        @"apiKey" : @"5628acc"
-    }];
-    XCTAssertNil(config);
-    config = [BSGConfigurationBuilder configurationFromOptions:@{
-        @"endpoints" : @[ @"http://example.com", @"http://foo.example.com" ],
-        @"apiKey" : @"5628acc"
-    }];
-    XCTAssertNil(config);
-    config = [BSGConfigurationBuilder configurationFromOptions:@{
-        @"endpoints" : @{},
-        @"apiKey" : @"5628acc"
-    }];
-    XCTAssertNil(config);
-}
-
-- (void)testDecodeEndpointsUnknownKeys {
-    BugsnagConfiguration *config = [BSGConfigurationBuilder configurationFromOptions:@{
-        @"endpoints" : @{
-            @"notify" : @"https://notify.example.com",
-            @"sessions" : @"https://sessions.example.com",
-            @"florps" : @"https://florps.example.com",
-        },
-        @"apiKey" : @"b128acce"
-    }];
-    XCTAssertNil(config);
-}
-
-- (void)testDecodeEndpointsWithoutApiKey {
-    BugsnagConfiguration *config = [BSGConfigurationBuilder configurationFromOptions:@{
-        @"endpoints" : @{
-            @"notify" : @"https://notify.example.com",
-            @"sessions" : @"https://sessions.example.com"
-        },
-    }];
-    XCTAssertNil(config);
-}
-
-- (void)testDecodeEndpointsOnlyNotifySet {
-    BugsnagConfiguration *config = [BSGConfigurationBuilder configurationFromOptions:@{
-        @"endpoints" : @{
-            @"notify" : @"https://notify.example.com",
-        },
-    }];
-    XCTAssertNil(config);
-}
-
-- (void)testDecodeEndpointsOnlySessionsSet {
-    BugsnagConfiguration *config = [BSGConfigurationBuilder configurationFromOptions:@{
-        @"endpoints" : @{@"sessions" : @"https://sessions.example.com"},
-    }];
-    XCTAssertNil(config);
-}
-
-- (void)testDecodeEndpointsBothSet {
-    BugsnagConfiguration *config =
-        [BSGConfigurationBuilder configurationFromOptions:@{
-            @"endpoints" : @{
-                @"notify" : @"https://notify.example.com",
-                @"sessions" : @"https://sessions.example.com"
-            },
-            @"apiKey" : @"b128acce"
-        }];
-    XCTAssertNotNil(config);
-    XCTAssertEqualObjects(@"b128acce", config.apiKey);
-    XCTAssertEqualObjects([NSURL URLWithString:@"https://notify.example.com"],
-                          config.notifyURL);
-    XCTAssertEqualObjects([NSURL URLWithString:@"https://sessions.example.com"],
-                          config.sessionURL);
-}
-
-- (void)testDecodeReleaseStageWithoutApiKey {
-    BugsnagConfiguration *config = [BSGConfigurationBuilder configurationFromOptions:@{
-        @"releaseStage" : @[ @"three" ],
-    }];
-    XCTAssertNil(config);
-}
-
-- (void)testDecodeReleaseStageInvalidType {
-    BugsnagConfiguration *config = [BSGConfigurationBuilder configurationFromOptions:@{
-        @"releaseStage" : @NO,
-        @"apiKey" : @"ac928faeec"
-    }];
-    XCTAssertNil(config);
-}
-
-- (void)testDecodeReleaseStage {
-    BugsnagConfiguration *config =
-        [BSGConfigurationBuilder configurationFromOptions:@{
-            @"releaseStage" : @"debug",
-            @"apiKey" : @"b128acce"
-        }];
-    XCTAssertNotNil(config);
-    XCTAssertEqualObjects(@"b128acce", config.apiKey);
-    XCTAssertEqualObjects(@"debug", config.releaseStage);
-}
-
-- (void)testDecodeNotifyReleaseStagesInvalidTypes {
-    BugsnagConfiguration *config = [BSGConfigurationBuilder configurationFromOptions:@{
-        @"notifyReleaseStages" : @[ @"beta", @"prod", @300 ],
-        @"apiKey" : @"5628acc"
-    }];
-    XCTAssertNil(config);
-    config = [BSGConfigurationBuilder configurationFromOptions:@{
-        @"notifyReleaseStages" : @{@"name" : @"foo"},
-        @"apiKey" : @"5628acc"
-    }];
-    XCTAssertNil(config);
-    config = [BSGConfigurationBuilder configurationFromOptions:@{
-        @"notifyReleaseStages" : @"fooo",
-        @"apiKey" : @"5628acc"
-    }];
-    XCTAssertNil(config);
-}
-
-- (void)testDecodeNotifyReleaseStagesWithoutApiKey {
-    BugsnagConfiguration *config = [BSGConfigurationBuilder configurationFromOptions:@{
-        @"notifyReleaseStages" : @[ @"beta", @"prod" ],
-    }];
-    XCTAssertNil(config);
-}
-
-- (void)testDecodeNotifyReleaseStages {
-    BugsnagConfiguration *config =
-        [BSGConfigurationBuilder configurationFromOptions:@{
-            @"notifyReleaseStages" : @[ @"beta", @"prod" ],
-            @"apiKey" : @"b128acce"
-        }];
-    XCTAssertNotNil(config);
-    XCTAssertEqualObjects(@"b128acce", config.apiKey);
-    XCTAssertEqual(2, config.notifyReleaseStages.count);
-    XCTAssertTrue([config.notifyReleaseStages containsObject:@"beta"]);
-    XCTAssertTrue([config.notifyReleaseStages containsObject:@"prod"]);
-}
-
-- (void)testDecodeReportOOMsWithoutApiKey {
-    BugsnagConfiguration *config = [BSGConfigurationBuilder configurationFromOptions:@{
-        @"reportOOMs" : @NO,
-    }];
-    XCTAssertNil(config);
-}
-
-- (void)testDecodeReportOOMsInvalidType {
-    BugsnagConfiguration *config = [BSGConfigurationBuilder configurationFromOptions:@{
-        @"reportOOMs" : @[ @300 ],
-        @"apiKey" : @"5628acc"
-    }];
-    XCTAssertNil(config);
-    config = [BSGConfigurationBuilder configurationFromOptions:@{
-        @"reportOOMs" : @{@"type" : @"dessert"},
-        @"apiKey" : @"5628acc"
-    }];
-    XCTAssertNil(config);
-    config = [BSGConfigurationBuilder configurationFromOptions:@{
-        @"reportOOMs" : @"fooooo",
-        @"apiKey" : @"5628acc"
-    }];
-    XCTAssertNil(config);
-}
-
-- (void)testDecodeReportOOMs {
-    BugsnagConfiguration *config =
-        [BSGConfigurationBuilder configurationFromOptions:@{
-            @"reportOOMs" : @YES,
-            @"apiKey" : @"5763651be"
-        }];
-    XCTAssertNotNil(config);
-    XCTAssertEqualObjects(@"5763651be", config.apiKey);
-    XCTAssertTrue(config.reportOOMs);
-    config = [BSGConfigurationBuilder configurationFromOptions:@{
-        @"reportOOMs" : @NO,
-        @"apiKey" : @"a763651be"
-    }];
-    XCTAssertNotNil(config);
-    XCTAssertEqualObjects(@"a763651be", config.apiKey);
-    XCTAssertFalse(config.reportOOMs);
-}
-
-- (void)testDecodeReportBackgroundOOMs {
-    BugsnagConfiguration *config =
-        [BSGConfigurationBuilder configurationFromOptions:@{
-            @"reportBackgroundOOMs" : @YES,
-            @"apiKey" : @"5763651be"
-        }];
-    XCTAssertNotNil(config);
-    XCTAssertEqualObjects(@"5763651be", config.apiKey);
-    XCTAssertTrue(config.reportBackgroundOOMs);
-    config = [BSGConfigurationBuilder configurationFromOptions:@{
-        @"reportBackgroundOOMs" : @NO,
-        @"apiKey" : @"a763651be"
-    }];
-    XCTAssertNotNil(config);
-    XCTAssertEqualObjects(@"a763651be", config.apiKey);
-    XCTAssertFalse(config.reportBackgroundOOMs);
-}
-
-- (void)testDecodeReportBackgroundOOMsWithoutApiKey {
-    BugsnagConfiguration *config = [BSGConfigurationBuilder configurationFromOptions:@{
-        @"reportBackgroundOOMs" : @NO,
-    }];
-    XCTAssertNil(config);
-}
-
-- (void)testDecodeReportBackgroundOOMsInvalidType {
-    BugsnagConfiguration *config = [BSGConfigurationBuilder configurationFromOptions:@{
-        @"reportBackgroundOOMs" : @[ @300 ],
-        @"apiKey" : @"5628acc"
-    }];
-    XCTAssertNil(config);
-    config = [BSGConfigurationBuilder configurationFromOptions:@{
-        @"reportBackgroundOOMs" : @{@"type" : @"dessert"},
-        @"apiKey" : @"5628acc"
-    }];
-    XCTAssertNil(config);
-    config = [BSGConfigurationBuilder configurationFromOptions:@{
-        @"reportBackgroundOOMs" : @"fooooo",
-        @"apiKey" : @"5628acc"
-    }];
-    XCTAssertNil(config);
-}
-
-- (void)testDecodeFullConfig {
-    BugsnagConfiguration *config =
-        [BSGConfigurationBuilder configurationFromOptions:@{
-            @"autoNotify" : @NO,
-            @"autoSessions" : @YES,
-            @"autoBreadcrumbs" : @NO,
-            @"endpoints" : @{
-                @"notify" : @"https://reports.example.co",
-                @"sessions" : @"https://sessions.example.co"
-            },
-            @"reportBackgroundOOMs" : @YES,
-            @"reportOOMs" : @YES,
-            @"releaseStage" : @"beta1",
-            @"notifyReleaseStages" : @[ @"beta2", @"prod" ],
-            @"apiKey" : @"5625251ceff"
-        }];
-    XCTAssertNotNil(config);
-    XCTAssertEqualObjects(@"5625251ceff", config.apiKey);
-    XCTAssertEqualObjects(@"beta1", config.releaseStage);
-    XCTAssertTrue(config.shouldAutoCaptureSessions);
-    XCTAssertTrue(config.reportOOMs);
-    XCTAssertTrue(config.reportBackgroundOOMs);
-    XCTAssertFalse(config.automaticallyCollectBreadcrumbs);
-    XCTAssertFalse(config.autoNotify);
-    XCTAssertEqual(2, config.notifyReleaseStages.count);
-    XCTAssertTrue([config.notifyReleaseStages containsObject:@"beta2"]);
-    XCTAssertTrue([config.notifyReleaseStages containsObject:@"prod"]);
-    XCTAssertEqualObjects([NSURL URLWithString:@"https://reports.example.co"],
-                          config.notifyURL);
-    XCTAssertEqualObjects([NSURL URLWithString:@"https://sessions.example.co"],
-                          config.sessionURL);
-}
-
-- (void)testDecodeFullConfigMinusApiKey {
-    BugsnagConfiguration *config = [BSGConfigurationBuilder configurationFromOptions:@{
-        @"autoNotify" : @NO,
-        @"autoSessions" : @YES,
-        @"autoBreadcrumbs" : @NO,
-        @"endpoints" : @{
-            @"notify" : @"https://reports.example.co",
-            @"sessions" : @"https://sessions.example.co"
-        },
-        @"reportBackgroundOOMs" : @YES,
-        @"reportOOMs" : @YES,
-        @"releaseStage" : @"beta1",
-        @"notifyReleaseStages" : @[ @"beta2", @"prod" ],
-    }];
-    XCTAssertNil(config);
-}
-
-- (void)testDecodeUnknownKeys {
-    BugsnagConfiguration *config = [BSGConfigurationBuilder configurationFromOptions:@{
-        @"giraffes" : @3,
-        @"autoNotify" : @NO,
-        @"autoSessions" : @YES,
-        @"autoBreadcrumbs" : @NO,
-        @"endpoints" : @{
-            @"notify" : @"https://reports.example.co",
-            @"sessions" : @"https://sessions.example.co"
-        },
-        @"reportBackgroundOOMs" : @YES,
-        @"reportOOMs" : @YES,
-        @"releaseStage" : @"beta1",
-        @"notifyReleaseStages" : @[ @"beta2", @"prod" ],
-        @"apiKey" : @"5625251ceff"
-    }];
-    XCTAssertNil(config);
 }
 
 @end

--- a/Tests/BugsnagConfigurationTests.m
+++ b/Tests/BugsnagConfigurationTests.m
@@ -3,7 +3,6 @@
  */
 
 #import <XCTest/XCTest.h>
-#import <objc/runtime.h>
 
 #import "BugsnagTestConstants.h"
 #import "Bugsnag.h"
@@ -14,7 +13,6 @@
 #import "BugsnagUser.h"
 #import "BSG_KSCrashType.h"
 #import "BSG_SSKeychain.h"
-
 
 // =============================================================================
 // MARK: - Required private methods

--- a/features/config_from_plist.feature
+++ b/features/config_from_plist.feature
@@ -1,0 +1,12 @@
+Feature: Loading Bugsnag configuration from Info.plist
+    Configuration options can be specified in build at build time to avoid
+    writing code for those options.
+
+    Scenario: Specifying config in Info.plist
+        When I run "LoadConfigFromFileScenario"
+        And I wait for a request
+        Then the request is valid for the error reporting API
+        And the "Bugsnag-API-Key" header equals "0192837465afbecd0192837465afbecd"
+        And the event "metaData.nserror.domain" equals "iOSTestApp.LaunchError"
+        And the event "app.releaseStage" equals "beta2"
+

--- a/features/fixtures/ios-swift-cocoapods/iOSTestApp.xcodeproj/project.pbxproj
+++ b/features/fixtures/ios-swift-cocoapods/iOSTestApp.xcodeproj/project.pbxproj
@@ -27,6 +27,7 @@
 		8AA05A2F23BE700C00C7AD00 /* ManyConcurrentNotifyNoBackgroundThreads.m in Sources */ = {isa = PBXBuildFile; fileRef = 8AA05A2E23BE700C00C7AD00 /* ManyConcurrentNotifyNoBackgroundThreads.m */; };
 		8AA7C2D72327DD3D002255B2 /* ConfigChangesAfterStartScenarios.m in Sources */ = {isa = PBXBuildFile; fileRef = 8AA7C2D52327DD3D002255B2 /* ConfigChangesAfterStartScenarios.m */; };
 		8AB1081923301FE600672818 /* ReleaseStageScenarios.swift in Sources */ = {isa = PBXBuildFile; fileRef = 8AB1081823301FE600672818 /* ReleaseStageScenarios.swift */; };
+		8AB65FCC22DC77CB001200AB /* LoadConfigFromFileScenario.swift in Sources */ = {isa = PBXBuildFile; fileRef = 8AB65FCB22DC77CB001200AB /* LoadConfigFromFileScenario.swift */; };
 		8AB8866420404DD30003E444 /* AppDelegate.swift in Sources */ = {isa = PBXBuildFile; fileRef = 8AB8866320404DD30003E444 /* AppDelegate.swift */; };
 		8AB8866620404DD30003E444 /* ViewController.swift in Sources */ = {isa = PBXBuildFile; fileRef = 8AB8866520404DD30003E444 /* ViewController.swift */; };
 		8AB8866920404DD30003E444 /* Main.storyboard in Resources */ = {isa = PBXBuildFile; fileRef = 8AB8866720404DD30003E444 /* Main.storyboard */; };
@@ -129,6 +130,7 @@
 		8AA7C2D52327DD3D002255B2 /* ConfigChangesAfterStartScenarios.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; path = ConfigChangesAfterStartScenarios.m; sourceTree = "<group>"; };
 		8AA7C2D62327DD3D002255B2 /* ConfigChangesAfterStartScenarios.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = ConfigChangesAfterStartScenarios.h; sourceTree = "<group>"; };
 		8AB1081823301FE600672818 /* ReleaseStageScenarios.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = ReleaseStageScenarios.swift; sourceTree = "<group>"; };
+		8AB65FCB22DC77CB001200AB /* LoadConfigFromFileScenario.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = LoadConfigFromFileScenario.swift; sourceTree = "<group>"; };
 		8AB8866020404DD30003E444 /* iOSTestApp.app */ = {isa = PBXFileReference; explicitFileType = wrapper.application; includeInIndex = 0; path = iOSTestApp.app; sourceTree = BUILT_PRODUCTS_DIR; };
 		8AB8866320404DD30003E444 /* AppDelegate.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AppDelegate.swift; sourceTree = "<group>"; };
 		8AB8866520404DD30003E444 /* ViewController.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ViewController.swift; sourceTree = "<group>"; };
@@ -405,6 +407,7 @@
 				00507A63242BFE5600EF1B87 /* EnabledBreadcrumbTypesIsNilScenario.swift */,
 				E77AFEF72449C6460082B8BB /* AttachCustomStacktraceHook.h */,
 				E7F6087B244F0A3A00F1532A /* BugsnagHooks.h */,
+				8AB65FCB22DC77CB001200AB /* LoadConfigFromFileScenario.swift */,
 			);
 			path = scenarios;
 			sourceTree = "<group>";
@@ -535,6 +538,7 @@
 				F4295A036B228AF608641699 /* UserDisabledScenario.swift in Sources */,
 				8A14F0F62282D4AE00337B05 /* ReportOOMsDisabledScenario.m in Sources */,
 				0011E6672403D13100ED71CD /* UserPersistenceScenarios.m in Sources */,
+				8AB65FCC22DC77CB001200AB /* LoadConfigFromFileScenario.swift in Sources */,
 				E7767F13221C21E30006648C /* ResumedSessionScenario.swift in Sources */,
 				8AEFC73120F8D1A000A78779 /* AutoSessionWithUserScenario.m in Sources */,
 				8AB1081923301FE600672818 /* ReleaseStageScenarios.swift in Sources */,

--- a/features/fixtures/ios-swift-cocoapods/iOSTestApp/Info.plist
+++ b/features/fixtures/ios-swift-cocoapods/iOSTestApp/Info.plist
@@ -52,5 +52,25 @@
 			</dict>
 		</dict>
 	</dict>
+	<key>bugsnag</key>
+	<dict>
+		<key>apiKey</key>
+		<string>0192837465afbecd0192837465afbecd</string>
+		<key>releaseStage</key>
+		<string>beta2</string>
+		<key>notifyReleaseStages</key>
+		<array>
+			<string>beta2</string>
+			<string>prod</string>
+		</array>
+		<key>reportOOMs</key>
+		<false/>
+		<key>autoNotify</key>
+		<false/>
+		<key>autoBreadcrumbs</key>
+		<false/>
+		<key>autoTrackSessions</key>
+		<false/>
+	</dict>
 </dict>
 </plist>

--- a/features/fixtures/ios-swift-cocoapods/iOSTestApp/scenarios/LoadConfigFromFileScenario.swift
+++ b/features/fixtures/ios-swift-cocoapods/iOSTestApp/scenarios/LoadConfigFromFileScenario.swift
@@ -1,0 +1,25 @@
+
+import Foundation
+import UIKit
+import Bugsnag
+
+class LaunchError : Error {
+
+    init() {
+    }
+}
+
+@objc class LoadConfigFromFileScenario: Scenario {
+
+    override func startBugsnag() {
+        let fileConfig = BugsnagConfiguration.loadConfig()
+        fileConfig.endpoints.notify = config.endpoints.notify
+        fileConfig.endpoints.sessions = config.endpoints.sessions
+        config = fileConfig
+        Bugsnag.start(with: config)
+    }
+
+    override func run() {
+        Bugsnag.notifyError(LaunchError())
+    }
+}

--- a/iOS/Bugsnag.xcodeproj/project.pbxproj
+++ b/iOS/Bugsnag.xcodeproj/project.pbxproj
@@ -64,6 +64,9 @@
 		8A72A0392396590300328051 /* BugsnagPlugin.h in Headers */ = {isa = PBXBuildFile; fileRef = 8A72A0352396535000328051 /* BugsnagPlugin.h */; settings = {ATTRIBUTES = (Public, ); }; };
 		8AA661AD23D8C1F50031ECC8 /* BSGConnectivityTest.m in Sources */ = {isa = PBXBuildFile; fileRef = 8AA661AC23D8C1F50031ECC8 /* BSGConnectivityTest.m */; };
 		8AF1748E23070F0300902CC2 /* BSG_KSCrashIdentifier.m in Sources */ = {isa = PBXBuildFile; fileRef = 8A530CBF22FDC3AE00F0C108 /* BSG_KSCrashIdentifier.m */; };
+		8A89F3F222D8B62B000D34D1 /* BSGConfigurationBuilder.h in Headers */ = {isa = PBXBuildFile; fileRef = 8A89F3F022D8B62B000D34D1 /* BSGConfigurationBuilder.h */; };
+		8A89F3F322D8B62B000D34D1 /* BSGConfigurationBuilder.m in Sources */ = {isa = PBXBuildFile; fileRef = 8A89F3F122D8B62B000D34D1 /* BSGConfigurationBuilder.m */; };
+		8A89F3F522D8B81F000D34D1 /* BSGConfigurationBuilderTests.m in Sources */ = {isa = PBXBuildFile; fileRef = 8A89F3F422D8B81F000D34D1 /* BSGConfigurationBuilderTests.m */; };
 		E70E52152216E41C00A590AB /* BugsnagSessionTrackerStopTest.m in Sources */ = {isa = PBXBuildFile; fileRef = E70E52142216E41C00A590AB /* BugsnagSessionTrackerStopTest.m */; };
 		E70EE0781FD7039E00FA745C /* RFC3339DateTool_Tests.m in Sources */ = {isa = PBXBuildFile; fileRef = E70EE0771FD7039D00FA745C /* RFC3339DateTool_Tests.m */; };
 		E70EE07E1FD703D600FA745C /* NSError+SimpleConstructor_Tests.m in Sources */ = {isa = PBXBuildFile; fileRef = E70EE07A1FD703D500FA745C /* NSError+SimpleConstructor_Tests.m */; };
@@ -569,6 +572,9 @@
 		8A72A0352396535000328051 /* BugsnagPlugin.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; name = BugsnagPlugin.h; path = ../Source/BugsnagPlugin.h; sourceTree = "<group>"; };
 		8AA661AC23D8C1F50031ECC8 /* BSGConnectivityTest.m */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.objc; name = BSGConnectivityTest.m; path = ../../Tests/BSGConnectivityTest.m; sourceTree = "<group>"; };
 		8AF2894923339CCA00E8EB27 /* Config.xcconfig */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = text.xcconfig; name = Config.xcconfig; path = ../Configurations/Config.xcconfig; sourceTree = "<group>"; };
+		8A89F3F022D8B62B000D34D1 /* BSGConfigurationBuilder.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; name = BSGConfigurationBuilder.h; path = ../Source/BSGConfigurationBuilder.h; sourceTree = "<group>"; };
+		8A89F3F122D8B62B000D34D1 /* BSGConfigurationBuilder.m */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.objc; name = BSGConfigurationBuilder.m; path = ../Source/BSGConfigurationBuilder.m; sourceTree = "<group>"; };
+		8A89F3F422D8B81F000D34D1 /* BSGConfigurationBuilderTests.m */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.objc; name = BSGConfigurationBuilderTests.m; path = ../../Tests/BSGConfigurationBuilderTests.m; sourceTree = "<group>"; };
 		E70E52142216E41C00A590AB /* BugsnagSessionTrackerStopTest.m */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.objc; name = BugsnagSessionTrackerStopTest.m; path = ../../Tests/BugsnagSessionTrackerStopTest.m; sourceTree = "<group>"; };
 		E70EE0771FD7039D00FA745C /* RFC3339DateTool_Tests.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; name = RFC3339DateTool_Tests.m; path = ../Tests/KSCrash/RFC3339DateTool_Tests.m; sourceTree = SOURCE_ROOT; };
 		E70EE07A1FD703D500FA745C /* NSError+SimpleConstructor_Tests.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; name = "NSError+SimpleConstructor_Tests.m"; path = "../Tests/KSCrash/NSError+SimpleConstructor_Tests.m"; sourceTree = SOURCE_ROOT; };
@@ -850,6 +856,14 @@
 				8A70D9C822539C81006B696F /* BSGOutOfMemoryWatchdog.m */,
 				8A627CCF1EC2A5FD00F7C04E /* BSGSerialization.h */,
 				8A627CD11EC2A62900F7C04E /* BSGSerialization.m */,
+				8A89F3F022D8B62B000D34D1 /* BSGConfigurationBuilder.h */,
+				8A89F3F122D8B62B000D34D1 /* BSGConfigurationBuilder.m */,
+				8A2C8F3D1C6BBE3C00846019 /* Bugsnag.h */,
+				8A2C8F3E1C6BBE3C00846019 /* Bugsnag.m */,
+				F42950F4A741305B77E95389 /* BugsnagApiClient.h */,
+				F4295E2778677786239F2B28 /* BugsnagApiClient.m */,
+				8A2C8F3F1C6BBE3C00846019 /* BugsnagBreadcrumb.h */,
+				8A2C8F401C6BBE3C00846019 /* BugsnagBreadcrumb.m */,
 				8A2C8F411C6BBE3C00846019 /* BugsnagCollections.h */,
 				8A2C8F421C6BBE3C00846019 /* BugsnagCollections.m */,
 				E72962D01F4BBA8A00CEA15D /* BugsnagCrashSentry.h */,
@@ -927,6 +941,11 @@
 				8A2C8F951C6BC08600846019 /* report.json */,
 				000DF29223DB4A6B00A883CE /* Swift Tests */,
 				E70EE0891FD7047D00FA745C /* KSCrash */,
+				F429551527EAE3AFE1F605FE /* BugsnagThreadTest.m */,
+				E70E52142216E41C00A590AB /* BugsnagSessionTrackerStopTest.m */,
+				8A120069221C36420008C9C3 /* BSGFilepathTests.m */,
+				8A70D9CC2253C484006B696F /* BSGOutOfMemoryWatchdogTests.m */,
+				8A89F3F422D8B81F000D34D1 /* BSGConfigurationBuilderTests.m */,
 			);
 			name = Tests;
 			path = BugsnagTests;
@@ -1300,6 +1319,7 @@
 				8A381D4B1EAA49A700AF8429 /* BugsnagLogger.h in Headers */,
 				E7107C771F4C97F100BB3F98 /* BSG_KSSingleton.h in Headers */,
 				E7107C861F4C97F100BB3F98 /* BSG_KSCrashReportFilter.h in Headers */,
+				8A89F3F222D8B62B000D34D1 /* BSGConfigurationBuilder.h in Headers */,
 				E72962D81F4BBA8B00CEA15D /* BugsnagErrorReportApiClient.h in Headers */,
 				E7107C5C1F4C97F100BB3F98 /* BSG_KSBacktrace_Private.h in Headers */,
 				E7107C371F4C97F100BB3F98 /* BSG_KSCrashC.h in Headers */,
@@ -1488,6 +1508,7 @@
 				E790C4452434984B006FFB26 /* BugsnagDevice.m in Sources */,
 				E7107C681F4C97F100BB3F98 /* BSG_KSLogger.m in Sources */,
 				E78C1EF71FCC61EA00B976D3 /* BugsnagSessionTrackingPayload.m in Sources */,
+				8A89F3F322D8B62B000D34D1 /* BSGConfigurationBuilder.m in Sources */,
 				E7107C751F4C97F100BB3F98 /* BSG_KSSignalInfo.c in Sources */,
 				E7107C6D1F4C97F100BB3F98 /* BSG_KSMach_x86_32.c in Sources */,
 				E72352B71F55718E00436528 /* BSGConnectivity.m in Sources */,
@@ -1561,6 +1582,7 @@
 				E7A9E56B2436363900D99F8A /* BugsnagDeviceTest.m in Sources */,
 				E7D2E670243B8F8D005A3041 /* BugsnagStacktraceTest.m in Sources */,
 				E73D443A243E1912001686F5 /* BugsnagErrorTest.m in Sources */,
+				8A89F3F522D8B81F000D34D1 /* BSGConfigurationBuilderTests.m in Sources */,
 				E7B970311FD702DA00590C27 /* KSLogger_Tests.m in Sources */,
 				E7529F9C243CAE02006B4932 /* BugsnagThreadSerializationTest.m in Sources */,
 				8AA661AD23D8C1F50031ECC8 /* BSGConnectivityTest.m in Sources */,

--- a/iOS/Bugsnag.xcodeproj/project.pbxproj
+++ b/iOS/Bugsnag.xcodeproj/project.pbxproj
@@ -62,11 +62,11 @@
 		8A70D9CB22539C81006B696F /* BSGOutOfMemoryWatchdog.m in Sources */ = {isa = PBXBuildFile; fileRef = 8A70D9C822539C81006B696F /* BSGOutOfMemoryWatchdog.m */; };
 		8A70D9CD2253C484006B696F /* BSGOutOfMemoryWatchdogTests.m in Sources */ = {isa = PBXBuildFile; fileRef = 8A70D9CC2253C484006B696F /* BSGOutOfMemoryWatchdogTests.m */; };
 		8A72A0392396590300328051 /* BugsnagPlugin.h in Headers */ = {isa = PBXBuildFile; fileRef = 8A72A0352396535000328051 /* BugsnagPlugin.h */; settings = {ATTRIBUTES = (Public, ); }; };
-		8AA661AD23D8C1F50031ECC8 /* BSGConnectivityTest.m in Sources */ = {isa = PBXBuildFile; fileRef = 8AA661AC23D8C1F50031ECC8 /* BSGConnectivityTest.m */; };
-		8AF1748E23070F0300902CC2 /* BSG_KSCrashIdentifier.m in Sources */ = {isa = PBXBuildFile; fileRef = 8A530CBF22FDC3AE00F0C108 /* BSG_KSCrashIdentifier.m */; };
 		8A89F3F222D8B62B000D34D1 /* BSGConfigurationBuilder.h in Headers */ = {isa = PBXBuildFile; fileRef = 8A89F3F022D8B62B000D34D1 /* BSGConfigurationBuilder.h */; };
 		8A89F3F322D8B62B000D34D1 /* BSGConfigurationBuilder.m in Sources */ = {isa = PBXBuildFile; fileRef = 8A89F3F122D8B62B000D34D1 /* BSGConfigurationBuilder.m */; };
 		8A89F3F522D8B81F000D34D1 /* BSGConfigurationBuilderTests.m in Sources */ = {isa = PBXBuildFile; fileRef = 8A89F3F422D8B81F000D34D1 /* BSGConfigurationBuilderTests.m */; };
+		8AA661AD23D8C1F50031ECC8 /* BSGConnectivityTest.m in Sources */ = {isa = PBXBuildFile; fileRef = 8AA661AC23D8C1F50031ECC8 /* BSGConnectivityTest.m */; };
+		8AF1748E23070F0300902CC2 /* BSG_KSCrashIdentifier.m in Sources */ = {isa = PBXBuildFile; fileRef = 8A530CBF22FDC3AE00F0C108 /* BSG_KSCrashIdentifier.m */; };
 		E70E52152216E41C00A590AB /* BugsnagSessionTrackerStopTest.m in Sources */ = {isa = PBXBuildFile; fileRef = E70E52142216E41C00A590AB /* BugsnagSessionTrackerStopTest.m */; };
 		E70EE0781FD7039E00FA745C /* RFC3339DateTool_Tests.m in Sources */ = {isa = PBXBuildFile; fileRef = E70EE0771FD7039D00FA745C /* RFC3339DateTool_Tests.m */; };
 		E70EE07E1FD703D600FA745C /* NSError+SimpleConstructor_Tests.m in Sources */ = {isa = PBXBuildFile; fileRef = E70EE07A1FD703D500FA745C /* NSError+SimpleConstructor_Tests.m */; };
@@ -369,6 +369,9 @@
 		E79148291FD828E6003EFEBF /* BugsnagUser.h in CopyFiles */ = {isa = PBXBuildFile; fileRef = E72BF77D1FC86A7A004BE82F /* BugsnagUser.h */; };
 		E794E8031F9F743D00A67EE7 /* BugsnagKeys.h in Headers */ = {isa = PBXBuildFile; fileRef = E794E8021F9F743D00A67EE7 /* BugsnagKeys.h */; };
 		E7A56789245AE79C009BE2F1 /* BugsnagClientPayloadInfoTest.m in Sources */ = {isa = PBXBuildFile; fileRef = E7A56788245AE79C009BE2F1 /* BugsnagClientPayloadInfoTest.m */; };
+		E7A8EA3A24606A3E00CCBBD1 /* BSGConfigurationBuilder.h in CopyFiles */ = {isa = PBXBuildFile; fileRef = 8A89F3F022D8B62B000D34D1 /* BSGConfigurationBuilder.h */; };
+		E7A8EA3B24606C6B00CCBBD1 /* BSGConfigurationBuilder.m in Sources */ = {isa = PBXBuildFile; fileRef = 8A89F3F122D8B62B000D34D1 /* BSGConfigurationBuilder.m */; };
+		E7A8EA612461813700CCBBD1 /* TestsInfo.plist in Resources */ = {isa = PBXBuildFile; fileRef = E7A8EA602461813700CCBBD1 /* TestsInfo.plist */; };
 		E7A9E56B2436363900D99F8A /* BugsnagDeviceTest.m in Sources */ = {isa = PBXBuildFile; fileRef = E7A9E56A2436363900D99F8A /* BugsnagDeviceTest.m */; };
 		E7AB4B9C2423E16C004F015A /* BugsnagOnBreadcrumbTest.m in Sources */ = {isa = PBXBuildFile; fileRef = E7AB4B9B2423E16C004F015A /* BugsnagOnBreadcrumbTest.m */; };
 		E7B3291A1FD707EC0098FC47 /* KSCrashReportConverter_Tests.m in Sources */ = {isa = PBXBuildFile; fileRef = E7B329171FD707EC0098FC47 /* KSCrashReportConverter_Tests.m */; };
@@ -416,6 +419,7 @@
 			dstSubfolderSpec = 16;
 			files = (
 				E7819BAD2459758300A7EBDD /* BugsnagNotifier.h in CopyFiles */,
+				E7A8EA3A24606A3E00CCBBD1 /* BSGConfigurationBuilder.h in CopyFiles */,
 				E7565F7C245082580041768E /* BugsnagErrorTypes.h in CopyFiles */,
 				E77AFEF22448A13C0082B8BB /* BugsnagSessionInternal.h in CopyFiles */,
 				E77AFF0C244A18A00082B8BB /* BugsnagEndpointConfiguration.h in CopyFiles */,
@@ -531,7 +535,6 @@
 		8A2C8F181C6BBD2300846019 /* Bugsnag.framework */ = {isa = PBXFileReference; explicitFileType = wrapper.framework; includeInIndex = 0; path = Bugsnag.framework; sourceTree = BUILT_PRODUCTS_DIR; };
 		8A2C8F1D1C6BBD2300846019 /* Info.plist */ = {isa = PBXFileReference; lastKnownFileType = text.plist.xml; path = Info.plist; sourceTree = SOURCE_ROOT; };
 		8A2C8F221C6BBD2300846019 /* Tests.xctest */ = {isa = PBXFileReference; explicitFileType = wrapper.cfbundle; includeInIndex = 0; path = Tests.xctest; sourceTree = BUILT_PRODUCTS_DIR; };
-		8A2C8F291C6BBD2300846019 /* TestsInfo.plist */ = {isa = PBXFileReference; lastKnownFileType = text.plist.xml; path = TestsInfo.plist; sourceTree = SOURCE_ROOT; };
 		8A2C8F321C6BBD7200846019 /* module.modulemap */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = "sourcecode.module-map"; path = module.modulemap; sourceTree = SOURCE_ROOT; };
 		8A2C8F3D1C6BBE3C00846019 /* Bugsnag.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; name = Bugsnag.h; path = ../Source/Bugsnag.h; sourceTree = SOURCE_ROOT; };
 		8A2C8F3E1C6BBE3C00846019 /* Bugsnag.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; name = Bugsnag.m; path = ../Source/Bugsnag.m; sourceTree = SOURCE_ROOT; };
@@ -570,11 +573,11 @@
 		8A70D9C822539C81006B696F /* BSGOutOfMemoryWatchdog.m */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.objc; name = BSGOutOfMemoryWatchdog.m; path = ../Source/BSGOutOfMemoryWatchdog.m; sourceTree = "<group>"; };
 		8A70D9CC2253C484006B696F /* BSGOutOfMemoryWatchdogTests.m */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.objc; path = BSGOutOfMemoryWatchdogTests.m; sourceTree = "<group>"; };
 		8A72A0352396535000328051 /* BugsnagPlugin.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; name = BugsnagPlugin.h; path = ../Source/BugsnagPlugin.h; sourceTree = "<group>"; };
-		8AA661AC23D8C1F50031ECC8 /* BSGConnectivityTest.m */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.objc; name = BSGConnectivityTest.m; path = ../../Tests/BSGConnectivityTest.m; sourceTree = "<group>"; };
-		8AF2894923339CCA00E8EB27 /* Config.xcconfig */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = text.xcconfig; name = Config.xcconfig; path = ../Configurations/Config.xcconfig; sourceTree = "<group>"; };
 		8A89F3F022D8B62B000D34D1 /* BSGConfigurationBuilder.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; name = BSGConfigurationBuilder.h; path = ../Source/BSGConfigurationBuilder.h; sourceTree = "<group>"; };
 		8A89F3F122D8B62B000D34D1 /* BSGConfigurationBuilder.m */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.objc; name = BSGConfigurationBuilder.m; path = ../Source/BSGConfigurationBuilder.m; sourceTree = "<group>"; };
 		8A89F3F422D8B81F000D34D1 /* BSGConfigurationBuilderTests.m */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.objc; name = BSGConfigurationBuilderTests.m; path = ../../Tests/BSGConfigurationBuilderTests.m; sourceTree = "<group>"; };
+		8AA661AC23D8C1F50031ECC8 /* BSGConnectivityTest.m */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.objc; name = BSGConnectivityTest.m; path = ../../Tests/BSGConnectivityTest.m; sourceTree = "<group>"; };
+		8AF2894923339CCA00E8EB27 /* Config.xcconfig */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = text.xcconfig; name = Config.xcconfig; path = ../Configurations/Config.xcconfig; sourceTree = "<group>"; };
 		E70E52142216E41C00A590AB /* BugsnagSessionTrackerStopTest.m */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.objc; name = BugsnagSessionTrackerStopTest.m; path = ../../Tests/BugsnagSessionTrackerStopTest.m; sourceTree = "<group>"; };
 		E70EE0771FD7039D00FA745C /* RFC3339DateTool_Tests.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; name = RFC3339DateTool_Tests.m; path = ../Tests/KSCrash/RFC3339DateTool_Tests.m; sourceTree = SOURCE_ROOT; };
 		E70EE07A1FD703D500FA745C /* NSError+SimpleConstructor_Tests.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; name = "NSError+SimpleConstructor_Tests.m"; path = "../Tests/KSCrash/NSError+SimpleConstructor_Tests.m"; sourceTree = SOURCE_ROOT; };
@@ -735,6 +738,7 @@
 		E794E8021F9F743D00A67EE7 /* BugsnagKeys.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; name = BugsnagKeys.h; path = ../Source/BugsnagKeys.h; sourceTree = SOURCE_ROOT; };
 		E79FEBE61F4CB1320048FAD6 /* Foundation.framework */ = {isa = PBXFileReference; lastKnownFileType = wrapper.framework; name = Foundation.framework; path = System/Library/Frameworks/Foundation.framework; sourceTree = SDKROOT; };
 		E7A56788245AE79C009BE2F1 /* BugsnagClientPayloadInfoTest.m */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.objc; name = BugsnagClientPayloadInfoTest.m; path = ../../Tests/BugsnagClientPayloadInfoTest.m; sourceTree = "<group>"; };
+		E7A8EA602461813700CCBBD1 /* TestsInfo.plist */ = {isa = PBXFileReference; lastKnownFileType = text.plist; path = TestsInfo.plist; sourceTree = SOURCE_ROOT; };
 		E7A9E56A2436363900D99F8A /* BugsnagDeviceTest.m */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.objc; name = BugsnagDeviceTest.m; path = ../../Tests/BugsnagDeviceTest.m; sourceTree = "<group>"; };
 		E7AB4B9B2423E16C004F015A /* BugsnagOnBreadcrumbTest.m */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.objc; name = BugsnagOnBreadcrumbTest.m; path = ../../Tests/BugsnagOnBreadcrumbTest.m; sourceTree = "<group>"; };
 		E7B329171FD707EC0098FC47 /* KSCrashReportConverter_Tests.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; name = KSCrashReportConverter_Tests.m; path = ../Tests/KSCrash/KSCrashReportConverter_Tests.m; sourceTree = SOURCE_ROOT; };
@@ -856,8 +860,6 @@
 				8A70D9C822539C81006B696F /* BSGOutOfMemoryWatchdog.m */,
 				8A627CCF1EC2A5FD00F7C04E /* BSGSerialization.h */,
 				8A627CD11EC2A62900F7C04E /* BSGSerialization.m */,
-				8A89F3F022D8B62B000D34D1 /* BSGConfigurationBuilder.h */,
-				8A89F3F122D8B62B000D34D1 /* BSGConfigurationBuilder.m */,
 				8A2C8F3D1C6BBE3C00846019 /* Bugsnag.h */,
 				8A2C8F3E1C6BBE3C00846019 /* Bugsnag.m */,
 				F42950F4A741305B77E95389 /* BugsnagApiClient.h */,
@@ -898,7 +900,6 @@
 			isa = PBXGroup;
 			children = (
 				8AA661AC23D8C1F50031ECC8 /* BSGConnectivityTest.m */,
-				8A70D9CC2253C484006B696F /* BSGOutOfMemoryWatchdogTests.m */,
 				E790C49A2434C8C8006FFB26 /* BugsnagAppTest.m */,
 				009131BD23F5884E000810D9 /* BugsnagBaseUnitTest.m */,
 				009131BF23F58930000810D9 /* BugsnagBaseUnitTest.h */,
@@ -909,6 +910,7 @@
 				4B3B193422CA7B0900475354 /* BugsnagCollectionsBSGDictSetSafeObjectTest.m */,
 				4B775FCE22CBDEB4004839C5 /* BugsnagCollectionsBSGDictInsertIfNotNilTest.m */,
 				4BE6C42522CAD61A0056305D /* BugsnagCollectionsBSGDictMergeTest.m */,
+				8A89F3F422D8B81F000D34D1 /* BSGConfigurationBuilderTests.m */,
 				8A4E733E1DC13281001F7CC8 /* BugsnagConfigurationTests.m */,
 				E7A9E56A2436363900D99F8A /* BugsnagDeviceTest.m */,
 				E73D4439243E1912001686F5 /* BugsnagErrorTest.m */,
@@ -920,6 +922,7 @@
 				E7819BB6245979B800A7EBDD /* BugsnagNotifierTest.m */,
 				E7AB4B9B2423E16C004F015A /* BugsnagOnBreadcrumbTest.m */,
 				E728378A2451843000EE2B7D /* BugsnagOnCrashTest.m */,
+				8A70D9CC2253C484006B696F /* BSGOutOfMemoryWatchdogTests.m */,
 				E72AE1FF241A57B100ED8972 /* BugsnagPluginTest.m */,
 				E78C1EFB1FCC759B00B976D3 /* BugsnagSessionTest.m */,
 				E78C1EF01FCC2F1700B976D3 /* BugsnagSessionTrackerTest.m */,
@@ -937,15 +940,10 @@
 				E78C1EFD1FCC778700B976D3 /* BugsnagUserTest.m */,
 				F42954B7D892334E7551F0F3 /* RegisterErrorDataTest.m */,
 				000E6E9C23D8690E009D8194 /* Tests-Bridging-Header.h */,
-				8A2C8F291C6BBD2300846019 /* TestsInfo.plist */,
 				8A2C8F951C6BC08600846019 /* report.json */,
 				000DF29223DB4A6B00A883CE /* Swift Tests */,
 				E70EE0891FD7047D00FA745C /* KSCrash */,
-				F429551527EAE3AFE1F605FE /* BugsnagThreadTest.m */,
-				E70E52142216E41C00A590AB /* BugsnagSessionTrackerStopTest.m */,
-				8A120069221C36420008C9C3 /* BSGFilepathTests.m */,
-				8A70D9CC2253C484006B696F /* BSGOutOfMemoryWatchdogTests.m */,
-				8A89F3F422D8B81F000D34D1 /* BSGConfigurationBuilderTests.m */,
+				E7A8EA602461813700CCBBD1 /* TestsInfo.plist */,
 			);
 			name = Tests;
 			path = BugsnagTests;
@@ -1144,6 +1142,8 @@
 		E7565F7B245082100041768E /* Configuration */ = {
 			isa = PBXGroup;
 			children = (
+				8A89F3F022D8B62B000D34D1 /* BSGConfigurationBuilder.h */,
+				8A89F3F122D8B62B000D34D1 /* BSGConfigurationBuilder.m */,
 				8A2C8F431C6BBE3C00846019 /* BugsnagConfiguration.h */,
 				8A2C8F441C6BBE3C00846019 /* BugsnagConfiguration.m */,
 				E77AFF07244A18890082B8BB /* BugsnagEndpointConfiguration.h */,
@@ -1157,8 +1157,6 @@
 		E7A9E587243B23FF00D99F8A /* Client */ = {
 			isa = PBXGroup;
 			children = (
-				8A2C8F3D1C6BBE3C00846019 /* Bugsnag.h */,
-				8A2C8F3E1C6BBE3C00846019 /* Bugsnag.m */,
 				8A2C8F4B1C6BBE3C00846019 /* BugsnagClient.h */,
 				8A2C8F4C1C6BBE3C00846019 /* BugsnagClient.m */,
 				E790C424243354A8006FFB26 /* BugsnagClientInternal.h */,
@@ -1230,8 +1228,6 @@
 			children = (
 				E72352B41F55718E00436528 /* BSGConnectivity.h */,
 				E72352B51F55718E00436528 /* BSGConnectivity.m */,
-				F42950F4A741305B77E95389 /* BugsnagApiClient.h */,
-				F4295E2778677786239F2B28 /* BugsnagApiClient.m */,
 				E72962D21F4BBA8B00CEA15D /* BugsnagErrorReportApiClient.h */,
 				E72962D31F4BBA8B00CEA15D /* BugsnagErrorReportApiClient.m */,
 			);
@@ -1241,8 +1237,6 @@
 		E7A9E598243B246600D99F8A /* Breadcrumbs */ = {
 			isa = PBXGroup;
 			children = (
-				8A2C8F3F1C6BBE3C00846019 /* BugsnagBreadcrumb.h */,
-				8A2C8F401C6BBE3C00846019 /* BugsnagBreadcrumb.m */,
 				E77526B8242D0AE50077A42F /* BugsnagBreadcrumbs.h */,
 				E77526B9242D0AE50077A42F /* BugsnagBreadcrumbs.m */,
 			);
@@ -1465,6 +1459,7 @@
 			isa = PBXResourcesBuildPhase;
 			buildActionMask = 2147483647;
 			files = (
+				E7A8EA612461813700CCBBD1 /* TestsInfo.plist in Resources */,
 				8A2C8F961C6BC08600846019 /* report.json in Resources */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
@@ -1642,6 +1637,7 @@
 				E7397E3A1F83BC320034242A /* BSG_KSBacktrace.c in Sources */,
 				E7397E3B1F83BC320034242A /* BSG_KSDynamicLinker.c in Sources */,
 				E7397E3C1F83BC320034242A /* BSG_KSFileUtils.c in Sources */,
+				E7A8EA3B24606C6B00CCBBD1 /* BSGConfigurationBuilder.m in Sources */,
 				E7397E3D1F83BC320034242A /* BSG_KSJSONCodec.c in Sources */,
 				E790C44124349831006FFB26 /* BugsnagAppWithState.m in Sources */,
 				E77526BC242D0AE50077A42F /* BugsnagBreadcrumbs.m in Sources */,

--- a/iOS/Info.plist
+++ b/iOS/Info.plist
@@ -19,7 +19,7 @@
 	<key>CFBundleSignature</key>
 	<string>????</string>
 	<key>CFBundleVersion</key>
-	<string>$(CURRENT_PROJECT_VERSION)</string>
+	<string>1</string>
 	<key>NSPrincipalClass</key>
 	<string></string>
 </dict>

--- a/tvOS/Bugsnag.xcodeproj/project.pbxproj
+++ b/tvOS/Bugsnag.xcodeproj/project.pbxproj
@@ -209,6 +209,7 @@
 		E79148911FD82E77003EFEBF /* BugsnagUserTest.m in Sources */ = {isa = PBXBuildFile; fileRef = E791488D1FD82E77003EFEBF /* BugsnagUserTest.m */; };
 		E794E8071F9F748100A67EE7 /* BugsnagKeys.h in Headers */ = {isa = PBXBuildFile; fileRef = E794E8061F9F748100A67EE7 /* BugsnagKeys.h */; };
 		E7A5678D245AE7C1009BE2F1 /* BugsnagClientPayloadInfoTest.m in Sources */ = {isa = PBXBuildFile; fileRef = E7A5678C245AE7C0009BE2F1 /* BugsnagClientPayloadInfoTest.m */; };
+		E7A8EA632461817900CCBBD1 /* TestsInfo.plist in Resources */ = {isa = PBXBuildFile; fileRef = E7A8EA622461817900CCBBD1 /* TestsInfo.plist */; };
 		E7A9E56F2436366800D99F8A /* BugsnagDeviceTest.m in Sources */ = {isa = PBXBuildFile; fileRef = E7A9E56E2436366800D99F8A /* BugsnagDeviceTest.m */; };
 		E7CE78F21FD94F1B001D07E0 /* KSMach_Tests.m in Sources */ = {isa = PBXBuildFile; fileRef = E7CE78D81FD94F18001D07E0 /* KSMach_Tests.m */; };
 		E7CE78F31FD94F1B001D07E0 /* NSError+SimpleConstructor_Tests.m in Sources */ = {isa = PBXBuildFile; fileRef = E7CE78D91FD94F18001D07E0 /* NSError+SimpleConstructor_Tests.m */; };
@@ -278,7 +279,6 @@
 		8A8D51241D41343500D33797 /* Bugsnag.framework */ = {isa = PBXFileReference; explicitFileType = wrapper.framework; includeInIndex = 0; path = Bugsnag.framework; sourceTree = BUILT_PRODUCTS_DIR; };
 		8A8D51291D41343500D33797 /* Info.plist */ = {isa = PBXFileReference; lastKnownFileType = text.plist.xml; path = Info.plist; sourceTree = "<group>"; };
 		8AB151121D41356800C9B218 /* Tests.xctest */ = {isa = PBXFileReference; explicitFileType = wrapper.cfbundle; includeInIndex = 0; path = Tests.xctest; sourceTree = BUILT_PRODUCTS_DIR; };
-		8AB151161D41356800C9B218 /* TestsInfo.plist */ = {isa = PBXFileReference; lastKnownFileType = text.plist.xml; name = TestsInfo.plist; path = ../TestsInfo.plist; sourceTree = "<group>"; };
 		8AB1511D1D41361700C9B218 /* BugsnagBreadcrumbsTest.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; name = BugsnagBreadcrumbsTest.m; path = ../../Tests/BugsnagBreadcrumbsTest.m; sourceTree = "<group>"; };
 		8AB1511F1D41361700C9B218 /* BugsnagSinkTests.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; name = BugsnagSinkTests.m; path = ../../Tests/BugsnagSinkTests.m; sourceTree = "<group>"; };
 		8AB151201D41361700C9B218 /* report.json */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = text.json; name = report.json; path = ../../Tests/report.json; sourceTree = "<group>"; };
@@ -452,6 +452,7 @@
 		E791488D1FD82E77003EFEBF /* BugsnagUserTest.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; name = BugsnagUserTest.m; path = ../../Tests/BugsnagUserTest.m; sourceTree = "<group>"; };
 		E794E8061F9F748100A67EE7 /* BugsnagKeys.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; name = BugsnagKeys.h; path = ../Source/BugsnagKeys.h; sourceTree = "<group>"; };
 		E7A5678C245AE7C0009BE2F1 /* BugsnagClientPayloadInfoTest.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; name = BugsnagClientPayloadInfoTest.m; path = ../../Tests/BugsnagClientPayloadInfoTest.m; sourceTree = "<group>"; };
+		E7A8EA622461817900CCBBD1 /* TestsInfo.plist */ = {isa = PBXFileReference; lastKnownFileType = text.plist; path = TestsInfo.plist; sourceTree = SOURCE_ROOT; };
 		E7A9E56E2436366800D99F8A /* BugsnagDeviceTest.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; name = BugsnagDeviceTest.m; path = ../../Tests/BugsnagDeviceTest.m; sourceTree = "<group>"; };
 		E7CE78D81FD94F18001D07E0 /* KSMach_Tests.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; path = KSMach_Tests.m; sourceTree = "<group>"; };
 		E7CE78D91FD94F18001D07E0 /* NSError+SimpleConstructor_Tests.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; path = "NSError+SimpleConstructor_Tests.m"; sourceTree = "<group>"; };
@@ -545,8 +546,6 @@
 				E74D8E81243B388E00F2A630 /* Plugins */,
 				E74D8E91243B38E200F2A630 /* Storage */,
 				8AB151251D41366400C9B218 /* BSG_KSCrashReportWriter.h */,
-				8AB65FBD22DC72EA001200AB /* BSGConfigurationBuilder.h */,
-				8AB65FBE22DC72EA001200AB /* BSGConfigurationBuilder.m */,
 				8A6C6FAC2257882400E8EF24 /* BSGOutOfMemoryWatchdog.h */,
 				8A6C6FAB2257882400E8EF24 /* BSGOutOfMemoryWatchdog.m */,
 				8A627CD31EC3B69300F7C04E /* BSGSerialization.h */,
@@ -576,6 +575,7 @@
 			isa = PBXGroup;
 			children = (
 				E7CE78D71FD94EF1001D07E0 /* KSCrash */,
+				8AB65FC922DC74C7001200AB /* BSGConfigurationBuilderTests.m */,
 				E71DB9E32447105E00D0161E /* BSGConnectivityTest.m */,
 				4B3CD2B722C5676700DBFF33 /* BSGOutOfMemoryWatchdogTests.m */,
 				E790C4A02434CB5B006FFB26 /* BugsnagAppTest.m */,
@@ -586,8 +586,6 @@
 				8AB1511D1D41361700C9B218 /* BugsnagBreadcrumbsTest.m */,
 				E790C421243231EA006FFB26 /* BugsnagClientMirrorTest.m */,
 				E7A5678C245AE7C0009BE2F1 /* BugsnagClientPayloadInfoTest.m */,
-				8AB65FC922DC74C7001200AB /* BSGConfigurationBuilderTests.m */,
-				8A12006D221C51550008C9C3 /* BSGFilepathTests.m */,
 				4B406C1322CAD94100464D1D /* BugsnagCollectionsBSGDictMergeTest.m */,
 				4B406C1222CAD94100464D1D /* BugsnagCollectionsBSGDictSetSafeObjectTest.m */,
 				4B775FD022CBE01F004839C5 /* BugsnagCollectionsBSGDictInsertIfNotNilTest.m */,
@@ -619,7 +617,7 @@
 				4B3CD2BA22C5676800DBFF33 /* RegisterErrorDataTest.m */,
 				00D7ACA823E98A9A00FBE4A7 /* TestConstants.m */,
 				8AB151201D41361700C9B218 /* report.json */,
-				8AB151161D41356800C9B218 /* TestsInfo.plist */,
+				E7A8EA622461817900CCBBD1 /* TestsInfo.plist */,
 			);
 			path = Tests;
 			sourceTree = "<group>";
@@ -748,6 +746,8 @@
 		E7565F82245082A90041768E /* Configuration */ = {
 			isa = PBXGroup;
 			children = (
+				8AB65FBD22DC72EA001200AB /* BSGConfigurationBuilder.h */,
+				8AB65FBE22DC72EA001200AB /* BSGConfigurationBuilder.m */,
 				8AB1512C1D41366400C9B218 /* BugsnagConfiguration.h */,
 				8AB1512D1D41366400C9B218 /* BugsnagConfiguration.m */,
 				E77AFF11244A19260082B8BB /* BugsnagEndpointConfiguration.h */,
@@ -1121,6 +1121,7 @@
 			isa = PBXResourcesBuildPhase;
 			buildActionMask = 2147483647;
 			files = (
+				E7A8EA632461817900CCBBD1 /* TestsInfo.plist in Resources */,
 				8AB151241D41361700C9B218 /* report.json in Resources */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;

--- a/tvOS/Bugsnag.xcodeproj/project.pbxproj
+++ b/tvOS/Bugsnag.xcodeproj/project.pbxproj
@@ -38,6 +38,9 @@
 		8AB151171D41356800C9B218 /* Bugsnag.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = 8A8D51241D41343500D33797 /* Bugsnag.framework */; };
 		8AB151211D41361700C9B218 /* BugsnagBreadcrumbsTest.m in Sources */ = {isa = PBXBuildFile; fileRef = 8AB1511D1D41361700C9B218 /* BugsnagBreadcrumbsTest.m */; };
 		8AB151241D41361700C9B218 /* report.json in Resources */ = {isa = PBXBuildFile; fileRef = 8AB151201D41361700C9B218 /* report.json */; };
+		8AB65FC022DC72FE001200AB /* BSGConfigurationBuilder.m in Sources */ = {isa = PBXBuildFile; fileRef = 8AB65FBE22DC72EA001200AB /* BSGConfigurationBuilder.m */; };
+		8AB65FC122DC733C001200AB /* BSGConfigurationBuilder.h in Headers */ = {isa = PBXBuildFile; fileRef = 8AB65FBD22DC72EA001200AB /* BSGConfigurationBuilder.h */; };
+		8AB65FCA22DC74C7001200AB /* BSGConfigurationBuilderTests.m in Sources */ = {isa = PBXBuildFile; fileRef = 8AB65FC922DC74C7001200AB /* BSGConfigurationBuilderTests.m */; };
 		8ACF0F74201812AD00173809 /* BugsnagSinkTests.m in Sources */ = {isa = PBXBuildFile; fileRef = 8AB1511F1D41361700C9B218 /* BugsnagSinkTests.m */; };
 		8AD9A4F51D42EE87004E1CC5 /* Bugsnag.h in Headers */ = {isa = PBXBuildFile; fileRef = 8AB151261D41366400C9B218 /* Bugsnag.h */; settings = {ATTRIBUTES = (Public, ); }; };
 		8AD9A4F61D42EE8E004E1CC5 /* BugsnagBreadcrumb.h in Headers */ = {isa = PBXBuildFile; fileRef = 8AB151281D41366400C9B218 /* BugsnagBreadcrumb.h */; settings = {ATTRIBUTES = (Public, ); }; };
@@ -292,6 +295,9 @@
 		8AB151311D41366400C9B218 /* BugsnagMetadata.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; name = BugsnagMetadata.m; path = ../Source/BugsnagMetadata.m; sourceTree = "<group>"; };
 		8AB151341D41366400C9B218 /* BugsnagSink.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; name = BugsnagSink.h; path = ../Source/BugsnagSink.h; sourceTree = "<group>"; };
 		8AB151351D41366400C9B218 /* BugsnagSink.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; name = BugsnagSink.m; path = ../Source/BugsnagSink.m; sourceTree = "<group>"; };
+		8AB65FBD22DC72EA001200AB /* BSGConfigurationBuilder.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; name = BSGConfigurationBuilder.h; path = ../Source/BSGConfigurationBuilder.h; sourceTree = "<group>"; };
+		8AB65FBE22DC72EA001200AB /* BSGConfigurationBuilder.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; name = BSGConfigurationBuilder.m; path = ../Source/BSGConfigurationBuilder.m; sourceTree = "<group>"; };
+		8AB65FC922DC74C7001200AB /* BSGConfigurationBuilderTests.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; name = BSGConfigurationBuilderTests.m; path = ../../Tests/BSGConfigurationBuilderTests.m; sourceTree = "<group>"; };
 		8AD9FA8B1E0863A1002859A7 /* BugsnagConfigurationTests.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; name = BugsnagConfigurationTests.m; path = ../Tests/BugsnagConfigurationTests.m; sourceTree = SOURCE_ROOT; };
 		E71DB9E02447105D00D0161E /* BugsnagTests.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; name = BugsnagTests.m; path = ../../Tests/BugsnagTests.m; sourceTree = "<group>"; };
 		E71DB9E12447105E00D0161E /* BugsnagMetadataRedactionTest.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; name = BugsnagMetadataRedactionTest.m; path = ../../Tests/BugsnagMetadataRedactionTest.m; sourceTree = "<group>"; };
@@ -539,6 +545,8 @@
 				E74D8E81243B388E00F2A630 /* Plugins */,
 				E74D8E91243B38E200F2A630 /* Storage */,
 				8AB151251D41366400C9B218 /* BSG_KSCrashReportWriter.h */,
+				8AB65FBD22DC72EA001200AB /* BSGConfigurationBuilder.h */,
+				8AB65FBE22DC72EA001200AB /* BSGConfigurationBuilder.m */,
 				8A6C6FAC2257882400E8EF24 /* BSGOutOfMemoryWatchdog.h */,
 				8A6C6FAB2257882400E8EF24 /* BSGOutOfMemoryWatchdog.m */,
 				8A627CD31EC3B69300F7C04E /* BSGSerialization.h */,
@@ -578,6 +586,8 @@
 				8AB1511D1D41361700C9B218 /* BugsnagBreadcrumbsTest.m */,
 				E790C421243231EA006FFB26 /* BugsnagClientMirrorTest.m */,
 				E7A5678C245AE7C0009BE2F1 /* BugsnagClientPayloadInfoTest.m */,
+				8AB65FC922DC74C7001200AB /* BSGConfigurationBuilderTests.m */,
+				8A12006D221C51550008C9C3 /* BSGFilepathTests.m */,
 				4B406C1322CAD94100464D1D /* BugsnagCollectionsBSGDictMergeTest.m */,
 				4B406C1222CAD94100464D1D /* BugsnagCollectionsBSGDictSetSafeObjectTest.m */,
 				4B775FD022CBE01F004839C5 /* BugsnagCollectionsBSGDictInsertIfNotNilTest.m */,
@@ -951,6 +961,7 @@
 				E791487D1FD82E6D003EFEBF /* BugsnagSessionTracker.h in Headers */,
 				00D7ACA123E97FBD00FBE4A7 /* BugsnagEvent.h in Headers */,
 				8A3C591023968B2000B344AA /* BugsnagPlugin.h in Headers */,
+				8AB65FC122DC733C001200AB /* BSGConfigurationBuilder.h in Headers */,
 				E76617881F4E459C0094CECF /* BSG_KSCrashReportStore.h in Headers */,
 				E76617A51F4E459C0094CECF /* BSG_KSBacktrace.h in Headers */,
 				E794E8071F9F748100A67EE7 /* BugsnagKeys.h in Headers */,
@@ -1163,6 +1174,7 @@
 				E76617AB1F4E459C0094CECF /* BSG_KSFileUtils.c in Sources */,
 				E76617941F4E459C0094CECF /* BSG_KSCrashSentry.c in Sources */,
 				E76617B81F4E459C0094CECF /* BSG_KSMach_x86_64.c in Sources */,
+				8AB65FC022DC72FE001200AB /* BSGConfigurationBuilder.m in Sources */,
 				E76617CB1F4E459C0094CECF /* NSError+BSG_SimpleConstructor.m in Sources */,
 				E790C49824349D35006FFB26 /* BugsnagDevice.m in Sources */,
 				E79148891FD82E6D003EFEBF /* BugsnagFileStore.m in Sources */,
@@ -1245,6 +1257,7 @@
 				E762E9F01F73F6CF00E82B43 /* BugsnagHandledStateTest.m in Sources */,
 				E791488F1FD82E77003EFEBF /* BugsnagSessionTrackingPayloadTest.m in Sources */,
 				8AD9FA8D1E0863A1002859A7 /* BugsnagConfigurationTests.m in Sources */,
+				8AB65FCA22DC74C7001200AB /* BSGConfigurationBuilderTests.m in Sources */,
 				4B406C1422CAD94100464D1D /* BugsnagCollectionsBSGDictSetSafeObjectTest.m in Sources */,
 				E71DB9E72447105E00D0161E /* BugsnagTests.m in Sources */,
 				E7CE79021FD94F1B001D07E0 /* RFC3339DateTool_Tests.m in Sources */,

--- a/tvOS/Info.plist
+++ b/tvOS/Info.plist
@@ -19,7 +19,7 @@
 	<key>CFBundleSignature</key>
 	<string>????</string>
 	<key>CFBundleVersion</key>
-	<string>$(CURRENT_PROJECT_VERSION)</string>
+	<string>1</string>
 	<key>NSPrincipalClass</key>
 	<string></string>
 </dict>


### PR DESCRIPTION
## Goal

Allows loading of Configuration from Plist files, without creating a configuration object up front in code.

## Changeset

- Added `BugsnagConfiguration.loadConfig()` method, which reads from the main bundle's plist. Note that the naming is a required deviation from the spec due to an [existing method](https://developer.apple.com/documentation/objectivec/nsobject/1418815-load?language=objc) on `NSObject`
- Added non-public class `BSGConfigurationBuilder` which loads configuration options from the plist under the 'bugsnag' key
- Updated `BugsnagConfiguration` to set the `apiKey` property to an empty string if it is not a valid value or a string value. Previous behaviour was to keep it as the passed in value, even if the object was of a different type (such as a dictionary)

Reads the following values:

```
apiKey
appType
appVersion
autoDetectErrors
autoTrackSessions
bundleVersion
persistUser
releaseStage
enabledReleaseStages
endpoints
maxBreadcrumbs
redactedKeys
sendThreads
```

## Tests

- Added unit tests to verify the default and overridden values of configuration options loaded from a plist
- Added a mazerunner scenario which loads configuration from a plist
