### PR TITLE
Allow construction of app/device objects from json

### DIFF
--- a/Source/BugsnagAppWithState.m
+++ b/Source/BugsnagAppWithState.m
@@ -22,6 +22,34 @@
 
 @implementation BugsnagAppWithState
 
++ (BugsnagAppWithState *)appFromJson:(NSDictionary *)json {
+    BugsnagAppWithState *app = [BugsnagAppWithState new];
+
+    id duration = json[@"duration"];
+    if (duration && [duration isKindOfClass:[NSNumber class]]) {
+        app.duration = [(NSNumber *) duration unsignedIntValue];
+    }
+
+    id durationInForeground = json[@"durationInForeground"];
+    if (durationInForeground && [durationInForeground isKindOfClass:[NSNumber class]]) {
+        app.durationInForeground = [(NSNumber *) durationInForeground unsignedIntValue];
+    }
+
+    id inForeground = json[@"inForeground"];
+    if (inForeground) {
+        app.inForeground = [(NSNumber *) inForeground boolValue];
+    }
+
+    app.bundleVersion = json[@"bundleVersion"];
+    app.codeBundleId = json[@"codeBundleId"];
+    app.dsymUuid = json[@"dsymUuid"];
+    app.id = json[@"id"];
+    app.releaseStage = json[@"releaseStage"];
+    app.type = json[@"type"];
+    app.version = json[@"version"];
+    return app;
+}
+
 + (BugsnagAppWithState *)appWithOomData:(NSDictionary *)event
 {
     BugsnagAppWithState *app = [BugsnagAppWithState new];

--- a/Source/BugsnagDeviceWithState.m
+++ b/Source/BugsnagDeviceWithState.m
@@ -75,6 +75,33 @@ NSNumber *BSGDeviceFreeSpace(NSSearchPathDirectory directory) {
     return self;
 }
 
++ (BugsnagDeviceWithState *) deviceFromJson:(NSDictionary *)json {
+    BugsnagDeviceWithState *device = [BugsnagDeviceWithState new];
+    device.id = json[@"id"];
+    device.freeMemory = json[@"freeMemory"];
+    device.freeDisk = json[@"freeDisk"];
+    device.locale = json[@"locale"];
+    device.manufacturer = json[@"manufacturer"];
+    device.model = json[@"model"];
+    device.modelNumber = json[@"modelNumber"];
+    device.orientation = json[@"orientation"];
+    device.osName = json[@"osName"];
+    device.osVersion = json[@"osVersion"];
+    device.runtimeVersions = json[@"runtimeVersions"];
+    device.totalMemory = json[@"totalMemory"];
+
+    id jailbroken = json[@"jailbroken"];
+    if (jailbroken) {
+        device.jailbroken = [(NSNumber *) jailbroken boolValue];
+    }
+
+    id time = json[@"time"];
+    if (time && [time isKindOfClass:[NSString class]]) {
+        device.time = [device.formatter dateFromString:time];
+    }
+    return device;
+}
+
 + (BugsnagDeviceWithState *)deviceWithOomData:(NSDictionary *)data {
     BugsnagDeviceWithState *device = [BugsnagDeviceWithState new];
     device.id = data[@"id"];

--- a/Tests/BugsnagAppTest.m
+++ b/Tests/BugsnagAppTest.m
@@ -24,6 +24,7 @@
                                     config:(BugsnagConfiguration *)config
                               codeBundleId:(NSString *)codeBundleId;
 + (BugsnagAppWithState *)appWithOomData:(NSDictionary *)event;
++ (BugsnagAppWithState *)appFromJson:(NSDictionary *)json;
 - (NSDictionary *)toDict;
 @end
 
@@ -150,6 +151,37 @@
     XCTAssertEqualObjects(@"1", app.bundleVersion);
     XCTAssertEqualObjects(@"bundle-123", app.codeBundleId);
     XCTAssertNil(app.dsymUuid);
+    XCTAssertEqualObjects(@"com.example.foo.MyIosApp", app.id);
+    XCTAssertEqualObjects(@"beta", app.releaseStage);
+    XCTAssertEqualObjects(@"iOS", app.type);
+    XCTAssertEqualObjects(@"5.6.3", app.version);
+}
+
+- (void)testAppFromJson {
+    NSDictionary *json = @{
+            @"duration": @7000,
+            @"durationInForeground": @2000,
+            @"inForeground": @YES,
+            @"bundleVersion": @"1",
+            @"codeBundleId": @"bundle-123",
+            @"dsymUuid": @"dsym-uuid-123",
+            @"id": @"com.example.foo.MyIosApp",
+            @"releaseStage": @"beta",
+            @"type": @"iOS",
+            @"version": @"5.6.3",
+    };
+    BugsnagAppWithState *app = [BugsnagAppWithState appFromJson:json];
+    XCTAssertNotNil(app);
+
+    // verify stateful fields
+    XCTAssertEqual(7000, app.duration);
+    XCTAssertEqual(2000, app.durationInForeground);
+    XCTAssertTrue(app.inForeground);
+
+    // verify stateless fields
+    XCTAssertEqualObjects(@"1", app.bundleVersion);
+    XCTAssertEqualObjects(@"bundle-123", app.codeBundleId);
+    XCTAssertEqualObjects(@"dsym-uuid-123", app.dsymUuid);
     XCTAssertEqualObjects(@"com.example.foo.MyIosApp", app.id);
     XCTAssertEqualObjects(@"beta", app.releaseStage);
     XCTAssertEqualObjects(@"iOS", app.type);

--- a/Tests/BugsnagDeviceTest.m
+++ b/Tests/BugsnagDeviceTest.m
@@ -28,6 +28,8 @@ NSNumber *BSGDeviceFreeSpace(NSSearchPathDirectory directory);
 + (BugsnagDeviceWithState *)deviceWithOomData:(NSDictionary *)data;
 
 - (NSDictionary *)toDictionary;
+
++ (BugsnagDeviceWithState *) deviceFromJson:(NSDictionary *)json;
 @end
 
 @interface BugsnagDeviceTest : XCTestCase
@@ -213,6 +215,56 @@ NSNumber *BSGDeviceFreeSpace(NSSearchPathDirectory directory);
     XCTAssertEqualObjects(@"14B25", device.runtimeVersions[@"osBuild"]);
     XCTAssertEqualObjects(@"10.0.0 (clang-1000.11.45.5)", device.runtimeVersions[@"clangVersion"]);
     XCTAssertEqualObjects(@"bar", device.runtimeVersions[@"foo"]);
+}
+
+- (void)testDeviceFromJson {
+    NSDictionary *json = @{
+            @"jailbroken": @YES,
+            @"id": @"123",
+            @"locale": @"en-US",
+            @"manufacturer": @"Apple",
+            @"model": @"x86_64",
+            @"modelNumber": @"iPhone 6",
+            @"osName": @"iPhone OS",
+            @"osVersion": @"8.1",
+            @"totalMemory": @15065522176,
+            @"runtimeVersions": @{
+                    @"osBuild": @"14B25",
+                    @"clangVersion": @"10.0.0 (clang-1000.11.45.5)"
+            },
+            @"freeDisk": @509234098,
+            @"freeMemory": @742920192,
+            @"orientation": @"portrait",
+            @"time": @"2014-12-02T01:56:13Z"
+    };
+    BugsnagDeviceWithState *device = [BugsnagDeviceWithState deviceFromJson:json];
+    XCTAssertNotNil(device);
+
+    // verify stateless fields
+    XCTAssertTrue(device.jailbroken);
+    XCTAssertEqualObjects(@"123", device.id);
+    XCTAssertEqualObjects(@"en-US", device.locale);
+    XCTAssertEqualObjects(@"Apple", device.manufacturer);
+    XCTAssertEqualObjects(@"x86_64", device.model);
+    XCTAssertEqualObjects(@"iPhone 6", device.modelNumber);
+    XCTAssertEqualObjects(@"iPhone OS", device.osName);
+    XCTAssertEqualObjects(@"8.1", device.osVersion);
+    XCTAssertEqualObjects(@15065522176, device.totalMemory);
+    NSDictionary *runtimeVersions = @{
+            @"osBuild": @"14B25",
+            @"clangVersion": @"10.0.0 (clang-1000.11.45.5)"
+    };
+    XCTAssertEqualObjects(runtimeVersions, device.runtimeVersions);
+
+    // verify stateful fields
+    XCTAssertEqualObjects(@509234098, device.freeDisk);
+    XCTAssertEqualObjects(@742920192, device.freeMemory);
+    XCTAssertEqualObjects(@"portrait", device.orientation);
+
+    NSDateFormatter *formatter = [NSDateFormatter new];
+    formatter.dateFormat = @"yyyy'-'MM'-'dd'T'HH':'mm':'ssZZZ";
+    formatter.timeZone = [NSTimeZone timeZoneForSecondsFromGMT:0];
+    XCTAssertEqualObjects([formatter dateFromString:@"2014-12-02T01:56:13Z"], device.time);
 }
 
 @end


### PR DESCRIPTION
## Goal

Adds non-public methods for constructing `BugsnagAppWithState` and `BugsnagDeviceWithState` from JSON. These will be used by React Native when reading JS payloads.