### PR TITLE
Allow deserializing breadcrumbs from JSON for react-native

### DIFF
--- a/Source/BugsnagBreadcrumb.m
+++ b/Source/BugsnagBreadcrumb.m
@@ -191,14 +191,17 @@ BSGBreadcrumbType BSGBreadcrumbTypeFromString(NSString *value) {
 + (instancetype)breadcrumbFromDict:(NSDictionary *)dict {
     BOOL isValidCrumb = [dict[BSGKeyType] isKindOfClass:[NSString class]]
         && [dict[BSGKeyTimestamp] isKindOfClass:[NSString class]]
-        && [dict[BSGKeyMetadata] isKindOfClass:[NSDictionary class]]
+        && (
+            [dict[BSGKeyMetadata] isKindOfClass:[NSDictionary class]]
+            || [dict[@"metadata"] isKindOfClass:[NSDictionary class]] // react-native uses lowercase key
+            )
         // Accept legacy 'name' value if provided.
         && ([dict[BSGKeyMessage] isKindOfClass:[NSString class]]
             || [dict[BSGKeyName] isKindOfClass:[NSString class]]);
     if (isValidCrumb) {
         return [self breadcrumbWithBlock:^(BugsnagBreadcrumb *crumb) {
             crumb.message = dict[BSGKeyMessage] ?: dict[BSGKeyName];
-            crumb.metadata = dict[BSGKeyMetadata];
+            crumb.metadata = dict[BSGKeyMetadata] ?: dict[@"metadata"];
             crumb.timestamp = [[Bugsnag payloadDateFormatter] dateFromString:dict[BSGKeyTimestamp]];
             crumb.type = BSGBreadcrumbTypeFromString(dict[BSGKeyType]);
         }];


### PR DESCRIPTION
## Goal

Allows deserializing breadcrumbs from JSON in the react-native implementation. Breadcrumbs are deserialized from native events using the 'metaData' key whereas they are deserialized from JS payloads as 'metadata'. This change allows the method to use both.