### PR TITLE
Deserialize Error info stored in BugsnagEvent

### DIFF
--- a/Source/BugsnagError.m
+++ b/Source/BugsnagError.m
@@ -27,6 +27,19 @@ NSString *_Nonnull BSGSerializeErrorType(BSGErrorType errorType) {
     }
 }
 
+BSGErrorType BSGParseErrorType(NSString *errorType) {
+    if ([@"cocoa" isEqualToString:errorType]) {
+        return BSGErrorTypeCocoa;
+    } else if ([@"c" isEqualToString:errorType]) {
+        return BSGErrorTypeC;
+    } else if ([@"reactnativejs" isEqualToString:errorType]) {
+        return BSGErrorTypeReactNativeJs;
+    } else {
+        return BSGErrorTypeCocoa;
+    }
+}
+
+
 NSString *_Nonnull BSGParseErrorClass(NSDictionary *error, NSString *errorType) {
     NSString *errorClass;
 
@@ -60,6 +73,7 @@ NSString *BSGParseErrorMessage(NSDictionary *report, NSDictionary *error, NSStri
 
 @interface BugsnagStackframe ()
 - (NSDictionary *)toDictionary;
++ (BugsnagStackframe *)frameFromJson:(NSDictionary *)json;
 @end
 
 @interface BugsnagStacktrace ()
@@ -87,6 +101,39 @@ NSString *BSGParseErrorMessage(NSDictionary *report, NSDictionary *error, NSStri
         }
     }
     return self;
+}
+
+- (instancetype)initWithErrorClass:(NSString *)errorClass
+                      errorMessage:(NSString *)errorMessage
+                         errorType:(BSGErrorType)errorType
+                        stacktrace:(NSArray<BugsnagStackframe *> *)stacktrace {
+    if (self = [super init]) {
+        _errorClass = errorClass;
+        _errorMessage = errorMessage;
+        _type = errorType;
+        _stacktrace = stacktrace;
+    }
+    return self;
+}
+
++ (BugsnagError *)errorFromJson:(NSDictionary *)json {
+    NSArray *trace = json[BSGKeyStacktrace];
+    NSMutableArray *data = [NSMutableArray new];
+
+    if (trace != nil) {
+        for (NSDictionary *dict in trace) {
+            BugsnagStackframe *frame = [BugsnagStackframe frameFromJson:dict];
+
+            if (frame != nil) {
+                [data addObject:frame];
+            }
+        }
+    }
+    BugsnagError *error = [[BugsnagError alloc] initWithErrorClass:json[BSGKeyErrorClass]
+                                                      errorMessage:json[BSGKeyMessage]
+                                                         errorType:BSGParseErrorType(json[BSGKeyType])
+                                                        stacktrace:data];
+    return error;
 }
 
 - (NSDictionary *)findErrorReportingThread:(NSDictionary *)event {

--- a/Source/BugsnagEvent.m
+++ b/Source/BugsnagEvent.m
@@ -84,6 +84,7 @@ NSDictionary *_Nonnull BSGParseDeviceMetadata(NSDictionary *_Nonnull event);
 @interface BugsnagStackframe ()
 + (BugsnagStackframe *)frameFromDict:(NSDictionary *)dict
                           withImages:(NSArray *)binaryImages;
++ (BugsnagStackframe *)frameFromJson:(NSDictionary *)json;
 @end
 
 @interface BugsnagThread ()
@@ -122,6 +123,7 @@ NSDictionary *_Nonnull BSGParseDeviceMetadata(NSDictionary *_Nonnull event);
 @interface BugsnagError ()
 - (NSDictionary *)toDictionary;
 - (instancetype)initWithEvent:(NSDictionary *)event errorReportingThread:(BugsnagThread *)thread;
++ (BugsnagError *)errorFromJson:(NSDictionary *)json;
 @end
 
 // MARK: - KSCrashReport parsing
@@ -444,6 +446,20 @@ NSDictionary *BSGParseCustomException(NSDictionary *report,
 
     _app = [BugsnagAppWithState appFromJson:bugsnagPayload[@"app"]];
     _device = [BugsnagDeviceWithState deviceFromJson:bugsnagPayload[@"device"]];
+
+    NSArray *errorDicts = bugsnagPayload[BSGKeyExceptions];
+    NSMutableArray *data = [NSMutableArray new];
+
+    if (errorDicts != nil) {
+        for (NSDictionary *dict in errorDicts) {
+            BugsnagError *error = [BugsnagError errorFromJson:dict];
+
+            if (error != nil) {
+                [data addObject:error];
+            }
+        }
+    }
+    _errors = data;
 }
 
 - (NSMutableDictionary *)parseOnCrashData:(NSDictionary *)report {

--- a/Source/BugsnagStackframe.m
+++ b/Source/BugsnagStackframe.m
@@ -21,6 +21,28 @@
     return nil;
 }
 
++ (BugsnagStackframe *)frameFromJson:(NSDictionary *)json {
+    BugsnagStackframe *frame = [BugsnagStackframe new];
+    frame.machoFile = json[BSGKeyMachoFile];
+    frame.method = json[BSGKeyMethod];
+    frame.isPc = [json[BSGKeyIsPC] boolValue];
+    frame.isLr = [json[BSGKeyIsLR] boolValue];
+    frame.machoUuid = json[BSGKeyMachoUUID];
+    frame.machoVmAddress = [self readInt:json key:BSGKeyMachoVMAddress];
+    frame.frameAddress = [self readInt:json key:BSGKeyFrameAddress];
+    frame.symbolAddress = [self readInt:json key:BSGKeySymbolAddr];
+    frame.machoLoadAddress = [self readInt:json key:BSGKeyMachoLoadAddr];
+    return frame;
+}
+
++ (unsigned long)readInt:(NSDictionary *)json key:(NSString *)key {
+    NSString *obj = json[key];
+    if (obj) {
+        return strtoul([obj UTF8String], NULL, 16);
+    }
+    return 0;
+}
+
 + (BugsnagStackframe *)frameFromDict:(NSDictionary *)dict
                           withImages:(NSArray *)binaryImages {
     BugsnagStackframe *frame = [BugsnagStackframe new];

--- a/Tests/BugsnagEventPersistLoadTest.m
+++ b/Tests/BugsnagEventPersistLoadTest.m
@@ -11,6 +11,8 @@
 #import "BugsnagAppWithState.h"
 #import "BugsnagUser.h"
 #import "BugsnagDeviceWithState.h"
+#import "BugsnagError.h"
+#import "BugsnagStackframe.h"
 
 @interface BugsnagEvent ()
 - (instancetype)initWithKSReport:(NSDictionary *)report;
@@ -171,6 +173,48 @@
     XCTAssertEqualObjects(@{
             @"fiddleBorkVersion": @"2.3"
     }, device.runtimeVersions);
+}
+
+- (void)testErrorsOverride {
+    BugsnagEvent *event = [self generateEventWithOverrides:@{
+            @"exceptions": @[@{
+                    @"errorClass": @"InvalidNetworkError",
+                    @"message": @"No network connection",
+                    @"type": @"reactnativejs",
+                    @"stacktrace": @[
+                            @{
+                                    @"machoFile": @"/Users/foo/Bugsnag.h",
+                                    @"method": @"-[BugsnagClient notify:handledState:block:]",
+                                    @"machoUUID": @"B6D80CB5-A772-3D2F-B5A1-A3A137B8B58F",
+                                    @"frameAddress": @"0x10b5756bf",
+                                    @"symbolAddress": @"0x10b574fa0",
+                                    @"machoLoadAddress": @"0x10b54b000",
+                                    @"machoVMAddress": @"0x102340922",
+                                    @"isPC": @YES,
+                                    @"isLR": @YES
+                            }
+                    ]
+            }]
+    }];
+    BugsnagError *error = event.errors[0];
+    XCTAssertNotNil(error);
+    XCTAssertEqual(1, [event.errors count]);
+    XCTAssertEqualObjects(@"InvalidNetworkError", error.errorClass);
+    XCTAssertEqualObjects(@"No network connection", error.errorMessage);
+    XCTAssertEqual(BSGErrorTypeReactNativeJs, error.type);
+
+    BugsnagStackframe *frame = error.stacktrace[0];
+    XCTAssertNotNil(frame);
+    XCTAssertEqual(1, [error.stacktrace count]);
+    XCTAssertEqualObjects(@"-[BugsnagClient notify:handledState:block:]", frame.method);
+    XCTAssertEqualObjects(@"/Users/foo/Bugsnag.h", frame.machoFile);
+    XCTAssertEqualObjects(@"B6D80CB5-A772-3D2F-B5A1-A3A137B8B58F", frame.machoUuid);
+    XCTAssertEqual(0x102340922, frame.machoVmAddress);
+    XCTAssertEqual(0x10b574fa0, frame.symbolAddress);
+    XCTAssertEqual(0x10b54b000, frame.machoLoadAddress);
+    XCTAssertEqual(0x10b5756bf, frame.frameAddress);
+    XCTAssertTrue(frame.isPc);
+    XCTAssertTrue(frame.isLr);
 }
 
 @end


### PR DESCRIPTION
## Goal

Deserializes error payload information which is persisted as part of #585. This allows information added to callbacks for handled errors to be persisted after the error is written to disk.

## Changeset

Deserializes handled error information. This has required the addition of deserializer functions for the errors, which are covered by a new unit test.