### PR TITLE
Deserialize metadata/crumbs/severityReason in BugsnagEvent

### DIFF
--- a/Source/BugsnagBreadcrumb.m
+++ b/Source/BugsnagBreadcrumb.m
@@ -188,6 +188,16 @@ BSGBreadcrumbType BSGBreadcrumbTypeFromString(NSString *value) {
     return nil;
 }
 
++ (NSArray<BugsnagBreadcrumb *> *)breadcrumbArrayFromJson:(NSArray *)json {
+    NSMutableArray *data = [NSMutableArray new];
+
+    for (NSDictionary *dict in json) {
+        BugsnagBreadcrumb *crumb = [BugsnagBreadcrumb breadcrumbFromDict:dict];
+        [data addObject:crumb];
+    }
+    return data;
+}
+
 + (instancetype)breadcrumbFromDict:(NSDictionary *)dict {
     BOOL isValidCrumb = [dict[BSGKeyType] isKindOfClass:[NSString class]]
         && [dict[BSGKeyTimestamp] isKindOfClass:[NSString class]]

--- a/Source/BugsnagEvent.m
+++ b/Source/BugsnagEvent.m
@@ -48,6 +48,7 @@ NSDictionary *_Nonnull BSGParseDeviceMetadata(NSDictionary *_Nonnull event);
 + (instancetype _Nullable)breadcrumbWithBlock:
         (BSGBreadcrumbConfiguration _Nonnull)block;
 + (instancetype _Nullable)breadcrumbFromDict:(NSDictionary *_Nonnull)dict;
++ (NSArray<BugsnagBreadcrumb *> *)breadcrumbArrayFromJson:(NSArray *)json;
 @end
 
 @interface BugsnagUser ()
@@ -464,33 +465,10 @@ NSDictionary *BSGParseCustomException(NSDictionary *report,
     if (bugsnagPayload[@"metaData"]) {
         _metadata = [[BugsnagMetadata alloc] initWithDictionary:bugsnagPayload[@"metaData"]];
     }
-
     if (bugsnagPayload[@"breadcrumbs"]) {
-        NSArray *crumbs = bugsnagPayload[@"breadcrumbs"];
-        NSMutableArray *data = [NSMutableArray new];
-
-        for (NSDictionary *dict in crumbs) {
-            BugsnagBreadcrumb *crumb = [BugsnagBreadcrumb breadcrumbFromDict:dict];
-            [data addObject:crumb];
-        }
-        _breadcrumbs = data;
+        _breadcrumbs = [BugsnagBreadcrumb breadcrumbArrayFromJson:bugsnagPayload[@"breadcrumbs"]];
     }
-
-    BOOL unhandled = [bugsnagPayload[@"unhandled"] boolValue];
-    NSDictionary *data = bugsnagPayload[@"severityReason"];
-    BSGSeverity severity = BSGParseSeverity(bugsnagPayload[@"severity"]);
-
-    NSString *attrValue = nil;
-    NSDictionary *attrs = data[@"attributes"];
-
-    if (attrs != nil && [attrs count] == 1) { // only 1 attrValue is ever present
-        attrValue = [attrs allValues][0];
-    }
-    SeverityReasonType reason = [BugsnagHandledState severityReasonFromString:data[@"type"]];
-    _handledState = [[BugsnagHandledState alloc] initWithSeverityReason:reason
-                                                               severity:severity
-                                                              unhandled:unhandled
-                                                              attrValue:attrValue];
+    _handledState = [BugsnagHandledState handledStateFromJson:bugsnagPayload];
 }
 
 - (NSMutableDictionary *)parseOnCrashData:(NSDictionary *)report {

--- a/Source/BugsnagHandledState.h
+++ b/Source/BugsnagHandledState.h
@@ -56,6 +56,8 @@ NSString *BSGFormatSeverity(BSGSeverity severity);
 + (instancetype)handledStateWithSeverityReason:
     (SeverityReasonType)severityReason;
 
++ (instancetype)handledStateFromJson:(NSDictionary *)json;
+
 + (instancetype)handledStateWithSeverityReason:
                     (SeverityReasonType)severityReason
                                       severity:(BSGSeverity)severity

--- a/Source/BugsnagHandledState.m
+++ b/Source/BugsnagHandledState.m
@@ -47,6 +47,24 @@ static NSString *const kUserCallbackSetSeverity = @"userCallbackSetSeverity";
 
 @implementation BugsnagHandledState
 
++ (instancetype)handledStateFromJson:(NSDictionary *)json {
+    BOOL unhandled = [json[@"unhandled"] boolValue];
+    NSDictionary *data = json[@"severityReason"];
+    BSGSeverity severity = BSGParseSeverity(json[@"severity"]);
+
+    NSString *attrValue = nil;
+    NSDictionary *attrs = data[@"attributes"];
+
+    if (attrs != nil && [attrs count] == 1) { // only 1 attrValue is ever present
+        attrValue = [attrs allValues][0];
+    }
+    SeverityReasonType reason = [BugsnagHandledState severityReasonFromString:data[@"type"]];
+    return [[BugsnagHandledState alloc] initWithSeverityReason:reason
+                                                               severity:severity
+                                                              unhandled:unhandled
+                                                              attrValue:attrValue];
+}
+
 + (instancetype)handledStateWithSeverityReason:
     (SeverityReasonType)severityReason {
     return [self handledStateWithSeverityReason:severityReason

--- a/Source/BugsnagHandledState.m
+++ b/Source/BugsnagHandledState.m
@@ -60,9 +60,9 @@ static NSString *const kUserCallbackSetSeverity = @"userCallbackSetSeverity";
     }
     SeverityReasonType reason = [BugsnagHandledState severityReasonFromString:data[@"type"]];
     return [[BugsnagHandledState alloc] initWithSeverityReason:reason
-                                                               severity:severity
-                                                              unhandled:unhandled
-                                                              attrValue:attrValue];
+                                                      severity:severity
+                                                     unhandled:unhandled
+                                                     attrValue:attrValue];
 }
 
 + (instancetype)handledStateWithSeverityReason:


### PR DESCRIPTION
## Goal

Deserializes payload information which is persisted as part of #585. This allows information added to callbacks for handled errors to be persisted after the error is written to disk.

## Changeset

Deserializes handled error information for the following fields:

- metadata
- breadcrumbs
- severityReason