### PR TITLE
Deserialize Thread info stored in BugsnagEvent

### DIFF
--- a/Source/BugsnagEvent.m
+++ b/Source/BugsnagEvent.m
@@ -449,19 +449,6 @@ NSDictionary *BSGParseCustomException(NSDictionary *report,
     _app = [BugsnagAppWithState appFromJson:bugsnagPayload[@"app"]];
     _device = [BugsnagDeviceWithState deviceFromJson:bugsnagPayload[@"device"]];
 
-    NSArray *errorDicts = bugsnagPayload[BSGKeyExceptions];
-    NSMutableArray *data = [NSMutableArray new];
-
-    if (errorDicts != nil) {
-        for (NSDictionary *dict in errorDicts) {
-            BugsnagError *error = [BugsnagError errorFromJson:dict];
-
-            if (error != nil) {
-                [data addObject:error];
-            }
-        }
-    }
-    _errors = data;
 
     if (bugsnagPayload[@"metaData"]) {
         _metadata = [[BugsnagMetadata alloc] initWithDictionary:bugsnagPayload[@"metaData"]];

--- a/Source/BugsnagEvent.m
+++ b/Source/BugsnagEvent.m
@@ -469,6 +469,20 @@ NSDictionary *BSGParseCustomException(NSDictionary *report,
         _breadcrumbs = [BugsnagBreadcrumb breadcrumbArrayFromJson:bugsnagPayload[@"breadcrumbs"]];
     }
     _handledState = [BugsnagHandledState handledStateFromJson:bugsnagPayload];
+
+    NSArray *errorDicts = bugsnagPayload[BSGKeyExceptions];
+    NSMutableArray *data = [NSMutableArray new];
+
+    if (errorDicts != nil) {
+        for (NSDictionary *dict in errorDicts) {
+            BugsnagError *error = [BugsnagError errorFromJson:dict];
+
+            if (error != nil) {
+                [data addObject:error];
+            }
+        }
+    }
+    _errors = data;
 }
 
 - (NSMutableDictionary *)parseOnCrashData:(NSDictionary *)report {

--- a/Source/BugsnagEvent.m
+++ b/Source/BugsnagEvent.m
@@ -115,6 +115,7 @@ NSDictionary *_Nonnull BSGParseDeviceMetadata(NSDictionary *_Nonnull event);
                                          binaryImages:(NSArray *)binaryImages
                                                 depth:(NSUInteger)depth
                                             errorType:(NSString *)errorType;
++ (instancetype)threadFromJson:(NSDictionary *)json;
 @end
 
 @interface BugsnagStacktrace ()
@@ -470,6 +471,7 @@ NSDictionary *BSGParseCustomException(NSDictionary *report,
     }
     _handledState = [BugsnagHandledState handledStateFromJson:bugsnagPayload];
 
+    // deserialize exceptions
     NSArray *errorDicts = bugsnagPayload[BSGKeyExceptions];
     NSMutableArray *data = [NSMutableArray new];
 
@@ -483,6 +485,21 @@ NSDictionary *BSGParseCustomException(NSDictionary *report,
         }
     }
     _errors = data;
+
+    // deserialize threads
+    NSArray *threadDicts = bugsnagPayload[BSGKeyThreads];
+    NSMutableArray *threadData = [NSMutableArray new];
+
+    if (threadDicts != nil) {
+        for (NSDictionary *dict in threadDicts) {
+            BugsnagThread *thread = [BugsnagThread threadFromJson:dict];
+
+            if (thread != nil) {
+                [threadData addObject:thread];
+            }
+        }
+    }
+    _threads = threadData;
 }
 
 - (NSMutableDictionary *)parseOnCrashData:(NSDictionary *)report {

--- a/Source/BugsnagStacktrace.m
+++ b/Source/BugsnagStacktrace.m
@@ -8,11 +8,13 @@
 
 #import "BugsnagStacktrace.h"
 #import "BugsnagStackframe.h"
+#import "BugsnagKeys.h"
 
 @interface BugsnagStackframe ()
 + (BugsnagStackframe *)frameFromDict:(NSDictionary *)dict
                           withImages:(NSArray *)binaryImages;
 - (NSDictionary *)toDictionary;
++ (instancetype)frameFromJson:(NSDictionary *)json;
 @end
 
 @interface BugsnagStacktrace ()
@@ -20,6 +22,23 @@
 @end
 
 @implementation BugsnagStacktrace
+
++ (instancetype)stacktraceFromJson:(NSDictionary *)json {
+    BugsnagStacktrace *trace = [BugsnagStacktrace new];
+    NSMutableArray *data = [NSMutableArray new];
+
+    if (json != nil) {
+        for (NSDictionary *dict in json) {
+            BugsnagStackframe *frame = [BugsnagStackframe frameFromJson:dict];
+
+            if (frame != nil) {
+                [data addObject:frame];
+            }
+        }
+    }
+    trace.trace = data;
+    return trace;
+}
 
 - (instancetype)initWithTrace:(NSArray<NSDictionary *> *)trace
                  binaryImages:(NSArray<NSDictionary *> *)binaryImages {

--- a/Source/BugsnagThread.h
+++ b/Source/BugsnagThread.h
@@ -14,6 +14,7 @@ typedef NS_OPTIONS(NSUInteger, BSGThreadType) {
 };
 
 @class BugsnagStackframe;
+@class BugsnagStacktrace;
 
 /**
  * A representation of thread information recorded as part of a BugsnagEvent.

--- a/Source/BugsnagThread.m
+++ b/Source/BugsnagThread.m
@@ -20,10 +20,42 @@
 @end
 
 @interface BugsnagStacktrace ()
++ (instancetype)stacktraceFromJson:(NSDictionary *)json;
 @property NSMutableArray<BugsnagStackframe *> *trace;
 @end
 
 @implementation BugsnagThread
+
++ (instancetype)threadFromJson:(NSDictionary *)json {
+    if (json == nil) {
+        return nil;
+    }
+    NSString *type = json[@"type"];
+    BSGThreadType threadType = [@"cocoa" isEqualToString:type] ? BSGThreadTypeCocoa : BSGThreadTypeReactNativeJs;
+    BOOL errorReportingThread = json[@"errorReportingThread"] && [json[@"errorReportingThread"] boolValue];
+    BugsnagStacktrace *stacktrace = [BugsnagStacktrace stacktraceFromJson:json[BSGKeyStacktrace]];
+    BugsnagThread *thread = [[BugsnagThread alloc] initWithId:json[@"id"]
+                                                         name:json[@"name"]
+                                         errorReportingThread:errorReportingThread
+                                                         type:threadType
+                                                        trace:stacktrace];
+    return thread;
+}
+
+- (instancetype)initWithId:(NSString *)id
+                      name:(NSString *)name
+      errorReportingThread:(BOOL)errorReportingThread
+                      type:(BSGThreadType)type
+                     trace:(BugsnagStacktrace *)trace {
+    if (self = [super init]) {
+        _id = id;
+        _name = name;
+        _errorReportingThread = errorReportingThread;
+        _type = type;
+        _trace = trace;
+    }
+    return self;
+}
 
 - (instancetype)initWithThread:(NSDictionary *)thread binaryImages:(NSArray *)binaryImages {
     if (self = [super init]) {

--- a/Source/BugsnagThread.m
+++ b/Source/BugsnagThread.m
@@ -11,7 +11,7 @@
 #import "BugsnagStacktrace.h"
 #import "BugsnagKeys.h"
 
-BSGThreadType BSGDeserializeThreadType(NSString *type) {
+BSGThreadType BSGParseThreadType(NSString *type) {
     return [@"cocoa" isEqualToString:type] ? BSGThreadTypeCocoa : BSGThreadTypeReactNativeJs;
 }
 
@@ -39,7 +39,7 @@ NSString *BSGSerializeThreadType(BSGThreadType type) {
         return nil;
     }
     NSString *type = json[@"type"];
-    BSGThreadType threadType = BSGDeserializeThreadType(type);
+    BSGThreadType threadType = BSGParseThreadType(type);
     BOOL errorReportingThread = json[@"errorReportingThread"] && [json[@"errorReportingThread"] boolValue];
     BugsnagStacktrace *stacktrace = [BugsnagStacktrace stacktraceFromJson:json[BSGKeyStacktrace]];
     BugsnagThread *thread = [[BugsnagThread alloc] initWithId:json[@"id"]

--- a/Source/BugsnagThread.m
+++ b/Source/BugsnagThread.m
@@ -11,6 +11,14 @@
 #import "BugsnagStacktrace.h"
 #import "BugsnagKeys.h"
 
+BSGThreadType BSGDeserializeThreadType(NSString *type) {
+    return [@"cocoa" isEqualToString:type] ? BSGThreadTypeCocoa : BSGThreadTypeReactNativeJs;
+}
+
+NSString *BSGSerializeThreadType(BSGThreadType type) {
+    return type == BSGThreadTypeCocoa ? @"cocoa" : @"reactnativejs";
+}
+
 @interface BugsnagStacktrace ()
 - (NSArray *)toArray;
 @end
@@ -31,7 +39,7 @@
         return nil;
     }
     NSString *type = json[@"type"];
-    BSGThreadType threadType = [@"cocoa" isEqualToString:type] ? BSGThreadTypeCocoa : BSGThreadTypeReactNativeJs;
+    BSGThreadType threadType = BSGDeserializeThreadType(type);
     BOOL errorReportingThread = json[@"errorReportingThread"] && [json[@"errorReportingThread"] boolValue];
     BugsnagStacktrace *stacktrace = [BugsnagStacktrace stacktraceFromJson:json[BSGKeyStacktrace]];
     BugsnagThread *thread = [[BugsnagThread alloc] initWithId:json[@"id"]
@@ -78,7 +86,7 @@
     BSGDictInsertIfNotNil(dict, self.id, @"id");
     BSGDictInsertIfNotNil(dict, self.name, @"name");
     BSGDictSetSafeObject(dict, @(self.errorReportingThread), @"errorReportingThread");
-    BSGDictSetSafeObject(dict, self.type == BSGThreadTypeCocoa ? @"cocoa" : @"reactnativejs", @"type");
+    BSGDictSetSafeObject(dict, BSGSerializeThreadType(self.type), @"type");
     BSGDictSetSafeObject(dict, @(self.errorReportingThread), @"errorReportingThread");
     BSGDictSetSafeObject(dict, [self.trace toArray], @"stacktrace");
     return dict;

--- a/Tests/BugsnagEventPersistLoadTest.m
+++ b/Tests/BugsnagEventPersistLoadTest.m
@@ -286,48 +286,6 @@
     XCTAssertTrue(event.unhandled);
 }
 
-- (void)testErrorsOverride {
-    BugsnagEvent *event = [self generateEventWithOverrides:@{
-            @"exceptions": @[@{
-                    @"errorClass": @"InvalidNetworkError",
-                    @"message": @"No network connection",
-                    @"type": @"reactnativejs",
-                    @"stacktrace": @[
-                            @{
-                                    @"machoFile": @"/Users/foo/Bugsnag.h",
-                                    @"method": @"-[BugsnagClient notify:handledState:block:]",
-                                    @"machoUUID": @"B6D80CB5-A772-3D2F-B5A1-A3A137B8B58F",
-                                    @"frameAddress": @"0x10b5756bf",
-                                    @"symbolAddress": @"0x10b574fa0",
-                                    @"machoLoadAddress": @"0x10b54b000",
-                                    @"machoVMAddress": @"0x102340922",
-                                    @"isPC": @YES,
-                                    @"isLR": @YES
-                            }
-                    ]
-            }]
-    }];
-    BugsnagError *error = event.errors[0];
-    XCTAssertNotNil(error);
-    XCTAssertEqual(1, [event.errors count]);
-    XCTAssertEqualObjects(@"InvalidNetworkError", error.errorClass);
-    XCTAssertEqualObjects(@"No network connection", error.errorMessage);
-    XCTAssertEqual(BSGErrorTypeReactNativeJs, error.type);
-
-    BugsnagStackframe *frame = error.stacktrace[0];
-    XCTAssertNotNil(frame);
-    XCTAssertEqual(1, [error.stacktrace count]);
-    XCTAssertEqualObjects(@"-[BugsnagClient notify:handledState:block:]", frame.method);
-    XCTAssertEqualObjects(@"/Users/foo/Bugsnag.h", frame.machoFile);
-    XCTAssertEqualObjects(@"B6D80CB5-A772-3D2F-B5A1-A3A137B8B58F", frame.machoUuid);
-    XCTAssertEqual(0x102340922, frame.machoVmAddress);
-    XCTAssertEqual(0x10b574fa0, frame.symbolAddress);
-    XCTAssertEqual(0x10b54b000, frame.machoLoadAddress);
-    XCTAssertEqual(0x10b5756bf, frame.frameAddress);
-    XCTAssertTrue(frame.isPc);
-    XCTAssertTrue(frame.isLr);
-}
-
 - (void)testThreadsOverride {
     BugsnagEvent *event = [self generateEventWithOverrides:@{
             @"threads": @[

--- a/Tests/BugsnagEventPersistLoadTest.m
+++ b/Tests/BugsnagEventPersistLoadTest.m
@@ -20,6 +20,8 @@
 @interface Bugsnag ()
 + (NSDateFormatter *)payloadDateFormatter;
 @end
+#import "BugsnagError.h"
+#import "BugsnagStackframe.h"
 
 @interface BugsnagEvent ()
 - (instancetype)initWithKSReport:(NSDictionary *)report;
@@ -281,6 +283,48 @@
     XCTAssertEqual(BSGSeverityInfo, event.handledState.originalSeverity);
     XCTAssertEqual(BSGSeverityInfo, event.handledState.currentSeverity);
     XCTAssertTrue(event.unhandled);
+}
+
+- (void)testErrorsOverride {
+    BugsnagEvent *event = [self generateEventWithOverrides:@{
+            @"exceptions": @[@{
+                    @"errorClass": @"InvalidNetworkError",
+                    @"message": @"No network connection",
+                    @"type": @"reactnativejs",
+                    @"stacktrace": @[
+                            @{
+                                    @"machoFile": @"/Users/foo/Bugsnag.h",
+                                    @"method": @"-[BugsnagClient notify:handledState:block:]",
+                                    @"machoUUID": @"B6D80CB5-A772-3D2F-B5A1-A3A137B8B58F",
+                                    @"frameAddress": @"0x10b5756bf",
+                                    @"symbolAddress": @"0x10b574fa0",
+                                    @"machoLoadAddress": @"0x10b54b000",
+                                    @"machoVMAddress": @"0x102340922",
+                                    @"isPC": @YES,
+                                    @"isLR": @YES
+                            }
+                    ]
+            }]
+    }];
+    BugsnagError *error = event.errors[0];
+    XCTAssertNotNil(error);
+    XCTAssertEqual(1, [event.errors count]);
+    XCTAssertEqualObjects(@"InvalidNetworkError", error.errorClass);
+    XCTAssertEqualObjects(@"No network connection", error.errorMessage);
+    XCTAssertEqual(BSGErrorTypeReactNativeJs, error.type);
+
+    BugsnagStackframe *frame = error.stacktrace[0];
+    XCTAssertNotNil(frame);
+    XCTAssertEqual(1, [error.stacktrace count]);
+    XCTAssertEqualObjects(@"-[BugsnagClient notify:handledState:block:]", frame.method);
+    XCTAssertEqualObjects(@"/Users/foo/Bugsnag.h", frame.machoFile);
+    XCTAssertEqualObjects(@"B6D80CB5-A772-3D2F-B5A1-A3A137B8B58F", frame.machoUuid);
+    XCTAssertEqual(0x102340922, frame.machoVmAddress);
+    XCTAssertEqual(0x10b574fa0, frame.symbolAddress);
+    XCTAssertEqual(0x10b54b000, frame.machoLoadAddress);
+    XCTAssertEqual(0x10b5756bf, frame.frameAddress);
+    XCTAssertTrue(frame.isPc);
+    XCTAssertTrue(frame.isLr);
 }
 
 @end

--- a/Tests/BugsnagEventPersistLoadTest.m
+++ b/Tests/BugsnagEventPersistLoadTest.m
@@ -22,6 +22,7 @@
 @end
 #import "BugsnagError.h"
 #import "BugsnagStackframe.h"
+#import "BugsnagThread.h"
 
 @interface BugsnagEvent ()
 - (instancetype)initWithKSReport:(NSDictionary *)report;
@@ -316,6 +317,51 @@
     BugsnagStackframe *frame = error.stacktrace[0];
     XCTAssertNotNil(frame);
     XCTAssertEqual(1, [error.stacktrace count]);
+    XCTAssertEqualObjects(@"-[BugsnagClient notify:handledState:block:]", frame.method);
+    XCTAssertEqualObjects(@"/Users/foo/Bugsnag.h", frame.machoFile);
+    XCTAssertEqualObjects(@"B6D80CB5-A772-3D2F-B5A1-A3A137B8B58F", frame.machoUuid);
+    XCTAssertEqual(0x102340922, frame.machoVmAddress);
+    XCTAssertEqual(0x10b574fa0, frame.symbolAddress);
+    XCTAssertEqual(0x10b54b000, frame.machoLoadAddress);
+    XCTAssertEqual(0x10b5756bf, frame.frameAddress);
+    XCTAssertTrue(frame.isPc);
+    XCTAssertTrue(frame.isLr);
+}
+
+- (void)testThreadsOverride {
+    BugsnagEvent *event = [self generateEventWithOverrides:@{
+            @"threads": @[
+                    @{
+                            @"id": @"13",
+                            @"name": @"thread-id-1",
+                            @"errorReportingThread": @YES,
+                            @"type": @"reactnativejs",
+                            @"stacktrace": @[
+                            @{
+                                    @"machoFile": @"/Users/foo/Bugsnag.h",
+                                    @"method": @"-[BugsnagClient notify:handledState:block:]",
+                                    @"machoUUID": @"B6D80CB5-A772-3D2F-B5A1-A3A137B8B58F",
+                                    @"frameAddress": @"0x10b5756bf",
+                                    @"symbolAddress": @"0x10b574fa0",
+                                    @"machoLoadAddress": @"0x10b54b000",
+                                    @"machoVMAddress": @"0x102340922",
+                                    @"isPC": @YES,
+                                    @"isLR": @YES
+                            }
+                    ]}
+            ]
+    }];
+    BugsnagThread *thread = event.threads[0];
+    XCTAssertNotNil(thread);
+    XCTAssertEqual(1, [event.threads count]);
+    XCTAssertEqualObjects(@"13", thread.id);
+    XCTAssertEqualObjects(@"thread-id-1", thread.name);
+    XCTAssertTrue(thread.errorReportingThread);
+    XCTAssertEqual(BSGThreadTypeReactNativeJs, thread.type);
+
+    BugsnagStackframe *frame = thread.stacktrace[0];
+    XCTAssertNotNil(frame);
+    XCTAssertEqual(1, [thread.stacktrace count]);
     XCTAssertEqualObjects(@"-[BugsnagClient notify:handledState:block:]", frame.method);
     XCTAssertEqualObjects(@"/Users/foo/Bugsnag.h", frame.machoFile);
     XCTAssertEqualObjects(@"B6D80CB5-A772-3D2F-B5A1-A3A137B8B58F", frame.machoUuid);


### PR DESCRIPTION
## Goal

Deserializes thread payload information which is persisted as part of #585. This allows information added to callbacks for handled errors to be persisted after the error is written to disk.

## Changeset

Deserializes handled error information. This has required the addition of deserializer functions for threads, which are covered by a new unit test.