### PR TITLE
Populate BugsnagEvent with initial data

### DIFF
--- a/Source/BugsnagEvent.m
+++ b/Source/BugsnagEvent.m
@@ -435,7 +435,7 @@ NSDictionary *BSGParseCustomException(NSDictionary *report,
     if (bugsnagPayload == nil || ![bugsnagPayload isKindOfClass:[NSDictionary class]]) {
         return;
     }
-    self.apiKey = bugsnagPayload[@"apiKey"];
+    _apiKey = bugsnagPayload[@"apiKey"];
     _context = bugsnagPayload[@"context"];
     _groupingHash = bugsnagPayload[@"groupingHash"];
     _apiKey = bugsnagPayload[@"apiKey"];

--- a/Source/BugsnagEvent.m
+++ b/Source/BugsnagEvent.m
@@ -435,7 +435,7 @@ NSDictionary *BSGParseCustomException(NSDictionary *report,
     if (bugsnagPayload == nil || ![bugsnagPayload isKindOfClass:[NSDictionary class]]) {
         return;
     }
-
+    self.apiKey = bugsnagPayload[@"apiKey"];
     _context = bugsnagPayload[@"context"];
     _groupingHash = bugsnagPayload[@"groupingHash"];
     _apiKey = bugsnagPayload[@"apiKey"];
@@ -823,6 +823,20 @@ NSDictionary *BSGParseCustomException(NSDictionary *report,
 
 - (BOOL)unhandled {
     return self.handledState.unhandled;
+}
+
+// MARK: - setting readonly fields
+
+- (void)updateAppInternal:(BugsnagAppWithState *)app {
+    _app = app;
+}
+
+- (void)updateDeviceInternal:(BugsnagDeviceWithState *)device {
+    _device = device;
+}
+
+- (void)updateMetadataInternal:(BugsnagMetadata *)metadata {
+    _metadata = [metadata deepCopy];
 }
 
 // MARK: - <BugsnagMetadataStore>

--- a/Tests/BugsnagClientMirrorTest.m
+++ b/Tests/BugsnagClientMirrorTest.m
@@ -103,7 +103,10 @@
             @"setStateEventBlocks: v24@0:8@16",
             @"addObserverUsingBlock: v24@0:8@?16",
             @"notifyObservers: v24@0:8@16",
-            @"stateEventBlocks @16@0:8"
+            @"stateEventBlocks @16@0:8",
+            @"generateDeviceWithState: @24@0:8@16",
+            @"populateEventData: v24@0:8@16",
+            @"generateAppWithState: @24@0:8@16"
     ]];
 
     // the following methods are implemented on Bugsnag but do not need to


### PR DESCRIPTION
## Goal

Populates `BugsnagEvent` objects generated in `notifyInternal` with initial data about the application state. This allows users to read/write this information in `OnError` callbacks for handled errors, whose information is now persisted thanks to changes made in #585 

## Changeset

The following fields are now populated:

- context
- apiKey
- app
- breadcrumbs
- device
- metadata
- user

This changeset leaves the `errors.stacktrace` and `threads` properties unpopulated as these are currently harder to populate due to needing to parse binary images. These will be addressed in a future PR.

## Tests

Verified that the event is populated by inspecting the contents of `BugsnagEvent` in an `OnError` callback.