### PR TITLE
Remove cpp extension from podspec

### DIFF
--- a/Bugsnag.podspec.json
+++ b/Bugsnag.podspec.json
@@ -21,7 +21,7 @@
     "tvos": "9.0"
   },
   "source_files": [
-    "Source/{**/,}*.{m,h,mm,c,cpp}"
+    "Source/{**/,}*.{m,h,mm,c}"
   ],
   "requires_arc": true,
   "public_header_files": [


### PR DESCRIPTION
There are no `*.cpp` in this project.