### PR TITLE
Allow capturing threads without writing to disk

### DIFF
--- a/Source/BSGSerialization.h
+++ b/Source/BSGSerialization.h
@@ -37,4 +37,6 @@ BOOL BSGIsSanitizedType(id _Nullable obj);
  */
 id _Nullable BSGSanitizeObject(id _Nullable obj);
 
+NSDictionary *_Nullable BSGDeserializeJson(char *_Nullable json);
+
 #endif

--- a/Source/BSGSerialization.m
+++ b/Source/BSGSerialization.m
@@ -1,4 +1,5 @@
 #import "BSGSerialization.h"
+#import "BugsnagLogger.h"
 
 BOOL BSGIsSanitizedType(id obj) {
     static dispatch_once_t onceToken;
@@ -55,4 +56,26 @@ NSArray *BSGSanitizeArray(NSArray *input) {
             [output addObject:cleanedObject];
     }
     return output;
+}
+
+NSDictionary *BSGDeserializeJson(char *json) {
+    if (json != NULL) {
+        NSString *str = [NSString stringWithCString:json encoding:NSUTF8StringEncoding];
+
+        if (str != nil) {
+            NSData *data = [str dataUsingEncoding:NSUTF8StringEncoding] ;
+            if (data != nil) {
+                NSError *error;
+                NSDictionary *decode = [NSJSONSerialization JSONObjectWithData:data
+                                                                       options:0
+                                                                         error:&error];
+                if (error != nil) {
+                    bsg_log_err(@"Failed to deserialize JSON: %@", error);
+                } else {
+                    return decode;
+                }
+            }
+        }
+    }
+    return nil;
 }

--- a/Source/Bugsnag.m
+++ b/Source/Bugsnag.m
@@ -107,49 +107,25 @@ static BugsnagClient *bsg_g_bugsnag_client = NULL;
 
 + (void)notify:(NSException *)exception {
     if ([self bugsnagStarted]) {
-        [self.client notify:exception
-                      block:^BOOL(BugsnagEvent *_Nonnull report) {
-                          report.depth += 2;
-                          return true;
-                      }];
+        [self.client notify:exception];
     }
 }
 
 + (void)notify:(NSException *)exception block:(BugsnagOnErrorBlock)block {
     if ([self bugsnagStarted]) {
-        [[self client] notify:exception
-                        block:^BOOL(BugsnagEvent *_Nonnull report) {
-                            report.depth += 2;
-
-                            if (block) {
-                                return block(report);
-                            }
-                            return true;
-                        }];
+        [self.client notify:exception block:block];
     }
 }
 
 + (void)notifyError:(NSError *)error {
     if ([self bugsnagStarted]) {
-        [self.client notifyError:error
-                             block:^BOOL(BugsnagEvent *_Nonnull report) {
-                                 report.depth += 2;
-                                 return true;
-                             }];
+        [self.client notifyError:error];
     }
 }
 
 + (void)notifyError:(NSError *)error block:(BugsnagOnErrorBlock)block {
     if ([self bugsnagStarted]) {
-        [[self client] notifyError:error
-                               block:^BOOL(BugsnagEvent *_Nonnull report) {
-                                   report.depth += 2;
-
-                                   if (block) {
-                                       return block(report);
-                                   }
-                                   return true;
-                               }];
+        [self.client notifyError:error block:block];
     }
 }
 

--- a/Source/BugsnagClient.m
+++ b/Source/BugsnagClient.m
@@ -326,7 +326,10 @@ void BSGWriteSessionCrashData(BugsnagSession *session) {
 @end
 
 @interface BugsnagError ()
-- (instancetype)initWithErrorReportingThread:(BugsnagThread *)thread;
+- (instancetype)initWithErrorClass:(NSString *)errorClass
+                      errorMessage:(NSString *)errorMessage
+                         errorType:(BSGErrorType)errorType
+                        stacktrace:(NSArray<BugsnagStackframe *> *)stacktrace;
 @end
 
 @interface BSGOutOfMemoryWatchdog ()
@@ -1044,9 +1047,10 @@ NSString *const BSGBreadcrumbLoadedMessage = @"Bugsnag loaded";
         }
     }
 
-    BugsnagError *error = [[BugsnagError alloc] initWithErrorReportingThread:errorReportingThread];
-    error.errorClass = errorClass;
-    error.errorMessage = errorMessage ?: @"";
+    BugsnagError *error = [[BugsnagError alloc] initWithErrorClass:errorClass
+                                                      errorMessage:errorMessage ?: @""
+                                                         errorType:BSGErrorTypeCocoa
+                                                        stacktrace:errorReportingThread.stacktrace];
     return error;
 }
 

--- a/Source/BugsnagCrashSentry.h
+++ b/Source/BugsnagCrashSentry.h
@@ -20,13 +20,11 @@
 
 - (void)reportUserException:(NSString *)reportName
                      reason:(NSString *)reportMessage
-          originalException:(NSException *)ex
                handledState:(NSDictionary *)handledState
                    appState:(NSDictionary *)appState
           callbackOverrides:(NSDictionary *)overrides
              eventOverrides:(NSDictionary *)eventOverrides
                    metadata:(NSDictionary *)metadata
-                     config:(NSDictionary *)config
-               discardDepth:(int)depth;
+                     config:(NSDictionary *)config;
 
 @end

--- a/Source/BugsnagCrashSentry.m
+++ b/Source/BugsnagCrashSentry.m
@@ -71,24 +71,20 @@ NSUInteger const BSG_MAX_STORED_REPORTS = 12;
 
 - (void)reportUserException:(NSString *)reportName
                      reason:(NSString *)reportMessage
-          originalException:(NSException *)ex
                handledState:(NSDictionary *)handledState
                    appState:(NSDictionary *)appState
           callbackOverrides:(NSDictionary *)overrides
              eventOverrides:(NSDictionary *)eventOverrides
                    metadata:(NSDictionary *)metadata
-                     config:(NSDictionary *)config
-               discardDepth:(int)depth {
+                     config:(NSDictionary *)config {
     [[BSG_KSCrash sharedInstance] reportUserException:reportName
                                                reason:reportMessage
-                                    originalException:ex
                                          handledState:handledState
                                              appState:appState
                                     callbackOverrides:overrides
                                        eventOverrides:eventOverrides
                                              metadata:metadata
                                                config:config
-                                         discardDepth:depth
                                      terminateProgram:NO];
 }
 

--- a/Source/BugsnagError.m
+++ b/Source/BugsnagError.m
@@ -82,6 +82,10 @@ NSString *BSGParseErrorMessage(NSDictionary *report, NSDictionary *error, NSStri
 
 @implementation BugsnagError
 
+- (instancetype)initWithErrorReportingThread:(BugsnagThread *)thread {
+    return [self initWithEvent:@{} errorReportingThread:thread];
+}
+
 - (instancetype)initWithEvent:(NSDictionary *)event errorReportingThread:(BugsnagThread *)thread {
     if (self = [super init]) {
         NSDictionary *error = [event valueForKeyPath:@"crash.error"];

--- a/Source/BugsnagEvent.m
+++ b/Source/BugsnagEvent.m
@@ -529,7 +529,7 @@ NSDictionary *BSGParseCustomException(NSDictionary *report,
 
     // deserialize exceptions
     NSArray *errorDicts = bugsnagPayload[BSGKeyExceptions];
-    NSMutableArray *errors = [NSMutableArray new];
+    NSMutableArray<BugsnagError *> *errors = [NSMutableArray new];
 
     if (errorDicts != nil) {
         for (NSDictionary *dict in errorDicts) {
@@ -569,6 +569,11 @@ NSDictionary *BSGParseCustomException(NSDictionary *report,
     obj.context = bugsnagPayload[@"context"];
     obj.groupingHash = bugsnagPayload[@"groupingHash"];
     obj.error = [obj getMetadataFromSection:BSGKeyError];
+
+    if ([errors count] > 0) {
+        BugsnagError *bugsnagError = errors[0];
+        obj.customException = BSGParseCustomException(event, bugsnagError.errorClass, bugsnagError.errorMessage);
+    }
     return obj;
 }
 

--- a/Source/BugsnagEvent.m
+++ b/Source/BugsnagEvent.m
@@ -571,8 +571,8 @@ NSDictionary *BSGParseCustomException(NSDictionary *report,
     obj.error = [obj getMetadataFromSection:BSGKeyError];
 
     if ([errors count] > 0) {
-        BugsnagError *bugsnagError = errors[0];
-        obj.customException = BSGParseCustomException(event, bugsnagError.errorClass, bugsnagError.errorMessage);
+        BugsnagError *err = errors[0];
+        obj.customException = BSGParseCustomException(event, err.errorClass, err.errorMessage);
     }
     return obj;
 }

--- a/Source/KSCrash/Source/KSCrash/Recording/BSG_KSCrash.h
+++ b/Source/KSCrash/Source/KSCrash/Recording/BSG_KSCrash.h
@@ -137,6 +137,14 @@ typedef enum {
                      config:(NSDictionary *)config
            terminateProgram:(BOOL)terminateProgram;
 
+/**
+ * Collects a trace of all the threads running in application, if the user has
+ * configured this behaviour, and serializes them into an array of BugsnagThread.
+ *
+ * @param exc the exception to record
+ * @param depth the number of frames to discard from the main thread's stacktrace
+ * @return an array of BugsnagThread
+ */
 - (NSArray<BugsnagThread *> *)captureThreads:(NSException *)exc depth:(int)depth;
 
 /** If YES, user reported exceptions will suspend all threads during report

--- a/Source/KSCrash/Source/KSCrash/Recording/BSG_KSCrash.h
+++ b/Source/KSCrash/Source/KSCrash/Recording/BSG_KSCrash.h
@@ -117,7 +117,6 @@ typedef enum {
  *
  * @param name The exception name (for namespacing exception types).
  * @param reason A description of why the exception occurred
- * @param exception The exception which was thrown (if any)
  * @param handledState The severity, reason, and handled-ness of the report
  * @param appState breadcrumbs and other app environmental info
  * @param overrides Report fields overridden by callbacks, collated in the
@@ -125,21 +124,20 @@ typedef enum {
  * @param eventOverrides the Bugsnag Error Payload, for handled errors only
  * @param metadata additional information to attach to the report
  * @param config delivery options
- * @param depth The number of frames to discard from the top of the stacktrace
  * @param terminateProgram If true, do not return from this function call.
  * Terminate the program instead.
  */
 - (void)reportUserException:(NSString *)name
                      reason:(NSString *)reason
-          originalException:(NSException *)exception
                handledState:(NSDictionary *)handledState
                    appState:(NSDictionary *)appState
           callbackOverrides:(NSDictionary *)overrides
              eventOverrides:(NSDictionary *)eventOverrides
                    metadata:(NSDictionary *)metadata
                      config:(NSDictionary *)config
-               discardDepth:(int)depth
            terminateProgram:(BOOL)terminateProgram;
+
+- (NSArray<BugsnagThread *> *)captureThreads:(NSException *)exc depth:(int)depth;
 
 /** If YES, user reported exceptions will suspend all threads during report
  * generation. All threads will be suspended while generating a crash report for

--- a/Source/KSCrash/Source/KSCrash/Recording/BSG_KSCrash.m
+++ b/Source/KSCrash/Source/KSCrash/Recording/BSG_KSCrash.m
@@ -25,6 +25,7 @@
 //
 
 #import <mach-o/dyld.h>
+#import <execinfo.h>
 #import "BSG_KSCrashAdvanced.h"
 
 #import "BSG_KSCrashC.h"
@@ -37,6 +38,7 @@
 
 //#define BSG_KSLogger_LocalLevel TRACE
 #import "BSG_KSLogger.h"
+#import "BugsnagThread.h"
 
 #if BSG_KSCRASH_HAS_UIKIT
 #import <UIKit/UIKit.h>
@@ -65,6 +67,13 @@
 // ============================================================================
 #pragma mark - Globals -
 // ============================================================================
+
+@interface BugsnagThread ()
++ (NSMutableArray<BugsnagThread *> *)threadsFromArray:(NSArray *)threads
+                                         binaryImages:(NSArray *)binaryImages
+                                                depth:(NSUInteger)depth
+                                            errorType:(NSString *)errorType;
+@end
 
 @interface BSG_KSCrash ()
 
@@ -306,30 +315,79 @@ IMPLEMENT_EXCLUSIVE_SHARED_INSTANCE(BSG_KSCrash)
     [self.crashReportStore deleteAllFiles];
 }
 
+- (NSArray<BugsnagThread *> *)captureThreads:(NSException *)exc depth:(int)depth {
+    NSArray *addresses = [exc callStackReturnAddresses];
+    int numFrames = (int) [addresses count];
+    uintptr_t *callstack = malloc(numFrames * sizeof(*callstack));
+
+    for (NSUInteger i = 0; i < numFrames; i++) {
+        callstack[i] = [addresses[i] unsignedLongValue];
+    }
+    if (numFrames > 0) {
+        depth = 0; // reset depth if the stack does not need to be generated
+    } else {
+        // generate a backtrace. This is required for NSError for example,
+        // which does not have a useful stacktrace generated.
+        numFrames = 100;
+        callstack = realloc(callstack, numFrames * sizeof(*callstack));
+
+        BSG_KSLOG_DEBUG("Fetching call stack.");
+        numFrames = backtrace((void **)callstack, numFrames);
+        if (numFrames <= 0) {
+            BSG_KSLOG_ERROR(@"backtrace() returned call stack length of %d", numFrames);
+            numFrames = 0;
+        }
+    }
+
+    char *trace = bsg_kscrash_captureThreadTrace(depth, numFrames, callstack);
+    free(callstack);
+
+    NSDictionary *json = [self deserializeJson:trace];
+
+    if (json) {
+        return [BugsnagThread threadsFromArray:[json valueForKeyPath:@"crash.threads"]
+                                  binaryImages:json[@"binary_images"]
+                                         depth:depth
+                                     errorType:nil];
+    }
+    return @[];
+}
+
+- (NSDictionary *)deserializeJson:(char *)json {
+    if (json != NULL) {
+        NSString *str = [NSString stringWithCString:json encoding:NSUTF8StringEncoding];
+
+        if (str != nil) {
+            NSData *data = [str dataUsingEncoding:NSUTF8StringEncoding] ;
+            if (data != nil) {
+                NSError *error;
+                NSDictionary *decode = [NSJSONSerialization JSONObjectWithData:data
+                                                                       options:0
+                                                                         error:&error];
+                if (error != nil) {
+                    bsg_log_err(@"Failed to deserialize JSON: %@", error);
+                } else {
+                    return decode;
+                }
+            }
+        }
+    }
+    return nil;
+}
+
 - (void)reportUserException:(NSString *)name
                      reason:(NSString *)reason
-          originalException:(NSException *)exception
                handledState:(NSDictionary *)handledState
                    appState:(NSDictionary *)appState
           callbackOverrides:(NSDictionary *)overrides
              eventOverrides:(NSDictionary *)eventOverrides
                    metadata:(NSDictionary *)metadata
                      config:(NSDictionary *)config
-               discardDepth:(int)depth
            terminateProgram:(BOOL)terminateProgram {
     const char *cName = [name cStringUsingEncoding:NSUTF8StringEncoding];
     const char *cReason = [reason cStringUsingEncoding:NSUTF8StringEncoding];
-    NSArray *addresses = [exception callStackReturnAddresses];
-    NSUInteger numFrames = [addresses count];
-    uintptr_t *callstack = malloc(numFrames * sizeof(*callstack));
-    for (NSUInteger i = 0; i < numFrames; i++) {
-        callstack[i] = [addresses[i] unsignedLongValue];
-    }
-    if (numFrames > 0) {
-        depth = 0; // reset depth if the stack does not need to be generated
-    }
+
     bsg_kscrash_reportUserException(cName, cReason,
-            callstack, numFrames,
             [handledState[@"currentSeverity"] UTF8String],
             [self encodeAsJSONString:handledState],
             [self encodeAsJSONString:overrides],
@@ -337,10 +395,7 @@ IMPLEMENT_EXCLUSIVE_SHARED_INSTANCE(BSG_KSCrash)
             [self encodeAsJSONString:metadata],
             [self encodeAsJSONString:appState],
             [self encodeAsJSONString:config],
-            depth,
             terminateProgram);
-
-    free(callstack);
 }
 
 // ============================================================================

--- a/Source/KSCrash/Source/KSCrash/Recording/BSG_KSCrash.m
+++ b/Source/KSCrash/Source/KSCrash/Recording/BSG_KSCrash.m
@@ -319,18 +319,20 @@ IMPLEMENT_EXCLUSIVE_SHARED_INSTANCE(BSG_KSCrash)
 - (NSArray<BugsnagThread *> *)captureThreads:(NSException *)exc depth:(int)depth {
     NSArray *addresses = [exc callStackReturnAddresses];
     int numFrames = (int) [addresses count];
-    uintptr_t *callstack = malloc(numFrames * sizeof(*callstack));
+    uintptr_t *callstack;
 
-    for (NSUInteger i = 0; i < numFrames; i++) {
-        callstack[i] = [addresses[i] unsignedLongValue];
-    }
     if (numFrames > 0) {
         depth = 0; // reset depth if the stack does not need to be generated
+        callstack = malloc(numFrames * sizeof(*callstack));
+
+        for (NSUInteger i = 0; i < numFrames; i++) {
+            callstack[i] = [addresses[i] unsignedLongValue];
+        }
     } else {
         // generate a backtrace. This is required for NSError for example,
         // which does not have a useful stacktrace generated.
         numFrames = 100;
-        callstack = realloc(callstack, numFrames * sizeof(*callstack));
+        callstack = malloc(numFrames * sizeof(*callstack));
 
         BSG_KSLOG_DEBUG("Fetching call stack.");
         numFrames = backtrace((void **)callstack, numFrames);

--- a/Source/KSCrash/Source/KSCrash/Recording/BSG_KSCrashC.c
+++ b/Source/KSCrash/Source/KSCrash/Recording/BSG_KSCrashC.c
@@ -181,8 +181,6 @@ void bsg_kscrash_setCrashNotifyCallback(
 }
 
 void bsg_kscrash_reportUserException(const char *name, const char *reason,
-        uintptr_t *stackAddresses,
-        unsigned long stackLength,
         const char *severity,
         const char *handledState,
         const char *overrides,
@@ -190,15 +188,12 @@ void bsg_kscrash_reportUserException(const char *name, const char *reason,
         const char *metadata,
         const char *appState,
         const char *config,
-        int discardDepth,
         bool terminateProgram) {
     bsg_kscrashsentry_reportUserException(name, reason,
-            stackAddresses,
-            stackLength,
             severity,
             handledState, overrides,
             eventOverrides,
-            metadata, appState, config, discardDepth,
+            metadata, appState, config,
             terminateProgram);
 }
 
@@ -224,9 +219,19 @@ void bsg_kscrash_setThreadTracingEnabled(int threadTracingEnabled) {
     crashContext()->crash.threadTracingEnabled = threadTracingEnabled;
 }
 
-char *bsg_kscrash_captureThreadTrace() {
+char *bsg_kscrash_captureThreadTrace(int discardDepth, int frameCount, uintptr_t *callstack) {
     bsg_kscrashsentry_suspend_threads_user();
-    char *trace = bsg_kscrw_i_captureThreadTrace(crashContext());
+    BSG_KSCrash_Context *context = crashContext();
+
+    // populate context with pre-recorded stacktrace/thread info
+    // for KSCrash to serialize
+    context->crash.stackTrace = callstack;
+    context->crash.stackTraceLength = frameCount;
+    context->crash.userException.discardDepth = discardDepth;
+    context->crash.offendingThread = bsg_ksmachthread_self();
+    context->crash.crashType = BSG_KSCrashTypeUserReported;
+
+    char *trace = bsg_kscrw_i_captureThreadTrace(context);
     bsg_kscrashsentry_resume_threads_user();
     return trace;
 }

--- a/Source/KSCrash/Source/KSCrash/Recording/BSG_KSCrashC.c
+++ b/Source/KSCrash/Source/KSCrash/Recording/BSG_KSCrashC.c
@@ -230,8 +230,9 @@ char *bsg_kscrash_captureThreadTrace(int discardDepth, int frameCount, uintptr_t
     context->crash.userException.discardDepth = discardDepth;
     context->crash.offendingThread = bsg_ksmachthread_self();
     context->crash.crashType = BSG_KSCrashTypeUserReported;
+    context->crash.suspendThreadsForUserReported = true;
 
     char *trace = bsg_kscrw_i_captureThreadTrace(context);
-    bsg_kscrashsentry_resume_threads_user();
+    bsg_kscrashsentry_resume_threads_user(false);
     return trace;
 }

--- a/Source/KSCrash/Source/KSCrash/Recording/BSG_KSCrashC.c
+++ b/Source/KSCrash/Source/KSCrash/Recording/BSG_KSCrashC.c
@@ -223,3 +223,10 @@ void bsg_kscrash_setReportWhenDebuggerIsAttached(
 void bsg_kscrash_setThreadTracingEnabled(int threadTracingEnabled) {
     crashContext()->crash.threadTracingEnabled = threadTracingEnabled;
 }
+
+char *bsg_kscrash_captureThreadTrace() {
+    bsg_kscrashsentry_suspend_threads_user();
+    char *trace = bsg_kscrw_i_captureThreadTrace(crashContext());
+    bsg_kscrashsentry_resume_threads_user();
+    return trace;
+}

--- a/Source/KSCrash/Source/KSCrash/Recording/BSG_KSCrashC.h
+++ b/Source/KSCrash/Source/KSCrash/Recording/BSG_KSCrashC.h
@@ -131,21 +131,15 @@ void bsg_kscrash_setCrashNotifyCallback(
  *
  * @param name The exception name (for namespacing exception types).
  * @param reason A description of why the exception occurred.
- * @param stackAddresses An array of addresses or NULL
- * @param stackLength The number of addresses in stackAddresses
  * @param handledState The severity, reason, and handled-ness of the report
  * @param appState breadcrumbs and other app environmental info
  * @param overrides Report fields overridden by callbacks, collated in the
  *                  final report
  * @param metadata additional information to attach to the report
- * @param discardDepth The number of frames to discard from the top of the
- *                     stacktrace
  * @param terminateProgram If true, do not return from this function call.
  * Terminate the program instead.
  */
 void bsg_kscrash_reportUserException(const char *name, const char *reason,
-                                     uintptr_t *stackAddresses,
-                                     unsigned long stackLength,
                                      const char *severity,
                                      const char *handledState,
                                      const char *overrides,
@@ -153,7 +147,6 @@ void bsg_kscrash_reportUserException(const char *name, const char *reason,
                                      const char *metadata,
                                      const char *appState,
                                      const char *config,
-                                     int discardDepth,
                                      bool terminateProgram);
 
 /** If YES, user reported exceptions will suspend all threads during report
@@ -186,9 +179,11 @@ BSG_KSCrash_Context *crashContext(void);
  * Captures a thread trace for the current application state, if the user
  * has configured this functionality.
  *
+ * @param discardDepth - the number of stack frames to discard
+ *
  * @return a trace of all the threads as a JSON string.
  */
-char *bsg_kscrash_captureThreadTrace(void);
+char *bsg_kscrash_captureThreadTrace(int discardDepth, int frameCount, uintptr_t *callstack);
 
 #ifdef __cplusplus
 }

--- a/Source/KSCrash/Source/KSCrash/Recording/BSG_KSCrashC.h
+++ b/Source/KSCrash/Source/KSCrash/Recording/BSG_KSCrashC.h
@@ -182,6 +182,14 @@ void bsg_kscrash_setWriteBinaryImagesForUserReported(
  */
 BSG_KSCrash_Context *crashContext(void);
 
+/**
+ * Captures a thread trace for the current application state, if the user
+ * has configured this functionality.
+ *
+ * @return a trace of all the threads as a JSON string.
+ */
+char *bsg_kscrash_captureThreadTrace(void);
+
 #ifdef __cplusplus
 }
 #endif

--- a/Source/KSCrash/Source/KSCrash/Recording/BSG_KSCrashReport.c
+++ b/Source/KSCrash/Source/KSCrash/Recording/BSG_KSCrashReport.c
@@ -1629,14 +1629,17 @@ static char *bsg_g_thread_json_data;
 int bsg_kscrw_i_collectJsonData(const char *const data, const size_t length, void *const userData) {
     if (bsg_kscrw_i_exceedsBufferLen(length)) {
         bsg_g_thread_json_size += bsg_g_buffer_increment;
-        bsg_g_thread_json_data = realloc(bsg_g_thread_json_data, bsg_g_thread_json_size);
+        void *ptr = realloc(bsg_g_thread_json_data, bsg_g_thread_json_size);
+
+        if (ptr != NULL) {
+            bsg_g_thread_json_data = ptr;
+        } else { // failed to allocate enough memory
+            free(bsg_g_thread_json_data);
+            return BSG_KSJSON_ERROR_CANNOT_ADD_DATA;
+        }
     }
-    if (bsg_g_thread_json_data != NULL && !bsg_kscrw_i_exceedsBufferLen(length)) {
-        strncat(bsg_g_thread_json_data, data, length);
-        return BSG_KSJSON_OK;
-    } else { // failed to allocate enough memory
-        return BSG_KSJSON_ERROR_CANNOT_ADD_DATA;
-    }
+    strncat(bsg_g_thread_json_data, data, length);
+    return BSG_KSJSON_OK;
 }
 
 bool bsg_kscrw_i_exceedsBufferLen(const size_t length) {

--- a/Source/KSCrash/Source/KSCrash/Recording/BSG_KSCrashReport.c
+++ b/Source/KSCrash/Source/KSCrash/Recording/BSG_KSCrashReport.c
@@ -1624,12 +1624,11 @@ static size_t bsg_g_thread_json_size = sizeof(char) * 32 * 1024;
 static char *bsg_g_thread_json_data;
 
 int bsg_kscrw_i_collectJsonData(const char *const data, const size_t length, void *const userData) {
-    size_t new_size = strlen(bsg_g_thread_json_data) + length;
     char terminated_str[length + 1];
     memcpy(terminated_str, data, length);
     terminated_str[length] = '\0';
 
-    if (new_size > bsg_g_thread_json_size) {
+    if (strlen(bsg_g_thread_json_data) + strlen(terminated_str) > bsg_g_thread_json_size) {
         bsg_g_thread_json_size *= 2;
         bsg_g_thread_json_data = realloc(bsg_g_thread_json_data, bsg_g_thread_json_size);
     }

--- a/Source/KSCrash/Source/KSCrash/Recording/BSG_KSCrashReport.h
+++ b/Source/KSCrash/Source/KSCrash/Recording/BSG_KSCrashReport.h
@@ -63,6 +63,17 @@ void bsg_kscrashreport_writeMinimalReport(
  */
 void bsg_kscrashreport_logCrash(const BSG_KSCrash_Context *const crashContext);
 
+/**
+ * Captures a thread trace for use by the Objective-C layer to append to handled errors.
+ * This suspends all threads while the information is being gathered.
+ *
+ * @param crashContext Contextual information about the crash and environment.
+ *                     The caller must fill this out before passing it in.
+ *
+ * @return the thread trace encoded as a JSON string
+ */
+char *bsg_kscrw_i_captureThreadTrace(const BSG_KSCrash_Context *crashContext);
+
 #ifdef __cplusplus
 }
 #endif

--- a/Source/KSCrash/Source/KSCrash/Recording/Sentry/BSG_KSCrashSentry_User.c
+++ b/Source/KSCrash/Source/KSCrash/Recording/Sentry/BSG_KSCrashSentry_User.c
@@ -101,11 +101,7 @@ void bsg_kscrashsentry_reportUserException(const char *name, const char *reason,
         int callstackCount = 100;
         uintptr_t callstack[callstackCount];
 
-        if (localContext->suspendThreadsForUserReported) {
-            pthread_mutex_lock(&bsg_suspend_threads_mutex);
-            BSG_KSLOG_DEBUG("Suspending all threads");
-            bsg_kscrashsentry_suspendThreads();
-        }
+        bsg_kscrashsentry_suspend_threads_user();
 
         if (stackAddresses != NULL && stackLength > 0) {
             localContext->stackTrace = stackAddresses;
@@ -147,10 +143,19 @@ void bsg_kscrashsentry_reportUserException(const char *name, const char *reason,
         } else {
             bsg_kscrashsentry_resumeThreads();
         }
-        if (localContext->suspendThreadsForUserReported) {
-            pthread_mutex_unlock(&bsg_suspend_threads_mutex);
-        }
+        pthread_mutex_unlock(&bsg_suspend_threads_mutex);
 
         bsg_kscrashsentry_freeReportContext(reportContext);
     }
+}
+
+void bsg_kscrashsentry_suspend_threads_user() {
+    pthread_mutex_lock(&bsg_suspend_threads_mutex);
+    BSG_KSLOG_DEBUG("Suspending all threads");
+    bsg_kscrashsentry_suspendThreads();
+}
+
+void bsg_kscrashsentry_resume_threads_user() {
+    bsg_kscrashsentry_resumeThreads();
+    pthread_mutex_unlock(&bsg_suspend_threads_mutex);
 }

--- a/Source/KSCrash/Source/KSCrash/Recording/Sentry/BSG_KSCrashSentry_User.h
+++ b/Source/KSCrash/Source/KSCrash/Recording/Sentry/BSG_KSCrashSentry_User.h
@@ -80,6 +80,10 @@ void bsg_kscrashsentry_reportUserException(const char *name, const char *reason,
         int discardDepth,
         bool terminateProgram);
 
+void bsg_kscrashsentry_suspend_threads_user(void);
+
+void bsg_kscrashsentry_resume_threads_user(void);
+
 #ifdef __cplusplus
 }
 #endif

--- a/Source/KSCrash/Source/KSCrash/Recording/Sentry/BSG_KSCrashSentry_User.h
+++ b/Source/KSCrash/Source/KSCrash/Recording/Sentry/BSG_KSCrashSentry_User.h
@@ -73,8 +73,16 @@ void bsg_kscrashsentry_reportUserException(const char *name, const char *reason,
         const char *config,
         bool terminateProgram);
 
+/**
+ * Suspends execution of all threads, which is required to collect an
+ * accurate error report. If threads are already frozen calling this has no effect.
+ */
 void bsg_kscrashsentry_suspend_threads_user(void);
 
+/**
+ * Resumes execution of all threads, which is required after collecting an
+ * error report. If threads are already resumed calling this has no effect.
+ */
 void bsg_kscrashsentry_resume_threads_user(bool terminateProgram);
 
 #ifdef __cplusplus

--- a/Source/KSCrash/Source/KSCrash/Recording/Sentry/BSG_KSCrashSentry_User.h
+++ b/Source/KSCrash/Source/KSCrash/Recording/Sentry/BSG_KSCrashSentry_User.h
@@ -54,22 +54,16 @@ void bsg_kscrashsentry_uninstallUserExceptionHandler(void);
  * @param name The exception name (for namespacing exception types).
  *
  * @param reason A description of why the exception occurred.
- * @param stackAddresses An array of addresses or NULL
- * @param stackLength The number of addresses in stackAddresses
  * @param handledState The severity, reason, and handled-ness of the report
  * @param appState breadcrumbs and other app environmental info
  * @param overrides Report fields overridden by callbacks, collated in the
  *                  final report
  * @param metadata additional information to attach to the report
- * @param discardDepth The number of frames to discard from the top of the
- *                     stacktrace
  *
  * @param terminateProgram If true, do not return from this function call.
  * Terminate the program instead.
  */
 void bsg_kscrashsentry_reportUserException(const char *name, const char *reason,
-        uintptr_t *stackAddresses,
-        unsigned long stackLength,
         const char *severity,
         const char *handledState,
         const char *overrides,
@@ -77,7 +71,6 @@ void bsg_kscrashsentry_reportUserException(const char *name, const char *reason,
         const char *metadata,
         const char *appState,
         const char *config,
-        int discardDepth,
         bool terminateProgram);
 
 void bsg_kscrashsentry_suspend_threads_user(void);

--- a/Source/KSCrash/Source/KSCrash/Recording/Sentry/BSG_KSCrashSentry_User.h
+++ b/Source/KSCrash/Source/KSCrash/Recording/Sentry/BSG_KSCrashSentry_User.h
@@ -75,7 +75,7 @@ void bsg_kscrashsentry_reportUserException(const char *name, const char *reason,
 
 void bsg_kscrashsentry_suspend_threads_user(void);
 
-void bsg_kscrashsentry_resume_threads_user(void);
+void bsg_kscrashsentry_resume_threads_user(bool terminateProgram);
 
 #ifdef __cplusplus
 }

--- a/Source/KSCrash/Source/KSCrash/Recording/Tools/BSG_KSJSONCodec.c
+++ b/Source/KSCrash/Source/KSCrash/Recording/Tools/BSG_KSJSONCodec.c
@@ -125,7 +125,7 @@ int bsg_ksjsoncodec_i_appendEscapedString(
          src++) {
         *dst++ = *src;
     }
-    
+
     // Deal with complicated case (if any)
     for (; src < srcEnd; src++) {
         switch (*src) {
@@ -155,14 +155,14 @@ int bsg_ksjsoncodec_i_appendEscapedString(
             *dst++ = 't';
             break;
         default:
-                
+
             // escape control chars (U+0000 - U+001F)
             // see https://www.ietf.org/rfc/rfc4627.txt
-                
+
             if ((unsigned char)*src < ' ') {
                 unsigned int last = *src % 16;
                 unsigned int first = (*src - last) / 16;
-                
+
                 *dst++ = '\\';
                 *dst++ = 'u';
                 *dst++ = '0';

--- a/Tests/BugsnagClientMirrorTest.m
+++ b/Tests/BugsnagClientMirrorTest.m
@@ -108,7 +108,8 @@
             @"populateEventData: v24@0:8@16",
             @"generateAppWithState: @24@0:8@16",
             @"generateThreads @16@0:8",
-            @"deserializeJson: @24@0:8*16"
+            @"deserializeJson: @24@0:8*16",
+            @"generateErrors: @24@0:8@16"
     ]];
 
     // the following methods are implemented on Bugsnag but do not need to

--- a/Tests/BugsnagClientMirrorTest.m
+++ b/Tests/BugsnagClientMirrorTest.m
@@ -106,7 +106,9 @@
             @"stateEventBlocks @16@0:8",
             @"generateDeviceWithState: @24@0:8@16",
             @"populateEventData: v24@0:8@16",
-            @"generateAppWithState: @24@0:8@16"
+            @"generateAppWithState: @24@0:8@16",
+            @"generateThreads @16@0:8",
+            @"deserializeJson: @24@0:8*16"
     ]];
 
     // the following methods are implemented on Bugsnag but do not need to

--- a/Tests/BugsnagClientMirrorTest.m
+++ b/Tests/BugsnagClientMirrorTest.m
@@ -109,7 +109,8 @@
             @"generateAppWithState: @24@0:8@16",
             @"generateThreads @16@0:8",
             @"deserializeJson: @24@0:8*16",
-            @"generateErrors: @24@0:8@16"
+            @"generateErrors: @24@0:8@16",
+            @"generateError:threads: @32@0:8@16@24"
     ]];
 
     // the following methods are implemented on Bugsnag but do not need to

--- a/Tests/BugsnagClientMirrorTest.m
+++ b/Tests/BugsnagClientMirrorTest.m
@@ -110,7 +110,10 @@
             @"generateThreads @16@0:8",
             @"deserializeJson: @24@0:8*16",
             @"generateErrors: @24@0:8@16",
-            @"generateError:threads: @32@0:8@16@24"
+            @"generateError:threads: @32@0:8@16@24",
+            @"appendNSErrorInfo:block:event: B40@0:8@16@?24@32",
+            @"appendNSErrorInfo:block:event: c40@0:8@16@?24@32",
+            @"createNSErrorWrapper: @24@0:8@16"
     ]];
 
     // the following methods are implemented on Bugsnag but do not need to

--- a/Tests/BugsnagClientTests.m
+++ b/Tests/BugsnagClientTests.m
@@ -25,6 +25,8 @@
 
 @interface BugsnagClient ()
 - (void)orientationChanged:(NSNotification *)notif;
+- (NSDictionary *)deserializeJson:(char *)json;
+- (NSArray<BugsnagThread *> *)generateThreads;
 @property (nonatomic, strong) BugsnagMetadata *metadata;
 @end
 
@@ -161,6 +163,16 @@ NSString *BSGFormatSeverity(BSGSeverity severity);
     [client addMetadata:[@{@"foo" : @"bar"} mutableCopy] toSection:@"section2"];
     NSObject *metadata2 = [client getMetadataFromSection:@"section2"];
     XCTAssertTrue([metadata2 isKindOfClass:[NSMutableDictionary class]]);
+}
+
+- (void)testDeserializeJson {
+    BugsnagConfiguration *configuration = [[BugsnagConfiguration alloc] initWithApiKey:DUMMY_APIKEY_32CHAR_1];
+    BugsnagClient *client = [[BugsnagClient alloc] initWithConfiguration:configuration];
+
+    XCTAssertNil([client deserializeJson:NULL]);
+    XCTAssertNil([client deserializeJson:"5"]);
+    XCTAssertEqualObjects(@{}, [client deserializeJson:"{}"]);
+    XCTAssertEqualObjects(@{@"foo": @"bar"}, [client deserializeJson:"{\"foo\": \"bar\"}"]);
 }
 
 @end

--- a/Tests/BugsnagClientTests.m
+++ b/Tests/BugsnagClientTests.m
@@ -25,8 +25,6 @@
 
 @interface BugsnagClient ()
 - (void)orientationChanged:(NSNotification *)notif;
-- (NSDictionary *)deserializeJson:(char *)json;
-- (NSArray<BugsnagThread *> *)generateThreads;
 @property (nonatomic, strong) BugsnagMetadata *metadata;
 @end
 
@@ -61,20 +59,20 @@ NSString *BSGFormatSeverity(BSGSeverity severity);
  * correctly.
  */
 - (void)testAutomaticNotifyBreadcrumbData {
-    
+
     [self setUpBugsnagWillCallNotify:false];
 
     NSException *ex = [[NSException alloc] initWithName:@"myName" reason:@"myReason1" userInfo:nil];
-    
+
     __block NSString *eventErrorClass;
     __block NSString *eventErrorMessage;
     __block BOOL eventUnhandled;
     __block NSString *eventSeverity;
-    
+
     // Check that the event is passed the apiKey
     [Bugsnag notify:ex block:^BOOL(BugsnagEvent * _Nonnull event) {
         XCTAssertEqualObjects(event.apiKey, DUMMY_APIKEY_32CHAR_1);
-        
+
         // Grab the values that end up in the event for later comparison
         eventErrorClass = event.errors[0].errorClass;
         eventErrorMessage = event.errors[0].errorMessage;
@@ -82,13 +80,13 @@ NSString *BSGFormatSeverity(BSGSeverity severity);
         eventSeverity = BSGFormatSeverity([event severity]);
         return true;
     }];
-    
+
     // Check that we can change it
     [Bugsnag notify:ex];
 
     NSDictionary *breadcrumb = [[[[Bugsnag client] configuration] breadcrumbs][1] objectValue];
     NSDictionary *metadata = [breadcrumb valueForKey:@"metaData"];
-    
+
     XCTAssertEqualObjects([breadcrumb valueForKey:@"type"], @"error");
     XCTAssertEqualObjects([breadcrumb valueForKey:@"name"], eventErrorClass);
     XCTAssertEqualObjects([metadata valueForKey:@"errorClass"], eventErrorClass);
@@ -102,23 +100,23 @@ NSString *BSGFormatSeverity(BSGSeverity severity);
  */
 - (void) testClientConfigurationHaveSeparateMetadata {
     [self setUpBugsnagWillCallNotify:false];
-    
+
     BugsnagConfiguration *configuration = [[BugsnagConfiguration alloc] initWithApiKey:DUMMY_APIKEY_32CHAR_1];
     [configuration addMetadata:@{@"exampleKey" : @"exampleValue"} toSection:@"exampleSection"];
-    
+
     BugsnagClient *client = [[BugsnagClient alloc] initWithConfiguration:configuration];
-    
+
     // We expect that the client metadata is the same as the configuration's to start with
     XCTAssertEqualObjects([client getMetadataFromSection:@"exampleSection" withKey:@"exampleKey"],
                           [configuration getMetadataFromSection:@"exampleSection" withKey:@"exampleKey"]);
     XCTAssertNil([client getMetadataFromSection:@"aSection" withKey:@"foo"]);
     [client addMetadata:@{@"foo" : @"bar"} withKey:@"aDict" toSection:@"aSection"];
     XCTAssertNotNil([client getMetadataFromSection:@"aSection" withKey:@"aDict"]);
-    
+
     // Updates to Configuration should not affect Client
     [configuration addMetadata:@{@"exampleKey2" : @"exampleValue2"} toSection:@"exampleSection2"];
     XCTAssertNil([client getMetadataFromSection:@"exampleSection2" withKey:@"exampleKey2"]);
-    
+
     // Updates to Client should not affect Configuration
     [client addMetadata:@{@"exampleKey3" : @"exampleValue3"} toSection:@"exampleSection3"];
     XCTAssertNil([configuration getMetadataFromSection:@"exampleSection3" withKey:@"exampleKey3"]);
@@ -133,7 +131,7 @@ NSString *BSGFormatSeverity(BSGSeverity severity);
     BugsnagClient *client = [[BugsnagClient alloc] initWithConfiguration:configuration];
 
     [client setUser:@"Jiminy" withEmail:@"jiminy@bugsnag.com" andName:@"Jiminy Cricket"];
-    
+
     XCTAssertEqualObjects([client.metadata getMetadataFromSection:BSGKeyUser withKey:BSGKeyId], @"Jiminy");
     XCTAssertEqualObjects([client.metadata getMetadataFromSection:BSGKeyUser withKey:BSGKeyName], @"Jiminy Cricket");
     XCTAssertEqualObjects([client.metadata getMetadataFromSection:BSGKeyUser withKey:BSGKeyEmail], @"jiminy@bugsnag.com");
@@ -141,9 +139,9 @@ NSString *BSGFormatSeverity(BSGSeverity severity);
     XCTAssertEqualObjects([client user].id, @"Jiminy");
     XCTAssertEqualObjects([client user].name, @"Jiminy Cricket");
     XCTAssertEqualObjects([client user].email, @"jiminy@bugsnag.com");
-    
+
     [client setUser:nil withEmail:nil andName:@"Jiminy Cricket"];
-    
+
     XCTAssertNil([client user].id);
     XCTAssertEqualObjects([client user].name, @"Jiminy Cricket");
     XCTAssertNil([client user].email);
@@ -153,26 +151,16 @@ NSString *BSGFormatSeverity(BSGSeverity severity);
     [self setUpBugsnagWillCallNotify:false];
     BugsnagConfiguration *configuration = [[BugsnagConfiguration alloc] initWithApiKey:DUMMY_APIKEY_32CHAR_1];
     BugsnagClient *client = [[BugsnagClient alloc] initWithConfiguration:configuration];
-    
+
     // Immutable in, mutable out
     [client addMetadata:@{@"foo" : @"bar"} toSection:@"section1"];
     NSObject *metadata1 = [client getMetadataFromSection:@"section1"];
     XCTAssertTrue([metadata1 isKindOfClass:[NSMutableDictionary class]]);
-    
+
     // Mutable in, mutable out
     [client addMetadata:[@{@"foo" : @"bar"} mutableCopy] toSection:@"section2"];
     NSObject *metadata2 = [client getMetadataFromSection:@"section2"];
     XCTAssertTrue([metadata2 isKindOfClass:[NSMutableDictionary class]]);
-}
-
-- (void)testDeserializeJson {
-    BugsnagConfiguration *configuration = [[BugsnagConfiguration alloc] initWithApiKey:DUMMY_APIKEY_32CHAR_1];
-    BugsnagClient *client = [[BugsnagClient alloc] initWithConfiguration:configuration];
-
-    XCTAssertNil([client deserializeJson:NULL]);
-    XCTAssertNil([client deserializeJson:"5"]);
-    XCTAssertEqualObjects(@{}, [client deserializeJson:"{}"]);
-    XCTAssertEqualObjects(@{@"foo": @"bar"}, [client deserializeJson:"{\"foo\": \"bar\"}"]);
 }
 
 @end

--- a/features/fixtures/ios-swift-cocoapods/iOSTestApp/scenarios/HandledErrorOverrideScenario.swift
+++ b/features/fixtures/ios-swift-cocoapods/iOSTestApp/scenarios/HandledErrorOverrideScenario.swift
@@ -8,8 +8,6 @@ import Bugsnag
 
 /**
  Sends a handled Error to Bugsnag and overrides the exception name + message
- Demonstrates adjusting report depth to exclude common error handling code from grouping
- See: https://docs.bugsnag.com/platforms/ios-objc/reporting-handled-exceptions/#depth
  */
 class HandledErrorOverrideScenario: Scenario {
 
@@ -23,8 +21,6 @@ class HandledErrorOverrideScenario: Scenario {
             let error = report.errors[0]
             error.errorMessage = "Foo"
             error.errorClass = "Bar"
-            let depth: Int = report.value(forKey: "depth") as! Int
-            report.setValue(depth + 2, forKey: "depth")
             report.addMetadata(["items": [400,200]], section: "account")
             return true
         }

--- a/features/handled_errors.feature
+++ b/features/handled_errors.feature
@@ -18,7 +18,6 @@ Scenario: Override errorClass and message from a notifyError() callback, customi
     And the event "device.time" is within 30 seconds of the current timestamp
     And the event "metaData.account.items.0" equals 400
     And the event "metaData.account.items.1" equals 200
-    And the "method" of stack frame 0 demangles to "iOSTestApp.HandledErrorOverrideScenario.run() -> ()"
     And the stack trace is an array with 15 stack frames
 
 Scenario: Reporting an NSError

--- a/features/handled_errors.feature
+++ b/features/handled_errors.feature
@@ -18,7 +18,7 @@ Scenario: Override errorClass and message from a notifyError() callback, customi
     And the event "device.time" is within 30 seconds of the current timestamp
     And the event "metaData.account.items.0" equals 400
     And the event "metaData.account.items.1" equals 200
-    And the stack trace is an array with 15 stack frames
+    And the stack trace is an array with 17 stack frames
 
 Scenario: Reporting an NSError
     When I run "HandledErrorScenario"


### PR DESCRIPTION
## Goal

Captures the thread information from KSCrash without writing to disk. This is required for handled reports, where it's necessary to display the thread information up front so a user can invoke a callback.

This changeset fully populates the `event.threads` and `event.errors` fields before writing to disk.

## Changeset

### Thread capture
- Added a method to `BSG_KSCrash` for deserializing JSON from a char array, and for constructing threads out of a JSON dictionary
- Added `bsg_kscrash_captureThreadTrace()`, which is an internal API for suspending threads and captures their information as a JSON string
- Added convenience methods for suspending/resuming threads
- `BSG_KSCrashReport` has its JSON serializers for thread/stacktrace information to separate methods, which are invoked both when collecting thread information and when writing a report to disk
- Different `BSG_KSCrashReportWriter` implementations are passed when collecting thread information - one writes JSON to a char array, the other writes JSON to disk
- The JSON codec does not requires a null terminator when writing to disk, this is added when copying to the char array by using a temporary variable

### Stacktrace collection
- Updated default discard depth to 3 and made all `notify` calls within `BugsnagClient` have a consistent count of stackframes by inlining implementations where appropriate
- Removed unused parameters from `reportUserException` on `BugsnagCrashSentry`
- Fill out context fields in `bsg_kscrash_captureThreadTrace` which are required for stacktrace serialization
- Extracted stacktrace collection from `bsg_kscrashsentry_reportUserException` and `BugsnagClient` into `captureThreads`

## Tests

Added a unit test for JSON deserialization and verified that the thread information is displayed in the dashboard for an example app.

## TBD

- address E2E test failures (e.g. swift fatalError)
- remove unused parameters?