### PR TITLE
Sanitize dictionary to prevent NSNull values

### DIFF
--- a/OSX/Bugsnag.xcodeproj/project.pbxproj
+++ b/OSX/Bugsnag.xcodeproj/project.pbxproj
@@ -236,8 +236,7 @@
 		E7D2E673243B8FA8005A3041 /* BugsnagStacktrace.h in Headers */ = {isa = PBXBuildFile; fileRef = E7D2E671243B8FA7005A3041 /* BugsnagStacktrace.h */; };
 		E7D2E674243B8FA8005A3041 /* BugsnagStacktrace.m in Sources */ = {isa = PBXBuildFile; fileRef = E7D2E672243B8FA7005A3041 /* BugsnagStacktrace.m */; };
 		E7D2E676243B8FB6005A3041 /* BugsnagStacktraceTest.m in Sources */ = {isa = PBXBuildFile; fileRef = E7D2E675243B8FB6005A3041 /* BugsnagStacktraceTest.m */; };
-		E7F69CE2246EC4A600CEFED5 /* BugsnagMetadata.m in Sources */ = {isa = PBXBuildFile; fileRef = 8A2C8FC61C6BC2C800846019 /* BugsnagMetadata.m */; };
-		E7F69CE1246EA89100CEFED5 /* BugsnagMetadata.m in Sources */ = {isa = PBXBuildFile; fileRef = 8A2C8FC61C6BC2C800846019 /* BugsnagMetadata.m */; };
+		E7F69CE3246EC9B600CEFED5 /* BugsnagMetadata.m in Sources */ = {isa = PBXBuildFile; fileRef = 8A2C8FC61C6BC2C800846019 /* BugsnagMetadata.m */; };
 /* End PBXBuildFile section */
 
 /* Begin PBXContainerItemProxy section */
@@ -1161,8 +1160,7 @@
 			isa = PBXSourcesBuildPhase;
 			buildActionMask = 2147483647;
 			files = (
-				E7F69CE2246EC4A600CEFED5 /* BugsnagMetadata.m in Sources */,
-				E7F69CE1246EA89100CEFED5 /* BugsnagMetadata.m in Sources */,
+				E7F69CE3246EC9B600CEFED5 /* BugsnagMetadata.m in Sources */,
 				E79E6BCD1F4E3850002B35F9 /* BSG_KSString.c in Sources */,
 				E790C47924349CE2006FFB26 /* BugsnagDevice.m in Sources */,
 				E79E6BCF1F4E3850002B35F9 /* BSG_KSSysCtl.c in Sources */,

--- a/OSX/Bugsnag.xcodeproj/project.pbxproj
+++ b/OSX/Bugsnag.xcodeproj/project.pbxproj
@@ -237,6 +237,7 @@
 		E7D2E674243B8FA8005A3041 /* BugsnagStacktrace.m in Sources */ = {isa = PBXBuildFile; fileRef = E7D2E672243B8FA7005A3041 /* BugsnagStacktrace.m */; };
 		E7D2E676243B8FB6005A3041 /* BugsnagStacktraceTest.m in Sources */ = {isa = PBXBuildFile; fileRef = E7D2E675243B8FB6005A3041 /* BugsnagStacktraceTest.m */; };
 		E7F69CE2246EC4A600CEFED5 /* BugsnagMetadata.m in Sources */ = {isa = PBXBuildFile; fileRef = 8A2C8FC61C6BC2C800846019 /* BugsnagMetadata.m */; };
+		E7F69CE1246EA89100CEFED5 /* BugsnagMetadata.m in Sources */ = {isa = PBXBuildFile; fileRef = 8A2C8FC61C6BC2C800846019 /* BugsnagMetadata.m */; };
 /* End PBXBuildFile section */
 
 /* Begin PBXContainerItemProxy section */
@@ -1161,6 +1162,7 @@
 			buildActionMask = 2147483647;
 			files = (
 				E7F69CE2246EC4A600CEFED5 /* BugsnagMetadata.m in Sources */,
+				E7F69CE1246EA89100CEFED5 /* BugsnagMetadata.m in Sources */,
 				E79E6BCD1F4E3850002B35F9 /* BSG_KSString.c in Sources */,
 				E790C47924349CE2006FFB26 /* BugsnagDevice.m in Sources */,
 				E79E6BCF1F4E3850002B35F9 /* BSG_KSSysCtl.c in Sources */,

--- a/Source/BugsnagEvent.m
+++ b/Source/BugsnagEvent.m
@@ -449,7 +449,6 @@ NSDictionary *BSGParseCustomException(NSDictionary *report,
     _app = [BugsnagAppWithState appFromJson:bugsnagPayload[@"app"]];
     _device = [BugsnagDeviceWithState deviceFromJson:bugsnagPayload[@"device"]];
 
-
     if (bugsnagPayload[@"metaData"]) {
         _metadata = [[BugsnagMetadata alloc] initWithDictionary:bugsnagPayload[@"metaData"]];
     }

--- a/Source/BugsnagMetadata.m
+++ b/Source/BugsnagMetadata.m
@@ -61,7 +61,7 @@
  */
 - (NSMutableDictionary *)sanitizeDictionary:(NSDictionary *)dictionary {
     NSMutableDictionary *input;
-    if (dictionary != nil && [dictionary isKindOfClass:[NSDictionary class]]) {
+    if (dictionary != nil) {
         input = [dictionary mutableCopy];
     }
     for (NSString *key in [input allKeys]) {
@@ -70,20 +70,26 @@
         if (obj == [NSNull null]) {
             [input removeObjectForKey:key];
         } else if ([obj isKindOfClass:[NSDictionary class]]) {
-            input[key] = [self sanitizeDictionary:[obj mutableCopy]];
+            input[key] = [self sanitizeDictionary:obj];
         } else if ([obj isKindOfClass:[NSArray class]]) {
-            NSMutableArray *ary = [obj mutableCopy];
-            [ary removeObject:[NSNull null]];
-
-            for (NSUInteger k = 0; k < [ary count]; ++k) {
-                if ([ary[k] isKindOfClass:[NSDictionary class]]) {
-                    ary[k] = [self sanitizeDictionary:ary[k]];
-                }
-            }
-            input[key] = ary;
+            input[key] = [self sanitizeArray:obj];
         }
     }
     return input;
+}
+
+- (NSMutableArray *)sanitizeArray:(NSArray *)obj {
+    NSMutableArray *ary = [obj mutableCopy];
+    [ary removeObject:[NSNull null]];
+
+    for (NSUInteger k = 0; k < [ary count]; ++k) {
+        if ([ary[k] isKindOfClass:[NSDictionary class]]) {
+            ary[k] = [self sanitizeDictionary:ary[k]];
+        } else if ([ary[k] isKindOfClass:[NSArray class]]) {
+            ary[k] = [self sanitizeArray:ary[k]];
+        }
+    }
+    return ary;
 }
 
 - (NSDictionary *)toDictionary {

--- a/Source/BugsnagMetadata.m
+++ b/Source/BugsnagMetadata.m
@@ -60,10 +60,8 @@
  * @return a sanitized dictionary
  */
 - (NSMutableDictionary *)sanitizeDictionary:(NSDictionary *)dictionary {
-    NSMutableDictionary *input;
-    if (dictionary != nil) {
-        input = [dictionary mutableCopy];
-    }
+    NSMutableDictionary *input = [dictionary mutableCopy];
+
     for (NSString *key in [input allKeys]) {
         id obj = input[key];
 

--- a/Source/BugsnagMetadata.m
+++ b/Source/BugsnagMetadata.m
@@ -45,11 +45,28 @@
     if (self = [super init]) {
         // Ensure that the instantiating dictionary is mutable.
         // Saves checks later.
-        self.dictionary = [dict mutableCopy];
+        self.dictionary = [self sanitizeDictionary:[dict mutableCopy]];
         self.stateEventBlocks = [NSMutableArray new];
     }
     [self notifyObservers];
     return self;
+}
+
+- (NSMutableDictionary *)sanitizeDictionary:(NSMutableDictionary *)input {
+    for (NSString *key in [input allKeys]) {
+        id obj = input[key];
+
+        if (obj == [NSNull null]) {
+            [input removeObjectForKey:key];
+        } else if ([obj isKindOfClass:[NSDictionary class]]) {
+            input[key] = [self sanitizeDictionary:[obj mutableCopy]];
+        } else if ([obj isKindOfClass:[NSArray class]]) {
+            NSMutableArray *ary = [obj mutableCopy];
+            [ary removeObject:[NSNull null]];
+            input[key] = ary;
+        }
+    }
+    return input;
 }
 
 - (NSDictionary *)toDictionary {

--- a/Tests/BugsnagMetadataTests.m
+++ b/Tests/BugsnagMetadataTests.m
@@ -308,4 +308,20 @@
     XCTAssertEqualObjects(@[@"foo"], [metadata getMetadataFromSection:@"foo" withKey:@"custom"]);
 }
 
+- (void)testSanitizeNestedArrayDict {
+    BugsnagMetadata *metadata = [[BugsnagMetadata alloc] initWithDictionary:@{
+            @"foo": @{
+                    @"bar": @[
+                            @[
+                                    @{ @"custom": [NSNull null] }
+                            ]
+                    ]
+            }
+    }];
+    XCTAssertEqual(1, [metadata.dictionary count]);
+    NSArray *bar = [metadata getMetadataFromSection:@"foo" withKey:@"bar"];
+    NSDictionary *nestedDict = bar[0][0];
+    XCTAssertEqual(0, [nestedDict count]);
+}
+
 @end

--- a/Tests/BugsnagMetadataTests.m
+++ b/Tests/BugsnagMetadataTests.m
@@ -262,4 +262,50 @@
     XCTAssertTrue([metadata2 isKindOfClass:[NSMutableDictionary class]]);
 }
 
+- (void)testSanitizeSection {
+    BugsnagMetadata *metadata = [[BugsnagMetadata alloc] initWithDictionary:@{
+            @"custom": [NSNull null],
+            @"foo": @{
+                    @"bar": @YES
+            }
+    }];
+    XCTAssertEqual(1, [metadata.dictionary count]);
+    XCTAssertTrue([metadata getMetadataFromSection:@"foo" withKey:@"bar"]);
+}
+
+- (void)testSanitizeSectionValue {
+    BugsnagMetadata *metadata = [[BugsnagMetadata alloc] initWithDictionary:@{
+            @"foo": @{
+                    @"bar": @YES,
+                    @"custom": [NSNull null]
+            }
+    }];
+    XCTAssertEqual(1, [metadata.dictionary count]);
+    XCTAssertTrue([metadata getMetadataFromSection:@"foo" withKey:@"bar"]);
+}
+
+- (void)testSanitizeNestedDict {
+    BugsnagMetadata *metadata = [[BugsnagMetadata alloc] initWithDictionary:@{
+            @"foo": @{
+                    @"bar": @YES,
+                    @"custom": @{
+                            @"some_val": [NSNull null]
+                    }
+            }
+    }];
+    XCTAssertEqual(1, [metadata.dictionary count]);
+    XCTAssertEqualObjects(@{}, [metadata getMetadataFromSection:@"foo" withKey:@"custom"]);
+}
+
+- (void)testSanitizeNestedArray {
+    BugsnagMetadata *metadata = [[BugsnagMetadata alloc] initWithDictionary:@{
+            @"foo": @{
+                    @"bar": @YES,
+                    @"custom": @[[NSNull null], @"foo"]
+            }
+    }];
+    XCTAssertEqual(1, [metadata.dictionary count]);
+    XCTAssertEqualObjects(@[@"foo"], [metadata getMetadataFromSection:@"foo" withKey:@"custom"]);
+}
+
 @end

--- a/Tests/BugsnagOnCrashTest.m
+++ b/Tests/BugsnagOnCrashTest.m
@@ -52,7 +52,9 @@
                             @"test": @"test_val"
                     },
                     @"metaData": @{
-                            @"test": @"test_val"
+                            @"test": @{
+                                    @"foo": @"test_val"
+                            }
                     },
                     @"state": @{
                             @"test": @"test_val"


### PR DESCRIPTION
## Goal

The `BugsnagMetadata` implementation crashes if `NSNull` is present in the dictionary. To protect against invalid input the metadata implementation should be defensive and sanitize when reading information from disk, as otherwise this could lead to a crash when attempting to deliver.

## Changeset

When initializing `BugsnagMetadata` with a dictionary the section and its values are now checked for null, and any null values are removed. Unit test cases have been added to verify this behaviour.
