### PR TITLE
Read BugsnagSession for handled errors

### DIFF
--- a/Source/BugsnagEvent.m
+++ b/Source/BugsnagEvent.m
@@ -64,6 +64,7 @@ NSDictionary *_Nonnull BSGParseDeviceMetadata(NSDictionary *_Nonnull event);
 @end
 
 @interface BugsnagSession ()
++ (instancetype)fromJson:(NSDictionary *)json;
 @property NSUInteger unhandledCount;
 @property NSUInteger handledCount;
 @end
@@ -553,6 +554,7 @@ NSDictionary *BSGParseCustomException(NSDictionary *report,
             }
         }
     }
+    BugsnagSession *session = [BugsnagSession fromJson:bugsnagPayload[@"session"]];
 
     BugsnagEvent *obj = [self initWithApp:[BugsnagAppWithState appFromJson:bugsnagPayload[@"app"]]
                                    device:[BugsnagDeviceWithState deviceFromJson:bugsnagPayload[@"device"]]
@@ -562,7 +564,7 @@ NSDictionary *BSGParseCustomException(NSDictionary *report,
                               breadcrumbs:[BugsnagBreadcrumb breadcrumbArrayFromJson:bugsnagPayload[@"breadcrumbs"]]
                                    errors:errors
                                   threads:threads
-                                  session:nil];
+                                  session:session];
     obj.apiKey = bugsnagPayload[@"apiKey"];
     obj.context = bugsnagPayload[@"context"];
     obj.groupingHash = bugsnagPayload[@"groupingHash"];

--- a/Source/BugsnagSession.m
+++ b/Source/BugsnagSession.m
@@ -72,6 +72,27 @@ static NSString *const kBugsnagUser = @"user";
     return self;
 }
 
++ (instancetype)fromJson:(NSDictionary *)json {
+    if (!json) {
+        return nil;
+    }
+    BugsnagSession *session = [BugsnagSession new];
+    session.id = json[kBugsnagSessionId];
+
+    NSString *timestamp = json[kBugsnagStartedAt];
+
+    if (timestamp != nil) {
+        session.startedAt = [BSG_RFC3339DateTool dateFromString:timestamp];
+    }
+    NSDictionary *events = json[@"events"];
+
+    if (events != nil) {
+        session.unhandledCount = [events[@"unhandled"] unsignedIntegerValue];
+        session.handledCount = [events[@"handled"] unsignedIntegerValue];
+    }
+    return session;
+}
+
 - (instancetype)initWithDictionary:(NSDictionary *_Nonnull)dict {
     if (self = [super init]) {
         _id = dict[kBugsnagSessionId];

--- a/Tests/BugsnagEventPersistLoadTest.m
+++ b/Tests/BugsnagEventPersistLoadTest.m
@@ -27,10 +27,16 @@
 @interface BugsnagEvent ()
 - (instancetype)initWithKSReport:(NSDictionary *)report;
 @property(readonly, nonnull) BugsnagHandledState *handledState;
+@property BugsnagSession *session;
 @end
 
 @interface BugsnagDeviceWithState ()
 @property (nonatomic, readonly) NSDateFormatter *formatter;
+@end
+
+@interface BugsnagSession ()
+@property NSUInteger unhandledCount;
+@property NSUInteger handledCount;
 @end
 
 @interface BugsnagEventPersistLoadTest : XCTestCase
@@ -329,6 +335,25 @@
     XCTAssertEqual(0x10b5756bf, frame.frameAddress);
     XCTAssertTrue(frame.isPc);
     XCTAssertTrue(frame.isLr);
+}
+
+- (void)testSessionOverride {
+    BugsnagEvent *event = [self generateEventWithOverrides:@{
+            @"session": @{
+                    @"startedAt": @"2020-05-18T13:13:24Z",
+                    @"id": @"123",
+                    @"events": @{
+                            @"unhandled": @1,
+                            @"handled": @2
+                    }
+            }
+    }];
+
+    NSDate *date = [[Bugsnag payloadDateFormatter] dateFromString:@"2020-05-18T13:13:24Z"];
+    XCTAssertEqualObjects(date, event.session.startedAt);
+    XCTAssertEqualObjects(@"123", event.session.id);
+    XCTAssertEqual(1, event.session.unhandledCount);
+    XCTAssertEqual(2, event.session.handledCount);
 }
 
 @end


### PR DESCRIPTION
## Goal

Reads the session information for handled reports by reading from the Bugsnag payload section of a KSCrash report. This reads `event.session` which was stored in #585 

## Changeset

Added deserializer method to `BugsnagSession`, and a unit test for JSON deserialization.