### PR TITLE
Support thread trace deserialization for React Native

### DIFF
--- a/Source/BugsnagClient.m
+++ b/Source/BugsnagClient.m
@@ -107,6 +107,9 @@ static bool hasRecordedSessions;
 @property NSUInteger handledCount;
 @end
 
+@interface BugsnagThread ()
++ (NSMutableArray *)serializeThreads:(NSArray<BugsnagThread *> *)threads;
+@end
 
 @interface BugsnagAppWithState ()
 + (BugsnagAppWithState *)appWithDictionary:(NSDictionary *)event
@@ -1551,7 +1554,8 @@ NSString *const BSGBreadcrumbLoadedMessage = @"Bugsnag loaded";
 - (NSArray *)collectThreads {
     int depth = (int)(BSGNotifierStackFrameCount);
     NSException *exc = [NSException exceptionWithName:@"Bugsnag" reason:@"" userInfo:nil];
-    return [[BSG_KSCrash sharedInstance] captureThreads:exc depth:depth];
+    NSArray<BugsnagThread *> *threads = [[BSG_KSCrash sharedInstance] captureThreads:exc depth:depth];
+    return [BugsnagThread serializeThreads:threads];
 }
 
 - (void)addRuntimeVersionInfo:(NSString *)info

--- a/Source/BugsnagEvent.m
+++ b/Source/BugsnagEvent.m
@@ -752,8 +752,8 @@ NSDictionary *BSGParseCustomException(NSDictionary *report,
             BSGArrayAddSafeObject(array, [error toDictionary]);
         }
         BSGDictSetSafeObject(event, array, BSGKeyExceptions);
-        BSGDictSetSafeObject(event, [BugsnagThread serializeThreads:self.threads], BSGKeyThreads);
     }
+    BSGDictSetSafeObject(event, [BugsnagThread serializeThreads:self.threads], BSGKeyThreads);
 
     // Build Event
     BSGDictSetSafeObject(event, BSGFormatSeverity(self.severity), BSGKeySeverity);


### PR DESCRIPTION
## Goal

Supports thread trace deserialization in React Native. This changes the `collectThreads` method to return an array of dictionaries which avoids the need for additional Cocoa serialization code within the bugsnag-js repository.

Additionally, the `toJson` method of `BugsnagEvent` has fixed a bug where threads weren't serialized if a custom stacktrace was set.
