### PR TITLE
Move onCrashHandler data to individual metadata sections

### DIFF
--- a/Source/BugsnagEvent.m
+++ b/Source/BugsnagEvent.m
@@ -477,7 +477,9 @@ NSDictionary *BSGParseCustomException(NSDictionary *report,
 
     NSMutableDictionary *userAtCrash = [self parseOnCrashData:event];
     if (userAtCrash != nil) {
-        [metadata addMetadata:userAtCrash toSection:@BSG_KSCrashField_OnCrashMetadataSectionName];
+        for (NSString *section in [userAtCrash allKeys]) {
+            [metadata addMetadata:userAtCrash[section] toSection:section];
+        }
     }
     NSString *deviceAppHash = [event valueForKeyPath:@"system.device_app_hash"];
     BugsnagDeviceWithState *device = [BugsnagDeviceWithState deviceWithDictionary:event];
@@ -601,6 +603,12 @@ NSDictionary *BSGParseCustomException(NSDictionary *report,
             @"id",
     ];
     [userAtCrash removeObjectsForKeys:blacklistedKeys];
+
+    for (NSString *key in [userAtCrash allKeys]) { // remove any non-dictionary values
+        if (![userAtCrash[key] isKindOfClass:[NSDictionary class]]) {
+            [userAtCrash removeObjectForKey:key];
+        }
+    }
     return userAtCrash;
 }
 

--- a/Source/BugsnagEvent.m
+++ b/Source/BugsnagEvent.m
@@ -606,6 +606,7 @@ NSDictionary *BSGParseCustomException(NSDictionary *report,
 
     for (NSString *key in [userAtCrash allKeys]) { // remove any non-dictionary values
         if (![userAtCrash[key] isKindOfClass:[NSDictionary class]]) {
+            bsg_log_warn(@"Removing value added in onCrashHandler for key %@ as it is not a dictionary value", key);
             [userAtCrash removeObjectForKey:key];
         }
     }

--- a/Tests/BugsnagOnCrashTest.m
+++ b/Tests/BugsnagOnCrashTest.m
@@ -46,6 +46,7 @@
 - (void)testBlacklistedFields {
     BugsnagEvent *event = [[BugsnagEvent alloc] initWithKSReport:@{
             @"user": @{
+                    @"foo": @"some value here",
                     @"customer": @{@"name": @"Joe Bloggs"},
                     @"overrides": @{
                             @"test": @{@"test_key": @"test_val"}

--- a/Tests/BugsnagOnCrashTest.m
+++ b/Tests/BugsnagOnCrashTest.m
@@ -28,10 +28,12 @@
 - (void)testOnCrashData {
     BugsnagEvent *event = [[BugsnagEvent alloc] initWithKSReport:@{
             @"user": @{
-                    @"name": @"Joe Bloggs"
+                    @"customer": @{
+                            @"name": @"Joe Bloggs"
+                    }
             }
     }];
-    NSMutableDictionary *data = [event getMetadataFromSection:@"onCrash"];
+    NSMutableDictionary *data = [event getMetadataFromSection:@"customer"];
     XCTAssertNotNil(data);
     XCTAssertEqual(1, [data count]);
     XCTAssertEqualObjects(@"Joe Bloggs", data[@"name"]);
@@ -44,23 +46,21 @@
 - (void)testBlacklistedFields {
     BugsnagEvent *event = [[BugsnagEvent alloc] initWithKSReport:@{
             @"user": @{
-                    @"name": @"Joe Bloggs",
+                    @"customer": @{@"name": @"Joe Bloggs"},
                     @"overrides": @{
-                            @"test": @"test_val"
+                            @"test": @{@"test_key": @"test_val"}
                     },
                     @"handledState": @{
-                            @"test": @"test_val"
+                            @"test": @{@"test_key": @"test_val"}
                     },
                     @"metaData": @{
-                            @"test": @{
-                                    @"foo": @"test_val"
-                            }
+                            @"test": @{@"test_key": @"test_val"}
                     },
                     @"state": @{
-                            @"test": @"test_val"
+                            @"test": @{@"test_key": @"test_val"}
                     },
                     @"config": @{
-                            @"test": @"test_val"
+                            @"test": @{@"test_key": @"test_val"}
                     },
                     @"depth": @2,
                     @"id": @"E7E3A6E8-D1FE-426D-B7BB-B247C957A109",
@@ -69,7 +69,7 @@
                     @"unhandledCount": @1,
             }
     }];
-    NSMutableDictionary *data = [event getMetadataFromSection:@"onCrash"];
+    NSMutableDictionary *data = [event getMetadataFromSection:@"customer"];
     XCTAssertNotNil(data);
     XCTAssertEqual(1, [data count]);
     XCTAssertEqualObjects(@"Joe Bloggs", data[@"name"]);
@@ -82,16 +82,18 @@
 - (void)testMergePrecedence {
     BugsnagEvent *event = [[BugsnagEvent alloc] initWithKSReport:@{
             @"user": @{
-                    @"name": @"Joe Bloggs",
+                    @"customer": @{
+                            @"name": @"Joe Bloggs",
+                    },
                     @"metaData": @{
-                            @"onCrash": @{
+                            @"customer": @{
                                     @"name": @"Beryl Merryweather",
                                     @"age": @76
                             }
                     }
             }
     }];
-    NSMutableDictionary *data = [event getMetadataFromSection:@"onCrash"];
+    NSMutableDictionary *data = [event getMetadataFromSection:@"customer"];
     XCTAssertNotNil(data);
     XCTAssertEqual(2, [data count]);
     XCTAssertEqualObjects(@"Joe Bloggs", data[@"name"]);


### PR DESCRIPTION
## Goal

Rather than adding `onCrashhandler` into a separate section with a key of "custom", the data is now a string:map structure that is merged in to the top level of existing metadata. Any other data elements that are not a dictionary are dropped.

Updated unit tests to verify and tested that the behaviour was as expected when sending an event from an example app to the dashboard.
