### PR TITLE
Use NSNumber rather than int for public properties on BugsnagEvent

### DIFF
--- a/Source/BugsnagAppWithState.h
+++ b/Source/BugsnagAppWithState.h
@@ -19,13 +19,13 @@
 /**
  * The number of milliseconds the application was running before the event occurred
  */
-@property(nonatomic) NSUInteger duration;
+@property(nonatomic, nullable) NSNumber *duration;
 
 /**
  * The number of milliseconds the application was running in the foreground before the
  * event occurred
  */
-@property(nonatomic) NSUInteger durationInForeground;
+@property(nonatomic, nullable) NSNumber *durationInForeground;
 
 /**
  * Whether the application was in the foreground when the event occurred

--- a/Source/BugsnagAppWithState.m
+++ b/Source/BugsnagAppWithState.m
@@ -72,11 +72,11 @@
     NSDictionary *stats = system[@"application_stats"];
 
     // convert from seconds to milliseconds
-    NSUInteger activeTimeSinceLaunch = (NSUInteger) ([stats[@"active_time_since_launch"] longValue] * 1000);
-    NSUInteger backgroundTimeSinceLaunch = (NSUInteger) ([stats[@"background_time_since_launch"] longValue] * 1000);
+    NSNumber *activeTimeSinceLaunch = @([stats[@"active_time_since_launch"] longValue] * 1000);
+    NSNumber *backgroundTimeSinceLaunch = @([stats[@"background_time_since_launch"] longValue] * 1000);
 
-    app.durationInForeground = @(activeTimeSinceLaunch);
-    app.duration = @(activeTimeSinceLaunch + backgroundTimeSinceLaunch);
+    app.durationInForeground = activeTimeSinceLaunch;
+    app.duration = @([activeTimeSinceLaunch longValue] + [backgroundTimeSinceLaunch longValue]);
     app.inForeground = [stats[@"application_in_foreground"] boolValue];
     [BugsnagApp populateFields:app dictionary:event config:config codeBundleId:codeBundleId];
     return app;

--- a/Source/BugsnagAppWithState.m
+++ b/Source/BugsnagAppWithState.m
@@ -27,12 +27,12 @@
 
     id duration = json[@"duration"];
     if (duration && [duration isKindOfClass:[NSNumber class]]) {
-        app.duration = [(NSNumber *) duration unsignedIntValue];
+        app.duration = duration;
     }
 
     id durationInForeground = json[@"durationInForeground"];
     if (durationInForeground && [durationInForeground isKindOfClass:[NSNumber class]]) {
-        app.durationInForeground = [(NSNumber *) durationInForeground unsignedIntValue];
+        app.durationInForeground = durationInForeground;
     }
 
     id inForeground = json[@"inForeground"];
@@ -75,8 +75,8 @@
     NSUInteger activeTimeSinceLaunch = (NSUInteger) ([stats[@"active_time_since_launch"] longValue] * 1000);
     NSUInteger backgroundTimeSinceLaunch = (NSUInteger) ([stats[@"background_time_since_launch"] longValue] * 1000);
 
-    app.durationInForeground = activeTimeSinceLaunch;
-    app.duration = activeTimeSinceLaunch + backgroundTimeSinceLaunch;
+    app.durationInForeground = @(activeTimeSinceLaunch);
+    app.duration = @(activeTimeSinceLaunch + backgroundTimeSinceLaunch);
     app.inForeground = [stats[@"application_in_foreground"] boolValue];
     [BugsnagApp populateFields:app dictionary:event config:config codeBundleId:codeBundleId];
     return app;
@@ -85,8 +85,8 @@
 - (NSDictionary *)toDict
 {
     NSMutableDictionary *dict = (NSMutableDictionary *) [super toDict];
-    BSGDictInsertIfNotNil(dict, @(self.duration), @"duration");
-    BSGDictInsertIfNotNil(dict, @(self.durationInForeground), @"durationInForeground");
+    BSGDictInsertIfNotNil(dict, self.duration, @"duration");
+    BSGDictInsertIfNotNil(dict, self.durationInForeground, @"durationInForeground");
     BSGDictInsertIfNotNil(dict, @(self.inForeground), @"inForeground");
     return dict;
 }

--- a/Source/BugsnagStackframe.h
+++ b/Source/BugsnagStackframe.h
@@ -31,22 +31,22 @@
 /**
  * The stack frame address
  */
-@property unsigned long frameAddress;
+@property(nullable) NSNumber *frameAddress;
 
 /**
  * The VM address of the Mach-O file
  */
-@property unsigned long machoVmAddress;
+@property(nullable) NSNumber *machoVmAddress;
 
 /**
  * The address of the stackframe symbol
  */
-@property unsigned long symbolAddress;
+@property(nullable) NSNumber *symbolAddress;
 
 /**
  * The load address of the Mach-O file
  */
-@property unsigned long machoLoadAddress;
+@property(nullable) NSNumber *machoLoadAddress;
 
 /**
  * Whether the frame was within the program counter

--- a/Source/BugsnagStackframe.m
+++ b/Source/BugsnagStackframe.m
@@ -35,30 +35,30 @@
     return frame;
 }
 
-+ (unsigned long)readInt:(NSDictionary *)json key:(NSString *)key {
++ (NSNumber *)readInt:(NSDictionary *)json key:(NSString *)key {
     NSString *obj = json[key];
     if (obj) {
-        return strtoul([obj UTF8String], NULL, 16);
+        return @(strtoul([obj UTF8String], NULL, 16));
     }
-    return 0;
+    return nil;
 }
 
 + (BugsnagStackframe *)frameFromDict:(NSDictionary *)dict
                           withImages:(NSArray *)binaryImages {
     BugsnagStackframe *frame = [BugsnagStackframe new];
-    frame.frameAddress = [dict[BSGKeyInstructionAddress] unsignedLongValue];
-    frame.symbolAddress = [dict[BSGKeySymbolAddress] unsignedLongValue];
-    frame.machoLoadAddress = [dict[BSGKeyObjectAddress] unsignedLongValue];
+    frame.frameAddress = dict[BSGKeyInstructionAddress];
+    frame.symbolAddress = dict[BSGKeySymbolAddress];
+    frame.machoLoadAddress = dict[BSGKeyObjectAddress];
     frame.machoFile = dict[BSGKeyObjectName];
     frame.method = dict[BSGKeySymbolName];
     frame.isPc = [dict[BSGKeyIsPC] boolValue];
     frame.isLr = [dict[BSGKeyIsLR] boolValue];
 
-    NSDictionary *image = [self findImageAddr:frame.machoLoadAddress inImages:binaryImages];
+    NSDictionary *image = [self findImageAddr:[frame.machoLoadAddress unsignedLongValue] inImages:binaryImages];
 
     if (image != nil) {
         frame.machoUuid = image[BSGKeyUuid];
-        frame.machoVmAddress = [image[BSGKeyImageVmAddress] unsignedLongValue];
+        frame.machoVmAddress = image[BSGKeyImageVmAddress];
         return frame;
     } else { // invalid frame, skip
         return nil;
@@ -71,17 +71,22 @@
     BSGDictInsertIfNotNil(dict, self.method, BSGKeyMethod);
     BSGDictInsertIfNotNil(dict, self.machoUuid, BSGKeyMachoUUID);
 
-    NSString *frameAddr = [NSString stringWithFormat:BSGKeyFrameAddrFormat, self.frameAddress];
-    BSGDictSetSafeObject(dict, frameAddr, BSGKeyFrameAddress);
-
-    NSString *symbolAddr = [NSString stringWithFormat:BSGKeyFrameAddrFormat, self.symbolAddress];
-    BSGDictSetSafeObject(dict, symbolAddr, BSGKeySymbolAddr);
-
-    NSString *imageAddr = [NSString stringWithFormat:BSGKeyFrameAddrFormat, self.machoLoadAddress];
-    BSGDictSetSafeObject(dict, imageAddr, BSGKeyMachoLoadAddr);
-
-    NSString *vmAddr = [NSString stringWithFormat:BSGKeyFrameAddrFormat, self.machoVmAddress];
-    BSGDictSetSafeObject(dict, vmAddr, BSGKeyMachoVMAddress);
+    if (self.frameAddress) {
+        NSString *frameAddr = [NSString stringWithFormat:BSGKeyFrameAddrFormat, [self.frameAddress unsignedLongValue]];
+        BSGDictSetSafeObject(dict, frameAddr, BSGKeyFrameAddress);
+    }
+    if (self.symbolAddress) {
+        NSString *symbolAddr = [NSString stringWithFormat:BSGKeyFrameAddrFormat, [self.symbolAddress unsignedLongValue]];
+        BSGDictSetSafeObject(dict, symbolAddr, BSGKeySymbolAddr);
+    }
+    if (self.machoLoadAddress) {
+        NSString *imageAddr = [NSString stringWithFormat:BSGKeyFrameAddrFormat, [self.machoLoadAddress unsignedLongValue]];
+        BSGDictSetSafeObject(dict, imageAddr, BSGKeyMachoLoadAddr);
+    }
+    if (self.machoVmAddress) {
+        NSString *vmAddr = [NSString stringWithFormat:BSGKeyFrameAddrFormat, [self.machoVmAddress unsignedLongValue]];
+        BSGDictSetSafeObject(dict, vmAddr, BSGKeyMachoVMAddress);
+    }
     return dict;
 }
 

--- a/Tests/BugsnagAppTest.m
+++ b/Tests/BugsnagAppTest.m
@@ -82,8 +82,8 @@
     BugsnagAppWithState *app = [BugsnagAppWithState appWithDictionary:self.data config:self.config codeBundleId:self.codeBundleId];
 
     // verify stateful fields
-    XCTAssertEqual(7000, app.duration);
-    XCTAssertEqual(2000, app.durationInForeground);
+    XCTAssertEqualObjects(@7000, app.duration);
+    XCTAssertEqualObjects(@2000, app.durationInForeground);
     XCTAssertTrue(app.inForeground);
 
     // verify stateless fields
@@ -115,8 +115,8 @@
     NSDictionary *dict = [app toDict];
 
     // verify stateful fields
-    XCTAssertEqual(7000, [dict[@"duration"] longValue]);
-    XCTAssertEqual(2000, [dict[@"durationInForeground"] longValue]);
+    XCTAssertEqualObjects(@7000, dict[@"duration"]);
+    XCTAssertEqualObjects(@2000, dict[@"durationInForeground"]);
     XCTAssertTrue([dict[@"inForeground"] boolValue]);
 
     // verify stateless fields
@@ -143,8 +143,8 @@
     BugsnagAppWithState *app = [BugsnagAppWithState appWithOomData:oomData];
 
     // verify stateful fields
-    XCTAssertEqual(0, app.duration);
-    XCTAssertEqual(0, app.durationInForeground);
+    XCTAssertNil(app.duration);
+    XCTAssertNil(app.durationInForeground);
     XCTAssertTrue(app.inForeground);
 
     // verify stateless fields
@@ -174,8 +174,8 @@
     XCTAssertNotNil(app);
 
     // verify stateful fields
-    XCTAssertEqual(7000, app.duration);
-    XCTAssertEqual(2000, app.durationInForeground);
+    XCTAssertEqualObjects(@7000, app.duration);
+    XCTAssertEqualObjects(@2000, app.durationInForeground);
     XCTAssertTrue(app.inForeground);
 
     // verify stateless fields

--- a/Tests/BugsnagEventPersistLoadTest.m
+++ b/Tests/BugsnagEventPersistLoadTest.m
@@ -137,8 +137,8 @@
             }
     }];
     BugsnagAppWithState *app = event.app;
-    XCTAssertEqual(5092, app.duration);
-    XCTAssertEqual(4293, app.durationInForeground);
+    XCTAssertEqual(@5092, app.duration);
+    XCTAssertEqual(@4293, app.durationInForeground);
     XCTAssertFalse(app.inForeground);
     XCTAssertEqualObjects(@"5.69", app.bundleVersion);
     XCTAssertEqualObjects(@"293.4", app.codeBundleId);
@@ -226,10 +226,10 @@
     XCTAssertEqualObjects(@"-[BugsnagClient notify:handledState:block:]", frame.method);
     XCTAssertEqualObjects(@"/Users/foo/Bugsnag.h", frame.machoFile);
     XCTAssertEqualObjects(@"B6D80CB5-A772-3D2F-B5A1-A3A137B8B58F", frame.machoUuid);
-    XCTAssertEqual(0x102340922, frame.machoVmAddress);
-    XCTAssertEqual(0x10b574fa0, frame.symbolAddress);
-    XCTAssertEqual(0x10b54b000, frame.machoLoadAddress);
-    XCTAssertEqual(0x10b5756bf, frame.frameAddress);
+    XCTAssertEqualObjects(@0x102340922, frame.machoVmAddress);
+    XCTAssertEqualObjects(@0x10b574fa0, frame.symbolAddress);
+    XCTAssertEqualObjects(@0x10b54b000, frame.machoLoadAddress);
+    XCTAssertEqualObjects(@0x10b5756bf, frame.frameAddress);
     XCTAssertTrue(frame.isPc);
     XCTAssertTrue(frame.isLr);
 }
@@ -329,10 +329,10 @@
     XCTAssertEqualObjects(@"-[BugsnagClient notify:handledState:block:]", frame.method);
     XCTAssertEqualObjects(@"/Users/foo/Bugsnag.h", frame.machoFile);
     XCTAssertEqualObjects(@"B6D80CB5-A772-3D2F-B5A1-A3A137B8B58F", frame.machoUuid);
-    XCTAssertEqual(0x102340922, frame.machoVmAddress);
-    XCTAssertEqual(0x10b574fa0, frame.symbolAddress);
-    XCTAssertEqual(0x10b54b000, frame.machoLoadAddress);
-    XCTAssertEqual(0x10b5756bf, frame.frameAddress);
+    XCTAssertEqualObjects(@0x102340922, frame.machoVmAddress);
+    XCTAssertEqualObjects(@0x10b574fa0, frame.symbolAddress);
+    XCTAssertEqualObjects(@0x10b54b000, frame.machoLoadAddress);
+    XCTAssertEqualObjects(@0x10b5756bf, frame.frameAddress);
     XCTAssertTrue(frame.isPc);
     XCTAssertTrue(frame.isLr);
 }

--- a/Tests/BugsnagStackframeTest.m
+++ b/Tests/BugsnagStackframeTest.m
@@ -42,10 +42,10 @@
     XCTAssertEqualObjects(@"-[BugsnagClient notify:handledState:block:]", frame.method);
     XCTAssertEqualObjects(@"/Users/foo/Bugsnag.h", frame.machoFile);
     XCTAssertEqualObjects(@"B6D80CB5-A772-3D2F-B5A1-A3A137B8B58F", frame.machoUuid);
-    XCTAssertEqual(0x102340922, frame.machoVmAddress);
-    XCTAssertEqual(0x10b574fa0, frame.symbolAddress);
-    XCTAssertEqual(0x10b54b000, frame.machoLoadAddress);
-    XCTAssertEqual(0x10b5756bf, frame.frameAddress);
+    XCTAssertEqualObjects(@0x102340922, frame.machoVmAddress);
+    XCTAssertEqualObjects(@0x10b574fa0, frame.symbolAddress);
+    XCTAssertEqualObjects(@0x10b54b000, frame.machoLoadAddress);
+    XCTAssertEqualObjects(@0x10b5756bf, frame.frameAddress);
     XCTAssertFalse(frame.isPc);
     XCTAssertFalse(frame.isLr);
 }


### PR DESCRIPTION
## Goal

Uses `NSNumber` rather than int on properties on `BugsnagEvent`, as `NSNumber` is nullable and allows for redaction of its values. This better matches the notifier specification.

## Tests

Updated existing unit tests to handle new property types.
