### PR TITLE
Add E2E assertions for config.autoDetectErrors

### DIFF
--- a/features/auto_detect_errors.feature
+++ b/features/auto_detect_errors.feature
@@ -1,0 +1,25 @@
+Feature: autoDetectErrors flag controls whether errors are captured automatically
+    Bugsnag captures several error types by default. If the autoDetectErrors flag
+    is false it should only capture handled errors which the user has reported.
+
+    Scenario: Uncaught NSException not reported when autoDetectErrors is false
+        When I run "AutoDetectFalseHandledScenario"
+        And I wait to receive a request
+        Then the request is valid for the error reporting API version "4.0" for the "iOS Bugsnag Notifier" notifier
+        And the payload field "events" is an array with 1 elements
+        And the event "unhandled" is false
+        And I discard the oldest request
+        When I run "AutoDetectFalseNSExceptionScenario" and relaunch the app
+        And I configure Bugsnag for "Scenario"
+        Then I should receive no requests
+
+    Scenario: Signal not reported when autoDetectErrors is false
+        When I run "AutoDetectFalseHandledScenario"
+        And I wait to receive a request
+        Then the request is valid for the error reporting API version "4.0" for the "iOS Bugsnag Notifier" notifier
+        And the payload field "events" is an array with 1 elements
+        And the event "unhandled" is false
+        And I discard the oldest request
+        When I run "AutoDetectFalseAbortScenario" and relaunch the app
+        And I configure Bugsnag for "Scenario"
+        Then I should receive no requests

--- a/features/fixtures/ios-swift-cocoapods/iOSTestApp.xcodeproj/project.pbxproj
+++ b/features/fixtures/ios-swift-cocoapods/iOSTestApp.xcodeproj/project.pbxproj
@@ -41,6 +41,9 @@
 		8AF8FCAC22BD1E5400A967CA /* UnhandledInternalNotifyScenario.swift in Sources */ = {isa = PBXBuildFile; fileRef = 8AF8FCAB22BD1E5400A967CA /* UnhandledInternalNotifyScenario.swift */; };
 		8AF8FCAE22BD23BA00A967CA /* HandledInternalNotifyScenario.swift in Sources */ = {isa = PBXBuildFile; fileRef = 8AF8FCAD22BD23BA00A967CA /* HandledInternalNotifyScenario.swift */; };
 		C4D0B5FF8E60C0835B86DFE9 /* Pods_iOSTestApp.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = 4994F05E0421A0B037DD2CC5 /* Pods_iOSTestApp.framework */; };
+		E75040A02478019D005D33BD /* AutoDetectFalseHandledScenario.swift in Sources */ = {isa = PBXBuildFile; fileRef = E750409F2478019D005D33BD /* AutoDetectFalseHandledScenario.swift */; };
+		E75040A2247801A8005D33BD /* AutoDetectFalseNSExceptionScenario.swift in Sources */ = {isa = PBXBuildFile; fileRef = E75040A1247801A8005D33BD /* AutoDetectFalseNSExceptionScenario.swift */; };
+		E75040A42478052D005D33BD /* AutoDetectFalseAbortScenario.swift in Sources */ = {isa = PBXBuildFile; fileRef = E75040A32478052D005D33BD /* AutoDetectFalseAbortScenario.swift */; };
 		E7767F11221C21D90006648C /* StoppedSessionScenario.swift in Sources */ = {isa = PBXBuildFile; fileRef = E7767F10221C21D90006648C /* StoppedSessionScenario.swift */; };
 		E7767F13221C21E30006648C /* ResumedSessionScenario.swift in Sources */ = {isa = PBXBuildFile; fileRef = E7767F12221C21E30006648C /* ResumedSessionScenario.swift */; };
 		E7767F15221C223C0006648C /* NewSessionScenario.swift in Sources */ = {isa = PBXBuildFile; fileRef = E7767F14221C223C0006648C /* NewSessionScenario.swift */; };
@@ -148,6 +151,9 @@
 		8AF8FCAB22BD1E5400A967CA /* UnhandledInternalNotifyScenario.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = UnhandledInternalNotifyScenario.swift; sourceTree = "<group>"; };
 		8AF8FCAD22BD23BA00A967CA /* HandledInternalNotifyScenario.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = HandledInternalNotifyScenario.swift; sourceTree = "<group>"; };
 		960A6E7D4E847F1D76A4FD06 /* Pods-iOSTestApp.release.xcconfig */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.xcconfig; name = "Pods-iOSTestApp.release.xcconfig"; path = "Pods/Target Support Files/Pods-iOSTestApp/Pods-iOSTestApp.release.xcconfig"; sourceTree = "<group>"; };
+		E750409F2478019D005D33BD /* AutoDetectFalseHandledScenario.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AutoDetectFalseHandledScenario.swift; sourceTree = "<group>"; };
+		E75040A1247801A8005D33BD /* AutoDetectFalseNSExceptionScenario.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AutoDetectFalseNSExceptionScenario.swift; sourceTree = "<group>"; };
+		E75040A32478052D005D33BD /* AutoDetectFalseAbortScenario.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AutoDetectFalseAbortScenario.swift; sourceTree = "<group>"; };
 		E7767F10221C21D90006648C /* StoppedSessionScenario.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = StoppedSessionScenario.swift; sourceTree = "<group>"; };
 		E7767F12221C21E30006648C /* ResumedSessionScenario.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ResumedSessionScenario.swift; sourceTree = "<group>"; };
 		E7767F14221C223C0006648C /* NewSessionScenario.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = NewSessionScenario.swift; sourceTree = "<group>"; };
@@ -291,9 +297,20 @@
 			name = Frameworks;
 			sourceTree = "<group>";
 		};
+		E750409C24780158005D33BD /* AutoDetectErrors */ = {
+			isa = PBXGroup;
+			children = (
+				E750409F2478019D005D33BD /* AutoDetectFalseHandledScenario.swift */,
+				E75040A1247801A8005D33BD /* AutoDetectFalseNSExceptionScenario.swift */,
+				E75040A32478052D005D33BD /* AutoDetectFalseAbortScenario.swift */,
+			);
+			name = AutoDetectErrors;
+			sourceTree = "<group>";
+		};
 		F42953DE2BB41023C0B07F41 /* scenarios */ = {
 			isa = PBXGroup;
 			children = (
+				E750409C24780158005D33BD /* AutoDetectErrors */,
 				F49695A9244545EC00105DA9 /* Crashprobe */,
 				F49695B0244547CB00105DA9 /* Cross notifier notify */,
 				F49695AF2445477E00105DA9 /* Handled errors */,
@@ -579,6 +596,7 @@
 			isa = PBXSourcesBuildPhase;
 			buildActionMask = 2147483647;
 			files = (
+				E75040A02478019D005D33BD /* AutoDetectFalseHandledScenario.swift in Sources */,
 				8AB8866620404DD30003E444 /* ViewController.swift in Sources */,
 				8AB8866420404DD30003E444 /* AppDelegate.swift in Sources */,
 				00507A64242BFE5600EF1B87 /* EnabledBreadcrumbTypesIsNilScenario.swift in Sources */,
@@ -586,7 +604,9 @@
 				F42955E0916B8851F074D9B3 /* UserEmailScenario.swift in Sources */,
 				8A3B5F292407F66700CE4A3A /* ModifyBreadcrumbScenario.swift in Sources */,
 				8AA05A2F23BE700C00C7AD00 /* ManyConcurrentNotifyNoBackgroundThreads.m in Sources */,
+				E75040A2247801A8005D33BD /* AutoDetectFalseNSExceptionScenario.swift in Sources */,
 				F4295968571A4118D6A4606A /* UserEnabledScenario.swift in Sources */,
+				E75040A42478052D005D33BD /* AutoDetectFalseAbortScenario.swift in Sources */,
 				F4295A036B228AF608641699 /* UserDisabledScenario.swift in Sources */,
 				8A14F0F62282D4AE00337B05 /* (null) in Sources */,
 				0011E6672403D13100ED71CD /* UserPersistenceScenarios.m in Sources */,

--- a/features/fixtures/ios-swift-cocoapods/iOSTestApp/scenarios/AutoDetectFalseAbortScenario.swift
+++ b/features/fixtures/ios-swift-cocoapods/iOSTestApp/scenarios/AutoDetectFalseAbortScenario.swift
@@ -1,0 +1,26 @@
+//
+//  AutoDetectFalseAbortScenario.swift
+//  iOSTestApp
+//
+//  Created by Jamie Lynch on 22/05/2020.
+//  Copyright © 2020 Bugsnag. All rights reserved.
+//
+
+import Foundation
+import Bugsnag
+
+/**
+* Raises a SIGABRT with autoDetectErrors set to false, which should be ignored by Bugsnag
+*/
+internal class AutoDetectFalseAbortScenario: Scenario {
+
+    override func startBugsnag() {
+      self.config.autoTrackSessions = false
+      self.config.autoDetectErrors = false
+      super.startBugsnag()
+    }
+
+    override func run() {
+        abort()
+    }
+}

--- a/features/fixtures/ios-swift-cocoapods/iOSTestApp/scenarios/AutoDetectFalseHandledScenario.swift
+++ b/features/fixtures/ios-swift-cocoapods/iOSTestApp/scenarios/AutoDetectFalseHandledScenario.swift
@@ -1,0 +1,27 @@
+//
+//  AutoDetectFalseHandledScenario.swift
+//  iOSTestApp
+//
+//  Created by Jamie Lynch on 22/05/2020.
+//  Copyright © 2020 Bugsnag. All rights reserved.
+//
+
+import Foundation
+import Bugsnag
+
+/**
+ * Sends a handled error to Bugsnag with autoDetectErrors set to false
+ */
+internal class AutoDetectFalseHandledScenario: Scenario {
+
+    override func startBugsnag() {
+      self.config.autoTrackSessions = false
+      self.config.autoDetectErrors = false
+      super.startBugsnag()
+    }
+
+    override func run() {
+        let error = NSError(domain: "UserDefaultInfoScenario", code: 100, userInfo: nil)
+        Bugsnag.notifyError(error)
+    }
+}

--- a/features/fixtures/ios-swift-cocoapods/iOSTestApp/scenarios/AutoDetectFalseNSExceptionScenario.swift
+++ b/features/fixtures/ios-swift-cocoapods/iOSTestApp/scenarios/AutoDetectFalseNSExceptionScenario.swift
@@ -1,0 +1,26 @@
+//
+//  AutoDetectFalseNSExceptionScenario.swift
+//  iOSTestApp
+//
+//  Created by Jamie Lynch on 22/05/2020.
+//  Copyright © 2020 Bugsnag. All rights reserved.
+//
+
+import Foundation
+import Bugsnag
+
+/**
+ * Raises an unhandled NSException with autoDetectErrors set to false, which should be ignored by Bugsnag
+ */
+internal class AutoDetectFalseNSExceptionScenario: Scenario {
+
+    override func startBugsnag() {
+      self.config.autoTrackSessions = false
+      self.config.autoDetectErrors = false
+      super.startBugsnag()
+    }
+
+    override func run() {
+        NSException.init(name: NSExceptionName("SomeError"), reason: "Something went wrnog", userInfo: nil).raise()
+    }
+}


### PR DESCRIPTION
## Goal

Adds mazerunner scenarios for the `autoDetectErrors` flag to verify that only errors of a certain type are captured. This specifically tests that an uncaught NSException and a SIGABRT are not reported.