### PR TITLE
Add E2E scenarios for metadata redaction

### DIFF
--- a/features/fixtures/ios-swift-cocoapods/iOSTestApp.xcodeproj/project.pbxproj
+++ b/features/fixtures/ios-swift-cocoapods/iOSTestApp.xcodeproj/project.pbxproj
@@ -44,6 +44,9 @@
 		E75040A02478019D005D33BD /* AutoDetectFalseHandledScenario.swift in Sources */ = {isa = PBXBuildFile; fileRef = E750409F2478019D005D33BD /* AutoDetectFalseHandledScenario.swift */; };
 		E75040A2247801A8005D33BD /* AutoDetectFalseNSExceptionScenario.swift in Sources */ = {isa = PBXBuildFile; fileRef = E75040A1247801A8005D33BD /* AutoDetectFalseNSExceptionScenario.swift */; };
 		E75040A42478052D005D33BD /* AutoDetectFalseAbortScenario.swift in Sources */ = {isa = PBXBuildFile; fileRef = E75040A32478052D005D33BD /* AutoDetectFalseAbortScenario.swift */; };
+		E75040B02478214F005D33BD /* MetadataRedactionDefaultScenario.swift in Sources */ = {isa = PBXBuildFile; fileRef = E75040AD2478214E005D33BD /* MetadataRedactionDefaultScenario.swift */; };
+		E75040B12478214F005D33BD /* MetadataRedactionRegexScenario.swift in Sources */ = {isa = PBXBuildFile; fileRef = E75040AE2478214E005D33BD /* MetadataRedactionRegexScenario.swift */; };
+		E75040B22478214F005D33BD /* MetadataRedactionNestedScenario.swift in Sources */ = {isa = PBXBuildFile; fileRef = E75040AF2478214E005D33BD /* MetadataRedactionNestedScenario.swift */; };
 		E7767F11221C21D90006648C /* StoppedSessionScenario.swift in Sources */ = {isa = PBXBuildFile; fileRef = E7767F10221C21D90006648C /* StoppedSessionScenario.swift */; };
 		E7767F13221C21E30006648C /* ResumedSessionScenario.swift in Sources */ = {isa = PBXBuildFile; fileRef = E7767F12221C21E30006648C /* ResumedSessionScenario.swift */; };
 		E7767F15221C223C0006648C /* NewSessionScenario.swift in Sources */ = {isa = PBXBuildFile; fileRef = E7767F14221C223C0006648C /* NewSessionScenario.swift */; };
@@ -154,6 +157,9 @@
 		E750409F2478019D005D33BD /* AutoDetectFalseHandledScenario.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AutoDetectFalseHandledScenario.swift; sourceTree = "<group>"; };
 		E75040A1247801A8005D33BD /* AutoDetectFalseNSExceptionScenario.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AutoDetectFalseNSExceptionScenario.swift; sourceTree = "<group>"; };
 		E75040A32478052D005D33BD /* AutoDetectFalseAbortScenario.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AutoDetectFalseAbortScenario.swift; sourceTree = "<group>"; };
+		E75040AD2478214E005D33BD /* MetadataRedactionDefaultScenario.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = MetadataRedactionDefaultScenario.swift; sourceTree = "<group>"; };
+		E75040AE2478214E005D33BD /* MetadataRedactionRegexScenario.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = MetadataRedactionRegexScenario.swift; sourceTree = "<group>"; };
+		E75040AF2478214E005D33BD /* MetadataRedactionNestedScenario.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = MetadataRedactionNestedScenario.swift; sourceTree = "<group>"; };
 		E7767F10221C21D90006648C /* StoppedSessionScenario.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = StoppedSessionScenario.swift; sourceTree = "<group>"; };
 		E7767F12221C21E30006648C /* ResumedSessionScenario.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ResumedSessionScenario.swift; sourceTree = "<group>"; };
 		E7767F14221C223C0006648C /* NewSessionScenario.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = NewSessionScenario.swift; sourceTree = "<group>"; };
@@ -307,9 +313,20 @@
 			name = AutoDetectErrors;
 			sourceTree = "<group>";
 		};
+		E75040AC2478213D005D33BD /* Metadata Redaction */ = {
+			isa = PBXGroup;
+			children = (
+				E75040AD2478214E005D33BD /* MetadataRedactionDefaultScenario.swift */,
+				E75040AF2478214E005D33BD /* MetadataRedactionNestedScenario.swift */,
+				E75040AE2478214E005D33BD /* MetadataRedactionRegexScenario.swift */,
+			);
+			name = "Metadata Redaction";
+			sourceTree = "<group>";
+		};
 		F42953DE2BB41023C0B07F41 /* scenarios */ = {
 			isa = PBXGroup;
 			children = (
+				E75040AC2478213D005D33BD /* Metadata Redaction */,
 				E750409C24780158005D33BD /* AutoDetectErrors */,
 				F49695A9244545EC00105DA9 /* Crashprobe */,
 				F49695B0244547CB00105DA9 /* Cross notifier notify */,
@@ -612,10 +629,12 @@
 				0011E6672403D13100ED71CD /* UserPersistenceScenarios.m in Sources */,
 				8AB65FCC22DC77CB001200AB /* LoadConfigFromFileScenario.swift in Sources */,
 				E7767F13221C21E30006648C /* ResumedSessionScenario.swift in Sources */,
+				E75040B12478214F005D33BD /* MetadataRedactionRegexScenario.swift in Sources */,
 				8AEFC73120F8D1A000A78779 /* AutoSessionWithUserScenario.m in Sources */,
 				8AB1081923301FE600672818 /* ReleaseStageScenarios.swift in Sources */,
 				8AF6FD7A225E3FA00056EF9E /* ResumeSessionOOMScenario.m in Sources */,
 				00CEB60D24080C690004793D /* EnabledErrorTypesScenario.m in Sources */,
+				E75040B22478214F005D33BD /* MetadataRedactionNestedScenario.swift in Sources */,
 				F429565A951303E2C3136D0D /* UserIdScenario.swift in Sources */,
 				8A38C5D124094D7B00BC4463 /* DiscardedBreadcrumbTypeScenario.swift in Sources */,
 				8AEEBBD020FC9E1D00C60763 /* AutoSessionMixedEventsScenario.m in Sources */,
@@ -636,6 +655,7 @@
 				F42954B7318A02824C65C514 /* ObjCMsgSendScenario.m in Sources */,
 				8A22FC66225B598500CA8895 /* OOMForegroundScenario.m in Sources */,
 				F42953498545B853CC0B635E /* NullPointerScenario.m in Sources */,
+				E75040B02478214F005D33BD /* MetadataRedactionDefaultScenario.swift in Sources */,
 				8A840FBA21AF5C450041DBFA /* SwiftAssertion.swift in Sources */,
 				001E5502243B8FDA0009E31D /* AutoCaptureRunScenario.m in Sources */,
 				F429538D8941382EC2C857CE /* AsyncSafeThreadScenario.m in Sources */,

--- a/features/fixtures/ios-swift-cocoapods/iOSTestApp/scenarios/MetadataRedactionDefaultScenario.swift
+++ b/features/fixtures/ios-swift-cocoapods/iOSTestApp/scenarios/MetadataRedactionDefaultScenario.swift
@@ -1,0 +1,33 @@
+//
+//  MetadataRedactionDefaultScenario.swift
+//  iOSTestApp
+//
+//  Created by Jamie Lynch on 22/05/2020.
+//  Copyright © 2020 Bugsnag. All rights reserved.
+//
+
+import Foundation
+import Bugsnag
+
+/**
+ * Sends a handled Error to Bugsnag with some sensitive metadata that is redacted by default
+ */
+class MetadataRedactionDefaultScenario: Scenario {
+
+    override func startBugsnag() {
+      self.config.autoTrackSessions = false;
+      super.startBugsnag()
+    }
+
+    override func run() {
+        Bugsnag.addMetadata("hunter2", key: "password", section: "custom")
+        Bugsnag.addMetadata("brown fox", key: "normalKey", section: "custom")
+
+        let error = NSError(domain: "HandledErrorScenario", code: 100, userInfo: nil)
+        Bugsnag.notifyError(error) { (event) -> Bool in
+            let password = event.getMetadata(section: "custom", key: "password")
+            event.addMetadata(password, key: "callbackValue", section: "extras")
+            return true
+        }
+    }
+}

--- a/features/fixtures/ios-swift-cocoapods/iOSTestApp/scenarios/MetadataRedactionNestedScenario.swift
+++ b/features/fixtures/ios-swift-cocoapods/iOSTestApp/scenarios/MetadataRedactionNestedScenario.swift
@@ -1,0 +1,51 @@
+//
+//  MetadataRedactionNestedScenario.swift
+//  iOSTestApp
+//
+//  Created by Jamie Lynch on 22/05/2020.
+//  Copyright © 2020 Bugsnag. All rights reserved.
+//
+
+import Foundation
+import Bugsnag
+
+/**
+ * Sends a handled Error to Bugsnag with some nested metadata that is redacted with custom keys
+ */
+class MetadataRedactionNestedScenario: Scenario {
+
+    override func startBugsnag() {
+      self.config.autoTrackSessions = false;
+      self.config.redactedKeys = ["name", "age"]
+      super.startBugsnag()
+    }
+
+    override func run() {
+        let dictionary = [
+            "alpha": [
+                "password": "foo",
+                "name": "Bob"
+            ],
+            "beta": [
+                "gamma": [
+                    "password": "foo",
+                    "age": "7",
+                    "name": [
+                        "title": "Mr"
+                    ]
+                ]
+            ]
+        ]
+        Bugsnag.addOnSession { (block) -> Bool in
+            return true;
+        }
+        Bugsnag.addMetadata(dictionary, section: "custom")
+
+        let error = NSError(domain: "HandledErrorScenario", code: 100, userInfo: nil)
+        Bugsnag.notifyError(error) { (event) -> Bool in
+            let password = event.getMetadata(section: "custom", key: "password")
+            event.addMetadata(password, key: "callbackValue", section: "extras")
+            return true
+        }
+    }
+}

--- a/features/fixtures/ios-swift-cocoapods/iOSTestApp/scenarios/MetadataRedactionRegexScenario.swift
+++ b/features/fixtures/ios-swift-cocoapods/iOSTestApp/scenarios/MetadataRedactionRegexScenario.swift
@@ -1,0 +1,31 @@
+//
+//  MetadataRedactionRegexScenario.swift
+//  iOSTestApp
+//
+//  Created by Jamie Lynch on 22/05/2020.
+//  Copyright © 2020 Bugsnag. All rights reserved.
+//
+
+import Foundation
+import Bugsnag
+
+/**
+ * Sends a handled Error to Bugsnag with some sensitive metadata that is redacted with a regex
+ */
+class MetadataRedactionRegexScenario: Scenario {
+
+    override func startBugsnag() {
+      self.config.autoTrackSessions = false;
+      let regex = try! NSRegularExpression(pattern: "[a-z]at")
+      self.config.redactedKeys = [regex]
+      super.startBugsnag()
+    }
+
+    override func run() {
+        Bugsnag.addMetadata("meow", key: "cat", section: "animals")
+        Bugsnag.addMetadata("headwear", key: "hat", section: "clothes")
+        Bugsnag.addMetadata("unknown", key: "9at", section: "debris")
+        let error = NSError(domain: "HandledErrorScenario", code: 100, userInfo: nil)
+        Bugsnag.notifyError(error)
+    }
+}

--- a/features/metadata_redaction.feature
+++ b/features/metadata_redaction.feature
@@ -1,0 +1,26 @@
+Feature: Metadata values can be redacted
+    Values added to metadata can be redacted through the use of config.redactedKeys
+
+    Scenario: Default behaviour redacts 'password' values after callback is run
+        When I run "MetadataRedactionDefaultScenario"
+        And I wait to receive a request
+        Then the request is valid for the error reporting API version "4.0" for the "iOS Bugsnag Notifier" notifier
+        And the event "metaData.custom.password" equals "[REDACTED]"
+        And the event "metaData.custom.normalKey" equals "brown fox"
+        And the event "metaData.extras.callbackValue" equals "hunter2"
+
+    Scenario: Redaction works in deeply nested objects with custom keys
+        When I run "MetadataRedactionNestedScenario"
+        And I wait to receive a request
+        And the event "metaData.custom.alpha.password" equals "foo"
+        And the event "metaData.custom.alpha.name" equals "[REDACTED]"
+        And the event "metaData.custom.beta.gamma.password" equals "foo"
+        And the event "metaData.custom.beta.gamma.age" equals "[REDACTED]"
+        And the event "metaData.custom.beta.gamma.name" equals "[REDACTED]"
+
+    Scenario: Regex values are redacted
+        When I run "MetadataRedactionRegexScenario"
+        And I wait to receive a request
+        And the event "metaData.animals.cat" equals "[REDACTED]"
+        And the event "metaData.clothes.hat" equals "[REDACTED]"
+        And the event "metaData.debris.9at" equals "unknown"


### PR DESCRIPTION
## Goal

Adds mazerunner scenarios to verify that `event.metadata` values can be redacted by a string or regex set in `config.redactedKeys`. Verified the following:

- Values with key 'password' are removed by default
- Redaction takes place after an `OnError` callback
- Nested values are redacted