### PR TITLE
Add E2E tests for verifying user info

### DIFF
--- a/Tests/BugsnagConfigurationTests.m
+++ b/Tests/BugsnagConfigurationTests.m
@@ -81,7 +81,7 @@
     config.endpoints = [[BugsnagEndpointConfiguration alloc] initWithNotify:@"http://notify.example.com"
                                                                    sessions:@""];
     BugsnagSessionTracker *sessionTracker
-    = [[BugsnagSessionTracker alloc] initWithConfig:config client:nil postRecordCallback:nil];
+            = [[BugsnagSessionTracker alloc] initWithConfig:config client:nil postRecordCallback:nil];
 
     XCTAssertNil(sessionTracker.runningSession);
     [sessionTracker startNewSession];
@@ -93,7 +93,7 @@
     config.endpoints = [[BugsnagEndpointConfiguration alloc] initWithNotify:@"http://notify.example.com"
                                                                    sessions:@"f"];
     BugsnagSessionTracker *sessionTracker
-    = [[BugsnagSessionTracker alloc] initWithConfig:config client:nil postRecordCallback:nil];
+            = [[BugsnagSessionTracker alloc] initWithConfig:config client:nil postRecordCallback:nil];
 
     XCTAssertNil(sessionTracker.runningSession);
     [sessionTracker startNewSession];

--- a/Tests/BugsnagSessionTrackerStopTest.m
+++ b/Tests/BugsnagSessionTrackerStopTest.m
@@ -26,7 +26,9 @@
     [super setUp];
     self.configuration = [[BugsnagConfiguration alloc] initWithApiKey:DUMMY_APIKEY_32CHAR_1];
     self.configuration.autoTrackSessions = NO;
-    self.tracker = [[BugsnagSessionTracker alloc] initWithConfig:self.configuration client:nil postRecordCallback:nil];
+    self.tracker = [[BugsnagSessionTracker alloc] initWithConfig:self.configuration
+                                                          client:nil
+                                              postRecordCallback:nil];
 }
 
 /**

--- a/features/fixtures/ios-swift-cocoapods/iOSTestApp.xcodeproj/project.pbxproj
+++ b/features/fixtures/ios-swift-cocoapods/iOSTestApp.xcodeproj/project.pbxproj
@@ -60,6 +60,11 @@
 		E700EE78247D7A15008CFFB6 /* SIGILLScenario.m in Sources */ = {isa = PBXBuildFile; fileRef = E700EE77247D7A15008CFFB6 /* SIGILLScenario.m */; };
 		E700EE7B247D7A1F008CFFB6 /* SIGSEGVScenario.m in Sources */ = {isa = PBXBuildFile; fileRef = E700EE7A247D7A1F008CFFB6 /* SIGSEGVScenario.m */; };
 		E700EE7E247D7A61008CFFB6 /* SIGSYSScenario.m in Sources */ = {isa = PBXBuildFile; fileRef = E700EE7D247D7A61008CFFB6 /* SIGSYSScenario.m */; };
+		E700EE48247D1158008CFFB6 /* UserEventOverrideScenario.swift in Sources */ = {isa = PBXBuildFile; fileRef = E700EE47247D1158008CFFB6 /* UserEventOverrideScenario.swift */; };
+		E700EE4A247D1164008CFFB6 /* UserSessionOverrideScenario.swift in Sources */ = {isa = PBXBuildFile; fileRef = E700EE49247D1164008CFFB6 /* UserSessionOverrideScenario.swift */; };
+		E700EE4C247D12E4008CFFB6 /* UserFromConfigEventScenario.swift in Sources */ = {isa = PBXBuildFile; fileRef = E700EE4B247D12E4008CFFB6 /* UserFromConfigEventScenario.swift */; };
+		E700EE4E247D1317008CFFB6 /* UserFromClientScenario.swift in Sources */ = {isa = PBXBuildFile; fileRef = E700EE4D247D1317008CFFB6 /* UserFromClientScenario.swift */; };
+		E700EE50247D15DE008CFFB6 /* UserFromConfigSessionScenario.swift in Sources */ = {isa = PBXBuildFile; fileRef = E700EE4F247D15DE008CFFB6 /* UserFromConfigSessionScenario.swift */; };
 		E75040A02478019D005D33BD /* AutoDetectFalseHandledScenario.swift in Sources */ = {isa = PBXBuildFile; fileRef = E750409F2478019D005D33BD /* AutoDetectFalseHandledScenario.swift */; };
 		E75040A2247801A8005D33BD /* AutoDetectFalseNSExceptionScenario.swift in Sources */ = {isa = PBXBuildFile; fileRef = E75040A1247801A8005D33BD /* AutoDetectFalseNSExceptionScenario.swift */; };
 		E75040A42478052D005D33BD /* AutoDetectFalseAbortScenario.swift in Sources */ = {isa = PBXBuildFile; fileRef = E75040A32478052D005D33BD /* AutoDetectFalseAbortScenario.swift */; };
@@ -208,6 +213,11 @@
 		E700EE7A247D7A1F008CFFB6 /* SIGSEGVScenario.m */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.objc; path = SIGSEGVScenario.m; sourceTree = "<group>"; };
 		E700EE7C247D7A61008CFFB6 /* SIGSYSScenario.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; path = SIGSYSScenario.h; sourceTree = "<group>"; };
 		E700EE7D247D7A61008CFFB6 /* SIGSYSScenario.m */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.objc; path = SIGSYSScenario.m; sourceTree = "<group>"; };
+		E700EE47247D1158008CFFB6 /* UserEventOverrideScenario.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = UserEventOverrideScenario.swift; sourceTree = "<group>"; };
+		E700EE49247D1164008CFFB6 /* UserSessionOverrideScenario.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = UserSessionOverrideScenario.swift; sourceTree = "<group>"; };
+		E700EE4B247D12E4008CFFB6 /* UserFromConfigEventScenario.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = UserFromConfigEventScenario.swift; sourceTree = "<group>"; };
+		E700EE4D247D1317008CFFB6 /* UserFromClientScenario.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = UserFromClientScenario.swift; sourceTree = "<group>"; };
+		E700EE4F247D15DE008CFFB6 /* UserFromConfigSessionScenario.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = UserFromConfigSessionScenario.swift; sourceTree = "<group>"; };
 		E750409F2478019D005D33BD /* AutoDetectFalseHandledScenario.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AutoDetectFalseHandledScenario.swift; sourceTree = "<group>"; };
 		E75040A1247801A8005D33BD /* AutoDetectFalseNSExceptionScenario.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AutoDetectFalseNSExceptionScenario.swift; sourceTree = "<group>"; };
 		E75040A32478052D005D33BD /* AutoDetectFalseAbortScenario.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AutoDetectFalseAbortScenario.swift; sourceTree = "<group>"; };
@@ -541,6 +551,11 @@
 				F4295F595986A279FA3BDEA7 /* UserEmailScenario.swift */,
 				F42954E2B3FF0C5C0474DA74 /* UserEnabledScenario.swift */,
 				F42957C58F98EECD3ADD84B2 /* UserIdScenario.swift */,
+				E700EE47247D1158008CFFB6 /* UserEventOverrideScenario.swift */,
+				E700EE49247D1164008CFFB6 /* UserSessionOverrideScenario.swift */,
+				E700EE4B247D12E4008CFFB6 /* UserFromConfigEventScenario.swift */,
+				E700EE4D247D1317008CFFB6 /* UserFromClientScenario.swift */,
+				E700EE4F247D15DE008CFFB6 /* UserFromConfigSessionScenario.swift */,
 			);
 			name = User;
 			sourceTree = "<group>";
@@ -744,6 +759,7 @@
 				00507A64242BFE5600EF1B87 /* EnabledBreadcrumbTypesIsNilScenario.swift in Sources */,
 				8A98400320FD11BF0023ECD1 /* AutoSessionCustomVersionScenario.m in Sources */,
 				F42955E0916B8851F074D9B3 /* UserEmailScenario.swift in Sources */,
+				E700EE4C247D12E4008CFFB6 /* UserFromConfigEventScenario.swift in Sources */,
 				8A3B5F292407F66700CE4A3A /* ModifyBreadcrumbScenario.swift in Sources */,
 				8AA05A2F23BE700C00C7AD00 /* ManyConcurrentNotifyNoBackgroundThreads.m in Sources */,
 				E75040A2247801A8005D33BD /* AutoDetectFalseNSExceptionScenario.swift in Sources */,
@@ -772,6 +788,7 @@
 				F4295A94DD2D131A594A212C /* HandledErrorScenario.swift in Sources */,
 				F4295A7AA9B4A18992A2F020 /* HandledErrorOverrideScenario.swift in Sources */,
 				E700EE62247D4D42008CFFB6 /* OnCrashHandlerScenario.m in Sources */,
+				E700EE48247D1158008CFFB6 /* UserEventOverrideScenario.swift in Sources */,
 				F429502603396F8671B333B3 /* HandledExceptionScenario.swift in Sources */,
 				F4295497A1582010C16F1861 /* AbortScenario.m in Sources */,
 				E75040B424782597005D33BD /* ReleaseStageSessionScenario.swift in Sources */,
@@ -794,6 +811,7 @@
 				F42953498545B853CC0B635E /* NullPointerScenario.m in Sources */,
 				E75040B02478214F005D33BD /* MetadataRedactionDefaultScenario.swift in Sources */,
 				E700EE6C247D793A008CFFB6 /* SIGPIPEScenario.m in Sources */,
+				E700EE50247D15DE008CFFB6 /* UserFromConfigSessionScenario.swift in Sources */,
 				8A840FBA21AF5C450041DBFA /* SwiftAssertion.swift in Sources */,
 				001E5502243B8FDA0009E31D /* AutoCaptureRunScenario.m in Sources */,
 				E700EE55247D3204008CFFB6 /* OnSendOverwriteScenario.swift in Sources */,
@@ -816,6 +834,7 @@
 				E7767F15221C223C0006648C /* NewSessionScenario.swift in Sources */,
 				F42951BEB2518C610A85FE0D /* BuiltinTrapScenario.m in Sources */,
 				8AEFC79C20F92E2200A78779 /* AutoSessionUnhandledScenario.m in Sources */,
+				E700EE4E247D1317008CFFB6 /* UserFromClientScenario.swift in Sources */,
 				F4295397AD31C1C1E64144F5 /* NonExistentMethodScenario.m in Sources */,
 				E700EE53247D31EA008CFFB6 /* OnErrorOverwriteScenario.swift in Sources */,
 				8AEFC79920F9132C00A78779 /* AutoSessionHandledEventsScenario.m in Sources */,
@@ -826,6 +845,7 @@
 				F42958BE5DDACDBF653CA926 /* ManualSessionScenario.m in Sources */,
 				E7A324E8247E9D9A008B0052 /* BreadcrumbCallbackOrderScenario.swift in Sources */,
 				F42951BF19D7F35A03273CFB /* AutoSessionScenario.m in Sources */,
+				E700EE4A247D1164008CFFB6 /* UserSessionOverrideScenario.swift in Sources */,
 				8AF6FD77225E3F870056EF9E /* StopSessionOOMScenario.m in Sources */,
 				F4295109FCAB93708FDAFE12 /* DisabledSessionTrackingScenario.m in Sources */,
 			);

--- a/features/fixtures/ios-swift-cocoapods/iOSTestApp/scenarios/UserEventOverrideScenario.swift
+++ b/features/fixtures/ios-swift-cocoapods/iOSTestApp/scenarios/UserEventOverrideScenario.swift
@@ -1,0 +1,30 @@
+//
+//  UserEventOverrideScenario.swift
+//  iOSTestApp
+//
+//  Created by Jamie Lynch on 26/05/2020.
+//  Copyright © 2020 Bugsnag. All rights reserved.
+//
+
+import Foundation
+import Bugsnag
+
+/**
+ * Sends a handled error to Bugsnag which overrides the user information in the event
+ */
+internal class UserEventOverrideScenario: Scenario {
+
+    override func startBugsnag() {
+        self.config.autoTrackSessions = false;
+        super.startBugsnag()
+    }
+
+    override func run() {
+        Bugsnag.setUser("abc", withEmail: nil, andName: nil)
+        let error = NSError(domain: "UserIdScenario", code: 100, userInfo: nil)
+        Bugsnag.notifyError(error) { (event) -> Bool in
+            event.setUser("customId", withEmail: "customEmail", andName: "customName")
+            return true
+        }
+    }
+}

--- a/features/fixtures/ios-swift-cocoapods/iOSTestApp/scenarios/UserFromClientScenario.swift
+++ b/features/fixtures/ios-swift-cocoapods/iOSTestApp/scenarios/UserFromClientScenario.swift
@@ -1,0 +1,26 @@
+//
+//  UserFromClientScenario.swift
+//  iOSTestApp
+//
+//  Created by Jamie Lynch on 26/05/2020.
+//  Copyright © 2020 Bugsnag. All rights reserved.
+//
+
+import Foundation
+import Bugsnag
+
+/**
+ * Sends a session to Bugsnag which contains a user set from the Client
+ */
+internal class UserFromClientScenario: Scenario {
+
+    override func startBugsnag() {
+        self.config.autoTrackSessions = false;
+        super.startBugsnag()
+    }
+
+    override func run() {
+        Bugsnag.setUser("def", withEmail: "sue@gmail.com", andName: "Sue")
+        Bugsnag.startSession()
+    }
+}

--- a/features/fixtures/ios-swift-cocoapods/iOSTestApp/scenarios/UserFromConfigEventScenario.swift
+++ b/features/fixtures/ios-swift-cocoapods/iOSTestApp/scenarios/UserFromConfigEventScenario.swift
@@ -1,0 +1,32 @@
+//
+//  UserFromConfigEventScenario.swift
+//  iOSTestApp
+//
+//  Created by Jamie Lynch on 26/05/2020.
+//  Copyright © 2020 Bugsnag. All rights reserved.
+//
+
+import Foundation
+import Bugsnag
+
+/**
+ * Sends an event  to Bugsnag which contains a user set from Configuration
+ */
+internal class UserFromConfigEventScenario: Scenario {
+
+    override func startBugsnag() {
+        self.config.autoTrackSessions = false;
+        self.config.setUser("abc", withEmail: "fake@gmail.com", andName: "Fay K")
+        super.startBugsnag()
+    }
+
+    override func run() {
+        let user = Bugsnag.user()
+        Bugsnag.addMetadata(user.id, key: "id", section: "clientUserValue")
+        Bugsnag.addMetadata(user.email, key: "email", section: "clientUserValue")
+        Bugsnag.addMetadata(user.name, key: "name", section: "clientUserValue")
+
+        let error = NSError(domain: "UserFromConfigScenario", code: 100, userInfo: nil)
+        Bugsnag.notifyError(error)
+    }
+}

--- a/features/fixtures/ios-swift-cocoapods/iOSTestApp/scenarios/UserFromConfigEventScenario.swift
+++ b/features/fixtures/ios-swift-cocoapods/iOSTestApp/scenarios/UserFromConfigEventScenario.swift
@@ -22,6 +22,8 @@ internal class UserFromConfigEventScenario: Scenario {
 
     override func run() {
         let user = Bugsnag.user()
+        // set Client.user in the metadata so we can verify that the user set
+        // in Configuration is copied over during initialisation
         Bugsnag.addMetadata(user.id, key: "id", section: "clientUserValue")
         Bugsnag.addMetadata(user.email, key: "email", section: "clientUserValue")
         Bugsnag.addMetadata(user.name, key: "name", section: "clientUserValue")

--- a/features/fixtures/ios-swift-cocoapods/iOSTestApp/scenarios/UserFromConfigSessionScenario.swift
+++ b/features/fixtures/ios-swift-cocoapods/iOSTestApp/scenarios/UserFromConfigSessionScenario.swift
@@ -1,0 +1,27 @@
+//
+//  UserFromConfigSessionScenario.swift
+//  iOSTestApp
+//
+//  Created by Jamie Lynch on 26/05/2020.
+//  Copyright © 2020 Bugsnag. All rights reserved.
+//
+
+import Foundation
+import Bugsnag
+
+/**
+ * Sends a session to Bugsnag which contains a user set from Configuration
+ */
+internal class UserFromConfigSessionScenario: Scenario {
+
+    override func startBugsnag() {
+        self.config.autoTrackSessions = false;
+        self.config.setUser("abc", withEmail: "fake@gmail.com", andName: "Fay K")
+        super.startBugsnag()
+    }
+
+    override func run() {
+        Bugsnag.startSession()
+    }
+}
+

--- a/features/fixtures/ios-swift-cocoapods/iOSTestApp/scenarios/UserSessionOverrideScenario.swift
+++ b/features/fixtures/ios-swift-cocoapods/iOSTestApp/scenarios/UserSessionOverrideScenario.swift
@@ -1,0 +1,30 @@
+//
+//  UserSessionOverrideScenario.swift
+//  iOSTestApp
+//
+//  Created by Jamie Lynch on 26/05/2020.
+//  Copyright © 2020 Bugsnag. All rights reserved.
+//
+
+import Foundation
+import Bugsnag
+
+/**
+ * Sends a session to Bugsnag which overrides the user information
+ */
+internal class UserSessionOverrideScenario: Scenario {
+
+    override func startBugsnag() {
+        self.config.autoTrackSessions = false;
+        super.startBugsnag()
+    }
+
+    override func run() {
+        Bugsnag.setUser("abc", withEmail: nil, andName: nil)
+        Bugsnag.addOnSession { (session) -> Bool in
+            session.setUser("customId", withEmail: "customEmail", andName: "customName")
+            return true
+        }
+        Bugsnag.startSession()
+    }
+}

--- a/features/user.feature
+++ b/features/user.feature
@@ -45,3 +45,46 @@ Scenario: Only User ID field set
     And the event "user.id" equals "abc"
     And the event "user.email" is null
     And the event "user.name" is null
+
+Scenario: Overriding the user in the Event callback
+    When I run "UserEventOverrideScenario"
+    And I wait to receive a request
+    Then the request is valid for the error reporting API version "4.0" for the "iOS Bugsnag Notifier" notifier
+    And the event "user.id" equals "customId"
+    And the event "user.email" equals "customEmail"
+    And the event "user.name" equals "customName"
+
+Scenario: Overriding the user in the Session callback
+    When I run "UserSessionOverrideScenario"
+    And I wait to receive a request
+    Then the request is valid for the session reporting API version "1.0" for the "iOS Bugsnag Notifier" notifier
+    And the session "user.id" equals "customId"
+    And the session "user.email" equals "customEmail"
+    And the session "user.name" equals "customName"
+
+Scenario: Setting the user from Configuration for an event
+    When I run "UserFromConfigEventScenario"
+    And I wait to receive a request
+    Then the request is valid for the error reporting API version "4.0" for the "iOS Bugsnag Notifier" notifier
+    And the event "user.id" equals "abc"
+    And the event "user.email" equals "fake@gmail.com"
+    And the event "user.name" equals "Fay K"
+    And the event "metaData.clientUserValue.id" equals "abc"
+    And the event "metaData.clientUserValue.email" equals "fake@gmail.com"
+    And the event "metaData.clientUserValue.name" equals "Fay K"
+
+Scenario: Setting the user from Configuration for a session
+    When I run "UserFromConfigSessionScenario"
+    And I wait to receive a request
+    Then the request is valid for the session reporting API version "1.0" for the "iOS Bugsnag Notifier" notifier
+    And the session "user.id" equals "abc"
+    And the session "user.email" equals "fake@gmail.com"
+    And the session "user.name" equals "Fay K"
+
+Scenario: Setting the user from Client for sessions
+    When I run "UserFromClientScenario"
+    And I wait to receive a request
+    Then the request is valid for the session reporting API version "1.0" for the "iOS Bugsnag Notifier" notifier
+    And the session "user.id" equals "def"
+    And the session "user.email" equals "sue@gmail.com"
+    And the session "user.name" equals "Sue"


### PR DESCRIPTION
## Goal

Adds E2E tests to verify that user information is added to errors/sessions correctly.

The addition of E2E tests revealed a bug in the session implementation which have also been addressed here.

## Changeset

- `BugsnagSessionTracker` now uses the user from `client` rather than `config` as this is the one which is updated after initialisation
- Added E2E tests for verifying event/session callbacks can override the user
- Removed some user test coverage from unit tests as this is now covered by E2E tests
- Added E2E tests for verifying the user can be set from config/client for both events and sessions
