### PR TITLE
Add E2E tests for event callbacks

### DIFF
--- a/Tests/BugsnagConfigurationTests.m
+++ b/Tests/BugsnagConfigurationTests.m
@@ -166,6 +166,7 @@
     __block XCTestExpectation *expectation2 = [self expectationWithDescription:@"Remove On Session Block 2"];
     __block XCTestExpectation *expectation3 = [self expectationWithDescription:@"Remove On Session Block 3"];
     __block XCTestExpectation *expectation4 = [self expectationWithDescription:@"Remove On Session Block 4"];
+    expectation3.inverted = YES;
     expectation4.inverted = YES;
 
     BugsnagConfiguration *config = [[BugsnagConfiguration alloc] initWithApiKey:DUMMY_APIKEY_32CHAR_1];
@@ -206,7 +207,7 @@
     [Bugsnag startSession];
     [self waitForExpectations:@[expectation2] timeout:1.0];
 
-    // Check it's still called once the block's deleted (block has been copied in client init)
+    // Check block is not called after removing and initialisation
     [Bugsnag pauseSession];
     called++;
     [config removeOnSessionBlock:sessionBlock];
@@ -846,7 +847,7 @@ NSString * const kBugsnagUserUserId = @"BugsnagUserUserId";
     XCTAssertNotEqual(config.onCrashHandler, clone.onCrashHandler);
 
     // Array (of blocks)
-    XCTAssertNotEqual(config.onSendBlocks, clone.onSendBlocks);
+    XCTAssertEqual(config.onSendBlocks, clone.onSendBlocks);
     XCTAssertEqual(config.onSendBlocks[0], clone.onSendBlocks[0]);
     [clone setOnSendBlocks:[@[ onSendBlock2 ] mutableCopy]];
     XCTAssertNotEqual(config.onSendBlocks[0], clone.onSendBlocks[0]);

--- a/features/event_callbacks.feature
+++ b/features/event_callbacks.feature
@@ -1,0 +1,68 @@
+Feature: Callbacks can access and modify event information
+
+Scenario: Removing an OnSend callback does not affect other OnSend callbacks
+    When I run "OnSendCallbackRemovalScenario"
+    And I wait to receive a request
+    Then the request is valid for the error reporting API version "4.0" for the "iOS Bugsnag Notifier" notifier
+    And the event "metaData.callbacks.config" is null
+    And the event "metaData.callbacks.config2" equals "adding metadata"
+
+Scenario: An OnErrorCallback can overwrite information for a handled error
+    When I run "OnErrorOverwriteScenario"
+    And I wait to receive a request
+    Then the request is valid for the error reporting API version "4.0" for the "iOS Bugsnag Notifier" notifier
+    And the event "app.id" equals "customAppId"
+    And the event "context" equals "customContext"
+    And the event "device.id" equals "customDeviceId"
+    And the event "groupingHash" equals "customGroupingHash"
+    And the event "severity" equals "info"
+    And the event "user.id" equals "customId"
+    And the event "user.email" equals "customEmail"
+    And the event "user.name" equals "customName"
+
+Scenario: An OnSend callback can overwrite information for an unhandled error
+    When I run "SwiftAssertion" and relaunch the app
+    And I configure Bugsnag for "OnSendOverwriteScenario"
+    And I wait to receive a request
+    Then the request is valid for the error reporting API version "4.0" for the "iOS Bugsnag Notifier" notifier
+    And the event "app.id" equals "customAppId"
+    And the event "context" equals "customContext"
+    And the event "device.id" equals "customDeviceId"
+    And the event "groupingHash" equals "customGroupingHash"
+    And the event "severity" equals "info"
+    And the event "user.id" equals "customId"
+    And the event "user.email" equals "customEmail"
+    And the event "user.name" equals "customName"
+
+Scenario: Information set in OnCrashHandler is added to the final report
+    When I run "OnCrashHandlerScenario" and relaunch the app
+    And I configure Bugsnag for "OnSendOverwriteScenario"
+    And I wait to receive a request
+    Then the request is valid for the error reporting API version "4.0" for the "iOS Bugsnag Notifier" notifier
+    And the event "metaData.custom.strVal" equals "customStrValue"
+    And the event "metaData.custom.boolVal" is true
+    And the event "metaData.custom.intVal" equals 5
+    And the event "metaData.complex.objVal.foo" equals "bar"
+    And the event "metaData.custom.doubleVal" is not null
+    And the event "metaData.complex.arrayVal" is not null
+
+Scenario: The original error property is populated for a handled NSError
+    When I run "OriginalErrorNSErrorScenario"
+    And I wait to receive a request
+    Then the request is valid for the error reporting API version "4.0" for the "iOS Bugsnag Notifier" notifier
+    And the event "metaData.custom.hasOriginalError" is true
+
+Scenario: The original error property is populated for a handled NSException
+    When I run "OriginalErrorNSExceptionScenario"
+    And I wait to receive a request
+    Then the request is valid for the error reporting API version "4.0" for the "iOS Bugsnag Notifier" notifier
+    And the event "metaData.custom.hasOriginalError" is true
+
+Scenario: OnSend callbacks run in the order in which they were added
+    When I run "OnSendCallbackOrderScenario"
+    And I wait to receive a request
+    Then the request is valid for the error reporting API version "4.0" for the "iOS Bugsnag Notifier" notifier
+    And the event "metaData.callbacks.notify" equals 0
+    And the event "metaData.callbacks.config" equals 1
+    And the event "metaData.callbacks.client" equals 2
+    And the event "metaData.callbacks.secondClient" equals 3

--- a/features/fixtures/ios-swift-cocoapods/iOSTestApp.xcodeproj/project.pbxproj
+++ b/features/fixtures/ios-swift-cocoapods/iOSTestApp.xcodeproj/project.pbxproj
@@ -45,6 +45,13 @@
 		8AF8FCAC22BD1E5400A967CA /* UnhandledInternalNotifyScenario.swift in Sources */ = {isa = PBXBuildFile; fileRef = 8AF8FCAB22BD1E5400A967CA /* UnhandledInternalNotifyScenario.swift */; };
 		8AF8FCAE22BD23BA00A967CA /* HandledInternalNotifyScenario.swift in Sources */ = {isa = PBXBuildFile; fileRef = 8AF8FCAD22BD23BA00A967CA /* HandledInternalNotifyScenario.swift */; };
 		C4D0B5FF8E60C0835B86DFE9 /* Pods_iOSTestApp.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = 4994F05E0421A0B037DD2CC5 /* Pods_iOSTestApp.framework */; };
+		E700EE53247D31EA008CFFB6 /* OnErrorOverwriteScenario.swift in Sources */ = {isa = PBXBuildFile; fileRef = E700EE52247D31EA008CFFB6 /* OnErrorOverwriteScenario.swift */; };
+		E700EE55247D3204008CFFB6 /* OnSendOverwriteScenario.swift in Sources */ = {isa = PBXBuildFile; fileRef = E700EE54247D3204008CFFB6 /* OnSendOverwriteScenario.swift */; };
+		E700EE59247D321B008CFFB6 /* OriginalErrorNSErrorScenario.swift in Sources */ = {isa = PBXBuildFile; fileRef = E700EE58247D321B008CFFB6 /* OriginalErrorNSErrorScenario.swift */; };
+		E700EE5B247D3224008CFFB6 /* OriginalErrorNSExceptionScenario.swift in Sources */ = {isa = PBXBuildFile; fileRef = E700EE5A247D3224008CFFB6 /* OriginalErrorNSExceptionScenario.swift */; };
+		E700EE5D247D322D008CFFB6 /* OnSendCallbackOrderScenario.swift in Sources */ = {isa = PBXBuildFile; fileRef = E700EE5C247D322D008CFFB6 /* OnSendCallbackOrderScenario.swift */; };
+		E700EE62247D4D42008CFFB6 /* OnCrashHandlerScenario.m in Sources */ = {isa = PBXBuildFile; fileRef = E700EE61247D4D42008CFFB6 /* OnCrashHandlerScenario.m */; };
+		E700EE65247D6C08008CFFB6 /* OnSendCallbackRemovalScenario.m in Sources */ = {isa = PBXBuildFile; fileRef = E700EE64247D6C08008CFFB6 /* OnSendCallbackRemovalScenario.m */; };
 		E75040A02478019D005D33BD /* AutoDetectFalseHandledScenario.swift in Sources */ = {isa = PBXBuildFile; fileRef = E750409F2478019D005D33BD /* AutoDetectFalseHandledScenario.swift */; };
 		E75040A2247801A8005D33BD /* AutoDetectFalseNSExceptionScenario.swift in Sources */ = {isa = PBXBuildFile; fileRef = E75040A1247801A8005D33BD /* AutoDetectFalseNSExceptionScenario.swift */; };
 		E75040A42478052D005D33BD /* AutoDetectFalseAbortScenario.swift in Sources */ = {isa = PBXBuildFile; fileRef = E75040A32478052D005D33BD /* AutoDetectFalseAbortScenario.swift */; };
@@ -162,6 +169,15 @@
 		8AF8FCAB22BD1E5400A967CA /* UnhandledInternalNotifyScenario.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = UnhandledInternalNotifyScenario.swift; sourceTree = "<group>"; };
 		8AF8FCAD22BD23BA00A967CA /* HandledInternalNotifyScenario.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = HandledInternalNotifyScenario.swift; sourceTree = "<group>"; };
 		960A6E7D4E847F1D76A4FD06 /* Pods-iOSTestApp.release.xcconfig */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.xcconfig; name = "Pods-iOSTestApp.release.xcconfig"; path = "Pods/Target Support Files/Pods-iOSTestApp/Pods-iOSTestApp.release.xcconfig"; sourceTree = "<group>"; };
+		E700EE52247D31EA008CFFB6 /* OnErrorOverwriteScenario.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = OnErrorOverwriteScenario.swift; sourceTree = "<group>"; };
+		E700EE54247D3204008CFFB6 /* OnSendOverwriteScenario.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = OnSendOverwriteScenario.swift; sourceTree = "<group>"; };
+		E700EE58247D321B008CFFB6 /* OriginalErrorNSErrorScenario.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = OriginalErrorNSErrorScenario.swift; sourceTree = "<group>"; };
+		E700EE5A247D3224008CFFB6 /* OriginalErrorNSExceptionScenario.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = OriginalErrorNSExceptionScenario.swift; sourceTree = "<group>"; };
+		E700EE5C247D322D008CFFB6 /* OnSendCallbackOrderScenario.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = OnSendCallbackOrderScenario.swift; sourceTree = "<group>"; };
+		E700EE60247D4D42008CFFB6 /* OnCrashHandlerScenario.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; path = OnCrashHandlerScenario.h; sourceTree = "<group>"; };
+		E700EE61247D4D42008CFFB6 /* OnCrashHandlerScenario.m */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.objc; path = OnCrashHandlerScenario.m; sourceTree = "<group>"; };
+		E700EE63247D6C08008CFFB6 /* OnSendCallbackRemovalScenario.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; path = OnSendCallbackRemovalScenario.h; sourceTree = "<group>"; };
+		E700EE64247D6C08008CFFB6 /* OnSendCallbackRemovalScenario.m */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.objc; path = OnSendCallbackRemovalScenario.m; sourceTree = "<group>"; };
 		E750409F2478019D005D33BD /* AutoDetectFalseHandledScenario.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AutoDetectFalseHandledScenario.swift; sourceTree = "<group>"; };
 		E75040A1247801A8005D33BD /* AutoDetectFalseNSExceptionScenario.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AutoDetectFalseNSExceptionScenario.swift; sourceTree = "<group>"; };
 		E75040A32478052D005D33BD /* AutoDetectFalseAbortScenario.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AutoDetectFalseAbortScenario.swift; sourceTree = "<group>"; };
@@ -314,6 +330,22 @@
 			name = Frameworks;
 			sourceTree = "<group>";
 		};
+		E700EE51247D31CF008CFFB6 /* Event Callbacks */ = {
+			isa = PBXGroup;
+			children = (
+				E700EE52247D31EA008CFFB6 /* OnErrorOverwriteScenario.swift */,
+				E700EE54247D3204008CFFB6 /* OnSendOverwriteScenario.swift */,
+				E700EE58247D321B008CFFB6 /* OriginalErrorNSErrorScenario.swift */,
+				E700EE5A247D3224008CFFB6 /* OriginalErrorNSExceptionScenario.swift */,
+				E700EE5C247D322D008CFFB6 /* OnSendCallbackOrderScenario.swift */,
+				E700EE60247D4D42008CFFB6 /* OnCrashHandlerScenario.h */,
+				E700EE61247D4D42008CFFB6 /* OnCrashHandlerScenario.m */,
+				E700EE63247D6C08008CFFB6 /* OnSendCallbackRemovalScenario.h */,
+				E700EE64247D6C08008CFFB6 /* OnSendCallbackRemovalScenario.m */,
+			);
+			name = "Event Callbacks";
+			sourceTree = "<group>";
+		};
 		E750409C24780158005D33BD /* AutoDetectErrors */ = {
 			isa = PBXGroup;
 			children = (
@@ -341,6 +373,7 @@
 				E750409C24780158005D33BD /* AutoDetectErrors */,
 				F49695A9244545EC00105DA9 /* Crashprobe */,
 				F49695B0244547CB00105DA9 /* Cross notifier notify */,
+				E700EE51247D31CF008CFFB6 /* Event Callbacks */,
 				F49695AF2445477E00105DA9 /* Handled errors */,
 				F49695A3243EF7B600105DA9 /* OOMs */,
 				F49695AE2445476700105DA9 /* Plugin */,
@@ -645,17 +678,20 @@
 				8AB65FCC22DC77CB001200AB /* LoadConfigFromFileScenario.swift in Sources */,
 				E7767F13221C21E30006648C /* ResumedSessionScenario.swift in Sources */,
 				E75040B12478214F005D33BD /* MetadataRedactionRegexScenario.swift in Sources */,
+				E700EE5B247D3224008CFFB6 /* OriginalErrorNSExceptionScenario.swift in Sources */,
 				8AEFC73120F8D1A000A78779 /* AutoSessionWithUserScenario.m in Sources */,
 				8AB1081923301FE600672818 /* ReleaseStageScenarios.swift in Sources */,
 				8AF6FD7A225E3FA00056EF9E /* ResumeSessionOOMScenario.m in Sources */,
 				00CEB60D24080C690004793D /* EnabledErrorTypesScenario.m in Sources */,
 				E75040B22478214F005D33BD /* MetadataRedactionNestedScenario.swift in Sources */,
+				E700EE65247D6C08008CFFB6 /* OnSendCallbackRemovalScenario.m in Sources */,
 				F429565A951303E2C3136D0D /* UserIdScenario.swift in Sources */,
 				8A38C5D124094D7B00BC4463 /* DiscardedBreadcrumbTypeScenario.swift in Sources */,
 				8AEEBBD020FC9E1D00C60763 /* AutoSessionMixedEventsScenario.m in Sources */,
 				8AF8FCAC22BD1E5400A967CA /* UnhandledInternalNotifyScenario.swift in Sources */,
 				F4295A94DD2D131A594A212C /* HandledErrorScenario.swift in Sources */,
 				F4295A7AA9B4A18992A2F020 /* HandledErrorOverrideScenario.swift in Sources */,
+				E700EE62247D4D42008CFFB6 /* OnCrashHandlerScenario.m in Sources */,
 				F429502603396F8671B333B3 /* HandledExceptionScenario.swift in Sources */,
 				F4295497A1582010C16F1861 /* AbortScenario.m in Sources */,
 				8AF8FCAE22BD23BA00A967CA /* HandledInternalNotifyScenario.swift in Sources */,
@@ -669,10 +705,13 @@
 				8A32DB8222424E3000EDD92F /* NSExceptionShiftScenario.m in Sources */,
 				F42954B7318A02824C65C514 /* ObjCMsgSendScenario.m in Sources */,
 				8A22FC66225B598500CA8895 /* OOMForegroundScenario.m in Sources */,
+				E700EE5D247D322D008CFFB6 /* OnSendCallbackOrderScenario.swift in Sources */,
+				E700EE59247D321B008CFFB6 /* OriginalErrorNSErrorScenario.swift in Sources */,
 				F42953498545B853CC0B635E /* NullPointerScenario.m in Sources */,
 				E75040B02478214F005D33BD /* MetadataRedactionDefaultScenario.swift in Sources */,
 				8A840FBA21AF5C450041DBFA /* SwiftAssertion.swift in Sources */,
 				001E5502243B8FDA0009E31D /* AutoCaptureRunScenario.m in Sources */,
+				E700EE55247D3204008CFFB6 /* OnSendOverwriteScenario.swift in Sources */,
 				F429538D8941382EC2C857CE /* AsyncSafeThreadScenario.m in Sources */,
 				F42955869D33EE0E510B9651 /* ReadGarbagePointerScenario.m in Sources */,
 				8AEFC73420F8D1BB00A78779 /* ManualSessionWithUserScenario.m in Sources */,
@@ -691,6 +730,7 @@
 				F42951BEB2518C610A85FE0D /* BuiltinTrapScenario.m in Sources */,
 				8AEFC79C20F92E2200A78779 /* AutoSessionUnhandledScenario.m in Sources */,
 				F4295397AD31C1C1E64144F5 /* NonExistentMethodScenario.m in Sources */,
+				E700EE53247D31EA008CFFB6 /* OnErrorOverwriteScenario.swift in Sources */,
 				8AEFC79920F9132C00A78779 /* AutoSessionHandledEventsScenario.m in Sources */,
 				0037410F2473CF2300BE41AA /* AppAndDeviceAttributesScenario.swift in Sources */,
 				F4295A0B0DA0AF3B5502D29C /* PrivilegedInstructionScenario.m in Sources */,

--- a/features/fixtures/ios-swift-cocoapods/iOSTestApp/scenarios/OnCrashHandlerScenario.h
+++ b/features/fixtures/ios-swift-cocoapods/iOSTestApp/scenarios/OnCrashHandlerScenario.h
@@ -1,0 +1,18 @@
+//
+//  OnCrashHandlerScenario.h
+//  iOSTestApp
+//
+//  Created by Jamie Lynch on 26/05/2020.
+//  Copyright © 2020 Bugsnag. All rights reserved.
+//
+
+#import <Foundation/Foundation.h>
+#import "Scenario.h"
+
+NS_ASSUME_NONNULL_BEGIN
+
+@interface OnCrashHandlerScenario : Scenario
+
+@end
+
+NS_ASSUME_NONNULL_END

--- a/features/fixtures/ios-swift-cocoapods/iOSTestApp/scenarios/OnCrashHandlerScenario.m
+++ b/features/fixtures/ios-swift-cocoapods/iOSTestApp/scenarios/OnCrashHandlerScenario.m
@@ -1,0 +1,50 @@
+//
+//  OnCrashHandlerScenario.m
+//  iOSTestApp
+//
+//  Created by Jamie Lynch on 26/05/2020.
+//  Copyright © 2020 Bugsnag. All rights reserved.
+//
+
+#import "OnCrashHandlerScenario.h"
+
+// Create crash handler
+void HandleCrashedThread(const BSG_KSCrashReportWriter *writer) {
+    // write primitive values
+    writer->beginObject(writer, "custom");
+    {
+        writer->addStringElement(writer, "strVal", "customStrValue");
+        writer->addBooleanElement(writer, "boolVal", true);
+        writer->addIntegerElement(writer, "intVal", 5);
+        writer->addFloatingPointElement(writer, "doubleVal", 3.1495);
+    }
+    writer->endContainer(writer);
+
+    writer->beginObject(writer, "complex");
+    // write array value
+    {
+        writer->beginArray(writer, "arrayVal");
+        writer->endContainer(writer);
+    }
+    // write nested object value
+    {
+        writer->beginObject(writer, "objVal");
+        writer->addStringElement(writer, "foo", "bar");
+        writer->endContainer(writer);
+    }
+    writer->endContainer(writer);
+}
+
+@implementation OnCrashHandlerScenario
+
+- (void)startBugsnag {
+    self.config.autoTrackSessions = NO;
+    self.config.onCrashHandler = &HandleCrashedThread;
+    [super startBugsnag];
+}
+
+- (void)run {
+    abort();
+}
+
+@end

--- a/features/fixtures/ios-swift-cocoapods/iOSTestApp/scenarios/OnErrorOverwriteScenario.swift
+++ b/features/fixtures/ios-swift-cocoapods/iOSTestApp/scenarios/OnErrorOverwriteScenario.swift
@@ -1,0 +1,32 @@
+//
+//  OnErrorOverwriteScenario.swift
+//  iOSTestApp
+//
+//  Created by Jamie Lynch on 26/05/2020.
+//  Copyright © 2020 Bugsnag. All rights reserved.
+//
+
+import Foundation
+
+/**
+ * Verifies that an OnErrorCallback can overwrite information for a handled error
+ */
+class OnErrorOverwriteScenario : Scenario {
+    override func startBugsnag() {
+        self.config.autoTrackSessions = false;
+        super.startBugsnag()
+    }
+
+    override func run() {
+        let error = NSError(domain: "HandledErrorScenario", code: 100, userInfo: nil)
+        Bugsnag.notifyError(error) { (event) -> Bool in
+            event.app.id = "customAppId"
+            event.context = "customContext"
+            event.device.id = "customDeviceId"
+            event.groupingHash = "customGroupingHash"
+            event.severity = .info
+            event.setUser("customId", withEmail: "customEmail", andName: "customName")
+            return true
+        }
+    }
+}

--- a/features/fixtures/ios-swift-cocoapods/iOSTestApp/scenarios/OnSendCallbackOrderScenario.swift
+++ b/features/fixtures/ios-swift-cocoapods/iOSTestApp/scenarios/OnSendCallbackOrderScenario.swift
@@ -1,0 +1,47 @@
+//
+//  OnSendCallbackOrderScenario.swift
+//  iOSTestApp
+//
+//  Created by Jamie Lynch on 26/05/2020.
+//  Copyright © 2020 Bugsnag. All rights reserved.
+//
+
+import Foundation
+
+/**
+ * Verifies that OnSend callbacks run in the order in which they were added
+ */
+class OnSendCallbackOrderScenario : Scenario {
+
+    var callbackOrder = 0
+
+    override func startBugsnag() {
+        self.config.autoTrackSessions = false;
+        self.config.addOnSendError { (event) -> Bool in
+            event.addMetadata(self.callbackOrder, key: "config", section: "callbacks")
+            self.callbackOrder += 1
+            return true
+        }
+        super.startBugsnag()
+    }
+
+    override func run() {
+        Bugsnag.addOnSendError { (event) -> Bool in
+            event.addMetadata(self.callbackOrder, key: "client", section: "callbacks")
+            self.callbackOrder += 1
+            return true
+        }
+        Bugsnag.addOnSendError { (event) -> Bool in
+            event.addMetadata(self.callbackOrder, key: "secondClient", section: "callbacks")
+            self.callbackOrder += 1
+            return true
+        }
+
+        let error = NSError(domain: "OnSendCallbackOrderScenario", code: 100, userInfo: nil)
+        Bugsnag.notifyError(error) { (event) -> Bool in
+            event.addMetadata(self.callbackOrder, key: "notify", section: "callbacks")
+            self.callbackOrder += 1
+            return true
+        }
+    }
+}

--- a/features/fixtures/ios-swift-cocoapods/iOSTestApp/scenarios/OnSendCallbackRemovalScenario.h
+++ b/features/fixtures/ios-swift-cocoapods/iOSTestApp/scenarios/OnSendCallbackRemovalScenario.h
@@ -1,0 +1,18 @@
+//
+//  OnSendCallbackRemovalScenario.h
+//  iOSTestApp
+//
+//  Created by Jamie Lynch on 26/05/2020.
+//  Copyright © 2020 Bugsnag. All rights reserved.
+//
+
+#import <Foundation/Foundation.h>
+#import "Scenario.h"
+
+NS_ASSUME_NONNULL_BEGIN
+
+@interface OnSendCallbackRemovalScenario : Scenario
+
+@end
+
+NS_ASSUME_NONNULL_END

--- a/features/fixtures/ios-swift-cocoapods/iOSTestApp/scenarios/OnSendCallbackRemovalScenario.m
+++ b/features/fixtures/ios-swift-cocoapods/iOSTestApp/scenarios/OnSendCallbackRemovalScenario.m
@@ -1,0 +1,35 @@
+//
+//  OnSendCallbackRemovalScenario.m
+//  iOSTestApp
+//
+//  Created by Jamie Lynch on 26/05/2020.
+//  Copyright © 2020 Bugsnag. All rights reserved.
+//
+
+#import "OnSendCallbackRemovalScenario.h"
+
+/**
+ * Verifies that removing an OnSend callback does not affect other OnSend callbacks
+ */
+@implementation OnSendCallbackRemovalScenario
+
+- (void)startBugsnag {
+    id block = ^BOOL(BugsnagEvent * _Nonnull event) {
+        [event addMetadata:@"this should never happen" withKey:@"config" toSection:@"callbacks"];
+        return true;
+    };
+    self.config.autoTrackSessions = false;
+    [self.config addOnSendErrorBlock:block];
+
+    [self.config addOnSendErrorBlock:^BOOL(BugsnagEvent * _Nonnull event) {
+        [event addMetadata:@"adding metadata" withKey:@"config2" toSection:@"callbacks"];
+        return true;
+    }];
+    [super startBugsnag];
+    [Bugsnag removeOnSendErrorBlock:block];
+}
+
+- (void)run {
+    [Bugsnag notifyError:[NSError errorWithDomain:@"com.bugsnag" code:833 userInfo:nil]];
+}
+@end

--- a/features/fixtures/ios-swift-cocoapods/iOSTestApp/scenarios/OnSendOverwriteScenario.swift
+++ b/features/fixtures/ios-swift-cocoapods/iOSTestApp/scenarios/OnSendOverwriteScenario.swift
@@ -1,0 +1,32 @@
+//
+//  OnSendOverwriteScenario.swift
+//  iOSTestApp
+//
+//  Created by Jamie Lynch on 26/05/2020.
+//  Copyright © 2020 Bugsnag. All rights reserved.
+//
+
+import Foundation
+
+/**
+ * Verifies that an OnSend callback can overwrite information for an unhandled error
+ */
+class OnSendOverwriteScenario : Scenario {
+    override func startBugsnag() {
+        self.config.autoTrackSessions = false;
+        self.config.addOnSendError { (event) -> Bool in
+            event.app.id = "customAppId"
+            event.context = "customContext"
+            event.device.id = "customDeviceId"
+            event.groupingHash = "customGroupingHash"
+            event.severity = .info
+            event.setUser("customId", withEmail: "customEmail", andName: "customName")
+            return true
+        }
+        super.startBugsnag()
+    }
+
+    override func run() {
+
+    }
+}

--- a/features/fixtures/ios-swift-cocoapods/iOSTestApp/scenarios/OriginalErrorNSErrorScenario.swift
+++ b/features/fixtures/ios-swift-cocoapods/iOSTestApp/scenarios/OriginalErrorNSErrorScenario.swift
@@ -1,0 +1,28 @@
+//
+//  OriginalErrorNSErrorScenario.swift
+//  iOSTestApp
+//
+//  Created by Jamie Lynch on 26/05/2020.
+//  Copyright © 2020 Bugsnag. All rights reserved.
+//
+
+import Foundation
+
+/**
+ * Verifies that the original error property is populated for a handled NSError
+ */
+class OriginalErrorNSErrorScenario : Scenario {
+    override func startBugsnag() {
+        self.config.autoTrackSessions = false;
+        super.startBugsnag()
+    }
+
+    override func run() {
+        let error = NSError(domain: "HandledErrorScenario", code: 100, userInfo: nil)
+        Bugsnag.notifyError(error) { (event) -> Bool in
+            let hasOriginalError = error.isEqual(event.originalError)
+            event.addMetadata(hasOriginalError, key: "hasOriginalError", section: "custom")
+            return true
+        }
+    }
+}

--- a/features/fixtures/ios-swift-cocoapods/iOSTestApp/scenarios/OriginalErrorNSExceptionScenario.swift
+++ b/features/fixtures/ios-swift-cocoapods/iOSTestApp/scenarios/OriginalErrorNSExceptionScenario.swift
@@ -1,0 +1,31 @@
+//
+//  OriginalErrorNSExceptionScenario.swift
+//  iOSTestApp
+//
+//  Created by Jamie Lynch on 26/05/2020.
+//  Copyright © 2020 Bugsnag. All rights reserved.
+//
+
+import Foundation
+
+/**
+ * Verifies that the original error property is populated for a handled NSException
+ */
+class OriginalErrorNSExceptionScenario : Scenario {
+    override func startBugsnag() {
+        self.config.autoTrackSessions = false;
+        super.startBugsnag()
+    }
+
+    override func run() {
+        let exc = NSException(name: NSExceptionName("HandledExceptionScenario"),
+                            reason: "Message: HandledExceptionScenario",
+                          userInfo: nil)
+
+        Bugsnag.notify(exc) { (event) -> Bool in
+            let hasOriginalError = exc.isEqual(event.originalError)
+            event.addMetadata(hasOriginalError, key: "hasOriginalError", section: "custom")
+            return true
+        }
+    }
+}


### PR DESCRIPTION
## Goal

Adds E2E test coverage for callbacks which allow for the information to be accessed and mutated on the `BugsnagEvent` class. Additionally this fixes a minor bug where blocks were copied from `BugsnagConfiguration` when initialising `Bugsnag`, which prevented their removal if they had been added in `BugsnagConfiguration`.

## Changeset

- Alters `BugsnagConfiguration` so that a shallow copy rather than a deep copy is not made of callback blocks. Making a deep copy would mean that the blocks are different objects. The end result of this would be if a user called `config.addOnSendError:` and then `Bugsnag.removeOnSendError:` with the same block, it would not be removed. Existing unit test assertions have been updated accordingly
- Added tests to verify that `OnError` can overwrite fields for a handled error, and that `OnSendError` can for an unhandled error
- Added tests to verify that data can be added in an `OnCrashHandler` callback
- Added tests for callback ordering/addition/removal
- Added tests for verifying that the `event.originalError` property is set appropriately

