### PR TITLE
Add E2E scenarios for unhandled signals

### DIFF
--- a/features/crashprobe.feature
+++ b/features/crashprobe.feature
@@ -18,27 +18,6 @@ Scenario: Calling __builtin_trap()
     And the exception "errorClass" equals "EXC_BREAKPOINT"
     And the "method" of stack frame 0 equals "-[BuiltinTrapScenario run]"
 
-Scenario: Calling abort()
-    When I run "AbortScenario" and relaunch the app
-    And I configure Bugsnag for "AbortScenario"
-    And I wait to receive a request
-    Then the request is valid for the error reporting API version "4.0" for the "iOS Bugsnag Notifier" notifier
-    And the payload field "events" is an array with 1 elements
-    And the exception "errorClass" equals "SIGABRT"
-    And the "method" of stack frame 0 equals "__pthread_kill"
-    And the "method" of stack frame 1 equals "<redacted>"
-    And the "method" of stack frame 2 equals "abort"
-    And the "method" of stack frame 3 equals "-[AbortScenario run]"
-
-Scenario: Throwing a C++ exception
-    When I run "CxxExceptionScenario" and relaunch the app
-    And I configure Bugsnag for "CxxExceptionScenario"
-    And I wait to receive a request
-    Then the request is valid for the error reporting API version "4.0" for the "iOS Bugsnag Notifier" notifier
-    And the exception "errorClass" equals "P16kaboom_exception"
-    And the exception "type" equals "cocoa"
-    And the payload field "events.0.exceptions.0.stacktrace" is an array with 0 elements
-
 Scenario: Calling non-existent method
     When I run "NonExistentMethodScenario" and relaunch the app
     And I configure Bugsnag for "NonExistentMethodScenario"
@@ -163,18 +142,6 @@ Scenario: Read a garbage pointer
     And the exception "message" starts with "Attempted to dereference garbage pointer"
     And the exception "errorClass" equals "EXC_BAD_ACCESS"
     And the "method" of stack frame 0 equals "-[ReadGarbagePointerScenario run]"
-
-Scenario: Throw a NSException
-    When I run "ObjCExceptionScenario" and relaunch the app
-    And I configure Bugsnag for "ObjCExceptionScenario"
-    And I wait to receive a request
-    Then the request is valid for the error reporting API version "4.0" for the "iOS Bugsnag Notifier" notifier
-    And the exception "message" equals "An uncaught exception! SCREAM."
-    And the exception "errorClass" equals "NSGenericException"
-    And the "method" of stack frame 0 equals "<redacted>"
-    And the "method" of stack frame 1 equals "objc_exception_throw"
-    And the "method" of stack frame 2 equals "-[ObjCExceptionScenario run]"
-    And the event "device.time" is within 60 seconds of the current timestamp
 
 Scenario: Access a non-object as an object
     When I run "AccessNonObjectScenario" and relaunch the app

--- a/features/fixtures/ios-swift-cocoapods/iOSTestApp.xcodeproj/project.pbxproj
+++ b/features/fixtures/ios-swift-cocoapods/iOSTestApp.xcodeproj/project.pbxproj
@@ -52,6 +52,14 @@
 		E700EE5D247D322D008CFFB6 /* OnSendCallbackOrderScenario.swift in Sources */ = {isa = PBXBuildFile; fileRef = E700EE5C247D322D008CFFB6 /* OnSendCallbackOrderScenario.swift */; };
 		E700EE62247D4D42008CFFB6 /* OnCrashHandlerScenario.m in Sources */ = {isa = PBXBuildFile; fileRef = E700EE61247D4D42008CFFB6 /* OnCrashHandlerScenario.m */; };
 		E700EE65247D6C08008CFFB6 /* OnSendCallbackRemovalScenario.m in Sources */ = {isa = PBXBuildFile; fileRef = E700EE64247D6C08008CFFB6 /* OnSendCallbackRemovalScenario.m */; };
+		E700EE69247D73F8008CFFB6 /* UnhandledMachExceptionScenario.m in Sources */ = {isa = PBXBuildFile; fileRef = E700EE68247D73F8008CFFB6 /* UnhandledMachExceptionScenario.m */; };
+		E700EE6C247D793A008CFFB6 /* SIGPIPEScenario.m in Sources */ = {isa = PBXBuildFile; fileRef = E700EE6B247D793A008CFFB6 /* SIGPIPEScenario.m */; };
+		E700EE6F247D79F6008CFFB6 /* SIGTRAPScenario.m in Sources */ = {isa = PBXBuildFile; fileRef = E700EE6E247D79F6008CFFB6 /* SIGTRAPScenario.m */; };
+		E700EE72247D79FF008CFFB6 /* SIGBUSScenario.m in Sources */ = {isa = PBXBuildFile; fileRef = E700EE71247D79FF008CFFB6 /* SIGBUSScenario.m */; };
+		E700EE75247D7A0C008CFFB6 /* SIGFPEScenario.m in Sources */ = {isa = PBXBuildFile; fileRef = E700EE74247D7A0C008CFFB6 /* SIGFPEScenario.m */; };
+		E700EE78247D7A15008CFFB6 /* SIGILLScenario.m in Sources */ = {isa = PBXBuildFile; fileRef = E700EE77247D7A15008CFFB6 /* SIGILLScenario.m */; };
+		E700EE7B247D7A1F008CFFB6 /* SIGSEGVScenario.m in Sources */ = {isa = PBXBuildFile; fileRef = E700EE7A247D7A1F008CFFB6 /* SIGSEGVScenario.m */; };
+		E700EE7E247D7A61008CFFB6 /* SIGSYSScenario.m in Sources */ = {isa = PBXBuildFile; fileRef = E700EE7D247D7A61008CFFB6 /* SIGSYSScenario.m */; };
 		E75040A02478019D005D33BD /* AutoDetectFalseHandledScenario.swift in Sources */ = {isa = PBXBuildFile; fileRef = E750409F2478019D005D33BD /* AutoDetectFalseHandledScenario.swift */; };
 		E75040A2247801A8005D33BD /* AutoDetectFalseNSExceptionScenario.swift in Sources */ = {isa = PBXBuildFile; fileRef = E75040A1247801A8005D33BD /* AutoDetectFalseNSExceptionScenario.swift */; };
 		E75040A42478052D005D33BD /* AutoDetectFalseAbortScenario.swift in Sources */ = {isa = PBXBuildFile; fileRef = E75040A32478052D005D33BD /* AutoDetectFalseAbortScenario.swift */; };
@@ -179,6 +187,22 @@
 		E700EE61247D4D42008CFFB6 /* OnCrashHandlerScenario.m */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.objc; path = OnCrashHandlerScenario.m; sourceTree = "<group>"; };
 		E700EE63247D6C08008CFFB6 /* OnSendCallbackRemovalScenario.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; path = OnSendCallbackRemovalScenario.h; sourceTree = "<group>"; };
 		E700EE64247D6C08008CFFB6 /* OnSendCallbackRemovalScenario.m */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.objc; path = OnSendCallbackRemovalScenario.m; sourceTree = "<group>"; };
+		E700EE67247D73F8008CFFB6 /* UnhandledMachExceptionScenario.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; path = UnhandledMachExceptionScenario.h; sourceTree = "<group>"; };
+		E700EE68247D73F8008CFFB6 /* UnhandledMachExceptionScenario.m */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.objc; path = UnhandledMachExceptionScenario.m; sourceTree = "<group>"; };
+		E700EE6A247D793A008CFFB6 /* SIGPIPEScenario.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; path = SIGPIPEScenario.h; sourceTree = "<group>"; };
+		E700EE6B247D793A008CFFB6 /* SIGPIPEScenario.m */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.objc; path = SIGPIPEScenario.m; sourceTree = "<group>"; };
+		E700EE6D247D79F6008CFFB6 /* SIGTRAPScenario.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; path = SIGTRAPScenario.h; sourceTree = "<group>"; };
+		E700EE6E247D79F6008CFFB6 /* SIGTRAPScenario.m */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.objc; path = SIGTRAPScenario.m; sourceTree = "<group>"; };
+		E700EE70247D79FF008CFFB6 /* SIGBUSScenario.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; path = SIGBUSScenario.h; sourceTree = "<group>"; };
+		E700EE71247D79FF008CFFB6 /* SIGBUSScenario.m */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.objc; path = SIGBUSScenario.m; sourceTree = "<group>"; };
+		E700EE73247D7A0C008CFFB6 /* SIGFPEScenario.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; path = SIGFPEScenario.h; sourceTree = "<group>"; };
+		E700EE74247D7A0C008CFFB6 /* SIGFPEScenario.m */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.objc; path = SIGFPEScenario.m; sourceTree = "<group>"; };
+		E700EE76247D7A15008CFFB6 /* SIGILLScenario.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; path = SIGILLScenario.h; sourceTree = "<group>"; };
+		E700EE77247D7A15008CFFB6 /* SIGILLScenario.m */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.objc; path = SIGILLScenario.m; sourceTree = "<group>"; };
+		E700EE79247D7A1F008CFFB6 /* SIGSEGVScenario.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; path = SIGSEGVScenario.h; sourceTree = "<group>"; };
+		E700EE7A247D7A1F008CFFB6 /* SIGSEGVScenario.m */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.objc; path = SIGSEGVScenario.m; sourceTree = "<group>"; };
+		E700EE7C247D7A61008CFFB6 /* SIGSYSScenario.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; path = SIGSYSScenario.h; sourceTree = "<group>"; };
+		E700EE7D247D7A61008CFFB6 /* SIGSYSScenario.m */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.objc; path = SIGSYSScenario.m; sourceTree = "<group>"; };
 		E750409F2478019D005D33BD /* AutoDetectFalseHandledScenario.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AutoDetectFalseHandledScenario.swift; sourceTree = "<group>"; };
 		E75040A1247801A8005D33BD /* AutoDetectFalseNSExceptionScenario.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AutoDetectFalseNSExceptionScenario.swift; sourceTree = "<group>"; };
 		E75040A32478052D005D33BD /* AutoDetectFalseAbortScenario.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AutoDetectFalseAbortScenario.swift; sourceTree = "<group>"; };
@@ -348,6 +372,29 @@
 			name = "Event Callbacks";
 			sourceTree = "<group>";
 		};
+		E700EE66247D73B7008CFFB6 /* Unhandled Errors */ = {
+			isa = PBXGroup;
+			children = (
+				E700EE67247D73F8008CFFB6 /* UnhandledMachExceptionScenario.h */,
+				E700EE68247D73F8008CFFB6 /* UnhandledMachExceptionScenario.m */,
+				E700EE6A247D793A008CFFB6 /* SIGPIPEScenario.h */,
+				E700EE6B247D793A008CFFB6 /* SIGPIPEScenario.m */,
+				E700EE70247D79FF008CFFB6 /* SIGBUSScenario.h */,
+				E700EE71247D79FF008CFFB6 /* SIGBUSScenario.m */,
+				E700EE73247D7A0C008CFFB6 /* SIGFPEScenario.h */,
+				E700EE74247D7A0C008CFFB6 /* SIGFPEScenario.m */,
+				E700EE76247D7A15008CFFB6 /* SIGILLScenario.h */,
+				E700EE77247D7A15008CFFB6 /* SIGILLScenario.m */,
+				E700EE79247D7A1F008CFFB6 /* SIGSEGVScenario.h */,
+				E700EE7A247D7A1F008CFFB6 /* SIGSEGVScenario.m */,
+				E700EE6D247D79F6008CFFB6 /* SIGTRAPScenario.h */,
+				E700EE6E247D79F6008CFFB6 /* SIGTRAPScenario.m */,
+				E700EE7C247D7A61008CFFB6 /* SIGSYSScenario.h */,
+				E700EE7D247D7A61008CFFB6 /* SIGSYSScenario.m */,
+			);
+			name = "Unhandled Errors";
+			sourceTree = "<group>";
+		};
 		E750409C24780158005D33BD /* AutoDetectErrors */ = {
 			isa = PBXGroup;
 			children = (
@@ -385,6 +432,7 @@
 				F42954E8B66F3FB7F5333CF7 /* Scenario.m */,
 				F49695AC2445471400105DA9 /* Session stopping */,
 				F49695AB244546CA00105DA9 /* Session tracking */,
+				E700EE66247D73B7008CFFB6 /* Unhandled Errors */,
 				F49695AA244546B000105DA9 /* User */,
 				E75040B324782597005D33BD /* ReleaseStageSessionScenario.swift */,
 			);
@@ -664,6 +712,7 @@
 			isa = PBXSourcesBuildPhase;
 			buildActionMask = 2147483647;
 			files = (
+				E700EE7B247D7A1F008CFFB6 /* SIGSEGVScenario.m in Sources */,
 				E75040A02478019D005D33BD /* AutoDetectFalseHandledScenario.swift in Sources */,
 				8AB8866620404DD30003E444 /* ViewController.swift in Sources */,
 				8AB8866420404DD30003E444 /* AppDelegate.swift in Sources */,
@@ -674,18 +723,21 @@
 				8AA05A2F23BE700C00C7AD00 /* ManyConcurrentNotifyNoBackgroundThreads.m in Sources */,
 				E75040A2247801A8005D33BD /* AutoDetectFalseNSExceptionScenario.swift in Sources */,
 				F4295968571A4118D6A4606A /* UserEnabledScenario.swift in Sources */,
+				E700EE7E247D7A61008CFFB6 /* SIGSYSScenario.m in Sources */,
 				E75040A42478052D005D33BD /* AutoDetectFalseAbortScenario.swift in Sources */,
 				F4295A036B228AF608641699 /* UserDisabledScenario.swift in Sources */,
 				8A14F0F62282D4AE00337B05 /* BuildFile in Sources */,
 				0011E6672403D13100ED71CD /* UserPersistenceScenarios.m in Sources */,
 				8AB65FCC22DC77CB001200AB /* LoadConfigFromFileScenario.swift in Sources */,
 				E7767F13221C21E30006648C /* ResumedSessionScenario.swift in Sources */,
+				E700EE69247D73F8008CFFB6 /* UnhandledMachExceptionScenario.m in Sources */,
 				E75040B12478214F005D33BD /* MetadataRedactionRegexScenario.swift in Sources */,
 				E700EE5B247D3224008CFFB6 /* OriginalErrorNSExceptionScenario.swift in Sources */,
 				8AEFC73120F8D1A000A78779 /* AutoSessionWithUserScenario.m in Sources */,
 				8AB1081923301FE600672818 /* ReleaseStageScenarios.swift in Sources */,
 				8AF6FD7A225E3FA00056EF9E /* ResumeSessionOOMScenario.m in Sources */,
 				00CEB60D24080C690004793D /* EnabledErrorTypesScenario.m in Sources */,
+				E700EE78247D7A15008CFFB6 /* SIGILLScenario.m in Sources */,
 				E75040B22478214F005D33BD /* MetadataRedactionNestedScenario.swift in Sources */,
 				E700EE65247D6C08008CFFB6 /* OnSendCallbackRemovalScenario.m in Sources */,
 				F429565A951303E2C3136D0D /* UserIdScenario.swift in Sources */,
@@ -698,6 +750,7 @@
 				F429502603396F8671B333B3 /* HandledExceptionScenario.swift in Sources */,
 				F4295497A1582010C16F1861 /* AbortScenario.m in Sources */,
 				E75040B424782597005D33BD /* ReleaseStageSessionScenario.swift in Sources */,
+				E700EE75247D7A0C008CFFB6 /* SIGFPEScenario.m in Sources */,
 				8AF8FCAE22BD23BA00A967CA /* HandledInternalNotifyScenario.swift in Sources */,
 				8A42FD35225DEE04007AE561 /* SessionOOMScenario.m in Sources */,
 				F4295CEAD7C915EFA04898A5 /* Scenario.m in Sources */,
@@ -713,6 +766,7 @@
 				E700EE59247D321B008CFFB6 /* OriginalErrorNSErrorScenario.swift in Sources */,
 				F42953498545B853CC0B635E /* NullPointerScenario.m in Sources */,
 				E75040B02478214F005D33BD /* MetadataRedactionDefaultScenario.swift in Sources */,
+				E700EE6C247D793A008CFFB6 /* SIGPIPEScenario.m in Sources */,
 				8A840FBA21AF5C450041DBFA /* SwiftAssertion.swift in Sources */,
 				001E5502243B8FDA0009E31D /* AutoCaptureRunScenario.m in Sources */,
 				E700EE55247D3204008CFFB6 /* OnSendOverwriteScenario.swift in Sources */,
@@ -722,6 +776,7 @@
 				F4295B56219D228FAA99BC14 /* ObjCExceptionScenario.m in Sources */,
 				F4295218A62E41518DC3C057 /* AccessNonObjectScenario.m in Sources */,
 				8A72A0382396574F00328051 /* CustomPluginNotifierDescriptionScenario.m in Sources */,
+				E700EE72247D79FF008CFFB6 /* SIGBUSScenario.m in Sources */,
 				E7767F11221C21D90006648C /* StoppedSessionScenario.swift in Sources */,
 				F4295D19B9E67F5786011698 /* OverwriteLinkRegisterScenario.m in Sources */,
 				F42959124DB949EEF1420957 /* ReadOnlyPageScenario.m in Sources */,
@@ -737,6 +792,7 @@
 				E700EE53247D31EA008CFFB6 /* OnErrorOverwriteScenario.swift in Sources */,
 				8AEFC79920F9132C00A78779 /* AutoSessionHandledEventsScenario.m in Sources */,
 				0037410F2473CF2300BE41AA /* AppAndDeviceAttributesScenario.swift in Sources */,
+				E700EE6F247D79F6008CFFB6 /* SIGTRAPScenario.m in Sources */,
 				F4295A0B0DA0AF3B5502D29C /* PrivilegedInstructionScenario.m in Sources */,
 				F42958BE5DDACDBF653CA926 /* ManualSessionScenario.m in Sources */,
 				F42951BF19D7F35A03273CFB /* AutoSessionScenario.m in Sources */,

--- a/features/fixtures/ios-swift-cocoapods/iOSTestApp/scenarios/SIGBUSScenario.h
+++ b/features/fixtures/ios-swift-cocoapods/iOSTestApp/scenarios/SIGBUSScenario.h
@@ -1,0 +1,18 @@
+//
+//  SIGBUSScenario.h
+//  iOSTestApp
+//
+//  Created by Jamie Lynch on 26/05/2020.
+//  Copyright © 2020 Bugsnag. All rights reserved.
+//
+
+#import <Foundation/Foundation.h>
+#import "Scenario.h"
+
+NS_ASSUME_NONNULL_BEGIN
+
+@interface SIGBUSScenario : Scenario
+
+@end
+
+NS_ASSUME_NONNULL_END

--- a/features/fixtures/ios-swift-cocoapods/iOSTestApp/scenarios/SIGBUSScenario.m
+++ b/features/fixtures/ios-swift-cocoapods/iOSTestApp/scenarios/SIGBUSScenario.m
@@ -1,0 +1,22 @@
+//
+//  SIGBUSScenario.m
+//  iOSTestApp
+//
+//  Created by Jamie Lynch on 26/05/2020.
+//  Copyright © 2020 Bugsnag. All rights reserved.
+//
+
+#import "SIGBUSScenario.h"
+
+@implementation SIGBUSScenario
+
+- (void)startBugsnag {
+    self.config.autoTrackSessions = NO;
+    [super startBugsnag];
+}
+
+- (void)run {
+    raise(SIGBUS);
+}
+
+@end

--- a/features/fixtures/ios-swift-cocoapods/iOSTestApp/scenarios/SIGFPEScenario.h
+++ b/features/fixtures/ios-swift-cocoapods/iOSTestApp/scenarios/SIGFPEScenario.h
@@ -1,0 +1,18 @@
+//
+//  SIGFPEScenario.h
+//  iOSTestApp
+//
+//  Created by Jamie Lynch on 26/05/2020.
+//  Copyright © 2020 Bugsnag. All rights reserved.
+//
+
+#import <Foundation/Foundation.h>
+#import "Scenario.h"
+
+NS_ASSUME_NONNULL_BEGIN
+
+@interface SIGFPEScenario : Scenario
+
+@end
+
+NS_ASSUME_NONNULL_END

--- a/features/fixtures/ios-swift-cocoapods/iOSTestApp/scenarios/SIGFPEScenario.m
+++ b/features/fixtures/ios-swift-cocoapods/iOSTestApp/scenarios/SIGFPEScenario.m
@@ -1,0 +1,22 @@
+//
+//  SIGFPEScenario.m
+//  iOSTestApp
+//
+//  Created by Jamie Lynch on 26/05/2020.
+//  Copyright © 2020 Bugsnag. All rights reserved.
+//
+
+#import "SIGFPEScenario.h"
+
+@implementation SIGFPEScenario
+
+- (void)startBugsnag {
+    self.config.autoTrackSessions = NO;
+    [super startBugsnag];
+}
+
+- (void)run {
+    raise(SIGFPE);
+}
+
+@end

--- a/features/fixtures/ios-swift-cocoapods/iOSTestApp/scenarios/SIGILLScenario.h
+++ b/features/fixtures/ios-swift-cocoapods/iOSTestApp/scenarios/SIGILLScenario.h
@@ -1,0 +1,18 @@
+//
+//  SIGILLScenario.h
+//  iOSTestApp
+//
+//  Created by Jamie Lynch on 26/05/2020.
+//  Copyright © 2020 Bugsnag. All rights reserved.
+//
+
+#import <Foundation/Foundation.h>
+#import "Scenario.h"
+
+NS_ASSUME_NONNULL_BEGIN
+
+@interface SIGILLScenario : Scenario
+
+@end
+
+NS_ASSUME_NONNULL_END

--- a/features/fixtures/ios-swift-cocoapods/iOSTestApp/scenarios/SIGILLScenario.m
+++ b/features/fixtures/ios-swift-cocoapods/iOSTestApp/scenarios/SIGILLScenario.m
@@ -1,0 +1,22 @@
+//
+//  SIGILLScenario.m
+//  iOSTestApp
+//
+//  Created by Jamie Lynch on 26/05/2020.
+//  Copyright © 2020 Bugsnag. All rights reserved.
+//
+
+#import "SIGILLScenario.h"
+
+@implementation SIGILLScenario
+
+- (void)startBugsnag {
+    self.config.autoTrackSessions = NO;
+    [super startBugsnag];
+}
+
+- (void)run {
+    raise(SIGILL);
+}
+
+@end

--- a/features/fixtures/ios-swift-cocoapods/iOSTestApp/scenarios/SIGPIPEScenario.h
+++ b/features/fixtures/ios-swift-cocoapods/iOSTestApp/scenarios/SIGPIPEScenario.h
@@ -1,0 +1,18 @@
+//
+//  SIGPIPEScenario.h
+//  iOSTestApp
+//
+//  Created by Jamie Lynch on 26/05/2020.
+//  Copyright © 2020 Bugsnag. All rights reserved.
+//
+
+#import <Foundation/Foundation.h>
+#import "Scenario.h"
+
+NS_ASSUME_NONNULL_BEGIN
+
+@interface SIGPIPEScenario : Scenario
+
+@end
+
+NS_ASSUME_NONNULL_END

--- a/features/fixtures/ios-swift-cocoapods/iOSTestApp/scenarios/SIGPIPEScenario.m
+++ b/features/fixtures/ios-swift-cocoapods/iOSTestApp/scenarios/SIGPIPEScenario.m
@@ -1,0 +1,22 @@
+//
+//  SIGPIPEScenario.m
+//  iOSTestApp
+//
+//  Created by Jamie Lynch on 26/05/2020.
+//  Copyright © 2020 Bugsnag. All rights reserved.
+//
+
+#import "SIGPIPEScenario.h"
+
+@implementation SIGPIPEScenario
+
+- (void)startBugsnag {
+    self.config.autoTrackSessions = NO;
+    [super startBugsnag];
+}
+
+- (void)run {
+    raise(SIGPIPE);
+}
+
+@end

--- a/features/fixtures/ios-swift-cocoapods/iOSTestApp/scenarios/SIGSEGVScenario.h
+++ b/features/fixtures/ios-swift-cocoapods/iOSTestApp/scenarios/SIGSEGVScenario.h
@@ -1,0 +1,18 @@
+//
+//  SIGSEGVScenario.h
+//  iOSTestApp
+//
+//  Created by Jamie Lynch on 26/05/2020.
+//  Copyright © 2020 Bugsnag. All rights reserved.
+//
+
+#import <Foundation/Foundation.h>
+#import "Scenario.h"
+
+NS_ASSUME_NONNULL_BEGIN
+
+@interface SIGSEGVScenario : Scenario
+
+@end
+
+NS_ASSUME_NONNULL_END

--- a/features/fixtures/ios-swift-cocoapods/iOSTestApp/scenarios/SIGSEGVScenario.m
+++ b/features/fixtures/ios-swift-cocoapods/iOSTestApp/scenarios/SIGSEGVScenario.m
@@ -1,0 +1,22 @@
+//
+//  SIGSEGVScenario.m
+//  iOSTestApp
+//
+//  Created by Jamie Lynch on 26/05/2020.
+//  Copyright © 2020 Bugsnag. All rights reserved.
+//
+
+#import "SIGSEGVScenario.h"
+
+@implementation SIGSEGVScenario
+
+- (void)startBugsnag {
+    self.config.autoTrackSessions = NO;
+    [super startBugsnag];
+}
+
+- (void)run {
+    raise(SIGSEGV);
+}
+
+@end

--- a/features/fixtures/ios-swift-cocoapods/iOSTestApp/scenarios/SIGSYSScenario.h
+++ b/features/fixtures/ios-swift-cocoapods/iOSTestApp/scenarios/SIGSYSScenario.h
@@ -1,0 +1,18 @@
+//
+//  SIGSYSScenario.h
+//  iOSTestApp
+//
+//  Created by Jamie Lynch on 26/05/2020.
+//  Copyright © 2020 Bugsnag. All rights reserved.
+//
+
+#import <Foundation/Foundation.h>
+#import "Scenario.h"
+
+NS_ASSUME_NONNULL_BEGIN
+
+@interface SIGSYSScenario : Scenario
+
+@end
+
+NS_ASSUME_NONNULL_END

--- a/features/fixtures/ios-swift-cocoapods/iOSTestApp/scenarios/SIGSYSScenario.m
+++ b/features/fixtures/ios-swift-cocoapods/iOSTestApp/scenarios/SIGSYSScenario.m
@@ -1,0 +1,22 @@
+//
+//  SIGSYSScenario.m
+//  iOSTestApp
+//
+//  Created by Jamie Lynch on 26/05/2020.
+//  Copyright © 2020 Bugsnag. All rights reserved.
+//
+
+#import "SIGSYSScenario.h"
+
+@implementation SIGSYSScenario
+
+- (void)startBugsnag {
+    self.config.autoTrackSessions = NO;
+    [super startBugsnag];
+}
+
+- (void)run {
+    raise(SIGSYS);
+}
+
+@end

--- a/features/fixtures/ios-swift-cocoapods/iOSTestApp/scenarios/SIGTRAPScenario.h
+++ b/features/fixtures/ios-swift-cocoapods/iOSTestApp/scenarios/SIGTRAPScenario.h
@@ -1,0 +1,18 @@
+//
+//  SIGTRAPScenario.h
+//  iOSTestApp
+//
+//  Created by Jamie Lynch on 26/05/2020.
+//  Copyright © 2020 Bugsnag. All rights reserved.
+//
+
+#import <Foundation/Foundation.h>
+#import "Scenario.h"
+
+NS_ASSUME_NONNULL_BEGIN
+
+@interface SIGTRAPScenario : Scenario
+
+@end
+
+NS_ASSUME_NONNULL_END

--- a/features/fixtures/ios-swift-cocoapods/iOSTestApp/scenarios/SIGTRAPScenario.m
+++ b/features/fixtures/ios-swift-cocoapods/iOSTestApp/scenarios/SIGTRAPScenario.m
@@ -1,0 +1,22 @@
+//
+//  SIGTRAPScenario.m
+//  iOSTestApp
+//
+//  Created by Jamie Lynch on 26/05/2020.
+//  Copyright © 2020 Bugsnag. All rights reserved.
+//
+
+#import "SIGTRAPScenario.h"
+
+@implementation SIGTRAPScenario
+
+- (void)startBugsnag {
+    self.config.autoTrackSessions = NO;
+    [super startBugsnag];
+}
+
+- (void)run {
+    raise(SIGTRAP);
+}
+
+@end

--- a/features/fixtures/ios-swift-cocoapods/iOSTestApp/scenarios/UnhandledMachExceptionScenario.h
+++ b/features/fixtures/ios-swift-cocoapods/iOSTestApp/scenarios/UnhandledMachExceptionScenario.h
@@ -1,0 +1,18 @@
+//
+//  UnhandledMachExceptionScenario.h
+//  iOSTestApp
+//
+//  Created by Jamie Lynch on 26/05/2020.
+//  Copyright © 2020 Bugsnag. All rights reserved.
+//
+
+#import <Foundation/Foundation.h>
+#import "Scenario.h"
+
+NS_ASSUME_NONNULL_BEGIN
+
+@interface UnhandledMachExceptionScenario : Scenario
+
+@end
+
+NS_ASSUME_NONNULL_END

--- a/features/fixtures/ios-swift-cocoapods/iOSTestApp/scenarios/UnhandledMachExceptionScenario.m
+++ b/features/fixtures/ios-swift-cocoapods/iOSTestApp/scenarios/UnhandledMachExceptionScenario.m
@@ -1,0 +1,29 @@
+//
+//  UnhandledMachExceptionScenario.m
+//  iOSTestApp
+//
+//  Created by Jamie Lynch on 26/05/2020.
+//  Copyright © 2020 Bugsnag. All rights reserved.
+//
+
+#import "UnhandledMachExceptionScenario.h"
+
+@implementation UnhandledMachExceptionScenario
+
+- (void)startBugsnag {
+    self.config.autoTrackSessions = NO;
+    [super startBugsnag];
+}
+
+#pragma clang diagnostic push
+#pragma clang diagnostic ignored "-Winvalid-noreturn"
+- (void)run  __attribute__((noreturn)) {
+    // Send a handled exception to confirm the scenario is running.
+    [Bugsnag notify:[NSException exceptionWithName:NSGenericException reason:@"UnhandledMachExceptionScenario" userInfo:@{NSLocalizedDescriptionKey: @""}]];
+    dispatch_after(dispatch_time(DISPATCH_TIME_NOW, (int64_t)(2 * NSEC_PER_SEC)), dispatch_get_main_queue(), ^{
+        strcmp(0, ""); // Generate EXC_BAD_ACCESS (see e.g. https://stackoverflow.com/q/22488358/2431627)
+    });
+}
+#pragma clang diagnostic pop
+
+@end

--- a/features/unhandled_cpp_exception.feature
+++ b/features/unhandled_cpp_exception.feature
@@ -1,0 +1,10 @@
+Feature: Thrown C++ exceptions are captured by Bugsnag
+
+Scenario: Throwing a C++ exception
+    When I run "CxxExceptionScenario" and relaunch the app
+    And I configure Bugsnag for "CxxExceptionScenario"
+    And I wait to receive a request
+    Then the request is valid for the error reporting API version "4.0" for the "iOS Bugsnag Notifier" notifier
+    And the exception "errorClass" equals "P16kaboom_exception"
+    And the exception "type" equals "cocoa"
+    And the payload field "events.0.exceptions.0.stacktrace" is an array with 0 elements

--- a/features/unhandled_mach_exception.feature
+++ b/features/unhandled_mach_exception.feature
@@ -1,0 +1,7 @@
+Feature: Bugsnag captures an unhandled mach exception
+
+Scenario: Trigger a mach exception
+    When I run "UnhandledMachExceptionScenario" and relaunch the app
+    And I configure Bugsnag for "UnhandledMachExceptionScenario"
+    And I wait to receive a request
+    Then the request is valid for the error reporting API version "4.0" for the "iOS Bugsnag Notifier" notifier

--- a/features/unhandled_mach_exception.feature
+++ b/features/unhandled_mach_exception.feature
@@ -5,3 +5,4 @@ Scenario: Trigger a mach exception
     And I configure Bugsnag for "UnhandledMachExceptionScenario"
     And I wait to receive a request
     Then the request is valid for the error reporting API version "4.0" for the "iOS Bugsnag Notifier" notifier
+    And the event "exceptions.0.message" equals "UnhandledMachExceptionScenario"

--- a/features/unhandled_nsexception.feature
+++ b/features/unhandled_nsexception.feature
@@ -1,0 +1,13 @@
+Feature: Uncaught NSExceptions are captured by Bugsnag
+
+Scenario: Throw a NSException
+    When I run "ObjCExceptionScenario" and relaunch the app
+    And I configure Bugsnag for "ObjCExceptionScenario"
+    And I wait to receive a request
+    Then the request is valid for the error reporting API version "4.0" for the "iOS Bugsnag Notifier" notifier
+    And the exception "message" equals "An uncaught exception! SCREAM."
+    And the exception "errorClass" equals "NSGenericException"
+    And the "method" of stack frame 0 equals "<redacted>"
+    And the "method" of stack frame 1 equals "objc_exception_throw"
+    And the "method" of stack frame 2 equals "-[ObjCExceptionScenario run]"
+    And the event "device.time" is within 60 seconds of the current timestamp

--- a/features/unhandled_signal.feature
+++ b/features/unhandled_signal.feature
@@ -1,0 +1,69 @@
+Feature: Signals are captured as error reports in Bugsnag
+
+Scenario: Triggering SIGABRT
+    When I run "AbortScenario" and relaunch the app
+    And I configure Bugsnag for "AbortScenario"
+    And I wait to receive a request
+    Then the request is valid for the error reporting API version "4.0" for the "iOS Bugsnag Notifier" notifier
+    And the payload field "events" is an array with 1 elements
+    And the exception "errorClass" equals "SIGABRT"
+    And the "method" of stack frame 0 equals "__pthread_kill"
+    And the "method" of stack frame 1 equals "<redacted>"
+    And the "method" of stack frame 2 equals "abort"
+    And the "method" of stack frame 3 equals "-[AbortScenario run]"
+
+Scenario: Triggering SIGPIPE
+    When I run "SIGPIPEScenario" and relaunch the app
+    And I configure Bugsnag for "SIGPIPEScenario"
+    And I wait to receive a request
+    Then the request is valid for the error reporting API version "4.0" for the "iOS Bugsnag Notifier" notifier
+    And the payload field "events" is an array with 1 elements
+    And the exception "errorClass" equals "SIGPIPE"
+
+Scenario: Triggering SIGBUS
+    When I run "SIGBUSScenario" and relaunch the app
+    And I configure Bugsnag for "SIGBUSScenario"
+    And I wait to receive a request
+    Then the request is valid for the error reporting API version "4.0" for the "iOS Bugsnag Notifier" notifier
+    And the payload field "events" is an array with 1 elements
+    And the exception "errorClass" equals "SIGBUS"
+
+Scenario: Triggering SIGFPE
+    When I run "SIGFPEScenario" and relaunch the app
+    And I configure Bugsnag for "SIGFPEScenario"
+    And I wait to receive a request
+    Then the request is valid for the error reporting API version "4.0" for the "iOS Bugsnag Notifier" notifier
+    And the payload field "events" is an array with 1 elements
+    And the exception "errorClass" equals "SIGFPE"
+
+Scenario: Triggering SIGILL
+    When I run "SIGILLScenario" and relaunch the app
+    And I configure Bugsnag for "SIGILLScenario"
+    And I wait to receive a request
+    Then the request is valid for the error reporting API version "4.0" for the "iOS Bugsnag Notifier" notifier
+    And the payload field "events" is an array with 1 elements
+    And the exception "errorClass" equals "SIGILL"
+
+Scenario: Triggering SIGSEGV
+    When I run "SIGSEGVScenario" and relaunch the app
+    And I configure Bugsnag for "SIGSEGVScenario"
+    And I wait to receive a request
+    Then the request is valid for the error reporting API version "4.0" for the "iOS Bugsnag Notifier" notifier
+    And the payload field "events" is an array with 1 elements
+    And the exception "errorClass" equals "SIGSEGV"
+
+Scenario: Triggering SIGSYS
+    When I run "SIGSYSScenario" and relaunch the app
+    And I configure Bugsnag for "SIGSYSScenario"
+    And I wait to receive a request
+    Then the request is valid for the error reporting API version "4.0" for the "iOS Bugsnag Notifier" notifier
+    And the payload field "events" is an array with 1 elements
+    And the exception "errorClass" equals "SIGSYS"
+
+Scenario: Triggering SIGTRAP
+    When I run "SIGTRAPScenario" and relaunch the app
+    And I configure Bugsnag for "SIGTRAPScenario"
+    And I wait to receive a request
+    Then the request is valid for the error reporting API version "4.0" for the "iOS Bugsnag Notifier" notifier
+    And the payload field "events" is an array with 1 elements
+    And the exception "errorClass" equals "SIGTRAP"


### PR DESCRIPTION
## Goal

Adds E2E scenarios to verify that an error is captured for each different signal that Bugsnag sets a signal handler for. This changeset additionally moves existing unhandled scenarios from `crashprobe.feature` into a separate file to make test tracing more obvious.

## Changeset

- Added E2E scenarios to verify an error report is captured for all the signals Bugsnag sets a handler for
- Moved existing scenarios for NSException, mach exception, and C++ exception
