### PR TITLE
fix: App version is now set preferentially from supplied config

### DIFF
--- a/Source/BugsnagApp.m
+++ b/Source/BugsnagApp.m
@@ -43,7 +43,10 @@ NSDictionary *BSGParseAppMetadata(NSDictionary *event) {
                      codeBundleId:(NSString *)codeBundleId
 {
     BugsnagApp *app = [BugsnagApp new];
-    [self populateFields:app dictionary:event config:config codeBundleId:codeBundleId];
+    [self populateFields:app
+              dictionary:event
+                  config:config
+            codeBundleId:codeBundleId];
     return app;
 }
 
@@ -56,7 +59,10 @@ NSDictionary *BSGParseAppMetadata(NSDictionary *event) {
     app.id = system[@"CFBundleIdentifier"];
     app.bundleVersion = [event valueForKeyPath:@"user.config.bundleVersion"] ?: system[@"CFBundleVersion"];
     app.dsymUuid = system[@"app_uuid"];
-    app.version = [event valueForKeyPath:@"user.config.appVersion"] ?: system[@"CFBundleShortVersionString"];
+    // Preferentially take App version values from the event, the config and the system
+    app.version = [event valueForKeyPath:@"user.config.appVersion"] ?:
+        ([config valueForKey:@"appVersion"] ?:
+            system[@"CFBundleShortVersionString"]);
     app.releaseStage = [event valueForKeyPath:@"user.config.releaseStage"] ?: config.releaseStage;
     app.codeBundleId = codeBundleId;
     app.type = config.appType;

--- a/Source/BugsnagSessionTracker.m
+++ b/Source/BugsnagSessionTracker.m
@@ -144,7 +144,9 @@ NSString *const BSGSessionUpdateNotification = @"BugsnagSessionChanged";
     }
 
     NSDictionary *systemInfo = [BSG_KSSystemInfo systemInfo];
-    BugsnagApp *app = [BugsnagApp appWithDictionary:@{@"system": systemInfo} config:self.config codeBundleId:self.codeBundleId];
+    BugsnagApp *app = [BugsnagApp appWithDictionary:@{@"system": systemInfo}
+                                             config:self.config
+                                       codeBundleId:self.codeBundleId];
     BugsnagDevice *device = [BugsnagDevice deviceWithDictionary:@{@"system": systemInfo}];
     [device appendRuntimeInfo:self.extraRuntimeInfo];
 

--- a/Tests/BugsnagAppTest.m
+++ b/Tests/BugsnagAppTest.m
@@ -62,6 +62,7 @@
 
     self.config = [[BugsnagConfiguration alloc] initWithApiKey:DUMMY_APIKEY_32CHAR_1];
     self.config.appType = @"iOS";
+    self.config.appVersion = @"3.14.159";
     self.codeBundleId = @"bundle-123";
 }
 
@@ -75,7 +76,7 @@
     XCTAssertEqualObjects(@"com.example.foo.MyIosApp", app.id);
     XCTAssertEqualObjects(@"beta", app.releaseStage);
     XCTAssertEqualObjects(@"iOS", app.type);
-    XCTAssertEqualObjects(@"5.6.3", app.version);
+    XCTAssertEqualObjects(@"3.14.159", app.version);
 }
 
 - (void)testAppWithState {
@@ -93,10 +94,11 @@
     XCTAssertEqualObjects(@"com.example.foo.MyIosApp", app.id);
     XCTAssertEqualObjects(@"beta", app.releaseStage);
     XCTAssertEqualObjects(@"iOS", app.type);
-    XCTAssertEqualObjects(@"5.6.3", app.version);
+    XCTAssertEqualObjects(@"3.14.159", app.version);
 }
 
 - (void)testAppToDict {
+    self.config.appVersion = nil; // Check that the system value is picked up
     BugsnagApp *app = [BugsnagApp appWithDictionary:self.data config:self.config codeBundleId:self.codeBundleId];
     NSDictionary *dict = [app toDict];
 
@@ -111,6 +113,7 @@
 }
 
 - (void)testAppWithStateToDict {
+    self.config.appVersion = nil; // Check that the system value is picked up
     BugsnagAppWithState *app = [BugsnagAppWithState appWithDictionary:self.data config:self.config codeBundleId:self.codeBundleId];
     NSDictionary *dict = [app toDict];
 


### PR DESCRIPTION
## Goal

<!-- Why is this change necessary? -->
Sessions were not honouring `config.appVersion`.

## Changeset

`BugsnagApp`

## Tests

Added a value to the relevant config, set it to `nil` to ensure that system value is still picked up correctly when required.
