### PR TITLE
Make sessions respect enabledReleaseStages

### DIFF
--- a/Source/BugsnagSessionTracker.m
+++ b/Source/BugsnagSessionTracker.m
@@ -138,6 +138,10 @@ NSString *const BSGSessionUpdateNotification = @"BugsnagSessionChanged";
 }
 
 - (void)startNewSessionWithAutoCaptureValue:(BOOL)isAutoCaptured {
+    NSSet<NSString *> *releaseStages = self.config.enabledReleaseStages;
+    if (releaseStages != nil && ![releaseStages containsObject:self.config.releaseStage]) {
+        return;
+    }
     if (self.config.sessionURL == nil) {
         bsg_log_err(@"The session tracking endpoint has not been set. Session tracking is disabled");
         return;


### PR DESCRIPTION
## Goal

`config.enabledReleaseStages` should control whether events or sessions are captured. Previously this flag only controlled whether events should be captured, therefore we need to add similar logic to the `BugsnagSessionTracker` class to check the release stage.

Discovered as part of #621, which has tests for this.
