### PR TITLE
Sessions should use user supplied by client

### DIFF
--- a/Source/BugsnagClient.m
+++ b/Source/BugsnagClient.m
@@ -404,6 +404,7 @@ NSString *_lastOrientation = nil;
         });
 
         self.sessionTracker = [[BugsnagSessionTracker alloc] initWithConfig:self.configuration
+                                                                     client:self
                                                          postRecordCallback:^(BugsnagSession *session) {
                                                              BSGWriteSessionCrashData(session);
                                                          }];

--- a/Source/BugsnagSessionTracker.h
+++ b/Source/BugsnagSessionTracker.h
@@ -27,6 +27,7 @@ extern NSString *const BSGSessionUpdateNotification;
  @return A new session tracker
  */
 - (instancetype)initWithConfig:(BugsnagConfiguration *)config
+                        client:(BugsnagClient *)client
             postRecordCallback:(void(^)(BugsnagSession *))callback;
 
 /**

--- a/Source/BugsnagSessionTracker.m
+++ b/Source/BugsnagSessionTracker.m
@@ -6,6 +6,7 @@
 //  Copyright © 2017 Bugsnag. All rights reserved.
 //
 
+#import "BugsnagClient.h"
 #import "BugsnagSessionTracker.h"
 #import "BugsnagSessionFileStore.h"
 #import "BSG_KSLogger.h"
@@ -55,6 +56,7 @@ NSString *const BSGSessionUpdateNotification = @"BugsnagSessionChanged";
 
 @interface BugsnagSessionTracker ()
 @property (weak, nonatomic) BugsnagConfiguration *config;
+@property (weak, nonatomic) BugsnagClient *client;
 @property (strong, nonatomic) BugsnagSessionFileStore *sessionStore;
 @property (strong, nonatomic) BugsnagSessionTrackingApiClient *apiClient;
 @property (strong, nonatomic) NSDate *backgroundStartTime;
@@ -72,9 +74,11 @@ NSString *const BSGSessionUpdateNotification = @"BugsnagSessionChanged";
 @implementation BugsnagSessionTracker
 
 - (instancetype)initWithConfig:(BugsnagConfiguration *)config
+                        client:(BugsnagClient *)client
             postRecordCallback:(void(^)(BugsnagSession *))callback {
     if (self = [super init]) {
         _config = config;
+        _client = client;
         _apiClient = [[BugsnagSessionTrackingApiClient alloc] initWithConfig:config queueName:@"Session API queue"];
         _callback = callback;
 
@@ -156,7 +160,7 @@ NSString *const BSGSessionUpdateNotification = @"BugsnagSessionChanged";
 
     BugsnagSession *newSession = [[BugsnagSession alloc] initWithId:[[NSUUID UUID] UUIDString]
                                                           startDate:[NSDate date]
-                                                               user:self.config.user
+                                                               user:self.client.user
                                                        autoCaptured:isAutoCaptured
                                                                 app:app
                                                              device:device];

--- a/Tests/BugsnagConfigurationTests.m
+++ b/Tests/BugsnagConfigurationTests.m
@@ -81,7 +81,7 @@
     config.endpoints = [[BugsnagEndpointConfiguration alloc] initWithNotify:@"http://notify.example.com"
                                                                    sessions:@""];
     BugsnagSessionTracker *sessionTracker
-            = [[BugsnagSessionTracker alloc] initWithConfig:config postRecordCallback:nil];
+    = [[BugsnagSessionTracker alloc] initWithConfig:config client:nil postRecordCallback:nil];
 
     XCTAssertNil(sessionTracker.runningSession);
     [sessionTracker startNewSession];
@@ -93,7 +93,7 @@
     config.endpoints = [[BugsnagEndpointConfiguration alloc] initWithNotify:@"http://notify.example.com"
                                                                    sessions:@"f"];
     BugsnagSessionTracker *sessionTracker
-            = [[BugsnagSessionTracker alloc] initWithConfig:config postRecordCallback:nil];
+    = [[BugsnagSessionTracker alloc] initWithConfig:config client:nil postRecordCallback:nil];
 
     XCTAssertNil(sessionTracker.runningSession);
     [sessionTracker startNewSession];

--- a/Tests/BugsnagSessionTrackerStopTest.m
+++ b/Tests/BugsnagSessionTrackerStopTest.m
@@ -26,7 +26,7 @@
     [super setUp];
     self.configuration = [[BugsnagConfiguration alloc] initWithApiKey:DUMMY_APIKEY_32CHAR_1];
     self.configuration.autoTrackSessions = NO;
-    self.tracker = [[BugsnagSessionTracker alloc] initWithConfig:self.configuration postRecordCallback:nil];
+    self.tracker = [[BugsnagSessionTracker alloc] initWithConfig:self.configuration client:nil postRecordCallback:nil];
 }
 
 /**

--- a/Tests/BugsnagSessionTrackerTest.m
+++ b/Tests/BugsnagSessionTrackerTest.m
@@ -41,6 +41,7 @@
     self.configuration = [[BugsnagConfiguration alloc] initWithApiKey:DUMMY_APIKEY_32CHAR_1];
     [self.configuration deletePersistedUserData];
     self.sessionTracker = [[BugsnagSessionTracker alloc] initWithConfig:self.configuration
+                                                                 client:nil
                                                      postRecordCallback:nil];
 }
 
@@ -63,9 +64,6 @@
     XCTAssertNotNil(session);
     XCTAssertNotNil(session.id);
     XCTAssertTrue([[NSDate date] timeIntervalSinceDate:session.startedAt] < 1);
-    XCTAssertEqual(session.user.name, @"Bill");
-    XCTAssertEqual(session.user.id, @"123");
-    XCTAssertNil(session.user.email);
     XCTAssertFalse(session.autoCaptured);
 }
 
@@ -92,9 +90,6 @@
     XCTAssertNotNil(session);
     XCTAssertNotNil(session.id);
     XCTAssertTrue([[NSDate date] timeIntervalSinceDate:session.startedAt] < 1);
-    XCTAssertEqual(session.user.name, @"Bill");
-    XCTAssertEqual(session.user.id, @"123");
-    XCTAssertEqual(session.user.email, @"bill@example.com");
     XCTAssertTrue(session.autoCaptured);
 }
 
@@ -149,6 +144,7 @@
         return NO;
     }];
     self.sessionTracker = [[BugsnagSessionTracker alloc] initWithConfig:self.configuration
+                                                                 client:nil
                                                      postRecordCallback:nil];
     [self.sessionTracker startNewSession];
     XCTAssertNil(self.sessionTracker.currentSession);
@@ -163,6 +159,7 @@
         return YES;
     }];
     self.sessionTracker = [[BugsnagSessionTracker alloc] initWithConfig:self.configuration
+                                                                 client:nil
                                                      postRecordCallback:nil];
     [self.sessionTracker startNewSession];
     [self waitForExpectations:@[expectation] timeout:2];

--- a/features/session_tracking.feature
+++ b/features/session_tracking.feature
@@ -15,7 +15,7 @@ Scenario: Launching using the default configuration sends a single session
 
     And the session "id" is not null
     And the session "startedAt" is not null
-    And the session "user.id" is null
+    And the session "user.id" is not null
     And the session "user.email" is null
     And the session "user.name" is null
 
@@ -34,7 +34,7 @@ Scenario: Configuring a custom version sends it in a session request
 
     And the session "id" is not null
     And the session "startedAt" is not null
-    And the session "user.id" is null
+    And the session "user.id" is not null
     And the session "user.email" is null
     And the session "user.name" is null
 


### PR DESCRIPTION
## Goal

The session payload uses the user object supplied by Configuration. It should use the object from Client instead as this can be updated after Bugsnag has been initialised.

See #631 for tests to cover this functionality
