### PR TITLE
Catch NSException raised in callback blocks

### DIFF
--- a/Source/BugsnagClient.m
+++ b/Source/BugsnagClient.m
@@ -1006,8 +1006,12 @@ NSString *const BSGBreadcrumbLoadedMessage = @"Bugsnag loaded";
 - (void)notifyInternal:(BugsnagEvent *_Nonnull)event
                  block:(BugsnagOnErrorBlock)block
 {
-    if (block != nil && !block(event)) { // skip notifying if callback false
-        return;
+    @try {
+        if (block != nil && !block(event)) { // skip notifying if callback false
+            return;
+        }
+    } @catch (NSException *exception) {
+        bsg_log_err(@"Error from onError callback: %@", exception);
     }
 
     if (event.handledState.unhandled) {

--- a/Source/BugsnagSessionTracker.m
+++ b/Source/BugsnagSessionTracker.m
@@ -158,10 +158,15 @@ NSString *const BSGSessionUpdateNotification = @"BugsnagSessionChanged";
                                                              device:device];
 
     for (BugsnagOnSessionBlock onSessionBlock in self.config.onSessionBlocks) {
-        if (!onSessionBlock(newSession)) {
-            return;
+        @try {
+            if (!onSessionBlock(newSession)) {
+                return;
+            }
+        } @catch (NSException *exception) {
+            bsg_log_err(@"Error from onSession callback: %@", exception);
         }
     }
+
     self.currentSession = newSession;
     [self.sessionStore write:self.currentSession];
 


### PR DESCRIPTION
## Goal

Callback blocks should catch NSException as we can prevent user code from crashing the app and discarding the report. This was not implemented for `OnError` and `OnSession` - this changeset adds that.