### PR TITLE
Add E2E scenarios for session callbacks

### DIFF
--- a/features/fixtures/ios-swift-cocoapods/iOSTestApp.xcodeproj/project.pbxproj
+++ b/features/fixtures/ios-swift-cocoapods/iOSTestApp.xcodeproj/project.pbxproj
@@ -81,6 +81,11 @@
 		E7A324ED247E9DB3008B0052 /* BreadcrumbCallbackRemovalScenario.m in Sources */ = {isa = PBXBuildFile; fileRef = E7A324EC247E9DB3008B0052 /* BreadcrumbCallbackRemovalScenario.m */; };
 		E7A324EF247E9DBC008B0052 /* BreadcrumbCallbackCrashScenario.swift in Sources */ = {isa = PBXBuildFile; fileRef = E7A324EE247E9DBC008B0052 /* BreadcrumbCallbackCrashScenario.swift */; };
 		E7B79CDA24800A5D0039FB88 /* MetadataMergeScenario.swift in Sources */ = {isa = PBXBuildFile; fileRef = E7B79CD924800A5D0039FB88 /* MetadataMergeScenario.swift */; };
+		E7A324D8247E70B2008B0052 /* SessionCallbackOverrideScenario.swift in Sources */ = {isa = PBXBuildFile; fileRef = E7A324D7247E70B2008B0052 /* SessionCallbackOverrideScenario.swift */; };
+		E7A324DA247E70C4008B0052 /* SessionCallbackCrashScenario.swift in Sources */ = {isa = PBXBuildFile; fileRef = E7A324D9247E70C4008B0052 /* SessionCallbackCrashScenario.swift */; };
+		E7A324DE247E70E6008B0052 /* SessionCallbackOrderScenario.swift in Sources */ = {isa = PBXBuildFile; fileRef = E7A324DD247E70E6008B0052 /* SessionCallbackOrderScenario.swift */; };
+		E7A324E0247E70F9008B0052 /* SessionCallbackDiscardScenario.swift in Sources */ = {isa = PBXBuildFile; fileRef = E7A324DF247E70F9008B0052 /* SessionCallbackDiscardScenario.swift */; };
+		E7A324E3247E7C17008B0052 /* SessionCallbackRemovalScenario.m in Sources */ = {isa = PBXBuildFile; fileRef = E7A324E2247E7C17008B0052 /* SessionCallbackRemovalScenario.m */; };
 		E7DD40452473D980000EDC14 /* UserDefaultInfoScenario.swift in Sources */ = {isa = PBXBuildFile; fileRef = E7DD40442473D980000EDC14 /* UserDefaultInfoScenario.swift */; };
 		F429502603396F8671B333B3 /* HandledExceptionScenario.swift in Sources */ = {isa = PBXBuildFile; fileRef = F429526319377A8848136413 /* HandledExceptionScenario.swift */; };
 		F4295109FCAB93708FDAFE12 /* DisabledSessionTrackingScenario.m in Sources */ = {isa = PBXBuildFile; fileRef = F429563584D9BC3A5B86BECF /* DisabledSessionTrackingScenario.m */; };
@@ -237,6 +242,12 @@
 		E7A324EC247E9DB3008B0052 /* BreadcrumbCallbackRemovalScenario.m */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.objc; path = BreadcrumbCallbackRemovalScenario.m; sourceTree = "<group>"; };
 		E7A324EE247E9DBC008B0052 /* BreadcrumbCallbackCrashScenario.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = BreadcrumbCallbackCrashScenario.swift; sourceTree = "<group>"; };
 		E7B79CD924800A5D0039FB88 /* MetadataMergeScenario.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = MetadataMergeScenario.swift; sourceTree = "<group>"; };
+		E7A324D7247E70B2008B0052 /* SessionCallbackOverrideScenario.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SessionCallbackOverrideScenario.swift; sourceTree = "<group>"; };
+		E7A324D9247E70C4008B0052 /* SessionCallbackCrashScenario.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SessionCallbackCrashScenario.swift; sourceTree = "<group>"; };
+		E7A324DD247E70E6008B0052 /* SessionCallbackOrderScenario.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SessionCallbackOrderScenario.swift; sourceTree = "<group>"; };
+		E7A324DF247E70F9008B0052 /* SessionCallbackDiscardScenario.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SessionCallbackDiscardScenario.swift; sourceTree = "<group>"; };
+		E7A324E1247E7C17008B0052 /* SessionCallbackRemovalScenario.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; path = SessionCallbackRemovalScenario.h; sourceTree = "<group>"; };
+		E7A324E2247E7C17008B0052 /* SessionCallbackRemovalScenario.m */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.objc; path = SessionCallbackRemovalScenario.m; sourceTree = "<group>"; };
 		E7DD40442473D980000EDC14 /* UserDefaultInfoScenario.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = UserDefaultInfoScenario.swift; sourceTree = "<group>"; };
 		E7F6087B244F0A3A00F1532A /* BugsnagHooks.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; path = BugsnagHooks.h; sourceTree = "<group>"; };
 		EE18B3777C62D7BCA8DDBE30 /* Pods-iOSTestApp.debug.xcconfig */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.xcconfig; name = "Pods-iOSTestApp.debug.xcconfig"; path = "Pods/Target Support Files/Pods-iOSTestApp/Pods-iOSTestApp.debug.xcconfig"; sourceTree = "<group>"; };
@@ -451,6 +462,19 @@
 			name = "Breadcrumb Callbacks";
 			sourceTree = "<group>";
 		};
+		E7A324D4247E707D008B0052 /* Session Callbacks */ = {
+			isa = PBXGroup;
+			children = (
+				E7A324DF247E70F9008B0052 /* SessionCallbackDiscardScenario.swift */,
+				E7A324DD247E70E6008B0052 /* SessionCallbackOrderScenario.swift */,
+				E7A324D7247E70B2008B0052 /* SessionCallbackOverrideScenario.swift */,
+				E7A324D9247E70C4008B0052 /* SessionCallbackCrashScenario.swift */,
+				E7A324E1247E7C17008B0052 /* SessionCallbackRemovalScenario.h */,
+				E7A324E2247E7C17008B0052 /* SessionCallbackRemovalScenario.m */,
+			);
+			name = "Session Callbacks";
+			sourceTree = "<group>";
+		};
 		F42953DE2BB41023C0B07F41 /* scenarios */ = {
 			isa = PBXGroup;
 			children = (
@@ -467,6 +491,7 @@
 				8AB1081823301FE600672818 /* ReleaseStageScenarios.swift */,
 				F4295ABA693D273D52AA9F6B /* Scenario.h */,
 				F42954E8B66F3FB7F5333CF7 /* Scenario.m */,
+				E7A324D4247E707D008B0052 /* Session Callbacks */,
 				F49695AC2445471400105DA9 /* Session stopping */,
 				F49695AB244546CA00105DA9 /* Session tracking */,
 				E700EE66247D73B7008CFFB6 /* Unhandled Errors */,
@@ -823,6 +848,7 @@
 				8AEFC73420F8D1BB00A78779 /* ManualSessionWithUserScenario.m in Sources */,
 				F4295B56219D228FAA99BC14 /* ObjCExceptionScenario.m in Sources */,
 				F4295218A62E41518DC3C057 /* AccessNonObjectScenario.m in Sources */,
+				E7A324E0247E70F9008B0052 /* SessionCallbackDiscardScenario.swift in Sources */,
 				8A72A0382396574F00328051 /* CustomPluginNotifierDescriptionScenario.m in Sources */,
 				E700EE72247D79FF008CFFB6 /* SIGBUSScenario.m in Sources */,
 				E7767F11221C21D90006648C /* StoppedSessionScenario.swift in Sources */,
@@ -832,10 +858,14 @@
 				F42951A9FD696D9047149DA8 /* UndefinedInstructionScenario.m in Sources */,
 				E7A324E6247E9D8D008B0052 /* BreadcrumbCallbackDiscardScenario.swift in Sources */,
 				00432CC4240912A100826D05 /* EnabledErrorTypesCxxScenario.mm in Sources */,
+				E7A324DE247E70E6008B0052 /* SessionCallbackOrderScenario.swift in Sources */,
+				E7A324DA247E70C4008B0052 /* SessionCallbackCrashScenario.swift in Sources */,
 				F49695A62441098600105DA9 /* OOMBackgroundScenario.m in Sources */,
 				E7DD40452473D980000EDC14 /* UserDefaultInfoScenario.swift in Sources */,
+				E7A324E3247E7C17008B0052 /* SessionCallbackRemovalScenario.m in Sources */,
 				E7767F15221C223C0006648C /* NewSessionScenario.swift in Sources */,
 				F42951BEB2518C610A85FE0D /* BuiltinTrapScenario.m in Sources */,
+				E7A324D8247E70B2008B0052 /* SessionCallbackOverrideScenario.swift in Sources */,
 				8AEFC79C20F92E2200A78779 /* AutoSessionUnhandledScenario.m in Sources */,
 				E700EE4E247D1317008CFFB6 /* UserFromClientScenario.swift in Sources */,
 				E7B79CDA24800A5D0039FB88 /* MetadataMergeScenario.swift in Sources */,

--- a/features/fixtures/ios-swift-cocoapods/iOSTestApp/scenarios/DiscardSessionScenario.swift
+++ b/features/fixtures/ios-swift-cocoapods/iOSTestApp/scenarios/DiscardSessionScenario.swift
@@ -1,0 +1,9 @@
+//
+//  DiscardSessionScenario.swift
+//  iOSTestApp
+//
+//  Created by Jamie Lynch on 27/05/2020.
+//  Copyright © 2020 Bugsnag. All rights reserved.
+//
+
+import Foundation

--- a/features/fixtures/ios-swift-cocoapods/iOSTestApp/scenarios/SessionCallbackCrashScenario.swift
+++ b/features/fixtures/ios-swift-cocoapods/iOSTestApp/scenarios/SessionCallbackCrashScenario.swift
@@ -1,0 +1,39 @@
+//
+//  SessionCallbackCrashScenario.swift
+//  iOSTestApp
+//
+//  Created by Jamie Lynch on 27/05/2020.
+//  Copyright © 2020 Bugsnag. All rights reserved.
+//
+
+import Foundation
+
+class SessionCallbackCrashScenario : Scenario {
+
+    override func startBugsnag() {
+        self.config.autoTrackSessions = false;
+        self.config.addOnSession { (session) -> Bool in
+            session.app.id = "someAppId"
+            session.setUser("placeholderId", withEmail: nil, andName: nil)
+
+            // crash the callback, subsequent modifications don't take place
+            NSException(name: NSExceptionName("HandledExceptionScenario"),
+            reason: "Message: HandledExceptionScenario",
+                userInfo: nil).raise()
+
+            session.setUser("Jimmy", withEmail: nil, andName: nil)
+            return true
+        }
+
+        // overwrite app ID set in first callback
+        self.config.addOnSession { (session) -> Bool in
+            session.app.id = "customAppId"
+            return true
+        }
+        super.startBugsnag()
+    }
+
+    override func run() {
+        Bugsnag.startSession()
+    }
+}

--- a/features/fixtures/ios-swift-cocoapods/iOSTestApp/scenarios/SessionCallbackDiscardScenario.swift
+++ b/features/fixtures/ios-swift-cocoapods/iOSTestApp/scenarios/SessionCallbackDiscardScenario.swift
@@ -1,0 +1,30 @@
+//
+//  SessionCallbackDiscardScenario.swift
+//  iOSTestApp
+//
+//  Created by Jamie Lynch on 27/05/2020.
+//  Copyright © 2020 Bugsnag. All rights reserved.
+//
+
+import Foundation
+
+class SessionCallbackDiscardScenario : Scenario {
+
+    override func startBugsnag() {
+        self.config.autoTrackSessions = false;
+
+        var count = 0
+        self.config.addOnSession { (session) -> Bool in
+            // discard anything other than the first request
+            count += 1
+            return count == 1
+        }
+        super.startBugsnag()
+    }
+
+    override func run() {
+        Bugsnag.startSession()
+        Bugsnag.startSession()
+        Bugsnag.startSession()
+    }
+}

--- a/features/fixtures/ios-swift-cocoapods/iOSTestApp/scenarios/SessionCallbackOrderScenario.swift
+++ b/features/fixtures/ios-swift-cocoapods/iOSTestApp/scenarios/SessionCallbackOrderScenario.swift
@@ -1,0 +1,32 @@
+//
+//  SessionCallbackOrderScenario.swift
+//  iOSTestApp
+//
+//  Created by Jamie Lynch on 27/05/2020.
+//  Copyright © 2020 Bugsnag. All rights reserved.
+//
+
+import Foundation
+
+class SessionCallbackOrderScenario : Scenario {
+
+    override func startBugsnag() {
+        self.config.autoTrackSessions = false;
+
+        var count = 0
+        self.config.addOnSession { (session) -> Bool in
+            session.app.id = "First callback: \(count)"
+            count += 1
+            return true
+        }
+        self.config.addOnSession { (session) -> Bool in
+            session.device.id = "Second callback: \(count)"
+            return true
+        }
+        super.startBugsnag()
+    }
+
+    override func run() {
+        Bugsnag.startSession()
+    }
+}

--- a/features/fixtures/ios-swift-cocoapods/iOSTestApp/scenarios/SessionCallbackOverrideScenario.swift
+++ b/features/fixtures/ios-swift-cocoapods/iOSTestApp/scenarios/SessionCallbackOverrideScenario.swift
@@ -1,0 +1,27 @@
+//
+//  SessionCallbackOverrideScenario.swift
+//  iOSTestApp
+//
+//  Created by Jamie Lynch on 27/05/2020.
+//  Copyright © 2020 Bugsnag. All rights reserved.
+//
+
+import Foundation
+
+class SessionCallbackOverrideScenario : Scenario {
+
+    override func startBugsnag() {
+        self.config.autoTrackSessions = false;
+        self.config.addOnSession { (session) -> Bool in
+            session.app.id = "customAppId"
+            session.device.id = "customDeviceId"
+            session.setUser("customUserId", withEmail: nil, andName: nil)
+            return true
+        }
+        super.startBugsnag()
+    }
+
+    override func run() {
+        Bugsnag.startSession()
+    }
+}

--- a/features/fixtures/ios-swift-cocoapods/iOSTestApp/scenarios/SessionCallbackRemovalScenario.h
+++ b/features/fixtures/ios-swift-cocoapods/iOSTestApp/scenarios/SessionCallbackRemovalScenario.h
@@ -1,0 +1,18 @@
+//
+//  SessionCallbackRemovalScenario.h
+//  iOSTestApp
+//
+//  Created by Jamie Lynch on 27/05/2020.
+//  Copyright © 2020 Bugsnag. All rights reserved.
+//
+
+#import <Foundation/Foundation.h>
+#import "Scenario.h"
+
+NS_ASSUME_NONNULL_BEGIN
+
+@interface SessionCallbackRemovalScenario : Scenario
+
+@end
+
+NS_ASSUME_NONNULL_END

--- a/features/fixtures/ios-swift-cocoapods/iOSTestApp/scenarios/SessionCallbackRemovalScenario.m
+++ b/features/fixtures/ios-swift-cocoapods/iOSTestApp/scenarios/SessionCallbackRemovalScenario.m
@@ -1,0 +1,37 @@
+//
+//  SessionCallbackRemovalScenario.m
+//  iOSTestApp
+//
+//  Created by Jamie Lynch on 27/05/2020.
+//  Copyright © 2020 Bugsnag. All rights reserved.
+//
+
+#import "SessionCallbackRemovalScenario.h"
+#import "BugsnagSession.h"
+
+@implementation SessionCallbackRemovalScenario
+
+- (void)startBugsnag {
+    self.config.autoTrackSessions = false;
+
+    [self.config addOnSessionBlock:^BOOL(BugsnagSession * _Nonnull session) {
+        session.app.id = @"customAppId";
+        session.device.id = @"customDeviceId";
+        return true;
+    }];
+
+    id block = ^BOOL(BugsnagSession * _Nonnull session) {
+        session.app.id = nil;
+        session.device.id = nil;
+        return true;
+    };
+    [self.config addOnSessionBlock:block];
+    [self.config removeOnSessionBlock:block];
+    [super startBugsnag];
+}
+
+- (void)run {
+    [Bugsnag startSession];
+}
+
+@end

--- a/features/session_callbacks.feature
+++ b/features/session_callbacks.feature
@@ -1,0 +1,35 @@
+Feature: Callbacks can access and modify session information
+
+Scenario: Returning false in a callback discards sessions
+    When I run "SessionCallbackDiscardScenario"
+    And I wait to receive a request
+    And the request is valid for the session reporting API version "1.0" for the "iOS Bugsnag Notifier" notifier
+
+Scenario: Callbacks execute in the order in which they were added
+    When I run "SessionCallbackOrderScenario"
+    And I wait to receive a request
+    And the request is valid for the session reporting API version "1.0" for the "iOS Bugsnag Notifier" notifier
+    And the payload field "app.id" equals "First callback: 0"
+    And the payload field "device.id" equals "Second callback: 1"
+
+Scenario: Modifying session information with a callback
+    When I run "SessionCallbackOverrideScenario"
+    And I wait to receive a request
+    And the request is valid for the session reporting API version "1.0" for the "iOS Bugsnag Notifier" notifier
+    And the payload field "app.id" equals "customAppId"
+    And the payload field "device.id" equals "customDeviceId"
+    And the session "user.id" equals "customUserId"
+
+Scenario: Callbacks can be removed without affecting the functionality of other callbacks
+    When I run "SessionCallbackRemovalScenario"
+    And I wait to receive a request
+    And the request is valid for the session reporting API version "1.0" for the "iOS Bugsnag Notifier" notifier
+    And the payload field "app.id" equals "customAppId"
+    And the payload field "device.id" equals "customDeviceId"
+
+Scenario: An uncaught NSException in a callback does not affect session delivery
+    When I run "SessionCallbackCrashScenario"
+    And I wait to receive a request
+    And the request is valid for the session reporting API version "1.0" for the "iOS Bugsnag Notifier" notifier
+    And the payload field "app.id" equals "customAppId"
+    And the session "user.id" equals "placeholderId"

--- a/features/session_tracking.feature
+++ b/features/session_tracking.feature
@@ -13,7 +13,7 @@ Scenario: Launching using the default configuration sends a single session
     And the payload field "device.osName" equals "iOS"
     And the payload field "device.model" matches the test device model
 
-    And the session "id" is not null
+    And the payload field "sessions.0.id" is a UUID
     And the payload field "sessions.0.startedAt" is a parsable timestamp in seconds
     And the session "user.id" is not null
     And the session "user.email" is null
@@ -32,7 +32,7 @@ Scenario: Configuring a custom version sends it in a session request
     And the payload field "device.osName" equals "iOS"
     And the payload field "device.model" matches the test device model
 
-    And the session "id" is not null
+    And the payload field "sessions.0.id" is a UUID
     And the payload field "sessions.0.startedAt" is a parsable timestamp in seconds
     And the session "user.id" is not null
     And the session "user.email" is null
@@ -44,7 +44,8 @@ Scenario: Configuring user info sends it with auto-captured sessions
     And the request is valid for the session reporting API version "1.0" for the "iOS Bugsnag Notifier" notifier
     And the payload field "notifier.name" equals "iOS Bugsnag Notifier"
     And the payload field "sessions" is an array with 1 elements
-    And the session "id" is not null
+    And the payload field "sessions.0.id" is a UUID
+    And the payload field "sessions.0.startedAt" is a parsable timestamp in seconds
     And the session "user.id" equals "123"
     And the session "user.email" equals "joe@example.com"
     And the session "user.name" equals "Joe Bloggs"
@@ -55,7 +56,8 @@ Scenario: Configuring user info sends it with manually captured sessions
     And the request is valid for the session reporting API version "1.0" for the "iOS Bugsnag Notifier" notifier
     And the payload field "notifier.name" equals "iOS Bugsnag Notifier"
     And the payload field "sessions" is an array with 1 elements
-    And the session "id" is not null
+    And the payload field "sessions.0.id" is a UUID
+    And the payload field "sessions.0.startedAt" is a parsable timestamp in seconds
     And the session "user.id" equals "123"
     And the session "user.email" equals "joe@example.com"
     And the session "user.name" equals "Joe Bloggs"
@@ -66,7 +68,7 @@ Scenario: Disabling auto-capture and calling startSession() manually sends a sin
     And the request is valid for the session reporting API version "1.0" for the "iOS Bugsnag Notifier" notifier
     And the payload field "notifier.name" equals "iOS Bugsnag Notifier"
     And the payload field "sessions" is an array with 1 elements
-    And the session "id" is not null
+    And the payload field "sessions.0.id" is a UUID
     And the payload field "sessions.0.startedAt" is a parsable timestamp in seconds
     # This behaviour isn't established yet
     # And the session "user.id" is null
@@ -105,7 +107,7 @@ Scenario: Encountering an unhandled event during a session
     And I wait to receive 2 requests
     Then the request is valid for the session reporting API version "1.0" for the "iOS Bugsnag Notifier" notifier
     And the payload field "sessions" is an array with 1 elements
-    And the session "id" is not null
+    And the payload field "sessions.0.id" is a UUID
     And the payload field "sessions.0.startedAt" is a parsable timestamp in seconds
     And the payload field "sessions.0.id" is stored as the value "session_id"
     And I discard the oldest request
@@ -124,7 +126,7 @@ Scenario: Encountering handled and unhandled events during a session
     And I wait to receive 3 requests
     Then the request is valid for the session reporting API version "1.0" for the "iOS Bugsnag Notifier" notifier
     And the payload field "sessions" is an array with 1 elements
-    And the session "id" is not null
+    And the payload field "sessions.0.id" is a UUID
     And the payload field "sessions.0.startedAt" is a parsable timestamp in seconds
     And the payload field "sessions.0.id" is stored as the value "session_id"
     And I discard the oldest request

--- a/features/session_tracking.feature
+++ b/features/session_tracking.feature
@@ -14,7 +14,7 @@ Scenario: Launching using the default configuration sends a single session
     And the payload field "device.model" matches the test device model
 
     And the session "id" is not null
-    And the session "startedAt" is not null
+    And the payload field "sessions.0.startedAt" is a parsable timestamp in seconds
     And the session "user.id" is not null
     And the session "user.email" is null
     And the session "user.name" is null
@@ -33,7 +33,7 @@ Scenario: Configuring a custom version sends it in a session request
     And the payload field "device.model" matches the test device model
 
     And the session "id" is not null
-    And the session "startedAt" is not null
+    And the payload field "sessions.0.startedAt" is a parsable timestamp in seconds
     And the session "user.id" is not null
     And the session "user.email" is null
     And the session "user.name" is null
@@ -67,7 +67,7 @@ Scenario: Disabling auto-capture and calling startSession() manually sends a sin
     And the payload field "notifier.name" equals "iOS Bugsnag Notifier"
     And the payload field "sessions" is an array with 1 elements
     And the session "id" is not null
-    And the session "startedAt" is not null
+    And the payload field "sessions.0.startedAt" is a parsable timestamp in seconds
     # This behaviour isn't established yet
     # And the session "user.id" is null
     # And the session "user.email" is null
@@ -106,7 +106,7 @@ Scenario: Encountering an unhandled event during a session
     Then the request is valid for the session reporting API version "1.0" for the "iOS Bugsnag Notifier" notifier
     And the payload field "sessions" is an array with 1 elements
     And the session "id" is not null
-    And the session "startedAt" is not null
+    And the payload field "sessions.0.startedAt" is a parsable timestamp in seconds
     And the payload field "sessions.0.id" is stored as the value "session_id"
     And I discard the oldest request
 
@@ -125,7 +125,7 @@ Scenario: Encountering handled and unhandled events during a session
     Then the request is valid for the session reporting API version "1.0" for the "iOS Bugsnag Notifier" notifier
     And the payload field "sessions" is an array with 1 elements
     And the session "id" is not null
-    And the session "startedAt" is not null
+    And the payload field "sessions.0.startedAt" is a parsable timestamp in seconds
     And the payload field "sessions.0.id" is stored as the value "session_id"
     And I discard the oldest request
 

--- a/features/steps/v6uatsteps.rb
+++ b/features/steps/v6uatsteps.rb
@@ -28,3 +28,12 @@ Then(/^the payload field "(.+)" is a date$/) do |field_path|
     date = Date.parse(value) rescue nil
     assert_kind_of Date, date
 end
+
+# UUID
+
+Then(/^the payload field "(.+)" is a UUID$/) do |field_path|
+    value = read_key_path(Server.current_request[:body], field_path)
+    assert_not_nil(value, "Expected UUID, got nil for #{field_path}")
+    match = /[A-F0-9-]{36}/.match(value).size() > 0
+    assert_true(match, "Field #{field_path} is not a UUID, received #{value}")
+end


### PR DESCRIPTION
## Goal

Adds E2E scenarios to cover session callbacks functionality.

## Changeset

- Updated `startedAt` checks to verify the field is a timestamp
- Added scenarios to verify that:
  - sessions can be discarded by returning false in a callback
  - callbacks are run in the order in which they are added
  - exceptions thrown in the callback do not discard the session
  - callbacks allow for the modification of session data
  - `removeOnSession()` removes callbacks