### PR TITLE
Address bug in enabledBreadcrumbTypes record logic

### DIFF
--- a/OSX/Bugsnag.xcodeproj/project.pbxproj
+++ b/OSX/Bugsnag.xcodeproj/project.pbxproj
@@ -206,6 +206,7 @@
 		E79E6BDA1F4E3850002B35F9 /* BSG_RFC3339DateTool.m in Sources */ = {isa = PBXBuildFile; fileRef = E79E6B6E1F4E3850002B35F9 /* BSG_RFC3339DateTool.m */; };
 		E79E6BDB1F4E3850002B35F9 /* BSG_KSCrashReportFilter.h in Headers */ = {isa = PBXBuildFile; fileRef = E79E6B711F4E3850002B35F9 /* BSG_KSCrashReportFilter.h */; };
 		E79E6BDC1F4E3850002B35F9 /* BSG_KSCrashReportFilterCompletion.h in Headers */ = {isa = PBXBuildFile; fileRef = E79E6B721F4E3850002B35F9 /* BSG_KSCrashReportFilterCompletion.h */; };
+		E7A324F3247EB542008B0052 /* BugsnagEnabledBreadcrumbTest.m in Sources */ = {isa = PBXBuildFile; fileRef = E7A324F2247EB542008B0052 /* BugsnagEnabledBreadcrumbTest.m */; };
 		E7A5679D245B0511009BE2F1 /* BugsnagClientPayloadInfoTest.m in Sources */ = {isa = PBXBuildFile; fileRef = E7A5678A245AE7AF009BE2F1 /* BugsnagClientPayloadInfoTest.m */; };
 		E7A8EA65246181AA00CCBBD1 /* TestsInfo.plist in Resources */ = {isa = PBXBuildFile; fileRef = E7A8EA64246181AA00CCBBD1 /* TestsInfo.plist */; };
 		E7A9E56924361B6300D99F8A /* BugsnagAppTest.m in Sources */ = {isa = PBXBuildFile; fileRef = E790C4A22434CB6A006FFB26 /* BugsnagAppTest.m */; };
@@ -462,6 +463,7 @@
 		E79E6B6E1F4E3850002B35F9 /* BSG_RFC3339DateTool.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; name = BSG_RFC3339DateTool.m; path = ../Source/KSCrash/Source/KSCrash/Recording/Tools/BSG_RFC3339DateTool.m; sourceTree = SOURCE_ROOT; };
 		E79E6B711F4E3850002B35F9 /* BSG_KSCrashReportFilter.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; name = BSG_KSCrashReportFilter.h; path = ../Source/KSCrash/Source/KSCrash/Reporting/Filters/BSG_KSCrashReportFilter.h; sourceTree = SOURCE_ROOT; };
 		E79E6B721F4E3850002B35F9 /* BSG_KSCrashReportFilterCompletion.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; name = BSG_KSCrashReportFilterCompletion.h; path = ../Source/KSCrash/Source/KSCrash/Reporting/Filters/BSG_KSCrashReportFilterCompletion.h; sourceTree = SOURCE_ROOT; };
+		E7A324F2247EB542008B0052 /* BugsnagEnabledBreadcrumbTest.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; path = BugsnagEnabledBreadcrumbTest.m; sourceTree = "<group>"; };
 		E7A5678A245AE7AF009BE2F1 /* BugsnagClientPayloadInfoTest.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; path = BugsnagClientPayloadInfoTest.m; sourceTree = "<group>"; };
 		E7A8EA64246181AA00CCBBD1 /* TestsInfo.plist */ = {isa = PBXFileReference; lastKnownFileType = text.plist; path = TestsInfo.plist; sourceTree = SOURCE_ROOT; };
 		E7A9E56C2436365300D99F8A /* BugsnagDeviceTest.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; path = BugsnagDeviceTest.m; sourceTree = "<group>"; };
@@ -599,6 +601,7 @@
 				4B775FD222CBE02A004839C5 /* BugsnagCollectionsBSGDictInsertIfNotNilTest.m */,
 				8AD9FA851E0862DC002859A7 /* BugsnagConfigurationTests.m */,
 				E7A9E56C2436365300D99F8A /* BugsnagDeviceTest.m */,
+				E7A324F2247EB542008B0052 /* BugsnagEnabledBreadcrumbTest.m */,
 				E73D443B243E192F001686F5 /* BugsnagErrorTest.m */,
 				00D7ACA223E984B300FBE4A7 /* BugsnagEventTests.m */,
 				E796993C24699F810032F35A /* BugsnagEventPersistLoadTest.m */,
@@ -1265,6 +1268,7 @@
 				E7CE78BE1FD94E77001D07E0 /* KSCrashSentry_NSException_Tests.m in Sources */,
 				E7CE78C21FD94E77001D07E0 /* KSDynamicLinker_Tests.m in Sources */,
 				E722105E243B6A0F0083CF15 /* BugsnagStackframeTest.m in Sources */,
+				E7A324F3247EB542008B0052 /* BugsnagEnabledBreadcrumbTest.m in Sources */,
 				E7CE78CA1FD94E77001D07E0 /* KSString_Tests.m in Sources */,
 				E762E9F91F73F7F300E82B43 /* BugsnagHandledStateTest.m in Sources */,
 				E7CE78C51FD94E77001D07E0 /* KSLogger_Tests.m in Sources */,

--- a/Source/BugsnagConfiguration.m
+++ b/Source/BugsnagConfiguration.m
@@ -475,8 +475,8 @@ NSString * const kBugsnagUserUserId = @"BugsnagUserUserId";
  */
 - (BOOL)shouldRecordBreadcrumbType:(BSGBreadcrumbType)type {
     // enabledBreadcrumbTypes is BSGEnabledBreadcrumbTypeNone
-    if (!self.enabledBreadcrumbTypes) {
-        return YES;
+    if (self.enabledBreadcrumbTypes == BSGEnabledBreadcrumbTypeNone && type != BSGBreadcrumbTypeManual) {
+        return NO;
     }
 
     switch (type) {

--- a/Tests/BugsnagEnabledBreadcrumbTest.m
+++ b/Tests/BugsnagEnabledBreadcrumbTest.m
@@ -1,0 +1,62 @@
+//
+//  BugsnagEnabledBreadcrumbTest.m
+//  Tests
+//
+//  Created by Jamie Lynch on 27/05/2020.
+//  Copyright © 2020 Bugsnag. All rights reserved.
+//
+
+#import <XCTest/XCTest.h>
+#import "BugsnagConfiguration.h"
+#import "BugsnagTestConstants.h"
+
+@interface BugsnagConfiguration ()
+- (BOOL)shouldRecordBreadcrumbType:(BSGBreadcrumbType)type;
+@end
+
+@interface BugsnagEnabledBreadcrumbTest : XCTestCase
+
+@end
+
+@implementation BugsnagEnabledBreadcrumbTest
+
+- (void)testEnabledBreadcrumbNone {
+    BugsnagConfiguration *config = [[BugsnagConfiguration alloc] initWithApiKey:DUMMY_APIKEY_32CHAR_1];
+    config.enabledBreadcrumbTypes = BSGEnabledBreadcrumbTypeNone;
+    XCTAssertTrue([config shouldRecordBreadcrumbType:BSGBreadcrumbTypeManual]);
+    XCTAssertFalse([config shouldRecordBreadcrumbType:BSGBreadcrumbTypeError]);
+    XCTAssertFalse([config shouldRecordBreadcrumbType:BSGBreadcrumbTypeLog]);
+    XCTAssertFalse([config shouldRecordBreadcrumbType:BSGBreadcrumbTypeNavigation]);
+    XCTAssertFalse([config shouldRecordBreadcrumbType:BSGBreadcrumbTypeProcess]);
+    XCTAssertFalse([config shouldRecordBreadcrumbType:BSGBreadcrumbTypeRequest]);
+    XCTAssertFalse([config shouldRecordBreadcrumbType:BSGBreadcrumbTypeState]);
+    XCTAssertFalse([config shouldRecordBreadcrumbType:BSGBreadcrumbTypeUser]);
+}
+
+- (void)testEnabledBreadcrumbLog {
+    BugsnagConfiguration *config = [[BugsnagConfiguration alloc] initWithApiKey:DUMMY_APIKEY_32CHAR_1];
+    config.enabledBreadcrumbTypes = BSGEnabledBreadcrumbTypeLog;
+    XCTAssertTrue([config shouldRecordBreadcrumbType:BSGBreadcrumbTypeManual]);
+    XCTAssertFalse([config shouldRecordBreadcrumbType:BSGBreadcrumbTypeError]);
+    XCTAssertTrue([config shouldRecordBreadcrumbType:BSGBreadcrumbTypeLog]);
+    XCTAssertFalse([config shouldRecordBreadcrumbType:BSGBreadcrumbTypeNavigation]);
+    XCTAssertFalse([config shouldRecordBreadcrumbType:BSGBreadcrumbTypeProcess]);
+    XCTAssertFalse([config shouldRecordBreadcrumbType:BSGBreadcrumbTypeRequest]);
+    XCTAssertFalse([config shouldRecordBreadcrumbType:BSGBreadcrumbTypeState]);
+    XCTAssertFalse([config shouldRecordBreadcrumbType:BSGBreadcrumbTypeUser]);
+}
+
+- (void)testEnabledBreadcrumbMulti {
+    BugsnagConfiguration *config = [[BugsnagConfiguration alloc] initWithApiKey:DUMMY_APIKEY_32CHAR_1];
+    config.enabledBreadcrumbTypes = BSGEnabledBreadcrumbTypeState | BSGEnabledBreadcrumbTypeNavigation;
+    XCTAssertTrue([config shouldRecordBreadcrumbType:BSGBreadcrumbTypeManual]);
+    XCTAssertFalse([config shouldRecordBreadcrumbType:BSGBreadcrumbTypeError]);
+    XCTAssertFalse([config shouldRecordBreadcrumbType:BSGBreadcrumbTypeLog]);
+    XCTAssertTrue([config shouldRecordBreadcrumbType:BSGBreadcrumbTypeNavigation]);
+    XCTAssertFalse([config shouldRecordBreadcrumbType:BSGBreadcrumbTypeProcess]);
+    XCTAssertFalse([config shouldRecordBreadcrumbType:BSGBreadcrumbTypeRequest]);
+    XCTAssertTrue([config shouldRecordBreadcrumbType:BSGBreadcrumbTypeState]);
+    XCTAssertFalse([config shouldRecordBreadcrumbType:BSGBreadcrumbTypeUser]);
+}
+
+@end

--- a/features/breadcrumbs.feature
+++ b/features/breadcrumbs.feature
@@ -15,7 +15,6 @@ Feature: Attaching a series of notable events leading up to errors
         And I wait to receive a request
         Then the event has a "log" breadcrumb named "Noisy event"
         And the event has a "process" breadcrumb named "Important event"
-        Then the event has a "state" breadcrumb named "Bugsnag loaded"
 
     Scenario: An app lauches and subsequently sends a manual event using notify()
         When I run "HandledErrorScenario"

--- a/iOS/Bugsnag.xcodeproj/project.pbxproj
+++ b/iOS/Bugsnag.xcodeproj/project.pbxproj
@@ -14,12 +14,6 @@
 		000E6EA523D8AC8C009D8194 /* VERSION in Resources */ = {isa = PBXBuildFile; fileRef = 000E6EA123D8AC8C009D8194 /* VERSION */; };
 		000E6EA623D8AC8C009D8194 /* CHANGELOG.md in Resources */ = {isa = PBXBuildFile; fileRef = 000E6EA223D8AC8C009D8194 /* CHANGELOG.md */; };
 		0016B28A246EDC9A002B34C8 /* BugsnagSwiftPublicAPITests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 0016B289246EDC9A002B34C8 /* BugsnagSwiftPublicAPITests.swift */; };
-		004A41CE23FE91070092DF97 /* Security.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = 004A41CD23FE91070092DF97 /* Security.framework */; };
-		0061D84724067AF80041C068 /* LICENSE in Resources */ = {isa = PBXBuildFile; fileRef = 0061D84424067AF70041C068 /* LICENSE */; };
-		0061D84824067AF80041C068 /* LICENSE in Resources */ = {isa = PBXBuildFile; fileRef = 0061D84424067AF70041C068 /* LICENSE */; };
-		0061D84924067AF80041C068 /* BSG_SSKeychain.m in Sources */ = {isa = PBXBuildFile; fileRef = 0061D84524067AF70041C068 /* BSG_SSKeychain.m */; };
-		0061D84A24067AF80041C068 /* BSG_SSKeychain.m in Sources */ = {isa = PBXBuildFile; fileRef = 0061D84524067AF70041C068 /* BSG_SSKeychain.m */; };
-		0061D84B24067AF80041C068 /* BSG_SSKeychain.h in Headers */ = {isa = PBXBuildFile; fileRef = 0061D84624067AF80041C068 /* BSG_SSKeychain.h */; };
 		0071CB4B2460213200F562B1 /* BSG_KSMachHeaders.m in Sources */ = {isa = PBXBuildFile; fileRef = 0071CB4A2460213200F562B1 /* BSG_KSMachHeaders.m */; };
 		0071CB4C2460213200F562B1 /* BSG_KSMachHeaders.m in Sources */ = {isa = PBXBuildFile; fileRef = 0071CB4A2460213200F562B1 /* BSG_KSMachHeaders.m */; };
 		0071CB4F246025AF00F562B1 /* KSMachHeader_Tests.m in Sources */ = {isa = PBXBuildFile; fileRef = 0071CB4E246025AF00F562B1 /* KSMachHeader_Tests.m */; };
@@ -383,6 +377,7 @@
 		E79148291FD828E6003EFEBF /* BugsnagUser.h in CopyFiles */ = {isa = PBXBuildFile; fileRef = E72BF77D1FC86A7A004BE82F /* BugsnagUser.h */; };
 		E794E8031F9F743D00A67EE7 /* BugsnagKeys.h in Headers */ = {isa = PBXBuildFile; fileRef = E794E8021F9F743D00A67EE7 /* BugsnagKeys.h */; };
 		E7969934246996270032F35A /* BugsnagEventPersistLoadTest.m in Sources */ = {isa = PBXBuildFile; fileRef = E7969933246996270032F35A /* BugsnagEventPersistLoadTest.m */; };
+		E7A324F1247EB51B008B0052 /* BugsnagEnabledBreadcrumbTest.m in Sources */ = {isa = PBXBuildFile; fileRef = E7A324F0247EB51B008B0052 /* BugsnagEnabledBreadcrumbTest.m */; };
 		E7A56789245AE79C009BE2F1 /* BugsnagClientPayloadInfoTest.m in Sources */ = {isa = PBXBuildFile; fileRef = E7A56788245AE79C009BE2F1 /* BugsnagClientPayloadInfoTest.m */; };
 		E7A8EA3A24606A3E00CCBBD1 /* BSGConfigurationBuilder.h in CopyFiles */ = {isa = PBXBuildFile; fileRef = 8A89F3F022D8B62B000D34D1 /* BSGConfigurationBuilder.h */; };
 		E7A8EA3B24606C6B00CCBBD1 /* BSGConfigurationBuilder.m in Sources */ = {isa = PBXBuildFile; fileRef = 8A89F3F122D8B62B000D34D1 /* BSGConfigurationBuilder.m */; };
@@ -534,9 +529,6 @@
 		000E6EA223D8AC8C009D8194 /* CHANGELOG.md */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = net.daringfireball.markdown; name = CHANGELOG.md; path = ../CHANGELOG.md; sourceTree = "<group>"; };
 		0016B289246EDC9A002B34C8 /* BugsnagSwiftPublicAPITests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; name = BugsnagSwiftPublicAPITests.swift; path = "../../../Tests/Swift Tests/BugsnagSwiftPublicAPITests.swift"; sourceTree = "<group>"; };
 		004A41CD23FE91070092DF97 /* Security.framework */ = {isa = PBXFileReference; lastKnownFileType = wrapper.framework; name = Security.framework; path = Platforms/MacOSX.platform/Developer/SDKs/MacOSX10.15.sdk/System/Library/Frameworks/Security.framework; sourceTree = DEVELOPER_DIR; };
-		0061D84424067AF70041C068 /* LICENSE */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = text; path = LICENSE; sourceTree = "<group>"; };
-		0061D84524067AF70041C068 /* BSG_SSKeychain.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; path = BSG_SSKeychain.m; sourceTree = "<group>"; };
-		0061D84624067AF80041C068 /* BSG_SSKeychain.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = BSG_SSKeychain.h; sourceTree = "<group>"; };
 		0071CB4A2460213200F562B1 /* BSG_KSMachHeaders.m */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.objc; path = BSG_KSMachHeaders.m; sourceTree = "<group>"; };
 		0071CB4D2460216200F562B1 /* BSG_KSMachHeaders.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; path = BSG_KSMachHeaders.h; sourceTree = "<group>"; };
 		0071CB4E246025AF00F562B1 /* KSMachHeader_Tests.m */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.objc; path = KSMachHeader_Tests.m; sourceTree = "<group>"; };
@@ -764,6 +756,7 @@
 		E794E8021F9F743D00A67EE7 /* BugsnagKeys.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; name = BugsnagKeys.h; path = ../Source/BugsnagKeys.h; sourceTree = SOURCE_ROOT; };
 		E7969933246996270032F35A /* BugsnagEventPersistLoadTest.m */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.objc; name = BugsnagEventPersistLoadTest.m; path = ../../Tests/BugsnagEventPersistLoadTest.m; sourceTree = "<group>"; };
 		E79FEBE61F4CB1320048FAD6 /* Foundation.framework */ = {isa = PBXFileReference; lastKnownFileType = wrapper.framework; name = Foundation.framework; path = System/Library/Frameworks/Foundation.framework; sourceTree = SDKROOT; };
+		E7A324F0247EB51B008B0052 /* BugsnagEnabledBreadcrumbTest.m */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.objc; name = BugsnagEnabledBreadcrumbTest.m; path = ../../Tests/BugsnagEnabledBreadcrumbTest.m; sourceTree = "<group>"; };
 		E7A56788245AE79C009BE2F1 /* BugsnagClientPayloadInfoTest.m */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.objc; name = BugsnagClientPayloadInfoTest.m; path = ../../Tests/BugsnagClientPayloadInfoTest.m; sourceTree = "<group>"; };
 		E7A8EA602461813700CCBBD1 /* TestsInfo.plist */ = {isa = PBXFileReference; lastKnownFileType = text.plist; path = TestsInfo.plist; sourceTree = SOURCE_ROOT; };
 		E7A9E56A2436363900D99F8A /* BugsnagDeviceTest.m */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.objc; name = BugsnagDeviceTest.m; path = ../../Tests/BugsnagDeviceTest.m; sourceTree = "<group>"; };
@@ -932,6 +925,7 @@
 				8A89F3F422D8B81F000D34D1 /* BSGConfigurationBuilderTests.m */,
 				8A4E733E1DC13281001F7CC8 /* BugsnagConfigurationTests.m */,
 				E7A9E56A2436363900D99F8A /* BugsnagDeviceTest.m */,
+				E7A324F0247EB51B008B0052 /* BugsnagEnabledBreadcrumbTest.m */,
 				E73D4439243E1912001686F5 /* BugsnagErrorTest.m */,
 				8A2C8F8C1C6BBFDD00846019 /* BugsnagEventTests.m */,
 				4B47970922A9AE1F00FF9C2E /* BugsnagEventFromKSCrashReportTest.m */,
@@ -1612,6 +1606,7 @@
 				E70EE0921FD706C700FA745C /* KSDynamicLinker_Tests.m in Sources */,
 				E78C1EFC1FCC759B00B976D3 /* BugsnagSessionTest.m in Sources */,
 				E78C1EFE1FCC778700B976D3 /* BugsnagUserTest.m in Sources */,
+				E7A324F1247EB51B008B0052 /* BugsnagEnabledBreadcrumbTest.m in Sources */,
 				E722105C243B69F00083CF15 /* BugsnagStackframeTest.m in Sources */,
 				8A2C8F911C6BBFDD00846019 /* BugsnagSinkTests.m in Sources */,
 				E790C41E24323102006FFB26 /* BugsnagClientMirrorTest.m in Sources */,

--- a/tvOS/Bugsnag.xcodeproj/project.pbxproj
+++ b/tvOS/Bugsnag.xcodeproj/project.pbxproj
@@ -212,6 +212,7 @@
 		E79148911FD82E77003EFEBF /* BugsnagUserTest.m in Sources */ = {isa = PBXBuildFile; fileRef = E791488D1FD82E77003EFEBF /* BugsnagUserTest.m */; };
 		E794E8071F9F748100A67EE7 /* BugsnagKeys.h in Headers */ = {isa = PBXBuildFile; fileRef = E794E8061F9F748100A67EE7 /* BugsnagKeys.h */; };
 		E796994224699F9B0032F35A /* BugsnagEventPersistLoadTest.m in Sources */ = {isa = PBXBuildFile; fileRef = E796994024699F9B0032F35A /* BugsnagEventPersistLoadTest.m */; };
+		E7A324F5247EB559008B0052 /* BugsnagEnabledBreadcrumbTest.m in Sources */ = {isa = PBXBuildFile; fileRef = E7A324F4247EB558008B0052 /* BugsnagEnabledBreadcrumbTest.m */; };
 		E7A5678D245AE7C1009BE2F1 /* BugsnagClientPayloadInfoTest.m in Sources */ = {isa = PBXBuildFile; fileRef = E7A5678C245AE7C0009BE2F1 /* BugsnagClientPayloadInfoTest.m */; };
 		E7A8EA632461817900CCBBD1 /* TestsInfo.plist in Resources */ = {isa = PBXBuildFile; fileRef = E7A8EA622461817900CCBBD1 /* TestsInfo.plist */; };
 		E7A9E56F2436366800D99F8A /* BugsnagDeviceTest.m in Sources */ = {isa = PBXBuildFile; fileRef = E7A9E56E2436366800D99F8A /* BugsnagDeviceTest.m */; };
@@ -460,6 +461,7 @@
 		E791488D1FD82E77003EFEBF /* BugsnagUserTest.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; name = BugsnagUserTest.m; path = ../../Tests/BugsnagUserTest.m; sourceTree = "<group>"; };
 		E794E8061F9F748100A67EE7 /* BugsnagKeys.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; name = BugsnagKeys.h; path = ../Source/BugsnagKeys.h; sourceTree = "<group>"; };
 		E796994024699F9B0032F35A /* BugsnagEventPersistLoadTest.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; name = BugsnagEventPersistLoadTest.m; path = ../../Tests/BugsnagEventPersistLoadTest.m; sourceTree = "<group>"; };
+		E7A324F4247EB558008B0052 /* BugsnagEnabledBreadcrumbTest.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; name = BugsnagEnabledBreadcrumbTest.m; path = ../../Tests/BugsnagEnabledBreadcrumbTest.m; sourceTree = "<group>"; };
 		E7A5678C245AE7C0009BE2F1 /* BugsnagClientPayloadInfoTest.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; name = BugsnagClientPayloadInfoTest.m; path = ../../Tests/BugsnagClientPayloadInfoTest.m; sourceTree = "<group>"; };
 		E7A8EA622461817900CCBBD1 /* TestsInfo.plist */ = {isa = PBXFileReference; lastKnownFileType = text.plist; path = TestsInfo.plist; sourceTree = SOURCE_ROOT; };
 		E7A9E56E2436366800D99F8A /* BugsnagDeviceTest.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; name = BugsnagDeviceTest.m; path = ../../Tests/BugsnagDeviceTest.m; sourceTree = "<group>"; };
@@ -596,6 +598,7 @@
 				4B406C1222CAD94100464D1D /* BugsnagCollectionsBSGDictSetSafeObjectTest.m */,
 				4B775FD022CBE01F004839C5 /* BugsnagCollectionsBSGDictInsertIfNotNilTest.m */,
 				8AD9FA8B1E0863A1002859A7 /* BugsnagConfigurationTests.m */,
+				E7A324F4247EB558008B0052 /* BugsnagEnabledBreadcrumbTest.m */,
 				E73D443D243E1945001686F5 /* BugsnagErrorTest.m */,
 				00D7ACA623E98A5D00FBE4A7 /* BugsnagEventTests.m */,
 				E796994024699F9B0032F35A /* BugsnagEventPersistLoadTest.m */,
@@ -1256,6 +1259,7 @@
 				E79148901FD82E77003EFEBF /* BugsnagSessionTest.m in Sources */,
 				8AB151211D41361700C9B218 /* BugsnagBreadcrumbsTest.m in Sources */,
 				E7A5678D245AE7C1009BE2F1 /* BugsnagClientPayloadInfoTest.m in Sources */,
+				E7A324F5247EB559008B0052 /* BugsnagEnabledBreadcrumbTest.m in Sources */,
 				E7CE78F81FD94F1B001D07E0 /* KSCrashSentry_Tests.m in Sources */,
 				E7CE78F51FD94F1B001D07E0 /* XCTestCase+KSCrash.m in Sources */,
 				8A530CC622FDD71B00F0C108 /* KSCrashIdentifierTests.m in Sources */,


### PR DESCRIPTION
## Goal

If `config.enabledBreadcrumbTypes` was set to `BSGEnabledBreadcrumbTypeNone`, the `shouldRecordBreadcrumbType` method returned true for all breadcrumb types. This changeset makes it return false in this condition and adds unit test coverage to verify the change.

E2E tests added in #635 depend on this change.