### PR TITLE
Add E2E scenarios for breadcrumb callbacks

### DIFF
--- a/features/breadcrumb_callbacks.feature
+++ b/features/breadcrumb_callbacks.feature
@@ -1,0 +1,56 @@
+Feature: Callbacks can access and modify breadcrumb information
+
+Scenario: Returning false in a callback discards breadcrumbs
+    When I run "BreadcrumbCallbackDiscardScenario"
+    And I wait to receive a request
+    And the request is valid for the error reporting API version "4.0" for the "iOS Bugsnag Notifier" notifier
+    And the payload field "events.0.breadcrumbs" is an array with 1 elements
+    And the payload field "events.0.breadcrumbs.0.name" equals "Hello World"
+    And the payload field "events.0.breadcrumbs.0.type" equals "manual"
+    And the payload field "events.0.breadcrumbs.0.timestamp" is a parsable timestamp in seconds
+    And the payload field "events.0.breadcrumbs.0.metaData.foo" equals "bar"
+    And the payload field "events.0.breadcrumbs.0.metaData.addedVal" is true
+
+Scenario: Callbacks execute in the order in which they were added
+    When I run "BreadcrumbCallbackOrderScenario"
+    And I wait to receive a request
+    And the request is valid for the error reporting API version "4.0" for the "iOS Bugsnag Notifier" notifier
+    And the payload field "events.0.breadcrumbs" is an array with 1 elements
+    And the payload field "events.0.breadcrumbs.0.name" equals "Hello World"
+    And the payload field "events.0.breadcrumbs.0.type" equals "manual"
+    And the payload field "events.0.breadcrumbs.0.timestamp" is a parsable timestamp in seconds
+    And the payload field "events.0.breadcrumbs.0.metaData.firstCallback" equals 0
+    And the payload field "events.0.breadcrumbs.0.metaData.secondCallback" equals 1
+
+Scenario: Modifying breadcrumb information with a callback
+    When I run "BreadcrumbCallbackOverrideScenario"
+    And I wait to receive a request
+    And the request is valid for the error reporting API version "4.0" for the "iOS Bugsnag Notifier" notifier
+    And the payload field "events.0.breadcrumbs" is an array with 1 elements
+    And the payload field "events.0.breadcrumbs.0.name" equals "Feliz Navidad"
+    And the payload field "events.0.breadcrumbs.0.type" equals "manual"
+    And the payload field "events.0.breadcrumbs.0.timestamp" is a parsable timestamp in seconds
+    And the payload field "events.0.breadcrumbs.0.metaData.foo" equals "wham"
+
+Scenario: Callbacks can be removed without affecting the functionality of other callbacks
+    When I run "BreadcrumbCallbackRemovalScenario"
+    And I wait to receive a request
+    And the request is valid for the error reporting API version "4.0" for the "iOS Bugsnag Notifier" notifier
+    And the payload field "events.0.breadcrumbs" is an array with 1 elements
+    And the payload field "events.0.breadcrumbs.0.name" equals "Hello World"
+    And the payload field "events.0.breadcrumbs.0.type" equals "manual"
+    And the payload field "events.0.breadcrumbs.0.timestamp" is a parsable timestamp in seconds
+    And the payload field "events.0.breadcrumbs.0.metaData.foo" equals "bar"
+    And the payload field "events.0.breadcrumbs.0.metaData.firstCallback" equals "Whoops"
+
+Scenario: An uncaught NSException in a callback does not affect breadcrumb delivery
+    When I run "BreadcrumbCallbackCrashScenario"
+    And I wait to receive a request
+    And the request is valid for the error reporting API version "4.0" for the "iOS Bugsnag Notifier" notifier
+    And the payload field "events.0.breadcrumbs" is an array with 1 elements
+    And the payload field "events.0.breadcrumbs.0.name" equals "Hello World"
+    And the payload field "events.0.breadcrumbs.0.type" equals "manual"
+    And the payload field "events.0.breadcrumbs.0.timestamp" is a parsable timestamp in seconds
+    And the payload field "events.0.breadcrumbs.0.metaData.foo" equals "bar"
+    And the payload field "events.0.breadcrumbs.0.metaData.addedInCallback" is true
+    And the payload field "events.0.breadcrumbs.0.metaData.shouldNotHappen" is null

--- a/features/fixtures/ios-swift-cocoapods/iOSTestApp.xcodeproj/project.pbxproj
+++ b/features/fixtures/ios-swift-cocoapods/iOSTestApp.xcodeproj/project.pbxproj
@@ -61,6 +61,11 @@
 		E7767F11221C21D90006648C /* StoppedSessionScenario.swift in Sources */ = {isa = PBXBuildFile; fileRef = E7767F10221C21D90006648C /* StoppedSessionScenario.swift */; };
 		E7767F13221C21E30006648C /* ResumedSessionScenario.swift in Sources */ = {isa = PBXBuildFile; fileRef = E7767F12221C21E30006648C /* ResumedSessionScenario.swift */; };
 		E7767F15221C223C0006648C /* NewSessionScenario.swift in Sources */ = {isa = PBXBuildFile; fileRef = E7767F14221C223C0006648C /* NewSessionScenario.swift */; };
+		E7A324E6247E9D8D008B0052 /* BreadcrumbCallbackDiscardScenario.swift in Sources */ = {isa = PBXBuildFile; fileRef = E7A324E5247E9D8D008B0052 /* BreadcrumbCallbackDiscardScenario.swift */; };
+		E7A324E8247E9D9A008B0052 /* BreadcrumbCallbackOrderScenario.swift in Sources */ = {isa = PBXBuildFile; fileRef = E7A324E7247E9D9A008B0052 /* BreadcrumbCallbackOrderScenario.swift */; };
+		E7A324EA247E9DA5008B0052 /* BreadcrumbCallbackOverrideScenario.swift in Sources */ = {isa = PBXBuildFile; fileRef = E7A324E9247E9DA5008B0052 /* BreadcrumbCallbackOverrideScenario.swift */; };
+		E7A324ED247E9DB3008B0052 /* BreadcrumbCallbackRemovalScenario.m in Sources */ = {isa = PBXBuildFile; fileRef = E7A324EC247E9DB3008B0052 /* BreadcrumbCallbackRemovalScenario.m */; };
+		E7A324EF247E9DBC008B0052 /* BreadcrumbCallbackCrashScenario.swift in Sources */ = {isa = PBXBuildFile; fileRef = E7A324EE247E9DBC008B0052 /* BreadcrumbCallbackCrashScenario.swift */; };
 		E7DD40452473D980000EDC14 /* UserDefaultInfoScenario.swift in Sources */ = {isa = PBXBuildFile; fileRef = E7DD40442473D980000EDC14 /* UserDefaultInfoScenario.swift */; };
 		F429502603396F8671B333B3 /* HandledExceptionScenario.swift in Sources */ = {isa = PBXBuildFile; fileRef = F429526319377A8848136413 /* HandledExceptionScenario.swift */; };
 		F4295109FCAB93708FDAFE12 /* DisabledSessionTrackingScenario.m in Sources */ = {isa = PBXBuildFile; fileRef = F429563584D9BC3A5B86BECF /* DisabledSessionTrackingScenario.m */; };
@@ -188,6 +193,12 @@
 		E7767F12221C21E30006648C /* ResumedSessionScenario.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ResumedSessionScenario.swift; sourceTree = "<group>"; };
 		E7767F14221C223C0006648C /* NewSessionScenario.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = NewSessionScenario.swift; sourceTree = "<group>"; };
 		E77AFEF72449C6460082B8BB /* AttachCustomStacktraceHook.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; path = AttachCustomStacktraceHook.h; sourceTree = "<group>"; };
+		E7A324E5247E9D8D008B0052 /* BreadcrumbCallbackDiscardScenario.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = BreadcrumbCallbackDiscardScenario.swift; sourceTree = "<group>"; };
+		E7A324E7247E9D9A008B0052 /* BreadcrumbCallbackOrderScenario.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = BreadcrumbCallbackOrderScenario.swift; sourceTree = "<group>"; };
+		E7A324E9247E9DA5008B0052 /* BreadcrumbCallbackOverrideScenario.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = BreadcrumbCallbackOverrideScenario.swift; sourceTree = "<group>"; };
+		E7A324EB247E9DB3008B0052 /* BreadcrumbCallbackRemovalScenario.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; path = BreadcrumbCallbackRemovalScenario.h; sourceTree = "<group>"; };
+		E7A324EC247E9DB3008B0052 /* BreadcrumbCallbackRemovalScenario.m */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.objc; path = BreadcrumbCallbackRemovalScenario.m; sourceTree = "<group>"; };
+		E7A324EE247E9DBC008B0052 /* BreadcrumbCallbackCrashScenario.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = BreadcrumbCallbackCrashScenario.swift; sourceTree = "<group>"; };
 		E7DD40442473D980000EDC14 /* UserDefaultInfoScenario.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = UserDefaultInfoScenario.swift; sourceTree = "<group>"; };
 		E7F6087B244F0A3A00F1532A /* BugsnagHooks.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; path = BugsnagHooks.h; sourceTree = "<group>"; };
 		EE18B3777C62D7BCA8DDBE30 /* Pods-iOSTestApp.debug.xcconfig */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.xcconfig; name = "Pods-iOSTestApp.debug.xcconfig"; path = "Pods/Target Support Files/Pods-iOSTestApp/Pods-iOSTestApp.debug.xcconfig"; sourceTree = "<group>"; };
@@ -366,9 +377,23 @@
 			name = "Metadata Redaction";
 			sourceTree = "<group>";
 		};
+		E7A324E4247E9C96008B0052 /* Breadcrumb Callbacks */ = {
+			isa = PBXGroup;
+			children = (
+				E7A324E5247E9D8D008B0052 /* BreadcrumbCallbackDiscardScenario.swift */,
+				E7A324E7247E9D9A008B0052 /* BreadcrumbCallbackOrderScenario.swift */,
+				E7A324E9247E9DA5008B0052 /* BreadcrumbCallbackOverrideScenario.swift */,
+				E7A324EB247E9DB3008B0052 /* BreadcrumbCallbackRemovalScenario.h */,
+				E7A324EC247E9DB3008B0052 /* BreadcrumbCallbackRemovalScenario.m */,
+				E7A324EE247E9DBC008B0052 /* BreadcrumbCallbackCrashScenario.swift */,
+			);
+			name = "Breadcrumb Callbacks";
+			sourceTree = "<group>";
+		};
 		F42953DE2BB41023C0B07F41 /* scenarios */ = {
 			isa = PBXGroup;
 			children = (
+				E7A324E4247E9C96008B0052 /* Breadcrumb Callbacks */,
 				E75040AC2478213D005D33BD /* Metadata Redaction */,
 				E750409C24780158005D33BD /* AutoDetectErrors */,
 				F49695A9244545EC00105DA9 /* Crashprobe */,
@@ -642,7 +667,7 @@
 			files = (
 			);
 			inputPaths = (
-				"${PODS_ROOT}/Target Support Files/Pods-iOSTestApp/Pods-iOSTestApp-frameworks.sh",
+				"${SRCROOT}/Pods/Target Support Files/Pods-iOSTestApp/Pods-iOSTestApp-frameworks.sh",
 				"${BUILT_PRODUCTS_DIR}/Bugsnag/Bugsnag.framework",
 			);
 			name = "[CP] Embed Pods Frameworks";
@@ -651,7 +676,7 @@
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 			shellPath = /bin/sh;
-			shellScript = "\"${PODS_ROOT}/Target Support Files/Pods-iOSTestApp/Pods-iOSTestApp-frameworks.sh\"\n";
+			shellScript = "\"${SRCROOT}/Pods/Target Support Files/Pods-iOSTestApp/Pods-iOSTestApp-frameworks.sh\"\n";
 			showEnvVarsInLog = 0;
 		};
 /* End PBXShellScriptBuildPhase section */
@@ -696,10 +721,12 @@
 				F4295497A1582010C16F1861 /* AbortScenario.m in Sources */,
 				8AF8FCAE22BD23BA00A967CA /* HandledInternalNotifyScenario.swift in Sources */,
 				8A42FD35225DEE04007AE561 /* SessionOOMScenario.m in Sources */,
+				E7A324EF247E9DBC008B0052 /* BreadcrumbCallbackCrashScenario.swift in Sources */,
 				F4295CEAD7C915EFA04898A5 /* Scenario.m in Sources */,
 				F4295836C8AF75547C675E8D /* ReleasedObjectScenario.m in Sources */,
 				8A530CCC22FDDBF000F0C108 /* ManyConcurrentNotifyScenario.m in Sources */,
 				F42958881D3F34A76CADE4EC /* SwiftCrash.swift in Sources */,
+				E7A324EA247E9DA5008B0052 /* BreadcrumbCallbackOverrideScenario.swift in Sources */,
 				F42955DB6D08642528917FAB /* CxxExceptionScenario.mm in Sources */,
 				8A3B5F2B240807EE00CE4A3A /* ModifyBreadcrumbInNotify.swift in Sources */,
 				8A32DB8222424E3000EDD92F /* NSExceptionShiftScenario.m in Sources */,
@@ -723,6 +750,7 @@
 				F42959124DB949EEF1420957 /* ReadOnlyPageScenario.m in Sources */,
 				F4295B75B2244F442D84D9CA /* StackOverflowScenario.m in Sources */,
 				F42951A9FD696D9047149DA8 /* UndefinedInstructionScenario.m in Sources */,
+				E7A324E6247E9D8D008B0052 /* BreadcrumbCallbackDiscardScenario.swift in Sources */,
 				00432CC4240912A100826D05 /* EnabledErrorTypesCxxScenario.mm in Sources */,
 				F49695A62441098600105DA9 /* OOMBackgroundScenario.m in Sources */,
 				E7DD40452473D980000EDC14 /* UserDefaultInfoScenario.swift in Sources */,
@@ -732,9 +760,11 @@
 				F4295397AD31C1C1E64144F5 /* NonExistentMethodScenario.m in Sources */,
 				E700EE53247D31EA008CFFB6 /* OnErrorOverwriteScenario.swift in Sources */,
 				8AEFC79920F9132C00A78779 /* AutoSessionHandledEventsScenario.m in Sources */,
+				E7A324ED247E9DB3008B0052 /* BreadcrumbCallbackRemovalScenario.m in Sources */,
 				0037410F2473CF2300BE41AA /* AppAndDeviceAttributesScenario.swift in Sources */,
 				F4295A0B0DA0AF3B5502D29C /* PrivilegedInstructionScenario.m in Sources */,
 				F42958BE5DDACDBF653CA926 /* ManualSessionScenario.m in Sources */,
+				E7A324E8247E9D9A008B0052 /* BreadcrumbCallbackOrderScenario.swift in Sources */,
 				F42951BF19D7F35A03273CFB /* AutoSessionScenario.m in Sources */,
 				8AF6FD77225E3F870056EF9E /* StopSessionOOMScenario.m in Sources */,
 				F4295109FCAB93708FDAFE12 /* DisabledSessionTrackingScenario.m in Sources */,

--- a/features/fixtures/ios-swift-cocoapods/iOSTestApp/scenarios/BreadcrumbCallbackCrashScenario.swift
+++ b/features/fixtures/ios-swift-cocoapods/iOSTestApp/scenarios/BreadcrumbCallbackCrashScenario.swift
@@ -1,0 +1,36 @@
+//
+//  BreadcrumbCallbackCrashScenario.swift
+//  iOSTestApp
+//
+//  Created by Jamie Lynch on 27/05/2020.
+//  Copyright © 2020 Bugsnag. All rights reserved.
+//
+
+import Foundation
+
+class BreadcrumbCallbackCrashScenario : Scenario {
+
+    override func startBugsnag() {
+        self.config.autoTrackSessions = false;
+        self.config.enabledBreadcrumbTypes = []
+
+        self.config.addOnBreadcrumb { (crumb) -> Bool in
+            crumb.metadata["addedInCallback"] = true
+
+            // throw an exception to crash in the callback
+            NSException(name: NSExceptionName("BreadcrumbCallbackCrashScenario"),
+                        reason: "Message: BreadcrumbCallbackCrashScenario",
+                        userInfo: nil).raise()
+
+            crumb.metadata["shouldNotHappen"] = "it happened"
+            return true
+        }
+        super.startBugsnag()
+    }
+
+    override func run() {
+        Bugsnag.leaveBreadcrumb("Hello World", metadata: ["foo": "bar"], type: .manual)
+        let error = NSError(domain: "BreadcrumbCallbackCrashScenario", code: 100, userInfo: nil)
+        Bugsnag.notifyError(error)
+    }
+}

--- a/features/fixtures/ios-swift-cocoapods/iOSTestApp/scenarios/BreadcrumbCallbackDiscardScenario.swift
+++ b/features/fixtures/ios-swift-cocoapods/iOSTestApp/scenarios/BreadcrumbCallbackDiscardScenario.swift
@@ -1,0 +1,30 @@
+//
+//  BreadcrumbCallbackDiscardScenario.swift
+//  iOSTestApp
+//
+//  Created by Jamie Lynch on 27/05/2020.
+//  Copyright © 2020 Bugsnag. All rights reserved.
+//
+
+import Foundation
+
+class BreadcrumbCallbackDiscardScenario : Scenario {
+
+    override func startBugsnag() {
+        self.config.autoTrackSessions = false;
+        self.config.enabledBreadcrumbTypes = []
+
+        self.config.addOnBreadcrumb { (crumb) -> Bool in
+            crumb.metadata["addedVal"] = true
+            return crumb.message == "Hello World"
+        }
+        super.startBugsnag()
+    }
+
+    override func run() {
+        Bugsnag.leaveBreadcrumb("Hello World", metadata: ["foo": "bar"], type: .manual)
+        Bugsnag.leaveBreadcrumb(withMessage: "This breadcrumb will be discarded")
+        let error = NSError(domain: "BreadcrumbCallbackDiscardScenario", code: 100, userInfo: nil)
+        Bugsnag.notifyError(error)
+    }
+}

--- a/features/fixtures/ios-swift-cocoapods/iOSTestApp/scenarios/BreadcrumbCallbackOrderScenario.swift
+++ b/features/fixtures/ios-swift-cocoapods/iOSTestApp/scenarios/BreadcrumbCallbackOrderScenario.swift
@@ -1,0 +1,37 @@
+//
+//  BreadcrumbCallbackOrderScenario.swift
+//  iOSTestApp
+//
+//  Created by Jamie Lynch on 27/05/2020.
+//  Copyright © 2020 Bugsnag. All rights reserved.
+//
+
+import Foundation
+
+class BreadcrumbCallbackOrderScenario : Scenario {
+
+    override func startBugsnag() {
+        self.config.autoTrackSessions = false;
+        self.config.enabledBreadcrumbTypes = []
+
+        var count = 0
+        self.config.addOnBreadcrumb { (crumb) -> Bool in
+            crumb.metadata["firstCallback"] = count
+            count += 1
+            return true
+        }
+
+        self.config.addOnBreadcrumb { (crumb) -> Bool in
+            crumb.metadata["secondCallback"] = count
+            count += 1
+            return true
+        }
+        super.startBugsnag()
+    }
+
+    override func run() {
+        Bugsnag.leaveBreadcrumb(withMessage: "Hello World")
+        let error = NSError(domain: "BreadcrumbCallbackOrderScenario", code: 100, userInfo: nil)
+        Bugsnag.notifyError(error)
+    }
+}

--- a/features/fixtures/ios-swift-cocoapods/iOSTestApp/scenarios/BreadcrumbCallbackOverrideScenario.swift
+++ b/features/fixtures/ios-swift-cocoapods/iOSTestApp/scenarios/BreadcrumbCallbackOverrideScenario.swift
@@ -1,0 +1,31 @@
+//
+//  BreadcrumbCallbackOverrideScenario.swift
+//  iOSTestApp
+//
+//  Created by Jamie Lynch on 27/05/2020.
+//  Copyright © 2020 Bugsnag. All rights reserved.
+//
+
+import Foundation
+
+class BreadcrumbCallbackOverrideScenario : Scenario {
+
+    override func startBugsnag() {
+        self.config.autoTrackSessions = false;
+        self.config.enabledBreadcrumbTypes = .log
+
+        self.config.addOnBreadcrumb { (crumb) -> Bool in
+            crumb.message = "Feliz Navidad"
+            crumb.type = .manual
+            crumb.metadata["foo"] = "wham"
+            return true
+        }
+        super.startBugsnag()
+    }
+
+    override func run() {
+        Bugsnag.leaveBreadcrumb("Hello World", metadata: ["foo": "bar"], type: .log)
+        let error = NSError(domain: "BreadcrumbCallbackOverrideScenario", code: 100, userInfo: nil)
+        Bugsnag.notifyError(error)
+    }
+}

--- a/features/fixtures/ios-swift-cocoapods/iOSTestApp/scenarios/BreadcrumbCallbackRemovalScenario.h
+++ b/features/fixtures/ios-swift-cocoapods/iOSTestApp/scenarios/BreadcrumbCallbackRemovalScenario.h
@@ -1,0 +1,18 @@
+//
+//  BreadcrumbCallbackRemovalScenario.h
+//  iOSTestApp
+//
+//  Created by Jamie Lynch on 27/05/2020.
+//  Copyright © 2020 Bugsnag. All rights reserved.
+//
+
+#import <Foundation/Foundation.h>
+#import "Scenario.h"
+
+NS_ASSUME_NONNULL_BEGIN
+
+@interface BreadcrumbCallbackRemovalScenario : Scenario
+
+@end
+
+NS_ASSUME_NONNULL_END

--- a/features/fixtures/ios-swift-cocoapods/iOSTestApp/scenarios/BreadcrumbCallbackRemovalScenario.m
+++ b/features/fixtures/ios-swift-cocoapods/iOSTestApp/scenarios/BreadcrumbCallbackRemovalScenario.m
@@ -1,0 +1,42 @@
+//
+//  BreadcrumbCallbackRemovalScenario.m
+//  iOSTestApp
+//
+//  Created by Jamie Lynch on 27/05/2020.
+//  Copyright © 2020 Bugsnag. All rights reserved.
+//
+
+#import "BreadcrumbCallbackRemovalScenario.h"
+
+@implementation BreadcrumbCallbackRemovalScenario
+
+- (void)startBugsnag {
+    self.config.autoTrackSessions = false;
+    self.config.enabledBreadcrumbTypes = BSGBreadcrumbTypeManual;
+
+    [self.config addOnBreadcrumbBlock:^BOOL(BugsnagBreadcrumb * _Nonnull breadcrumb) {
+        NSMutableDictionary *dict = [breadcrumb.metadata mutableCopy];
+        dict[@"firstCallback"] = @"Whoops";
+        breadcrumb.metadata = dict;
+        return true;
+    }];
+
+    id block = ^BOOL(BugsnagBreadcrumb * _Nonnull breadcrumb) {
+        breadcrumb.message = @"Feliz Navidad";
+        return true;
+    };
+    [self.config addOnBreadcrumbBlock:block];
+    [self.config removeOnBreadcrumbBlock:block];
+
+    [super startBugsnag];
+}
+
+- (void)run {
+    [Bugsnag leaveBreadcrumbWithMessage:@"Hello World"
+                               metadata:@{@"foo": @"bar"}
+                                andType:BSGBreadcrumbTypeManual];
+    NSError *error = [NSError errorWithDomain:@"BreadcrumbCallbackRemovalScenario" code:100 userInfo:nil];
+    [Bugsnag notifyError:error];
+}
+
+@end


### PR DESCRIPTION
## Goal

Adds E2E scenarios to verify breadcrumb callback functionality.

## Changeset

- Updated existing scenario checks to verify the breadcrumb has a timestamp
- Added scenarios to verify that:
  - breadcrumbs can be discarded by returning false in a callback
  - callbacks are run in the order in which they are added
  - exceptions thrown in the callback do not discard the breadcrumb
  - callbacks allow for the modification of breadcrumb data
  - `removeOnBreadcrumb()` removes callbacks

