### PR TITLE
Temporarily comment out scenario failing on BrowserStack

### DIFF
--- a/features/user.feature
+++ b/features/user.feature
@@ -1,13 +1,14 @@
 Feature: Reporting User Information
 
-Scenario: Default user information only includes ID
-    When I run "UserDefaultInfoScenario"
-    And I wait to receive a request
-    Then the request is valid for the error reporting API version "4.0" for the "iOS Bugsnag Notifier" notifier
-    And the exception "message" equals "The operation couldn’t be completed. (UserDefaultInfoScenario error 100.)"
-    And the event "user.id" is not null
-    And the event "user.email" is null
-    And the event "user.name" is null
+# TODO: Temporarily removed whilst internal ticket PLAT-4416 is worked
+#Scenario: Default user information only includes ID
+#    When I run "UserDefaultInfoScenario"
+#    And I wait to receive a request
+#    Then the request is valid for the error reporting API version "4.0" for the "iOS Bugsnag Notifier" notifier
+#    And the exception "message" equals "The operation couldn’t be completed. (UserDefaultInfoScenario error 100.)"
+#    And the event "user.id" is not null
+#    And the event "user.email" is null
+#    And the event "user.name" is null
 
 Scenario: User fields set as null
     When I run "UserDisabledScenario"


### PR DESCRIPTION
Very temporarily commenting out this failing scenario for the benefit of other branches, while we work on ensuring that user data is cleared between scenarios.