### PR TITLE
Ensure scenarios are skipped when flagged so

### DIFF
--- a/.buildkite/pipeline.yml
+++ b/.buildkite/pipeline.yml
@@ -23,9 +23,6 @@ steps:
     concurrency: 10
     concurrency_group: browserstack-app
 
-  # Temporarily removing this block entirely to test all devices.
-  # - block: Trigger full test suite
-
   - label: ':ios: iOS 12 end-to-end tests'
     timeout_in_minutes: 60
     agents:
@@ -53,6 +50,8 @@ steps:
       DEVICE_TYPE: IOS_11
     concurrency: 10
     concurrency_group: browserstack-app
+    soft_fail:
+      - exit_status: "*"
 
   - label: ':ios: iOS 10 end-to-end tests'
     timeout_in_minutes: 60
@@ -67,3 +66,5 @@ steps:
       DEVICE_TYPE: IOS_10
     concurrency: 10
     concurrency_group: browserstack-app
+    soft_fail:
+      - exit_status: "*"

--- a/Makefile
+++ b/Makefile
@@ -111,7 +111,7 @@ endif
 ifeq ($(BROWSER_STACK_ACCESS_KEY),)
 	@$(error BROWSER_STACK_ACCESS_KEY is not defined)
 endif
-	@docker-compose run cocoa-maze-runner $(TEST_FEATURE)
+	@docker-compose run cocoa-maze-runner --tags 'not @skip' $(TEST_FEATURE)
 
 e2e:
 	@make e2e_build

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -2,6 +2,7 @@ version: '3.6'
 services:
   cocoa-maze-runner:
     image: 855461928731.dkr.ecr.us-west-1.amazonaws.com/maze-runner:latest-cli
+    command: ["--tags", "not @skip"]
     environment:
       APP_LOCATION: /app/build/iOSTestApp.ipa
       BROWSER_STACK_USERNAME:
@@ -13,6 +14,3 @@ services:
     volumes:
       - ./features/fixtures/ios-swift-cocoapods/output:/app/build
       - ./features/:/app/features/
-    # entrypoint: /bin/sh
-    # stdin_open: true
-    # tty: true

--- a/features/enabled_error_types.feature
+++ b/features/enabled_error_types.feature
@@ -27,7 +27,7 @@ Scenario: NSException Crash Reporting is disabled
     And the event "unhandled" is false
     And the payload field "events.0.exceptions.0.message" equals "DisableNSExceptionScenario - Handled"
 
-# TODO: Currently flakey, bubbling up SIGABRT
+# TODO: PLAT-4422 - Currently flakey, bubbling up SIGABRT.
 @skip
 Scenario: CPP Crash Reporting is disabled
     When I run "EnabledErrorTypesCxxScenario" and relaunch the app

--- a/features/enabled_error_types.feature
+++ b/features/enabled_error_types.feature
@@ -27,7 +27,8 @@ Scenario: NSException Crash Reporting is disabled
     And the event "unhandled" is false
     And the payload field "events.0.exceptions.0.message" equals "DisableNSExceptionScenario - Handled"
 
-@skip Currently flakey, bubbling up SIGABRT
+# TODO: Currently flakey, bubbling up SIGABRT
+@skip
 Scenario: CPP Crash Reporting is disabled
     When I run "EnabledErrorTypesCxxScenario" and relaunch the app
     And I configure Bugsnag for "EnabledErrorTypesCxxScenario"


### PR DESCRIPTION
## Goal

This change ensures that Maze Runner scenarios that are intended to be skipped are actually skipped, whether locally or on CI.

iOS 10 and 11 are also set to soft fail while investigations continue.

## Design

Changes were needed to both `docker-compose.yml` and `Makefile`, as is an argument is passed on the docker-compose command line it overrides the `command:` in the compose file.

`@skip` must appear on its own line - even a following comment if sufficient to confuse Cucumber and the scenario is run anyway.

## Tests

Manual inspection having run both locally and on CI confirms that the scenario is no longer executed (it isn't even mentioned).