### PR TITLE
Improve E2E assertions by verifying severityReasons

### DIFF
--- a/features/fixtures/ios-swift-cocoapods/iOSTestApp/scenarios/UnhandledMachExceptionScenario.m
+++ b/features/fixtures/ios-swift-cocoapods/iOSTestApp/scenarios/UnhandledMachExceptionScenario.m
@@ -15,15 +15,9 @@
     [super startBugsnag];
 }
 
-#pragma clang diagnostic push
-#pragma clang diagnostic ignored "-Winvalid-noreturn"
-- (void)run  __attribute__((noreturn)) {
-    // Send a handled exception to confirm the scenario is running.
-    [Bugsnag notify:[NSException exceptionWithName:NSGenericException reason:@"UnhandledMachExceptionScenario" userInfo:@{NSLocalizedDescriptionKey: @""}]];
-    dispatch_after(dispatch_time(DISPATCH_TIME_NOW, (int64_t)(2 * NSEC_PER_SEC)), dispatch_get_main_queue(), ^{
-        strcmp(0, ""); // Generate EXC_BAD_ACCESS (see e.g. https://stackoverflow.com/q/22488358/2431627)
-    });
+- (void)run {
+    void (*ptr)(void) = NULL;
+    ptr();
 }
-#pragma clang diagnostic pop
 
 @end

--- a/features/handled_errors.feature
+++ b/features/handled_errors.feature
@@ -15,6 +15,9 @@ Scenario: Override errorClass and message from a notifyError() callback, customi
     And the event "device.time" is within 30 seconds of the current timestamp
     And the event "metaData.account.items.0" equals 400
     And the event "metaData.account.items.1" equals 200
+    And the event "severity" equals "warning"
+    And the event "unhandled" is false
+    And the event "severityReason.type" equals "handledError"
     # This may be platform specific.
     # TODO Consider using a step to check for "at least {int} stack frames"
     # And the stack trace is an array with 15 stack frames
@@ -26,6 +29,9 @@ Scenario: Reporting an NSError
     And the payload field "events" is an array with 1 elements
     And the exception "errorClass" equals "NSError"
     And the exception "message" equals "The operation couldn’t be completed. (HandledErrorScenario error 100.)"
+    And the event "severity" equals "warning"
+    And the event "unhandled" is false
+    And the event "severityReason.type" equals "handledError"
     # This may be platform specific
     # And the stack trace is an array with 15 stack frames
 
@@ -36,6 +42,9 @@ Scenario: Reporting a handled exception
     And the payload field "events" is an array with 1 elements
     And the exception "errorClass" equals "HandledExceptionScenario"
     And the exception "message" equals "Message: HandledExceptionScenario"
+    And the event "severity" equals "warning"
+    And the event "unhandled" is false
+    And the event "severityReason.type" equals "handledException"
     # This may be platform specific
     # And the stack trace is an array with 15 stack frames
 
@@ -46,6 +55,9 @@ Scenario: Reporting a handled exception's stacktrace
     And the payload field "events" is an array with 1 elements
     And the exception "errorClass" equals "Tertiary failure"
     And the exception "message" equals "invalid invariant"
+    And the event "severity" equals "warning"
+    And the event "unhandled" is false
+    And the event "severityReason.type" equals "handledException"
     # This may be platform specific
     And the "method" of stack frame 0 equals "<redacted>"
     And the "method" of stack frame 1 equals "objc_exception_throw"

--- a/features/unhandled_cpp_exception.feature
+++ b/features/unhandled_cpp_exception.feature
@@ -8,3 +8,6 @@ Scenario: Throwing a C++ exception
     And the exception "errorClass" equals "P16kaboom_exception"
     And the exception "type" equals "cocoa"
     And the payload field "events.0.exceptions.0.stacktrace" is an array with 0 elements
+    And the event "severity" equals "error"
+    And the event "unhandled" is true
+    And the event "severityReason.type" equals "unhandledException"

--- a/features/unhandled_mach_exception.feature
+++ b/features/unhandled_mach_exception.feature
@@ -5,4 +5,7 @@ Scenario: Trigger a mach exception
     And I configure Bugsnag for "UnhandledMachExceptionScenario"
     And I wait to receive a request
     Then the request is valid for the error reporting API version "4.0" for the "iOS Bugsnag Notifier" notifier
-    And the event "exceptions.0.message" equals "UnhandledMachExceptionScenario"
+    And the event "exceptions.0.message" equals "Attempted to dereference null pointer."
+    And the event "severity" equals "error"
+    And the event "unhandled" is true
+    And the event "severityReason.type" equals "unhandledException"

--- a/features/unhandled_nsexception.feature
+++ b/features/unhandled_nsexception.feature
@@ -11,3 +11,6 @@ Scenario: Throw a NSException
     And the "method" of stack frame 1 equals "objc_exception_throw"
     And the "method" of stack frame 2 equals "-[ObjCExceptionScenario run]"
     And the event "device.time" is within 60 seconds of the current timestamp
+    And the event "severity" equals "error"
+    And the event "unhandled" is true
+    And the event "severityReason.type" equals "unhandledException"

--- a/features/unhandled_signal.feature
+++ b/features/unhandled_signal.feature
@@ -11,6 +11,10 @@ Scenario: Triggering SIGABRT
     And the "method" of stack frame 1 equals "<redacted>"
     And the "method" of stack frame 2 equals "abort"
     And the "method" of stack frame 3 equals "-[AbortScenario run]"
+    And the event "severity" equals "error"
+    And the event "unhandled" is true
+    And the event "severityReason.type" equals "signal"
+    And the event "severityReason.attributes.signalType" equals "SIGABRT"
 
 Scenario: Triggering SIGPIPE
     When I run "SIGPIPEScenario" and relaunch the app
@@ -19,6 +23,10 @@ Scenario: Triggering SIGPIPE
     Then the request is valid for the error reporting API version "4.0" for the "iOS Bugsnag Notifier" notifier
     And the payload field "events" is an array with 1 elements
     And the exception "errorClass" equals "SIGPIPE"
+    And the event "severity" equals "error"
+    And the event "unhandled" is true
+    And the event "severityReason.type" equals "signal"
+    And the event "severityReason.attributes.signalType" equals "SIGPIPE"
 
 Scenario: Triggering SIGBUS
     When I run "SIGBUSScenario" and relaunch the app
@@ -27,6 +35,10 @@ Scenario: Triggering SIGBUS
     Then the request is valid for the error reporting API version "4.0" for the "iOS Bugsnag Notifier" notifier
     And the payload field "events" is an array with 1 elements
     And the exception "errorClass" equals "SIGBUS"
+    And the event "severity" equals "error"
+    And the event "unhandled" is true
+    And the event "severityReason.type" equals "signal"
+    And the event "severityReason.attributes.signalType" equals "SIGBUS"
 
 Scenario: Triggering SIGFPE
     When I run "SIGFPEScenario" and relaunch the app
@@ -35,6 +47,10 @@ Scenario: Triggering SIGFPE
     Then the request is valid for the error reporting API version "4.0" for the "iOS Bugsnag Notifier" notifier
     And the payload field "events" is an array with 1 elements
     And the exception "errorClass" equals "SIGFPE"
+    And the event "severity" equals "error"
+    And the event "unhandled" is true
+    And the event "severityReason.type" equals "signal"
+    And the event "severityReason.attributes.signalType" equals "SIGFPE"
 
 Scenario: Triggering SIGILL
     When I run "SIGILLScenario" and relaunch the app
@@ -43,6 +59,10 @@ Scenario: Triggering SIGILL
     Then the request is valid for the error reporting API version "4.0" for the "iOS Bugsnag Notifier" notifier
     And the payload field "events" is an array with 1 elements
     And the exception "errorClass" equals "SIGILL"
+    And the event "severity" equals "error"
+    And the event "unhandled" is true
+    And the event "severityReason.type" equals "signal"
+    And the event "severityReason.attributes.signalType" equals "SIGILL"
 
 Scenario: Triggering SIGSEGV
     When I run "SIGSEGVScenario" and relaunch the app
@@ -51,6 +71,10 @@ Scenario: Triggering SIGSEGV
     Then the request is valid for the error reporting API version "4.0" for the "iOS Bugsnag Notifier" notifier
     And the payload field "events" is an array with 1 elements
     And the exception "errorClass" equals "SIGSEGV"
+    And the event "severity" equals "error"
+    And the event "unhandled" is true
+    And the event "severityReason.type" equals "signal"
+    And the event "severityReason.attributes.signalType" equals "SIGSEGV"
 
 Scenario: Triggering SIGSYS
     When I run "SIGSYSScenario" and relaunch the app
@@ -59,6 +83,10 @@ Scenario: Triggering SIGSYS
     Then the request is valid for the error reporting API version "4.0" for the "iOS Bugsnag Notifier" notifier
     And the payload field "events" is an array with 1 elements
     And the exception "errorClass" equals "SIGSYS"
+    And the event "severity" equals "error"
+    And the event "unhandled" is true
+    And the event "severityReason.type" equals "signal"
+    And the event "severityReason.attributes.signalType" equals "SIGSYS"
 
 Scenario: Triggering SIGTRAP
     When I run "SIGTRAPScenario" and relaunch the app
@@ -67,3 +95,7 @@ Scenario: Triggering SIGTRAP
     Then the request is valid for the error reporting API version "4.0" for the "iOS Bugsnag Notifier" notifier
     And the payload field "events" is an array with 1 elements
     And the exception "errorClass" equals "SIGTRAP"
+    And the event "severity" equals "error"
+    And the event "unhandled" is true
+    And the event "severityReason.type" equals "signal"
+    And the event "severityReason.attributes.signalType" equals "SIGTRAP"


### PR DESCRIPTION
## Goal

Improves the existing E2E scenarios which specifically check handled/unhandled errors by verifying the severity, severityReason, and unhandled flag are all set correctly.

This changeset also updates the scenario code for `UnhandledMachException`, which was erroneously sending a handled exception rather than generating `EXC_BAD_ACCESS`.