### PR TITLE
Assert the API Key is not nil or empty on init and accept otherwise invalid API keys

### DIFF
--- a/Tests/BSGConfigurationBuilderTests.m
+++ b/Tests/BSGConfigurationBuilderTests.m
@@ -15,24 +15,18 @@
 // MARK: - rejecting invalid plists
 
 - (void)testDecodeEmptyApiKey {
-    BugsnagConfiguration *config = [BSGConfigurationBuilder
-            configurationFromOptions:@{@"apiKey": @""}];
-    XCTAssertNotNil(config);
-    XCTAssertEqualObjects(@"", config.apiKey);
+    XCTAssertThrows([BSGConfigurationBuilder
+                     configurationFromOptions:@{@"apiKey": @""}]);
 }
 
 - (void)testDecodeInvalidTypeApiKey {
-    BugsnagConfiguration *config = [BSGConfigurationBuilder
-            configurationFromOptions:@{@"apiKey": @[@"one", @"two"]}];
-    XCTAssertNotNil(config);
-    XCTAssertEqualObjects(@"", config.apiKey);
+    XCTAssertThrows([BSGConfigurationBuilder
+                     configurationFromOptions:@{@"apiKey": @[@"one"]}]);
 }
 
 - (void)testDecodeWithoutApiKey {
-    BugsnagConfiguration *config = [BSGConfigurationBuilder
-            configurationFromOptions:@{@"autoDetectErrors": @NO}];
-    XCTAssertNotNil(config);
-    XCTAssertEqualObjects(@"", config.apiKey);
+    XCTAssertThrows([BSGConfigurationBuilder
+                     configurationFromOptions:@{@"autoDetectErrors": @NO}]);
 }
 
 - (void)testDecodeUnknownKeys {
@@ -44,9 +38,8 @@
 }
 
 - (void)testDecodeEmptyOptions {
-    BugsnagConfiguration *config = [BSGConfigurationBuilder configurationFromOptions:@{}];
-    XCTAssertNotNil(config);
-    XCTAssertEqualObjects(@"", config.apiKey);
+    XCTAssertThrows([BSGConfigurationBuilder
+                     configurationFromOptions:@{}]);
 }
 
 // MARK: - config loading

--- a/Tests/BugsnagConfigurationTests.m
+++ b/Tests/BugsnagConfigurationTests.m
@@ -635,18 +635,22 @@ NSString * const kBugsnagUserUserId = @"BugsnagUserUserId";
 // MARK: - Other tests
 // =============================================================================
 
+- (void)testInitWithApiKeyThrowsWhenMissing {
+    NSString *nilKey = nil;
+
+    XCTAssertThrows([[BugsnagConfiguration alloc] initWithApiKey:nilKey]);
+    XCTAssertThrows([[BugsnagConfiguration alloc] initWithApiKey:@""]);
+}
+
 /**
- * Test correct population of an NSError in the case of an invalid apiKey
+ * When passed an invalid API Key we log a warning message but will still use the key
  */
--(void)testDesignatedInitializerInvalidApiKey {
+- (void)testInitWithApiKeyUsesInvalidApiKeys {
     BugsnagConfiguration *invalidApiConfig = [[BugsnagConfiguration alloc] initWithApiKey:DUMMY_APIKEY_16CHAR];
     XCTAssertNotNil(invalidApiConfig);
     XCTAssertEqualObjects(invalidApiConfig.apiKey, DUMMY_APIKEY_16CHAR);
 }
 
-/**
-* Test NSError is not populated in the case of a valid apiKey
-*/
 -(void)testDesignatedInitializerValidApiKey {
     BugsnagConfiguration *validApiConfig1 = [[BugsnagConfiguration alloc] initWithApiKey:DUMMY_APIKEY_32CHAR_1];
     XCTAssertNotNil(validApiConfig1);
@@ -692,7 +696,8 @@ NSString * const kBugsnagUserUserId = @"BugsnagUserUserId";
 
 - (void)testApiKeySetter {
     BugsnagConfiguration *config = [[BugsnagConfiguration alloc] initWithApiKey:DUMMY_APIKEY_32CHAR_1];
-    XCTAssertTrue([config.apiKey isEqualToString:DUMMY_APIKEY_32CHAR_1]);
+    XCTAssertEqual(DUMMY_APIKEY_32CHAR_1, config.apiKey);
+
     config.apiKey = DUMMY_APIKEY_32CHAR_1;
     XCTAssertEqual(DUMMY_APIKEY_32CHAR_1, config.apiKey);
 
@@ -701,22 +706,16 @@ NSString * const kBugsnagUserUserId = @"BugsnagUserUserId";
     XCTAssertThrows(config.apiKey = nil);
 #pragma clang diagnostic pop
 
+    XCTAssertEqual(DUMMY_APIKEY_32CHAR_1, config.apiKey);
+
     XCTAssertThrows(config.apiKey = @"");
+    XCTAssertEqual(DUMMY_APIKEY_32CHAR_1, config.apiKey);
 
-    XCTAssertTrue([config.apiKey isEqualToString:DUMMY_APIKEY_32CHAR_1]);
+    config.apiKey = DUMMY_APIKEY_16CHAR;
+    XCTAssertEqual(DUMMY_APIKEY_16CHAR, config.apiKey);
 
-    XCTAssertThrows(config.apiKey = DUMMY_APIKEY_16CHAR);
-    XCTAssertThrows(config.apiKey = DUMMY_APIKEY_16CHAR);
-}
-
-- (void)testHasValidApiKey {
-    BugsnagConfiguration *config = [[BugsnagConfiguration alloc] initWithApiKey:DUMMY_APIKEY_32CHAR_1];
-
-    XCTAssertThrows(config.apiKey = DUMMY_APIKEY_16CHAR);
-    XCTAssertTrue([config.apiKey isEqualToString:DUMMY_APIKEY_32CHAR_1]);
-
-    config.apiKey = DUMMY_APIKEY_32CHAR_2;
-    XCTAssertTrue([config.apiKey isEqualToString:DUMMY_APIKEY_32CHAR_2]);
+    config.apiKey = DUMMY_APIKEY_32CHAR_1;
+    XCTAssertEqual(DUMMY_APIKEY_32CHAR_1, config.apiKey);
 }
 
 -(void)testBSGErrorTypes {

--- a/Tests/Swift Tests/BugsnagSwiftPublicAPITests.swift
+++ b/Tests/Swift Tests/BugsnagSwiftPublicAPITests.swift
@@ -46,7 +46,6 @@ class BugsnagSwiftPublicAPITests: XCTestCase {
     let onBreadcrumbBlock: BugsnagOnBreadcrumbBlock = { (breadcrumb) -> Bool in return false }
     
     func testBugsnagClass() throws {
-        Bugsnag.start(withApiKey: "")
         Bugsnag.start(withApiKey: apiKey);
         Bugsnag.start(with: BugsnagConfiguration(apiKey))
         
@@ -89,9 +88,8 @@ class BugsnagSwiftPublicAPITests: XCTestCase {
         }
         Bugsnag.removeOnBreadcrumb(block: onBreadcrumbBlock)
     }
-    
+
     func testBugsnagConfigurationClass() throws {
-        let _ = BugsnagConfiguration.loadConfig()
         let config = BugsnagConfiguration(apiKey)
 
         config.apiKey = apiKey


### PR DESCRIPTION
## Goal

<!-- Why is this change necessary? -->

Currently we convert `nil` and API keys that aren't 32 hex characters to an empty string

The expected behaviour is to reject `nil` and empty string API keys outright and to warn about API keys that aren't 32 hex characters but use them anyway

## Changeset

<!-- What changed? -->

- `setApiKey` now checks for a missing key (`nil` or empty) and throws
- `setApiKey` then checks if it's a valid 32 hex char string and warns if not but still uses the given string
- `initWithApiKey` now calls `setApiKey` rather than setting it itself, so it inherits the above logic
- `isValidApiKey` doesn't throw itself, so that it's always safe to call when we check the validity of the key

## Tests

<!-- How was it tested? -->

- Existing tests that pass a now-invalid key have been changed to assert it throws
- Existing tests that pass a 16 character string have been updated to reflect that this now uses the given string, instead of throwing or using an empty string (depending on if `setApiKey` or `initWithApiKey` is used)


<!-- 
--------------------------------------------------------------------------------

Have you:

* Commented the code sufficiently?
* Added a CHANGELOG entry, if necessary?
* Checked the scope to ensure the commits are only related to the goal above?	
* Considered asynchronicity and thread safety?
* Added any new headers to the "Copy Files" stage of the static iOS target?	
* Chosen the correct target branch?
* Considered all of the pre-release checks (see CONTRIBUTING.md), if this is a full release?

--------------------------------------------------------------------------------
-->
