### PR TITLE
Fix enabled error type test flake

### DIFF
--- a/features/enabled_error_types.feature
+++ b/features/enabled_error_types.feature
@@ -27,15 +27,13 @@ Scenario: NSException Crash Reporting is disabled
     And the event "unhandled" is false
     And the payload field "events.0.exceptions.0.message" equals "DisableNSExceptionScenario - Handled"
 
-# TODO: PLAT-4422 - Currently flakey, bubbling up SIGABRT.
-@skip
 Scenario: CPP Crash Reporting is disabled
     When I run "EnabledErrorTypesCxxScenario" and relaunch the app
     And I configure Bugsnag for "EnabledErrorTypesCxxScenario"
-    And I wait to receive a request
-    Then the request is valid for the error reporting API version "4.0" for the "iOS Bugsnag Notifier" notifier
-    And the event "unhandled" is false
-    And the payload field "events.0.exceptions.0.message" equals "EnabledErrorTypesCxxScenario - Handled"
+    And I wait to receive 2 requests
+    Then the request is valid for the session reporting API version "1.0" for the "iOS Bugsnag Notifier" notifier
+    And I discard the oldest request
+    Then the request is valid for the session reporting API version "1.0" for the "iOS Bugsnag Notifier" notifier
 
 Scenario: Mach Crash Reporting is disabled
     When I run "DisableMachExceptionScenario"

--- a/features/fixtures/ios-swift-cocoapods/iOSTestApp/scenarios/EnabledErrorTypesCxxScenario.mm
+++ b/features/fixtures/ios-swift-cocoapods/iOSTestApp/scenarios/EnabledErrorTypesCxxScenario.mm
@@ -20,15 +20,14 @@ const char *disabled_cxx_reporting_kaboom_exception::what() const throw() {
     errorTypes.cppExceptions = false;
     errorTypes.ooms = false;
     self.config.enabledErrorTypes = errorTypes;
-    self.config.autoTrackSessions = NO;
+    [self.config addOnSendErrorBlock:^BOOL(BugsnagEvent * _Nonnull event) {
+        // std::exception terminates with abort() by default, therefore discard SIGABRT
+        return ![@"SIGABRT" isEqualToString:event.errors[0].errorClass];
+    }];
     [super startBugsnag];
 }
 
 - (void)run {
-    // Send a handled exception to confirm the scenario is running.
-    [Bugsnag notify:[NSException exceptionWithName:NSGenericException reason:@"EnabledErrorTypesCxxScenario - Handled"
-                                          userInfo:@{NSLocalizedDescriptionKey: @""}]];
-    
     [self crash];
 }
 


### PR DESCRIPTION
## Goal

Fixes a flaky E2E test that checks enabled error types.

The root cause of this was that the `EnabledErrorTypesCxxScenario` creates a handled error, then immediately creates an unhandled error. This leads to a race where the handled error is delivered on a background thread and might not be sent to the mock API before the unhandled error triggers.

The fix for this is to delay the unhandled error for 2 seconds - note that is potentially applicable to other flaky scenarios which have been written in the same way. Verified by running this scenario 20 times on Buildkite without any failures.
