### PR TITLE
Allow passing of arguments to MazeRunner

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -111,7 +111,7 @@ endif
 ifeq ($(BROWSER_STACK_ACCESS_KEY),)
 	@$(error BROWSER_STACK_ACCESS_KEY is not defined)
 endif
-	@docker-compose run cocoa-maze-runner --tags 'not @skip' $(TEST_FEATURE)
+	@docker-compose run cocoa-maze-runner $(MAZE_ARGS) --tags 'not @skip' $(TEST_FEATURE)
 
 e2e:
 	@make e2e_build

--- a/scripts/e2e_test.sh
+++ b/scripts/e2e_test.sh
@@ -1,12 +1,24 @@
 #!/bin/bash
 
-if [ $# -eq 0 ] || [ $# -gt 2 ]; then
-  echo "Usage: e2e_test.sh <feature> [DEVICE_TYPE=IOS_13]"
-  echo "  where DEVICE_TYPE is one of (IOS_10, IOS_11, IOS_12, IOS_13)"
+if [ $# -eq 0 ]; then
+  echo "Usage: e2e_test.sh <feature> [DEVICE_TYPE=IOS_13] [MAZE_ARGS]"
+  echo
+  echo "    DEVICE_TYPE is one of (IOS_10, IOS_11, IOS_12, IOS_13), with use detected by the "
+  echo "      argument starting with \"IOS\""
+  echo
+  echo "    MAZE_ARGS is any number of arguments to be passed to Maze Runner"
+  echo
   exit 1
 fi;
 
 FEATURE=$1
-[ $# -eq 2 ] && DEVICE=$2 || DEVICE=IOS_13
+shift
 
-TEST_FEATURE=$FEATURE DEVICE_TYPE=$DEVICE make e2e
+if [ $# -gt 0 ] && [[ "$1" == IOS* ]]; then
+  DEVICE=$1
+  shift
+else
+   DEVICE=IOS_13
+fi;
+
+MAZE_ARGS="$*" TEST_FEATURE=$FEATURE DEVICE_TYPE=$DEVICE make e2e


### PR DESCRIPTION
Allows arguments to be passed to MazeRunner using the run_e2e helper script.  E.g:

```
./scripts/e2e_test.sh features/breadcrumbs.feature --retry 3 # Defaults to IOS_13
./scripts/e2e_test.sh features/breadcrumbs.feature IOS_12 --retry 3
```