### PR TITLE
e2e skeleton tests for app and device overrides

### DIFF
--- a/features/app_and_device_attributes.feature
+++ b/features/app_and_device_attributes.feature
@@ -42,3 +42,27 @@ Scenario: App and Device info is as expected
     And the payload field "events.0.app.duration" is a number
     And the payload field "events.0.app.durationInForeground" is a number
     And the payload field "events.0.app.inForeground" is not null
+
+Scenario: App and Device info is as expected when overridden via config
+    When I run "AppAndDeviceAttributesScenarioConfigOverride"
+    And I wait to receive a request
+    Then the request is valid for the error reporting API version "4.0" for the "iOS Bugsnag Notifier" notifier
+    And the "Bugsnag-API-Key" header equals "12312312312312312312312312312312"
+
+    And the payload field "events.0.app.type" equals "iLeet"
+    And the payload field "events.0.app.bundleVersion" does not equal "12345"
+    And the payload field "events.0.context" equals "myContext"
+    And the payload field "events.0.app.releaseStage" equals "secondStage"
+    
+Scenario: App and Device info is as expected when overridden via callback
+    When I run "AppAndDeviceAttributesScenarioCallbackOverride"
+    And I wait to receive a request
+    Then the request is valid for the error reporting API version "4.0" for the "iOS Bugsnag Notifier" notifier
+    And the "Bugsnag-API-Key" header equals "12312312312312312312312312312312"
+
+    And the payload field "events.0.app.type" equals "newAppType"
+    And the payload field "events.0.app.bundleVersion" does not equal "12345"
+    And the payload field "events.0.app.version" equals "999"
+    And the payload field "events.0.app.releaseStage" equals "thirdStage"
+    And the payload field "events.0.device.manufacturer" equals "Nokia"
+    And the payload field "events.0.device.modelNumber" equals "0898"

--- a/features/fixtures/ios-swift-cocoapods/iOSTestApp/scenarios/AppAndDeviceAttributesScenario.swift
+++ b/features/fixtures/ios-swift-cocoapods/iOSTestApp/scenarios/AppAndDeviceAttributesScenario.swift
@@ -12,7 +12,7 @@ import Bugsnag
 class AppAndDeviceAttributesScenario: Scenario {
 
     override func startBugsnag() {
-      self.config.autoTrackSessions = false;
+      self.config.autoTrackSessions = false
       super.startBugsnag()
     }
 
@@ -21,3 +21,51 @@ class AppAndDeviceAttributesScenario: Scenario {
         Bugsnag.notifyError(error)
     }
 }
+
+/**
+ * Override default values in config
+ */
+class AppAndDeviceAttributesScenarioConfigOverride: Scenario {
+
+    override func startBugsnag() {
+        self.config.autoTrackSessions = false
+        
+        self.config.appType = "iLeet"
+        self.config.bundleVersion = "12345"
+        self.config.context = "myContext"
+        self.config.releaseStage = "secondStage"
+        
+        super.startBugsnag()
+    }
+
+    override func run() {
+        let error = NSError(domain: "AppAndDeviceAttributesScenarioConfigOverride", code: 100, userInfo: nil)
+        Bugsnag.notifyError(error)
+    }
+}
+
+class AppAndDeviceAttributesScenarioCallbackOverride: Scenario {
+
+    override func startBugsnag() {
+        self.config.autoTrackSessions = false
+        
+        self.config.addOnSendError { (event) -> Bool in
+            event.app.type = "newAppType"
+            event.app.releaseStage = "thirdStage"
+            event.app.version = "999"
+            event.device.manufacturer = "Nokia"
+            event.device.modelNumber = "0898"
+            
+            return true
+        }
+        
+        super.startBugsnag()
+    }
+
+    override func run() {
+        let error = NSError(domain: "AppAndDeviceAttributesScenarioCallbackOverride", code: 100, userInfo: nil)
+        Bugsnag.notifyError(error)
+    }
+}
+
+


### PR DESCRIPTION
## Goal

Provides missing tests for overriding select app and device values in config and callbacks

## Design

Couple of new scenarios that do what they say - change values in config and in a callback.  No changelog since this just adds tests.