### PR TITLE
Update minimum supported OS versions in the Cocoapods spec and exampl…

### DIFF
--- a/Bugsnag.podspec.json
+++ b/Bugsnag.podspec.json
@@ -20,9 +20,9 @@
     "c++", "z"
   ],
   "platforms": {
-    "ios": "8.0",
+    "ios": "9.3",
     "osx": "10.11",
-    "tvos": "9.0"
+    "tvos": "9.2"
   },
   "source_files": [
     "Source/{**/,}*.{m,h,mm,c}"

--- a/examples/objective-c-ios/Podfile
+++ b/examples/objective-c-ios/Podfile
@@ -1,4 +1,4 @@
 target 'Bugsnag Test App' do
-    platform :ios, "8.0"
+    platform :ios, "9.3"
     pod 'Bugsnag', :path => "../.."
 end

--- a/examples/objective-c-osx/Podfile
+++ b/examples/objective-c-osx/Podfile
@@ -1,5 +1,5 @@
 target 'objective-c-osx' do
-    platform :osx, "10.8"
+    platform :osx, "10.11"
     pod 'Bugsnag', :path => "../.."
 end
 

--- a/examples/swift-ios/Podfile
+++ b/examples/swift-ios/Podfile
@@ -1,4 +1,4 @@
-platform :ios, '8.0'
+platform :ios, '9.3'
 
 target 'bugsnag-example' do
   pod 'Bugsnag', :path => "../.."


### PR DESCRIPTION
## Goal      <!-- Why is this change necessary? -->

The Cocoapods podspec didn't match the officially supported minimum OS versions.  This change updates those values and also updates the example projects.

## Tests

Manual creation of appropriate projects.
