### PR TITLE
feat: redacted keys' comparison is now case-insensitive

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,9 @@ Bugsnag Notifiers on other platforms.
 
 ## Enhancements
 
+* The comparison of redacted keys is now case-insensitive
+  [#653](https://github.com/bugsnag/bugsnag-cocoa/pull/653)
+
 * Unified the three main XCode projects
   [#633](https://github.com/bugsnag/bugsnag-cocoa/pull/633)
 

--- a/Source/BugsnagEvent.m
+++ b/Source/BugsnagEvent.m
@@ -840,7 +840,7 @@ NSDictionary *BSGParseCustomException(NSDictionary *report,
 - (BOOL)isRedactedKey:(NSString *)key {
     for (id obj in self.redactedKeys) {
         if ([obj isKindOfClass:[NSString class]]) {
-            if ([key isEqualToString:obj]) {
+            if ([[key lowercaseString] isEqualToString:[obj lowercaseString]]) {
                 return true;
             }
         } else if ([obj isKindOfClass:[NSRegularExpression class]]) {

--- a/Tests/BugsnagMetadataRedactionTest.m
+++ b/Tests/BugsnagMetadataRedactionTest.m
@@ -117,5 +117,27 @@
     XCTAssertEqualObjects(@"ba09", section[@"somekey"]);
 }
 
+- (void)testCaseInsensitiveKeys {
+    BugsnagEvent *event = [self generateEventWithMetadata:@{
+            @"password": @"hunter2",
+            @"somekey9": @"2fa0",
+            @"somekey": @"ba09",
+            @"CaseInsensitiveKey" : @"CaseInsensitiveValue",
+            @"caseInsensitiveKey" : @"CaseInsensitiveValue",
+            @"caseInsensitiveKeyX" : @"CaseInsensitiveValue",
+    }];
+    
+    // Note: this redacts both keys
+    event.redactedKeys = [NSSet setWithArray:@[@"password", @"Caseinsensitivekey"]];
+
+    NSDictionary *payload = [event toJson];
+    NSDictionary *section = payload[@"metaData"][@"custom"];
+    XCTAssertNotNil(section);
+    XCTAssertEqualObjects(@"[REDACTED]", section[@"password"]);
+    XCTAssertEqualObjects(@"[REDACTED]", section[@"CaseInsensitiveKey"]);
+    XCTAssertEqualObjects(@"[REDACTED]", section[@"caseInsensitiveKey"]);
+    XCTAssertEqualObjects(@"CaseInsensitiveValue", section[@"caseInsensitiveKeyX"]);
+    XCTAssertEqualObjects(@"ba09", section[@"somekey"]);
+}
 
 @end


### PR DESCRIPTION
## Goal

Comparison of redacted keys should be case insensitive for strings. 

## Design

Comparison of key with redacted keys is now lower-cased.  Keys and redacted keys remain as they were set.  One side-effect is that a single redaction key can redact multiple pieces of metadata (e.g. "Password", "password" and "PASSWORD").

<!-- Why was this approach used? -->

## Changeset

Lowercasing added to `BugsnagEvent.isRedactedKey()`

<!-- What changed? -->

## Tests

A single unit test.
