### PR TITLE
fix - report.app and report.appState are opposite

### DIFF
--- a/Source/BugsnagCrashReport.m
+++ b/Source/BugsnagCrashReport.m
@@ -276,8 +276,8 @@ static NSString *const DEFAULT_EXCEPTION_TYPE = @"cocoa";
             _context = BSGParseContext(report, _metaData);
             _deviceState = BSGParseDeviceState(report);
             _device = BSGParseDevice(report);
-            _app = BSGParseApp(report);
-            _appState = BSGParseAppState(report[BSGKeySystem],
+            _appState = BSGParseAppState(report);
+            _app = BSGParseApp(report[BSGKeySystem],
                                          BSGLoadConfigValue(report, @"appVersion"),
                                          _releaseStage, // Already loaded from config
                                          BSGLoadConfigValue(report, @"codeBundleId"));

--- a/Source/BugsnagKSCrashSysInfoParser.h
+++ b/Source/BugsnagKSCrashSysInfoParser.h
@@ -11,8 +11,8 @@
 #define PLATFORM_WORD_SIZE sizeof(void*)*8
 
 NSDictionary *_Nonnull BSGParseDevice(NSDictionary *_Nonnull report);
-NSDictionary *_Nonnull BSGParseApp(NSDictionary *_Nonnull report);
-NSDictionary *_Nonnull BSGParseAppState(NSDictionary *_Nonnull report, 
+NSDictionary *_Nonnull BSGParseAppState(NSDictionary *_Nonnull report);
+NSDictionary *_Nonnull BSGParseApp(NSDictionary *_Nonnull report,
                                         NSString *_Nullable preferredVersion, 
                                         NSString *_Nullable releaseStage, 
                                         NSString *_Nullable codeBundleId);

--- a/Source/BugsnagKSCrashSysInfoParser.m
+++ b/Source/BugsnagKSCrashSysInfoParser.m
@@ -65,7 +65,7 @@ NSDictionary *BSGParseDevice(NSDictionary *report) {
     return device;
 }
 
-NSDictionary *BSGParseApp(NSDictionary *report) {
+NSDictionary *BSGParseAppState(NSDictionary *report) {
     NSDictionary *system = report[BSGKeySystem];
 
     NSMutableDictionary *appState = [NSMutableDictionary dictionary];
@@ -90,7 +90,7 @@ NSDictionary *BSGParseApp(NSDictionary *report) {
     return appState;
 }
 
-NSDictionary *BSGParseAppState(NSDictionary *report, NSString *preferredVersion, NSString *releaseStage, NSString *codeBundleId) {
+NSDictionary *BSGParseApp(NSDictionary *report, NSString *preferredVersion, NSString *releaseStage, NSString *codeBundleId) {
     NSMutableDictionary *app = [NSMutableDictionary dictionary];
 
     NSString *version = preferredVersion ?: report[@"CFBundleShortVersionString"];

--- a/Source/BugsnagSessionTrackingPayload.m
+++ b/Source/BugsnagSessionTrackingPayload.m
@@ -39,7 +39,7 @@
     BSGDictSetSafeObject(dict, [Bugsnag notifier].details, BSGKeyNotifier);
     
     NSDictionary *systemInfo = [BSG_KSSystemInfo systemInfo];
-    BSGDictSetSafeObject(dict, BSGParseAppState(systemInfo,
+    BSGDictSetSafeObject(dict, BSGParseApp(systemInfo,
                                                 [Bugsnag configuration].appVersion,
                                                 [Bugsnag configuration].releaseStage,
                                                 [Bugsnag configuration].codeBundleId), @"app");

--- a/iOS/BugsnagTests/BugsnagKSCrashSysInfoParserTest.m
+++ b/iOS/BugsnagTests/BugsnagKSCrashSysInfoParserTest.m
@@ -56,7 +56,7 @@ NSNumber * _Nullable BSGDeviceFreeSpace(NSSearchPathDirectory directory);
         @"CFBundleVersion":@"4.1.1.2362",
         @"extra":@"foo",
     };
-    NSDictionary *state = BSGParseAppState(rawInfo, nil, @"prod", nil);
+    NSDictionary *state = BSGParseApp(rawInfo, nil, @"prod", nil);
     XCTAssertEqual(state.count, 5);
     XCTAssertEqualObjects(state[@"releaseStage"], @"prod");
     XCTAssertEqualObjects(state[@"version"], @"4.1.1");
@@ -77,7 +77,7 @@ NSNumber * _Nullable BSGDeviceFreeSpace(NSSearchPathDirectory directory);
         @"CFBundleVersion":@"4.1.1.2362",
         @"extra":@"foo",
     };
-    NSDictionary *state = BSGParseAppState(rawInfo, @"2.0", @"prod", @"4.2.0-cbd");
+    NSDictionary *state = BSGParseApp(rawInfo, @"2.0", @"prod", @"4.2.0-cbd");
     XCTAssertEqual(state.count, 5);
     XCTAssertEqualObjects(state[@"releaseStage"], @"prod");
     XCTAssertEqualObjects(state[@"version"], @"2.0");


### PR DESCRIPTION
## Goal

fix #658 - BugsnagCrashReport.app and BugsnagCrashReport.appState are opposite. 

## Design

correct them by exchanging the implementation

## Changeset


## Tests

<!-- How was it tested? -->



<!-- 
--------------------------------------------------------------------------------

Have you:

* Commented the code sufficiently?
* Added a CHANGELOG entry, if necessary?
* Checked the scope to ensure the commits are only related to the goal above?	
* Considered asynchronicity and thread safety?
* Added any new headers to the "Copy Files" stage of the static iOS target?	
* Chosen the correct target branch?
* Considered all of the pre-release checks (see CONTRIBUTING.md), if this is a full release?

--------------------------------------------------------------------------------
-->
