### PR TITLE
Only add NSError to metadata if not nil

### DIFF
--- a/Source/BugsnagEvent.m
+++ b/Source/BugsnagEvent.m
@@ -805,7 +805,7 @@ NSDictionary *BSGParseCustomException(NSDictionary *report,
     //  Inserted into `context` property
     [metadata removeObjectForKey:BSGKeyContext];
     // Build metadata
-    BSGDictSetSafeObject(metadata, [self error], BSGKeyError);
+    BSGDictInsertIfNotNil(metadata, self.error, BSGKeyError);
 
     // add user
     BSGDictInsertIfNotNil(event, [self.user toJson], BSGKeyUser);


### PR DESCRIPTION
## Goal

Prevents NSError from being added to the metadata when it is nil, which showed up as a useless tab on reports sent to the dashboard.

Verified by sending a handled NSError and handled NSException to the dashboard and checking only the NSError report contained the metadata tab.