### PR TITLE
Avoid dereferencing nil in JSON codec

### DIFF
--- a/Source/KSCrash/Source/KSCrash/Recording/BSG_KSCrashReportStore.m
+++ b/Source/KSCrash/Source/KSCrash/Recording/BSG_KSCrashReportStore.m
@@ -83,9 +83,10 @@ static NSString *const kCrashReportSuffix = @"-CrashReport-";
     if (dict != nil) {
         return dict;
     } else {
+        NSError *error = nil;
         NSMutableDictionary *fileContents = [NSMutableDictionary new];
         NSMutableDictionary *recrashReport =
-                [self readFile:[self pathToRecrashReportWithID:fileId] error:nil];
+                [self readFile:[self pathToRecrashReportWithID:fileId] error:&error];
         BSGDictInsertIfNotNil(fileContents, recrashReport, @BSG_KSCrashField_RecrashReport);
         return fileContents;
     }


### PR DESCRIPTION
## Goal

Avoids dereferencing a null pointer in the JSON codec if an error occurs when reading a file.