### PR TITLE
Avoid dereference null pointer in BSG_KSJSONCodec

### DIFF
--- a/Source/KSCrash/Source/KSCrash/Recording/BSG_KSCrashReportStore.m
+++ b/Source/KSCrash/Source/KSCrash/Recording/BSG_KSCrashReportStore.m
@@ -83,9 +83,10 @@ static NSString *const kCrashReportSuffix = @"-CrashReport-";
     if (dict != nil) {
         return dict;
     } else {
+        NSError *error = nil;
         NSMutableDictionary *fileContents = [NSMutableDictionary new];
         NSMutableDictionary *recrashReport =
-                [self readFile:[self pathToRecrashReportWithID:fileId] error:nil];
+                [self readFile:[self pathToRecrashReportWithID:fileId] error:&error];
         BSGDictInsertIfNotNil(fileContents, recrashReport, @BSG_KSCrashField_RecrashReport);
         return fileContents;
     }


### PR DESCRIPTION
## Goal

Prevents a null dereference in the JSON codec, which causes a crash.
