### PR TITLE
Avoid calling C++ termination handler for NSException

### DIFF
--- a/Source/KSCrash/Source/KSCrash/Recording/Sentry/BSG_KSCrashSentry_CPPException.mm
+++ b/Source/KSCrash/Source/KSCrash/Recording/Sentry/BSG_KSCrashSentry_CPPException.mm
@@ -186,10 +186,10 @@ static void CPPExceptionTerminate(void) {
             @"Crash handling complete. Restoring original handlers.");
         bsg_kscrashsentry_uninstall((BSG_KSCrashType)BSG_KSCrashTypeAll);
         bsg_kscrashsentry_resumeThreads();
-    }
 
-    if (bsg_g_originalTerminateHandler != NULL) {
-        bsg_g_originalTerminateHandler();
+        if (bsg_g_originalTerminateHandler != NULL) {
+            bsg_g_originalTerminateHandler();
+        }
     }
 }
 


### PR DESCRIPTION
## Goal

Avoids calling the original C++ termination handler for uncaught `NSException` objects. If `enabledErrorType.nsexceptions` is set to false, then the `BSG_KSCrashSentry_NSException` handler will not be installed, and any uncaught `NSException` will propagate through to the C++ handler instead. Calling the original handler ultimately results in a SIGABRT with the bugsnag method as the error context:

<img width="441" alt="Screenshot 2020-06-02 at 15 38 31" src="https://user-images.githubusercontent.com/11800640/83533203-2a29bb00-a4e7-11ea-84d5-9549d3c8a56d.png">

## Changeset

This changeset only calls the original termination handler for C++ exceptions that are not NSException, thus allowing for the correct context and other information to be gathered on the SIGABRT.

Verified by testing an NSException before and after the fix, with NSException capture both enabled/disabled.
