### PR TITLE
Mach crash reporting

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,7 +1,7 @@
 version: '3.6'
 services:
   cocoa-maze-runner:
-    image: 855461928731.dkr.ecr.us-west-1.amazonaws.com/maze-runner:latest-cli
+    image: 855461928731.dkr.ecr.us-west-1.amazonaws.com/maze-runner:master-cli
     command: ["--tags", "not @skip"]
     environment:
       APP_LOCATION: /app/build/iOSTestApp.ipa

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,7 +1,7 @@
 version: '3.6'
 services:
   cocoa-maze-runner:
-    image: 855461928731.dkr.ecr.us-west-1.amazonaws.com/maze-runner:master-cli
+    image: 855461928731.dkr.ecr.us-west-1.amazonaws.com/maze-runner:latest-cli
     command: ["--tags", "not @skip"]
     environment:
       APP_LOCATION: /app/build/iOSTestApp.ipa

--- a/features/enabled_error_types.feature
+++ b/features/enabled_error_types.feature
@@ -33,6 +33,8 @@ Feature: Enabled error types
   Scenario: CPP Crash Reporting is disabled
     When I run "EnabledErrorTypesCxxScenario" and relaunch the app
     And I configure Bugsnag for "EnabledErrorTypesCxxScenario"
+    # Give ignored SIGABRT report time to be processed
+    And I wait for 2 seconds
     And I wait to receive 2 requests
     Then the request is valid for the session reporting API version "1.0" for the "iOS Bugsnag Notifier" notifier
     And I discard the oldest request
@@ -42,6 +44,8 @@ Feature: Enabled error types
     When I run "DisableMachExceptionScenario"
     And I relaunch the app
     And I configure Bugsnag for "DisableMachExceptionScenario"
+    # Give ignored SIGSEGV report time to be processed
+    And I wait for 2 seconds
     And I wait to receive 2 requests
     Then the request is valid for the session reporting API version "1.0" for the "iOS Bugsnag Notifier" notifier
     And I discard the oldest request

--- a/features/enabled_error_types.feature
+++ b/features/enabled_error_types.feature
@@ -42,10 +42,10 @@ Feature: Enabled error types
     When I run "DisableMachExceptionScenario"
     And I relaunch the app
     And I configure Bugsnag for "DisableMachExceptionScenario"
-    And I wait to receive a request
-    Then the request is valid for the error reporting API version "4.0" for the "iOS Bugsnag Notifier" notifier
-    And the event "unhandled" is false
-    And the payload field "events.0.exceptions.0.message" equals "DisableMachExceptionScenario - Handled"
+    And I wait to receive 2 requests
+    Then the request is valid for the session reporting API version "1.0" for the "iOS Bugsnag Notifier" notifier
+    And I discard the oldest request
+    Then the request is valid for the session reporting API version "1.0" for the "iOS Bugsnag Notifier" notifier
 
   Scenario: Signals Crash Reporting is disabled
     When I run "DisableSignalsExceptionScenario" and relaunch the app


### PR DESCRIPTION
## Goal

Fix the failing Mach exception scenario.

## Design

After some amount of investigation and manually running scenarios locally, I determined that the notifier needed a little time to process error report files (which is was configured to ignore), in order that the file did not leak into the following scenario and cause a false failure (due to the notifier being configured differently).