### PR TITLE
charging from NSNumber -> BOOL

### DIFF
--- a/Source/BugsnagNotifier.m
+++ b/Source/BugsnagNotifier.m
@@ -734,7 +734,7 @@ NSString *const kAppWillTerminate = @"App Will Terminate";
 - (void)batteryChanged:(NSNotification *)notif {
     NSNumber *batteryLevel =
             @([UIDevice currentDevice].batteryLevel);
-    NSNumber *charging =
+    BOOL *charging =
             @([UIDevice currentDevice].batteryState ==
                     UIDeviceBatteryStateCharging);
 


### PR DESCRIPTION
## Goal

We're seeing invalid payloads returned from multiple endpoints coming only from events sourced in this SDK. The Device field is returning 1 or 0 rather than true or false. The expected behavior is documented here: https://docs.bugsnag.com/product/integrations/data-forwarding/sqs/

We can also compare to the android library: https://github.com/bugsnag/bugsnag-android/blob/7d2ae7782b018f14138f1019f4bf89ed0c9af67d/bugsnag-android-core/src/main/java/com/bugsnag/android/DeviceDataCollector.kt#L62 which has the correct type.

## Design

The value is already being evaluated as a BOOL, it's being implicitly casted to a NSNumber.

## Changeset

one type

## Tests

I did not add new tests