### PR TITLE
fix: the DYLD cache locking mechanism now determines the lock mechani…

### DIFF
--- a/Source/KSCrash/Source/KSCrash/Recording/BSG_KSCrash.m
+++ b/Source/KSCrash/Source/KSCrash/Recording/BSG_KSCrash.m
@@ -280,10 +280,11 @@ IMPLEMENT_EXCLUSIVE_SHARED_INSTANCE(BSG_KSCrash)
  * behaviour.
  */
 - (void)listenForLoadedBinaries {
+    // Store a static version of the OS for comparison efficiency
+    bsg_initialise_static_os();
     bsg_initialise_mach_binary_headers(BSG_INITIAL_MACH_BINARY_IMAGE_ARRAY_SIZE);
 
-    // Note: Internally, access to DYLD's binary image store is guarded by an OSSpinLock.  We therefore don't need to
-    // add additional guards around our access.
+    // Note: Access to DYLD's binary image store is guarded by locks.
     _dyld_register_func_for_remove_image(&bsg_mach_binary_image_removed);
     _dyld_register_func_for_add_image(&bsg_mach_binary_image_added);
 }

--- a/Source/KSCrash/Source/KSCrash/Recording/BSG_KSCrash.m
+++ b/Source/KSCrash/Source/KSCrash/Recording/BSG_KSCrash.m
@@ -280,8 +280,7 @@ IMPLEMENT_EXCLUSIVE_SHARED_INSTANCE(BSG_KSCrash)
  * behaviour.
  */
 - (void)listenForLoadedBinaries {
-    // Store a static version of the OS for comparison efficiency
-    bsg_check_spin_lock_support();
+    bsg_check_unfair_lock_support();
     bsg_initialise_mach_binary_headers(BSG_INITIAL_MACH_BINARY_IMAGE_ARRAY_SIZE);
 
     // Note: Access to DYLD's binary image store is guarded by locks.

--- a/Source/KSCrash/Source/KSCrash/Recording/BSG_KSCrash.m
+++ b/Source/KSCrash/Source/KSCrash/Recording/BSG_KSCrash.m
@@ -281,7 +281,7 @@ IMPLEMENT_EXCLUSIVE_SHARED_INSTANCE(BSG_KSCrash)
  */
 - (void)listenForLoadedBinaries {
     // Store a static version of the OS for comparison efficiency
-    bsg_initialise_static_os();
+    bsg_check_spin_lock_support();
     bsg_initialise_mach_binary_headers(BSG_INITIAL_MACH_BINARY_IMAGE_ARRAY_SIZE);
 
     // Note: Access to DYLD's binary image store is guarded by locks.

--- a/Source/KSCrash/Source/KSCrash/Recording/Tools/BSG_KSMachHeaders.h
+++ b/Source/KSCrash/Source/KSCrash/Recording/Tools/BSG_KSMachHeaders.h
@@ -105,6 +105,6 @@ BSG_Mach_Binary_Images *bsg_initialise_mach_binary_headers(uint32_t initialSize)
 /**
  * Store a static copy of the OS for comparison efficiency.
  */
-void bsg_initialise_static_os(void);
+void bsg_check_spin_lock_support(void);
 
 #endif /* BSG_KSMachHeaders_h */

--- a/Source/KSCrash/Source/KSCrash/Recording/Tools/BSG_KSMachHeaders.h
+++ b/Source/KSCrash/Source/KSCrash/Recording/Tools/BSG_KSMachHeaders.h
@@ -10,6 +10,8 @@
 #define BSG_KSMachHeaders_h
 
 #import <mach/machine.h>
+#import <os/lock.h>
+#import <libkern/OSAtomic.h>
 
 /**
  * An encapsulation of the Mach header - either 64 or 32 bit, along with some additional information required for
@@ -36,8 +38,12 @@ typedef struct {
 
 static BSG_Mach_Binary_Images bsg_mach_binary_images;
 
+// MARK: - Locking
+
 /**
- * An OS-version-specific lock, used to synchronise access to the array of binary image info.
+ * An OS-version-specific lock, used to synchronise access to the array of binary image info.  A combination of
+ * compile-time determination of the OS and and run-time determination of the OS version is used to ensure that
+ * the correct lock mechanism is used.
  *
  * os_unfair_lock is available from specific OS versions onwards:
  *     https://developer.apple.com/documentation/os/os_unfair_lock
@@ -45,45 +51,15 @@ static BSG_Mach_Binary_Images bsg_mach_binary_images;
  * It deprecates OSSpinLock:
  *     https://developer.apple.com/library/archive/documentation/System/Conceptual/ManPages_iPhoneOS/man3/spinlock.3.html
  *
- *  The #defined BSG_DYLD_CACHE_LOCK/UNLOCK avoid spurious warnings on later OSs.
+ * The imported headers have specific version info: <os/lock.h> and <libkern/OSAtomic.h>
  */
 
-#if defined(__IPHONE_10_0) || defined(__MAC_10_12) || defined(__TVOS_10_0) || defined(__WATCHOS_3_0)
-    #pragma clang diagnostic push
-    #pragma clang diagnostic ignored "-Wunguarded-availability"
-
-    #import <os/lock.h>
-    static os_unfair_lock bsg_mach_binary_images_access_lock = OS_UNFAIR_LOCK_INIT;
-
-    #ifndef BSG_DYLD_CACHE_LOCK
-    #define BSG_DYLD_CACHE_LOCK \
-        _Pragma("clang diagnostic push") \
-        _Pragma("clang diagnostic ignored \"-Wunguarded-availability\"") \
-        os_unfair_lock_lock(&bsg_mach_binary_images_access_lock); \
-        _Pragma("clang diagnostic pop")
-    #endif
-
-    #ifndef BSG_DYLD_CACHE_UNLOCK
-    #define BSG_DYLD_CACHE_UNLOCK \
-        _Pragma("clang diagnostic push") \
-        _Pragma("clang diagnostic ignored \"-Wunguarded-availability\"") \
-        os_unfair_lock_unlock(&bsg_mach_binary_images_access_lock); \
-        _Pragma("clang diagnostic pop")
-    #endif
-
-    #pragma clang diagnostic pop
-#else
-    #import <libkern/OSAtomic.h>
-    static OSSpinLock bsg_mach_binary_images_access_lock = OS_SPINLOCK_INIT;
-
-    #ifndef BSG_DYLD_CACHE_LOCK
-    #define BSG_DYLD_CACHE_LOCK OSSpinLockLock(&bsg_mach_binary_images_access_lock);
-    #endif
-
-    #ifndef BSG_DYLD_CACHE_UNLOCK
-    #define BSG_DYLD_CACHE_UNLOCK OSSpinLockUnlock(&bsg_mach_binary_images_access_lock);
-    #endif
-#endif
+void bsg_spin_lock(void);
+void bsg_spin_unlock(void);
+void bsg_unfair_lock(void);
+void bsg_unfair_unlock(void);
+void bsg_dyld_cache_lock(void);
+void bsg_dyld_cache_unlock(void);
 
 // MARK: - Replicate the DYLD API
 
@@ -125,5 +101,10 @@ void bsg_mach_binary_image_removed(const struct mach_header *mh, intptr_t slide)
  * Create an empty array with initial capacity to hold Mach header info.
  */
 BSG_Mach_Binary_Images *bsg_initialise_mach_binary_headers(uint32_t initialSize);
+
+/**
+ * Store a static copy of the OS for comparison efficiency.
+ */
+void bsg_initialise_static_os(void);
 
 #endif /* BSG_KSMachHeaders_h */

--- a/Source/KSCrash/Source/KSCrash/Recording/Tools/BSG_KSMachHeaders.h
+++ b/Source/KSCrash/Source/KSCrash/Recording/Tools/BSG_KSMachHeaders.h
@@ -103,8 +103,8 @@ void bsg_mach_binary_image_removed(const struct mach_header *mh, intptr_t slide)
 BSG_Mach_Binary_Images *bsg_initialise_mach_binary_headers(uint32_t initialSize);
 
 /**
- * Store a static copy of the OS for comparison efficiency.
+ * Determines whether the OS supports unfair locks or not.
  */
-void bsg_check_spin_lock_support(void);
+void bsg_check_unfair_lock_support(void);
 
 #endif /* BSG_KSMachHeaders_h */

--- a/Source/KSCrash/Source/KSCrash/Recording/Tools/BSG_KSMachHeaders.m
+++ b/Source/KSCrash/Source/KSCrash/Recording/Tools/BSG_KSMachHeaders.m
@@ -11,6 +11,118 @@
 #import <Foundation/Foundation.h>
 #import "BSG_KSDynamicLinker.h"
 #import "BSG_KSMachHeaders.h"
+#import "BugsnagPlatformConditional.h"
+
+// MARK: - Locking
+
+// Pragma's hide unavoidable (and expected) deprecation/unavailable warnings
+_Pragma("clang diagnostic push")
+_Pragma("clang diagnostic ignored \"-Wunguarded-availability\"")
+static os_unfair_lock bsg_mach_binary_images_access_lock_unfair = OS_UNFAIR_LOCK_INIT;
+_Pragma("clang diagnostic pop")
+
+_Pragma("clang diagnostic push")
+_Pragma("clang diagnostic ignored \"-Wdeprecated-declarations\"")
+static OSSpinLock bsg_mach_binary_images_access_lock_spin = OS_SPINLOCK_INIT;
+_Pragma("clang diagnostic pop")
+
+// A static copy of the OS for comparison efficiency
+static NSOperatingSystemVersion bsg_os_version;
+
+// Lock helpers.  These use bulky Pragmas to hide warnings so are in their own functions for clarity.
+
+void bsg_spin_lock() {
+    _Pragma("clang diagnostic push")
+    _Pragma("clang diagnostic ignored \"-Wdeprecated-declarations\"")
+    OSSpinLockLock(&bsg_mach_binary_images_access_lock_spin);
+    _Pragma("clang diagnostic pop")
+}
+
+void bsg_spin_unlock() {
+    _Pragma("clang diagnostic push")
+    _Pragma("clang diagnostic ignored \"-Wdeprecated-declarations\"")
+    OSSpinLockUnlock(&bsg_mach_binary_images_access_lock_spin);
+    _Pragma("clang diagnostic pop")
+}
+
+void bsg_unfair_lock() {
+    _Pragma("clang diagnostic push")
+    _Pragma("clang diagnostic ignored \"-Wunguarded-availability\"")
+    os_unfair_lock_lock(&bsg_mach_binary_images_access_lock_unfair);
+    _Pragma("clang diagnostic pop")
+}
+
+void bsg_unfair_unlock() {
+    _Pragma("clang diagnostic push")
+    _Pragma("clang diagnostic ignored \"-Wunguarded-availability\"")
+    os_unfair_lock_unlock(&bsg_mach_binary_images_access_lock_unfair);
+    _Pragma("clang diagnostic pop")
+}
+
+// Lock and unlock sections of code
+
+void bsg_dyld_cache_lock() {
+#if BSG_PLATFORM_IOS
+    if (bsg_os_version.majorVersion < 10) {
+        bsg_spin_lock();
+        return;
+    }
+    bsg_unfair_lock();
+#elif BSG_PLATFORM_OSX
+    if (bsg_os_version.majorVersion < 10 && bsg_os_version.minorVersion < 12) {
+        bsg_spin_lock();
+        return;
+    }
+    bsg_unfair_lock();
+#elif BSG_PLATFORM_TVOS
+    if (bsg_os_version.majorVersion < 10) {
+        bsg_spin_lock();
+        return;
+    }
+    bsg_unfair_lock();
+#elif BSG_PLATFORM_WATCHOS
+    if (bsg_os_version.majorVersion < 3) {
+        bsg_spin_lock();
+        return;
+    }
+    bsg_unfair_lock();
+#endif
+}
+
+void bsg_dyld_cache_unlock() {
+#if BSG_PLATFORM_IOS
+    if (bsg_os_version.majorVersion < 10) {
+        bsg_spin_unlock();
+        return;
+    }
+    bsg_unfair_unlock();
+#elif BSG_PLATFORM_OSX
+    if (bsg_os_version.majorVersion < 10 && bsg_os_version.minorVersion < 12) {
+        bsg_spin_unlock();
+        return;
+    }
+    bsg_unfair_unlock();
+#elif BSG_PLATFORM_TVOS
+    if (bsg_os_version.majorVersion < 10) {
+        bsg_spin_unlock();
+        return;
+    }
+    bsg_unfair_unlock();
+#elif BSG_PLATFORM_WATCHOS
+    if (bsg_os_version.majorVersion < 3) {
+        bsg_spin_unlock();
+        return;
+    }
+    bsg_unfair_unlock();
+#endif
+}
+
+/**
+ * Store a static copy of the OS for comparison efficiency.
+ */
+void bsg_initialise_static_os() {
+    bsg_os_version = [[NSProcessInfo processInfo] operatingSystemVersion];
+}
 
 // MARK: - Replicate the DYLD API
 
@@ -53,7 +165,7 @@ BSG_Mach_Binary_Image_Info *bsg_dyld_get_image_info(uint32_t imageIndex) {
  */
 void bsg_add_mach_binary_image(BSG_Mach_Binary_Image_Info element) {
     
-    BSG_DYLD_CACHE_LOCK
+    bsg_dyld_cache_lock();
     
     // Expand array if necessary.  We're slightly paranoid here.  An OOM is likely to be indicative of bigger problems
     // but we should still do *our* best not to crash the app.
@@ -69,7 +181,7 @@ void bsg_add_mach_binary_image(BSG_Mach_Binary_Image_Info element) {
         }
         else {
             // Exit early, don't expand the array, don't store the header info and unlock
-            BSG_DYLD_CACHE_UNLOCK
+            bsg_dyld_cache_unlock();
             return;
         }
     }
@@ -77,7 +189,7 @@ void bsg_add_mach_binary_image(BSG_Mach_Binary_Image_Info element) {
     // Store the value, increment the number of used elements
     bsg_mach_binary_images.contents[bsg_mach_binary_images.used++] = element;
     
-    BSG_DYLD_CACHE_UNLOCK
+    bsg_dyld_cache_unlock();
 }
 
 /**
@@ -87,7 +199,7 @@ void bsg_add_mach_binary_image(BSG_Mach_Binary_Image_Info element) {
  */
 void bsg_remove_mach_binary_image(uint64_t imageVmAddr) {
     
-    BSG_DYLD_CACHE_LOCK
+    bsg_dyld_cache_lock();
     
     for (uint32_t i=0; i<bsg_mach_binary_images.used; i++) {
         BSG_Mach_Binary_Image_Info item = bsg_mach_binary_images.contents[i];
@@ -104,9 +216,16 @@ void bsg_remove_mach_binary_image(uint64_t imageVmAddr) {
         }
     }
     
-    BSG_DYLD_CACHE_UNLOCK
+    bsg_dyld_cache_unlock();
 }
 
+/**
+ * Create an empty array with initial capacity to hold Mach header info.
+ *
+ * @param initialSize The initial array capacity
+ *
+ * @returns A struct for holding Mach binary image info
+*/
 BSG_Mach_Binary_Images *bsg_initialise_mach_binary_headers(uint32_t initialSize) {
     bsg_mach_binary_images.contents = (BSG_Mach_Binary_Image_Info *)malloc(initialSize * sizeof(BSG_Mach_Binary_Image_Info));
     bsg_mach_binary_images.used = 0;


### PR DESCRIPTION
## Goal

The previous fix for a DYLD deadlock issue has compile-time checks that determine the locking mechanism to use.  This can cause apps with low deployment targets to fail IRL due to being built and tested on more modern OSs.

## Design

The previous lock determination mechanism was purely compile-time `#ifdef`-based.  This fix uses a combination of checks: 

- Compile-time to determine the OS-type without resorting to weakly supported hybrid checks
- Run-time to determine the version of the OS in a cross-platform way.

The bulk of the logic was moved from setting `#define`s in the header to the combination approach in the main `.m` file.

The fix was targeted at v6 due to ongoing UAT but could also easily be back-ported to the v5 release.

<!-- Why was this approach used? -->

## Changeset

`BSG_KSMachHeaders` and `BSG_KSCrash`

<!-- What changed? -->

## Tests

Run on both real iOS 9.3 iPad and in v13.X simulator.




<!-- How was it tested? -->



<!-- 
--------------------------------------------------------------------------------

Have you:

* Commented the code sufficiently?
* Added a CHANGELOG entry, if necessary?
* Checked the scope to ensure the commits are only related to the goal above?	
* Considered asynchronicity and thread safety?
* Added any new headers to the "Copy Files" stage of the static iOS target?	
* Chosen the correct target branch?
* Considered all of the pre-release checks (see CONTRIBUTING.md), if this is a full release?

--------------------------------------------------------------------------------
-->
