### PR TITLE
Allow starting Bugsnag from PList

### DIFF
--- a/Bugsnag/Bugsnag.h
+++ b/Bugsnag/Bugsnag.h
@@ -50,6 +50,15 @@
 
 /** Start listening for crashes.
  *
+ * This method initializes Bugsnag with the configuration set in your PList. Any uncaught
+ * NSExceptions, C++ exceptions, mach exceptions or signals will be logged to
+ * disk before your app crashes. The next time your app boots, we send any such
+ * reports to Bugsnag.
+ */
++ (BugsnagClient *_Nonnull)start;
+
+/** Start listening for crashes.
+ *
  * This method initializes Bugsnag with the default configuration. Any uncaught
  * NSExceptions, C++ exceptions, mach exceptions or signals will be logged to
  * disk before your app crashes. The next time your app boots, we send any such

--- a/Bugsnag/Bugsnag.m
+++ b/Bugsnag/Bugsnag.m
@@ -69,6 +69,11 @@ static BugsnagClient *bsg_g_bugsnag_client = NULL;
 
 @implementation Bugsnag
 
++ (BugsnagClient *_Nonnull)start {
+    BugsnagConfiguration *configuration = [BugsnagConfiguration loadConfig];
+    return [self startWithConfiguration:configuration];
+}
+
 + (BugsnagClient *_Nonnull)startWithApiKey:(NSString *_Nonnull)apiKey {
     BugsnagConfiguration *configuration = [[BugsnagConfiguration alloc] initWithApiKey:apiKey];
     return [self startWithConfiguration:configuration];

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,6 +13,9 @@ how to upgrade.
 
 ## Enhancements
 
+* Allow starting Bugsnag from PList
+  [#676](https://github.com/bugsnag/bugsnag-cocoa/pull/676)
+
 * The comparison of redacted keys is now case-insensitive
   [#653](https://github.com/bugsnag/bugsnag-cocoa/pull/653)
 

--- a/Tests/BugsnagClientMirrorTest.m
+++ b/Tests/BugsnagClientMirrorTest.m
@@ -129,7 +129,8 @@
             @"bugsnagStarted B16@0:8",
             @"bugsnagStarted c16@0:8",
             @"leaveBreadcrumbWithBlock: v24@0:8@?16",
-            @"getContext @16@0:8"
+            @"getContext @16@0:8",
+            @"start @16@0:8"
     ]];
 }
 

--- a/UPGRADING.md
+++ b/UPGRADING.md
@@ -132,6 +132,7 @@ Bugsnag.getMetadata("section" key:"key")
 
 ```diff
 ObjC:
++ [Bugsnag start]
 
 - [Bugsnag startBugsnagWithApiKey]
 + [Bugsnag startWithApiKey]
@@ -158,6 +159,8 @@ ObjC:
 + [Bugsnag notify:block:]
 
 Swift:
++ Bugsnag.start
+
 - Bugsnag.startBugsnagWith(:apiKey)
 + Bugsnag.startWith(:apiKey)
 


### PR DESCRIPTION
## Goal

Exposes an API for starting Bugsnag from information in a PList, rather than supplying `BugsnagConfiguration` or an apiKey directly.

## Changeset

Added `+ (BugsnagClient *_Nonnull)start;`, which loads configuration from a PList.

Tested by verifying Bugsnag can send error reports in an example app when loading from a PList.