### PR TITLE
Added plist loading to examples

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,7 +1,7 @@
 Changelog
 =========
 
-## 6.0.0 (TBD)
+## TBD
 
 __This version contains many breaking changes__. It is part of an effort to unify our notifier
 libraries across platforms, making the user interface more consistent, and implementations better

--- a/examples/objective-c-ios/Bugsnag Test App.xcodeproj/project.pbxproj
+++ b/examples/objective-c-ios/Bugsnag Test App.xcodeproj/project.pbxproj
@@ -19,7 +19,6 @@
 		F40B874B16AA233500676BB2 /* UIKit.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = F40B874A16AA233500676BB2 /* UIKit.framework */; };
 		F40B874D16AA233500676BB2 /* Foundation.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = F40B874C16AA233500676BB2 /* Foundation.framework */; };
 		F40B874F16AA233500676BB2 /* CoreGraphics.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = F40B874E16AA233500676BB2 /* CoreGraphics.framework */; };
-		F40B875516AA233500676BB2 /* InfoPlist.strings in Resources */ = {isa = PBXBuildFile; fileRef = F40B875316AA233500676BB2 /* InfoPlist.strings */; };
 		F40B875716AA233500676BB2 /* main.m in Sources */ = {isa = PBXBuildFile; fileRef = F40B875616AA233500676BB2 /* main.m */; };
 		F40B875B16AA233500676BB2 /* AppDelegate.m in Sources */ = {isa = PBXBuildFile; fileRef = F40B875A16AA233500676BB2 /* AppDelegate.m */; };
 		F40B875D16AA233500676BB2 /* Default.png in Resources */ = {isa = PBXBuildFile; fileRef = F40B875C16AA233500676BB2 /* Default.png */; };
@@ -73,8 +72,7 @@
 		F40B874A16AA233500676BB2 /* UIKit.framework */ = {isa = PBXFileReference; lastKnownFileType = wrapper.framework; name = UIKit.framework; path = System/Library/Frameworks/UIKit.framework; sourceTree = SDKROOT; };
 		F40B874C16AA233500676BB2 /* Foundation.framework */ = {isa = PBXFileReference; lastKnownFileType = wrapper.framework; name = Foundation.framework; path = System/Library/Frameworks/Foundation.framework; sourceTree = SDKROOT; };
 		F40B874E16AA233500676BB2 /* CoreGraphics.framework */ = {isa = PBXFileReference; lastKnownFileType = wrapper.framework; name = CoreGraphics.framework; path = System/Library/Frameworks/CoreGraphics.framework; sourceTree = SDKROOT; };
-		F40B875216AA233500676BB2 /* Bugsnag Test App-Info.plist */ = {isa = PBXFileReference; lastKnownFileType = text.plist.xml; path = "Bugsnag Test App-Info.plist"; sourceTree = "<group>"; };
-		F40B875416AA233500676BB2 /* en */ = {isa = PBXFileReference; lastKnownFileType = text.plist.strings; name = en; path = en.lproj/InfoPlist.strings; sourceTree = "<group>"; };
+		F40B875216AA233500676BB2 /* Info.plist */ = {isa = PBXFileReference; lastKnownFileType = text.plist.xml; path = Info.plist; sourceTree = "<group>"; };
 		F40B875616AA233500676BB2 /* main.m */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.objc; path = main.m; sourceTree = "<group>"; };
 		F40B875816AA233500676BB2 /* Bugsnag Test App-Prefix.pch */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; path = "Bugsnag Test App-Prefix.pch"; sourceTree = "<group>"; };
 		F40B875916AA233500676BB2 /* AppDelegate.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; path = AppDelegate.h; sourceTree = "<group>"; };
@@ -199,14 +197,15 @@
 		F40B875016AA233500676BB2 /* Bugsnag Test App */ = {
 			isa = PBXGroup;
 			children = (
-				8A4882E3224BCD5D0035B94C /* OutOfMemoryController.h */,
-				8A4882E4224BCD5D0035B94C /* OutOfMemoryController.m */,
 				F40B875916AA233500676BB2 /* AppDelegate.h */,
 				F40B875A16AA233500676BB2 /* AppDelegate.m */,
-				F40B876216AA233500676BB2 /* MainStoryboard.storyboard */,
 				F40B876816AA233500676BB2 /* ViewController.h */,
 				F40B876916AA233500676BB2 /* ViewController.m */,
+				8A4882E3224BCD5D0035B94C /* OutOfMemoryController.h */,
+				8A4882E4224BCD5D0035B94C /* OutOfMemoryController.m */,
+				F40B875216AA233500676BB2 /* Info.plist */,
 				0013DB142449E934003DB182 /* Images.xcassets */,
+				F40B876216AA233500676BB2 /* MainStoryboard.storyboard */,
 				F40B875116AA233500676BB2 /* Supporting Files */,
 			);
 			path = "Bugsnag Test App";
@@ -215,8 +214,6 @@
 		F40B875116AA233500676BB2 /* Supporting Files */ = {
 			isa = PBXGroup;
 			children = (
-				F40B875216AA233500676BB2 /* Bugsnag Test App-Info.plist */,
-				F40B875316AA233500676BB2 /* InfoPlist.strings */,
 				F40B875616AA233500676BB2 /* main.m */,
 				F40B875816AA233500676BB2 /* Bugsnag Test App-Prefix.pch */,
 				F40B875C16AA233500676BB2 /* Default.png */,
@@ -323,7 +320,6 @@
 						TestTargetID = F40B874516AA233500676BB2;
 					};
 					E7AB1DDE1F2F3AC0000AAF94 = {
-						DevelopmentTeam = LB9U9M53WT;
 						TestTargetID = F40B874516AA233500676BB2;
 					};
 					F40B874516AA233500676BB2 = {
@@ -381,7 +377,6 @@
 			buildActionMask = 2147483647;
 			files = (
 				00C3ED5823F2D6D900757DBD /* README.md in Resources */,
-				F40B875516AA233500676BB2 /* InfoPlist.strings in Resources */,
 				0013DB152449E934003DB182 /* Images.xcassets in Resources */,
 				F40B875D16AA233500676BB2 /* Default.png in Resources */,
 				F40B875F16AA233500676BB2 /* Default@2x.png in Resources */,
@@ -481,14 +476,6 @@
 /* End PBXTargetDependency section */
 
 /* Begin PBXVariantGroup section */
-		F40B875316AA233500676BB2 /* InfoPlist.strings */ = {
-			isa = PBXVariantGroup;
-			children = (
-				F40B875416AA233500676BB2 /* en */,
-			);
-			name = InfoPlist.strings;
-			sourceTree = "<group>";
-		};
 		F40B876216AA233500676BB2 /* MainStoryboard.storyboard */ = {
 			isa = PBXVariantGroup;
 			children = (
@@ -670,7 +657,7 @@
 				CLANG_WARN_UNREACHABLE_CODE = YES;
 				COPY_PHASE_STRIP = NO;
 				DEBUG_INFORMATION_FORMAT = dwarf;
-				DEVELOPMENT_TEAM = LB9U9M53WT;
+				DEVELOPMENT_TEAM = "";
 				ENABLE_STRICT_OBJC_MSGSEND = YES;
 				ENABLE_TESTABILITY = YES;
 				GCC_NO_COMMON_BLOCKS = YES;
@@ -687,7 +674,7 @@
 				PRODUCT_NAME = "$(TARGET_NAME)";
 				SWIFT_ACTIVE_COMPILATION_CONDITIONS = DEBUG;
 				SWIFT_OPTIMIZATION_LEVEL = "-Onone";
-				SWIFT_VERSION = 3.0;
+				SWIFT_VERSION = 4.0;
 				TEST_TARGET_NAME = "Bugsnag Test App";
 			};
 			name = Debug;
@@ -710,7 +697,7 @@
 				CLANG_WARN_UNREACHABLE_CODE = YES;
 				COPY_PHASE_STRIP = NO;
 				DEBUG_INFORMATION_FORMAT = "dwarf-with-dsym";
-				DEVELOPMENT_TEAM = LB9U9M53WT;
+				DEVELOPMENT_TEAM = "";
 				ENABLE_NS_ASSERTIONS = NO;
 				ENABLE_STRICT_OBJC_MSGSEND = YES;
 				GCC_NO_COMMON_BLOCKS = YES;
@@ -726,7 +713,7 @@
 				PRODUCT_BUNDLE_IDENTIFIER = com.bugsnag.BugsnagUIHarness;
 				PRODUCT_NAME = "$(TARGET_NAME)";
 				SWIFT_OPTIMIZATION_LEVEL = "-Owholemodule";
-				SWIFT_VERSION = 3.0;
+				SWIFT_VERSION = 4.0;
 				TEST_TARGET_NAME = "Bugsnag Test App";
 			};
 			name = Release;
@@ -844,7 +831,7 @@
 				GCC_PRECOMPILE_PREFIX_HEADER = YES;
 				GCC_PREFIX_HEADER = "Bugsnag Test App/Bugsnag Test App-Prefix.pch";
 				GCC_SYMBOLS_PRIVATE_EXTERN = YES;
-				INFOPLIST_FILE = "Bugsnag Test App/Bugsnag Test App-Info.plist";
+				INFOPLIST_FILE = "Bugsnag Test App/Info.plist";
 				PRODUCT_BUNDLE_IDENTIFIER = "bugsnag.${PRODUCT_NAME:rfc1034identifier}";
 				PRODUCT_NAME = "$(TARGET_NAME)";
 				PROVISIONING_PROFILE = "";
@@ -869,7 +856,7 @@
 				GCC_GENERATE_DEBUGGING_SYMBOLS = YES;
 				GCC_PRECOMPILE_PREFIX_HEADER = YES;
 				GCC_PREFIX_HEADER = "Bugsnag Test App/Bugsnag Test App-Prefix.pch";
-				INFOPLIST_FILE = "Bugsnag Test App/Bugsnag Test App-Info.plist";
+				INFOPLIST_FILE = "Bugsnag Test App/Info.plist";
 				PRODUCT_BUNDLE_IDENTIFIER = "bugsnag.${PRODUCT_NAME:rfc1034identifier}";
 				PRODUCT_NAME = "$(TARGET_NAME)";
 				PROVISIONING_PROFILE = "";

--- a/examples/objective-c-ios/Bugsnag Test App/AppDelegate.m
+++ b/examples/objective-c-ios/Bugsnag Test App/AppDelegate.m
@@ -14,15 +14,24 @@
 - (BOOL)application:(UIApplication *)application didFinishLaunchingWithOptions:(NSDictionary *)launchOptions {
     
     /**
-     This is the minimum amount of setup required for Bugsnag to work.  Simply input your apiKey and the application will deliver all error and session notifications to the appropriate dashboard.
+     This is the minimum amount of setup required for Bugsnag to work.  Simply add your API key to the app's .plist (Supporting Files/Bugsnag Test App-Info.plist) and the application will deliver all error and session notifications to the appropriate dashboard.
+     
+     You can find your API key in your Bugsnag dashboard under the settings menu.
      */
-    NSString *apiKey = @"<YOUR_APIKEY_HERE>";
-    [Bugsnag startWithApiKey:apiKey];
+    [Bugsnag start];
     
     /**
+     Bugsnag behavior can be configured through the plist and/or further extended in code by creating a BugsnagConfiguration object and passing it to [Bugsnag startWithConfiguration].
+     
      All subsequent setup is optional, and will configure your Bugsnag setup in different ways. A few common examples are included here, for more detailed explanations please look at the documented configuration options at https://docs.bugsnag.com/platforms/ios/configuration-options/
      */
-//     BugsnagConfiguration *config = [[BugsnagConfiguration alloc] initWithApiKey:apiKey];
+    
+    // Create config object from the application plist
+//    BugsnagConfiguration *config = [BugsnagConfiguration loadConfig];
+    
+    // ... or construct an empty object
+//    BugsnagConfiguration *config = [[BugsnagConfiguration alloc] initWithApiKey:@"YOUR-API-KEY"];
+    
     /**
      This sets some user information that will be attached to each error.
      */
@@ -46,18 +55,20 @@
     /**
      Enabled error types allow you to customize exactly what errors are automatically captured and delivered to your Bugsnag dashboard.  A detailed breakdown of each error type can be found in the configuration option documentation.
      */
-//    BugsnagErrorTypes *enabledErrorTypes = [BugsnagErrorTypes alloc];
-//    enabledErrorTypes.ooms = NO;
-//    enabledErrorTypes.unhandledExceptions = YES;
-//    enabledErrorTypes.machExceptions = YES;
-//    [config setEnabledErrorTypes:enabledErrorTypes];
+//    config.enabledErrorTypes.ooms = NO;
+//    config.enabledErrorTypes.unhandledExceptions = YES;
+//    config.enabledErrorTypes.machExceptions = YES;
     
     /**
      If there's information that you do not wish sent to your Bugsnag dashboard, such as passwords or user information, you can set the keys as redacted. When a notification is sent to Bugsnag all keys matching your set filters will be redacted before they leave your application.
      All automatically captured data can be found here: https://docs.bugsnag.com/platforms/ios/automatically-captured-data/.
      */
 //    [config setRedactedKeys:[NSSet setWithArray:@[@"filter_me", @"firstName", @"lastName"]]];
-    //[Bugsnag startWithConfiguration:config];
+    
+    /**
+     Finally, start Bugsnag with the specified configuration:
+     */
+//    [Bugsnag startWithConfiguration:config];
     
     return YES;
 }

--- a/examples/objective-c-ios/Bugsnag Test App/Info.plist
+++ b/examples/objective-c-ios/Bugsnag Test App/Info.plist
@@ -2,6 +2,11 @@
 <!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
 <plist version="1.0">
 <dict>
+    <key>bugsnag</key>
+    <dict>
+        <key>apiKey</key>
+        <string>YOUR-API-KEY</string>
+    </dict>
 	<key>CFBundleDevelopmentRegion</key>
 	<string>en</string>
 	<key>CFBundleDisplayName</key>

--- a/examples/objective-c-ios/Bugsnag Test App/ViewController.m
+++ b/examples/objective-c-ios/Bugsnag Test App/ViewController.m
@@ -8,7 +8,7 @@
 
 #import "ViewController.h"
 #import "OutOfMemoryController.h"
-#import "Bugsnag.h"
+#import <Bugsnag/Bugsnag.h>
 #import <pthread.h>
 #import <stdlib.h>
 

--- a/examples/objective-c-ios/Bugsnag Test App/en.lproj/InfoPlist.strings
+++ b/examples/objective-c-ios/Bugsnag Test App/en.lproj/InfoPlist.strings
@@ -1,2 +1,0 @@
-/* Localized versions of Info.plist keys */
-

--- a/examples/objective-c-ios/README.md
+++ b/examples/objective-c-ios/README.md
@@ -1,6 +1,6 @@
-# iOS Example application with Bugsnag
+# Example iOS application with Bugsnag
 
-This application was made to demonstrate various features of the Bugsnag Cocoa notifier when used in an iOS application.
+This application was made to demonstrate various features of the Bugsnag Cocoa notifier when used in an iOS application written in Objective-C.
 
 When running the application you will see a number of elements that will exercise different features provided by Bugsnag.  These are broadly divided into the following sections:
 
@@ -15,16 +15,11 @@ Specific implementation details can be found in the `ViewController.m` file.
 
 1. Run `pod install`
 2. Open the generated workspace in XCode
-3. Insert your API key in the AppDelegate's `application:didFinishLaunchingWithOptions:`
-
-    `NSString *apiKey = @"<YOUR_APIKEY_HERE>";`
-
+3. Add your API key to the `bugsnag` dictionary of `Info.plist` 
 4. Run the app! There are several examples of different kinds of errors which can be thrown.
 
 #### Configuration examples
 
-A set of configuration examples have been included underneath the minimum setup.  To use, simply comment out the AppDelegate's:
-`[Bugsnag startWithApiKey:apiKey];`
-and uncomment the subsequent  configuration lines.
+A set of configuration examples have been included underneath the minimum setup.  To use, simply comment out the AppDelegate's: `[Bugsnag start]` and uncomment the subsequent configuration lines.
 
 Each line has a brief explanation of what the option does, and for full information please read the documentation at https://docs.bugsnag.com/platforms/ios/configuration-options/.

--- a/examples/objective-c-osx/README.md
+++ b/examples/objective-c-osx/README.md
@@ -1,9 +1,23 @@
-# Example MacOS integration with Bugsnag
+# Example macOS integration with Bugsnag
+
+This application was made to demonstrate various features of the Bugsnag Cocoa notifier when used in a macOS application written in Objective-C.
+
+When running the application you will see a number of elements that will exercise different features provided by Bugsnag.  These are broadly divided into the following sections:
+
+- Crashes: Events which terminate the app are sent to Bugsnag automatically. Reopen the app after a crash to send reports.
+- Handled errors and exceptions: Events which can be handled gracefully can also be reported to Bugsnag.
+
+Specific implementation details can be found in the `ViewController.m` file.
+
+### Running the app
 
 1. Run `pod install`
 2. Open the generated workspace in XCode
-3. Insert your API key in the AppDelegate's `application:didFinishLaunchingWithOptions:`
-
-    `NSString *apiKey = @"<YOUR_APIKEY_HERE>";`
-
+3. Add your API key to the `bugsnag` dictionary of `Info.plist` 
 4. Run the app! There are several examples of different kinds of errors which can be thrown.
+
+#### Configuration examples
+
+A set of configuration examples have been included underneath the minimum setup.  To use, simply comment out the AppDelegate's: `[Bugsnag start]` and uncomment the subsequent configuration lines.
+
+Each line has a brief explanation of what the option does, and for full information please read the documentation at https://docs.bugsnag.com/platforms/macos/configuration-options/.

--- a/examples/objective-c-osx/objective-c-osx.xcodeproj/project.pbxproj
+++ b/examples/objective-c-osx/objective-c-osx.xcodeproj/project.pbxproj
@@ -112,11 +112,12 @@
 				93BE1CD51B62CC360016380C /* AppDelegate.m */,
 				93BE1CD91B62CC360016380C /* ViewController.h */,
 				93BE1CDA1B62CC360016380C /* ViewController.m */,
+				93CF94F61B66B09300D1558C /* CustomApplication.h */,
+				93CF94F71B66B09300D1558C /* CustomApplication.m */,
+				93BE1CD31B62CC360016380C /* Info.plist */,
 				93BE1CDC1B62CC360016380C /* Images.xcassets */,
 				93BE1CDE1B62CC360016380C /* Main.storyboard */,
 				93BE1CD21B62CC360016380C /* Supporting Files */,
-				93CF94F61B66B09300D1558C /* CustomApplication.h */,
-				93CF94F71B66B09300D1558C /* CustomApplication.m */,
 			);
 			path = "objective-c-osx";
 			sourceTree = "<group>";
@@ -124,7 +125,6 @@
 		93BE1CD21B62CC360016380C /* Supporting Files */ = {
 			isa = PBXGroup;
 			children = (
-				93BE1CD31B62CC360016380C /* Info.plist */,
 				93BE1CD71B62CC360016380C /* main.m */,
 			);
 			name = "Supporting Files";

--- a/examples/objective-c-osx/objective-c-osx/AppDelegate.m
+++ b/examples/objective-c-osx/objective-c-osx/AppDelegate.m
@@ -13,17 +13,66 @@
 
 @end
 
-void exceptionHandler(NSException *ex) {
-    NSLog(@"%@", [ex reason]);
-}
-
 @implementation AppDelegate
 
 - (void)applicationDidFinishLaunching:(NSNotification *)aNotification {
+        
+    /**
+     This is the minimum amount of setup required for Bugsnag to work.  Simply add your API key to the app's .plist (Supporting Files/Bugsnag Test App-Info.plist) and the application will deliver all error and session notifications to the appropriate dashboard.
+     
+     You can find your API key in your Bugsnag dashboard under the settings menu.
+     */
+    [Bugsnag start];
     
-    NSString *apiKey = @"<YOUR_APIKEY_HERE>";
-    BugsnagConfiguration *config = [[BugsnagConfiguration alloc] initWithApiKey:apiKey];
-    [Bugsnag startWithConfiguration:config];
+    /**
+     Bugsnag behavior can be configured through the plist and/or further extended in code by creating a BugsnagConfiguration object and passing it to [Bugsnag startWithConfiguration].
+     
+     All subsequent setup is optional, and will configure your Bugsnag setup in different ways. A few common examples are included here, for more detailed explanations please look at the documented configuration options at https://docs.bugsnag.com/platforms/macos/configuration-options/
+     */
+    
+    // Create config object from the application plist
+//    BugsnagConfiguration *config = [BugsnagConfiguration loadConfig];
+    
+    // ... or construct an empty object
+//    BugsnagConfiguration *config = [[BugsnagConfiguration alloc] initWithApiKey:@"YOUR-API-KEY"];
+    
+    /**
+     This sets some user information that will be attached to each error.
+     */
+//    [config setUser:@"DefaultUser" withEmail:@"Not@real.fake" andName:@"Default User"];
+    
+    /**
+     The appVersion will let you see what release an error is present in.  This will be picked up automatically from your build settings, but can be manually overwritten as well.
+     */
+//    [config setAppVersion:@"1.5.0"];
+    
+    /**
+     When persisting a user you won't need to set the user information everytime the app opens, instead it will be persisted between each app session.
+     */
+//    [config setPersistUser:YES];
+    
+    /**
+     This option allows you to send more or less detail about errors to Bugsnag.  Setting it to Always or Unhandled means you'll have detailed stacktraces of all app threads available when debugging unexpected errors.
+     */
+//    [config setSendThreads:BSGThreadSendPolicyAlways];
+    
+    /**
+     Enabled error types allow you to customize exactly what errors are automatically captured and delivered to your Bugsnag dashboard.  A detailed breakdown of each error type can be found in the configuration option documentation.
+     */
+//    config.enabledErrorTypes.ooms = NO;
+//    config.enabledErrorTypes.unhandledExceptions = YES;
+//    config.enabledErrorTypes.machExceptions = YES;
+    
+    /**
+     If there's information that you do not wish sent to your Bugsnag dashboard, such as passwords or user information, you can set the keys as redacted. When a notification is sent to Bugsnag all keys matching your set filters will be redacted before they leave your application.
+     All automatically captured data can be found here: https://docs.bugsnag.com/platforms/ios/automatically-captured-data/.
+     */
+//    [config setRedactedKeys:[NSSet setWithArray:@[@"filter_me", @"firstName", @"lastName"]]];
+    
+    /**
+     Finally, start Bugsnag with the specified configuration:
+     */
+//    [Bugsnag startWithConfiguration:config];
     
 }
 

--- a/examples/objective-c-osx/objective-c-osx/Info.plist
+++ b/examples/objective-c-osx/objective-c-osx/Info.plist
@@ -2,6 +2,11 @@
 <!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
 <plist version="1.0">
 <dict>
+    <key>bugsnag</key>
+    <dict>
+        <key>apiKey</key>
+        <string>YOUR-API-KEY</string>
+    </dict>
 	<key>CFBundleDevelopmentRegion</key>
 	<string>en</string>
 	<key>CFBundleExecutable</key>

--- a/examples/swift-ios/README.md
+++ b/examples/swift-ios/README.md
@@ -1,9 +1,25 @@
 # Example Swift iOS integration with Bugsnag
 
+This application was made to demonstrate various features of the Bugsnag Cocoa notifier when used in an iOS application written in Swift and Objective-C.
+
+When running the application you will see a number of elements that will exercise different features provided by Bugsnag.  These are broadly divided into the following sections:
+
+- Crashes: Events which terminate the app are sent to Bugsnag automatically. Reopen the app after a crash to send reports.
+- Handled errors and exceptions: Events which can be handled gracefully can also be reported to Bugsnag.
+- Metadata, breadcrumbs, and callbacks: Adding diagnostic data and modifying how the event shows on the Bugsnag dashboard.
+- Sessions: Demonstrates the methods of manually determining when sessions are created and expire.
+
+Specific implementation details can be found in the `ViewController.swift` file.
+
+### Running the app
+
 1. Run `pod install`
 2. Open the generated workspace in XCode
-3. Insert your API key in the AppDelegate's `application(_ application:, didFinishLaunchingWithOptions:)`
-
-    `let apiKey = "<YOUR_APIKEY_HERE>"`
-
+3. Add your API key to the `bugsnag` dictionary of `Info.plist` 
 4. Run the app! There are several examples of different kinds of errors which can be thrown.
+
+#### Configuration examples
+
+A set of configuration examples have been included underneath the minimum setup.  To use, simply comment out the AppDelegate's: `Bugsnag.start` and uncomment the subsequent configuration lines.
+
+Each line has a brief explanation of what the option does, and for full information please read the documentation at https://docs.bugsnag.com/platforms/ios/configuration-options/.

--- a/examples/swift-ios/bugsnag-example.xcodeproj/project.pbxproj
+++ b/examples/swift-ios/bugsnag-example.xcodeproj/project.pbxproj
@@ -52,6 +52,8 @@
 		D175F4DE1ACDBEFA009AFFB7 /* AnotherClass.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = AnotherClass.swift; sourceTree = "<group>"; };
 		D175F4E01ACDBFD9009AFFB7 /* AnObjCClass.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = AnObjCClass.h; sourceTree = "<group>"; };
 		D175F4E11ACDBFD9009AFFB7 /* AnObjCClass.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; path = AnObjCClass.m; sourceTree = "<group>"; };
+		E6152E17248ABA8D00CE9FC6 /* libBugsnag.a */ = {isa = PBXFileReference; explicitFileType = archive.ar; path = libBugsnag.a; sourceTree = BUILT_PRODUCTS_DIR; };
+		E6152E19248ABAAF00CE9FC6 /* libBugsnag.a */ = {isa = PBXFileReference; explicitFileType = archive.ar; path = libBugsnag.a; sourceTree = BUILT_PRODUCTS_DIR; };
 		E75E62DE1F4CE1D8000C44C0 /* libc++.tbd */ = {isa = PBXFileReference; lastKnownFileType = "sourcecode.text-based-dylib-definition"; name = "libc++.tbd"; path = "usr/lib/libc++.tbd"; sourceTree = SDKROOT; };
 		E75E62E01F4CE1DD000C44C0 /* libz.tbd */ = {isa = PBXFileReference; lastKnownFileType = "sourcecode.text-based-dylib-definition"; name = libz.tbd; path = usr/lib/libz.tbd; sourceTree = SDKROOT; };
 /* End PBXFileReference section */
@@ -113,25 +115,17 @@
 			isa = PBXGroup;
 			children = (
 				D175F4BD1ACDBD81009AFFB7 /* AppDelegate.swift */,
-				D175F4DD1ACDBE24009AFFB7 /* bugsnag-example-Bridging-Header.h */,
 				D175F4BF1ACDBD81009AFFB7 /* ViewController.swift */,
-				D175F4C11ACDBD81009AFFB7 /* Main.storyboard */,
-				D175F4C41ACDBD81009AFFB7 /* Images.xcassets */,
-				D175F4C61ACDBD81009AFFB7 /* LaunchScreen.xib */,
-				D175F4BB1ACDBD81009AFFB7 /* Supporting Files */,
 				D175F4DE1ACDBEFA009AFFB7 /* AnotherClass.swift */,
+				D175F4BC1ACDBD81009AFFB7 /* Info.plist */,
+				D175F4DD1ACDBE24009AFFB7 /* bugsnag-example-Bridging-Header.h */,
 				D175F4E01ACDBFD9009AFFB7 /* AnObjCClass.h */,
 				D175F4E11ACDBFD9009AFFB7 /* AnObjCClass.m */,
+				D175F4C41ACDBD81009AFFB7 /* Images.xcassets */,
+				D175F4C11ACDBD81009AFFB7 /* Main.storyboard */,
+				D175F4C61ACDBD81009AFFB7 /* LaunchScreen.xib */,
 			);
 			path = "bugsnag-example";
-			sourceTree = "<group>";
-		};
-		D175F4BB1ACDBD81009AFFB7 /* Supporting Files */ = {
-			isa = PBXGroup;
-			children = (
-				D175F4BC1ACDBD81009AFFB7 /* Info.plist */,
-			);
-			name = "Supporting Files";
 			sourceTree = "<group>";
 		};
 		D175F4D01ACDBD81009AFFB7 /* bugsnag-exampleTests */ = {
@@ -154,6 +148,8 @@
 		FD51012AA06FE025CCC45C93 /* Frameworks */ = {
 			isa = PBXGroup;
 			children = (
+				E6152E19248ABAAF00CE9FC6 /* libBugsnag.a */,
+				E6152E17248ABA8D00CE9FC6 /* libBugsnag.a */,
 				E75E62E01F4CE1DD000C44C0 /* libz.tbd */,
 				E75E62DE1F4CE1D8000C44C0 /* libc++.tbd */,
 				1A8C72BF7F8211697881F641 /* libPods-bugsnag-example.a */,

--- a/examples/swift-ios/bugsnag-example/AppDelegate.swift
+++ b/examples/swift-ios/bugsnag-example/AppDelegate.swift
@@ -26,10 +26,63 @@ class AppDelegate: UIResponder, UIApplicationDelegate {
     var window: UIWindow?
 
     func application(_ application: UIApplication, didFinishLaunchingWithOptions launchOptions: [UIApplication.LaunchOptionsKey: Any]?) -> Bool {
+
+        /**
+         This is the minimum amount of setup required for Bugsnag to work.  Simply add your API key to the app's .plist (Supporting Files/Info.plist) and the application will deliver all error and session notifications to the appropriate dashboard.
+         
+         You can find your API key in your Bugsnag dashboard under the settings menu.
+         */
+        Bugsnag.start()
+
+        /**
+         Bugsnag behavior can be configured through the plist and/or further extended in code by creating a BugsnagConfiguration object and passing it to [Bugsnag startWithConfiguration].
+         
+         All subsequent setup is optional, and will configure your Bugsnag setup in different ways. A few common examples are included here, for more detailed explanations please look at the documented configuration options at https://docs.bugsnag.com/platforms/ios/configuration-options/
+         */
         
-        let apiKey = "<YOUR_APIKEY_HERE>"
-        let config = BugsnagConfiguration(apiKey)
-        Bugsnag.start(with: config)
+        // Create config object from the application plist
+//      let config = BugsnagConfiguration.loadConfig()
+        
+        // ... or construct an empty object
+//      let config = BugsnagConfiguration("YOUR-API-KEY")
+
+        /**
+         This sets some user information that will be attached to each error.
+         */
+//        config.setUser("DefaultUser", withEmail:"Not@real.fake", andName:"Default User")
+
+        /**
+         The appVersion will let you see what release an error is present in.  This will be picked up automatically from your build settings, but can be manually overwritten as well.
+         */
+//        config.appVersion = "1.5.0"
+
+        /**
+         When persisting a user you won't need to set the user information everytime the app opens, instead it will be persisted between each app session.
+         */
+//        config.persistUser = true
+
+        /**
+         This option allows you to send more or less detail about errors to Bugsnag.  Setting it to Always or Unhandled means you'll have detailed stacktraces of all app threads available when debugging unexpected errors.
+         */
+//        config.sendThreads = .always
+
+        /**
+         Enabled error types allow you to customize exactly what errors are automatically captured and delivered to your Bugsnag dashboard.  A detailed breakdown of each error type can be found in the configuration option documentation.
+         */
+//        config.enabledErrorTypes.ooms = false
+//        config.enabledErrorTypes.unhandledExceptions = true
+//        config.enabledErrorTypes.machExceptions = true
+
+        /**
+         If there's information that you do not wish sent to your Bugsnag dashboard, such as passwords or user information, you can set the keys as redacted. When a notification is sent to Bugsnag all keys matching your set filters will be redacted before they leave your application.
+         All automatically captured data can be found here: https://docs.bugsnag.com/platforms/ios/automatically-captured-data/.
+         */
+//        config.redactedKeys = ["password", "credit_card_number"]
+
+        /**
+         Finally, start Bugsnag with the specified configuration:
+         */
+//        Bugsnag.start(with: config)
 
         return true
     }

--- a/examples/swift-ios/bugsnag-example/Info.plist
+++ b/examples/swift-ios/bugsnag-example/Info.plist
@@ -2,6 +2,11 @@
 <!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
 <plist version="1.0">
 <dict>
+    <key>bugsnag</key>
+    <dict>
+        <key>apiKey</key>
+        <string>YOUR-API-KEY</string>
+    </dict>
 	<key>CFBundleDevelopmentRegion</key>
 	<string>en</string>
 	<key>CFBundleExecutable</key>

--- a/examples/swift-ios/bugsnag-example/ViewController.swift
+++ b/examples/swift-ios/bugsnag-example/ViewController.swift
@@ -60,9 +60,9 @@ class ViewController: UITableViewController {
         do {
             try FileManager.default.removeItem(atPath:"//invalid/file")
         } catch {
-            Bugsnag.notifyError(error) { report in
+            Bugsnag.notifyError(error) { event in
                 // modify report properties in the (optional) block
-                report.severity = .info
+                event.severity = .info
                 return true
             }
         }


### PR DESCRIPTION
## Goal

With the change of emphasis from configuration in code to plist, the examples have been amended to read from plist file, with commented out examples for how to override it in code.

PR also contains some general tidying of readme and project structure.

