### PR TITLE
Relax time checks, as BrowserStack devices can be several hours out

### DIFF
--- a/features/handled_errors.feature
+++ b/features/handled_errors.feature
@@ -12,14 +12,14 @@ Scenario: Override errorClass and message from a notifyError() callback, customi
     Then the request is valid for the error reporting API version "4.0" for the "iOS Bugsnag Notifier" notifier
     And the exception "errorClass" equals "Bar"
     And the exception "message" equals "Foo"
-    And the event "device.time" is within 30 seconds of the current timestamp
+    And the payload field "events.0.device.time" is a date
     And the event "metaData.account.items.0" equals 400
     And the event "metaData.account.items.1" equals 200
     And the event "severity" equals "warning"
     And the event "unhandled" is false
     And the event "severityReason.type" equals "handledError"
-    # This may be platform specific.
-    # TODO Consider using a step to check for "at least {int} stack frames"
+    # TODO This may be platform specific:
+    # Consider using a step to check for "at least {int} stack frames"
     # And the stack trace is an array with 15 stack frames
 
 Scenario: Reporting an NSError
@@ -32,7 +32,7 @@ Scenario: Reporting an NSError
     And the event "severity" equals "warning"
     And the event "unhandled" is false
     And the event "severityReason.type" equals "handledError"
-    # This may be platform specific
+    # TODO This may be platform specific:
     # And the stack trace is an array with 15 stack frames
 
 Scenario: Reporting a handled exception

--- a/features/unhandled_nsexception.feature
+++ b/features/unhandled_nsexception.feature
@@ -10,7 +10,7 @@ Scenario: Throw a NSException
     And the "method" of stack frame 0 equals "<redacted>"
     And the "method" of stack frame 1 equals "objc_exception_throw"
     And the "method" of stack frame 2 equals "-[ObjCExceptionScenario run]"
-    And the event "device.time" is within 60 seconds of the current timestamp
+    And the payload field "events.0.device.time" is a date
     And the event "severity" equals "error"
     And the event "unhandled" is true
     And the event "severityReason.type" equals "unhandledException"


### PR DESCRIPTION
## Goal

Fixes occasional flakes caused by BrowserStack device times being several hours at at times.
