### PR TITLE
Clear UserDefaults data before every scenario

### DIFF
--- a/features/app_and_device_attributes.feature
+++ b/features/app_and_device_attributes.feature
@@ -1,13 +1,16 @@
 Feature: App and Device attributes present
 
-Scenario: App and Device info is as expected
+  Background:
+    Given I clear all UserDefaults data
+
+  Scenario: App and Device info is as expected
     When I run "AppAndDeviceAttributesScenario"
     And I wait to receive a request
     Then the request is valid for the error reporting API version "4.0" for the "iOS Bugsnag Notifier" notifier
     And the "Bugsnag-API-Key" header equals "12312312312312312312312312312312"
-    
+
     # Device
-    
+
     And the payload field "events.0.device.osName" equals "iOS"
     And the payload field "events.0.device.jailbroken" is false
     And the payload field "events.0.device.osVersion" matches the regex "\d+\.\d+"
@@ -17,7 +20,7 @@ Scenario: App and Device info is as expected
     And the payload field "events.0.device.model" matches the test device model
     And the payload field "events.0.device.modelNumber" is not null
     And the payload field "events.0.device.runtimeVersions.osBuild" is not null
-    And the payload field "events.0.device.runtimeVersions.clangVersion" is not null 
+    And the payload field "events.0.device.runtimeVersions.clangVersion" is not null
     And the payload field "events.0.device.totalMemory" is an integer
 
     # DeviceWithState
@@ -28,22 +31,22 @@ Scenario: App and Device info is as expected
     And the payload field "events.0.device.time" is a date
 
     # App
-    
-    # (codeBundleId is RN only, so ommitted)
+
+    # (codeBundleId is RN only, so omitted)
     And the payload field "events.0.app.bundleVersion" is not null
     #And the payload field "events.0.app.dsymUUIDs" is a non-empty array # Fails, == nil
     And the payload field "events.0.app.id" equals "com.bugsnag.iOSTestApp"
     And the payload field "events.0.app.releaseStage" equals "development"
     And the payload field "events.0.app.type" equals "iOS"
     And the payload field "events.0.app.version" equals "1.0.3"
-    
+
     # AppWithState
-    
+
     And the payload field "events.0.app.duration" is a number
     And the payload field "events.0.app.durationInForeground" is a number
     And the payload field "events.0.app.inForeground" is not null
 
-Scenario: App and Device info is as expected when overridden via config
+  Scenario: App and Device info is as expected when overridden via config
     When I run "AppAndDeviceAttributesScenarioConfigOverride"
     And I wait to receive a request
     Then the request is valid for the error reporting API version "4.0" for the "iOS Bugsnag Notifier" notifier
@@ -53,8 +56,8 @@ Scenario: App and Device info is as expected when overridden via config
     And the payload field "events.0.app.bundleVersion" does not equal "12345"
     And the payload field "events.0.context" equals "myContext"
     And the payload field "events.0.app.releaseStage" equals "secondStage"
-    
-Scenario: App and Device info is as expected when overridden via callback
+
+  Scenario: App and Device info is as expected when overridden via callback
     When I run "AppAndDeviceAttributesScenarioCallbackOverride"
     And I wait to receive a request
     Then the request is valid for the error reporting API version "4.0" for the "iOS Bugsnag Notifier" notifier

--- a/features/auto_detect_errors.feature
+++ b/features/auto_detect_errors.feature
@@ -2,6 +2,9 @@ Feature: autoDetectErrors flag controls whether errors are captured automaticall
     Bugsnag captures several error types by default. If the autoDetectErrors flag
     is false it should only capture handled errors which the user has reported.
 
+    Background:
+        Given I clear all UserDefaults data
+
     Scenario: Uncaught NSException not reported when autoDetectErrors is false
         When I run "AutoDetectFalseHandledScenario"
         And I wait to receive a request

--- a/features/breadcrumb_callbacks.feature
+++ b/features/breadcrumb_callbacks.feature
@@ -1,6 +1,9 @@
 Feature: Callbacks can access and modify breadcrumb information
 
-Scenario: Returning false in a callback discards breadcrumbs
+  Background:
+    Given I clear all UserDefaults data
+
+  Scenario: Returning false in a callback discards breadcrumbs
     When I run "BreadcrumbCallbackDiscardScenario"
     And I wait to receive a request
     And the request is valid for the error reporting API version "4.0" for the "iOS Bugsnag Notifier" notifier
@@ -11,7 +14,7 @@ Scenario: Returning false in a callback discards breadcrumbs
     And the payload field "events.0.breadcrumbs.0.metaData.foo" equals "bar"
     And the payload field "events.0.breadcrumbs.0.metaData.addedVal" is true
 
-Scenario: Callbacks execute in the order in which they were added
+  Scenario: Callbacks execute in the order in which they were added
     When I run "BreadcrumbCallbackOrderScenario"
     And I wait to receive a request
     And the request is valid for the error reporting API version "4.0" for the "iOS Bugsnag Notifier" notifier
@@ -22,7 +25,7 @@ Scenario: Callbacks execute in the order in which they were added
     And the payload field "events.0.breadcrumbs.0.metaData.firstCallback" equals 0
     And the payload field "events.0.breadcrumbs.0.metaData.secondCallback" equals 1
 
-Scenario: Modifying breadcrumb information with a callback
+  Scenario: Modifying breadcrumb information with a callback
     When I run "BreadcrumbCallbackOverrideScenario"
     And I wait to receive a request
     And the request is valid for the error reporting API version "4.0" for the "iOS Bugsnag Notifier" notifier
@@ -32,7 +35,7 @@ Scenario: Modifying breadcrumb information with a callback
     And the payload field "events.0.breadcrumbs.0.timestamp" is a parsable timestamp in seconds
     And the payload field "events.0.breadcrumbs.0.metaData.foo" equals "wham"
 
-Scenario: Callbacks can be removed without affecting the functionality of other callbacks
+  Scenario: Callbacks can be removed without affecting the functionality of other callbacks
     When I run "BreadcrumbCallbackRemovalScenario"
     And I wait to receive a request
     And the request is valid for the error reporting API version "4.0" for the "iOS Bugsnag Notifier" notifier
@@ -43,7 +46,7 @@ Scenario: Callbacks can be removed without affecting the functionality of other 
     And the payload field "events.0.breadcrumbs.0.metaData.foo" equals "bar"
     And the payload field "events.0.breadcrumbs.0.metaData.firstCallback" equals "Whoops"
 
-Scenario: An uncaught NSException in a callback does not affect breadcrumb delivery
+  Scenario: An uncaught NSException in a callback does not affect breadcrumb delivery
     When I run "BreadcrumbCallbackCrashScenario"
     And I wait to receive a request
     And the request is valid for the error reporting API version "4.0" for the "iOS Bugsnag Notifier" notifier

--- a/features/breadcrumbs.feature
+++ b/features/breadcrumbs.feature
@@ -1,38 +1,41 @@
 Feature: Attaching a series of notable events leading up to errors
-    A breadcrumb contains supplementary data which will be sent along with
-    events. Breadcrumbs are intended to be pieces of information which can
-    lead the developer to the cause of the event being reported.
+  A breadcrumb contains supplementary data which will be sent along with
+  events. Breadcrumbs are intended to be pieces of information which can
+  lead the developer to the cause of the event being reported.
 
-    Scenario: Manually leaving a breadcrumb of a discarded type and discarding automatic
-        When I run "DiscardedBreadcrumbTypeScenario"
-        And I wait to receive a request
-        Then the event has a "log" breadcrumb named "Noisy event"
-        And the event has a "process" breadcrumb named "Important event"
-        And the event does not have a "event" breadcrumb
+  Background:
+    Given I clear all UserDefaults data
 
-    Scenario: Leaving breadcrumbs when enabledBreadcrumbTypes is empty
-        When I run "EnabledBreadcrumbTypesIsNilScenario"
-        And I wait to receive a request
-        Then the event has a "log" breadcrumb named "Noisy event"
-        And the event has a "process" breadcrumb named "Important event"
+  Scenario: Manually leaving a breadcrumb of a discarded type and discarding automatic
+    When I run "DiscardedBreadcrumbTypeScenario"
+    And I wait to receive a request
+    Then the event has a "log" breadcrumb named "Noisy event"
+    And the event has a "process" breadcrumb named "Important event"
+    And the event does not have a "event" breadcrumb
 
-    Scenario: An app lauches and subsequently sends a manual event using notify()
-        When I run "HandledErrorScenario"
-        And I wait to receive a request
-        Then the event has a "state" breadcrumb named "Bugsnag loaded"
+  Scenario: Leaving breadcrumbs when enabledBreadcrumbTypes is empty
+    When I run "EnabledBreadcrumbTypesIsNilScenario"
+    And I wait to receive a request
+    Then the event has a "log" breadcrumb named "Noisy event"
+    And the event has a "process" breadcrumb named "Important event"
 
-    Scenario: An app lauches and subsequently crashes
-        When I run "BuiltinTrapScenario" and relaunch the app
-        And I configure Bugsnag for "BuiltinTrapScenario"
-        And I wait to receive a request
-        Then the event has a "state" breadcrumb named "Bugsnag loaded"
+  Scenario: An app lauches and subsequently sends a manual event using notify()
+    When I run "HandledErrorScenario"
+    And I wait to receive a request
+    Then the event has a "state" breadcrumb named "Bugsnag loaded"
 
-    Scenario: Modifying a breadcrumb name
-        When I run "ModifyBreadcrumbScenario"
-        And I wait to receive a request
-        Then the event has a "manual" breadcrumb named "Cache locked"
+  Scenario: An app lauches and subsequently crashes
+    When I run "BuiltinTrapScenario" and relaunch the app
+    And I configure Bugsnag for "BuiltinTrapScenario"
+    And I wait to receive a request
+    Then the event has a "state" breadcrumb named "Bugsnag loaded"
 
-    Scenario: Modifying a breadcrumb name in callback
-        When I run "ModifyBreadcrumbInNotify"
-        And I wait to receive a request
-        Then the event has a "manual" breadcrumb named "Cache locked"
+  Scenario: Modifying a breadcrumb name
+    When I run "ModifyBreadcrumbScenario"
+    And I wait to receive a request
+    Then the event has a "manual" breadcrumb named "Cache locked"
+
+  Scenario: Modifying a breadcrumb name in callback
+    When I run "ModifyBreadcrumbInNotify"
+    And I wait to receive a request
+    Then the event has a "manual" breadcrumb named "Cache locked"

--- a/features/config_from_plist.feature
+++ b/features/config_from_plist.feature
@@ -1,11 +1,14 @@
 Feature: Loading Bugsnag configuration from Info.plist
-    Configuration options can be specified in build at build time to avoid
-    writing code for those options.
+  Configuration options can be specified in build at build time to avoid
+  writing code for those options.
 
-    Scenario: Specifying config in Info.plist
-        When I run "LoadConfigFromFileScenario"
-        And I wait to receive a request
-        And the "Bugsnag-API-Key" header equals "0192837465afbecd0192837465afbecd"
-        And the event "metaData.nserror.domain" equals "iOSTestApp.LaunchError"
-        And the event "app.releaseStage" equals "beta2"
+  Background:
+    Given I clear all UserDefaults data
+
+  Scenario: Specifying config in Info.plist
+    When I run "LoadConfigFromFileScenario"
+    And I wait to receive a request
+    And the "Bugsnag-API-Key" header equals "0192837465afbecd0192837465afbecd"
+    And the event "metaData.nserror.domain" equals "iOSTestApp.LaunchError"
+    And the event "app.releaseStage" equals "beta2"
 

--- a/features/context.feature
+++ b/features/context.feature
@@ -1,37 +1,40 @@
 Feature: The context can be automatically and manually set on errors
 
-Scenario: Automatic context from a handled NSError
+  Background:
+    Given I clear all UserDefaults data
+
+  Scenario: Automatic context from a handled NSError
     When I run "AutoContextNSErrorScenario"
     And I wait to receive a request
     Then the request is valid for the error reporting API version "4.0" for the "iOS Bugsnag Notifier" notifier
     And the event "context" equals "AutoContextNSErrorScenario (100)"
 
-Scenario: Automatic context from a handled NSException
+  Scenario: Automatic context from a handled NSException
     When I run "AutoContextNSExceptionScenario"
     And I wait to receive a request
     Then the request is valid for the error reporting API version "4.0" for the "iOS Bugsnag Notifier" notifier
     And the event "context" is null
 
-Scenario: Automatic context from a C error
+  Scenario: Automatic context from a C error
     When I run "AbortScenario" and relaunch the app
     And I configure Bugsnag for "AbortScenario"
     And I wait to receive a request
     Then the request is valid for the error reporting API version "4.0" for the "iOS Bugsnag Notifier" notifier
     And the event "context" is null
 
-Scenario: Manual context from Configuration
+  Scenario: Manual context from Configuration
     When I run "ManualContextConfigurationScenario"
     And I wait to receive a request
     Then the request is valid for the error reporting API version "4.0" for the "iOS Bugsnag Notifier" notifier
     And the event "context" equals "contextFromConfig"
 
-Scenario: Manual context from Client
+  Scenario: Manual context from Client
     When I run "ManualContextClientScenario"
     And I wait to receive a request
     Then the request is valid for the error reporting API version "4.0" for the "iOS Bugsnag Notifier" notifier
     And the event "context" equals "contextFromClient"
 
-Scenario: Manual context from an OnError callback
+  Scenario: Manual context from an OnError callback
     When I run "ManualContextOnErrorScenario"
     And I wait to receive a request
     Then the request is valid for the error reporting API version "4.0" for the "iOS Bugsnag Notifier" notifier

--- a/features/crashprobe.feature
+++ b/features/crashprobe.feature
@@ -1,6 +1,9 @@
 Feature: Reporting crash events
 
-Scenario: Executing privileged instruction
+  Background:
+    Given I clear all UserDefaults data
+
+  Scenario: Executing privileged instruction
     When I run "PrivilegedInstructionScenario" and relaunch the app
     And I configure Bugsnag for "PrivilegedInstructionScenario"
     And I wait to receive a request
@@ -9,7 +12,7 @@ Scenario: Executing privileged instruction
     And the exception "errorClass" equals "EXC_BAD_INSTRUCTION"
     And the "method" of stack frame 0 equals "-[PrivilegedInstructionScenario run]"
 
-Scenario: Calling __builtin_trap()
+  Scenario: Calling __builtin_trap()
     When I run "BuiltinTrapScenario" and relaunch the app
     And I configure Bugsnag for "BuiltinTrapScenario"
     And I wait to receive a request
@@ -18,7 +21,7 @@ Scenario: Calling __builtin_trap()
     And the exception "errorClass" equals "EXC_BREAKPOINT"
     And the "method" of stack frame 0 equals "-[BuiltinTrapScenario run]"
 
-Scenario: Calling non-existent method
+  Scenario: Calling non-existent method
     When I run "NonExistentMethodScenario" and relaunch the app
     And I configure Bugsnag for "NonExistentMethodScenario"
     And I wait to receive a request
@@ -33,7 +36,7 @@ Scenario: Calling non-existent method
     And the "method" of stack frame 4 equals "_CF_forwarding_prep_0"
     And the "method" of stack frame 5 equals "-[NonExistentMethodScenario run]"
 
-Scenario: Trigger a crash after overwriting the link register
+  Scenario: Trigger a crash after overwriting the link register
     When I run "OverwriteLinkRegisterScenario" and relaunch the app
     And I configure Bugsnag for "OverwriteLinkRegisterScenario"
     And I wait to receive a request
@@ -42,7 +45,7 @@ Scenario: Trigger a crash after overwriting the link register
     And the exception "message" equals "Attempted to dereference null pointer."
     And the "method" of stack frame 0 equals "-[OverwriteLinkRegisterScenario run]"
 
-Scenario: Attempt to write into a read-only page
+  Scenario: Attempt to write into a read-only page
     When I run "ReadOnlyPageScenario" and relaunch the app
     And I configure Bugsnag for "ReadOnlyPageScenario"
     And I wait to receive a request
@@ -50,7 +53,7 @@ Scenario: Attempt to write into a read-only page
     And the exception "errorClass" equals "EXC_BAD_ACCESS"
     And the "method" of stack frame 0 equals "-[ReadOnlyPageScenario run]"
 
-Scenario: Stack overflow
+  Scenario: Stack overflow
     When I run "StackOverflowScenario" and relaunch the app
     And I configure Bugsnag for "StackOverflowScenario"
     And I wait to receive a request
@@ -68,7 +71,7 @@ Scenario: Stack overflow
     And the "method" of stack frame 8 equals "-[StackOverflowScenario run]"
     And the "method" of stack frame 9 equals "-[StackOverflowScenario run]"
 
-Scenario: Crash inside objc_msgSend()
+  Scenario: Crash inside objc_msgSend()
     When I run "ObjCMsgSendScenario" and relaunch the app
     And I configure Bugsnag for "ObjCMsgSendScenario"
     And I wait to receive a request
@@ -77,7 +80,7 @@ Scenario: Crash inside objc_msgSend()
     And the exception "message" equals "Attempted to dereference garbage pointer 0x38."
     And the "method" of stack frame 0 equals "objc_msgSend"
 
-Scenario: Attempt to execute an instruction undefined on the current architecture
+  Scenario: Attempt to execute an instruction undefined on the current architecture
     When I run "UndefinedInstructionScenario" and relaunch the app
     And I configure Bugsnag for "UndefinedInstructionScenario"
     And I wait to receive a request
@@ -85,7 +88,7 @@ Scenario: Attempt to execute an instruction undefined on the current architectur
     And the exception "errorClass" equals "EXC_BAD_INSTRUCTION"
     And the "method" of stack frame 0 equals "-[UndefinedInstructionScenario run]"
 
-Scenario: Send a message to an object whose memory has already been freed
+  Scenario: Send a message to an object whose memory has already been freed
     When I run "ReleasedObjectScenario" and relaunch the app
     And I configure Bugsnag for "ReleasedObjectScenario"
     And I wait to receive a request
@@ -97,7 +100,7 @@ Scenario: Send a message to an object whose memory has already been freed
 
 # N.B. this scenario is "imprecise" on CrashProbe due to line number info,
 # which is not tested here as this would require symbolication
-Scenario: Crash within Swift code
+  Scenario: Crash within Swift code
     When I run "SwiftCrash" and relaunch the app
     And I configure Bugsnag for "SwiftCrash"
     And I wait to receive a request
@@ -105,7 +108,7 @@ Scenario: Crash within Swift code
     # And the exception "message" equals "Unexpectedly found nil while unwrapping an Optional value"
     And the exception "errorClass" equals "Fatal error"
 
-Scenario: Assertion failure in Swift code
+  Scenario: Assertion failure in Swift code
     When I run "SwiftAssertion" and relaunch the app
     And I configure Bugsnag for "SwiftAssertion"
     And I wait to receive a request
@@ -113,7 +116,7 @@ Scenario: Assertion failure in Swift code
     And the exception "errorClass" equals "Fatal error"
     # And the exception "message" equals "several unfortunate things just happened"
 
-Scenario: Dereference a null pointer
+  Scenario: Dereference a null pointer
     When I run "NullPointerScenario" and relaunch the app
     And I configure Bugsnag for "NullPointerScenario"
     And I wait to receive a request
@@ -122,7 +125,7 @@ Scenario: Dereference a null pointer
     And the exception "errorClass" equals "EXC_BAD_ACCESS"
     And the "method" of stack frame 0 equals "-[NullPointerScenario run]"
 
-Scenario: Trigger a crash with libsystem_pthread's _pthread_list_lock held
+  Scenario: Trigger a crash with libsystem_pthread's _pthread_list_lock held
     When I run "AsyncSafeThreadScenario" and relaunch the app
     And I configure Bugsnag for "AsyncSafeThreadScenario"
     And I wait to receive a request
@@ -132,9 +135,9 @@ Scenario: Trigger a crash with libsystem_pthread's _pthread_list_lock held
     And the exception "errorClass" equals "EXC_BAD_ACCESS"
     And the stacktrace contains methods:
     # |pthread_getname_np|
-    |-[AsyncSafeThreadScenario run]|
+      | -[AsyncSafeThreadScenario run] |
 
-Scenario: Read a garbage pointer
+  Scenario: Read a garbage pointer
     When I run "ReadGarbagePointerScenario" and relaunch the app
     And I configure Bugsnag for "ReadGarbagePointerScenario"
     And I wait to receive a request
@@ -143,7 +146,7 @@ Scenario: Read a garbage pointer
     And the exception "errorClass" equals "EXC_BAD_ACCESS"
     And the "method" of stack frame 0 equals "-[ReadGarbagePointerScenario run]"
 
-Scenario: Access a non-object as an object
+  Scenario: Access a non-object as an object
     When I run "AccessNonObjectScenario" and relaunch the app
     And I configure Bugsnag for "AccessNonObjectScenario"
     And I wait to receive a request

--- a/features/cross_notifier_notify.feature
+++ b/features/cross_notifier_notify.feature
@@ -1,71 +1,74 @@
 Feature: Communicating events between notifiers
 
-    Other Bugsnag libraries include bugsnag-cocoa as a dependency for capturing
-    native cocoa crashes, but may have additional events to report, both
-    handled and unhandled. Those events should be reported correctly when
-    using bugsnag-cocoa as the delivery layer.
+  Other Bugsnag libraries include bugsnag-cocoa as a dependency for capturing
+  native cocoa crashes, but may have additional events to report, both
+  handled and unhandled. Those events should be reported correctly when
+  using bugsnag-cocoa as the delivery layer.
 
-    Scenario: Report a handled event through internalNotify()
-        Report a handled exception, including a custom stacktrace and severity.
-        Event counts in the report's session should match the handled-ness.
+  Background:
+    Given I clear all UserDefaults data
 
-        When I run "HandledInternalNotifyScenario"
-        And I wait to receive 2 requests
-        Then the request is valid for the session reporting API version "1.0" for the "iOS Bugsnag Notifier" notifier
-        And the payload field "sessions.0.id" is stored as the value "session_id"
-        And I discard the oldest request
-        Then the request is valid for the error reporting API version "4.0" for the "iOS Bugsnag Notifier" notifier
-        And the exception "errorClass" equals "Handled Error!"
-        And the exception "message" equals "Internally reported a handled event"
-        And the exception "type" equals "unreal"
-        And the event "severity" equals "warning"
-        And the event "severityReason.type" equals "handledException"
+  Scenario: Report a handled event through internalNotify()
+  Report a handled exception, including a custom stacktrace and severity.
+  Event counts in the report's session should match the handled-ness.
 
-        And the "method" of stack frame 0 equals "foo()"
-        And the "file" of stack frame 0 equals "src/Giraffe.mm"
-        And the "lineNumber" of stack frame 0 equals 200
-        And the "method" of stack frame 1 equals "bar()"
-        And the "file" of stack frame 1 equals "parser.js"
-        And the "lineNumber" of stack frame 1 is null
-        And the "method" of stack frame 2 equals "yes()"
-        And the "file" of stack frame 2 is null
-        And the "lineNumber" of stack frame 2 is null
-        And the event "unhandled" is false
+    When I run "HandledInternalNotifyScenario"
+    And I wait to receive 2 requests
+    Then the request is valid for the session reporting API version "1.0" for the "iOS Bugsnag Notifier" notifier
+    And the payload field "sessions.0.id" is stored as the value "session_id"
+    And I discard the oldest request
+    Then the request is valid for the error reporting API version "4.0" for the "iOS Bugsnag Notifier" notifier
+    And the exception "errorClass" equals "Handled Error!"
+    And the exception "message" equals "Internally reported a handled event"
+    And the exception "type" equals "unreal"
+    And the event "severity" equals "warning"
+    And the event "severityReason.type" equals "handledException"
 
-        And the payload field "events" is an array with 1 elements
-        And the payload field "events.0.session.events.handled" equals 1
-        And the payload field "events.0.session.events.unhandled" equals 0
-        And the payload field "events.0.session.id" equals the stored value "session_id"
+    And the "method" of stack frame 0 equals "foo()"
+    And the "file" of stack frame 0 equals "src/Giraffe.mm"
+    And the "lineNumber" of stack frame 0 equals 200
+    And the "method" of stack frame 1 equals "bar()"
+    And the "file" of stack frame 1 equals "parser.js"
+    And the "lineNumber" of stack frame 1 is null
+    And the "method" of stack frame 2 equals "yes()"
+    And the "file" of stack frame 2 is null
+    And the "lineNumber" of stack frame 2 is null
+    And the event "unhandled" is false
 
-    Scenario: Report an unhandled event through internalNotify()
-        Report an unhandled exception, including a custom stacktrace and severity.
-        Event counts in the report's session should match the handled-ness.
+    And the payload field "events" is an array with 1 elements
+    And the payload field "events.0.session.events.handled" equals 1
+    And the payload field "events.0.session.events.unhandled" equals 0
+    And the payload field "events.0.session.id" equals the stored value "session_id"
 
-        When I run "UnhandledInternalNotifyScenario"
-        And I configure Bugsnag for "UnhandledInternalNotifyScenario"
-        And I wait to receive 2 requests
-        Then the request is valid for the session reporting API version "1.0" for the "iOS Bugsnag Notifier" notifier
-        And the payload field "sessions.0.id" is stored as the value "session_id"
-        And I discard the oldest request
-        Then the request is valid for the error reporting API version "4.0" for the "iOS Bugsnag Notifier" notifier
-        And the exception "errorClass" equals "Unhandled Error?!"
-        And the exception "message" equals "Internally reported an unhandled event"
-        And the exception "type" equals "fake"
-        And the event "severity" equals "info"
-        And the event "severityReason.type" equals "userCallbackSetSeverity"
+  Scenario: Report an unhandled event through internalNotify()
+  Report an unhandled exception, including a custom stacktrace and severity.
+  Event counts in the report's session should match the handled-ness.
 
-        And the "method" of stack frame 0 equals "bar()"
-        And the "file" of stack frame 0 equals "foo.js"
-        And the "lineNumber" of stack frame 0 equals 43
-        And the "method" of stack frame 1 equals "baz()"
-        And the "file" of stack frame 1 equals "[native code]"
-        And the "lineNumber" of stack frame 1 is null
-        And the "method" of stack frame 2 equals "is_done()"
-        And the "file" of stack frame 2 is null
-        And the "lineNumber" of stack frame 2 is null
-        And the event "unhandled" is true
+    When I run "UnhandledInternalNotifyScenario"
+    And I configure Bugsnag for "UnhandledInternalNotifyScenario"
+    And I wait to receive 2 requests
+    Then the request is valid for the session reporting API version "1.0" for the "iOS Bugsnag Notifier" notifier
+    And the payload field "sessions.0.id" is stored as the value "session_id"
+    And I discard the oldest request
+    Then the request is valid for the error reporting API version "4.0" for the "iOS Bugsnag Notifier" notifier
+    And the exception "errorClass" equals "Unhandled Error?!"
+    And the exception "message" equals "Internally reported an unhandled event"
+    And the exception "type" equals "fake"
+    And the event "severity" equals "info"
+    And the event "severityReason.type" equals "userCallbackSetSeverity"
 
-        And the payload field "events" is an array with 1 elements
-        And the payload field "events.0.session.events.handled" equals 0
-        And the payload field "events.0.session.events.unhandled" equals 1
-        And the payload field "events.0.session.id" equals the stored value "session_id"
+    And the "method" of stack frame 0 equals "bar()"
+    And the "file" of stack frame 0 equals "foo.js"
+    And the "lineNumber" of stack frame 0 equals 43
+    And the "method" of stack frame 1 equals "baz()"
+    And the "file" of stack frame 1 equals "[native code]"
+    And the "lineNumber" of stack frame 1 is null
+    And the "method" of stack frame 2 equals "is_done()"
+    And the "file" of stack frame 2 is null
+    And the "lineNumber" of stack frame 2 is null
+    And the event "unhandled" is true
+
+    And the payload field "events" is an array with 1 elements
+    And the payload field "events.0.session.events.handled" equals 0
+    And the payload field "events.0.session.events.unhandled" equals 1
+    And the payload field "events.0.session.id" equals the stored value "session_id"

--- a/features/enabled_error_types.feature
+++ b/features/enabled_error_types.feature
@@ -1,6 +1,9 @@
 Feature: Enabled error types
 
-Scenario: All Crash reporting is disabled
+  Background:
+    Given I clear all UserDefaults data
+
+  Scenario: All Crash reporting is disabled
     # Sessions: on, unhandled crashes: off
     When I run "DisableAllExceptManualExceptionsAndCrashScenario" and relaunch the app
     And I configure Bugsnag for "DisableAllExceptManualExceptionsAndCrashScenario"
@@ -9,7 +12,7 @@ Scenario: All Crash reporting is disabled
     And I discard the oldest request
     Then the request is valid for the session reporting API version "1.0" for the "iOS Bugsnag Notifier" notifier
 
-Scenario: All Crash reporting is disabled but manual notification works
+  Scenario: All Crash reporting is disabled but manual notification works
     # enabledErrorTypes = None, Generate a manual notification, crash
     When I run "DisableAllExceptManualExceptionsSendManualAndCrashScenario" and relaunch the app
     And I configure Bugsnag for "DisableAllExceptManualExceptionsSendManualAndCrashScenario"
@@ -17,7 +20,7 @@ Scenario: All Crash reporting is disabled but manual notification works
     And I wait to receive a request
     Then the request is valid for the error reporting API version "4.0" for the "iOS Bugsnag Notifier" notifier
 
-Scenario: NSException Crash Reporting is disabled
+  Scenario: NSException Crash Reporting is disabled
     When I run "DisableNSExceptionScenario" and relaunch the app
     And I configure Bugsnag for "DisableNSExceptionScenario"
 
@@ -27,7 +30,7 @@ Scenario: NSException Crash Reporting is disabled
     And the event "unhandled" is false
     And the payload field "events.0.exceptions.0.message" equals "DisableNSExceptionScenario - Handled"
 
-Scenario: CPP Crash Reporting is disabled
+  Scenario: CPP Crash Reporting is disabled
     When I run "EnabledErrorTypesCxxScenario" and relaunch the app
     And I configure Bugsnag for "EnabledErrorTypesCxxScenario"
     And I wait to receive 2 requests
@@ -35,7 +38,7 @@ Scenario: CPP Crash Reporting is disabled
     And I discard the oldest request
     Then the request is valid for the session reporting API version "1.0" for the "iOS Bugsnag Notifier" notifier
 
-Scenario: Mach Crash Reporting is disabled
+  Scenario: Mach Crash Reporting is disabled
     When I run "DisableMachExceptionScenario"
     And I relaunch the app
     And I configure Bugsnag for "DisableMachExceptionScenario"
@@ -44,7 +47,7 @@ Scenario: Mach Crash Reporting is disabled
     And the event "unhandled" is false
     And the payload field "events.0.exceptions.0.message" equals "DisableMachExceptionScenario - Handled"
 
-Scenario: Signals Crash Reporting is disabled
+  Scenario: Signals Crash Reporting is disabled
     When I run "DisableSignalsExceptionScenario" and relaunch the app
     And I configure Bugsnag for "DisableSignalsExceptionScenario"
     And I wait for 5 seconds

--- a/features/error_reporting_thread.feature
+++ b/features/error_reporting_thread.feature
@@ -1,6 +1,9 @@
 Feature: Error Reporting Thread
 
-Scenario: Only 1 thread is flagged as the error reporting thread
+  Background:
+    Given I clear all UserDefaults data
+
+  Scenario: Only 1 thread is flagged as the error reporting thread
     When I run "HandledErrorScenario"
     And I wait to receive a request
     Then the request is valid for the error reporting API version "4.0" for the "iOS Bugsnag Notifier" notifier

--- a/features/event_callbacks.feature
+++ b/features/event_callbacks.feature
@@ -1,13 +1,16 @@
 Feature: Callbacks can access and modify event information
 
-Scenario: Removing an OnSend callback does not affect other OnSend callbacks
+  Background:
+    Given I clear all UserDefaults data
+
+  Scenario: Removing an OnSend callback does not affect other OnSend callbacks
     When I run "OnSendCallbackRemovalScenario"
     And I wait to receive a request
     Then the request is valid for the error reporting API version "4.0" for the "iOS Bugsnag Notifier" notifier
     And the event "metaData.callbacks.config" is null
     And the event "metaData.callbacks.config2" equals "adding metadata"
 
-Scenario: An OnErrorCallback can overwrite information for a handled error
+  Scenario: An OnErrorCallback can overwrite information for a handled error
     When I run "OnErrorOverwriteScenario"
     And I wait to receive a request
     Then the request is valid for the error reporting API version "4.0" for the "iOS Bugsnag Notifier" notifier
@@ -20,7 +23,7 @@ Scenario: An OnErrorCallback can overwrite information for a handled error
     And the event "user.email" equals "customEmail"
     And the event "user.name" equals "customName"
 
-Scenario: An OnSend callback can overwrite information for an unhandled error
+  Scenario: An OnSend callback can overwrite information for an unhandled error
     When I run "SwiftAssertion" and relaunch the app
     And I configure Bugsnag for "OnSendOverwriteScenario"
     And I wait to receive a request
@@ -34,7 +37,7 @@ Scenario: An OnSend callback can overwrite information for an unhandled error
     And the event "user.email" equals "customEmail"
     And the event "user.name" equals "customName"
 
-Scenario: Information set in OnCrashHandler is added to the final report
+  Scenario: Information set in OnCrashHandler is added to the final report
     When I run "OnCrashHandlerScenario" and relaunch the app
     And I configure Bugsnag for "OnSendOverwriteScenario"
     And I wait to receive a request
@@ -46,19 +49,19 @@ Scenario: Information set in OnCrashHandler is added to the final report
     And the event "metaData.custom.doubleVal" is not null
     And the event "metaData.complex.arrayVal" is not null
 
-Scenario: The original error property is populated for a handled NSError
+  Scenario: The original error property is populated for a handled NSError
     When I run "OriginalErrorNSErrorScenario"
     And I wait to receive a request
     Then the request is valid for the error reporting API version "4.0" for the "iOS Bugsnag Notifier" notifier
     And the event "metaData.custom.hasOriginalError" is true
 
-Scenario: The original error property is populated for a handled NSException
+  Scenario: The original error property is populated for a handled NSException
     When I run "OriginalErrorNSExceptionScenario"
     And I wait to receive a request
     Then the request is valid for the error reporting API version "4.0" for the "iOS Bugsnag Notifier" notifier
     And the event "metaData.custom.hasOriginalError" is true
 
-Scenario: OnSend callbacks run in the order in which they were added
+  Scenario: OnSend callbacks run in the order in which they were added
     When I run "OnSendCallbackOrderScenario"
     And I wait to receive a request
     Then the request is valid for the error reporting API version "4.0" for the "iOS Bugsnag Notifier" notifier

--- a/features/fixtures/ios-swift-cocoapods/iOSTestApp.xcodeproj/project.pbxproj
+++ b/features/fixtures/ios-swift-cocoapods/iOSTestApp.xcodeproj/project.pbxproj
@@ -16,7 +16,7 @@
 		00432CC4240912A100826D05 /* EnabledErrorTypesCxxScenario.mm in Sources */ = {isa = PBXBuildFile; fileRef = 00432CC2240912A000826D05 /* EnabledErrorTypesCxxScenario.mm */; };
 		00507A64242BFE5600EF1B87 /* EnabledBreadcrumbTypesIsNilScenario.swift in Sources */ = {isa = PBXBuildFile; fileRef = 00507A63242BFE5600EF1B87 /* EnabledBreadcrumbTypesIsNilScenario.swift */; };
 		00CEB60D24080C690004793D /* EnabledErrorTypesScenario.m in Sources */ = {isa = PBXBuildFile; fileRef = 00CEB60C24080C690004793D /* EnabledErrorTypesScenario.m */; };
-		8A14F0F62282D4AE00337B05 /* (null) in Sources */ = {isa = PBXBuildFile; };
+		8A14F0F62282D4AE00337B05 /* BuildFile in Sources */ = {isa = PBXBuildFile; };
 		8A22FC66225B598500CA8895 /* OOMForegroundScenario.m in Sources */ = {isa = PBXBuildFile; fileRef = 8A22FC65225B598500CA8895 /* OOMForegroundScenario.m */; };
 		8A32DB8222424E3000EDD92F /* NSExceptionShiftScenario.m in Sources */ = {isa = PBXBuildFile; fileRef = 8A32DB8122424E3000EDD92F /* NSExceptionShiftScenario.m */; };
 		8A38C5D124094D7B00BC4463 /* DiscardedBreadcrumbTypeScenario.swift in Sources */ = {isa = PBXBuildFile; fileRef = 8A38C5D024094D7B00BC4463 /* DiscardedBreadcrumbTypeScenario.swift */; };
@@ -45,6 +45,11 @@
 		8AF8FCAC22BD1E5400A967CA /* UnhandledInternalNotifyScenario.swift in Sources */ = {isa = PBXBuildFile; fileRef = 8AF8FCAB22BD1E5400A967CA /* UnhandledInternalNotifyScenario.swift */; };
 		8AF8FCAE22BD23BA00A967CA /* HandledInternalNotifyScenario.swift in Sources */ = {isa = PBXBuildFile; fileRef = 8AF8FCAD22BD23BA00A967CA /* HandledInternalNotifyScenario.swift */; };
 		C4D0B5FF8E60C0835B86DFE9 /* Pods_iOSTestApp.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = 4994F05E0421A0B037DD2CC5 /* Pods_iOSTestApp.framework */; };
+		E700EE48247D1158008CFFB6 /* UserEventOverrideScenario.swift in Sources */ = {isa = PBXBuildFile; fileRef = E700EE47247D1158008CFFB6 /* UserEventOverrideScenario.swift */; };
+		E700EE4A247D1164008CFFB6 /* UserSessionOverrideScenario.swift in Sources */ = {isa = PBXBuildFile; fileRef = E700EE49247D1164008CFFB6 /* UserSessionOverrideScenario.swift */; };
+		E700EE4C247D12E4008CFFB6 /* UserFromConfigEventScenario.swift in Sources */ = {isa = PBXBuildFile; fileRef = E700EE4B247D12E4008CFFB6 /* UserFromConfigEventScenario.swift */; };
+		E700EE4E247D1317008CFFB6 /* UserFromClientScenario.swift in Sources */ = {isa = PBXBuildFile; fileRef = E700EE4D247D1317008CFFB6 /* UserFromClientScenario.swift */; };
+		E700EE50247D15DE008CFFB6 /* UserFromConfigSessionScenario.swift in Sources */ = {isa = PBXBuildFile; fileRef = E700EE4F247D15DE008CFFB6 /* UserFromConfigSessionScenario.swift */; };
 		E700EE53247D31EA008CFFB6 /* OnErrorOverwriteScenario.swift in Sources */ = {isa = PBXBuildFile; fileRef = E700EE52247D31EA008CFFB6 /* OnErrorOverwriteScenario.swift */; };
 		E700EE55247D3204008CFFB6 /* OnSendOverwriteScenario.swift in Sources */ = {isa = PBXBuildFile; fileRef = E700EE54247D3204008CFFB6 /* OnSendOverwriteScenario.swift */; };
 		E700EE59247D321B008CFFB6 /* OriginalErrorNSErrorScenario.swift in Sources */ = {isa = PBXBuildFile; fileRef = E700EE58247D321B008CFFB6 /* OriginalErrorNSErrorScenario.swift */; };
@@ -60,11 +65,6 @@
 		E700EE78247D7A15008CFFB6 /* SIGILLScenario.m in Sources */ = {isa = PBXBuildFile; fileRef = E700EE77247D7A15008CFFB6 /* SIGILLScenario.m */; };
 		E700EE7B247D7A1F008CFFB6 /* SIGSEGVScenario.m in Sources */ = {isa = PBXBuildFile; fileRef = E700EE7A247D7A1F008CFFB6 /* SIGSEGVScenario.m */; };
 		E700EE7E247D7A61008CFFB6 /* SIGSYSScenario.m in Sources */ = {isa = PBXBuildFile; fileRef = E700EE7D247D7A61008CFFB6 /* SIGSYSScenario.m */; };
-		E700EE48247D1158008CFFB6 /* UserEventOverrideScenario.swift in Sources */ = {isa = PBXBuildFile; fileRef = E700EE47247D1158008CFFB6 /* UserEventOverrideScenario.swift */; };
-		E700EE4A247D1164008CFFB6 /* UserSessionOverrideScenario.swift in Sources */ = {isa = PBXBuildFile; fileRef = E700EE49247D1164008CFFB6 /* UserSessionOverrideScenario.swift */; };
-		E700EE4C247D12E4008CFFB6 /* UserFromConfigEventScenario.swift in Sources */ = {isa = PBXBuildFile; fileRef = E700EE4B247D12E4008CFFB6 /* UserFromConfigEventScenario.swift */; };
-		E700EE4E247D1317008CFFB6 /* UserFromClientScenario.swift in Sources */ = {isa = PBXBuildFile; fileRef = E700EE4D247D1317008CFFB6 /* UserFromClientScenario.swift */; };
-		E700EE50247D15DE008CFFB6 /* UserFromConfigSessionScenario.swift in Sources */ = {isa = PBXBuildFile; fileRef = E700EE4F247D15DE008CFFB6 /* UserFromConfigSessionScenario.swift */; };
 		E75040A02478019D005D33BD /* AutoDetectFalseHandledScenario.swift in Sources */ = {isa = PBXBuildFile; fileRef = E750409F2478019D005D33BD /* AutoDetectFalseHandledScenario.swift */; };
 		E75040A2247801A8005D33BD /* AutoDetectFalseNSExceptionScenario.swift in Sources */ = {isa = PBXBuildFile; fileRef = E75040A1247801A8005D33BD /* AutoDetectFalseNSExceptionScenario.swift */; };
 		E75040A42478052D005D33BD /* AutoDetectFalseAbortScenario.swift in Sources */ = {isa = PBXBuildFile; fileRef = E75040A32478052D005D33BD /* AutoDetectFalseAbortScenario.swift */; };
@@ -75,22 +75,22 @@
 		E7767F11221C21D90006648C /* StoppedSessionScenario.swift in Sources */ = {isa = PBXBuildFile; fileRef = E7767F10221C21D90006648C /* StoppedSessionScenario.swift */; };
 		E7767F13221C21E30006648C /* ResumedSessionScenario.swift in Sources */ = {isa = PBXBuildFile; fileRef = E7767F12221C21E30006648C /* ResumedSessionScenario.swift */; };
 		E7767F15221C223C0006648C /* NewSessionScenario.swift in Sources */ = {isa = PBXBuildFile; fileRef = E7767F14221C223C0006648C /* NewSessionScenario.swift */; };
-		E7A324E6247E9D8D008B0052 /* BreadcrumbCallbackDiscardScenario.swift in Sources */ = {isa = PBXBuildFile; fileRef = E7A324E5247E9D8D008B0052 /* BreadcrumbCallbackDiscardScenario.swift */; };
-		E7A324E8247E9D9A008B0052 /* BreadcrumbCallbackOrderScenario.swift in Sources */ = {isa = PBXBuildFile; fileRef = E7A324E7247E9D9A008B0052 /* BreadcrumbCallbackOrderScenario.swift */; };
-		E7A324EA247E9DA5008B0052 /* BreadcrumbCallbackOverrideScenario.swift in Sources */ = {isa = PBXBuildFile; fileRef = E7A324E9247E9DA5008B0052 /* BreadcrumbCallbackOverrideScenario.swift */; };
-		E7A324ED247E9DB3008B0052 /* BreadcrumbCallbackRemovalScenario.m in Sources */ = {isa = PBXBuildFile; fileRef = E7A324EC247E9DB3008B0052 /* BreadcrumbCallbackRemovalScenario.m */; };
-		E7A324EF247E9DBC008B0052 /* BreadcrumbCallbackCrashScenario.swift in Sources */ = {isa = PBXBuildFile; fileRef = E7A324EE247E9DBC008B0052 /* BreadcrumbCallbackCrashScenario.swift */; };
-		E7B79CDA24800A5D0039FB88 /* MetadataMergeScenario.swift in Sources */ = {isa = PBXBuildFile; fileRef = E7B79CD924800A5D0039FB88 /* MetadataMergeScenario.swift */; };
 		E7A324D8247E70B2008B0052 /* SessionCallbackOverrideScenario.swift in Sources */ = {isa = PBXBuildFile; fileRef = E7A324D7247E70B2008B0052 /* SessionCallbackOverrideScenario.swift */; };
 		E7A324DA247E70C4008B0052 /* SessionCallbackCrashScenario.swift in Sources */ = {isa = PBXBuildFile; fileRef = E7A324D9247E70C4008B0052 /* SessionCallbackCrashScenario.swift */; };
 		E7A324DE247E70E6008B0052 /* SessionCallbackOrderScenario.swift in Sources */ = {isa = PBXBuildFile; fileRef = E7A324DD247E70E6008B0052 /* SessionCallbackOrderScenario.swift */; };
 		E7A324E0247E70F9008B0052 /* SessionCallbackDiscardScenario.swift in Sources */ = {isa = PBXBuildFile; fileRef = E7A324DF247E70F9008B0052 /* SessionCallbackDiscardScenario.swift */; };
 		E7A324E3247E7C17008B0052 /* SessionCallbackRemovalScenario.m in Sources */ = {isa = PBXBuildFile; fileRef = E7A324E2247E7C17008B0052 /* SessionCallbackRemovalScenario.m */; };
+		E7A324E6247E9D8D008B0052 /* BreadcrumbCallbackDiscardScenario.swift in Sources */ = {isa = PBXBuildFile; fileRef = E7A324E5247E9D8D008B0052 /* BreadcrumbCallbackDiscardScenario.swift */; };
+		E7A324E8247E9D9A008B0052 /* BreadcrumbCallbackOrderScenario.swift in Sources */ = {isa = PBXBuildFile; fileRef = E7A324E7247E9D9A008B0052 /* BreadcrumbCallbackOrderScenario.swift */; };
+		E7A324EA247E9DA5008B0052 /* BreadcrumbCallbackOverrideScenario.swift in Sources */ = {isa = PBXBuildFile; fileRef = E7A324E9247E9DA5008B0052 /* BreadcrumbCallbackOverrideScenario.swift */; };
+		E7A324ED247E9DB3008B0052 /* BreadcrumbCallbackRemovalScenario.m in Sources */ = {isa = PBXBuildFile; fileRef = E7A324EC247E9DB3008B0052 /* BreadcrumbCallbackRemovalScenario.m */; };
+		E7A324EF247E9DBC008B0052 /* BreadcrumbCallbackCrashScenario.swift in Sources */ = {isa = PBXBuildFile; fileRef = E7A324EE247E9DBC008B0052 /* BreadcrumbCallbackCrashScenario.swift */; };
 		E7B79CD0247FD6660039FB88 /* ManualContextConfigurationScenario.swift in Sources */ = {isa = PBXBuildFile; fileRef = E7B79CCF247FD6660039FB88 /* ManualContextConfigurationScenario.swift */; };
 		E7B79CD2247FD66E0039FB88 /* ManualContextClientScenario.swift in Sources */ = {isa = PBXBuildFile; fileRef = E7B79CD1247FD66E0039FB88 /* ManualContextClientScenario.swift */; };
 		E7B79CD4247FD6760039FB88 /* ManualContextOnErrorScenario.swift in Sources */ = {isa = PBXBuildFile; fileRef = E7B79CD3247FD6760039FB88 /* ManualContextOnErrorScenario.swift */; };
 		E7B79CD6247FD7750039FB88 /* AutoContextNSErrorScenario.swift in Sources */ = {isa = PBXBuildFile; fileRef = E7B79CD5247FD7750039FB88 /* AutoContextNSErrorScenario.swift */; };
 		E7B79CD8247FD7810039FB88 /* AutoContextNSExceptionScenario.swift in Sources */ = {isa = PBXBuildFile; fileRef = E7B79CD7247FD7810039FB88 /* AutoContextNSExceptionScenario.swift */; };
+		E7B79CDA24800A5D0039FB88 /* MetadataMergeScenario.swift in Sources */ = {isa = PBXBuildFile; fileRef = E7B79CD924800A5D0039FB88 /* MetadataMergeScenario.swift */; };
 		E7DD40452473D980000EDC14 /* UserDefaultInfoScenario.swift in Sources */ = {isa = PBXBuildFile; fileRef = E7DD40442473D980000EDC14 /* UserDefaultInfoScenario.swift */; };
 		F429502603396F8671B333B3 /* HandledExceptionScenario.swift in Sources */ = {isa = PBXBuildFile; fileRef = F429526319377A8848136413 /* HandledExceptionScenario.swift */; };
 		F4295109FCAB93708FDAFE12 /* DisabledSessionTrackingScenario.m in Sources */ = {isa = PBXBuildFile; fileRef = F429563584D9BC3A5B86BECF /* DisabledSessionTrackingScenario.m */; };
@@ -199,6 +199,11 @@
 		8AF8FCAB22BD1E5400A967CA /* UnhandledInternalNotifyScenario.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = UnhandledInternalNotifyScenario.swift; sourceTree = "<group>"; };
 		8AF8FCAD22BD23BA00A967CA /* HandledInternalNotifyScenario.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = HandledInternalNotifyScenario.swift; sourceTree = "<group>"; };
 		960A6E7D4E847F1D76A4FD06 /* Pods-iOSTestApp.release.xcconfig */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.xcconfig; name = "Pods-iOSTestApp.release.xcconfig"; path = "Pods/Target Support Files/Pods-iOSTestApp/Pods-iOSTestApp.release.xcconfig"; sourceTree = "<group>"; };
+		E700EE47247D1158008CFFB6 /* UserEventOverrideScenario.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = UserEventOverrideScenario.swift; sourceTree = "<group>"; };
+		E700EE49247D1164008CFFB6 /* UserSessionOverrideScenario.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = UserSessionOverrideScenario.swift; sourceTree = "<group>"; };
+		E700EE4B247D12E4008CFFB6 /* UserFromConfigEventScenario.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = UserFromConfigEventScenario.swift; sourceTree = "<group>"; };
+		E700EE4D247D1317008CFFB6 /* UserFromClientScenario.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = UserFromClientScenario.swift; sourceTree = "<group>"; };
+		E700EE4F247D15DE008CFFB6 /* UserFromConfigSessionScenario.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = UserFromConfigSessionScenario.swift; sourceTree = "<group>"; };
 		E700EE52247D31EA008CFFB6 /* OnErrorOverwriteScenario.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = OnErrorOverwriteScenario.swift; sourceTree = "<group>"; };
 		E700EE54247D3204008CFFB6 /* OnSendOverwriteScenario.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = OnSendOverwriteScenario.swift; sourceTree = "<group>"; };
 		E700EE58247D321B008CFFB6 /* OriginalErrorNSErrorScenario.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = OriginalErrorNSErrorScenario.swift; sourceTree = "<group>"; };
@@ -224,11 +229,6 @@
 		E700EE7A247D7A1F008CFFB6 /* SIGSEGVScenario.m */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.objc; path = SIGSEGVScenario.m; sourceTree = "<group>"; };
 		E700EE7C247D7A61008CFFB6 /* SIGSYSScenario.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; path = SIGSYSScenario.h; sourceTree = "<group>"; };
 		E700EE7D247D7A61008CFFB6 /* SIGSYSScenario.m */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.objc; path = SIGSYSScenario.m; sourceTree = "<group>"; };
-		E700EE47247D1158008CFFB6 /* UserEventOverrideScenario.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = UserEventOverrideScenario.swift; sourceTree = "<group>"; };
-		E700EE49247D1164008CFFB6 /* UserSessionOverrideScenario.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = UserSessionOverrideScenario.swift; sourceTree = "<group>"; };
-		E700EE4B247D12E4008CFFB6 /* UserFromConfigEventScenario.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = UserFromConfigEventScenario.swift; sourceTree = "<group>"; };
-		E700EE4D247D1317008CFFB6 /* UserFromClientScenario.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = UserFromClientScenario.swift; sourceTree = "<group>"; };
-		E700EE4F247D15DE008CFFB6 /* UserFromConfigSessionScenario.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = UserFromConfigSessionScenario.swift; sourceTree = "<group>"; };
 		E750409F2478019D005D33BD /* AutoDetectFalseHandledScenario.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AutoDetectFalseHandledScenario.swift; sourceTree = "<group>"; };
 		E75040A1247801A8005D33BD /* AutoDetectFalseNSExceptionScenario.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AutoDetectFalseNSExceptionScenario.swift; sourceTree = "<group>"; };
 		E75040A32478052D005D33BD /* AutoDetectFalseAbortScenario.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AutoDetectFalseAbortScenario.swift; sourceTree = "<group>"; };
@@ -240,24 +240,24 @@
 		E7767F12221C21E30006648C /* ResumedSessionScenario.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ResumedSessionScenario.swift; sourceTree = "<group>"; };
 		E7767F14221C223C0006648C /* NewSessionScenario.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = NewSessionScenario.swift; sourceTree = "<group>"; };
 		E77AFEF72449C6460082B8BB /* AttachCustomStacktraceHook.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; path = AttachCustomStacktraceHook.h; sourceTree = "<group>"; };
-		E7A324E5247E9D8D008B0052 /* BreadcrumbCallbackDiscardScenario.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = BreadcrumbCallbackDiscardScenario.swift; sourceTree = "<group>"; };
-		E7A324E7247E9D9A008B0052 /* BreadcrumbCallbackOrderScenario.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = BreadcrumbCallbackOrderScenario.swift; sourceTree = "<group>"; };
-		E7A324E9247E9DA5008B0052 /* BreadcrumbCallbackOverrideScenario.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = BreadcrumbCallbackOverrideScenario.swift; sourceTree = "<group>"; };
-		E7A324EB247E9DB3008B0052 /* BreadcrumbCallbackRemovalScenario.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; path = BreadcrumbCallbackRemovalScenario.h; sourceTree = "<group>"; };
-		E7A324EC247E9DB3008B0052 /* BreadcrumbCallbackRemovalScenario.m */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.objc; path = BreadcrumbCallbackRemovalScenario.m; sourceTree = "<group>"; };
-		E7A324EE247E9DBC008B0052 /* BreadcrumbCallbackCrashScenario.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = BreadcrumbCallbackCrashScenario.swift; sourceTree = "<group>"; };
-		E7B79CD924800A5D0039FB88 /* MetadataMergeScenario.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = MetadataMergeScenario.swift; sourceTree = "<group>"; };
 		E7A324D7247E70B2008B0052 /* SessionCallbackOverrideScenario.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SessionCallbackOverrideScenario.swift; sourceTree = "<group>"; };
 		E7A324D9247E70C4008B0052 /* SessionCallbackCrashScenario.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SessionCallbackCrashScenario.swift; sourceTree = "<group>"; };
 		E7A324DD247E70E6008B0052 /* SessionCallbackOrderScenario.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SessionCallbackOrderScenario.swift; sourceTree = "<group>"; };
 		E7A324DF247E70F9008B0052 /* SessionCallbackDiscardScenario.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SessionCallbackDiscardScenario.swift; sourceTree = "<group>"; };
 		E7A324E1247E7C17008B0052 /* SessionCallbackRemovalScenario.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; path = SessionCallbackRemovalScenario.h; sourceTree = "<group>"; };
 		E7A324E2247E7C17008B0052 /* SessionCallbackRemovalScenario.m */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.objc; path = SessionCallbackRemovalScenario.m; sourceTree = "<group>"; };
+		E7A324E5247E9D8D008B0052 /* BreadcrumbCallbackDiscardScenario.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = BreadcrumbCallbackDiscardScenario.swift; sourceTree = "<group>"; };
+		E7A324E7247E9D9A008B0052 /* BreadcrumbCallbackOrderScenario.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = BreadcrumbCallbackOrderScenario.swift; sourceTree = "<group>"; };
+		E7A324E9247E9DA5008B0052 /* BreadcrumbCallbackOverrideScenario.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = BreadcrumbCallbackOverrideScenario.swift; sourceTree = "<group>"; };
+		E7A324EB247E9DB3008B0052 /* BreadcrumbCallbackRemovalScenario.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; path = BreadcrumbCallbackRemovalScenario.h; sourceTree = "<group>"; };
+		E7A324EC247E9DB3008B0052 /* BreadcrumbCallbackRemovalScenario.m */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.objc; path = BreadcrumbCallbackRemovalScenario.m; sourceTree = "<group>"; };
+		E7A324EE247E9DBC008B0052 /* BreadcrumbCallbackCrashScenario.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = BreadcrumbCallbackCrashScenario.swift; sourceTree = "<group>"; };
 		E7B79CCF247FD6660039FB88 /* ManualContextConfigurationScenario.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ManualContextConfigurationScenario.swift; sourceTree = "<group>"; };
 		E7B79CD1247FD66E0039FB88 /* ManualContextClientScenario.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ManualContextClientScenario.swift; sourceTree = "<group>"; };
 		E7B79CD3247FD6760039FB88 /* ManualContextOnErrorScenario.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ManualContextOnErrorScenario.swift; sourceTree = "<group>"; };
 		E7B79CD5247FD7750039FB88 /* AutoContextNSErrorScenario.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AutoContextNSErrorScenario.swift; sourceTree = "<group>"; };
 		E7B79CD7247FD7810039FB88 /* AutoContextNSExceptionScenario.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AutoContextNSExceptionScenario.swift; sourceTree = "<group>"; };
+		E7B79CD924800A5D0039FB88 /* MetadataMergeScenario.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = MetadataMergeScenario.swift; sourceTree = "<group>"; };
 		E7DD40442473D980000EDC14 /* UserDefaultInfoScenario.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = UserDefaultInfoScenario.swift; sourceTree = "<group>"; };
 		E7F6087B244F0A3A00F1532A /* BugsnagHooks.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; path = BugsnagHooks.h; sourceTree = "<group>"; };
 		EE18B3777C62D7BCA8DDBE30 /* Pods-iOSTestApp.debug.xcconfig */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.xcconfig; name = "Pods-iOSTestApp.debug.xcconfig"; path = "Pods/Target Support Files/Pods-iOSTestApp/Pods-iOSTestApp.debug.xcconfig"; sourceTree = "<group>"; };
@@ -460,19 +460,6 @@
 			name = "Metadata Redaction";
 			sourceTree = "<group>";
 		};
-		E7A324E4247E9C96008B0052 /* Breadcrumb Callbacks */ = {
-			isa = PBXGroup;
-			children = (
-				E7A324E5247E9D8D008B0052 /* BreadcrumbCallbackDiscardScenario.swift */,
-				E7A324E7247E9D9A008B0052 /* BreadcrumbCallbackOrderScenario.swift */,
-				E7A324E9247E9DA5008B0052 /* BreadcrumbCallbackOverrideScenario.swift */,
-				E7A324EB247E9DB3008B0052 /* BreadcrumbCallbackRemovalScenario.h */,
-				E7A324EC247E9DB3008B0052 /* BreadcrumbCallbackRemovalScenario.m */,
-				E7A324EE247E9DBC008B0052 /* BreadcrumbCallbackCrashScenario.swift */,
-			);
-			name = "Breadcrumb Callbacks";
-			sourceTree = "<group>";
-		};
 		E7A324D4247E707D008B0052 /* Session Callbacks */ = {
 			isa = PBXGroup;
 			children = (
@@ -484,6 +471,19 @@
 				E7A324E2247E7C17008B0052 /* SessionCallbackRemovalScenario.m */,
 			);
 			name = "Session Callbacks";
+			sourceTree = "<group>";
+		};
+		E7A324E4247E9C96008B0052 /* Breadcrumb Callbacks */ = {
+			isa = PBXGroup;
+			children = (
+				E7A324E5247E9D8D008B0052 /* BreadcrumbCallbackDiscardScenario.swift */,
+				E7A324E7247E9D9A008B0052 /* BreadcrumbCallbackOrderScenario.swift */,
+				E7A324E9247E9DA5008B0052 /* BreadcrumbCallbackOverrideScenario.swift */,
+				E7A324EB247E9DB3008B0052 /* BreadcrumbCallbackRemovalScenario.h */,
+				E7A324EC247E9DB3008B0052 /* BreadcrumbCallbackRemovalScenario.m */,
+				E7A324EE247E9DBC008B0052 /* BreadcrumbCallbackCrashScenario.swift */,
+			);
+			name = "Breadcrumb Callbacks";
 			sourceTree = "<group>";
 		};
 		E7B79CCD247FD6400039FB88 /* Context */ = {
@@ -792,7 +792,7 @@
 			files = (
 			);
 			inputPaths = (
-				"${SRCROOT}/Pods/Target Support Files/Pods-iOSTestApp/Pods-iOSTestApp-frameworks.sh",
+				"${PODS_ROOT}/Target Support Files/Pods-iOSTestApp/Pods-iOSTestApp-frameworks.sh",
 				"${BUILT_PRODUCTS_DIR}/Bugsnag/Bugsnag.framework",
 			);
 			name = "[CP] Embed Pods Frameworks";
@@ -801,7 +801,7 @@
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 			shellPath = /bin/sh;
-			shellScript = "\"${SRCROOT}/Pods/Target Support Files/Pods-iOSTestApp/Pods-iOSTestApp-frameworks.sh\"\n";
+			shellScript = "\"${PODS_ROOT}/Target Support Files/Pods-iOSTestApp/Pods-iOSTestApp-frameworks.sh\"\n";
 			showEnvVarsInLog = 0;
 		};
 /* End PBXShellScriptBuildPhase section */
@@ -826,7 +826,7 @@
 				E700EE7E247D7A61008CFFB6 /* SIGSYSScenario.m in Sources */,
 				E75040A42478052D005D33BD /* AutoDetectFalseAbortScenario.swift in Sources */,
 				F4295A036B228AF608641699 /* UserDisabledScenario.swift in Sources */,
-				8A14F0F62282D4AE00337B05 /* (null) in Sources */,
+				8A14F0F62282D4AE00337B05 /* BuildFile in Sources */,
 				0011E6672403D13100ED71CD /* UserPersistenceScenarios.m in Sources */,
 				8AB65FCC22DC77CB001200AB /* LoadConfigFromFileScenario.swift in Sources */,
 				E7B79CD4247FD6760039FB88 /* ManualContextOnErrorScenario.swift in Sources */,

--- a/features/fixtures/ios-swift-cocoapods/iOSTestApp/Base.lproj/Main.storyboard
+++ b/features/fixtures/ios-swift-cocoapods/iOSTestApp/Base.lproj/Main.storyboard
@@ -53,6 +53,7 @@
                             </button>
                             <button opaque="NO" contentMode="scaleToFill" contentHorizontalAlignment="center" contentVerticalAlignment="center" buttonType="roundedRect" lineBreakMode="middleTruncation" translatesAutoresizingMaskIntoConstraints="NO" id="zEv-jB-Vej">
                                 <rect key="frame" x="20" y="343" width="374" height="30"/>
+                                <accessibility key="accessibilityConfiguration" identifier="ClearUserDefaultsButton"/>
                                 <state key="normal" title="Clear User Defaults"/>
                                 <connections>
                                     <action selector="clearUserData:" destination="BYZ-38-t0r" eventType="touchUpInside" id="ZcO-Ew-Mhu"/>

--- a/features/handled_errors.feature
+++ b/features/handled_errors.feature
@@ -1,11 +1,14 @@
 Feature: Handled Errors and Exceptions
 
-Scenario: Override errorClass and message from a notifyError() callback, customize report
+  Background:
+    Given I clear all UserDefaults data
 
-    Discard 2 lines from the stacktrace, as we have single place to report and log errors, see
-    https://docs.bugsnag.com/platforms/ios-objc/reporting-handled-exceptions/#depth
-    This way top of the stacktrace is not logError but run
-    Include configured metadata dictionary into the report
+  Scenario: Override errorClass and message from a notifyError() callback, customize report
+
+  Discard 2 lines from the stacktrace, as we have single place to report and log errors, see
+  https://docs.bugsnag.com/platforms/ios-objc/reporting-handled-exceptions/#depth
+  This way top of the stacktrace is not logError but run
+  Include configured metadata dictionary into the report
 
     When I run "HandledErrorOverrideScenario"
     And I wait to receive a request
@@ -22,7 +25,7 @@ Scenario: Override errorClass and message from a notifyError() callback, customi
     # TODO Consider using a step to check for "at least {int} stack frames"
     # And the stack trace is an array with 15 stack frames
 
-Scenario: Reporting an NSError
+  Scenario: Reporting an NSError
     When I run "HandledErrorScenario"
     And I wait to receive a request
     Then the request is valid for the error reporting API version "4.0" for the "iOS Bugsnag Notifier" notifier
@@ -35,7 +38,7 @@ Scenario: Reporting an NSError
     # This may be platform specific
     # And the stack trace is an array with 15 stack frames
 
-Scenario: Reporting a handled exception
+  Scenario: Reporting a handled exception
     When I run "HandledExceptionScenario"
     And I wait to receive a request
     Then the request is valid for the error reporting API version "4.0" for the "iOS Bugsnag Notifier" notifier
@@ -48,7 +51,7 @@ Scenario: Reporting a handled exception
     # This may be platform specific
     # And the stack trace is an array with 15 stack frames
 
-Scenario: Reporting a handled exception's stacktrace
+  Scenario: Reporting a handled exception's stacktrace
     When I run "NSExceptionShiftScenario"
     And I wait to receive a request
     Then the request is valid for the error reporting API version "4.0" for the "iOS Bugsnag Notifier" notifier
@@ -64,26 +67,26 @@ Scenario: Reporting a handled exception's stacktrace
     And the "method" of stack frame 2 equals "-[NSExceptionShiftScenario causeAnException]"
     And the "method" of stack frame 3 equals "-[NSExceptionShiftScenario run]"
 
-Scenario: Reporting handled errors concurrently
+  Scenario: Reporting handled errors concurrently
     When I run "ManyConcurrentNotifyScenario"
     And I wait to receive a request
     Then the request is valid for the error reporting API version "4.0" for the "iOS Bugsnag Notifier" notifier
     And the payload field "events" is an array with 8 elements
     And each event in the payload matches one of:
-        | exceptions.0.errorClass | exceptions.0.message |
-        | FooError                | Err 0   |
-        | FooError                | Err 1   |
-        | FooError                | Err 2   |
-        | FooError                | Err 3   |
+      | exceptions.0.errorClass | exceptions.0.message |
+      | FooError                | Err 0                |
+      | FooError                | Err 1                |
+      | FooError                | Err 2                |
+      | FooError                | Err 3                |
 
-Scenario: Reporting handled errors concurrently in an environment without background thread reporting
+  Scenario: Reporting handled errors concurrently in an environment without background thread reporting
     When I run "ManyConcurrentNotifyNoBackgroundThreads"
     And I wait to receive a request
     Then the request is valid for the error reporting API version "4.0" for the "iOS Bugsnag Notifier" notifier
     And the payload field "events" is an array with 8 elements
     And each event in the payload matches one of:
-        | exceptions.0.errorClass | exceptions.0.message |
-        | BarError                | Err 0   |
-        | BarError                | Err 1   |
-        | BarError                | Err 2   |
-        | BarError                | Err 3   |
+      | exceptions.0.errorClass | exceptions.0.message |
+      | BarError                | Err 0                |
+      | BarError                | Err 1                |
+      | BarError                | Err 2                |
+      | BarError                | Err 3                |

--- a/features/metadata_merging.feature
+++ b/features/metadata_merging.feature
@@ -1,9 +1,12 @@
 Feature: Metadata values are merged in a defined order
 
-    Scenario: Merging metadata values
-        When I run "MetadataMergeScenario"
-        And I wait to receive a request
-        Then the request is valid for the error reporting API version "4.0" for the "iOS Bugsnag Notifier" notifier
-        And the event "metaData.custom.nonNullValue" equals "overriddenValue"
-        And the event "metaData.custom.nullValue" is null
-        And the event "metaData.custom.invalidValue" equals "initialValue"
+  Background:
+    Given I clear all UserDefaults data
+
+  Scenario: Merging metadata values
+    When I run "MetadataMergeScenario"
+    And I wait to receive a request
+    Then the request is valid for the error reporting API version "4.0" for the "iOS Bugsnag Notifier" notifier
+    And the event "metaData.custom.nonNullValue" equals "overriddenValue"
+    And the event "metaData.custom.nullValue" is null
+    And the event "metaData.custom.invalidValue" equals "initialValue"

--- a/features/metadata_redaction.feature
+++ b/features/metadata_redaction.feature
@@ -1,26 +1,29 @@
 Feature: Metadata values can be redacted
-    Values added to metadata can be redacted through the use of config.redactedKeys
+  Values added to metadata can be redacted through the use of config.redactedKeys
 
-    Scenario: Default behaviour redacts 'password' values after callback is run
-        When I run "MetadataRedactionDefaultScenario"
-        And I wait to receive a request
-        Then the request is valid for the error reporting API version "4.0" for the "iOS Bugsnag Notifier" notifier
-        And the event "metaData.custom.password" equals "[REDACTED]"
-        And the event "metaData.custom.normalKey" equals "brown fox"
-        And the event "metaData.extras.callbackValue" equals "hunter2"
+  Background:
+    Given I clear all UserDefaults data
 
-    Scenario: Redaction works in deeply nested objects with custom keys
-        When I run "MetadataRedactionNestedScenario"
-        And I wait to receive a request
-        And the event "metaData.custom.alpha.password" equals "foo"
-        And the event "metaData.custom.alpha.name" equals "[REDACTED]"
-        And the event "metaData.custom.beta.gamma.password" equals "foo"
-        And the event "metaData.custom.beta.gamma.age" equals "[REDACTED]"
-        And the event "metaData.custom.beta.gamma.name" equals "[REDACTED]"
+  Scenario: Default behaviour redacts 'password' values after callback is run
+    When I run "MetadataRedactionDefaultScenario"
+    And I wait to receive a request
+    Then the request is valid for the error reporting API version "4.0" for the "iOS Bugsnag Notifier" notifier
+    And the event "metaData.custom.password" equals "[REDACTED]"
+    And the event "metaData.custom.normalKey" equals "brown fox"
+    And the event "metaData.extras.callbackValue" equals "hunter2"
 
-    Scenario: Regex values are redacted
-        When I run "MetadataRedactionRegexScenario"
-        And I wait to receive a request
-        And the event "metaData.animals.cat" equals "[REDACTED]"
-        And the event "metaData.clothes.hat" equals "[REDACTED]"
-        And the event "metaData.debris.9at" equals "unknown"
+  Scenario: Redaction works in deeply nested objects with custom keys
+    When I run "MetadataRedactionNestedScenario"
+    And I wait to receive a request
+    And the event "metaData.custom.alpha.password" equals "foo"
+    And the event "metaData.custom.alpha.name" equals "[REDACTED]"
+    And the event "metaData.custom.beta.gamma.password" equals "foo"
+    And the event "metaData.custom.beta.gamma.age" equals "[REDACTED]"
+    And the event "metaData.custom.beta.gamma.name" equals "[REDACTED]"
+
+  Scenario: Regex values are redacted
+    When I run "MetadataRedactionRegexScenario"
+    And I wait to receive a request
+    And the event "metaData.animals.cat" equals "[REDACTED]"
+    And the event "metaData.clothes.hat" equals "[REDACTED]"
+    And the event "metaData.debris.9at" equals "unknown"

--- a/features/out_of_memory.feature
+++ b/features/out_of_memory.feature
@@ -1,7 +1,10 @@
 Feature: Reporting out of memory events
-    If the app is terminated without either a reported crash or a "will
-    terminate" event, and the underlying OS and app versions remain the same,
-    it is likely that the app has been killed.
+  If the app is terminated without either a reported crash or a "will
+  terminate" event, and the underlying OS and app versions remain the same,
+  it is likely that the app has been killed.
+#  Background:
+#    Given I clear all UserDefaults data
+
 
     # Scenario: The app is terminated normally
     #    The application can be gracefully terminated by the OS if more

--- a/features/plugin_interface.feature
+++ b/features/plugin_interface.feature
@@ -1,16 +1,18 @@
 Feature: Add custom behavior through a plugin interface
 
-    Some internal libraries may build on top of the Bugsnag Cocoa library and
-    require custom behavior prior to the library being fully initialized. This
-    interface allows for installing that behavior before calling the regular
-    initialization process.
+  Some internal libraries may build on top of the Bugsnag Cocoa library and
+  require custom behavior prior to the library being fully initialized. This
+  interface allows for installing that behavior before calling the regular
+  initialization process.
 
-    @skip Not currently implemented
-    Scenario: Changing payload notifier description
-        When I run "CustomPluginNotifierDescriptionScenario" and relaunch the app
-        And I configure Bugsnag for "CustomPluginNotifierDescriptionScenario"
-        And I wait to receive a request
-        Then the payload field "notifier.name" equals "Foo Handler Library"
-        And the payload field "notifier.version" equals "2.1.0"
-        And the payload field "notifier.url" equals "https://example.com"
-        And the exception "errorClass" equals "EXC_BREAKPOINT"
+  Background:
+    Given I clear all UserDefaults data
+
+  Scenario: Changing payload notifier description
+    When I run "CustomPluginNotifierDescriptionScenario" and relaunch the app
+    And I configure Bugsnag for "CustomPluginNotifierDescriptionScenario"
+    And I wait to receive a request
+    Then the payload field "notifier.name" equals "Foo Handler Library"
+    And the payload field "notifier.version" equals "2.1.0"
+    And the payload field "notifier.url" equals "https://example.com"
+    And the exception "errorClass" equals "EXC_BREAKPOINT"

--- a/features/release_stage_errors.feature
+++ b/features/release_stage_errors.feature
@@ -1,49 +1,52 @@
 Feature: Discarding reports based on release stage
 
-    Scenario: Unhandled error ignored when release stage is not present in enabledReleaseStages
-        When I run "UnhandledErrorInvalidReleaseStage" and relaunch the app
-        And I configure Bugsnag for "UnhandledErrorInvalidReleaseStage"
-        Then I should receive no requests
+  Background:
+    Given I clear all UserDefaults data
 
-    Scenario: Unhandled error captured when release stage is present in enabledReleaseStages
-        When I run "UnhandledErrorValidReleaseStage" and relaunch the app
-        And I configure Bugsnag for "UnhandledErrorValidReleaseStage"
-        And I wait to receive a request
-        Then the request is valid for the error reporting API version "4.0" for the "iOS Bugsnag Notifier" notifier
-        And the exception "errorClass" equals "SIGABRT"
-        And the event "unhandled" is true
-        And the event "app.releaseStage" equals "prod"
+  Scenario: Unhandled error ignored when release stage is not present in enabledReleaseStages
+    When I run "UnhandledErrorInvalidReleaseStage" and relaunch the app
+    And I configure Bugsnag for "UnhandledErrorInvalidReleaseStage"
+    Then I should receive no requests
 
-    Scenario: Crash when release stage is changed to not present in enabledReleaseStages before the event
-        If the current run has a different release stage than the crashing context,
-        the report should only be sent if the release stage was in enabledReleaseStages
-        at the time of the crash. Release stages can change for a single build of an app
-        if the app is used as a test harness or if the build can receive code updates,
-        such as JavaScript execution contexts.
+  Scenario: Unhandled error captured when release stage is present in enabledReleaseStages
+    When I run "UnhandledErrorValidReleaseStage" and relaunch the app
+    And I configure Bugsnag for "UnhandledErrorValidReleaseStage"
+    And I wait to receive a request
+    Then the request is valid for the error reporting API version "4.0" for the "iOS Bugsnag Notifier" notifier
+    And the exception "errorClass" equals "SIGABRT"
+    And the event "unhandled" is true
+    And the event "app.releaseStage" equals "prod"
 
-        When I run "UnhandledErrorChangeInvalidReleaseStage" and relaunch the app
-        And I configure Bugsnag for "UnhandledErrorChangeInvalidReleaseStage"
-        Then I should receive no requests
+  Scenario: Crash when release stage is changed to not present in enabledReleaseStages before the event
+  If the current run has a different release stage than the crashing context,
+  the report should only be sent if the release stage was in enabledReleaseStages
+  at the time of the crash. Release stages can change for a single build of an app
+  if the app is used as a test harness or if the build can receive code updates,
+  such as JavaScript execution contexts.
 
-    Scenario: Crash when release stage is changed to be present in enabledReleaseStages before the event
-        When I run "UnhandledErrorChangeValidReleaseStage" and relaunch the app
-        And I configure Bugsnag for "UnhandledErrorChangeValidReleaseStage"
-        And I wait to receive a request
-        Then the request is valid for the error reporting API version "4.0" for the "iOS Bugsnag Notifier" notifier
-        And the exception "errorClass" equals "SIGABRT"
-        And the event "unhandled" is true
-        And the event "app.releaseStage" equals "prod"
+    When I run "UnhandledErrorChangeInvalidReleaseStage" and relaunch the app
+    And I configure Bugsnag for "UnhandledErrorChangeInvalidReleaseStage"
+    Then I should receive no requests
 
-    Scenario: Handled error when release stage is not present in enabledReleaseStages
-        When I run "HandledErrorInvalidReleaseStage"
-        And I configure Bugsnag for "HandledErrorInvalidReleaseStage"
-        Then I should receive no requests
+  Scenario: Crash when release stage is changed to be present in enabledReleaseStages before the event
+    When I run "UnhandledErrorChangeValidReleaseStage" and relaunch the app
+    And I configure Bugsnag for "UnhandledErrorChangeValidReleaseStage"
+    And I wait to receive a request
+    Then the request is valid for the error reporting API version "4.0" for the "iOS Bugsnag Notifier" notifier
+    And the exception "errorClass" equals "SIGABRT"
+    And the event "unhandled" is true
+    And the event "app.releaseStage" equals "prod"
 
-    Scenario: Handled error when release stage is present in enabledReleaseStages
-        When I run "HandledErrorValidReleaseStage"
-        And I wait to receive a request
-        Then the request is valid for the error reporting API version "4.0" for the "iOS Bugsnag Notifier" notifier
-        And the exception "errorClass" equals "iOSTestApp.MagicError"
-        And the exception "message" equals "incoming!"
-        And the event "unhandled" is false
-        And the event "app.releaseStage" equals "prod"
+  Scenario: Handled error when release stage is not present in enabledReleaseStages
+    When I run "HandledErrorInvalidReleaseStage"
+    And I configure Bugsnag for "HandledErrorInvalidReleaseStage"
+    Then I should receive no requests
+
+  Scenario: Handled error when release stage is present in enabledReleaseStages
+    When I run "HandledErrorValidReleaseStage"
+    And I wait to receive a request
+    Then the request is valid for the error reporting API version "4.0" for the "iOS Bugsnag Notifier" notifier
+    And the exception "errorClass" equals "iOSTestApp.MagicError"
+    And the exception "message" equals "incoming!"
+    And the event "unhandled" is false
+    And the event "app.releaseStage" equals "prod"

--- a/features/release_stage_sessions.feature
+++ b/features/release_stage_sessions.feature
@@ -1,19 +1,22 @@
 Feature: Discarding sessions based on release stage
 
-    Scenario: Automatic sessions are only sent when enabledReleaseStages contains the releaseStage
-        When I run "EnabledReleaseStageAutoSessionScenario"
-        And I wait to receive a request
-        And the request is valid for the session reporting API version "1.0" for the "iOS Bugsnag Notifier" notifier
-        And I discard the oldest request
-        And I relaunch the app
-        And I configure Bugsnag for "DisabledReleaseStageAutoSessionScenario"
-        Then I should receive no requests
+  Background:
+    Given I clear all UserDefaults data
 
-    Scenario: Manual sessions are only sent when enabledReleaseStages contains the releaseStage
-        When I run "EnabledReleaseStageManualSessionScenario"
-        And I wait to receive a request
-        And the request is valid for the session reporting API version "1.0" for the "iOS Bugsnag Notifier" notifier
-        And I discard the oldest request
-        And I relaunch the app
-        And I configure Bugsnag for "DisabledReleaseStageManualSessionScenario"
-        Then I should receive no requests
+  Scenario: Automatic sessions are only sent when enabledReleaseStages contains the releaseStage
+    When I run "EnabledReleaseStageAutoSessionScenario"
+    And I wait to receive a request
+    And the request is valid for the session reporting API version "1.0" for the "iOS Bugsnag Notifier" notifier
+    And I discard the oldest request
+    And I relaunch the app
+    And I configure Bugsnag for "DisabledReleaseStageAutoSessionScenario"
+    Then I should receive no requests
+
+  Scenario: Manual sessions are only sent when enabledReleaseStages contains the releaseStage
+    When I run "EnabledReleaseStageManualSessionScenario"
+    And I wait to receive a request
+    And the request is valid for the session reporting API version "1.0" for the "iOS Bugsnag Notifier" notifier
+    And I discard the oldest request
+    And I relaunch the app
+    And I configure Bugsnag for "DisabledReleaseStageManualSessionScenario"
+    Then I should receive no requests

--- a/features/runtime_versions.feature
+++ b/features/runtime_versions.feature
@@ -1,20 +1,23 @@
 Feature: Runtime versions are included in all requests
 
-Scenario: Runtime versions included in Cocoa error
+  Background:
+    Given I clear all UserDefaults data
+
+  Scenario: Runtime versions included in Cocoa error
     When I run "HandledErrorScenario"
     And I wait to receive a request
     Then the request is valid for the error reporting API version "4.0" for the "iOS Bugsnag Notifier" notifier
     And the payload field "events.0.device.runtimeVersions.osBuild" is not null
     And the payload field "events.0.device.runtimeVersions.clangVersion" is not null
 
-Scenario: Runtime versions included in Cocoa session
+  Scenario: Runtime versions included in Cocoa session
     When I run "ManualSessionScenario"
     And I wait to receive a request
     Then the request is valid for the session reporting API version "1.0" for the "iOS Bugsnag Notifier" notifier
     And the payload field "device.runtimeVersions.osBuild" is not null
     And the payload field "device.runtimeVersions.clangVersion" is not null
 
-Scenario: Runtime versions included in C layer ThrownErrorScenario
+  Scenario: Runtime versions included in C layer ThrownErrorScenario
     And I run "CxxExceptionScenario" and relaunch the app
     And I configure Bugsnag for "CxxExceptionScenario"
     And I wait to receive a request

--- a/features/session_callbacks.feature
+++ b/features/session_callbacks.feature
@@ -1,18 +1,21 @@
 Feature: Callbacks can access and modify session information
 
-Scenario: Returning false in a callback discards sessions
+  Background:
+    Given I clear all UserDefaults data
+
+  Scenario: Returning false in a callback discards sessions
     When I run "SessionCallbackDiscardScenario"
     And I wait to receive a request
     And the request is valid for the session reporting API version "1.0" for the "iOS Bugsnag Notifier" notifier
 
-Scenario: Callbacks execute in the order in which they were added
+  Scenario: Callbacks execute in the order in which they were added
     When I run "SessionCallbackOrderScenario"
     And I wait to receive a request
     And the request is valid for the session reporting API version "1.0" for the "iOS Bugsnag Notifier" notifier
     And the payload field "app.id" equals "First callback: 0"
     And the payload field "device.id" equals "Second callback: 1"
 
-Scenario: Modifying session information with a callback
+  Scenario: Modifying session information with a callback
     When I run "SessionCallbackOverrideScenario"
     And I wait to receive a request
     And the request is valid for the session reporting API version "1.0" for the "iOS Bugsnag Notifier" notifier
@@ -20,14 +23,14 @@ Scenario: Modifying session information with a callback
     And the payload field "device.id" equals "customDeviceId"
     And the session "user.id" equals "customUserId"
 
-Scenario: Callbacks can be removed without affecting the functionality of other callbacks
+  Scenario: Callbacks can be removed without affecting the functionality of other callbacks
     When I run "SessionCallbackRemovalScenario"
     And I wait to receive a request
     And the request is valid for the session reporting API version "1.0" for the "iOS Bugsnag Notifier" notifier
     And the payload field "app.id" equals "customAppId"
     And the payload field "device.id" equals "customDeviceId"
 
-Scenario: An uncaught NSException in a callback does not affect session delivery
+  Scenario: An uncaught NSException in a callback does not affect session delivery
     When I run "SessionCallbackCrashScenario"
     And I wait to receive a request
     And the request is valid for the session reporting API version "1.0" for the "iOS Bugsnag Notifier" notifier

--- a/features/session_stopping.feature
+++ b/features/session_stopping.feature
@@ -1,17 +1,20 @@
 Feature: Stopping and resuming sessions
 
-Scenario: When a session is stopped the error has no session information
+  Background:
+    Given I clear all UserDefaults data
+
+  Scenario: When a session is stopped the error has no session information
     When I run "StoppedSessionScenario"
     And I wait to receive 2 requests
     Then the request is valid for the session reporting API version "1.0" for the "iOS Bugsnag Notifier" notifier
     And I discard the oldest request
     Then the request is valid for the error reporting API version "4.0" for the "iOS Bugsnag Notifier" notifier
     And each event in the payload matches one of:
-        | exceptions.0.message                                           | has session |
-        | The operation couldn’t be completed. (First error error 101.)  | yes         |
-        | The operation couldn’t be completed. (Second error error 101.) | no          |
+      | exceptions.0.message                                           | has session |
+      | The operation couldn’t be completed. (First error error 101.)  | yes         |
+      | The operation couldn’t be completed. (Second error error 101.) | no          |
 
-Scenario: When a session is resumed the error uses the previous session information
+  Scenario: When a session is resumed the error uses the previous session information
     When I run "ResumedSessionScenario"
     And I wait to receive 2 requests
     Then the request is valid for the session reporting API version "1.0" for the "iOS Bugsnag Notifier" notifier
@@ -22,11 +25,11 @@ Scenario: When a session is resumed the error uses the previous session informat
     And the payload field "events.1.session.id" equals the stored value "session_id"
     And the payload field "events.1.session.startedAt" equals the stored value "started_at"
     And each event in the payload matches one of:
-        | exceptions.0.message                                           | session.events.handled |
-        | The operation couldn’t be completed. (First error error 101.)  | 1                      |
-        | The operation couldn’t be completed. (Second error error 101.) | 2                      |
+      | exceptions.0.message                                           | session.events.handled |
+      | The operation couldn’t be completed. (First error error 101.)  | 1                      |
+      | The operation couldn’t be completed. (Second error error 101.) | 2                      |
 
-Scenario: When a new session is started the error uses different session information
+  Scenario: When a new session is started the error uses different session information
     When I run "NewSessionScenario"
     And I wait to receive 3 requests
     Then the request is valid for the session reporting API version "1.0" for the "iOS Bugsnag Notifier" notifier
@@ -37,6 +40,6 @@ Scenario: When a new session is started the error uses different session informa
     And the payload field "events.0.session.id" is stored as the value "session_id_one"
     And the payload field "events.1.session.id" does not equal the stored value "session_id_one"
     And each event in the payload matches one of:
-        | exceptions.0.message                                           | session.events.handled |
-        | The operation couldn’t be completed. (First error error 101.)  | 1                      |
-        | The operation couldn’t be completed. (Second error error 101.) | 1                      |
+      | exceptions.0.message                                           | session.events.handled |
+      | The operation couldn’t be completed. (First error error 101.)  | 1                      |
+      | The operation couldn’t be completed. (Second error error 101.) | 1                      |

--- a/features/session_tracking.feature
+++ b/features/session_tracking.feature
@@ -1,6 +1,9 @@
 Feature: Session Tracking
 
-Scenario: Launching using the default configuration sends a single session
+  Background:
+    Given I clear all UserDefaults data
+
+  Scenario: Launching using the default configuration sends a single session
     When I run "AutoSessionScenario"
     And I wait to receive a request
     And the request is valid for the session reporting API version "1.0" for the "iOS Bugsnag Notifier" notifier
@@ -19,7 +22,7 @@ Scenario: Launching using the default configuration sends a single session
     And the session "user.email" is null
     And the session "user.name" is null
 
-Scenario: Configuring a custom version sends it in a session request
+  Scenario: Configuring a custom version sends it in a session request
     When I run "AutoSessionCustomVersionScenario"
     And I wait to receive a request
     And the request is valid for the session reporting API version "1.0" for the "iOS Bugsnag Notifier" notifier
@@ -38,7 +41,7 @@ Scenario: Configuring a custom version sends it in a session request
     And the session "user.email" is null
     And the session "user.name" is null
 
-Scenario: Configuring user info sends it with auto-captured sessions
+  Scenario: Configuring user info sends it with auto-captured sessions
     When I run "AutoSessionWithUserScenario"
     And I wait to receive a request
     And the request is valid for the session reporting API version "1.0" for the "iOS Bugsnag Notifier" notifier
@@ -50,7 +53,7 @@ Scenario: Configuring user info sends it with auto-captured sessions
     And the session "user.email" equals "joe@example.com"
     And the session "user.name" equals "Joe Bloggs"
 
-Scenario: Configuring user info sends it with manually captured sessions
+  Scenario: Configuring user info sends it with manually captured sessions
     When I run "ManualSessionWithUserScenario"
     And I wait to receive a request
     And the request is valid for the session reporting API version "1.0" for the "iOS Bugsnag Notifier" notifier
@@ -62,7 +65,7 @@ Scenario: Configuring user info sends it with manually captured sessions
     And the session "user.email" equals "joe@example.com"
     And the session "user.name" equals "Joe Bloggs"
 
-Scenario: Disabling auto-capture and calling startSession() manually sends a single session
+  Scenario: Disabling auto-capture and calling startSession() manually sends a single session
     When I run "ManualSessionScenario"
     And I wait to receive a request
     And the request is valid for the session reporting API version "1.0" for the "iOS Bugsnag Notifier" notifier
@@ -75,12 +78,12 @@ Scenario: Disabling auto-capture and calling startSession() manually sends a sin
     # And the session "user.email" is null
     # And the session "user.name" is null
 
-Scenario: Disabling auto-capture sends no sessions
+  Scenario: Disabling auto-capture sends no sessions
     When I run "DisabledSessionTrackingScenario"
     And I wait for 3 seconds
     Then I should receive no requests
 
-Scenario: Encountering a handled event during a session
+  Scenario: Encountering a handled event during a session
     When I run "AutoSessionHandledEventsScenario"
     And I wait to receive 3 requests
     Then the request is valid for the session reporting API version "1.0" for the "iOS Bugsnag Notifier" notifier
@@ -98,7 +101,7 @@ Scenario: Encountering a handled event during a session
     And the payload field "events.0.session.events.handled" equals 2
     And the payload field "events.0.session.id" equals the stored value "session_id"
 
-Scenario: Encountering an unhandled event during a session
+  Scenario: Encountering an unhandled event during a session
     When I run "AutoSessionUnhandledScenario"
     And I wait for 2 seconds
     And I relaunch the app
@@ -118,7 +121,7 @@ Scenario: Encountering an unhandled event during a session
     And the payload field "events.0.session.events.unhandled" equals 1
     And the payload field "events.0.session.id" equals the stored value "session_id"
 
-Scenario: Encountering handled and unhandled events during a session
+  Scenario: Encountering handled and unhandled events during a session
     When I run "AutoSessionMixedEventsScenario"
     And I wait for 5 seconds
     And I relaunch the app
@@ -137,11 +140,11 @@ Scenario: Encountering handled and unhandled events during a session
     Then the request is valid for the error reporting API version "4.0" for the "iOS Bugsnag Notifier" notifier
     And the payload field "events" is an array with 3 elements
     And each event in the payload matches one of:
-        | exceptions.0.errorClass | session.events.handled | session.events.unhandled |
-        | FirstErr                | 1                      | 0                        |
-        | SecondErr               | 2                      | 0                        |
-        | Kaboom                  | 2                      | 1                        |
+      | exceptions.0.errorClass | session.events.handled | session.events.unhandled |
+      | FirstErr                | 1                      | 0                        |
+      | SecondErr               | 2                      | 0                        |
+      | Kaboom                  | 2                      | 1                        |
     And the payload field "events.0.session.id" equals the stored value "session_id"
     And the payload field "events.1.session.id" equals the stored value "session_id"
     And the payload field "events.2.session.id" equals the stored value "session_id"
-    
+

--- a/features/steps/ios_steps.rb
+++ b/features/steps/ios_steps.rb
@@ -22,6 +22,13 @@ When("I run {string} and relaunch the app") do |event_type|
   }
 end
 
+When("I clear all UserDefaults data") do
+  steps %Q{
+    Given the element "ClearUserDefaultsButton" is present
+    And I click the element "ClearUserDefaultsButton"
+  }
+end
+
 When("I close the keyboard") do
   steps %Q{
     Given the element "CloseKeyboardItem" is present

--- a/features/unhandled_cpp_exception.feature
+++ b/features/unhandled_cpp_exception.feature
@@ -1,6 +1,9 @@
 Feature: Thrown C++ exceptions are captured by Bugsnag
 
-Scenario: Throwing a C++ exception
+  Background:
+    Given I clear all UserDefaults data
+
+  Scenario: Throwing a C++ exception
     When I run "CxxExceptionScenario" and relaunch the app
     And I configure Bugsnag for "CxxExceptionScenario"
     And I wait to receive a request

--- a/features/unhandled_mach_exception.feature
+++ b/features/unhandled_mach_exception.feature
@@ -1,6 +1,9 @@
 Feature: Bugsnag captures an unhandled mach exception
 
-Scenario: Trigger a mach exception
+  Background:
+    Given I clear all UserDefaults data
+
+  Scenario: Trigger a mach exception
     When I run "UnhandledMachExceptionScenario" and relaunch the app
     And I configure Bugsnag for "UnhandledMachExceptionScenario"
     And I wait to receive a request

--- a/features/unhandled_nsexception.feature
+++ b/features/unhandled_nsexception.feature
@@ -1,6 +1,9 @@
 Feature: Uncaught NSExceptions are captured by Bugsnag
 
-Scenario: Throw a NSException
+  Background:
+    Given I clear all UserDefaults data
+
+  Scenario: Throw a NSException
     When I run "ObjCExceptionScenario" and relaunch the app
     And I configure Bugsnag for "ObjCExceptionScenario"
     And I wait to receive a request

--- a/features/unhandled_signal.feature
+++ b/features/unhandled_signal.feature
@@ -1,6 +1,9 @@
 Feature: Signals are captured as error reports in Bugsnag
 
-Scenario: Triggering SIGABRT
+  Background:
+    Given I clear all UserDefaults data
+
+  Scenario: Triggering SIGABRT
     When I run "AbortScenario" and relaunch the app
     And I configure Bugsnag for "AbortScenario"
     And I wait to receive a request
@@ -8,7 +11,7 @@ Scenario: Triggering SIGABRT
     And the payload field "events" is an array with 1 elements
     And the exception "errorClass" equals "SIGABRT"
     And the "method" of stack frame 0 equals "__pthread_kill"
-    And the "method" of stack frame 1 matches "^(<redacted>|pthread_kill)$"
+    And the "method" of stack frame 1 matches "^(<redacted>| pthread_kill)$"
     And the "method" of stack frame 2 equals "abort"
     And the "method" of stack frame 3 equals "-[AbortScenario run]"
     And the event "severity" equals "error"
@@ -16,7 +19,7 @@ Scenario: Triggering SIGABRT
     And the event "severityReason.type" equals "signal"
     And the event "severityReason.attributes.signalType" equals "SIGABRT"
 
-Scenario: Triggering SIGPIPE
+  Scenario: Triggering SIGPIPE
     When I run "SIGPIPEScenario" and relaunch the app
     And I configure Bugsnag for "SIGPIPEScenario"
     And I wait to receive a request
@@ -28,7 +31,7 @@ Scenario: Triggering SIGPIPE
     And the event "severityReason.type" equals "signal"
     And the event "severityReason.attributes.signalType" equals "SIGPIPE"
 
-Scenario: Triggering SIGBUS
+  Scenario: Triggering SIGBUS
     When I run "SIGBUSScenario" and relaunch the app
     And I configure Bugsnag for "SIGBUSScenario"
     And I wait to receive a request
@@ -40,7 +43,7 @@ Scenario: Triggering SIGBUS
     And the event "severityReason.type" equals "signal"
     And the event "severityReason.attributes.signalType" equals "SIGBUS"
 
-Scenario: Triggering SIGFPE
+  Scenario: Triggering SIGFPE
     When I run "SIGFPEScenario" and relaunch the app
     And I configure Bugsnag for "SIGFPEScenario"
     And I wait to receive a request
@@ -52,7 +55,7 @@ Scenario: Triggering SIGFPE
     And the event "severityReason.type" equals "signal"
     And the event "severityReason.attributes.signalType" equals "SIGFPE"
 
-Scenario: Triggering SIGILL
+  Scenario: Triggering SIGILL
     When I run "SIGILLScenario" and relaunch the app
     And I configure Bugsnag for "SIGILLScenario"
     And I wait to receive a request
@@ -64,7 +67,7 @@ Scenario: Triggering SIGILL
     And the event "severityReason.type" equals "signal"
     And the event "severityReason.attributes.signalType" equals "SIGILL"
 
-Scenario: Triggering SIGSEGV
+  Scenario: Triggering SIGSEGV
     When I run "SIGSEGVScenario" and relaunch the app
     And I configure Bugsnag for "SIGSEGVScenario"
     And I wait to receive a request
@@ -76,7 +79,7 @@ Scenario: Triggering SIGSEGV
     And the event "severityReason.type" equals "signal"
     And the event "severityReason.attributes.signalType" equals "SIGSEGV"
 
-Scenario: Triggering SIGSYS
+  Scenario: Triggering SIGSYS
     When I run "SIGSYSScenario" and relaunch the app
     And I configure Bugsnag for "SIGSYSScenario"
     And I wait to receive a request
@@ -88,7 +91,7 @@ Scenario: Triggering SIGSYS
     And the event "severityReason.type" equals "signal"
     And the event "severityReason.attributes.signalType" equals "SIGSYS"
 
-Scenario: Triggering SIGTRAP
+  Scenario: Triggering SIGTRAP
     When I run "SIGTRAPScenario" and relaunch the app
     And I configure Bugsnag for "SIGTRAPScenario"
     And I wait to receive a request

--- a/features/user.feature
+++ b/features/user.feature
@@ -1,16 +1,18 @@
 Feature: Reporting User Information
 
-# TODO: Temporarily removed whilst internal ticket PLAT-4416 is worked
-#Scenario: Default user information only includes ID
-#    When I run "UserDefaultInfoScenario"
-#    And I wait to receive a request
-#    Then the request is valid for the error reporting API version "4.0" for the "iOS Bugsnag Notifier" notifier
-#    And the exception "message" equals "The operation couldn’t be completed. (UserDefaultInfoScenario error 100.)"
-#    And the event "user.id" is not null
-#    And the event "user.email" is null
-#    And the event "user.name" is null
+  Background:
+    Given I clear all UserDefaults data
 
-Scenario: User fields set as null
+  Scenario: Default user information only includes ID
+    When I run "UserDefaultInfoScenario"
+    And I wait to receive a request
+    Then the request is valid for the error reporting API version "4.0" for the "iOS Bugsnag Notifier" notifier
+    And the exception "message" equals "The operation couldn’t be completed. (UserDefaultInfoScenario error 100.)"
+    And the event "user.id" is not null
+    And the event "user.email" is null
+    And the event "user.name" is null
+
+  Scenario: User fields set as null
     When I run "UserDisabledScenario"
     And I wait to receive a request
     Then the request is valid for the error reporting API version "4.0" for the "iOS Bugsnag Notifier" notifier
@@ -19,7 +21,7 @@ Scenario: User fields set as null
     And the event "user.email" is null
     And the event "user.name" is null
 
-Scenario: Only User email field set
+  Scenario: Only User email field set
     When I run "UserEmailScenario"
     And I wait to receive a request
     Then the request is valid for the error reporting API version "4.0" for the "iOS Bugsnag Notifier" notifier
@@ -28,7 +30,7 @@ Scenario: Only User email field set
     And the event "user.email" equals "user@example.com"
     And the event "user.name" is null
 
-Scenario: All user fields set
+  Scenario: All user fields set
     When I run "UserEnabledScenario"
     And I wait to receive a request
     Then the request is valid for the error reporting API version "4.0" for the "iOS Bugsnag Notifier" notifier
@@ -37,7 +39,7 @@ Scenario: All user fields set
     And the event "user.email" equals "user@example.com"
     And the event "user.name" equals "Joe Bloggs"
 
-Scenario: Only User ID field set
+  Scenario: Only User ID field set
     When I run "UserIdScenario"
     And I wait to receive a request
     Then the request is valid for the error reporting API version "4.0" for the "iOS Bugsnag Notifier" notifier
@@ -46,7 +48,7 @@ Scenario: Only User ID field set
     And the event "user.email" is null
     And the event "user.name" is null
 
-Scenario: Overriding the user in the Event callback
+  Scenario: Overriding the user in the Event callback
     When I run "UserEventOverrideScenario"
     And I wait to receive a request
     Then the request is valid for the error reporting API version "4.0" for the "iOS Bugsnag Notifier" notifier
@@ -54,7 +56,7 @@ Scenario: Overriding the user in the Event callback
     And the event "user.email" equals "customEmail"
     And the event "user.name" equals "customName"
 
-Scenario: Overriding the user in the Session callback
+  Scenario: Overriding the user in the Session callback
     When I run "UserSessionOverrideScenario"
     And I wait to receive a request
     Then the request is valid for the session reporting API version "1.0" for the "iOS Bugsnag Notifier" notifier
@@ -62,7 +64,7 @@ Scenario: Overriding the user in the Session callback
     And the session "user.email" equals "customEmail"
     And the session "user.name" equals "customName"
 
-Scenario: Setting the user from Configuration for an event
+  Scenario: Setting the user from Configuration for an event
     When I run "UserFromConfigEventScenario"
     And I wait to receive a request
     Then the request is valid for the error reporting API version "4.0" for the "iOS Bugsnag Notifier" notifier
@@ -73,7 +75,7 @@ Scenario: Setting the user from Configuration for an event
     And the event "metaData.clientUserValue.email" equals "fake@gmail.com"
     And the event "metaData.clientUserValue.name" equals "Fay K"
 
-Scenario: Setting the user from Configuration for a session
+  Scenario: Setting the user from Configuration for a session
     When I run "UserFromConfigSessionScenario"
     And I wait to receive a request
     Then the request is valid for the session reporting API version "1.0" for the "iOS Bugsnag Notifier" notifier
@@ -81,7 +83,7 @@ Scenario: Setting the user from Configuration for a session
     And the session "user.email" equals "fake@gmail.com"
     And the session "user.name" equals "Fay K"
 
-Scenario: Setting the user from Client for sessions
+  Scenario: Setting the user from Client for sessions
     When I run "UserFromClientScenario"
     And I wait to receive a request
     Then the request is valid for the session reporting API version "1.0" for the "iOS Bugsnag Notifier" notifier

--- a/features/user_persistence.feature
+++ b/features/user_persistence.feature
@@ -1,6 +1,9 @@
 Feature: Persisting User Information
 
-Scenario: User Info is persisted across app runs
+  Background:
+    Given I clear all UserDefaults data
+
+  Scenario: User Info is persisted across app runs
     When I run "UserPersistencePersistUserScenario"
 
     # User is set and comes through
@@ -30,7 +33,7 @@ Scenario: User Info is persisted across app runs
     And the payload field "events.0.user.email" equals "baz@grok.com"
     And the payload field "events.0.user.name" equals "bar"
 
-Scenario: User Info is not persisted across app runs
+  Scenario: User Info is not persisted across app runs
     When I run "UserPersistenceDontPersistUserScenario"
 
     # User is set and comes through


### PR DESCRIPTION
## Goal

This change resolves a persistent test failure when all features are run, caused by UserDefaults set in an earlier scenario affecting a later test that expects UserDefaults data to be clear.

## Design

A button was added to the test fixture in a previous PR that allows UserDefaults to be cleared.  This change builds that into the tests by pressing the button before every scenario.  Having discovered the initial issue of tests bleeding into each other, this action is now performed as standard, whether technically required or not, to ensure independence of tests.

## Changeset

I have also reformatted all of the `.feature` files, as their use of whitespace was rather inconsistent. 

## Tests

All scenarios in `user.feature` should now pass in the CI run.



<!-- 
--------------------------------------------------------------------------------

Have you:

* Commented the code sufficiently?
* Added a CHANGELOG entry, if necessary?
* Checked the scope to ensure the commits are only related to the goal above?	
* Considered asynchronicity and thread safety?
* Added any new headers to the "Copy Files" stage of the static iOS target?	
* Chosen the correct target branch?
* Considered all of the pre-release checks (see CONTRIBUTING.md), if this is a full release?

--------------------------------------------------------------------------------
-->
