### PR TITLE
Respect altered apiKey field on BugsnagEvent

### DIFF
--- a/Bugsnag/BugsnagErrorReportSink.m
+++ b/Bugsnag/BugsnagErrorReportSink.m
@@ -142,10 +142,12 @@
         BugsnagEvent *event = storedEvents[filename];
         NSDictionary *requestPayload = [self prepareEventPayload:event];
 
+        NSMutableDictionary *apiHeaders = [[configuration errorApiHeaders] mutableCopy];
+        BSGDictSetSafeObject(apiHeaders, event.apiKey, BSGHeaderApiKey);
         [self.apiClient sendItems:1
                       withPayload:requestPayload
                             toURL:configuration.notifyURL
-                          headers:[configuration errorApiHeaders]
+                          headers:apiHeaders
                      onCompletion:^(NSUInteger reportCount, BOOL success, NSError *error) {
                          [self finishActiveRequest:filename success:success error:error block:block];
                      }];
@@ -174,7 +176,7 @@
 - (NSDictionary *)prepareEventPayload:(BugsnagEvent *)event {
     NSMutableDictionary *data = [[NSMutableDictionary alloc] init];
     BSGDictSetSafeObject(data, [[Bugsnag client].notifier toDict], BSGKeyNotifier);
-    BSGDictSetSafeObject(data, [Bugsnag client].configuration.apiKey, BSGKeyApiKey);
+    BSGDictSetSafeObject(data, event.apiKey, BSGKeyApiKey);
     BSGDictSetSafeObject(data, @"4.0", @"payloadVersion");
     BSGDictSetSafeObject(data, @[[event toJson]], BSGKeyEvents);
     return data;

--- a/Bugsnag/Configuration/BugsnagConfiguration.m
+++ b/Bugsnag/Configuration/BugsnagConfiguration.m
@@ -44,6 +44,7 @@
 #import "BugsnagStateEvent.h"
 #import "BugsnagCollections.h"
 #import "BugsnagMetadataInternal.h"
+#import "BugsnagKeys.h"
 
 static NSString *const kHeaderApiPayloadVersion = @"Bugsnag-Payload-Version";
 static NSString *const kHeaderApiKey = @"Bugsnag-Api-Key";
@@ -343,7 +344,7 @@ NSString * const kBugsnagUserUserId = @"BugsnagUserUserId";
 - (NSDictionary *)errorApiHeaders {
     return @{
              kHeaderApiPayloadVersion: @"4.0",
-             kHeaderApiKey: self.apiKey,
+             BSGHeaderApiKey: self.apiKey,
              kHeaderApiSentAt: [BSG_RFC3339DateTool stringFromDate:[NSDate new]]
     };
 }

--- a/Bugsnag/Configuration/BugsnagConfiguration.m
+++ b/Bugsnag/Configuration/BugsnagConfiguration.m
@@ -46,9 +46,6 @@
 #import "BugsnagMetadataInternal.h"
 #import "BugsnagKeys.h"
 
-static NSString *const kHeaderApiPayloadVersion = @"Bugsnag-Payload-Version";
-static NSString *const kHeaderApiKey = @"Bugsnag-Api-Key";
-static NSString *const kHeaderApiSentAt = @"Bugsnag-Sent-At";
 static NSString *const BSGApiKeyMissingError = @"No Bugsnag API Key set";
 static NSString *const BSGInitError = @"Init is unavailable.  Use [[BugsnagConfiguration alloc] initWithApiKey:] instead.";
 static const int BSGApiKeyLength = 32;
@@ -343,17 +340,17 @@ NSString * const kBugsnagUserUserId = @"BugsnagUserUserId";
 
 - (NSDictionary *)errorApiHeaders {
     return @{
-             kHeaderApiPayloadVersion: @"4.0",
+             BSGHeaderApiPayloadVersion: @"4.0",
              BSGHeaderApiKey: self.apiKey,
-             kHeaderApiSentAt: [BSG_RFC3339DateTool stringFromDate:[NSDate new]]
+             BSGHeaderApiSentAt: [BSG_RFC3339DateTool stringFromDate:[NSDate new]]
     };
 }
 
 - (NSDictionary *)sessionApiHeaders {
     return @{
-             kHeaderApiPayloadVersion: @"1.0",
-             kHeaderApiKey: self.apiKey,
-             kHeaderApiSentAt: [BSG_RFC3339DateTool stringFromDate:[NSDate new]]
+             BSGHeaderApiPayloadVersion: @"1.0",
+             BSGHeaderApiKey: self.apiKey,
+             BSGHeaderApiSentAt: [BSG_RFC3339DateTool stringFromDate:[NSDate new]]
              };
 }
 

--- a/Bugsnag/Helpers/BugsnagKeys.h
+++ b/Bugsnag/Helpers/BugsnagKeys.h
@@ -100,6 +100,7 @@ extern NSString *const BSGKeyUser;
 extern NSString *const BSGKeyUuid;
 extern NSString *const BSGKeyVersion;
 extern NSString *const BSGKeyWarning;
+extern NSString *const BSGHeaderApiKey;
 
 #define BSGKeyHwCputype "hw.cputype"
 #define BSGKeyHwCpusubtype "hw.cpusubtype"

--- a/Bugsnag/Helpers/BugsnagKeys.h
+++ b/Bugsnag/Helpers/BugsnagKeys.h
@@ -101,6 +101,8 @@ extern NSString *const BSGKeyUuid;
 extern NSString *const BSGKeyVersion;
 extern NSString *const BSGKeyWarning;
 extern NSString *const BSGHeaderApiKey;
+extern NSString *const BSGHeaderApiPayloadVersion;
+extern NSString *const BSGHeaderApiSentAt;
 
 #define BSGKeyHwCputype "hw.cputype"
 #define BSGKeyHwCpusubtype "hw.cpusubtype"

--- a/Bugsnag/Helpers/BugsnagKeys.m
+++ b/Bugsnag/Helpers/BugsnagKeys.m
@@ -96,3 +96,4 @@ NSString *const BSGKeyUser = @"user";
 NSString *const BSGKeyUuid = @"uuid";
 NSString *const BSGKeyVersion = @"version";
 NSString *const BSGKeyWarning = @"warning";
+NSString *const BSGHeaderApiKey = @"Bugsnag-Api-Key";

--- a/Bugsnag/Helpers/BugsnagKeys.m
+++ b/Bugsnag/Helpers/BugsnagKeys.m
@@ -97,3 +97,5 @@ NSString *const BSGKeyUuid = @"uuid";
 NSString *const BSGKeyVersion = @"version";
 NSString *const BSGKeyWarning = @"warning";
 NSString *const BSGHeaderApiKey = @"Bugsnag-Api-Key";
+NSString *const BSGHeaderApiPayloadVersion = @"Bugsnag-Payload-Version";
+NSString *const BSGHeaderApiSentAt = @"Bugsnag-Sent-At";


### PR DESCRIPTION
## Goal

Use the value of `event.apiKey` when sending error reports, so that the correct key is used when making requests to the Bugsnag API.

This relies on changes in #669 which ensure events are not batched into a single request.

## Changeset

- Updated `BugsnagErrorReportSink` to use the `apiKey` set on the `BugsnagEvent`, after the point where `OnSendError` callbacks are executed
- Altered the constructor for `initWithUserData` as it was erroneously creating two objects when invoked. This seems to have been introduced in a merge - the redundant code has been removed and this is now more inline with the other two constructors.

## Tests
Manually verified that a handled and unhandled error use the correct API key.


