### PR TITLE
Checks for case-insensitive exact match redaction

### DIFF
--- a/features/fixtures/ios-swift-cocoapods/iOSTestApp/scenarios/MetadataRedactionDefaultScenario.swift
+++ b/features/fixtures/ios-swift-cocoapods/iOSTestApp/scenarios/MetadataRedactionDefaultScenario.swift
@@ -21,6 +21,8 @@ class MetadataRedactionDefaultScenario: Scenario {
 
     override func run() {
         Bugsnag.addMetadata("hunter2", key: "password", section: "custom")
+        Bugsnag.addMetadata("hunter3", key: "Password", section: "custom")
+        Bugsnag.addMetadata("not redacted", key: "password2", section: "custom")
         Bugsnag.addMetadata("brown fox", key: "normalKey", section: "custom")
 
         let error = NSError(domain: "HandledErrorScenario", code: 100, userInfo: nil)

--- a/features/metadata_redaction.feature
+++ b/features/metadata_redaction.feature
@@ -9,6 +9,8 @@ Feature: Metadata values can be redacted
     And I wait to receive a request
     Then the request is valid for the error reporting API version "4.0" for the "iOS Bugsnag Notifier" notifier
     And the event "metaData.custom.password" equals "[REDACTED]"
+    And the event "metaData.custom.Password" equals "[REDACTED]"
+    And the event "metaData.custom.password2" equals "not redacted"
     And the event "metaData.custom.normalKey" equals "brown fox"
     And the event "metaData.extras.callbackValue" equals "hunter2"
 


### PR DESCRIPTION
## Goal

Added extra checks to the e2e tests to verify that metadata keys are matched exactly but case-insensitively when considered for redaction.

## Design

There were already unit tests in place for this, but adding a couple of checks to the MazeRunner  scenario makes is really clear to the outside world and was super easy.