### PR TITLE
fix(BugsnagConfiguration): remove unused shouldAutoCaptureSessions property

### DIFF
--- a/Bugsnag/Configuration/BugsnagConfiguration.m
+++ b/Bugsnag/Configuration/BugsnagConfiguration.m
@@ -555,16 +555,6 @@ NSString * const kBugsnagUserUserId = @"BugsnagUserUserId";
     }
 }
 
-// MARK: -
-
-- (void)setShouldAutoCaptureSessions:(BOOL)shouldAutoCaptureSessions {
-    self.autoTrackSessions = shouldAutoCaptureSessions;
-}
-
-- (BOOL)shouldAutoCaptureSessions {
-    return self.autoTrackSessions;
-}
-
 // MARK: - enabledBreadcrumbTypes
 
 - (BSGEnabledBreadcrumbType)enabledBreadcrumbTypes {


### PR DESCRIPTION
## Goal

We have renamed the property to autoTrackSessions but not removed the configuration option.