### PR TITLE
Add public API validation for Bugsnag

### DIFF
--- a/Tests/BugsnagApiValidationTest.m
+++ b/Tests/BugsnagApiValidationTest.m
@@ -7,6 +7,8 @@
 //
 
 #import <XCTest/XCTest.h>
+#import <Bugsnag/Bugsnag.h>
+#import "BugsnagTestConstants.h"
 
 /**
  * Validates that the Bugsnag API interface handles any invalid input gracefully.
@@ -17,24 +19,131 @@
 
 @implementation BugsnagApiValidationTest
 
-- (void)setUp {
-    // Put setup code here. This method is called before the invocation of each test method in the class.
++ (void)setUp {
+    [Bugsnag startWithApiKey:DUMMY_APIKEY_32CHAR_1];
 }
 
-- (void)tearDown {
-    // Put teardown code here. This method is called after the invocation of each test method in the class.
+- (void)testAppDidCrashLastLaunch {
+    XCTAssertFalse([Bugsnag appDidCrashLastLaunch]);
 }
 
-- (void)testExample {
-    // This is an example of a functional test case.
-    // Use XCTAssert and related functions to verify your tests produce the correct results.
+- (void)testValidNotify {
+    [Bugsnag notify:[NSException exceptionWithName:@"FooException" reason:@"whoops" userInfo:nil]];
 }
 
-- (void)testPerformanceExample {
-    // This is an example of a performance test case.
-    [self measureBlock:^{
-        // Put the code you want to measure the time of here.
+- (void)testValidNotifyBlock {
+    NSException *exc = [NSException exceptionWithName:@"FooException" reason:@"whoops" userInfo:nil];
+    [Bugsnag notify:exc block:nil];
+    [Bugsnag notify:exc block:^BOOL(BugsnagEvent *event) {
+        return NO;
     }];
+}
+
+- (void)testValidNotifyError {
+    NSError *error = [NSError errorWithDomain:@"BarError" code:500 userInfo:nil];
+    [Bugsnag notifyError:error];
+}
+
+- (void)testValidNotifyErrorBlock {
+    NSError *error = [NSError errorWithDomain:@"BarError" code:500 userInfo:nil];
+    [Bugsnag notifyError:error block:nil];
+    [Bugsnag notifyError:error block:^BOOL(BugsnagEvent *event) {
+        return NO;
+    }];
+}
+
+- (void)testValidLeaveBreadcrumbWithMessage {
+    [Bugsnag leaveBreadcrumbWithMessage:@"Foo"];
+}
+
+- (void)testValidLeaveBreadcrumbForNotificationName {
+    [Bugsnag leaveBreadcrumbForNotificationName:@"some invalid value"];
+}
+
+- (void)testValidLeaveBreadcrumbWithMessageMetadata {
+    [Bugsnag leaveBreadcrumbWithMessage:@"Foo" metadata:nil andType:BSGBreadcrumbTypeProcess];
+    [Bugsnag leaveBreadcrumbWithMessage:@"Foo" metadata:@{@"test": @2} andType:BSGBreadcrumbTypeState];
+}
+
+- (void)testValidStartSession {
+    [Bugsnag startSession];
+}
+
+- (void)testValidPauseSession {
+    [Bugsnag pauseSession];
+}
+
+- (void)testValidResumeSession {
+    [Bugsnag resumeSession];
+}
+
+- (void)testValidContext {
+    Bugsnag.context = nil;
+    XCTAssertNil(Bugsnag.context);
+    Bugsnag.context = @"Foo";
+    XCTAssertEqualObjects(@"Foo", Bugsnag.context);
+}
+
+- (void)testValidAppDidCrashLastLaunch {
+    XCTAssertFalse(Bugsnag.appDidCrashLastLaunch);
+}
+
+- (void)testValidUser {
+    [Bugsnag setUser:nil withEmail:nil andName:nil];
+    XCTAssertNotNil(Bugsnag.user);
+    XCTAssertNil(Bugsnag.user.id);
+    XCTAssertNil(Bugsnag.user.email);
+    XCTAssertNil(Bugsnag.user.name);
+
+    [Bugsnag setUser:@"123" withEmail:@"joe@foo.com" andName:@"Joe"];
+    XCTAssertNotNil(Bugsnag.user);
+    XCTAssertEqualObjects(@"123", Bugsnag.user.id);
+    XCTAssertEqualObjects(@"joe@foo.com", Bugsnag.user.email);
+    XCTAssertEqualObjects(@"Joe", Bugsnag.user.name);
+}
+
+- (void)testValidOnSessionBlock {
+    BOOL (^block)(BugsnagSession *) = ^BOOL(BugsnagSession *session) {
+        return NO;
+    };
+    [Bugsnag addOnSessionBlock:block];
+    [Bugsnag removeOnSessionBlock:block];
+}
+
+- (void)testValidOnSendErrorBlock {
+    BOOL (^block)(BugsnagEvent *) = ^BOOL(BugsnagEvent *event) {
+        return NO;
+    };
+    [Bugsnag addOnSendErrorBlock:block];
+    [Bugsnag removeOnSendErrorBlock:block];
+}
+
+- (void)testValidOnBreadcrumbBlock {
+    BOOL (^block)(BugsnagBreadcrumb *) = ^BOOL(BugsnagBreadcrumb *breadcrumb) {
+        return NO;
+    };
+    [Bugsnag addOnBreadcrumbBlock:block];
+    [Bugsnag removeOnBreadcrumbBlock:block];
+}
+
+- (void)testValidAddMetadata {
+    [Bugsnag addMetadata:@{} toSection:@"foo"];
+    XCTAssertNil([Bugsnag getMetadataFromSection:@"foo"]);
+
+    [Bugsnag addMetadata:nil withKey:@"nom" toSection:@"foo"];
+    [Bugsnag addMetadata:@"" withKey:@"bar" toSection:@"foo"];
+    XCTAssertNil([Bugsnag getMetadataFromSection:@"foo" withKey:@"nom"]);
+    XCTAssertEqualObjects(@"", [Bugsnag getMetadataFromSection:@"foo" withKey:@"bar"]);
+}
+
+- (void)testValidClearMetadata {
+    [Bugsnag clearMetadataFromSection:@""];
+    [Bugsnag clearMetadataFromSection:@"" withKey:@""];
+}
+
+- (void)testValidGetMetadata {
+    [Bugsnag getMetadataFromSection:@""];
+    [Bugsnag getMetadataFromSection:@"" withKey:@""];
 }
 
 @end


### PR DESCRIPTION
## Goal

Adds unit tests to verify that the public API for `Bugsnag` handles incorrect input in an expected way.

## Changeset

Added a unit test to verify that each notable field accessible from `Bugsnag` can handle valid/invalid input correctly. This depends on the changeset in #693.
