### PR TITLE
Verify that large breadcrumbs are no longer dropped

### DIFF
--- a/Tests/BugsnagClientTests.m
+++ b/Tests/BugsnagClientTests.m
@@ -241,10 +241,12 @@ NSString *BSGFormatSeverity(BSGSeverity severity);
 
     // large breadcrumb is also left without issue
     __block NSUInteger crumbSize = 0;
+    __block BugsnagBreadcrumb *crumb;
 
     [client addOnBreadcrumbBlock:^BOOL(BugsnagBreadcrumb *breadcrumb) {
         NSData *data = [NSJSONSerialization dataWithJSONObject:[breadcrumb objectValue] options:0 error:nil];
         crumbSize = data.length;
+        crumb = breadcrumb;
         return true;
     }];
 
@@ -254,6 +256,9 @@ NSString *BSGFormatSeverity(BSGSeverity severity);
                                andType:BSGBreadcrumbTypeManual];
     XCTAssertTrue(crumbSize > 4096); // previous 4kb limit
     XCTAssertEqual(2, [breadcrumbs count]);
+    XCTAssertNotNil(crumb);
+    XCTAssertEqualObjects(@"Hello World", crumb.message);
+    XCTAssertEqualObjects(largeMetadata, crumb.metadata);
 }
 
 - (NSDictionary *)generateLargeMetadata {

--- a/Tests/BugsnagClientTests.m
+++ b/Tests/BugsnagClientTests.m
@@ -32,6 +32,10 @@
 - (NSDictionary *)objectValue;
 @end
 
+@interface BugsnagBreadcrumbs ()
+@property(nonatomic, readwrite, strong) NSMutableArray *breadcrumbs;
+@end
+
 @interface BugsnagConfiguration ()
 @property(readonly, strong, nullable) BugsnagBreadcrumbs *breadcrumbs;
 @property(readwrite, retain, nullable) BugsnagMetadata *metadata;
@@ -216,6 +220,51 @@ NSString *BSGFormatSeverity(BSGSeverity severity);
     BugsnagConfiguration *configAfter = client.configuration;
 
     [self assertEqualConfiguration:initialConfig withActual:configAfter];
+}
+
+
+/**
+ * Verifies that a large breadcrumb is not dropped (historically there was a 4kB limit)
+ */
+- (void)testLargeBreadcrumbSize {
+    BugsnagConfiguration *configuration = [[BugsnagConfiguration alloc] initWithApiKey:DUMMY_APIKEY_32CHAR_1];
+    configuration.enabledBreadcrumbTypes = BSGEnabledBreadcrumbTypeNone;
+    BugsnagClient *client = [[BugsnagClient alloc] initWithConfiguration:configuration];
+    [client start];
+
+    NSMutableArray *breadcrumbs = client.configuration.breadcrumbs.breadcrumbs;
+    XCTAssertEqual(0, [breadcrumbs count]);
+
+    // small breadcrumb can be left without issue
+    [client leaveBreadcrumbWithMessage:@"Hello World"];
+    XCTAssertEqual(1, [breadcrumbs count]);
+
+    // large breadcrumb is also left without issue
+    __block NSUInteger crumbSize = 0;
+
+    [client addOnBreadcrumbBlock:^BOOL(BugsnagBreadcrumb *breadcrumb) {
+        NSData *data = [NSJSONSerialization dataWithJSONObject:[breadcrumb objectValue] options:0 error:nil];
+        crumbSize = data.length;
+        return true;
+    }];
+
+    NSDictionary *largeMetadata = [self generateLargeMetadata];
+    [client leaveBreadcrumbWithMessage:@"Hello World"
+                              metadata:largeMetadata
+                               andType:BSGBreadcrumbTypeManual];
+    XCTAssertTrue(crumbSize > 4096); // previous 4kb limit
+    XCTAssertEqual(2, [breadcrumbs count]);
+}
+
+- (NSDictionary *)generateLargeMetadata {
+    NSMutableDictionary *dict = [NSMutableDictionary new];
+
+    for (int k = 0; k < 10000; ++k) {
+        NSString *key = [NSString stringWithFormat:@"%d", k];
+        NSString *value = [NSString stringWithFormat:@"Some metadata value here %d", k];
+        dict[key] = value;
+    }
+    return dict;
 }
 
 @end


### PR DESCRIPTION
## Goal

Verifies that breadcrumbs with a serialized size > 4kb are not dropped when added to the Client. This behaviour changed in #433.