### PR TITLE
Add E2E scenarios to verify thread information

### DIFF
--- a/features/fixtures/ios-swift-cocoapods/iOSTestApp.xcodeproj/project.pbxproj
+++ b/features/fixtures/ios-swift-cocoapods/iOSTestApp.xcodeproj/project.pbxproj
@@ -77,6 +77,7 @@
 		E75040B424782597005D33BD /* ReleaseStageSessionScenario.swift in Sources */ = {isa = PBXBuildFile; fileRef = E75040B324782597005D33BD /* ReleaseStageSessionScenario.swift */; };
 		E753F24624927409001FB671 /* NotifyCallbackCrashScenario.swift in Sources */ = {isa = PBXBuildFile; fileRef = E753F24524927409001FB671 /* NotifyCallbackCrashScenario.swift */; };
 		E753F24824927412001FB671 /* OnSendErrorCallbackCrashScenario.swift in Sources */ = {isa = PBXBuildFile; fileRef = E753F24724927412001FB671 /* OnSendErrorCallbackCrashScenario.swift */; };
+		E753F25424937A83001FB671 /* ThreadScenarios.m in Sources */ = {isa = PBXBuildFile; fileRef = E753F25324937A83001FB671 /* ThreadScenarios.m */; };
 		E7767F11221C21D90006648C /* StoppedSessionScenario.swift in Sources */ = {isa = PBXBuildFile; fileRef = E7767F10221C21D90006648C /* StoppedSessionScenario.swift */; };
 		E7767F13221C21E30006648C /* ResumedSessionScenario.swift in Sources */ = {isa = PBXBuildFile; fileRef = E7767F12221C21E30006648C /* ResumedSessionScenario.swift */; };
 		E7767F15221C223C0006648C /* NewSessionScenario.swift in Sources */ = {isa = PBXBuildFile; fileRef = E7767F14221C223C0006648C /* NewSessionScenario.swift */; };
@@ -244,6 +245,8 @@
 		E75040B324782597005D33BD /* ReleaseStageSessionScenario.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ReleaseStageSessionScenario.swift; sourceTree = "<group>"; };
 		E753F24524927409001FB671 /* NotifyCallbackCrashScenario.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = NotifyCallbackCrashScenario.swift; sourceTree = "<group>"; };
 		E753F24724927412001FB671 /* OnSendErrorCallbackCrashScenario.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = OnSendErrorCallbackCrashScenario.swift; sourceTree = "<group>"; };
+		E753F25224937A83001FB671 /* ThreadScenarios.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; path = ThreadScenarios.h; sourceTree = "<group>"; };
+		E753F25324937A83001FB671 /* ThreadScenarios.m */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.objc; path = ThreadScenarios.m; sourceTree = "<group>"; };
 		E7767F10221C21D90006648C /* StoppedSessionScenario.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = StoppedSessionScenario.swift; sourceTree = "<group>"; };
 		E7767F12221C21E30006648C /* ResumedSessionScenario.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ResumedSessionScenario.swift; sourceTree = "<group>"; };
 		E7767F14221C223C0006648C /* NewSessionScenario.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = NewSessionScenario.swift; sourceTree = "<group>"; };
@@ -470,6 +473,15 @@
 			name = "Metadata Redaction";
 			sourceTree = "<group>";
 		};
+		E753F24924928F18001FB671 /* Threads */ = {
+			isa = PBXGroup;
+			children = (
+				E753F25224937A83001FB671 /* ThreadScenarios.h */,
+				E753F25324937A83001FB671 /* ThreadScenarios.m */,
+			);
+			name = Threads;
+			sourceTree = "<group>";
+		};
 		E7A324D4247E707D008B0052 /* Session Callbacks */ = {
 			isa = PBXGroup;
 			children = (
@@ -518,6 +530,7 @@
 		F42953DE2BB41023C0B07F41 /* scenarios */ = {
 			isa = PBXGroup;
 			children = (
+				E753F24924928F18001FB671 /* Threads */,
 				E7A324E4247E9C96008B0052 /* Breadcrumb Callbacks */,
 				E75040AC2478213D005D33BD /* Metadata Redaction */,
 				E750409C24780158005D33BD /* AutoDetectErrors */,
@@ -893,6 +906,7 @@
 				F429538D8941382EC2C857CE /* AsyncSafeThreadScenario.m in Sources */,
 				F42955869D33EE0E510B9651 /* ReadGarbagePointerScenario.m in Sources */,
 				8AEFC73420F8D1BB00A78779 /* ManualSessionWithUserScenario.m in Sources */,
+				E753F25424937A83001FB671 /* ThreadScenarios.m in Sources */,
 				F4295B56219D228FAA99BC14 /* ObjCExceptionScenario.m in Sources */,
 				F4295218A62E41518DC3C057 /* AccessNonObjectScenario.m in Sources */,
 				E7A324E0247E70F9008B0052 /* SessionCallbackDiscardScenario.swift in Sources */,

--- a/features/fixtures/ios-swift-cocoapods/iOSTestApp/scenarios/ThreadScenarios.h
+++ b/features/fixtures/ios-swift-cocoapods/iOSTestApp/scenarios/ThreadScenarios.h
@@ -1,0 +1,22 @@
+//
+//  ThreadScenarios.h
+//  iOSTestApp
+//
+//  Created by Jamie Lynch on 12/06/2020.
+//  Copyright © 2020 Bugsnag. All rights reserved.
+//
+
+#import <Foundation/Foundation.h>
+#import "Scenario.h"
+
+@interface HandledErrorThreadSendAlwaysScenario : Scenario
+@end
+
+@interface UnhandledErrorThreadSendAlwaysScenario : Scenario
+@end
+
+@interface HandledErrorThreadSendUnhandledOnlyScenario : Scenario
+@end
+
+@interface UnhandledErrorThreadSendNeverScenario : Scenario
+@end

--- a/features/fixtures/ios-swift-cocoapods/iOSTestApp/scenarios/ThreadScenarios.m
+++ b/features/fixtures/ios-swift-cocoapods/iOSTestApp/scenarios/ThreadScenarios.m
@@ -1,0 +1,66 @@
+//
+//  ThreadScenarios.m
+//  iOSTestApp
+//
+//  Created by Jamie Lynch on 12/06/2020.
+//  Copyright © 2020 Bugsnag. All rights reserved.
+//
+
+#import "ThreadScenarios.h"
+
+@implementation HandledErrorThreadSendAlwaysScenario
+
+- (void)startBugsnag {
+    self.config.autoTrackSessions = false;
+    [super startBugsnag];
+}
+
+- (void)run {
+    NSException *exc = [NSException exceptionWithName:@"HandledErrorThreadSendAlwaysScenario" reason:@"HandledErrorThreadSendAlwaysScenario" userInfo:nil];
+    [Bugsnag notify:exc];
+}
+
+@end
+
+@implementation UnhandledErrorThreadSendAlwaysScenario
+
+- (void)startBugsnag {
+    self.config.autoTrackSessions = false;
+    [super startBugsnag];
+}
+
+- (void)run {
+    NSException *exc = [NSException exceptionWithName:@"UnhandledErrorThreadSendAlwaysScenario" reason:@"UnhandledErrorThreadSendAlwaysScenario" userInfo:nil];
+    [exc raise];
+}
+
+@end
+
+@implementation HandledErrorThreadSendUnhandledOnlyScenario
+
+- (void)startBugsnag {
+    self.config.autoTrackSessions = false;
+    self.config.sendThreads = BSGThreadSendPolicyUnhandledOnly;
+    [super startBugsnag];
+}
+
+- (void)run {
+    NSException *exc = [NSException exceptionWithName:@"HandledErrorThreadSendUnhandledOnlyScenario" reason:@"HandledErrorThreadSendUnhandledOnlyScenario" userInfo:nil];
+    [Bugsnag notify:exc];
+}
+@end
+
+@implementation UnhandledErrorThreadSendNeverScenario
+
+- (void)startBugsnag {
+    self.config.autoTrackSessions = false;
+    self.config.sendThreads = BSGThreadSendPolicyNever;
+    [super startBugsnag];
+}
+
+- (void)run {
+    NSException *exc = [NSException exceptionWithName:@"UnhandledErrorThreadSendNeverScenario" reason:@"UnhandledErrorThreadSendNeverScenario" userInfo:nil];
+    [exc raise];
+}
+
+@end

--- a/features/threads.feature
+++ b/features/threads.feature
@@ -1,0 +1,52 @@
+Feature: Handled Errors and Exceptions
+
+  Background:
+    Given I clear all UserDefaults data
+
+  Scenario: Threads are captured for handled errors by default
+    When I run "HandledErrorThreadSendAlwaysScenario"
+    And I wait to receive a request
+    Then the request is valid for the error reporting API version "4.0" for the "iOS Bugsnag Notifier" notifier
+    And the event "unhandled" is false
+    And the payload field "events" is an array with 1 elements
+    And the exception "message" equals "HandledErrorThreadSendAlwaysScenario"
+    And the thread information is valid for the event
+
+  Scenario: Threads are captured for unhandled errors by default
+    When I run "UnhandledErrorThreadSendAlwaysScenario" and relaunch the app
+    And I configure Bugsnag for "UnhandledErrorThreadSendAlwaysScenario"
+    And I wait to receive a request
+    Then the request is valid for the error reporting API version "4.0" for the "iOS Bugsnag Notifier" notifier
+    And the event "unhandled" is true
+    And the payload field "events" is an array with 1 elements
+    And the exception "message" equals "UnhandledErrorThreadSendAlwaysScenario"
+    And the thread information is valid for the event
+
+  Scenario: Threads are not captured for handled errors when sendThreads is set to unhandled_only
+    When I run "HandledErrorThreadSendUnhandledOnlyScenario"
+    And I wait to receive a request
+    Then the request is valid for the error reporting API version "4.0" for the "iOS Bugsnag Notifier" notifier
+    And the event "unhandled" is false
+    And the payload field "events" is an array with 1 elements
+    And the exception "errorClass" equals "HandledErrorThreadSendUnhandledOnlyScenario"
+    And the payload field "events.0.threads" is an array with 1 elements
+    And the payload field "events.0.threads.0.errorReportingThread" is true
+    And the payload field "events.0.threads.0.id" is not null
+    And the payload field "events.0.threads.0.name" is null
+    And the payload field "events.0.threads.0.type" equals "cocoa"
+    And the thread information is valid for the event
+
+  Scenario: Threads are not captured for unhandled errors when sendThreads is set to never
+    When I run "UnhandledErrorThreadSendNeverScenario" and relaunch the app
+    And I configure Bugsnag for "UnhandledErrorThreadSendNeverScenario"
+    And I wait to receive a request
+    Then the request is valid for the error reporting API version "4.0" for the "iOS Bugsnag Notifier" notifier
+    And the event "unhandled" is true
+    And the payload field "events" is an array with 1 elements
+    And the exception "message" equals "UnhandledErrorThreadSendNeverScenario"
+    And the payload field "events.0.threads" is an array with 1 elements
+    And the payload field "events.0.threads.0.errorReportingThread" is true
+    And the payload field "events.0.threads.0.id" is not null
+    And the payload field "events.0.threads.0.name" is null
+    And the payload field "events.0.threads.0.type" equals "cocoa"
+    And the thread information is valid for the event


### PR DESCRIPTION
## Goal

Adds E2E scenarios to verify that thread information is recorded correctly.

## Changeset

- Added scenario to verify threads are captured for unhandled/handled error
- Added scenario to verify that `sendThreads` controls whether threads are captured
- Added steps to mazerunner to verify that the `errorReportingThread` flag is set once, and that the thread information contains the expected fields