### PR TITLE
Ensure connectivity check listens for gain of connection

### DIFF
--- a/Bugsnag/Delivery/BSGConnectivity.m
+++ b/Bugsnag/Delivery/BSGConnectivity.m
@@ -51,7 +51,9 @@ BOOL BSGConnectivityShouldReportChange(SCNetworkReachabilityFlags flags) {
     #endif
     __block BOOL shouldReport = YES;
     // Check if the reported state is different from the last known state (if any)
-    if ((flags & importantFlags) != (bsg_current_reachability_state & importantFlags)) {
+    SCNetworkReachabilityFlags newFlags = flags & importantFlags;
+    SCNetworkReachabilityFlags oldFlags = bsg_current_reachability_state & importantFlags;
+    if (newFlags != oldFlags) {
         // When first subscribing to be notified of changes, the callback is
         // invoked immmediately even if nothing has changed. So this block
         // ignores the very first check, reporting all others.
@@ -136,6 +138,7 @@ void BSGConnectivityCallback(SCNetworkReachabilityRef target,
         SCNetworkReachabilitySetCallback(bsg_reachability_ref, NULL, NULL);
         SCNetworkReachabilitySetDispatchQueue(bsg_reachability_ref, NULL);
     }
+    bsg_current_reachability_state = -1;
 }
 
 @end

--- a/Bugsnag/Delivery/BSGConnectivity.m
+++ b/Bugsnag/Delivery/BSGConnectivity.m
@@ -31,7 +31,7 @@
 
 static SCNetworkReachabilityRef bsg_reachability_ref;
 BSGConnectivityChangeBlock bsg_reachability_change_block;
-SCNetworkReachabilityFlags bsg_current_reachability_state;
+SCNetworkReachabilityFlags bsg_current_reachability_state = -1;
 
 NSString *const BSGConnectivityCellular = @"cellular";
 NSString *const BSGConnectivityWiFi = @"wifi";

--- a/Bugsnag/Delivery/BSGConnectivity.m
+++ b/Bugsnag/Delivery/BSGConnectivity.m
@@ -55,7 +55,7 @@ BOOL BSGConnectivityShouldReportChange(SCNetworkReachabilityFlags flags) {
         // When first subscribing to be notified of changes, the callback is
         // invoked immmediately even if nothing has changed. So this block
         // ignores the very first check, reporting all others.
-        if (bsg_current_reachability_state == 0) {
+        if (bsg_current_reachability_state == -1) {
             shouldReport = NO;
         }
         // Cache the reachability state to report the previous value representation

--- a/Tests/BSGConnectivityTest.m
+++ b/Tests/BSGConnectivityTest.m
@@ -75,27 +75,27 @@ void BSGConnectivityCallback(SCNetworkReachabilityRef target,
     // Ignore very first call to change block as "in real life" the first
     // invocation is a false positive
     [self simulateConnectivityChangeTo:kSCNetworkReachabilityFlagsReachable];
-    XCTAssertEqual(1, timesCalled);
+    XCTAssertEqual(0, timesCalled);
 
     [self simulateConnectivityChangeTo:kSCNetworkReachabilityFlagsReachable | kSCNetworkReachabilityFlagsIsWWAN];
-    XCTAssertEqual(2, timesCalled);
+    XCTAssertEqual(1, timesCalled);
     XCTAssertEqualObjects(@"cellular", description);
 
     [self simulateConnectivityChangeTo:kSCNetworkReachabilityFlagsReachable];
-    XCTAssertEqual(3, timesCalled);
+    XCTAssertEqual(2, timesCalled);
     XCTAssertEqualObjects(@"wifi", description);
 
     // No change
     [self simulateConnectivityChangeTo:kSCNetworkReachabilityFlagsReachable | kSCNetworkReachabilityFlagsConnectionOnDemand];
-    XCTAssertEqual(3, timesCalled);
+    XCTAssertEqual(2, timesCalled);
 
     [self simulateConnectivityChangeTo:kSCNetworkReachabilityFlagsIsWWAN];
-    XCTAssertEqual(4, timesCalled);
+    XCTAssertEqual(3, timesCalled);
     XCTAssertEqualObjects(@"none", description);
 
     // Insignificant change
     [self simulateConnectivityChangeTo:kSCNetworkReachabilityFlagsIsWWAN | kSCNetworkReachabilityFlagsConnectionOnDemand];
-    XCTAssertEqual(4, timesCalled);
+    XCTAssertEqual(3, timesCalled);
 }
 #else
 - (void)testCallbackInvokedForSignificantChange {

--- a/Tests/BSGConnectivityTest.m
+++ b/Tests/BSGConnectivityTest.m
@@ -75,27 +75,27 @@ void BSGConnectivityCallback(SCNetworkReachabilityRef target,
     // Ignore very first call to change block as "in real life" the first
     // invocation is a false positive
     [self simulateConnectivityChangeTo:kSCNetworkReachabilityFlagsReachable];
-    XCTAssertEqual(0, timesCalled);
+    XCTAssertEqual(1, timesCalled);
 
     [self simulateConnectivityChangeTo:kSCNetworkReachabilityFlagsReachable | kSCNetworkReachabilityFlagsIsWWAN];
-    XCTAssertEqual(1, timesCalled);
+    XCTAssertEqual(2, timesCalled);
     XCTAssertEqualObjects(@"cellular", description);
 
     [self simulateConnectivityChangeTo:kSCNetworkReachabilityFlagsReachable];
-    XCTAssertEqual(2, timesCalled);
+    XCTAssertEqual(3, timesCalled);
     XCTAssertEqualObjects(@"wifi", description);
 
     // No change
     [self simulateConnectivityChangeTo:kSCNetworkReachabilityFlagsReachable | kSCNetworkReachabilityFlagsConnectionOnDemand];
-    XCTAssertEqual(2, timesCalled);
+    XCTAssertEqual(3, timesCalled);
 
     [self simulateConnectivityChangeTo:kSCNetworkReachabilityFlagsIsWWAN];
-    XCTAssertEqual(3, timesCalled);
+    XCTAssertEqual(4, timesCalled);
     XCTAssertEqualObjects(@"none", description);
 
     // Insignificant change
     [self simulateConnectivityChangeTo:kSCNetworkReachabilityFlagsIsWWAN | kSCNetworkReachabilityFlagsConnectionOnDemand];
-    XCTAssertEqual(3, timesCalled);
+    XCTAssertEqual(4, timesCalled);
 }
 #else
 - (void)testCallbackInvokedForSignificantChange {


### PR DESCRIPTION
## Goal

Sets the default value for `bsg_current_reachability_state` to -1. This prevents the connectivity listener from not firing when a connection is regained, as 0 is a valid value for the bitmask cached later in the method.
