### PR TITLE
fix: reinstate termination handler in C++ handler

### DIFF
--- a/Bugsnag/KSCrash/Source/KSCrash/Recording/Sentry/BSG_KSCrashSentry_CPPException.mm
+++ b/Bugsnag/KSCrash/Source/KSCrash/Recording/Sentry/BSG_KSCrashSentry_CPPException.mm
@@ -186,10 +186,9 @@ static void CPPExceptionTerminate(void) {
             @"Crash handling complete. Restoring original handlers.");
         bsg_kscrashsentry_uninstall((BSG_KSCrashType)BSG_KSCrashTypeAll);
         bsg_kscrashsentry_resumeThreads();
-
-        if (bsg_g_originalTerminateHandler != NULL) {
-            bsg_g_originalTerminateHandler();
-        }
+    }
+    if (bsg_g_originalTerminateHandler != NULL) {
+        bsg_g_originalTerminateHandler();
     }
 }
 


### PR DESCRIPTION
## Goal

Calls the original termination handler, reverting changes made in #666 to the C++ handler. Calling the original handler allows the NSException stacktrace to be logged out correctly and avoids the signal handler from being erroneously called and attempting to open a file descriptor.
