### PR TITLE
Fix flaky auto session test scenario

### DIFF
--- a/features/fixtures/ios-swift-cocoapods/iOSTestApp/scenarios/AutoSessionUnhandledScenario.m
+++ b/features/fixtures/ios-swift-cocoapods/iOSTestApp/scenarios/AutoSessionUnhandledScenario.m
@@ -11,19 +11,22 @@
 @implementation AutoSessionUnhandledScenario
 
 - (void)startBugsnag {
-    if ([self.eventMode isEqualToString:@"noevent"])
+    if ([self.eventMode isEqualToString:@"noevent"]) {
         self.config.autoTrackSessions = NO;
-    else
+    } else {
         self.config.autoTrackSessions = YES;
+    }
     [super startBugsnag];
 }
 
 - (void)run {
-    dispatch_after(dispatch_time(DISPATCH_TIME_NOW, 2 * NSEC_PER_SEC), dispatch_get_main_queue(), ^{
-        NSException *ex = [NSException exceptionWithName:@"Kaboom" reason:@"The connection exploded" userInfo:nil];
+    if (![self.eventMode isEqualToString:@"noevent"]) {
+        dispatch_after(dispatch_time(DISPATCH_TIME_NOW, 4 * NSEC_PER_SEC), dispatch_get_main_queue(), ^{
+            NSException *ex = [NSException exceptionWithName:@"Kaboom" reason:@"The connection exploded" userInfo:nil];
 
-        @throw ex;
-    });
+            @throw ex;
+        });    
+    }
 }
 
 @end

--- a/features/session_tracking.feature
+++ b/features/session_tracking.feature
@@ -103,7 +103,7 @@ Feature: Session Tracking
 
   Scenario: Encountering an unhandled event during a session
     When I run "AutoSessionUnhandledScenario"
-    And I wait for 2 seconds
+    And I wait for 4 seconds
     And I relaunch the app
     And I set the app to "noevent" mode
     And I configure Bugsnag for "AutoSessionUnhandledScenario"


### PR DESCRIPTION
## Goal

The `AutoSessionUnhandledScenario` occasionally fails on CI. This failure appears to be a race condition where the session or error is not delivered before the test fixture throws an uncaught exception.

## Changeset

- Updated `AutoSessionUnhandledScenario` to only throw an exception on the first launch of the scenario
- Increase the time window to deliver the first session from 2 to 4 seconds, before throwing an exception

This has been tested by running the scenario 15 times without a failure.