### PR TITLE
Serialize correct stackframe fields for symbolication

### DIFF
--- a/Bugsnag/Payload/BugsnagStackframe.m
+++ b/Bugsnag/Payload/BugsnagStackframe.m
@@ -59,6 +59,7 @@
     if (image != nil) {
         frame.machoUuid = image[BSGKeyUuid];
         frame.machoVmAddress = image[BSGKeyImageVmAddress];
+        frame.machoFile = image[BSGKeyName];
         return frame;
     } else { // invalid frame, skip
         return nil;
@@ -86,6 +87,12 @@
     if (self.machoVmAddress != nil) {
         NSString *vmAddr = [NSString stringWithFormat:BSGKeyFrameAddrFormat, [self.machoVmAddress unsignedLongValue]];
         BSGDictSetSafeObject(dict, vmAddr, BSGKeyMachoVMAddress);
+    }
+    if (self.isPc) {
+        BSGDictSetSafeObject(dict, @(self.isPc), BSGKeyIsPC);
+    }
+    if (self.isLr) {
+        BSGDictSetSafeObject(dict, @(self.isLr), BSGKeyIsLR);
     }
     return dict;
 }

--- a/Tests/BugsnagErrorTest.m
+++ b/Tests/BugsnagErrorTest.m
@@ -91,7 +91,7 @@ NSString *BSGParseErrorMessage(NSDictionary *report, NSDictionary *error, NSStri
     XCTAssertEqual(1, [error.stacktrace count]);
     BugsnagStackframe *frame = error.stacktrace[0];
     XCTAssertEqualObjects(@"kscrashsentry_reportUserException", frame.method);
-    XCTAssertEqualObjects(@"CrashProbeiOS", frame.machoFile);
+    XCTAssertEqualObjects(@"/Users/joesmith/foo", frame.machoFile);
     XCTAssertEqualObjects(@"D0A41830-4FD2-3B02-A23B-0741AD4C7F52", frame.machoUuid);
 }
 
@@ -107,7 +107,7 @@ NSString *BSGParseErrorMessage(NSDictionary *report, NSDictionary *error, NSStri
     NSDictionary *frame = dict[@"stacktrace"][0];
     XCTAssertEqualObjects(@"kscrashsentry_reportUserException", frame[@"method"]);
     XCTAssertEqualObjects(@"D0A41830-4FD2-3B02-A23B-0741AD4C7F52", frame[@"machoUUID"]);
-    XCTAssertEqualObjects(@"CrashProbeiOS", frame[@"machoFile"]);
+    XCTAssertEqualObjects(@"/Users/joesmith/foo", frame[@"machoFile"]);
 }
 
 - (BugsnagThread *)findErrorReportingThread:(NSDictionary *)event {

--- a/Tests/BugsnagStackframeTest.m
+++ b/Tests/BugsnagStackframeTest.m
@@ -26,7 +26,7 @@
             @"symbol_addr": @0x10b574fa0,
             @"instruction_addr": @0x10b5756bf,
             @"object_addr": @0x10b54b000,
-            @"object_name": @"/Users/foo/Bugsnag.h",
+            @"object_name": @"/Library/bar/Bugsnag.h",
             @"symbol_name": @"-[BugsnagClient notify:handledState:block:]",
     };
     self.binaryImages = @[@{
@@ -60,6 +60,17 @@
     XCTAssertEqualObjects(@"0x10b574fa0", dict[@"symbolAddress"]);
     XCTAssertEqualObjects(@"0x10b54b000", dict[@"machoLoadAddress"]);
     XCTAssertEqualObjects(@"0x10b5756bf", dict[@"frameAddress"]);
+    XCTAssertNil(dict[@"isPC"]);
+    XCTAssertNil(dict[@"isLR"]);
+}
+
+- (void)testStackframeToDictPcLr {
+    BugsnagStackframe *frame = [BugsnagStackframe frameFromDict:self.frameDict withImages:self.binaryImages];
+    frame.isPc = true;
+    frame.isLr = true;
+    NSDictionary *dict = [frame toDictionary];
+    XCTAssertTrue(dict[@"isPC"]);
+    XCTAssertTrue(dict[@"isLR"]);
 }
 
 - (void)testStackframeBools {

--- a/Tests/BugsnagThreadTest.m
+++ b/Tests/BugsnagThreadTest.m
@@ -68,7 +68,7 @@
     XCTAssertEqual(1, [thread.stacktrace count]);
     BugsnagStackframe *frame = thread.stacktrace[0];
     XCTAssertEqualObjects(@"kscrashsentry_reportUserException", frame.method);
-    XCTAssertEqualObjects(@"CrashProbeiOS", frame.machoFile);
+    XCTAssertEqualObjects(@"/Users/joesmith/foo", frame.machoFile);
     XCTAssertEqualObjects(@"D0A41830-4FD2-3B02-A23B-0741AD4C7F52", frame.machoUuid);
 }
 
@@ -86,7 +86,7 @@
     XCTAssertEqual(1, [dict[@"stacktrace"] count]);
     NSDictionary *frame = dict[@"stacktrace"][0];
     XCTAssertEqualObjects(@"kscrashsentry_reportUserException", frame[@"method"]);
-    XCTAssertEqualObjects(@"CrashProbeiOS", frame[@"machoFile"]);
+    XCTAssertEqualObjects(@"/Users/joesmith/foo", frame[@"machoFile"]);
     XCTAssertEqualObjects(@"D0A41830-4FD2-3B02-A23B-0741AD4C7F52", frame[@"machoUUID"]);
 }
 


### PR DESCRIPTION
## Goal

Symbolication of stacktraces did not match v5 due to a bug in how fields were serialized. This changeset fixes the serialization of stackframes to regain the desired behaviour.

## Changeset

- Assigned the `machoFile` from the `binary_images` section of the KSCrash report, as this contains the absolute path of the machoFile rather than the relative path which was being used
- Serialized `isPC` and `isLR` fields when they are set to `true`

## Tests

Updated unit tests and added new coverage to verify `isPC/isLR` are serialized.

Verified that the symbolication appears as expected in an example app with debug symbols enabled + disabled. Visually inspected the JSON payload to confirm that it matches what was sent in v5.
