### PR TITLE
fix(examples): remove constraint warning on storyboards

### DIFF
--- a/UPGRADING.md
+++ b/UPGRADING.md
@@ -41,10 +41,10 @@ With an entry in your `Info.plist` file:
 </dict>
 ```
 
-You can add further configuration options to your `Info.plist` or construct a `BugsnagConfiguration` to set further options in code. For full details, see the online docs
-([iOS](https://docs.bugsnag.com/platforms/ios/configuration-options/#setting-configuration-options) |
- [macOS](https://docs.bugsnag.com/platforms/macos/configuration-options/#setting-configuration-options) |
- [tvOS](https://docs.bugsnag.com/platforms/tvos/configuration-options/#setting-configuration-options).)
+You can add further configuration options to your `Info.plist` or construct a `BugsnagConfiguration` to set further options in code. For full details, see the online docs:
+[iOS](https://docs.bugsnag.com/platforms/ios/configuration-options/#setting-configuration-options) |
+[macOS](https://docs.bugsnag.com/platforms/macos/configuration-options/#setting-configuration-options) |
+[tvOS](https://docs.bugsnag.com/platforms/tvos/configuration-options/#setting-configuration-options).
 
 #### Additions
 

--- a/examples/objective-c-ios/Bugsnag Test App/en.lproj/MainStoryboard.storyboard
+++ b/examples/objective-c-ios/Bugsnag Test App/en.lproj/MainStoryboard.storyboard
@@ -41,8 +41,9 @@
                                             <rect key="frame" x="0.0" y="0.0" width="414" height="44"/>
                                             <autoresizingMask key="autoresizingMask"/>
                                             <subviews>
-                                                <button opaque="NO" contentMode="scaleToFill" contentHorizontalAlignment="center" contentVerticalAlignment="center" buttonType="roundedRect" lineBreakMode="middleTruncation" translatesAutoresizingMaskIntoConstraints="NO" id="MkL-AZ-Bqt">
+                                                <button opaque="NO" contentMode="scaleToFill" fixedFrame="YES" preservesSuperviewLayoutMargins="YES" contentHorizontalAlignment="center" contentVerticalAlignment="center" buttonType="roundedRect" lineBreakMode="middleTruncation" translatesAutoresizingMaskIntoConstraints="NO" id="MkL-AZ-Bqt">
                                                     <rect key="frame" x="16" y="7" width="138" height="30"/>
+                                                    <autoresizingMask key="autoresizingMask" flexibleMaxX="YES" flexibleMaxY="YES"/>
                                                     <state key="normal" title="Uncaught exception">
                                                         <color key="titleShadowColor" red="0.5" green="0.5" blue="0.5" alpha="1" colorSpace="custom" customColorSpace="sRGB"/>
                                                     </state>
@@ -51,11 +52,6 @@
                                                     </connections>
                                                 </button>
                                             </subviews>
-                                            <constraints>
-                                                <constraint firstItem="MkL-AZ-Bqt" firstAttribute="leading" secondItem="Z68-om-Prg" secondAttribute="leading" constant="16" id="GkU-vp-bD7"/>
-                                                <constraint firstItem="MkL-AZ-Bqt" firstAttribute="centerY" secondItem="Z68-om-Prg" secondAttribute="centerY" id="SL6-tG-UhJ"/>
-                                                <constraint firstAttribute="trailing" relation="greaterThanOrEqual" secondItem="MkL-AZ-Bqt" secondAttribute="trailing" constant="20" symbolic="YES" id="YLh-wO-kxn"/>
-                                            </constraints>
                                         </tableViewCellContentView>
                                     </tableViewCell>
                                     <tableViewCell clipsSubviews="YES" contentMode="scaleToFill" insetsLayoutMarginsFromSafeArea="NO" selectionStyle="blue" hidesAccessoryWhenEditing="NO" indentationLevel="1" indentationWidth="0.0" id="8Sn-lK-a7g">
@@ -65,8 +61,9 @@
                                             <rect key="frame" x="0.0" y="0.0" width="414" height="44"/>
                                             <autoresizingMask key="autoresizingMask"/>
                                             <subviews>
-                                                <button opaque="NO" contentMode="scaleToFill" contentHorizontalAlignment="center" contentVerticalAlignment="center" buttonType="roundedRect" lineBreakMode="middleTruncation" translatesAutoresizingMaskIntoConstraints="NO" id="wc6-pu-JVA">
+                                                <button opaque="NO" contentMode="scaleToFill" fixedFrame="YES" preservesSuperviewLayoutMargins="YES" contentHorizontalAlignment="center" contentVerticalAlignment="center" buttonType="roundedRect" lineBreakMode="middleTruncation" translatesAutoresizingMaskIntoConstraints="NO" id="wc6-pu-JVA">
                                                     <rect key="frame" x="16" y="7" width="248" height="30"/>
+                                                    <autoresizingMask key="autoresizingMask" flexibleMaxX="YES" flexibleMaxY="YES"/>
                                                     <state key="normal" title="POSIX signal (not simulator friendly)">
                                                         <color key="titleShadowColor" red="0.5" green="0.5" blue="0.5" alpha="1" colorSpace="custom" customColorSpace="sRGB"/>
                                                     </state>
@@ -75,11 +72,6 @@
                                                     </connections>
                                                 </button>
                                             </subviews>
-                                            <constraints>
-                                                <constraint firstItem="wc6-pu-JVA" firstAttribute="centerY" secondItem="3dJ-Ye-puY" secondAttribute="centerY" id="4cy-R4-sKX"/>
-                                                <constraint firstItem="wc6-pu-JVA" firstAttribute="leading" secondItem="3dJ-Ye-puY" secondAttribute="leading" constant="16" id="NnE-fc-KKo"/>
-                                                <constraint firstAttribute="trailing" relation="greaterThanOrEqual" secondItem="wc6-pu-JVA" secondAttribute="trailing" constant="20" symbolic="YES" id="e6s-IQ-CSI"/>
-                                            </constraints>
                                         </tableViewCellContentView>
                                     </tableViewCell>
                                     <tableViewCell clipsSubviews="YES" contentMode="scaleToFill" insetsLayoutMarginsFromSafeArea="NO" selectionStyle="blue" hidesAccessoryWhenEditing="NO" indentationLevel="1" indentationWidth="0.0" id="Yhl-gQ-P06">
@@ -89,8 +81,9 @@
                                             <rect key="frame" x="0.0" y="0.0" width="414" height="44"/>
                                             <autoresizingMask key="autoresizingMask"/>
                                             <subviews>
-                                                <button opaque="NO" contentMode="scaleToFill" contentHorizontalAlignment="center" contentVerticalAlignment="center" buttonType="roundedRect" lineBreakMode="middleTruncation" translatesAutoresizingMaskIntoConstraints="NO" id="Ylc-KZ-kmq">
+                                                <button opaque="NO" contentMode="scaleToFill" fixedFrame="YES" preservesSuperviewLayoutMargins="YES" contentHorizontalAlignment="center" contentVerticalAlignment="center" buttonType="roundedRect" lineBreakMode="middleTruncation" translatesAutoresizingMaskIntoConstraints="NO" id="Ylc-KZ-kmq">
                                                     <rect key="frame" x="16" y="7" width="132" height="30"/>
+                                                    <autoresizingMask key="autoresizingMask" flexibleMaxX="YES" flexibleMaxY="YES"/>
                                                     <state key="normal" title="Memory corruption">
                                                         <color key="titleShadowColor" red="0.5" green="0.5" blue="0.5" alpha="1" colorSpace="custom" customColorSpace="sRGB"/>
                                                     </state>
@@ -99,11 +92,6 @@
                                                     </connections>
                                                 </button>
                                             </subviews>
-                                            <constraints>
-                                                <constraint firstItem="Ylc-KZ-kmq" firstAttribute="centerY" secondItem="zVu-Ug-2Kf" secondAttribute="centerY" id="LE4-lF-8bi"/>
-                                                <constraint firstItem="Ylc-KZ-kmq" firstAttribute="leading" secondItem="zVu-Ug-2Kf" secondAttribute="leading" constant="16" id="TeK-yh-cXX"/>
-                                                <constraint firstAttribute="trailing" relation="greaterThanOrEqual" secondItem="Ylc-KZ-kmq" secondAttribute="trailing" constant="20" symbolic="YES" id="dUb-Zc-1qJ"/>
-                                            </constraints>
                                         </tableViewCellContentView>
                                     </tableViewCell>
                                     <tableViewCell clipsSubviews="YES" contentMode="scaleToFill" insetsLayoutMarginsFromSafeArea="NO" selectionStyle="blue" hidesAccessoryWhenEditing="NO" indentationLevel="1" indentationWidth="0.0" id="Oxa-rC-wVQ">
@@ -113,8 +101,9 @@
                                             <rect key="frame" x="0.0" y="0.0" width="414" height="44"/>
                                             <autoresizingMask key="autoresizingMask"/>
                                             <subviews>
-                                                <button opaque="NO" contentMode="scaleToFill" contentHorizontalAlignment="center" contentVerticalAlignment="center" buttonType="roundedRect" lineBreakMode="middleTruncation" translatesAutoresizingMaskIntoConstraints="NO" id="6K4-3G-uRI">
+                                                <button opaque="NO" contentMode="scaleToFill" fixedFrame="YES" preservesSuperviewLayoutMargins="YES" contentHorizontalAlignment="center" contentVerticalAlignment="center" buttonType="roundedRect" lineBreakMode="middleTruncation" translatesAutoresizingMaskIntoConstraints="NO" id="6K4-3G-uRI">
                                                     <rect key="frame" x="16" y="7" width="102" height="30"/>
+                                                    <autoresizingMask key="autoresizingMask" flexibleMaxX="YES" flexibleMaxY="YES"/>
                                                     <state key="normal" title="Stack overflow">
                                                         <color key="titleShadowColor" red="0.5" green="0.5" blue="0.5" alpha="1" colorSpace="custom" customColorSpace="sRGB"/>
                                                     </state>
@@ -123,11 +112,6 @@
                                                     </connections>
                                                 </button>
                                             </subviews>
-                                            <constraints>
-                                                <constraint firstAttribute="trailing" relation="greaterThanOrEqual" secondItem="6K4-3G-uRI" secondAttribute="trailing" constant="20" symbolic="YES" id="jKf-UF-UBC"/>
-                                                <constraint firstItem="6K4-3G-uRI" firstAttribute="centerY" secondItem="rYc-OF-DON" secondAttribute="centerY" id="sBt-w1-I2i"/>
-                                                <constraint firstItem="6K4-3G-uRI" firstAttribute="leading" secondItem="rYc-OF-DON" secondAttribute="leading" constant="16" id="uZu-cs-KjR"/>
-                                            </constraints>
                                         </tableViewCellContentView>
                                     </tableViewCell>
                                     <tableViewCell clipsSubviews="YES" contentMode="scaleToFill" insetsLayoutMarginsFromSafeArea="NO" selectionStyle="blue" hidesAccessoryWhenEditing="NO" indentationLevel="1" indentationWidth="0.0" id="kTk-Cf-4A3">
@@ -137,19 +121,15 @@
                                             <rect key="frame" x="0.0" y="0.0" width="414" height="44"/>
                                             <autoresizingMask key="autoresizingMask"/>
                                             <subviews>
-                                                <button opaque="NO" contentMode="scaleToFill" contentHorizontalAlignment="center" contentVerticalAlignment="center" buttonType="roundedRect" lineBreakMode="middleTruncation" translatesAutoresizingMaskIntoConstraints="NO" id="6kT-FU-9Vb">
+                                                <button opaque="NO" contentMode="scaleToFill" fixedFrame="YES" preservesSuperviewLayoutMargins="YES" contentHorizontalAlignment="center" contentVerticalAlignment="center" buttonType="roundedRect" lineBreakMode="middleTruncation" translatesAutoresizingMaskIntoConstraints="NO" id="6kT-FU-9Vb">
                                                     <rect key="frame" x="16" y="7" width="280" height="30"/>
+                                                    <autoresizingMask key="autoresizingMask" flexibleMaxX="YES" flexibleMaxY="YES"/>
                                                     <state key="normal" title="Memory pressure (not simulator friendly)"/>
                                                     <connections>
                                                         <action selector="crashMemoryPressure:" destination="uYB-Rg-v98" eventType="touchUpInside" id="uzO-LY-FUe"/>
                                                     </connections>
                                                 </button>
                                             </subviews>
-                                            <constraints>
-                                                <constraint firstItem="6kT-FU-9Vb" firstAttribute="leading" secondItem="WsA-pq-zKg" secondAttribute="leading" constant="16" id="bNp-H9-TyN"/>
-                                                <constraint firstItem="6kT-FU-9Vb" firstAttribute="centerY" secondItem="WsA-pq-zKg" secondAttribute="centerY" id="fid-St-MgN"/>
-                                                <constraint firstAttribute="trailing" relation="greaterThanOrEqual" secondItem="6kT-FU-9Vb" secondAttribute="trailing" constant="20" symbolic="YES" id="vI0-vT-sH8"/>
-                                            </constraints>
                                         </tableViewCellContentView>
                                     </tableViewCell>
                                 </cells>
@@ -163,8 +143,9 @@
                                             <rect key="frame" x="0.0" y="0.0" width="414" height="44"/>
                                             <autoresizingMask key="autoresizingMask"/>
                                             <subviews>
-                                                <button opaque="NO" contentMode="scaleToFill" contentHorizontalAlignment="center" contentVerticalAlignment="center" buttonType="roundedRect" lineBreakMode="middleTruncation" translatesAutoresizingMaskIntoConstraints="NO" id="gsL-Pw-GHc">
+                                                <button opaque="NO" contentMode="scaleToFill" fixedFrame="YES" preservesSuperviewLayoutMargins="YES" contentHorizontalAlignment="center" contentVerticalAlignment="center" buttonType="roundedRect" lineBreakMode="middleTruncation" translatesAutoresizingMaskIntoConstraints="NO" id="gsL-Pw-GHc">
                                                     <rect key="frame" x="16" y="7" width="182" height="30"/>
+                                                    <autoresizingMask key="autoresizingMask" flexibleMaxX="YES" flexibleMaxY="YES"/>
                                                     <state key="normal" title="Use notify() from try/catch">
                                                         <color key="titleShadowColor" red="0.5" green="0.5" blue="0.5" alpha="1" colorSpace="custom" customColorSpace="sRGB"/>
                                                     </state>
@@ -173,11 +154,6 @@
                                                     </connections>
                                                 </button>
                                             </subviews>
-                                            <constraints>
-                                                <constraint firstAttribute="trailing" relation="greaterThanOrEqual" secondItem="gsL-Pw-GHc" secondAttribute="trailing" constant="20" symbolic="YES" id="7NW-yY-qCN"/>
-                                                <constraint firstItem="gsL-Pw-GHc" firstAttribute="leading" secondItem="qW2-pi-SzL" secondAttribute="leading" constant="16" id="I3Y-kv-nic"/>
-                                                <constraint firstItem="gsL-Pw-GHc" firstAttribute="centerY" secondItem="qW2-pi-SzL" secondAttribute="centerY" id="aMI-c6-aRD"/>
-                                            </constraints>
                                         </tableViewCellContentView>
                                     </tableViewCell>
                                     <tableViewCell clipsSubviews="YES" contentMode="scaleToFill" insetsLayoutMarginsFromSafeArea="NO" selectionStyle="blue" hidesAccessoryWhenEditing="NO" indentationLevel="1" indentationWidth="0.0" id="fZi-2v-vlx">
@@ -187,8 +163,9 @@
                                             <rect key="frame" x="0.0" y="0.0" width="414" height="44"/>
                                             <autoresizingMask key="autoresizingMask"/>
                                             <subviews>
-                                                <button opaque="NO" contentMode="scaleToFill" contentHorizontalAlignment="center" contentVerticalAlignment="center" buttonType="roundedRect" lineBreakMode="middleTruncation" translatesAutoresizingMaskIntoConstraints="NO" id="Lq8-kV-y3N">
+                                                <button opaque="NO" contentMode="scaleToFill" fixedFrame="YES" contentHorizontalAlignment="center" contentVerticalAlignment="center" buttonType="roundedRect" lineBreakMode="middleTruncation" translatesAutoresizingMaskIntoConstraints="NO" id="Lq8-kV-y3N">
                                                     <rect key="frame" x="16" y="7" width="191" height="30"/>
+                                                    <autoresizingMask key="autoresizingMask" flexibleMaxX="YES" flexibleMaxY="YES"/>
                                                     <state key="normal" title="Call notify() asynchronously">
                                                         <color key="titleShadowColor" red="0.5" green="0.5" blue="0.5" alpha="1" colorSpace="custom" customColorSpace="sRGB"/>
                                                     </state>
@@ -197,11 +174,6 @@
                                                     </connections>
                                                 </button>
                                             </subviews>
-                                            <constraints>
-                                                <constraint firstItem="Lq8-kV-y3N" firstAttribute="centerY" secondItem="DfY-Um-9hb" secondAttribute="centerY" id="2uQ-Mb-H2n"/>
-                                                <constraint firstItem="Lq8-kV-y3N" firstAttribute="leading" secondItem="DfY-Um-9hb" secondAttribute="leading" constant="16" id="7dz-H7-SsO"/>
-                                                <constraint firstAttribute="trailing" relation="greaterThanOrEqual" secondItem="Lq8-kV-y3N" secondAttribute="trailing" constant="20" symbolic="YES" id="XFU-uc-xRe"/>
-                                            </constraints>
                                         </tableViewCellContentView>
                                     </tableViewCell>
                                     <tableViewCell clipsSubviews="YES" contentMode="scaleToFill" insetsLayoutMarginsFromSafeArea="NO" selectionStyle="blue" hidesAccessoryWhenEditing="NO" indentationLevel="1" indentationWidth="0.0" id="t4o-vg-er6">
@@ -211,8 +183,9 @@
                                             <rect key="frame" x="0.0" y="0.0" width="414" height="44"/>
                                             <autoresizingMask key="autoresizingMask"/>
                                             <subviews>
-                                                <button opaque="NO" contentMode="scaleToFill" contentHorizontalAlignment="center" contentVerticalAlignment="center" buttonType="roundedRect" lineBreakMode="middleTruncation" translatesAutoresizingMaskIntoConstraints="NO" id="T16-Wx-wJ1">
+                                                <button opaque="NO" contentMode="scaleToFill" fixedFrame="YES" preservesSuperviewLayoutMargins="YES" contentHorizontalAlignment="center" contentVerticalAlignment="center" buttonType="roundedRect" lineBreakMode="middleTruncation" translatesAutoresizingMaskIntoConstraints="NO" id="T16-Wx-wJ1">
                                                     <rect key="frame" x="16" y="7" width="234" height="30"/>
+                                                    <autoresizingMask key="autoresizingMask" flexibleMaxX="YES" flexibleMaxY="YES"/>
                                                     <state key="normal" title="Send an NSError with notifyError()">
                                                         <color key="titleShadowColor" red="0.5" green="0.5" blue="0.5" alpha="1" colorSpace="custom" customColorSpace="sRGB"/>
                                                     </state>
@@ -221,11 +194,6 @@
                                                     </connections>
                                                 </button>
                                             </subviews>
-                                            <constraints>
-                                                <constraint firstItem="T16-Wx-wJ1" firstAttribute="leading" secondItem="bUh-rr-kY1" secondAttribute="leading" constant="16" id="F9k-Ak-XPA"/>
-                                                <constraint firstItem="T16-Wx-wJ1" firstAttribute="centerY" secondItem="bUh-rr-kY1" secondAttribute="centerY" id="hZj-aP-sC4"/>
-                                                <constraint firstAttribute="trailing" relation="greaterThanOrEqual" secondItem="T16-Wx-wJ1" secondAttribute="trailing" constant="20" symbolic="YES" id="jW4-xd-O0r"/>
-                                            </constraints>
                                         </tableViewCellContentView>
                                     </tableViewCell>
                                 </cells>
@@ -235,12 +203,13 @@
                                     <tableViewCell clipsSubviews="YES" contentMode="scaleToFill" insetsLayoutMarginsFromSafeArea="NO" selectionStyle="blue" hidesAccessoryWhenEditing="NO" indentationLevel="1" indentationWidth="0.0" id="Xml-lW-dEC">
                                         <rect key="frame" x="0.0" y="590.5" width="414" height="44"/>
                                         <autoresizingMask key="autoresizingMask"/>
-                                        <tableViewCellContentView key="contentView" opaque="NO" clipsSubviews="YES" multipleTouchEnabled="YES" contentMode="center" insetsLayoutMarginsFromSafeArea="NO" tableViewCell="Xml-lW-dEC" id="WVv-Ay-AQP">
+                                        <tableViewCellContentView key="contentView" opaque="NO" clipsSubviews="YES" multipleTouchEnabled="YES" contentMode="center" preservesSuperviewLayoutMargins="YES" insetsLayoutMarginsFromSafeArea="NO" tableViewCell="Xml-lW-dEC" id="WVv-Ay-AQP">
                                             <rect key="frame" x="0.0" y="0.0" width="414" height="44"/>
                                             <autoresizingMask key="autoresizingMask"/>
                                             <subviews>
-                                                <button opaque="NO" contentMode="scaleToFill" contentHorizontalAlignment="center" contentVerticalAlignment="center" buttonType="roundedRect" lineBreakMode="middleTruncation" translatesAutoresizingMaskIntoConstraints="NO" id="FP3-49-kDn">
+                                                <button opaque="NO" contentMode="scaleToFill" fixedFrame="YES" contentHorizontalAlignment="center" contentVerticalAlignment="center" buttonType="roundedRect" lineBreakMode="middleTruncation" translatesAutoresizingMaskIntoConstraints="NO" id="FP3-49-kDn">
                                                     <rect key="frame" x="16" y="7" width="138" height="30"/>
+                                                    <autoresizingMask key="autoresizingMask" flexibleMaxX="YES" flexibleMaxY="YES"/>
                                                     <state key="normal" title="Add client metadata">
                                                         <color key="titleShadowColor" red="0.5" green="0.5" blue="0.5" alpha="1" colorSpace="custom" customColorSpace="sRGB"/>
                                                     </state>
@@ -249,22 +218,18 @@
                                                     </connections>
                                                 </button>
                                             </subviews>
-                                            <constraints>
-                                                <constraint firstItem="FP3-49-kDn" firstAttribute="centerY" secondItem="WVv-Ay-AQP" secondAttribute="centerY" id="MPl-8R-TMd"/>
-                                                <constraint firstAttribute="trailing" relation="greaterThanOrEqual" secondItem="FP3-49-kDn" secondAttribute="trailing" constant="20" symbolic="YES" id="Md4-4B-pJ3"/>
-                                                <constraint firstItem="FP3-49-kDn" firstAttribute="leading" secondItem="WVv-Ay-AQP" secondAttribute="leading" constant="16" id="fGa-Cc-nTf"/>
-                                            </constraints>
                                         </tableViewCellContentView>
                                     </tableViewCell>
                                     <tableViewCell clipsSubviews="YES" contentMode="scaleToFill" insetsLayoutMarginsFromSafeArea="NO" selectionStyle="blue" hidesAccessoryWhenEditing="NO" indentationLevel="1" indentationWidth="0.0" id="dPJ-z6-yma">
                                         <rect key="frame" x="0.0" y="634.5" width="414" height="44"/>
                                         <autoresizingMask key="autoresizingMask"/>
-                                        <tableViewCellContentView key="contentView" opaque="NO" clipsSubviews="YES" multipleTouchEnabled="YES" contentMode="center" insetsLayoutMarginsFromSafeArea="NO" tableViewCell="dPJ-z6-yma" id="96p-LU-lNg">
+                                        <tableViewCellContentView key="contentView" opaque="NO" clipsSubviews="YES" multipleTouchEnabled="YES" contentMode="center" preservesSuperviewLayoutMargins="YES" insetsLayoutMarginsFromSafeArea="NO" tableViewCell="dPJ-z6-yma" id="96p-LU-lNg">
                                             <rect key="frame" x="0.0" y="0.0" width="414" height="44"/>
                                             <autoresizingMask key="autoresizingMask"/>
                                             <subviews>
-                                                <button opaque="NO" contentMode="scaleToFill" contentHorizontalAlignment="center" contentVerticalAlignment="center" buttonType="roundedRect" lineBreakMode="middleTruncation" translatesAutoresizingMaskIntoConstraints="NO" id="4jB-Ac-ONf">
+                                                <button opaque="NO" contentMode="scaleToFill" fixedFrame="YES" contentHorizontalAlignment="center" contentVerticalAlignment="center" buttonType="roundedRect" lineBreakMode="middleTruncation" translatesAutoresizingMaskIntoConstraints="NO" id="4jB-Ac-ONf">
                                                     <rect key="frame" x="16" y="7" width="149" height="30"/>
+                                                    <autoresizingMask key="autoresizingMask" flexibleMaxX="YES" flexibleMaxY="YES"/>
                                                     <state key="normal" title="Add filtered metadata">
                                                         <color key="titleShadowColor" red="0.5" green="0.5" blue="0.5" alpha="1" colorSpace="custom" customColorSpace="sRGB"/>
                                                     </state>
@@ -273,11 +238,6 @@
                                                     </connections>
                                                 </button>
                                             </subviews>
-                                            <constraints>
-                                                <constraint firstAttribute="trailing" relation="greaterThanOrEqual" secondItem="4jB-Ac-ONf" secondAttribute="trailing" constant="20" symbolic="YES" id="M1d-U5-1E9"/>
-                                                <constraint firstItem="4jB-Ac-ONf" firstAttribute="centerY" secondItem="96p-LU-lNg" secondAttribute="centerY" id="eyv-Iy-wTS"/>
-                                                <constraint firstItem="4jB-Ac-ONf" firstAttribute="leading" secondItem="96p-LU-lNg" secondAttribute="leading" constant="16" id="g2w-ZT-e71"/>
-                                            </constraints>
                                         </tableViewCellContentView>
                                     </tableViewCell>
                                     <tableViewCell clipsSubviews="YES" contentMode="scaleToFill" insetsLayoutMarginsFromSafeArea="NO" selectionStyle="blue" hidesAccessoryWhenEditing="NO" indentationLevel="1" indentationWidth="0.0" id="JVr-4s-rQC">
@@ -287,8 +247,9 @@
                                             <rect key="frame" x="0.0" y="0.0" width="414" height="44"/>
                                             <autoresizingMask key="autoresizingMask"/>
                                             <subviews>
-                                                <button opaque="NO" contentMode="scaleToFill" contentHorizontalAlignment="center" contentVerticalAlignment="center" buttonType="roundedRect" lineBreakMode="middleTruncation" translatesAutoresizingMaskIntoConstraints="NO" id="bDy-36-6kb">
+                                                <button opaque="NO" contentMode="scaleToFill" fixedFrame="YES" preservesSuperviewLayoutMargins="YES" contentHorizontalAlignment="center" contentVerticalAlignment="center" buttonType="roundedRect" lineBreakMode="middleTruncation" translatesAutoresizingMaskIntoConstraints="NO" id="bDy-36-6kb">
                                                     <rect key="frame" x="16" y="7" width="157" height="30"/>
+                                                    <autoresizingMask key="autoresizingMask" flexibleMaxX="YES" flexibleMaxY="YES"/>
                                                     <state key="normal" title="Add metadata callback">
                                                         <color key="titleShadowColor" red="0.5" green="0.5" blue="0.5" alpha="1" colorSpace="custom" customColorSpace="sRGB"/>
                                                     </state>
@@ -297,11 +258,6 @@
                                                     </connections>
                                                 </button>
                                             </subviews>
-                                            <constraints>
-                                                <constraint firstItem="bDy-36-6kb" firstAttribute="leading" secondItem="50m-iu-ppV" secondAttribute="leading" constant="16" id="DOp-Fj-H4B"/>
-                                                <constraint firstItem="bDy-36-6kb" firstAttribute="centerY" secondItem="50m-iu-ppV" secondAttribute="centerY" id="SIv-SX-12T"/>
-                                                <constraint firstAttribute="trailing" relation="greaterThanOrEqual" secondItem="bDy-36-6kb" secondAttribute="trailing" constant="20" symbolic="YES" id="Skd-ql-jeH"/>
-                                            </constraints>
                                         </tableViewCellContentView>
                                     </tableViewCell>
                                     <tableViewCell clipsSubviews="YES" contentMode="scaleToFill" insetsLayoutMarginsFromSafeArea="NO" selectionStyle="blue" hidesAccessoryWhenEditing="NO" indentationLevel="1" indentationWidth="0.0" id="Ym9-ue-F4d">
@@ -311,8 +267,9 @@
                                             <rect key="frame" x="0.0" y="0.0" width="414" height="44"/>
                                             <autoresizingMask key="autoresizingMask"/>
                                             <subviews>
-                                                <button opaque="NO" contentMode="scaleToFill" contentHorizontalAlignment="center" contentVerticalAlignment="center" buttonType="roundedRect" lineBreakMode="middleTruncation" translatesAutoresizingMaskIntoConstraints="NO" id="fQQ-zy-T8S">
+                                                <button opaque="NO" contentMode="scaleToFill" fixedFrame="YES" preservesSuperviewLayoutMargins="YES" contentHorizontalAlignment="center" contentVerticalAlignment="center" buttonType="roundedRect" lineBreakMode="middleTruncation" translatesAutoresizingMaskIntoConstraints="NO" id="fQQ-zy-T8S">
                                                     <rect key="frame" x="16" y="7" width="105" height="30"/>
+                                                    <autoresizingMask key="autoresizingMask" flexibleMaxX="YES" flexibleMaxY="YES"/>
                                                     <state key="normal" title="Clear metadata">
                                                         <color key="titleShadowColor" red="0.5" green="0.5" blue="0.5" alpha="1" colorSpace="custom" customColorSpace="sRGB"/>
                                                     </state>
@@ -321,11 +278,6 @@
                                                     </connections>
                                                 </button>
                                             </subviews>
-                                            <constraints>
-                                                <constraint firstAttribute="trailing" relation="greaterThanOrEqual" secondItem="fQQ-zy-T8S" secondAttribute="trailing" constant="20" symbolic="YES" id="4O6-hS-SRT"/>
-                                                <constraint firstItem="fQQ-zy-T8S" firstAttribute="centerY" secondItem="z0j-Et-9re" secondAttribute="centerY" id="UMk-Ad-KDh"/>
-                                                <constraint firstItem="fQQ-zy-T8S" firstAttribute="leading" secondItem="z0j-Et-9re" secondAttribute="leading" constant="16" id="zlI-ef-7e1"/>
-                                            </constraints>
                                         </tableViewCellContentView>
                                     </tableViewCell>
                                     <tableViewCell clipsSubviews="YES" contentMode="scaleToFill" insetsLayoutMarginsFromSafeArea="NO" selectionStyle="blue" hidesAccessoryWhenEditing="NO" indentationLevel="1" indentationWidth="0.0" id="X6n-ZN-aIR">
@@ -335,8 +287,9 @@
                                             <rect key="frame" x="0.0" y="0.0" width="414" height="44"/>
                                             <autoresizingMask key="autoresizingMask"/>
                                             <subviews>
-                                                <button opaque="NO" contentMode="scaleToFill" contentHorizontalAlignment="center" contentVerticalAlignment="center" buttonType="roundedRect" lineBreakMode="middleTruncation" translatesAutoresizingMaskIntoConstraints="NO" id="Ct1-sv-ZXx">
+                                                <button opaque="NO" contentMode="scaleToFill" fixedFrame="YES" preservesSuperviewLayoutMargins="YES" contentHorizontalAlignment="center" contentVerticalAlignment="center" buttonType="roundedRect" lineBreakMode="middleTruncation" translatesAutoresizingMaskIntoConstraints="NO" id="Ct1-sv-ZXx">
                                                     <rect key="frame" x="16" y="7" width="146" height="30"/>
+                                                    <autoresizingMask key="autoresizingMask" flexibleMaxX="YES" flexibleMaxY="YES"/>
                                                     <state key="normal" title="Add severity callback">
                                                         <color key="titleShadowColor" red="0.5" green="0.5" blue="0.5" alpha="1" colorSpace="custom" customColorSpace="sRGB"/>
                                                     </state>
@@ -345,11 +298,6 @@
                                                     </connections>
                                                 </button>
                                             </subviews>
-                                            <constraints>
-                                                <constraint firstAttribute="trailing" relation="greaterThanOrEqual" secondItem="Ct1-sv-ZXx" secondAttribute="trailing" constant="20" symbolic="YES" id="1lf-mX-ccb"/>
-                                                <constraint firstItem="Ct1-sv-ZXx" firstAttribute="leading" secondItem="F08-qY-aWV" secondAttribute="leading" constant="16" id="qQf-8W-C44"/>
-                                                <constraint firstItem="Ct1-sv-ZXx" firstAttribute="centerY" secondItem="F08-qY-aWV" secondAttribute="centerY" id="vDc-j5-x8R"/>
-                                            </constraints>
                                         </tableViewCellContentView>
                                     </tableViewCell>
                                     <tableViewCell clipsSubviews="YES" contentMode="scaleToFill" insetsLayoutMarginsFromSafeArea="NO" selectionStyle="blue" hidesAccessoryWhenEditing="NO" indentationLevel="1" indentationWidth="0.0" id="iLJ-67-m29">
@@ -359,8 +307,9 @@
                                             <rect key="frame" x="0.0" y="0.0" width="414" height="44"/>
                                             <autoresizingMask key="autoresizingMask"/>
                                             <subviews>
-                                                <button opaque="NO" contentMode="scaleToFill" contentHorizontalAlignment="center" contentVerticalAlignment="center" buttonType="roundedRect" lineBreakMode="middleTruncation" translatesAutoresizingMaskIntoConstraints="NO" id="unC-Ou-LMY">
+                                                <button opaque="NO" contentMode="scaleToFill" fixedFrame="YES" preservesSuperviewLayoutMargins="YES" contentHorizontalAlignment="center" contentVerticalAlignment="center" buttonType="roundedRect" lineBreakMode="middleTruncation" translatesAutoresizingMaskIntoConstraints="NO" id="unC-Ou-LMY">
                                                     <rect key="frame" x="16" y="7" width="170" height="30"/>
+                                                    <autoresizingMask key="autoresizingMask" flexibleMaxX="YES" flexibleMaxY="YES"/>
                                                     <state key="normal" title="Add custom breadcrumb">
                                                         <color key="titleShadowColor" red="0.5" green="0.5" blue="0.5" alpha="1" colorSpace="custom" customColorSpace="sRGB"/>
                                                     </state>
@@ -369,11 +318,6 @@
                                                     </connections>
                                                 </button>
                                             </subviews>
-                                            <constraints>
-                                                <constraint firstAttribute="trailing" relation="greaterThanOrEqual" secondItem="unC-Ou-LMY" secondAttribute="trailing" constant="20" symbolic="YES" id="Ovb-Qv-dLx"/>
-                                                <constraint firstItem="unC-Ou-LMY" firstAttribute="centerY" secondItem="3jS-Q9-XXa" secondAttribute="centerY" id="T4r-jA-UNx"/>
-                                                <constraint firstItem="unC-Ou-LMY" firstAttribute="leading" secondItem="3jS-Q9-XXa" secondAttribute="leading" constant="16" id="nzH-sv-EmB"/>
-                                            </constraints>
                                         </tableViewCellContentView>
                                     </tableViewCell>
                                     <tableViewCell clipsSubviews="YES" contentMode="scaleToFill" insetsLayoutMarginsFromSafeArea="NO" selectionStyle="blue" hidesAccessoryWhenEditing="NO" indentationLevel="1" indentationWidth="0.0" id="VU0-88-oQg">
@@ -383,8 +327,9 @@
                                             <rect key="frame" x="0.0" y="0.0" width="414" height="44"/>
                                             <autoresizingMask key="autoresizingMask"/>
                                             <subviews>
-                                                <button opaque="NO" contentMode="scaleToFill" contentHorizontalAlignment="center" contentVerticalAlignment="center" buttonType="roundedRect" lineBreakMode="middleTruncation" translatesAutoresizingMaskIntoConstraints="NO" id="dqk-pN-qmq">
+                                                <button opaque="NO" contentMode="scaleToFill" fixedFrame="YES" preservesSuperviewLayoutMargins="YES" contentHorizontalAlignment="center" contentVerticalAlignment="center" buttonType="roundedRect" lineBreakMode="middleTruncation" translatesAutoresizingMaskIntoConstraints="NO" id="dqk-pN-qmq">
                                                     <rect key="frame" x="16" y="7" width="176" height="30"/>
+                                                    <autoresizingMask key="autoresizingMask" flexibleMaxX="YES" flexibleMaxY="YES"/>
                                                     <state key="normal" title="Add breadcrumb callback">
                                                         <color key="titleShadowColor" red="0.5" green="0.5" blue="0.5" alpha="1" colorSpace="custom" customColorSpace="sRGB"/>
                                                     </state>
@@ -393,11 +338,6 @@
                                                     </connections>
                                                 </button>
                                             </subviews>
-                                            <constraints>
-                                                <constraint firstAttribute="trailing" relation="greaterThanOrEqual" secondItem="dqk-pN-qmq" secondAttribute="trailing" constant="20" symbolic="YES" id="1gH-FX-via"/>
-                                                <constraint firstItem="dqk-pN-qmq" firstAttribute="leading" secondItem="fh1-bq-dqm" secondAttribute="leading" constant="16" id="KQr-jN-PKN"/>
-                                                <constraint firstItem="dqk-pN-qmq" firstAttribute="centerY" secondItem="fh1-bq-dqm" secondAttribute="centerY" id="R1M-2X-T36"/>
-                                            </constraints>
                                         </tableViewCellContentView>
                                     </tableViewCell>
                                     <tableViewCell clipsSubviews="YES" contentMode="scaleToFill" insetsLayoutMarginsFromSafeArea="NO" selectionStyle="blue" hidesAccessoryWhenEditing="NO" indentationLevel="1" indentationWidth="0.0" id="tQI-H9-Pif">
@@ -407,8 +347,9 @@
                                             <rect key="frame" x="0.0" y="0.0" width="414" height="44"/>
                                             <autoresizingMask key="autoresizingMask"/>
                                             <subviews>
-                                                <button opaque="NO" contentMode="scaleToFill" contentHorizontalAlignment="center" contentVerticalAlignment="center" buttonType="roundedRect" lineBreakMode="middleTruncation" translatesAutoresizingMaskIntoConstraints="NO" id="hDD-t2-6cS">
+                                                <button opaque="NO" contentMode="scaleToFill" fixedFrame="YES" preservesSuperviewLayoutMargins="YES" contentHorizontalAlignment="center" contentVerticalAlignment="center" buttonType="roundedRect" lineBreakMode="middleTruncation" translatesAutoresizingMaskIntoConstraints="NO" id="hDD-t2-6cS">
                                                     <rect key="frame" x="16" y="7" width="57" height="30"/>
+                                                    <autoresizingMask key="autoresizingMask" flexibleMaxX="YES" flexibleMaxY="YES"/>
                                                     <state key="normal" title="Set user">
                                                         <color key="titleShadowColor" red="0.5" green="0.5" blue="0.5" alpha="1" colorSpace="custom" customColorSpace="sRGB"/>
                                                     </state>
@@ -417,11 +358,6 @@
                                                     </connections>
                                                 </button>
                                             </subviews>
-                                            <constraints>
-                                                <constraint firstItem="hDD-t2-6cS" firstAttribute="centerY" secondItem="z7r-dO-CFN" secondAttribute="centerY" id="9vT-a0-Lyf"/>
-                                                <constraint firstAttribute="trailing" relation="greaterThanOrEqual" secondItem="hDD-t2-6cS" secondAttribute="trailing" constant="20" symbolic="YES" id="WTu-I1-PPB"/>
-                                                <constraint firstItem="hDD-t2-6cS" firstAttribute="leading" secondItem="z7r-dO-CFN" secondAttribute="leading" constant="16" id="xhl-98-juw"/>
-                                            </constraints>
                                         </tableViewCellContentView>
                                     </tableViewCell>
                                 </cells>
@@ -435,8 +371,9 @@
                                             <rect key="frame" x="0.0" y="0.0" width="414" height="44"/>
                                             <autoresizingMask key="autoresizingMask"/>
                                             <subviews>
-                                                <button opaque="NO" contentMode="scaleToFill" contentHorizontalAlignment="center" contentVerticalAlignment="center" buttonType="roundedRect" lineBreakMode="middleTruncation" translatesAutoresizingMaskIntoConstraints="NO" id="58Z-MC-Lhx">
+                                                <button opaque="NO" contentMode="scaleToFill" fixedFrame="YES" preservesSuperviewLayoutMargins="YES" contentHorizontalAlignment="center" contentVerticalAlignment="center" buttonType="roundedRect" lineBreakMode="middleTruncation" translatesAutoresizingMaskIntoConstraints="NO" id="58Z-MC-Lhx">
                                                     <rect key="frame" x="16" y="7" width="122" height="30"/>
+                                                    <autoresizingMask key="autoresizingMask" flexibleMaxX="YES" flexibleMaxY="YES"/>
                                                     <state key="normal" title="Start new session">
                                                         <color key="titleShadowColor" red="0.5" green="0.5" blue="0.5" alpha="1" colorSpace="custom" customColorSpace="sRGB"/>
                                                     </state>
@@ -445,11 +382,6 @@
                                                     </connections>
                                                 </button>
                                             </subviews>
-                                            <constraints>
-                                                <constraint firstItem="58Z-MC-Lhx" firstAttribute="leading" secondItem="zNt-QR-Det" secondAttribute="leading" constant="16" id="7y8-bz-f8Y"/>
-                                                <constraint firstItem="58Z-MC-Lhx" firstAttribute="centerY" secondItem="zNt-QR-Det" secondAttribute="centerY" id="cge-Pj-Kdt"/>
-                                                <constraint firstAttribute="trailing" relation="greaterThanOrEqual" secondItem="58Z-MC-Lhx" secondAttribute="trailing" constant="20" symbolic="YES" id="qhA-YW-cHV"/>
-                                            </constraints>
                                         </tableViewCellContentView>
                                     </tableViewCell>
                                     <tableViewCell clipsSubviews="YES" contentMode="scaleToFill" insetsLayoutMarginsFromSafeArea="NO" selectionStyle="blue" hidesAccessoryWhenEditing="NO" indentationLevel="1" indentationWidth="0.0" id="cfA-li-lxr">
@@ -459,8 +391,9 @@
                                             <rect key="frame" x="0.0" y="0.0" width="414" height="44"/>
                                             <autoresizingMask key="autoresizingMask"/>
                                             <subviews>
-                                                <button opaque="NO" contentMode="scaleToFill" contentHorizontalAlignment="center" contentVerticalAlignment="center" buttonType="roundedRect" lineBreakMode="middleTruncation" translatesAutoresizingMaskIntoConstraints="NO" id="Q7Q-Dq-Dlu">
+                                                <button opaque="NO" contentMode="scaleToFill" fixedFrame="YES" preservesSuperviewLayoutMargins="YES" contentHorizontalAlignment="center" contentVerticalAlignment="center" buttonType="roundedRect" lineBreakMode="middleTruncation" translatesAutoresizingMaskIntoConstraints="NO" id="Q7Q-Dq-Dlu">
                                                     <rect key="frame" x="16" y="7" width="151" height="30"/>
+                                                    <autoresizingMask key="autoresizingMask" flexibleMaxX="YES" flexibleMaxY="YES"/>
                                                     <state key="normal" title="Pause current session">
                                                         <color key="titleShadowColor" red="0.5" green="0.5" blue="0.5" alpha="1" colorSpace="custom" customColorSpace="sRGB"/>
                                                     </state>
@@ -469,11 +402,6 @@
                                                     </connections>
                                                 </button>
                                             </subviews>
-                                            <constraints>
-                                                <constraint firstItem="Q7Q-Dq-Dlu" firstAttribute="leading" secondItem="kLX-Zm-Pyu" secondAttribute="leading" constant="16" id="0Dg-jW-a2I"/>
-                                                <constraint firstAttribute="trailing" relation="greaterThanOrEqual" secondItem="Q7Q-Dq-Dlu" secondAttribute="trailing" constant="20" symbolic="YES" id="WAg-ZK-ux4"/>
-                                                <constraint firstItem="Q7Q-Dq-Dlu" firstAttribute="centerY" secondItem="kLX-Zm-Pyu" secondAttribute="centerY" id="f3G-oY-Xb2"/>
-                                            </constraints>
                                         </tableViewCellContentView>
                                     </tableViewCell>
                                     <tableViewCell clipsSubviews="YES" contentMode="scaleToFill" insetsLayoutMarginsFromSafeArea="NO" selectionStyle="blue" hidesAccessoryWhenEditing="NO" indentationLevel="1" indentationWidth="0.0" id="6J4-hS-TCq">
@@ -483,8 +411,9 @@
                                             <rect key="frame" x="0.0" y="0.0" width="414" height="44"/>
                                             <autoresizingMask key="autoresizingMask"/>
                                             <subviews>
-                                                <button opaque="NO" contentMode="scaleToFill" contentHorizontalAlignment="center" contentVerticalAlignment="center" buttonType="roundedRect" lineBreakMode="middleTruncation" translatesAutoresizingMaskIntoConstraints="NO" id="v7G-Wx-s97">
+                                                <button opaque="NO" contentMode="scaleToFill" fixedFrame="YES" preservesSuperviewLayoutMargins="YES" contentHorizontalAlignment="center" contentVerticalAlignment="center" buttonType="roundedRect" lineBreakMode="middleTruncation" translatesAutoresizingMaskIntoConstraints="NO" id="v7G-Wx-s97">
                                                     <rect key="frame" x="16" y="7" width="165" height="30"/>
+                                                    <autoresizingMask key="autoresizingMask" flexibleMaxX="YES" flexibleMaxY="YES"/>
                                                     <state key="normal" title="Resume current session">
                                                         <color key="titleShadowColor" red="0.5" green="0.5" blue="0.5" alpha="1" colorSpace="custom" customColorSpace="sRGB"/>
                                                     </state>
@@ -493,11 +422,6 @@
                                                     </connections>
                                                 </button>
                                             </subviews>
-                                            <constraints>
-                                                <constraint firstItem="v7G-Wx-s97" firstAttribute="leading" secondItem="KqM-oJ-SbO" secondAttribute="leading" constant="16" id="BNH-Wj-hWO"/>
-                                                <constraint firstItem="v7G-Wx-s97" firstAttribute="centerY" secondItem="KqM-oJ-SbO" secondAttribute="centerY" id="Gxw-rK-Iik"/>
-                                                <constraint firstAttribute="trailing" relation="greaterThanOrEqual" secondItem="v7G-Wx-s97" secondAttribute="trailing" constant="20" symbolic="YES" id="mcP-PL-QbP"/>
-                                            </constraints>
                                         </tableViewCellContentView>
                                     </tableViewCell>
                                 </cells>

--- a/examples/swift-ios/bugsnag-example/Base.lproj/Main.storyboard
+++ b/examples/swift-ios/bugsnag-example/Base.lproj/Main.storyboard
@@ -1,11 +1,9 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<document type="com.apple.InterfaceBuilder3.CocoaTouch.Storyboard.XIB" version="3.0" toolsVersion="14460.31" targetRuntime="iOS.CocoaTouch" propertyAccessControl="none" useAutolayout="YES" useTraitCollections="YES" colorMatched="YES" initialViewController="G92-m4-VCF">
-    <device id="retina6_1" orientation="portrait">
-        <adaptation id="fullscreen"/>
-    </device>
+<document type="com.apple.InterfaceBuilder3.CocoaTouch.Storyboard.XIB" version="3.0" toolsVersion="16097" targetRuntime="iOS.CocoaTouch" propertyAccessControl="none" useAutolayout="YES" useTraitCollections="YES" colorMatched="YES" initialViewController="G92-m4-VCF">
+    <device id="retina6_1" orientation="portrait" appearance="light"/>
     <dependencies>
         <deployment identifier="iOS"/>
-        <plugIn identifier="com.apple.InterfaceBuilder.IBCocoaTouchPlugin" version="14460.20"/>
+        <plugIn identifier="com.apple.InterfaceBuilder.IBCocoaTouchPlugin" version="16087"/>
         <capability name="documents saved in the Xcode 8 format" minToolsVersion="8.0"/>
     </dependencies>
     <scenes>
@@ -24,110 +22,90 @@
                                         <rect key="frame" x="0.0" y="55.5" width="414" height="44"/>
                                         <autoresizingMask key="autoresizingMask"/>
                                         <tableViewCellContentView key="contentView" opaque="NO" clipsSubviews="YES" multipleTouchEnabled="YES" contentMode="center" preservesSuperviewLayoutMargins="YES" insetsLayoutMarginsFromSafeArea="NO" tableViewCell="QbB-rU-kYH" id="NUP-7Y-ZOe">
-                                            <rect key="frame" x="0.0" y="0.0" width="414" height="43.5"/>
+                                            <rect key="frame" x="0.0" y="0.0" width="414" height="44"/>
                                             <autoresizingMask key="autoresizingMask"/>
                                             <subviews>
-                                                <button opaque="NO" contentMode="scaleToFill" contentHorizontalAlignment="leading" contentVerticalAlignment="center" buttonType="roundedRect" lineBreakMode="middleTruncation" translatesAutoresizingMaskIntoConstraints="NO" id="dKl-4y-FY8">
+                                                <button opaque="NO" contentMode="scaleToFill" fixedFrame="YES" preservesSuperviewLayoutMargins="YES" contentHorizontalAlignment="leading" contentVerticalAlignment="center" buttonType="roundedRect" lineBreakMode="middleTruncation" translatesAutoresizingMaskIntoConstraints="NO" id="dKl-4y-FY8">
                                                     <rect key="frame" x="16" y="7" width="398" height="30"/>
+                                                    <autoresizingMask key="autoresizingMask" flexibleMaxX="YES" flexibleMaxY="YES"/>
                                                     <state key="normal" title="Uncaught exception"/>
                                                     <connections>
                                                         <action selector="generateUncaughtException:" destination="9hK-Do-Aqc" eventType="touchUpInside" id="0Aq-hf-LLG"/>
                                                     </connections>
                                                 </button>
                                             </subviews>
-                                            <constraints>
-                                                <constraint firstItem="dKl-4y-FY8" firstAttribute="leading" secondItem="NUP-7Y-ZOe" secondAttribute="leading" constant="16" id="9YH-qf-ekK"/>
-                                                <constraint firstAttribute="trailing" secondItem="dKl-4y-FY8" secondAttribute="trailing" id="CXd-m2-NBN"/>
-                                                <constraint firstItem="dKl-4y-FY8" firstAttribute="centerY" secondItem="NUP-7Y-ZOe" secondAttribute="centerY" id="irp-6n-Bin"/>
-                                            </constraints>
                                         </tableViewCellContentView>
                                     </tableViewCell>
                                     <tableViewCell clipsSubviews="YES" contentMode="scaleToFill" preservesSuperviewLayoutMargins="YES" selectionStyle="default" indentationWidth="10" id="faP-iZ-xbK">
                                         <rect key="frame" x="0.0" y="99.5" width="414" height="44"/>
                                         <autoresizingMask key="autoresizingMask"/>
                                         <tableViewCellContentView key="contentView" opaque="NO" clipsSubviews="YES" multipleTouchEnabled="YES" contentMode="center" preservesSuperviewLayoutMargins="YES" insetsLayoutMarginsFromSafeArea="NO" tableViewCell="faP-iZ-xbK" id="TXb-Wu-rDg">
-                                            <rect key="frame" x="0.0" y="0.0" width="414" height="43.5"/>
+                                            <rect key="frame" x="0.0" y="0.0" width="414" height="44"/>
                                             <autoresizingMask key="autoresizingMask"/>
                                             <subviews>
-                                                <button opaque="NO" contentMode="scaleToFill" contentHorizontalAlignment="leading" contentVerticalAlignment="center" buttonType="roundedRect" lineBreakMode="middleTruncation" translatesAutoresizingMaskIntoConstraints="NO" id="VDE-Mo-ZHy">
+                                                <button opaque="NO" contentMode="scaleToFill" fixedFrame="YES" preservesSuperviewLayoutMargins="YES" contentHorizontalAlignment="leading" contentVerticalAlignment="center" buttonType="roundedRect" lineBreakMode="middleTruncation" translatesAutoresizingMaskIntoConstraints="NO" id="VDE-Mo-ZHy">
                                                     <rect key="frame" x="16" y="7" width="398" height="30"/>
+                                                    <autoresizingMask key="autoresizingMask" flexibleMaxX="YES" flexibleMaxY="YES"/>
                                                     <state key="normal" title="POSIX signal"/>
                                                     <connections>
                                                         <action selector="generatePOSIXSignal:" destination="9hK-Do-Aqc" eventType="touchUpInside" id="82J-Un-gBe"/>
                                                     </connections>
                                                 </button>
                                             </subviews>
-                                            <constraints>
-                                                <constraint firstItem="VDE-Mo-ZHy" firstAttribute="centerY" secondItem="TXb-Wu-rDg" secondAttribute="centerY" id="coE-hL-TaQ"/>
-                                                <constraint firstAttribute="trailing" secondItem="VDE-Mo-ZHy" secondAttribute="trailing" id="nWf-VD-d0u"/>
-                                                <constraint firstItem="VDE-Mo-ZHy" firstAttribute="leading" secondItem="TXb-Wu-rDg" secondAttribute="leading" constant="16" id="wjq-2L-8Xo"/>
-                                            </constraints>
                                         </tableViewCellContentView>
                                     </tableViewCell>
                                     <tableViewCell clipsSubviews="YES" contentMode="scaleToFill" preservesSuperviewLayoutMargins="YES" selectionStyle="default" indentationWidth="10" id="0Jp-Zg-DPd">
                                         <rect key="frame" x="0.0" y="143.5" width="414" height="44"/>
                                         <autoresizingMask key="autoresizingMask"/>
                                         <tableViewCellContentView key="contentView" opaque="NO" clipsSubviews="YES" multipleTouchEnabled="YES" contentMode="center" preservesSuperviewLayoutMargins="YES" insetsLayoutMarginsFromSafeArea="NO" tableViewCell="0Jp-Zg-DPd" id="bhB-G9-rkY">
-                                            <rect key="frame" x="0.0" y="0.0" width="414" height="43.5"/>
+                                            <rect key="frame" x="0.0" y="0.0" width="414" height="44"/>
                                             <autoresizingMask key="autoresizingMask"/>
                                             <subviews>
-                                                <button opaque="NO" contentMode="scaleToFill" contentHorizontalAlignment="leading" contentVerticalAlignment="center" buttonType="roundedRect" lineBreakMode="middleTruncation" translatesAutoresizingMaskIntoConstraints="NO" id="zHv-iF-OX3">
+                                                <button opaque="NO" contentMode="scaleToFill" fixedFrame="YES" preservesSuperviewLayoutMargins="YES" contentHorizontalAlignment="leading" contentVerticalAlignment="center" buttonType="roundedRect" lineBreakMode="middleTruncation" translatesAutoresizingMaskIntoConstraints="NO" id="zHv-iF-OX3">
                                                     <rect key="frame" x="16" y="7" width="398" height="30"/>
+                                                    <autoresizingMask key="autoresizingMask" flexibleMaxX="YES" flexibleMaxY="YES"/>
                                                     <state key="normal" title="Memory corruption"/>
                                                     <connections>
                                                         <action selector="generateMemoryCorruption:" destination="9hK-Do-Aqc" eventType="touchUpInside" id="DIu-04-fPT"/>
                                                     </connections>
                                                 </button>
                                             </subviews>
-                                            <constraints>
-                                                <constraint firstItem="zHv-iF-OX3" firstAttribute="centerY" secondItem="bhB-G9-rkY" secondAttribute="centerY" id="YKs-9D-1aO"/>
-                                                <constraint firstItem="zHv-iF-OX3" firstAttribute="leading" secondItem="bhB-G9-rkY" secondAttribute="leading" constant="16" id="eIw-6h-ycy"/>
-                                                <constraint firstAttribute="trailing" secondItem="zHv-iF-OX3" secondAttribute="trailing" id="qsL-7T-vDd"/>
-                                            </constraints>
                                         </tableViewCellContentView>
                                     </tableViewCell>
                                     <tableViewCell clipsSubviews="YES" contentMode="scaleToFill" preservesSuperviewLayoutMargins="YES" selectionStyle="default" indentationWidth="10" id="nl4-Ib-Cug">
                                         <rect key="frame" x="0.0" y="187.5" width="414" height="44"/>
                                         <autoresizingMask key="autoresizingMask"/>
                                         <tableViewCellContentView key="contentView" opaque="NO" clipsSubviews="YES" multipleTouchEnabled="YES" contentMode="center" preservesSuperviewLayoutMargins="YES" insetsLayoutMarginsFromSafeArea="NO" tableViewCell="nl4-Ib-Cug" id="igM-Ms-EQN">
-                                            <rect key="frame" x="0.0" y="0.0" width="414" height="43.5"/>
+                                            <rect key="frame" x="0.0" y="0.0" width="414" height="44"/>
                                             <autoresizingMask key="autoresizingMask"/>
                                             <subviews>
-                                                <button opaque="NO" contentMode="scaleToFill" contentHorizontalAlignment="leading" contentVerticalAlignment="center" buttonType="roundedRect" lineBreakMode="middleTruncation" translatesAutoresizingMaskIntoConstraints="NO" id="gTW-a1-OEW">
+                                                <button opaque="NO" contentMode="scaleToFill" fixedFrame="YES" preservesSuperviewLayoutMargins="YES" contentHorizontalAlignment="leading" contentVerticalAlignment="center" buttonType="roundedRect" lineBreakMode="middleTruncation" translatesAutoresizingMaskIntoConstraints="NO" id="gTW-a1-OEW">
                                                     <rect key="frame" x="16" y="7" width="398" height="30"/>
+                                                    <autoresizingMask key="autoresizingMask" flexibleMaxX="YES" flexibleMaxY="YES"/>
                                                     <state key="normal" title="Stack overflow"/>
                                                     <connections>
                                                         <action selector="generateStackOverflow:" destination="9hK-Do-Aqc" eventType="touchUpInside" id="IQg-0a-NSe"/>
                                                     </connections>
                                                 </button>
                                             </subviews>
-                                            <constraints>
-                                                <constraint firstItem="gTW-a1-OEW" firstAttribute="leading" secondItem="igM-Ms-EQN" secondAttribute="leading" constant="16" id="3qf-uZ-RjK"/>
-                                                <constraint firstItem="gTW-a1-OEW" firstAttribute="centerY" secondItem="igM-Ms-EQN" secondAttribute="centerY" id="nrI-IA-JwF"/>
-                                                <constraint firstAttribute="trailing" secondItem="gTW-a1-OEW" secondAttribute="trailing" id="png-g2-qC6"/>
-                                            </constraints>
                                         </tableViewCellContentView>
                                     </tableViewCell>
                                     <tableViewCell clipsSubviews="YES" contentMode="scaleToFill" preservesSuperviewLayoutMargins="YES" selectionStyle="default" indentationWidth="10" id="i5r-OQ-QyO">
                                         <rect key="frame" x="0.0" y="231.5" width="414" height="44"/>
                                         <autoresizingMask key="autoresizingMask"/>
                                         <tableViewCellContentView key="contentView" opaque="NO" clipsSubviews="YES" multipleTouchEnabled="YES" contentMode="center" preservesSuperviewLayoutMargins="YES" insetsLayoutMarginsFromSafeArea="NO" tableViewCell="i5r-OQ-QyO" id="5qq-qB-YDh">
-                                            <rect key="frame" x="0.0" y="0.0" width="414" height="43.5"/>
+                                            <rect key="frame" x="0.0" y="0.0" width="414" height="44"/>
                                             <autoresizingMask key="autoresizingMask"/>
                                             <subviews>
-                                                <button opaque="NO" contentMode="scaleToFill" contentHorizontalAlignment="leading" contentVerticalAlignment="center" buttonType="roundedRect" lineBreakMode="middleTruncation" translatesAutoresizingMaskIntoConstraints="NO" id="Wh1-Fq-EmE">
+                                                <button opaque="NO" contentMode="scaleToFill" fixedFrame="YES" preservesSuperviewLayoutMargins="YES" contentHorizontalAlignment="leading" contentVerticalAlignment="center" buttonType="roundedRect" lineBreakMode="middleTruncation" translatesAutoresizingMaskIntoConstraints="NO" id="Wh1-Fq-EmE">
                                                     <rect key="frame" x="16" y="7" width="398" height="30"/>
+                                                    <autoresizingMask key="autoresizingMask" flexibleMaxX="YES" flexibleMaxY="YES"/>
                                                     <state key="normal" title="Assertion failure"/>
                                                     <connections>
                                                         <action selector="generateAssertionFailure:" destination="9hK-Do-Aqc" eventType="touchUpInside" id="nCO-qY-oCh"/>
                                                     </connections>
                                                 </button>
                                             </subviews>
-                                            <constraints>
-                                                <constraint firstItem="Wh1-Fq-EmE" firstAttribute="centerY" secondItem="5qq-qB-YDh" secondAttribute="centerY" id="8Id-9q-WrG"/>
-                                                <constraint firstItem="Wh1-Fq-EmE" firstAttribute="leading" secondItem="5qq-qB-YDh" secondAttribute="leading" constant="16" id="OFk-Dh-Oie"/>
-                                                <constraint firstAttribute="trailing" secondItem="Wh1-Fq-EmE" secondAttribute="trailing" id="c4f-Jl-GwQ"/>
-                                            </constraints>
                                         </tableViewCellContentView>
                                     </tableViewCell>
                                 </cells>
@@ -138,22 +116,18 @@
                                         <rect key="frame" x="0.0" y="367" width="414" height="44"/>
                                         <autoresizingMask key="autoresizingMask"/>
                                         <tableViewCellContentView key="contentView" opaque="NO" clipsSubviews="YES" multipleTouchEnabled="YES" contentMode="center" preservesSuperviewLayoutMargins="YES" insetsLayoutMarginsFromSafeArea="NO" tableViewCell="lC1-Sl-uHl" id="Sdc-Gj-y4b">
-                                            <rect key="frame" x="0.0" y="0.0" width="414" height="43.5"/>
+                                            <rect key="frame" x="0.0" y="0.0" width="414" height="44"/>
                                             <autoresizingMask key="autoresizingMask"/>
                                             <subviews>
-                                                <button opaque="NO" contentMode="scaleToFill" contentHorizontalAlignment="leading" contentVerticalAlignment="center" buttonType="roundedRect" lineBreakMode="middleTruncation" translatesAutoresizingMaskIntoConstraints="NO" id="rQs-Qy-wfI">
-                                                    <rect key="frame" x="16" y="7" width="398" height="30"/>
+                                                <button opaque="NO" contentMode="scaleToFill" fixedFrame="YES" preservesSuperviewLayoutMargins="YES" contentHorizontalAlignment="leading" contentVerticalAlignment="center" buttonType="roundedRect" lineBreakMode="middleTruncation" translatesAutoresizingMaskIntoConstraints="NO" id="rQs-Qy-wfI">
+                                                    <rect key="frame" x="16" y="7" width="193" height="30"/>
+                                                    <autoresizingMask key="autoresizingMask" flexibleMaxX="YES" flexibleMaxY="YES"/>
                                                     <state key="normal" title="Send error with notifyError()"/>
                                                     <connections>
                                                         <action selector="sendAnError:" destination="9hK-Do-Aqc" eventType="touchUpInside" id="Hds-Ph-aIh"/>
                                                     </connections>
                                                 </button>
                                             </subviews>
-                                            <constraints>
-                                                <constraint firstAttribute="trailing" secondItem="rQs-Qy-wfI" secondAttribute="trailing" id="Q0q-1e-hAB"/>
-                                                <constraint firstItem="rQs-Qy-wfI" firstAttribute="centerY" secondItem="Sdc-Gj-y4b" secondAttribute="centerY" id="Zya-9j-h7I"/>
-                                                <constraint firstItem="rQs-Qy-wfI" firstAttribute="leading" secondItem="Sdc-Gj-y4b" secondAttribute="leading" constant="16" id="si3-ZM-QaO"/>
-                                            </constraints>
                                         </tableViewCellContentView>
                                     </tableViewCell>
                                 </cells>


### PR DESCRIPTION
## Goal

The iOS examples currently show a constraint warning from the labels in the navigation table:

```
[Warning] Warning once only: Detected a case where constraints ambiguously suggest a height of zero for a tableview cell's content view. We're considering the collapse unintentional and using standard height instead.
```

I've removed the layout constraints and set them to "Preserve Superview Margins" as suggested here: https://twitter.com/qdoug/status/1024661398771642368

## Tests

Manually inspected Obj-C and Swift apps on simulator.
