### PR TITLE
Ensure client metadata/user is serialized for unhandled errors

### DIFF
--- a/Bugsnag/Client/BugsnagClient.m
+++ b/Bugsnag/Client/BugsnagClient.m
@@ -415,7 +415,7 @@ NSString *_lastOrientation = nil;
         // Start with a copy of the configuration metadata
         self.metadata = [[configuration metadata] deepCopy];
         // sync initial state
-        [self metadataChanged:self.configuration.metadata];
+        [self metadataChanged:self.metadata];
         [self metadataChanged:self.configuration.config];
         [self metadataChanged:self.state];
 
@@ -428,7 +428,7 @@ NSString *_lastOrientation = nil;
             [weakSelf metadataChanged:event.data];
         };
         [self addObserverWithBlock:observer];
-        [self.configuration.metadata addObserverWithBlock:observer];
+        [self.metadata addObserverWithBlock:observer];
         [self.configuration.config addObserverWithBlock:observer];
         [self.state addObserverWithBlock:observer];
 
@@ -1099,7 +1099,7 @@ NSString *const BSGBreadcrumbLoadedMessage = @"Bugsnag loaded";
 
 - (void)metadataChanged:(BugsnagMetadata *)metadata {
     @synchronized(metadata) {
-        if (metadata == self.configuration.metadata) {
+        if (metadata == self.metadata) {
             if ([self.metadataLock tryLock]) {
                 BSSerializeJSONDictionary([metadata toDictionary],
                                           &bsg_g_bugsnag_data.metadataJSON);


### PR DESCRIPTION
## Goal

Metadata added via the client and the user is not serialized for unhandled errors. This occurs because the `BugsnagClient` now makes a copy of the metadata on `BugsnagConfiguration`, but is still attempting to serialize the `BugsnagConfiguration` metadata.

This updates the `BugsnagClient` so that Client's metadata is serialized into JSON whenever it changes, so that it is ready to be added to any unhandled error that occurs.

## Tests

Manually verified that an unhandled error has custom data/user information added via the client.
