### PR TITLE
fix(client): remove client operations for adding/removing callbacks

### DIFF
--- a/Bugsnag/Bugsnag.h
+++ b/Bugsnag/Bugsnag.h
@@ -272,27 +272,6 @@
     NS_SWIFT_NAME(removeOnSession(block:));
 
 // =============================================================================
-// MARK: - onSend
-// =============================================================================
-
-/**
- *  Add a callback to be invoked before a report is sent to Bugsnag, to
- *  change the report contents as needed
- *
- *  @param block A block which returns YES if the report should be sent
- */
-+ (void)addOnSendErrorBlock:(BugsnagOnSendErrorBlock _Nonnull)block
-    NS_SWIFT_NAME(addOnSendError(block:));
-
-/**
- * Remove the callback that would be invoked before an event is sent.
- *
- * @param block The block to be removed.
- */
-+ (void)removeOnSendErrorBlock:(BugsnagOnSendErrorBlock _Nonnull)block
-    NS_SWIFT_NAME(removeOnSendError(block:));
-
-// =============================================================================
 // MARK: - onBreadcrumb
 // =============================================================================
 

--- a/Bugsnag/Bugsnag.m
+++ b/Bugsnag/Bugsnag.m
@@ -344,24 +344,6 @@ static BugsnagClient *bsg_g_bugsnag_client = NULL;
 }
 
 // =============================================================================
-// MARK: - onSend
-// =============================================================================
-
-+ (void)addOnSendErrorBlock:(BugsnagOnSendErrorBlock _Nonnull)block
-{
-    if ([self bugsnagStarted]) {
-        [self.client addOnSendErrorBlock:block];
-    }
-}
-
-+ (void)removeOnSendErrorBlock:(BugsnagOnSendErrorBlock _Nonnull)block
-{
-    if ([self bugsnagStarted]) {
-        [self.client removeOnSendErrorBlock:block];
-    }
-}
-
-// =============================================================================
 // MARK: - OnBreadcrumb
 // =============================================================================
 

--- a/Bugsnag/Client/BugsnagClient.h
+++ b/Bugsnag/Client/BugsnagClient.h
@@ -224,27 +224,6 @@ NS_SWIFT_NAME(leaveBreadcrumb(_:metadata:type:));
         andName:(NSString *_Nullable)name;
 
 // =============================================================================
-// MARK: - onSend
-// =============================================================================
-
-/**
- *  Add a callback to be invoked before a report is sent to Bugsnag, to
- *  change the report contents as needed
- *
- *  @param block A block which returns YES if the report should be sent
- */
-- (void)addOnSendErrorBlock:(BugsnagOnSendErrorBlock _Nonnull)block
-    NS_SWIFT_NAME(addOnSendError(block:));
-
-/**
- * Remove an onSend callback, if it exists
- *
- * @param block The block to remove
- */
-- (void)removeOnSendErrorBlock:(BugsnagOnSendErrorBlock _Nonnull)block
-    NS_SWIFT_NAME(removeOnSendError(block:));
-
-// =============================================================================
 // MARK: - onBreadcrumb
 // =============================================================================
 

--- a/Bugsnag/Client/BugsnagClient.m
+++ b/Bugsnag/Client/BugsnagClient.m
@@ -815,18 +815,6 @@ NSString *const BSGBreadcrumbLoadedMessage = @"Bugsnag loaded";
 }
 
 // =============================================================================
-// MARK: - onSend
-// =============================================================================
-
-- (void)addOnSendErrorBlock:(BugsnagOnSendErrorBlock _Nonnull)block {
-    [self.configuration addOnSendErrorBlock:block];
-}
-
-- (void)removeOnSendErrorBlock:(BugsnagOnSendErrorBlock _Nonnull)block {
-    [self.configuration removeOnSendErrorBlock:block];
-}
-
-// =============================================================================
 // MARK: - onBreadcrumb
 // =============================================================================
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -283,9 +283,9 @@ how to upgrade.
   of callbacks run when a session starts.
   [#483](https://github.com/bugsnag/bugsnag-cocoa/pull/483)
   
-* Added `addOnSendBlock:`, `removeOnSendBlock:` and `clearOnSendBlocks` methods to `Bugsnag` 
-  and `BugsnagConfiguration`.
+* Added `addOnSendBlock:`, `removeOnSendBlock:` to `BugsnagConfiguration`.
   [#485](https://github.com/bugsnag/bugsnag-cocoa/pull/485)
+  [#485](https://github.com/bugsnag/bugsnag-cocoa/pull/713)
   
 * Enhanced device orientation change breadcrumbs.  These are now reported with "from" and "to" values
   in a form consistent with the Android notifier.

--- a/Tests/BugsnagApiValidationTest.m
+++ b/Tests/BugsnagApiValidationTest.m
@@ -110,14 +110,6 @@
     [Bugsnag removeOnSessionBlock:block];
 }
 
-- (void)testValidOnSendErrorBlock {
-    BOOL (^block)(BugsnagEvent *) = ^BOOL(BugsnagEvent *event) {
-        return NO;
-    };
-    [Bugsnag addOnSendErrorBlock:block];
-    [Bugsnag removeOnSendErrorBlock:block];
-}
-
 - (void)testValidOnBreadcrumbBlock {
     BOOL (^block)(BugsnagBreadcrumb *) = ^BOOL(BugsnagBreadcrumb *breadcrumb) {
         return NO;

--- a/Tests/ClientApiValidationTest.m
+++ b/Tests/ClientApiValidationTest.m
@@ -110,14 +110,6 @@
     [self.client removeOnSessionBlock:block];
 }
 
-- (void)testValidOnSendErrorBlock {
-    BOOL (^block)(BugsnagEvent *) = ^BOOL(BugsnagEvent *event) {
-        return NO;
-    };
-    [self.client addOnSendErrorBlock:block];
-    [self.client removeOnSendErrorBlock:block];
-}
-
 - (void)testValidOnBreadcrumbBlock {
     BOOL (^block)(BugsnagBreadcrumb *) = ^BOOL(BugsnagBreadcrumb *breadcrumb) {
         return NO;

--- a/Tests/Swift Tests/BugsnagSwiftPublicAPITests.swift
+++ b/Tests/Swift Tests/BugsnagSwiftPublicAPITests.swift
@@ -76,12 +76,6 @@ class BugsnagSwiftPublicAPITests: XCTestCase {
         }
         Bugsnag.removeOnSession(block: sessionBlock)
         
-        Bugsnag.addOnSendError(block: onSendErrorBlock)
-        Bugsnag.addOnSendError { (event: BugsnagEvent) -> Bool in
-            return true
-        }
-        Bugsnag.removeOnSendError(block: onSendErrorBlock)
-        
         Bugsnag.addOnBreadcrumb(block: onBreadcrumbBlock)
         Bugsnag.addOnBreadcrumb { (breadcrumb: BugsnagBreadcrumb) -> Bool in
             return true
@@ -284,12 +278,6 @@ class BugsnagSwiftPublicAPITests: XCTestCase {
             return true
         }
         client.removeOnSession(block: sessionBlock)
-        
-        client.addOnSendError(block: onSendErrorBlock)
-        client.addOnSendError { (event: BugsnagEvent) -> Bool in
-            return true
-        }
-        client.removeOnSendError(block: onSendErrorBlock)
         
         client.addOnBreadcrumb(block: onBreadcrumbBlock)
         client.addOnBreadcrumb { (breadcrumb: BugsnagBreadcrumb) -> Bool in

--- a/features/event_callbacks.feature
+++ b/features/event_callbacks.feature
@@ -67,8 +67,6 @@ Feature: Callbacks can access and modify event information
     Then the request is valid for the error reporting API version "4.0" for the "iOS Bugsnag Notifier" notifier
     And the event "metaData.callbacks.notify" equals 0
     And the event "metaData.callbacks.config" equals 1
-    And the event "metaData.callbacks.client" equals 2
-    And the event "metaData.callbacks.secondClient" equals 3
 
   Scenario: An uncaught NSException in a notify callback does not affect error delivery
     When I run "NotifyCallbackCrashScenario"

--- a/features/fixtures/ios-swift-cocoapods/iOSTestApp/scenarios/OnSendCallbackOrderScenario.swift
+++ b/features/fixtures/ios-swift-cocoapods/iOSTestApp/scenarios/OnSendCallbackOrderScenario.swift
@@ -26,17 +26,6 @@ class OnSendCallbackOrderScenario : Scenario {
     }
 
     override func run() {
-        Bugsnag.addOnSendError { (event) -> Bool in
-            event.addMetadata(self.callbackOrder, key: "client", section: "callbacks")
-            self.callbackOrder += 1
-            return true
-        }
-        Bugsnag.addOnSendError { (event) -> Bool in
-            event.addMetadata(self.callbackOrder, key: "secondClient", section: "callbacks")
-            self.callbackOrder += 1
-            return true
-        }
-
         let error = NSError(domain: "OnSendCallbackOrderScenario", code: 100, userInfo: nil)
         Bugsnag.notifyError(error) { (event) -> Bool in
             event.addMetadata(self.callbackOrder, key: "notify", section: "callbacks")

--- a/features/fixtures/ios-swift-cocoapods/iOSTestApp/scenarios/OnSendCallbackRemovalScenario.m
+++ b/features/fixtures/ios-swift-cocoapods/iOSTestApp/scenarios/OnSendCallbackRemovalScenario.m
@@ -25,8 +25,8 @@
         [event addMetadata:@"adding metadata" withKey:@"config2" toSection:@"callbacks"];
         return true;
     }];
+    [self.config removeOnSendErrorBlock:block];
     [super startBugsnag];
-    [Bugsnag removeOnSendErrorBlock:block];
 }
 
 - (void)run {


### PR DESCRIPTION
## Goal

Decision made that modifying delivery-time callbacks on the client doesn't seem very useful (as it's on the subsequent launch) and likely to cause confusion, so removing them from the API.

## Changeset

* Removed from code and headers
* Removed tests for the methods specifically
* Updated expectations on e2e tests
