### PR TITLE
Ensure app/device metadata is added to handled error reports

### DIFF
--- a/Bugsnag/Client/BugsnagClient.m
+++ b/Bugsnag/Client/BugsnagClient.m
@@ -622,7 +622,7 @@ NSString *const BSGBreadcrumbLoadedMessage = @"Bugsnag loaded";
     // add metadata about app/device
     NSDictionary *systemInfo = [BSG_KSSystemInfo systemInfo];
     [self.metadata addMetadata:BSGParseAppMetadata(@{@"system": systemInfo}) toSection:BSGKeyApp];
-    [self.metadata addMetadata:BSGParseDeviceMetadata(systemInfo) toSection:BSGKeyDevice];
+    [self.metadata addMetadata:BSGParseDeviceMetadata(@{@"system": systemInfo}) toSection:BSGKeyDevice];
 }
 
 - (void)addTerminationObserver:(NSString *)name {

--- a/Bugsnag/Payload/BugsnagAppWithState.m
+++ b/Bugsnag/Payload/BugsnagAppWithState.m
@@ -40,9 +40,14 @@
         app.inForeground = [(NSNumber *) inForeground boolValue];
     }
 
+    NSArray *dsyms = json[@"dsymUUIDs"];
+
+    if (dsyms && [dsyms count] > 0) {
+        app.dsymUuid = dsyms[0];
+    }
+
     app.bundleVersion = json[@"bundleVersion"];
     app.codeBundleId = json[@"codeBundleId"];
-    app.dsymUuid = json[@"dsymUuid"];
     app.id = json[@"id"];
     app.releaseStage = json[@"releaseStage"];
     app.type = json[@"type"];

--- a/Bugsnag/Payload/BugsnagDeviceWithState.m
+++ b/Bugsnag/Payload/BugsnagDeviceWithState.m
@@ -18,11 +18,7 @@ NSDictionary *BSGParseDeviceMetadata(NSDictionary *event) {
     NSMutableDictionary *device = [NSMutableDictionary new];
     NSDictionary *state = [event valueForKeyPath:@"user.state.deviceState"];
     [device addEntriesFromDictionary:state];
-
-    // insert for unhandled errors
     BSGDictInsertIfNotNil(device, [event valueForKeyPath:@"system.time_zone"], @"timezone");
-    // handled errors in different location
-    BSGDictInsertIfNotNil(device, [event valueForKeyPath:@"time_zone"], @"timezone");
 
 #if BSG_PLATFORM_SIMULATOR
     BSGDictSetSafeObject(device, @YES, @"simulator");

--- a/Bugsnag/Payload/BugsnagDeviceWithState.m
+++ b/Bugsnag/Payload/BugsnagDeviceWithState.m
@@ -18,7 +18,11 @@ NSDictionary *BSGParseDeviceMetadata(NSDictionary *event) {
     NSMutableDictionary *device = [NSMutableDictionary new];
     NSDictionary *state = [event valueForKeyPath:@"user.state.deviceState"];
     [device addEntriesFromDictionary:state];
-    BSGDictSetSafeObject(device, [event valueForKeyPath:@"system.time_zone"], @"timezone");
+
+    // insert for unhandled errors
+    BSGDictInsertIfNotNil(device, [event valueForKeyPath:@"system.time_zone"], @"timezone");
+    // handled errors in different location
+    BSGDictInsertIfNotNil(device, [event valueForKeyPath:@"time_zone"], @"timezone");
 
 #if BSG_PLATFORM_SIMULATOR
     BSGDictSetSafeObject(device, @YES, @"simulator");

--- a/Tests/BugsnagAppTest.m
+++ b/Tests/BugsnagAppTest.m
@@ -167,7 +167,7 @@
             @"inForeground": @YES,
             @"bundleVersion": @"1",
             @"codeBundleId": @"bundle-123",
-            @"dsymUuid": @"dsym-uuid-123",
+            @"dsymUUIDs": @[@"dsym-uuid-123"],
             @"id": @"com.example.foo.MyIosApp",
             @"releaseStage": @"beta",
             @"type": @"iOS",

--- a/Tests/BugsnagEventPersistLoadTest.m
+++ b/Tests/BugsnagEventPersistLoadTest.m
@@ -129,7 +129,7 @@
                     @"inForeground": @NO,
                     @"bundleVersion": @"5.69",
                     @"codeBundleId": @"293.4",
-                    @"dsymUuid": @"f0ab09ee",
+                    @"dsymUUIDs": @[@"f0ab09ee"],
                     @"id": @"uk.co.bugsnag",
                     @"releaseStage": @"beta",
                     @"type": @"custom",

--- a/Tests/BugsnagEventTests.m
+++ b/Tests/BugsnagEventTests.m
@@ -595,6 +595,7 @@
 
     [client notify:ex block:^BOOL(BugsnagEvent * _Nonnull event) {
         [event clearMetadataFromSection:@"user"];
+        [event clearMetadataFromSection:@"device"];
         NSDictionary *invalidDict = @{};
         NSDictionary *validDict = @{@"myKey" : @"myValue"};
         [event addMetadata:invalidDict toSection:@"mySection"];
@@ -613,6 +614,7 @@
 
     [client notify:ex block:^BOOL(BugsnagEvent * _Nonnull event) {
         [event clearMetadataFromSection:@"user"];
+        [event clearMetadataFromSection:@"device"];
         [event addMetadata:[NSNull null] withKey:@"myKey" toSection:@"mySection"];
 
         // Invalid value for a non-existant section doesn't cause the section to be created


### PR DESCRIPTION
## Goal

Certain App/Device metadata fields were missing from handled error reports due to a refactor in how these are serialized on disk. This PR reinstates them.

## Changeset

Reinstated the following fields for handled errors:

```
app.dsymUUIDs - missing due to bug in deserialization function
device.orientation - not added to `BugsnagDeviceWithState`
metaData.app.name - now populated in initial self.metadata
metaData.device.batteryLevel - populated from self.metadata
metaData.device.charging - populated from self.metadata
metaData.device.simulator - now populated in initial self.metadata
metaData.device.timezone - now populated in initial self.metadata
metaData.device.wordSize - now populated in initial self.metadata
```

## Tests

Updated unit test coverage. Manually verified that a handled + unhandled error contain the expected information.
