### PR TITLE
fix(recording): address unterminated string in thread gathering logic

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,11 @@
 Changelog
 =========
 
+## TBD
+
+* Address unterminated string in thread gathering logic
+  [#720](https://github.com/bugsnag/bugsnag-cocoa/pull/720)
+
 ## 6.0.0 (2020-06-22)
 
 __This version contains many breaking changes__. It is part of an effort to unify our notifier


### PR DESCRIPTION
## Goal

Fixes #719 in gathering thread data for handled errors - the initial memory allocation was incorrectly proceeded by a `strlen` call with no initial terminator added.

## Changeset

Changed the `bsg_kscrw_i_resetThreadTraceData` function from `memset`ing all the data to just null-terminating at 0, which is sufficient for our needs.

Also re-worked the logic slightly to encapsulate all the memory management (including initial malloc) in `bsg_kscrw_i_collectJsonData` and also guarded against `malloc` failing.

## Tests

Ran the example app with Malloc Scribble, Malloc Guard Edges and Guard Malloc enabled.

Also manually tested returning `BSG_KSJSON_ERROR_CANNOT_ADD_DATA` from `bsg_kscrw_i_collectJsonData` to ensure that the error was still delivered.
