### PR TITLE
Make stacktrace properties for error/thread readwrite

### DIFF
--- a/Bugsnag/Payload/BugsnagError.h
+++ b/Bugsnag/Payload/BugsnagError.h
@@ -34,7 +34,7 @@ typedef NS_OPTIONS(NSUInteger, BSGErrorType) {
 /**
  * Sets a representation of this error's stacktrace
  */
-@property(readonly, nonnull) NSArray<BugsnagStackframe *> *stacktrace;
+@property(nonnull) NSArray<BugsnagStackframe *> *stacktrace;
 
 /**
  * The type of the captured error

--- a/Bugsnag/Payload/BugsnagThread.h
+++ b/Bugsnag/Payload/BugsnagThread.h
@@ -39,7 +39,7 @@ typedef NS_OPTIONS(NSUInteger, BSGThreadType) {
 /**
  * Sets a representation of this thread's stacktrace
  */
-@property(readonly, nonnull) NSArray<BugsnagStackframe *> *stacktrace;
+@property(nonnull) NSArray<BugsnagStackframe *> *stacktrace;
 
 /**
  * Determines the type of thread based on the originating platform

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,9 @@ Changelog
 
 ## TBD
 
+* Make stacktrace properties for error/thread readwrite
+  [#722](https://github.com/bugsnag/bugsnag-cocoa/pull/722)
+
 * Address unterminated string in thread gathering logic
   [#720](https://github.com/bugsnag/bugsnag-cocoa/pull/720)
 

--- a/Tests/BugsnagErrorTest.m
+++ b/Tests/BugsnagErrorTest.m
@@ -199,4 +199,13 @@ NSString *BSGParseErrorMessage(NSDictionary *report, NSDictionary *error, NSStri
     }, @{}, @"mach"));
 }
 
+- (void)testStacktraceOverride {
+    BugsnagThread *thread = [self findErrorReportingThread:self.event];
+    BugsnagError *error = [[BugsnagError alloc] initWithEvent:self.event errorReportingThread:thread];
+    XCTAssertNotNil(error.stacktrace);
+    XCTAssertEqual(1, error.stacktrace.count);
+    error.stacktrace = @[];
+    XCTAssertEqual(0, error.stacktrace.count);
+}
+
 @end

--- a/Tests/BugsnagThreadTest.m
+++ b/Tests/BugsnagThreadTest.m
@@ -205,4 +205,12 @@
     XCTAssertEqual(0, [trace[2] count]);
 }
 
+- (void)testStacktraceOverride {
+    BugsnagThread *thread = [[BugsnagThread alloc] initWithThread:self.thread binaryImages:self.binaryImages];
+    XCTAssertNotNil(thread.stacktrace);
+    XCTAssertEqual(1, thread.stacktrace.count);
+    thread.stacktrace = @[];
+    XCTAssertEqual(0, thread.stacktrace.count);
+}
+
 @end


### PR DESCRIPTION
## Goal

Makes the stacktrace property on `errors.stacktrace` mutable, to allow users to modify the stacktrace.

## Tests

Added a unit test to verify the stacktrace is mutable.
