### PR TITLE
Moved binary images store declaration from header file

### DIFF
--- a/Bugsnag/KSCrash/Source/KSCrash/Recording/Tools/BSG_KSMachHeaders.h
+++ b/Bugsnag/KSCrash/Source/KSCrash/Recording/Tools/BSG_KSMachHeaders.h
@@ -36,7 +36,6 @@ typedef struct {
     BSG_Mach_Binary_Image_Info *contents;
 } BSG_Mach_Binary_Images;
 
-static BSG_Mach_Binary_Images bsg_mach_binary_images;
 
 // MARK: - Locking
 

--- a/Bugsnag/KSCrash/Source/KSCrash/Recording/Tools/BSG_KSMachHeaders.m
+++ b/Bugsnag/KSCrash/Source/KSCrash/Recording/Tools/BSG_KSMachHeaders.m
@@ -15,6 +15,8 @@
 
 // MARK: - Locking
 
+static BSG_Mach_Binary_Images bsg_mach_binary_images;
+
 // Pragma's hide unavoidable (and expected) deprecation/unavailable warnings
 _Pragma("clang diagnostic push")
 _Pragma("clang diagnostic ignored \"-Wunguarded-availability\"")


### PR DESCRIPTION
## Goal

The `bsg_mach_binary_images` static variable is currently declared in a header which is potentially causing bugsnag/bugsnag-react-native#462:

```
Definition of '' must be imported from module 'BugsnagReactNative.BSG_KSMachHeaders' before it is required
```

## Design

Declaring it in the header potentially creates multiple instances of the variable so is not good practice.

## Tests

Ensured unhandled errors are symbolicating correctly.

TODO: run against deadlock repro case
