### PR TITLE
V5 backports

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,16 +1,33 @@
 Changelog
 =========
 
+## TBD
+
+### Bug Fixes
+
+The following bug fixes have been applied to the v5 branch to provide a patch
+for users who have not yet upgraded to v6:
+
+* Fix incorrect string comparison of thread names in Mach exception handling
+  [#721](https://github.com/bugsnag/bugsnag-cocoa/pull/721)
+
+* Move binary images store declaration from header file
+  [#725](https://github.com/bugsnag/bugsnag-cocoa/pull/725)
+
+* Avoid dereference null pointer in JSON serialisation
+  [#637](https://github.com/bugsnag/bugsnag-cocoa/pull/637)
+  [Naugladur](https://github.com/Naugladur)
+
 ## 5.23.3 (2020-06-05)
 
-## Bug Fixes
+### Bug Fixes
 
 * Fix DYLD lock mechanism preventing compilation on iOS <10.
   [#675](https://github.com/bugsnag/bugsnag-cocoa/pull/675)
 
 ## 5.23.2 (2020-05-13)
 
-## Bug Fixes
+### Bug Fixes
 
 * Fixed an issue where an app could deadlock during a crash if unfavourable 
   timing caused DYLD lock contention.
@@ -18,7 +35,7 @@ Changelog
 
 ## 5.23.1 (2020-04-08)
 
-## Bug fixes
+### Bug fixes
 
 * Fix possible report corruption when using `notify()` from multiple threads
   when configured to skip capturing/reporting background thread contents

--- a/Source/KSCrash/Source/KSCrash/Recording/BSG_KSCrashReportStore.m
+++ b/Source/KSCrash/Source/KSCrash/Recording/BSG_KSCrashReportStore.m
@@ -83,9 +83,10 @@ static NSString *const kCrashReportSuffix = @"-CrashReport-";
     if (dict != nil) {
         return dict;
     } else {
+        NSError *error = nil;
         NSMutableDictionary *fileContents = [NSMutableDictionary new];
         NSMutableDictionary *recrashReport =
-                [self readFile:[self pathToRecrashReportWithID:fileId] error:nil];
+                [self readFile:[self pathToRecrashReportWithID:fileId] error:&error];
         BSGDictInsertIfNotNil(fileContents, recrashReport, @BSG_KSCrashField_RecrashReport);
         return fileContents;
     }

--- a/Source/KSCrash/Source/KSCrash/Recording/Sentry/BSG_KSCrashSentry_MachException.c
+++ b/Source/KSCrash/Source/KSCrash/Recording/Sentry/BSG_KSCrashSentry_MachException.c
@@ -206,7 +206,7 @@ void *ksmachexc_i_handleExceptions(void *const userData) {
 
     const char *threadName = (const char *)userData;
     pthread_setname_np(threadName);
-    if (threadName == kThreadSecondary) {
+    if (strcmp(threadName, kThreadSecondary) == 0) {
         BSG_KSLOG_DEBUG("This is the secondary thread. Suspending.");
         thread_suspend(bsg_ksmachthread_self());
     }

--- a/Source/KSCrash/Source/KSCrash/Recording/Tools/BSG_KSMachHeaders.h
+++ b/Source/KSCrash/Source/KSCrash/Recording/Tools/BSG_KSMachHeaders.h
@@ -36,7 +36,6 @@ typedef struct {
     BSG_Mach_Binary_Image_Info *contents;
 } BSG_Mach_Binary_Images;
 
-static BSG_Mach_Binary_Images bsg_mach_binary_images;
 
 // MARK: - Locking
 

--- a/Source/KSCrash/Source/KSCrash/Recording/Tools/BSG_KSMachHeaders.m
+++ b/Source/KSCrash/Source/KSCrash/Recording/Tools/BSG_KSMachHeaders.m
@@ -14,6 +14,8 @@
 
 // MARK: - Locking
 
+static BSG_Mach_Binary_Images bsg_mach_binary_images;
+
 // Pragma's hide unavoidable (and expected) deprecation/unavailable warnings
 _Pragma("clang diagnostic push")
 _Pragma("clang diagnostic ignored \"-Wunguarded-availability\"")


### PR DESCRIPTION
## Goal

Apply bug fixes from v6 to v5 for legacy users and whilst v5 is still in use in other notifiers (e.g. React Native).

* Fix incorrect string comparison of thread names in Mach exception handling
  [#721](https://github.com/bugsnag/bugsnag-cocoa/pull/721)

* Move binary images store declaration from header file
  [#725](https://github.com/bugsnag/bugsnag-cocoa/pull/725)

* Avoid dereference null pointer in JSON serialisation
  [#637](https://github.com/bugsnag/bugsnag-cocoa/pull/637)
  [Naugladur](https://github.com/Naugladur)

## Tests

Smoke tested on this branch - previous testing completed on v6.
