### PR TITLE
Automatically instantiate BugsnagReactNativePlugin

### DIFF
--- a/Bugsnag/Client/BugsnagClient.m
+++ b/Bugsnag/Client/BugsnagClient.m
@@ -433,7 +433,8 @@ NSString *_lastOrientation = nil;
         [self.configuration.config addObserverWithBlock:observer];
         [self.state addObserverWithBlock:observer];
 
-        self.pluginClient = [[BugsnagPluginClient alloc] initWithPlugins:self.configuration.plugins];
+        self.pluginClient = [[BugsnagPluginClient alloc] initWithPlugins:self.configuration.plugins
+                                                                  client:self];
 
 #if BSG_PLATFORM_IOS
         _lastOrientation = BSGOrientationNameFromEnum([UIDevice currentDevice].orientation);

--- a/Bugsnag/Plugins/BugsnagPluginClient.h
+++ b/Bugsnag/Plugins/BugsnagPluginClient.h
@@ -14,7 +14,8 @@ NS_ASSUME_NONNULL_BEGIN
 
 @interface BugsnagPluginClient : NSObject
 
-- (instancetype _Nonnull)initWithPlugins:(NSMutableSet<id<BugsnagPlugin>> *_Nonnull)plugins;
+- (instancetype _Nonnull)initWithPlugins:(NSMutableSet<id<BugsnagPlugin>> *_Nonnull)plugins
+                                  client:(BugsnagClient *)client;
 - (void)loadPlugins;
 
 @end

--- a/Bugsnag/Plugins/BugsnagPluginClient.m
+++ b/Bugsnag/Plugins/BugsnagPluginClient.m
@@ -11,27 +11,49 @@
 #import "BugsnagPlugin.h"
 #import "BugsnagLogger.h"
 
+static NSString *const kPluginReactNative = @"BugsnagReactNativePlugin";
+
 @interface Bugsnag ()
 + (BugsnagClient *)client;
 @end
 
 @interface BugsnagPluginClient ()
 @property NSSet<id<BugsnagPlugin>> *plugins;
+@property BugsnagClient *client;
 @end
 
 @implementation BugsnagPluginClient
 
-- (instancetype _Nonnull)initWithPlugins:(NSMutableSet<id<BugsnagPlugin>> *_Nonnull)plugins {
+- (instancetype _Nonnull)initWithPlugins:(NSMutableSet<id<BugsnagPlugin>> *_Nonnull)plugins
+                                  client:(BugsnagClient *)client {
     if (self = [super init]) {
-        _plugins = [NSSet setWithSet:plugins];
+        NSMutableSet *instantiatedPlugins = [plugins mutableCopy];
+        id rnPlugin = [self instantiateBugsnagPlugin:kPluginReactNative];
+
+        if (rnPlugin) {
+            [instantiatedPlugins addObject:rnPlugin];
+        }
+        _plugins = [NSSet setWithSet:instantiatedPlugins];
+        _client = client;
     }
     return self;
+}
+
+/**
+ * Automagically instantiate plugins which Bugsnag uses via class name (e.g. BugsnagReactNativePlugin)
+ */
+- (id)instantiateBugsnagPlugin:(NSString *)clzName {
+    Class clz = NSClassFromString(clzName);
+    if (clz) {
+        return [clz new];
+    }
+    return nil;
 }
 
 - (void)loadPlugins {
     for (id<BugsnagPlugin> plugin in self.plugins) {
         @try {
-            [plugin load:[Bugsnag client]];
+            [plugin load:self.client];
         } @catch (NSException *exception) {
             bsg_log_err(@"Failed to load plugin %@, continuing with initialisation.", plugin);
         }


### PR DESCRIPTION
## Goal

Automatically instantiates the `BugsnagReactNativePlugin` if the class exists. This change is required to set callbacks in React Native which are invoked before the React Native layer has initialized.

## Changeset

- Refactored `BugsnagPluginClient` to take a `client` in the constructor rather than relying on the static facade
- Instantiated the `BugsnagReactNativePlugin` class if it exists and add it to the set of plugins to be loaded