### PR TITLE
fix(kscrash): disable introspection for handled thread traces

### DIFF
--- a/Bugsnag/KSCrash/Source/KSCrash/Recording/BSG_KSCrashC.c
+++ b/Bugsnag/KSCrash/Source/KSCrash/Recording/BSG_KSCrashC.c
@@ -226,6 +226,9 @@ char *bsg_kscrash_captureThreadTrace(int discardDepth, int frameCount, uintptr_t
     context->crash.userException.discardDepth = discardDepth;
     context->crash.offendingThread = bsg_ksmachthread_self();
     context->crash.crashType = BSG_KSCrashTypeUserReported;
+
+    // No need to gather notable addresses for handled errors
+    context->config.introspectionRules.enabled = false;
     
     // Only suspend threads if tracing is set to always
     // (to ensure trace is captured at the same point in time)

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,11 @@
 Changelog
 =========
 
+## TBD
+
+* Disable reporting of notable addresses from registers for handled errors
+  [#741](https://github.com/bugsnag/bugsnag-cocoa/pull/741)
+
 ## 6.0.1 (2020-06-29)
 
 * Move binary images store declaration from header file


### PR DESCRIPTION
## Goal

We do not use the data captured inside the `notable_addresses` field of the crash report and this data is not useful for handled exceptions anyway as it's intended for looking for crash reasons. Now that we are gathering thread traces in memory, the strings used in the trace appear to get picked up from the registers, making for a lot of unnecessary processing.

## Changeset

Disabled `config.introspectionRules.enabled` when getting a thread trace for handled errors.

## Tests

Verified no difference in payload before/after change. 
