### PR TITLE
test(mach): fix macOS tests

### DIFF
--- a/Bugsnag/KSCrash/Source/KSCrash/Recording/BSG_KSCrashC.c
+++ b/Bugsnag/KSCrash/Source/KSCrash/Recording/BSG_KSCrashC.c
@@ -102,6 +102,7 @@ BSG_KSCrashType bsg_kscrash_install(const char *const crashReportFilePath,
     // Initialize local store of dynamically loaded libraries so that binary
     // image information can be extracted for reports
     bsg_mach_headers_initialize();
+    bsg_mach_headers_register_for_changes();
     
     if (bsg_g_installed) {
         BSG_KSLOG_DEBUG("Crash reporter already installed.");

--- a/Bugsnag/KSCrash/Source/KSCrash/Recording/Tools/BSG_KSMachHeaders.h
+++ b/Bugsnag/KSCrash/Source/KSCrash/Recording/Tools/BSG_KSMachHeaders.h
@@ -43,6 +43,11 @@ typedef struct bsg_mach_image {
 void bsg_mach_headers_initialize(void);
 
 /**
+  * Registers with dyld to keep data updated when libraries are loaded and unloaded
+ */
+void bsg_mach_headers_register_for_changes(void);
+
+/**
  * Returns the head of the link list of headers
  */
 BSG_Mach_Header_Info *bsg_mach_headers_get_images(void);

--- a/Bugsnag/KSCrash/Source/KSCrash/Recording/Tools/BSG_KSMachHeaders.m
+++ b/Bugsnag/KSCrash/Source/KSCrash/Recording/Tools/BSG_KSMachHeaders.m
@@ -103,12 +103,16 @@ void bsg_mach_headers_initialize() {
     
     bsg_g_mach_headers_images_head = NULL;
     bsg_g_mach_headers_images_tail = NULL;
+}
+
+void bsg_mach_headers_register_for_changes() {
     
     // Register for binary images being loaded and unloaded. dyld calls the add function once
     // for each library that has already been loaded and then keeps this cache up-to-date
     // with future changes
     _dyld_register_func_for_add_image(&bsg_mach_headers_add_image);
     _dyld_register_func_for_remove_image(&bsg_mach_headers_remove_image);
+
 }
 
 /**

--- a/Tests/KSCrash/KSMachHeader_Tests.m
+++ b/Tests/KSCrash/KSMachHeader_Tests.m
@@ -12,7 +12,6 @@
 
 void bsg_mach_headers_add_image(const struct mach_header *mh, intptr_t slide);
 
-
 const struct mach_header header1 = {
     .magic = MH_MAGIC,
     .cputype = 0,
@@ -48,40 +47,43 @@ const struct segment_command command2 = {
     
     bsg_mach_headers_initialize();
     
-    // Get to the end of the list of system images to check additions
-    BSG_Mach_Header_Info *listTail;
-    for (BSG_Mach_Header_Info *img = bsg_mach_headers_get_images(); img != NULL; img = img->next) {
-        listTail = img;
-    }
-    
     bsg_mach_headers_add_image(&header1, 0);
     
-    XCTAssertEqual(listTail->next->imageVmAddr, 111);
-    XCTAssert(listTail->next->unloaded == FALSE);
+    BSG_Mach_Header_Info *listTail;
+    
+    listTail = bsg_mach_headers_get_images();
+    XCTAssertEqual(listTail->imageVmAddr, 111);
+    XCTAssert(listTail->unloaded == FALSE);
     
     bsg_mach_headers_add_image(&header2, 0);
-    
-    XCTAssertEqual(listTail->next->imageVmAddr, 111);
+
+    listTail = bsg_mach_headers_get_images();
+    XCTAssertEqual(listTail->imageVmAddr, 111);
+    XCTAssert(listTail->unloaded == FALSE);
+    XCTAssertEqual(listTail->next->imageVmAddr, 222);
     XCTAssert(listTail->next->unloaded == FALSE);
-    XCTAssertEqual(listTail->next->next->imageVmAddr, 222);
-    XCTAssert(listTail->next->next->unloaded == FALSE);
-    
+
     bsg_mach_headers_remove_image(&header1, 0);
-    XCTAssertEqual(listTail->next->imageVmAddr, 111);
-    XCTAssert(listTail->next->unloaded == TRUE);
-    XCTAssertEqual(listTail->next->next->imageVmAddr, 222);
-    XCTAssert(listTail->next->next->unloaded == FALSE);
     
+    listTail = bsg_mach_headers_get_images();
+    XCTAssertEqual(listTail->imageVmAddr, 111);
+    XCTAssert(listTail->unloaded == TRUE);
+    XCTAssertEqual(listTail->next->imageVmAddr, 222);
+    XCTAssert(listTail->next->unloaded == FALSE);
+
     bsg_mach_headers_remove_image(&header2, 0);
-    XCTAssertEqual(listTail->next->imageVmAddr, 111);
+    
+    listTail = bsg_mach_headers_get_images();
+    XCTAssertEqual(listTail->imageVmAddr, 111);
+    XCTAssert(listTail->unloaded == TRUE);
+    XCTAssertEqual(listTail->next->imageVmAddr, 222);
     XCTAssert(listTail->next->unloaded == TRUE);
-    XCTAssertEqual(listTail->next->next->imageVmAddr, 222);
-    XCTAssert(listTail->next->next->unloaded == TRUE);
     
 }
 
 - (void)testFindImageAtAddress {
     bsg_mach_headers_initialize();
+    
     bsg_mach_headers_add_image(&header1, 0);
     bsg_mach_headers_add_image(&header2, 0);
     


### PR DESCRIPTION
## Goal

The macOS unit tests currently fail on `next` on my machine as the unit tests are picking up libraries loaded by the OS and not matching the expected mach record added by the unit test.

I've split out registering for dyld updates into a separate function so that the tests can verify the behavior without libraries loaded by the runtime interfering.
