### PR TITLE
fix(issue template): pod version command incorrect

### DIFF
--- a/.github/ISSUE_TEMPLATE/Bug_report.md
+++ b/.github/ISSUE_TEMPLATE/Bug_report.md
@@ -17,7 +17,7 @@ about: Create a report to help us improve the library
 Library versions:
 
 * Bugsnag version (from your Podfile, Podfile.lock, or elsewhere):
-* CocoaPods version (if any) (`pod -v`):
+* CocoaPods version (if any) (`pod --version`):
 * Carthage version (if any):
 * iOS/tvOS/macOS version(s)
 * debug mode or production?:

--- a/.github/SUPPORT.md
+++ b/.github/SUPPORT.md
@@ -7,7 +7,7 @@ Include the following information to help us understand your environment:
 
 ### Library versions
 
-* CocoaPods version (if any) (`pod -v`):
+* CocoaPods version (if any) (`pod --version`):
 * Carthage version (if any):
 * iOS/tvOS/macOS version(s)
 * debug mode or production?:


### PR DESCRIPTION
## Goal
`pod -v` is now `pod --version`, updated in all docs accordingly.

## Changeset
Changed the command instruction in:
* `.github/ISSUE_TEMPLATE/Bug_report.md`
* `.github/SUPPORT.md`

## Tests
Using cocoapods 1.8.4 (latest), run `pod -v` results in:
```
$ pod -v
[!] Unknown command: `-v`
Did you mean: env?
...
```
Running `pod --version` results in:
```
$ pod --version
1.8.4
```