### PR TITLE
docs(breadcrumbs): updated outdated docs for BugsnagBreadcrumbs.arrayValue

### DIFF
--- a/Bugsnag/Breadcrumbs/BugsnagBreadcrumbs.h
+++ b/Bugsnag/Breadcrumbs/BugsnagBreadcrumbs.h
@@ -36,9 +36,7 @@ typedef void (^BSGBreadcrumbConfiguration)(BugsnagBreadcrumb *_Nonnull);
     (void (^_Nonnull)(BugsnagBreadcrumb *_Nonnull))block;
 
 /**
- * Serializable array representation of breadcrumbs, represented as nested
- * strings in the format:
- * [[timestamp,message]...]
+ * Generates an array of dictionaries representing the current buffer of breadcrumbs.
  */
 - (NSArray *_Nonnull)arrayValue;
 


### PR DESCRIPTION
## Goal

As per #747, the docs on BugsnagBreadcrumbs.arrayValue were out of date as they now return an array of dictionaries, not strings.