### PR TITLE
Use correct depth when collecting threads from RN

### DIFF
--- a/Bugsnag/Client/BugsnagClient.m
+++ b/Bugsnag/Client/BugsnagClient.m
@@ -1565,7 +1565,11 @@ NSString *const BSGBreadcrumbLoadedMessage = @"Bugsnag loaded";
 }
 
 - (NSArray *)collectThreads {
-    int depth = (int)(BSGNotifierStackFrameCount);
+    // discard the following
+    // 1. [BugsnagReactNative getPayloadInfo:resolve:reject:]
+    // 2. [BugsnagClient collectThreads:]
+    // 3. [BSG_KSCrash captureThreads:]
+    int depth = 3;
     NSException *exc = [NSException exceptionWithName:@"Bugsnag" reason:@"" userInfo:nil];
     NSArray<BugsnagThread *> *threads = [[BSG_KSCrash sharedInstance] captureThreads:exc depth:depth];
     return [BugsnagThread serializeThreads:threads];


### PR DESCRIPTION
## Goal

Alters the number of stackframes discarded when collecting threads in a React Native app, so that bugsnag frames do not show up in the thread trace.

Tested by using the RN example app to send a handled JS error before and after the change.