### PR TITLE
fix(breadcrumbs): further refactor of count into barrier guard

### DIFF
--- a/Bugsnag/Breadcrumbs/BugsnagBreadcrumbs.m
+++ b/Bugsnag/Breadcrumbs/BugsnagBreadcrumbs.m
@@ -116,9 +116,9 @@
 }
 
 - (NSArray *)arrayValue {
-    __block NSMutableArray *contents =
-        [[NSMutableArray alloc] initWithCapacity:self.breadcrumbs.count];
+    __block NSMutableArray *contents;
     dispatch_barrier_sync(self.readWriteQueue, ^{
+        contents = [[NSMutableArray alloc] initWithCapacity:self.breadcrumbs.count];
         for (BugsnagBreadcrumb *crumb in self.breadcrumbs) {
             NSDictionary *objectValue = [crumb objectValue];
             NSError *error = nil;


### PR DESCRIPTION
## Goal

Fixes a further race condition caught in QA. I had initially thought to exclude the count from the barrier guard as it's just the initial capacity and so in the condition where the count changes shortly afterwards, there is just a minor performance impact to reinitialise the array.

However, in the interests of covering all uncertainties, I have now moved this into the barrier guard.

## Tests

Tested using a tight loop of breadcrumbs followed by a `notify` call:
```
for (int i = 1; i <= 200; i++)
{
    dispatch_queue_t _processingQueue = dispatch_queue_create("CrashReporting", DISPATCH_QUEUE_SERIAL);
    dispatch_async(_processingQueue, ^{
                   [Bugsnag leaveBreadcrumbWithMessage:@"message"];
    });
}
```