### PR TITLE
fix(session tracker): fix synchronization of de-duplication code

### DIFF
--- a/Bugsnag/Delivery/BugsnagSessionTrackingApiClient.m
+++ b/Bugsnag/Delivery/BugsnagSessionTrackingApiClient.m
@@ -50,12 +50,15 @@
     NSDictionary<NSString *, NSDictionary *> *filesWithIds = [store allFilesByName];
 
     for (NSString *fileId in [filesWithIds allKeys]) {
-        // skip dupe requests
-        if ([self isActiveRequest:fileId]) {
-            continue;
+
+        // De-duplicate files as deletion of the file is asynchronous and so multiple calls
+        // to this method will result in multiple send requests
+        @synchronized (self.activeIds) {
+            if ([self.activeIds containsObject:fileId]) {
+                continue;
+            }
+            [self.activeIds addObject:fileId];
         }
-        // add request
-        [self.activeIds addObject:fileId];
 
         BugsnagSession *session = [[BugsnagSession alloc] initWithDictionary:filesWithIds[fileId]];
 
@@ -77,7 +80,7 @@
                     headers:HTTPHeaders
                onCompletion:^(NSUInteger sentCount, BOOL success, NSError *error) {
                    if (success && error == nil) {
-                       bsg_log_info(@"Sent %lu sessions to Bugsnag", (unsigned long) sessionCount);
+                       bsg_log_info(@"Sent session %@ to Bugsnag", session.id);
                        [store deleteFileWithId:fileId];
                    } else {
                        bsg_log_warn(@"Failed to send sessions to Bugsnag: %@", error);

--- a/Bugsnag/Delivery/BugsnagSessionTrackingApiClient.m
+++ b/Bugsnag/Delivery/BugsnagSessionTrackingApiClient.m
@@ -67,7 +67,6 @@
                 initWithSessions:@[session]
                           config:[Bugsnag configuration]
                     codeBundleId:self.codeBundleId];
-            NSUInteger sessionCount = payload.sessions.count;
             NSMutableDictionary *data = [payload toJson];
             NSDictionary *HTTPHeaders = @{
                     @"Bugsnag-Payload-Version": @"1.0",
@@ -87,19 +86,12 @@
                    }
 
                    // remove request
-                   [self.activeIds removeObject:fileId];
+                   @synchronized (self.activeIds) {
+                       [self.activeIds removeObject:fileId];
+                   }
                }];
         }];
     }
-}
-
-- (BOOL)isActiveRequest:(NSString *)fileId {
-    for (NSString *val in self.activeIds) {
-        if ([val isEqualToString:fileId]) {
-            return true;
-        }
-    }
-    return false;
 }
 
 @end

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,12 @@
 Changelog
 =========
 
+## TBD
+
+### Bug fixes
+
+* Synchronize access to sessions being delivered in de-duplication code
+
 ## 6.1.1 (2020-07-16)
 
 ### Bug fixes

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,7 @@ Changelog
 ### Bug fixes
 
 * Synchronize access to sessions being delivered in de-duplication code
+  [#756](https://github.com/bugsnag/bugsnag-cocoa/pull/756)
 
 ## 6.1.1 (2020-07-16)
 


### PR DESCRIPTION
## Goal

Fixes #750 - makes the list checking logic in session sending thread safe.

## Changeset

* Delivery/BugsnagSessionTrackingApiClient.m - used `NSSet`'s `containsObject` rather than iterate ourselves and wrapped the list mutation in a synchronized block.
* Delivery/BugsnagSessionTrackingApiClient.m - also updated the log message to show session ID rather than a count (as this is always 1 now)

## Tests

Load-tested calling `startSession` across multiple threads:

```
    for (int i = 1; i <= 200; i++)
    {
        dispatch_queue_t _processingQueue = dispatch_queue_create("CrashReporting", DISPATCH_QUEUE_SERIAL);
        dispatch_async(_processingQueue, ^{
            [Bugsnag startSession];
        });
    }
```

