### PR TITLE
Serialize codeBundleId for unhandled errors

### DIFF
--- a/Bugsnag/BugsnagErrorReportSink.m
+++ b/Bugsnag/BugsnagErrorReportSink.m
@@ -45,16 +45,11 @@
 - (NSDictionary *)toDict;
 @end
 
-@interface BugsnagClient ()
-@property (nonatomic) NSString *codeBundleId;
-@end
-
 @interface BugsnagEvent ()
 - (NSDictionary *_Nonnull)toJson;
 - (BOOL)shouldBeSent;
 - (instancetype _Nonnull)initWithKSReport:(NSDictionary *_Nonnull)report;
 @property NSSet<NSString *> *redactedKeys;
-@property (nonatomic) NSString *codeBundleId;
 @end
 
 @interface BugsnagConfiguration ()
@@ -123,7 +118,6 @@
     for (NSString *fileKey in keys) {
         NSDictionary *report = ksCrashReports[fileKey];
         BugsnagEvent *event = [[BugsnagEvent alloc] initWithKSReport:report];
-        event.codeBundleId = [Bugsnag client].codeBundleId;
         event.redactedKeys = configuration.redactedKeys;
 
         if ([event shouldBeSent] && [self runOnSendBlocks:configuration event:event]) {

--- a/Bugsnag/Client/BugsnagClient.m
+++ b/Bugsnag/Client/BugsnagClient.m
@@ -669,6 +669,7 @@ NSString *const BSGBreadcrumbLoadedMessage = @"Bugsnag loaded";
 
 - (void)setCodeBundleId:(NSString *)codeBundleId {
     _codeBundleId = codeBundleId;
+    [self.state addMetadata:codeBundleId withKey:BSGKeyCodeBundleId toSection:BSGKeyApp];
     self.oomWatchdog.codeBundleId = codeBundleId;
     self.sessionTracker.codeBundleId = codeBundleId;
 }

--- a/Bugsnag/Helpers/BugsnagKeys.h
+++ b/Bugsnag/Helpers/BugsnagKeys.h
@@ -25,6 +25,7 @@ extern NSString *const BSGKeyBatteryLevel;
 extern NSString *const BSGKeyBreadcrumbs;
 extern NSString *const BSGKeyBundleVersion;
 extern NSString *const BSGKeyCharging;
+extern NSString *const BSGKeyCodeBundleId;
 extern NSString *const BSGKeyConfig;
 extern NSString *const BSGKeyContext;
 extern NSString *const BSGKeyCppException;

--- a/Bugsnag/Helpers/BugsnagKeys.m
+++ b/Bugsnag/Helpers/BugsnagKeys.m
@@ -21,6 +21,7 @@ NSString *const BSGKeyBatteryLevel = @"batteryLevel";
 NSString *const BSGKeyBreadcrumbs = @"breadcrumbs";
 NSString *const BSGKeyBundleVersion = @"bundleVersion";
 NSString *const BSGKeyCharging = @"charging";
+NSString *const BSGKeyCodeBundleId = @"codeBundleId";
 NSString *const BSGKeyConfig = @"config";
 NSString *const BSGKeyContext = @"context";
 NSString *const BSGKeyCppException = @"cpp_exception";

--- a/Bugsnag/Payload/BugsnagApp.m
+++ b/Bugsnag/Payload/BugsnagApp.m
@@ -64,7 +64,7 @@ NSDictionary *BSGParseAppMetadata(NSDictionary *event) {
         ([config valueForKey:@"appVersion"] ?:
             system[@"CFBundleShortVersionString"]);
     app.releaseStage = [event valueForKeyPath:@"user.config.releaseStage"] ?: config.releaseStage;
-    app.codeBundleId = codeBundleId;
+    app.codeBundleId = [event valueForKeyPath:@"user.state.app.codeBundleId"] ?: codeBundleId;
     app.type = config.appType;
 }
 

--- a/Tests/BugsnagEventTests.m
+++ b/Tests/BugsnagEventTests.m
@@ -35,6 +35,7 @@
 @interface BugsnagEvent ()
 - (NSDictionary *_Nonnull)toJson;
 - (BOOL)shouldBeSent;
+- (instancetype)initWithUserData:(NSDictionary *)event;
 - (instancetype)initWithKSReport:(NSDictionary *)report;
 - (instancetype)initWithApp:(BugsnagAppWithState *)app
                      device:(BugsnagDeviceWithState *)device
@@ -795,6 +796,32 @@
     XCTAssertNil(event.user.id);
     XCTAssertNil(event.user.name);
     XCTAssertNil(event.user.email);
+}
+
+- (void)testCodeBundleIdHandled {
+    BugsnagEvent *event = [[BugsnagEvent alloc] initWithUserData:@{
+            @"user": @{
+                    @"event": @{
+                            @"app": @{
+                                    @"codeBundleId": @"cb-123"
+                            }
+                    }
+            }
+    }];
+    XCTAssertEqualObjects(@"cb-123", event.app.codeBundleId);
+}
+
+- (void)testCodeBundleIdUnhandled {
+    BugsnagEvent *event = [[BugsnagEvent alloc] initWithKSReport:@{
+            @"user": @{
+                    @"state": @{
+                            @"app": @{
+                                    @"codeBundleId": @"cb-123"
+                            }
+                    }
+            }
+    }];
+    XCTAssertEqualObjects(@"cb-123", event.app.codeBundleId);
 }
 
 @end


### PR DESCRIPTION
## Goal

Serializes `codeBundleId` when writing unhandled errors, which use a different serialization mechanism to handled errors.

This prevents the codeBundleId from being null when sending an unhandled error report on the next launch.

## Tests

Added unit tests to verify that the deserialization in `BugsnagEvent` works for both handled + unhandled errors.
