### PR TITLE
Serialize runtimeVersions info for unhandled errors

### DIFF
--- a/Bugsnag/Client/BugsnagClient.m
+++ b/Bugsnag/Client/BugsnagClient.m
@@ -1576,6 +1576,7 @@ NSString *const BSGBreadcrumbLoadedMessage = @"Bugsnag loaded";
     if (info != nil && key != nil) {
         self.extraRuntimeInfo[key] = info;
     }
+    [self.state addMetadata:self.extraRuntimeInfo withKey:BSGKeyExtraRuntimeInfo toSection:BSGKeyDevice];
 }
 
 @end

--- a/Bugsnag/Helpers/BugsnagKeys.h
+++ b/Bugsnag/Helpers/BugsnagKeys.h
@@ -42,6 +42,7 @@ extern NSString *const BSGKeyException;
 extern NSString *const BSGKeyExceptionName;
 extern NSString *const BSGKeyExceptions;
 extern NSString *const BSGKeyExecutableName;
+extern NSString *const BSGKeyExtraRuntimeInfo;
 extern NSString *const BSGKeyFrameAddrFormat;
 extern NSString *const BSGKeyFrameAddress;
 extern NSString *const BSGKeyGroupingHash;

--- a/Bugsnag/Helpers/BugsnagKeys.m
+++ b/Bugsnag/Helpers/BugsnagKeys.m
@@ -38,6 +38,7 @@ NSString *const BSGKeyException = @"exception";
 NSString *const BSGKeyExceptionName = @"exception_name";
 NSString *const BSGKeyExceptions = @"exceptions";
 NSString *const BSGKeyExecutableName = @"CFBundleExecutable";
+NSString *const BSGKeyExtraRuntimeInfo = @"extraRuntimeInfo";
 NSString *const BSGKeyFrameAddrFormat = @"0x%lx";
 NSString *const BSGKeyFrameAddress = @"frameAddress";
 NSString *const BSGKeyGroupingHash = @"groupingHash";

--- a/Bugsnag/Payload/BugsnagDeviceWithState.m
+++ b/Bugsnag/Payload/BugsnagDeviceWithState.m
@@ -57,7 +57,7 @@ NSNumber *BSGDeviceFreeSpace(NSSearchPathDirectory directory) {
 @interface BugsnagDevice ()
 + (void)populateFields:(BugsnagDevice *)device
             dictionary:(NSDictionary *)event;
-
+- (void)appendRuntimeInfo:(NSDictionary *)info;
 - (NSDictionary *)toDictionary;
 @end
 
@@ -113,6 +113,13 @@ NSNumber *BSGDeviceFreeSpace(NSSearchPathDirectory directory) {
     if (val != nil) {
         device.time = [BSG_RFC3339DateTool dateFromString:val];
     }
+
+    NSDictionary *extraRuntimeInfo = [event valueForKeyPath:@"user.state.device.extraRuntimeInfo"];
+
+    if (extraRuntimeInfo) {
+        [device appendRuntimeInfo:extraRuntimeInfo];
+    }
+
     return device;
 }
 

--- a/Tests/BugsnagEventTests.m
+++ b/Tests/BugsnagEventTests.m
@@ -824,4 +824,28 @@
     XCTAssertEqualObjects(@"cb-123", event.app.codeBundleId);
 }
 
+- (void)testRuntimeVersionsUnhandled {
+    NSDictionary *runtimeVersions = @{
+            @"fooVersion": @"5.23",
+            @"barVersion": @"7.902.40fc"
+    };
+    BugsnagEvent *event = [[BugsnagEvent alloc] initWithKSReport:@{
+            @"system": @{
+                    @"os_version": @"13.2"
+            },
+            @"user": @{
+                    @"state": @{
+                            @"device": @{
+                                    @"extraRuntimeInfo": runtimeVersions
+                            }
+                    }
+            }
+    }];
+    NSDictionary *expected = @{
+            @"fooVersion": @"5.23",
+            @"barVersion": @"7.902.40fc",
+            @"osBuild": @"13.2"
+    };
+    XCTAssertEqualObjects(expected, event.device.runtimeVersions);
+}
 @end


### PR DESCRIPTION
## Goal

Ensures that additional runtimeVersions information for React Native is serialized when constructing an unhandled error report.

## Changeset

- Serialized additional runtimeVersions information in `self.state` when adding to the `BugsnagClient`
- Appended this information when deserializing the error report from disk

## Tests

Added a unit test to verify deserialization and verified that the JSON payload (as inspected via a debugger) contains the correct runtimeVersions info.
