### PR TITLE
Respect bundle version set from config

### DIFF
--- a/Bugsnag/Payload/BugsnagApp.m
+++ b/Bugsnag/Payload/BugsnagApp.m
@@ -57,12 +57,12 @@ NSDictionary *BSGParseAppMetadata(NSDictionary *event) {
 {
     NSDictionary *system = event[BSGKeySystem];
     app.id = system[@"CFBundleIdentifier"];
-    app.bundleVersion = [event valueForKeyPath:@"user.config.bundleVersion"] ?: system[@"CFBundleVersion"];
+    app.bundleVersion = [event valueForKeyPath:@"user.config.bundleVersion"] ?:
+            (config.bundleVersion ?: system[@"CFBundleVersion"]);
     app.dsymUuid = system[@"app_uuid"];
     // Preferentially take App version values from the event, the config and the system
     app.version = [event valueForKeyPath:@"user.config.appVersion"] ?:
-        ([config valueForKey:@"appVersion"] ?:
-            system[@"CFBundleShortVersionString"]);
+        (config.appVersion ?: system[@"CFBundleShortVersionString"]);
     app.releaseStage = [event valueForKeyPath:@"user.config.releaseStage"] ?: config.releaseStage;
     app.codeBundleId = [event valueForKeyPath:@"user.state.app.codeBundleId"] ?: codeBundleId;
     app.type = config.appType;

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,8 @@ Changelog
 ## TBD
 
 ### Bug fixes
+* Respect bundle version set from config
+  [#762](https://github.com/bugsnag/bugsnag-cocoa/pull/762)
 
 * Ensure foreground stats are recorded for handled errors
   [#755](https://github.com/bugsnag/bugsnag-cocoa/pull/755)

--- a/Tests/BugsnagAppTest.m
+++ b/Tests/BugsnagAppTest.m
@@ -214,4 +214,26 @@
     XCTAssertEqualObjects(@"1.2.3", app.version);
 }
 
+- (void)testBundleVersionPrecedence {
+    // default to system.CFBundleVersion
+    self.config.bundleVersion = nil;
+    BugsnagAppWithState *app = [BugsnagAppWithState appWithDictionary:self.data config:self.config codeBundleId:self.codeBundleId];
+    XCTAssertEqualObjects(@"1", app.bundleVersion);
+
+    // 2nd precedence is config.bundleVersion
+    self.config.bundleVersion = @"4.2.6";
+    app = [BugsnagAppWithState appWithDictionary:self.data config:self.config codeBundleId:self.codeBundleId];
+    XCTAssertEqualObjects(@"4.2.6", app.bundleVersion);
+
+    // 1st precedence is user.config.bundleVersion
+    NSMutableDictionary *data = [self.data mutableCopy];
+    data[@"user"] = @{
+            @"config": @{
+                    @"bundleVersion": @"1.2.3"
+            }
+    };
+    app = [BugsnagAppWithState appWithDictionary:data config:self.config codeBundleId:self.codeBundleId];
+    XCTAssertEqualObjects(@"1.2.3", app.bundleVersion);
+}
+
 @end

--- a/Tests/BugsnagAppTest.m
+++ b/Tests/BugsnagAppTest.m
@@ -62,6 +62,7 @@
 
     self.config = [[BugsnagConfiguration alloc] initWithApiKey:DUMMY_APIKEY_32CHAR_1];
     self.config.appType = @"iOS";
+    self.config.bundleVersion = nil;
     self.config.appVersion = @"3.14.159";
     self.codeBundleId = @"bundle-123";
 }

--- a/Tests/BugsnagErrorReportSinkTests.m
+++ b/Tests/BugsnagErrorReportSinkTests.m
@@ -71,6 +71,7 @@
                                                                    sessions:@"http://localhost:1234"];
     BugsnagClient *client = [[BugsnagClient alloc] initWithConfiguration:config];
     [client start];
+    // required due to BugsnagEvent using global singleton
     [Bugsnag configuration].bundleVersion = @"3.2";
     BugsnagEvent *report =
             [[BugsnagEvent alloc] initWithKSReport:self.rawReportData];

--- a/Tests/BugsnagErrorReportSinkTests.m
+++ b/Tests/BugsnagErrorReportSinkTests.m
@@ -21,6 +21,10 @@
 @property NSDictionary *processedData;
 @end
 
+@interface Bugsnag ()
++ (BugsnagConfiguration *)configuration;
+@end
+
 @interface BugsnagClient ()
 - (void)start;
 @end
@@ -67,6 +71,7 @@
                                                                    sessions:@"http://localhost:1234"];
     BugsnagClient *client = [[BugsnagClient alloc] initWithConfiguration:config];
     [client start];
+    [Bugsnag configuration].bundleVersion = @"3.2";
     BugsnagEvent *report =
             [[BugsnagEvent alloc] initWithKSReport:self.rawReportData];
     self.processedData = [[BugsnagErrorReportSink new] prepareEventPayload:report];
@@ -320,7 +325,7 @@
     XCTAssertEqualObjects(app[@"id"], @"net.hockeyapp.CrashProbeiOS");
     XCTAssertNotNil(app[@"type"]);
     XCTAssertEqualObjects(app[@"version"], @"1.0");
-    XCTAssertEqualObjects(app[@"bundleVersion"], @"1");
+    XCTAssertEqualObjects(app[@"bundleVersion"], @"3.2");
     XCTAssertEqualObjects(app[@"releaseStage"], @"production");
     XCTAssertEqualObjects(app[@"dsymUUIDs"], @[@"D0A41830-4FD2-3B02-A23B-0741AD4C7F52"]);
     XCTAssertEqualObjects(app[@"duration"], @4000);

--- a/Tests/BugsnagEventFromKSCrashReportTest.m
+++ b/Tests/BugsnagEventFromKSCrashReportTest.m
@@ -38,6 +38,7 @@
                                 JSONObjectWithData:[contents dataUsingEncoding:NSUTF8StringEncoding]
                                 options:0
                                 error:nil];
+    // required due to BugsnagEvent using global singleton
     [Bugsnag configuration].bundleVersion = @"3";
     self.event = [[BugsnagEvent alloc] initWithKSReport:dictionary];
 }

--- a/Tests/BugsnagEventFromKSCrashReportTest.m
+++ b/Tests/BugsnagEventFromKSCrashReportTest.m
@@ -9,6 +9,10 @@
 @import XCTest;
 #import "Bugsnag.h"
 
+@interface Bugsnag ()
++ (BugsnagConfiguration *)configuration;
+@end
+
 @interface BugsnagEventFromKSCrashReportTest : XCTestCase
 @property BugsnagEvent *event;
 @end
@@ -34,6 +38,7 @@
                                 JSONObjectWithData:[contents dataUsingEncoding:NSUTF8StringEncoding]
                                 options:0
                                 error:nil];
+    [Bugsnag configuration].bundleVersion = @"3";
     self.event = [[BugsnagEvent alloc] initWithKSReport:dictionary];
 }
 
@@ -113,7 +118,7 @@
 - (void)testAppVersion {
     NSDictionary *dictionary = [self.event toJson];
     XCTAssertEqualObjects(@"1.0", dictionary[@"app"][@"version"]);
-    XCTAssertEqualObjects(@"1", dictionary[@"app"][@"bundleVersion"]);
+    XCTAssertEqualObjects(@"3", dictionary[@"app"][@"bundleVersion"]);
 }
 
 - (void)testThreadsPopulated {

--- a/Tests/BugsnagSessionTest.m
+++ b/Tests/BugsnagSessionTest.m
@@ -80,6 +80,7 @@
 
     BugsnagConfiguration *config = [[BugsnagConfiguration alloc] initWithApiKey:DUMMY_APIKEY_32CHAR_1];
     config.appType = @"iOS";
+    config.bundleVersion = nil;
     return [BugsnagApp appWithDictionary:appData config:config codeBundleId:@"bundle-123"];
 }
 

--- a/Tests/BugsnagSessionTrackingPayloadTest.m
+++ b/Tests/BugsnagSessionTrackingPayloadTest.m
@@ -73,6 +73,7 @@
 
     BugsnagConfiguration *config = [[BugsnagConfiguration alloc] initWithApiKey:DUMMY_APIKEY_32CHAR_1];
     config.appType = @"iOS";
+    config.bundleVersion = nil;
     return [BugsnagApp appWithDictionary:appData config:config codeBundleId:@"bundle-123"];
 }
 

--- a/features/app_and_device_attributes.feature
+++ b/features/app_and_device_attributes.feature
@@ -64,7 +64,7 @@ Feature: App and Device attributes present
     And the "Bugsnag-API-Key" header equals "12312312312312312312312312312312"
 
     And the payload field "events.0.app.type" equals "newAppType"
-    And the payload field "events.0.app.bundleVersion" equals "5"
+    And the payload field "events.0.app.bundleVersion" equals "42"
     And the payload field "events.0.app.version" equals "999"
     And the payload field "events.0.app.releaseStage" equals "thirdStage"
     And the payload field "events.0.device.manufacturer" equals "Nokia"

--- a/features/app_and_device_attributes.feature
+++ b/features/app_and_device_attributes.feature
@@ -53,7 +53,7 @@ Feature: App and Device attributes present
     And the "Bugsnag-API-Key" header equals "12312312312312312312312312312312"
 
     And the payload field "events.0.app.type" equals "iLeet"
-    And the payload field "events.0.app.bundleVersion" does not equal "12345"
+    And the payload field "events.0.app.bundleVersion" equals "12345"
     And the payload field "events.0.context" equals "myContext"
     And the payload field "events.0.app.releaseStage" equals "secondStage"
 
@@ -64,7 +64,7 @@ Feature: App and Device attributes present
     And the "Bugsnag-API-Key" header equals "12312312312312312312312312312312"
 
     And the payload field "events.0.app.type" equals "newAppType"
-    And the payload field "events.0.app.bundleVersion" does not equal "12345"
+    And the payload field "events.0.app.bundleVersion" equals "5"
     And the payload field "events.0.app.version" equals "999"
     And the payload field "events.0.app.releaseStage" equals "thirdStage"
     And the payload field "events.0.device.manufacturer" equals "Nokia"

--- a/features/fixtures/ios-swift-cocoapods/iOSTestApp/scenarios/AppAndDeviceAttributesScenario.swift
+++ b/features/fixtures/ios-swift-cocoapods/iOSTestApp/scenarios/AppAndDeviceAttributesScenario.swift
@@ -53,6 +53,7 @@ class AppAndDeviceAttributesScenarioCallbackOverride: Scenario {
             event.app.type = "newAppType"
             event.app.releaseStage = "thirdStage"
             event.app.version = "999"
+            event.app.bundleVersion = "42"
             event.device.manufacturer = "Nokia"
             event.device.modelNumber = "0898"
             


### PR DESCRIPTION
## Goal

Respects the bundle version override set from config for handled errors. This was only read correctly for unhandled errors due to a different serialization mechanism. This changeset updates `BugsnagApp` to read the value from config if it is present.

## Tests

Verified that the bundleVersion is set correctly for a handled + unhandled error in an example app.
