### PR TITLE
Populate app/device metadata fields for RN errors

### DIFF
--- a/Bugsnag/Client/BugsnagClient.m
+++ b/Bugsnag/Client/BugsnagClient.m
@@ -458,6 +458,7 @@ NSString *_lastOrientation = nil;
 
     // additionally listen for metadata updates
     [self.metadata addObserverWithBlock:observer];
+    [self.metadata notifyObservers];
 }
 
 - (void)removeObserverWithBlock:(BugsnagObserverBlock _Nonnull)observer {
@@ -465,7 +466,6 @@ NSString *_lastOrientation = nil;
 
     // additionally remove metadata listener
     [self.metadata removeObserverWithBlock:observer];
-    [self.metadata notifyObservers];
 }
 
 - (void)notifyObservers:(BugsnagStateEvent *)event {

--- a/Bugsnag/Client/BugsnagClient.m
+++ b/Bugsnag/Client/BugsnagClient.m
@@ -107,10 +107,6 @@ NSDictionary *BSGParseDeviceMetadata(NSDictionary *event);
 + (BugsnagClient *)client;
 @end
 
-@interface BugsnagMetadata ()
-- (void)notifyObservers;
-@end
-
 @interface BugsnagSession ()
 @property NSUInteger unhandledCount;
 @property NSUInteger handledCount;
@@ -458,7 +454,10 @@ NSString *_lastOrientation = nil;
 
     // additionally listen for metadata updates
     [self.metadata addObserverWithBlock:observer];
-    [self.metadata notifyObservers];
+
+    // sync the new observer with changes to metadata so far
+    BugsnagStateEvent *event = [[BugsnagStateEvent alloc] initWithName:kStateEventMetadata data:self.metadata];
+    observer(event);
 }
 
 - (void)removeObserverWithBlock:(BugsnagObserverBlock _Nonnull)observer {

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,9 @@ Changelog
 
 ### Bug fixes
 
+* Populate app/device metadata fields for RN errors
+  [#763](https://github.com/bugsnag/bugsnag-cocoa/pull/763)
+
 * Ensure foreground stats are recorded for handled errors
   [#755](https://github.com/bugsnag/bugsnag-cocoa/pull/755)
 

--- a/Tests/BugsnagStateEventTest.m
+++ b/Tests/BugsnagStateEventTest.m
@@ -59,13 +59,15 @@
 }
 
 - (void)testMetadataUpdate {
-    XCTAssertNil(self.event);
+    XCTAssertNotNil(self.event);
+    self.event = nil;
     [self.client addMetadata:@"Bar" withKey:@"Foo" toSection:@"test"];
     XCTAssertEqualObjects(self.client.metadata, self.event.data);
 }
 
 - (void)testRemoveObserver {
-    XCTAssertNil(self.event);
+    XCTAssertNotNil(self.event);
+    self.event = nil;
     [self.client removeObserverWithBlock:self.block];
     [self.client setUser:@"123" withEmail:@"test@example.com" andName:@"Jamie"];
     [self.client setContext:@"Foo"];


### PR DESCRIPTION
## Goal

Fixes the population of the following app/device metadata fields in RN errors:

```
app.name
device.batteryLevel
device.charging
device.simulator
device.timezone
device.wordsize
```

This changeset comes in two parts:

1. Performing an initial sync of metadata whenever a state event observer is added. This allows the JS layer on React Native to pass down the stateless fields in metadata.
2. Always adding stateful device metadata fields when `notifyInternal` is called.

## Tests

Verified in a local example app that the fields are populated.
