### PR TITLE
Use strcmp() instead of ==  to compare C strings correctly.

### DIFF
--- a/Source/KSCrash/Source/KSCrash/Recording/Sentry/BSG_KSCrashSentry_MachException.c
+++ b/Source/KSCrash/Source/KSCrash/Recording/Sentry/BSG_KSCrashSentry_MachException.c
@@ -206,7 +206,7 @@ void *ksmachexc_i_handleExceptions(void *const userData) {
 
     const char *threadName = (const char *)userData;
     pthread_setname_np(threadName);
-    if (threadName == kThreadSecondary) {
+    if (strcmp(threadName, kThreadSecondary) == 0) {
         BSG_KSLOG_DEBUG("This is the secondary thread. Suspending.");
         thread_suspend(bsg_ksmachthread_self());
     }


### PR DESCRIPTION
## Goal

In Xcode 12 beta 3, compiling the Bugsnag iOS target causes a compiler error to occur:

```
Result of comparison against a string literal is unspecified (use an explicit string comparison function instead)
```

This pull request relieves that error.

## Design

`strcmp()` is used to compare the contents of two C strings, where as `==` compares the position of two pointers. I assume that in this file, we are wanting to compare of the contents of `kThreadSecondary`.

## Changeset

`==` was replaced with `strcmp()`.

## Tests

I ran the tests locally and they all passed.