### PR TITLE
Call react native observer with initial user/context values

### DIFF
--- a/Bugsnag/Client/BugsnagClient.m
+++ b/Bugsnag/Client/BugsnagClient.m
@@ -458,6 +458,11 @@ NSString *_lastOrientation = nil;
     // sync the new observer with changes to metadata so far
     BugsnagStateEvent *event = [[BugsnagStateEvent alloc] initWithName:kStateEventMetadata data:self.metadata];
     observer(event);
+
+    NSDictionary *userJson = [self.user toJson];
+    observer([[BugsnagStateEvent alloc] initWithName:kStateEventUser data:userJson]);
+
+    observer([[BugsnagStateEvent alloc] initWithName:kStateEventContext data:self.context]);
 }
 
 - (void)removeObserverWithBlock:(BugsnagObserverBlock _Nonnull)observer {

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,10 @@ Changelog
 ## TBD
 
 ### Bug fixes
+
+* Call react native observer with initial user/context values
+  [#768](https://github.com/bugsnag/bugsnag-cocoa/pull/768)
+
 * Respect bundle version set from config
   [#762](https://github.com/bugsnag/bugsnag-cocoa/pull/762)
 

--- a/Tests/BugsnagStateEventTest.m
+++ b/Tests/BugsnagStateEventTest.m
@@ -20,6 +20,10 @@
 - (void)removeObserverWithBlock:(BugsnagObserverBlock _Nonnull)observer;
 @end
 
+@interface BugsnagMetadata ()
+- (NSDictionary *)toDictionary;
+@end
+
 @interface BugsnagStateEventTest : XCTestCase
 @property BugsnagClient *client;
 @property BugsnagStateEvent *event;
@@ -73,6 +77,35 @@
     [self.client setContext:@"Foo"];
     [self.client addMetadata:@"Bar" withKey:@"Foo" toSection:@"test"];
     XCTAssertNil(self.event);
+}
+
+- (void)testAddObserverTriggersCallback {
+    [self.client setUser:@"123" withEmail:@"test@example.com" andName:@"Jamie"];
+    [self.client setContext:@"Foo"];
+    [self.client addMetadata:@"Bar" withKey:@"Foo" toSection:@"test"];
+
+    __block NSDictionary *user;
+    __block NSString *context;
+    __block BugsnagMetadata *metadata;
+
+    self.block = ^(BugsnagStateEvent *event) {
+        if ([kStateEventContext isEqualToString:event.type]) {
+            context = event.data;
+        } else if ([kStateEventUser isEqualToString:event.type]) {
+            user = event.data;
+        } else if ([kStateEventMetadata isEqualToString:event.type]) {
+            metadata = event.data;
+        }
+    };
+    XCTAssertNil(user);
+    XCTAssertNil(context);
+    XCTAssertNil(metadata);
+    [self.client addObserverWithBlock:self.block];
+
+    NSDictionary *expectedUser = @{@"id": @"123", @"email": @"test@example.com", @"name": @"Jamie"};
+    XCTAssertEqualObjects(expectedUser, user);
+    XCTAssertEqualObjects(@"Foo", context);
+    XCTAssertEqualObjects(self.client.metadata, metadata);
 }
 
 @end


### PR DESCRIPTION
## Goal

React Native initializes later on which results in the user and context state events being missed. When adding the RN observer for metadata it should therefore automatically send an event to the new observer for User/Context as well as metadata, in order to provide the initial value.

## Tests
Verified by adding a unit test to confirm the observer is now called.