### PR TITLE
Persist user when set on client

### DIFF
--- a/Bugsnag/Client/BugsnagClient.m
+++ b/Bugsnag/Client/BugsnagClient.m
@@ -801,17 +801,22 @@ NSString *const BSGBreadcrumbLoadedMessage = @"Bugsnag loaded";
 
 - (BugsnagUser *_Nonnull)user
 {
-    return _user;
+    return self.configuration.user;
 }
 
 - (void)setUser:(NSString *_Nullable)userId
       withEmail:(NSString *_Nullable)email
         andName:(NSString *_Nullable)name
 {
-    _user = [[BugsnagUser alloc] initWithUserId:userId name:name emailAddress:email];
+    [self.configuration setUser:userId withEmail:email andName:name];
     NSDictionary *userJson = [_user toJson];
     [self.state addMetadata:userJson toSection:BSGKeyUser];
-    [self notifyObservers:[[BugsnagStateEvent alloc] initWithName:kStateEventUser data:userJson]];
+
+    NSMutableDictionary *dict = [NSMutableDictionary new];
+    BSGDictInsertIfNotNil(dict, userId, @"id");
+    BSGDictInsertIfNotNil(dict, email, @"email");
+    BSGDictInsertIfNotNil(dict, name, @"name");
+    [self notifyObservers:[[BugsnagStateEvent alloc] initWithName:kStateEventUser data:dict]];
 }
 
 // =============================================================================

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,13 @@
 Changelog
 =========
 
+## TBD
+
+### Bug fixes
+
+* Persist user when set on client
+  [#770](https://github.com/bugsnag/bugsnag-cocoa/pull/770)
+
 ## 6.1.2 (2020-07-21)
 
 ### Bug fixes

--- a/features/fixtures/ios-swift-cocoapods/iOSTestApp/scenarios/UserPersistenceScenarios.h
+++ b/features/fixtures/ios-swift-cocoapods/iOSTestApp/scenarios/UserPersistenceScenarios.h
@@ -15,6 +15,9 @@
 @interface UserPersistencePersistUserScenario : Scenario
 @end
 
+@interface UserPersistencePersistUserClientScenario : Scenario
+@end
+
 @interface UserPersistenceDontPersistUserScenario : Scenario
 @end
 

--- a/features/fixtures/ios-swift-cocoapods/iOSTestApp/scenarios/UserPersistenceScenarios.m
+++ b/features/fixtures/ios-swift-cocoapods/iOSTestApp/scenarios/UserPersistenceScenarios.m
@@ -10,7 +10,7 @@
 #import "UserPersistenceScenarios.h"
 
 /**
- * Set a user and persist it
+ * Set a user on the config and persist it
  */
 @implementation UserPersistencePersistUserScenario
 
@@ -21,6 +21,25 @@
 }
 
 - (void)run {
+    dispatch_after(dispatch_time(DISPATCH_TIME_NOW, (int64_t)(2 * NSEC_PER_SEC)), dispatch_get_main_queue(), ^{
+        [Bugsnag notifyError:[NSError errorWithDomain:@"com.bugsnag" code:833 userInfo:nil]];
+    });
+}
+
+@end
+
+/**
+ * Set a user on the client and persist it
+ */
+@implementation UserPersistencePersistUserClientScenario
+
+- (void)startBugsnag {
+    self.config.persistUser = YES;
+    [super startBugsnag];
+}
+
+- (void)run {
+    [Bugsnag setUser:@"foo" withEmail:@"baz@grok.com" andName:@"bar"];
     dispatch_after(dispatch_time(DISPATCH_TIME_NOW, (int64_t)(2 * NSEC_PER_SEC)), dispatch_get_main_queue(), ^{
         [Bugsnag notifyError:[NSError errorWithDomain:@"com.bugsnag" code:833 userInfo:nil]];
     });


### PR DESCRIPTION
## Goal

Ensures that when `config.persistUser` is `true` and the user is set on the `Client`, that the user information is persisted for the next launch. This changeset ensures that the `Client` property sets the `Configuration` user property, which stores the information in `NSUserDefaults`. Additionally an E2E scenario has been added to test setting the user on `Client`.