### PR TITLE
[PLAT-4797] Fix flakey Session test

### DIFF
--- a/features/fixtures/ios-swift-cocoapods/iOSTestApp/scenarios/AutoSessionUnhandledScenario.m
+++ b/features/fixtures/ios-swift-cocoapods/iOSTestApp/scenarios/AutoSessionUnhandledScenario.m
@@ -21,7 +21,7 @@
 
 - (void)run {
     if (![self.eventMode isEqualToString:@"noevent"]) {
-        dispatch_after(dispatch_time(DISPATCH_TIME_NOW, 4 * NSEC_PER_SEC), dispatch_get_main_queue(), ^{
+        dispatch_after(dispatch_time(DISPATCH_TIME_NOW, 2 * NSEC_PER_SEC), dispatch_get_main_queue(), ^{
             NSException *ex = [NSException exceptionWithName:@"Kaboom" reason:@"The connection exploded" userInfo:nil];
 
             @throw ex;


### PR DESCRIPTION
## Goal

When run on a slow running device there is a chance that the AutoSessionUnhandledScenario will be interrupted by an app restart before the delayed error is triggered to be sent to maze runner.  This attempts to address that issue.

## Design

There were two possible methods of addressing the issue:
1. Reducing the delay on the error so that the app won't be reset before it's sent
2. Adding a timeout between the scenario start and the reset that will definitely be larger than the current error delay

I chose #1 as it is less impactful on the scenario timing.

## Tests

The problem scenario was run repeatedly until failure.  During diagnose prior to the fix it would fail on average on the 3rd or 4th run.  After implementing the fix it didn't fail after 17 consecutive runs of the scenario.

## Notes

The flakiness and restarts that can be seen in the pipeline run are due to the Appium sessions being lost halfway through the test runs.  This is a known issue that has been prioritised.