### PR TITLE
[PLAT-4798] Add a short delay to stack overflow test scenario

### DIFF
--- a/features/crashprobe.feature
+++ b/features/crashprobe.feature
@@ -54,7 +54,10 @@ Feature: Reporting crash events
     And the "method" of stack frame 0 equals "-[ReadOnlyPageScenario run]"
 
   Scenario: Stack overflow
-    When I run "StackOverflowScenario" and relaunch the app
+    When I run "StackOverflowScenario"
+    # Present to allow the scenario to crash
+    And I wait for 3 seconds
+    And I relaunch the app
     And I configure Bugsnag for "StackOverflowScenario"
     And I wait to receive a request
     Then the request is valid for the error reporting API version "4.0" for the "iOS Bugsnag Notifier" notifier


### PR DESCRIPTION
## Goal
Reduce the chance that the Stack Overflow test scenario will fail

## Design
By adding a short delay between starting the scenario and restarting the test fixture we can be more certain that the application has successfully crashed.
While this isn't an ideal fix, it will allow us to resolve some current flakes a more permanent fix is already ticketed and will be prioritised.

## Tests
Ran for 20+ successful runs locally.

