### PR TITLE
[PLAT-4799] Allow `EXC_BREAKCRUMB` for `errorClass` in swift assertion test

### DIFF
--- a/features/crashprobe.feature
+++ b/features/crashprobe.feature
@@ -113,7 +113,9 @@ Feature: Reporting crash events
     And I configure Bugsnag for "SwiftAssertion"
     And I wait to receive a request
     Then the request is valid for the error reporting API version "4.0" for the "iOS Bugsnag Notifier" notifier
-    And the exception "errorClass" equals "Fatal error"
+    And the exception "errorClass" equals one of:
+      | Fatal error    |
+      | EXC_BREAKPOINT |
     # And the exception "message" equals "several unfortunate things just happened"
 
   Scenario: Dereference a null pointer

--- a/features/crashprobe.feature
+++ b/features/crashprobe.feature
@@ -113,6 +113,7 @@ Feature: Reporting crash events
     And I configure Bugsnag for "SwiftAssertion"
     And I wait to receive a request
     Then the request is valid for the error reporting API version "4.0" for the "iOS Bugsnag Notifier" notifier
+    # Temporary workaround until potential issue is investigated thoroughly [PLAT-4875]
     And the exception "errorClass" equals one of:
       | Fatal error    |
       | EXC_BREAKPOINT |

--- a/features/steps/ios_steps.rb
+++ b/features/steps/ios_steps.rb
@@ -230,6 +230,11 @@ Then("the thread information is valid for the event") do
     assert_equal(frame, thread_frame, "Thread and stacktrace differ at #{index}. Stack=#{frame}, thread=#{thread_frame}")
   end
 end
+
+Then("the exception {string} equals one of:") do |keypath, possible_values|
+  value = read_key_path(Server.current_request[:body], "events.0.exceptions.0.#{keypath}")
+  assert_includes(possible_values.raw.flatten, value)
+end
   
 def wait_for_true
   max_attempts = 300


### PR DESCRIPTION
## Goal
This will stop the flake caused by an unexpected change in response for a failed assertion in swift with the a later minor release of iOS.
