### PR TITLE
Make presence of space optional

### DIFF
--- a/features/unhandled_signal.feature
+++ b/features/unhandled_signal.feature
@@ -11,7 +11,7 @@ Feature: Signals are captured as error reports in Bugsnag
     And the payload field "events" is an array with 1 elements
     And the exception "errorClass" equals "SIGABRT"
     And the "method" of stack frame 0 equals "__pthread_kill"
-    And the "method" of stack frame 1 matches "^(<redacted>| pthread_kill)$"
+    And the "method" of stack frame 1 matches "^(<redacted>| ?pthread_kill)$"
     And the "method" of stack frame 2 equals "abort"
     And the "method" of stack frame 3 equals "-[AbortScenario run]"
     And the event "severity" equals "error"


### PR DESCRIPTION
## Goal

Fix a test failure seen on iOS 10

## Design

I'm not sure if the optional space is strictly needed, as I don't know if we ever see the value with a space in tests.  But it seemed safest to make it that way in terms of further failure - and harmless enough in any case.

## Testing

The current instability on iOS 10 may mean that we don't see the fix in action right away, but I have tested the concept in an `irb` session:
```
require 'test/unit'
include Test::Unit::Assertions
regex = Regexp.new(" ?match")
assert_match(regex, "match")
=> nil
assert_match(regex, " match")
=> nil
```
(`nil` if good - an exception results when it fails)