### PR TITLE
Avoid crash reporting OOMs if nil provided as codeBundleId

### DIFF
--- a/Bugsnag/BSGOutOfMemoryWatchdog.m
+++ b/Bugsnag/BSGOutOfMemoryWatchdog.m
@@ -17,6 +17,7 @@
 #import "Private.h"
 #import "BugsnagErrorTypes.h"
 #import "BSG_RFC3339DateTool.h"
+#import "BugsnagCollections.h"
 
 @interface BSGOutOfMemoryWatchdog ()
 @property(nonatomic, getter=isWatching) BOOL watching;
@@ -167,7 +168,7 @@
 
 - (void)setCodeBundleId:(NSString *)codeBundleId {
     _codeBundleId = codeBundleId;
-    self.cachedFileInfo[@"app"][@"codeBundleId"] = codeBundleId;
+    BSGDictInsertIfNotNil(self.cachedFileInfo[@"app"], codeBundleId, @"codeBundleId");
 
     if ([self isWatching]) {
         [self writeSentinelFile];
@@ -258,7 +259,7 @@
     app[@"version"] = systemInfo[@BSG_KSSystemField_BundleShortVersion] ?: @"";
     app[@"bundleVersion"] = systemInfo[@BSG_KSSystemField_BundleVersion] ?: @"";
     // 'codeBundleId' only (optionally) exists for React Native clients and defaults otherwise to nil
-    app[@"codeBundleId"] = self.codeBundleId;
+    BSGDictInsertIfNotNil(app, self.codeBundleId, @"codeBundleId");
 #if BSGOOMAvailable
     UIApplicationState state = [BSG_KSSystemInfo currentAppState];
     app[@"inForeground"] = @([BSG_KSSystemInfo isInForeground:state]);

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,13 @@
 Changelog
 =========
 
+## TBD
+
+### Bug fixes
+
+* Avoid crash reporting OOMs if nil provided as codeBundleId
+  [#784](https://github.com/bugsnag/bugsnag-cocoa/pull/784)
+
 ## 6.1.3 (2020-08-17)
 
 ### Bug fixes


### PR DESCRIPTION
## Goal

Avoids a crash reporting OOMs if nil provided as codeBundleId. This was caused by attempting to add nil to an `NSDictionary`.