### PR TITLE
[PLAT-3907] Add timeout to reset to avoid duplicate payloads

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,7 +1,7 @@
 version: '3.6'
 services:
   cocoa-maze-runner:
-    image: 855461928731.dkr.ecr.us-west-1.amazonaws.com/maze-runner:latest-cli
+    image: 855461928731.dkr.ecr.us-west-1.amazonaws.com/maze-runner:latest-v2-cli
     command: ["--tags", "not @skip"]
     environment:
       APP_LOCATION: /app/build/iOSTestApp.ipa

--- a/features/support/env.rb
+++ b/features/support/env.rb
@@ -13,7 +13,7 @@ After do |scenario|
   if $driver
     # [:syslog, :crashlog, :performance, :server, :safariConsole, :safariNetwork]
     # puts $driver.driver.logs.get(:crashlog)
-    $driver.reset
+    $driver.reset_with_timeout
   end
 end
 


### PR DESCRIPTION
## Goal
Attempts to address duplicate payload issues using a timeout before each application reset.
This has already been implemented in Maze-runner, this change uses the newly added method.
