### PR TITLE
Allow garbage pointer to actually be null

### DIFF
--- a/features/crashprobe.feature
+++ b/features/crashprobe.feature
@@ -148,7 +148,7 @@ Feature: Reporting crash events
     And I configure Bugsnag for "ReadGarbagePointerScenario"
     And I wait to receive a request
     Then the request is valid for the error reporting API version "4.0" for the "iOS Bugsnag Notifier" notifier
-    And the exception "message" starts with "Attempted to dereference garbage pointer"
+    And the exception "message" matches "Attempted to dereference (garbage|null) pointer"
     And the exception "errorClass" equals "EXC_BAD_ACCESS"
     And the "method" of stack frame 0 equals "-[ReadGarbagePointerScenario run]"
 


### PR DESCRIPTION
## Goal

Analysis has shown that on rare occasions it is possible for the garbage point in scenario "Read a garbage pointer" to actually become 0, leading to the exception message saying "null" rather than "garbage" pointer.  This change relaxes the test expectation to allow that, thus avoiding an unnecessary flake.