### PR TITLE
[PLAT-4777] Fix some analyzer false positives.

### DIFF
--- a/Bugsnag/KSCrash/Source/KSCrash/Recording/Tools/BSG_KSMach.c
+++ b/Bugsnag/KSCrash/Source/KSCrash/Recording/Tools/BSG_KSMach.c
@@ -347,6 +347,8 @@ bool bsg_ksmachsuspendAllThreadsExcept(thread_t *exceptThreads,
                 // Don't treat this as a fatal error.
                 BSG_KSLOG_DEBUG("thread_suspend (%08x): %s", thread,
                                 mach_error_string(kr));
+                // Suppress dead store warning when log level > debug
+                (void)kr;
             }
         }
     }
@@ -386,6 +388,8 @@ bool bsg_ksmachresumeAllThreadsExcept(thread_t *exceptThreads,
                 // Don't treat this as a fatal error.
                 BSG_KSLOG_DEBUG("thread_resume (%08x): %s", thread,
                                  mach_error_string(kr));
+                // Suppress dead store warning when log level > debug
+                (void)kr;
             }
         }
     }

--- a/Bugsnag/KSCrash/Source/KSCrash/Recording/Tools/BSG_KSMachHeaders.m
+++ b/Bugsnag/KSCrash/Source/KSCrash/Recording/Tools/BSG_KSMachHeaders.m
@@ -192,7 +192,7 @@ bool bsg_mach_headers_populate_info(const struct mach_header *header, intptr_t s
 void bsg_mach_headers_add_image(const struct mach_header *header, intptr_t slide) {
     
     BSG_Mach_Header_Info *newImage = malloc(sizeof(BSG_Mach_Header_Info));
-    if (newImage != NULL && errno != ENOMEM) {
+    if (newImage != NULL) {
         if (bsg_mach_headers_populate_info(header, slide, newImage)) {
             
             bsg_mach_headers_cache_lock();

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,13 @@
 Changelog
 =========
 
+## TBD
+
+### Bug fixes
+
+* Quiet some Analyzer false positives
+  [#789](https://github.com/bugsnag/bugsnag-cocoa/pull/789)
+
 ## 6.1.3 (2020-08-17)
 
 ### Bug fixes


### PR DESCRIPTION
## Goal

The analyzer was issuing false warnings. We need it to be 100% clean.

Fixes #771 

## Design & changeset

- kr was being flagged when the logger is not set to debug. Use the `(void)kr;` trick to mark it always in use.
- malloc() always returns NULL on OOM; we don't need to also check errno. Even though both happen in tandem, there's no way for the analyzer to know that, so just check NULL only. https://developer.apple.com/library/archive/documentation/System/Conceptual/ManPages_iPhoneOS/man3/malloc.3.html

## Testing

Re-ran the analyzer
