### PR TITLE
[PLAT-4685] Guard against non-string keys when encoding metadata to JSON

### DIFF
--- a/Bugsnag/KSCrash/Source/KSCrash/Recording/Tools/BSG_KSJSONCodecObjC.m
+++ b/Bugsnag/KSCrash/Source/KSCrash/Recording/Tools/BSG_KSJSONCodecObjC.m
@@ -447,10 +447,12 @@ int bsg_ksjsoncodecobjc_i_encodeObject(BSG_KSJSONCodec *codec, id object,
             keys = [keys sortedArrayUsingSelector:@selector(compare:)];
         }
         for (id key in keys) {
-            if ((result = bsg_ksjsoncodecobjc_i_encodeObject(
-                     codec, [object valueForKey:key], key, context)) !=
-                BSG_KSJSON_OK) {
-                return result;
+            if([key isKindOfClass:[NSString class]]) {
+                if ((result = bsg_ksjsoncodecobjc_i_encodeObject(
+                         codec, [object valueForKey:key], key, context)) !=
+                    BSG_KSJSON_OK) {
+                    return result;
+                }
             }
         }
         return bsg_ksjsonendContainer(context);

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,13 @@
 Changelog
 =========
 
+## TBD
+
+### Bug fixes
+
+* Guard against non-string metadata map keys
+  [#790](https://bugsnag.atlassian.net/browse/PLAT-4685)
+
 ## 6.1.3 (2020-08-17)
 
 ### Bug fixes


### PR DESCRIPTION
## Goal

Passing metadata with non-string keys when reporting errors caused the JSON encoder to crash. This PR guards against that condition.

## Design

Since only string keys are allowed in JSON, it's easiest to just ignore any metadata keys that aren't strings.

## Testing

New unit test
