### PR TITLE
JSON codec wrapper to handle exceptions

### DIFF
--- a/Bugsnag.xcodeproj/project.pbxproj
+++ b/Bugsnag.xcodeproj/project.pbxproj
@@ -746,6 +746,18 @@
 		3A700AF824A6492F0068CD1B /* BugsnagError.h in CopyFiles */ = {isa = PBXBuildFile; fileRef = 3A700A9124A63A8E0068CD1B /* BugsnagError.h */; };
 		3A700AF924A6492F0068CD1B /* BugsnagDeviceWithState.h in CopyFiles */ = {isa = PBXBuildFile; fileRef = 3A700A9224A63A8E0068CD1B /* BugsnagDeviceWithState.h */; };
 		3A700AFA24A6492F0068CD1B /* BugsnagMetadata.h in CopyFiles */ = {isa = PBXBuildFile; fileRef = 3A700A9324A63A8E0068CD1B /* BugsnagMetadata.h */; };
+		CB9103642502320A00E9D1E2 /* BugsnagApiClientTest.m in Sources */ = {isa = PBXBuildFile; fileRef = CB9103632502320A00E9D1E2 /* BugsnagApiClientTest.m */; };
+		CB9103662502404000E9D1E2 /* BSGSerializationTest.m in Sources */ = {isa = PBXBuildFile; fileRef = CB9103652502404000E9D1E2 /* BSGSerializationTest.m */; };
+		CBCF77A325010648004AF22A /* BSGJSONSerialization.h in Headers */ = {isa = PBXBuildFile; fileRef = CBCF77A125010648004AF22A /* BSGJSONSerialization.h */; };
+		CBCF77A425010648004AF22A /* BSGJSONSerialization.h in Headers */ = {isa = PBXBuildFile; fileRef = CBCF77A125010648004AF22A /* BSGJSONSerialization.h */; };
+		CBCF77A525010648004AF22A /* BSGJSONSerialization.h in Headers */ = {isa = PBXBuildFile; fileRef = CBCF77A125010648004AF22A /* BSGJSONSerialization.h */; };
+		CBCF77A625010648004AF22A /* BSGJSONSerialization.m in Sources */ = {isa = PBXBuildFile; fileRef = CBCF77A225010648004AF22A /* BSGJSONSerialization.m */; };
+		CBCF77A725010648004AF22A /* BSGJSONSerialization.m in Sources */ = {isa = PBXBuildFile; fileRef = CBCF77A225010648004AF22A /* BSGJSONSerialization.m */; };
+		CBCF77A825010648004AF22A /* BSGJSONSerialization.m in Sources */ = {isa = PBXBuildFile; fileRef = CBCF77A225010648004AF22A /* BSGJSONSerialization.m */; };
+		CBCF77A925010648004AF22A /* BSGJSONSerialization.m in Sources */ = {isa = PBXBuildFile; fileRef = CBCF77A225010648004AF22A /* BSGJSONSerialization.m */; };
+		CBCF77AB250142E0004AF22A /* BSGJSONSerializerTest.m in Sources */ = {isa = PBXBuildFile; fileRef = CBCF77AA250142E0004AF22A /* BSGJSONSerializerTest.m */; };
+		CBCF77AC250142E0004AF22A /* BSGJSONSerializerTest.m in Sources */ = {isa = PBXBuildFile; fileRef = CBCF77AA250142E0004AF22A /* BSGJSONSerializerTest.m */; };
+		CBCF77AD250142E0004AF22A /* BSGJSONSerializerTest.m in Sources */ = {isa = PBXBuildFile; fileRef = CBCF77AA250142E0004AF22A /* BSGJSONSerializerTest.m */; };
 		E701FA9F2490EF4A008D842F /* BugsnagApiValidationTest.m in Sources */ = {isa = PBXBuildFile; fileRef = E701FA9E2490EF4A008D842F /* BugsnagApiValidationTest.m */; };
 		E701FAA02490EF4A008D842F /* BugsnagApiValidationTest.m in Sources */ = {isa = PBXBuildFile; fileRef = E701FA9E2490EF4A008D842F /* BugsnagApiValidationTest.m */; };
 		E701FAA12490EF4A008D842F /* BugsnagApiValidationTest.m in Sources */ = {isa = PBXBuildFile; fileRef = E701FA9E2490EF4A008D842F /* BugsnagApiValidationTest.m */; };
@@ -1256,6 +1268,11 @@
 		3A700A9124A63A8E0068CD1B /* BugsnagError.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; path = BugsnagError.h; sourceTree = "<group>"; };
 		3A700A9224A63A8E0068CD1B /* BugsnagDeviceWithState.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; path = BugsnagDeviceWithState.h; sourceTree = "<group>"; };
 		3A700A9324A63A8E0068CD1B /* BugsnagMetadata.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; path = BugsnagMetadata.h; sourceTree = "<group>"; };
+		CB9103632502320A00E9D1E2 /* BugsnagApiClientTest.m */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.objc; path = BugsnagApiClientTest.m; sourceTree = "<group>"; };
+		CB9103652502404000E9D1E2 /* BSGSerializationTest.m */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.objc; path = BSGSerializationTest.m; sourceTree = "<group>"; };
+		CBCF77A125010648004AF22A /* BSGJSONSerialization.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; path = BSGJSONSerialization.h; sourceTree = "<group>"; };
+		CBCF77A225010648004AF22A /* BSGJSONSerialization.m */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.objc; path = BSGJSONSerialization.m; sourceTree = "<group>"; };
+		CBCF77AA250142E0004AF22A /* BSGJSONSerializerTest.m */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.objc; path = BSGJSONSerializerTest.m; sourceTree = "<group>"; };
 		E701FA9E2490EF4A008D842F /* BugsnagApiValidationTest.m */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.objc; path = BugsnagApiValidationTest.m; sourceTree = "<group>"; };
 		E701FAA62490EF77008D842F /* ClientApiValidationTest.m */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.objc; path = ClientApiValidationTest.m; sourceTree = "<group>"; };
 		E701FAAA2490EFD9008D842F /* EventApiValidationTest.m */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.objc; path = EventApiValidationTest.m; sourceTree = "<group>"; };
@@ -1584,8 +1601,11 @@
 			children = (
 				00896A3F2486DBDD00DC48C2 /* BSGConfigurationBuilderTests.m */,
 				008966C62486D43600DC48C2 /* BSGConnectivityTest.m */,
+				CBCF77AA250142E0004AF22A /* BSGJSONSerializerTest.m */,
 				008966C82486D43600DC48C2 /* BSGOutOfMemoryWatchdogTests.m */,
+				CB9103652502404000E9D1E2 /* BSGSerializationTest.m */,
 				008966C22486D43600DC48C2 /* BugsnagAppTest.m */,
+				CB9103632502320A00E9D1E2 /* BugsnagApiClientTest.m */,
 				E701FA9E2490EF4A008D842F /* BugsnagApiValidationTest.m */,
 				008966CD2486D43600DC48C2 /* BugsnagBreadcrumbsTest.m */,
 				008966CA2486D43600DC48C2 /* BugsnagClientMirrorTest.m */,
@@ -1693,6 +1713,8 @@
 				008968132486DA5600DC48C2 /* BugsnagKeys.m */,
 				008968142486DA5600DC48C2 /* BugsnagLogger.h */,
 				008968122486DA5600DC48C2 /* BugsnagPlatformConditional.h */,
+				CBCF77A125010648004AF22A /* BSGJSONSerialization.h */,
+				CBCF77A225010648004AF22A /* BSGJSONSerialization.m */,
 			);
 			path = Helpers;
 			sourceTree = "<group>";
@@ -1877,6 +1899,7 @@
 				008968F42486DAB800DC48C2 /* BugsnagSessionFileStore.h in Headers */,
 				00AD1F1D2486A17900A27979 /* BSGOutOfMemoryWatchdog.h in Headers */,
 				008968882486DA9600DC48C2 /* BugsnagHandledState.h in Headers */,
+				CBCF77A325010648004AF22A /* BSGJSONSerialization.h in Headers */,
 				00896A082486DAD100DC48C2 /* BSG_KSCrashSentry_Private.h in Headers */,
 				0089683E2486DA6C00DC48C2 /* BugsnagMetadataInternal.h in Headers */,
 				008969722486DAD000DC48C2 /* BSG_KSSignalInfo.h in Headers */,
@@ -1973,6 +1996,7 @@
 				00AD1F1E2486A17900A27979 /* BSGOutOfMemoryWatchdog.h in Headers */,
 				008968892486DA9600DC48C2 /* BugsnagHandledState.h in Headers */,
 				00896A092486DAD100DC48C2 /* BSG_KSCrashSentry_Private.h in Headers */,
+				CBCF77A425010648004AF22A /* BSGJSONSerialization.h in Headers */,
 				0089683F2486DA6C00DC48C2 /* BugsnagMetadataInternal.h in Headers */,
 				008969732486DAD000DC48C2 /* BSG_KSSignalInfo.h in Headers */,
 				008967C32486DA1900DC48C2 /* BugsnagClientInternal.h in Headers */,
@@ -2069,6 +2093,7 @@
 				00AD1F1F2486A17900A27979 /* BSGOutOfMemoryWatchdog.h in Headers */,
 				0089688A2486DA9600DC48C2 /* BugsnagHandledState.h in Headers */,
 				00896A0A2486DAD100DC48C2 /* BSG_KSCrashSentry_Private.h in Headers */,
+				CBCF77A525010648004AF22A /* BSGJSONSerialization.h in Headers */,
 				008968402486DA6C00DC48C2 /* BugsnagMetadataInternal.h in Headers */,
 				008969742486DAD100DC48C2 /* BSG_KSSignalInfo.h in Headers */,
 				008967C42486DA1900DC48C2 /* BugsnagClientInternal.h in Headers */,
@@ -2371,6 +2396,7 @@
 				008968AB2486DA9600DC48C2 /* BugsnagStateEvent.m in Sources */,
 				008968E12486DAA700DC48C2 /* BugsnagPluginClient.m in Sources */,
 				008968842486DA9600DC48C2 /* BugsnagNotifier.m in Sources */,
+				CBCF77A625010648004AF22A /* BSGJSONSerialization.m in Sources */,
 				008968912486DA9600DC48C2 /* BugsnagError.m in Sources */,
 				0089687C2486DA9500DC48C2 /* BugsnagBreadcrumb.m in Sources */,
 				008967FA2486DA4500DC48C2 /* BugsnagApiClient.m in Sources */,
@@ -2446,6 +2472,7 @@
 				008967722486D43700DC48C2 /* KSSysCtl_Tests.m in Sources */,
 				0089676C2486D43700DC48C2 /* BugsnagTestsDummyClass.m in Sources */,
 				008966EB2486D43700DC48C2 /* BugsnagDeviceTest.m in Sources */,
+				CBCF77AB250142E0004AF22A /* BSGJSONSerializerTest.m in Sources */,
 				008967A22486D43700DC48C2 /* KSCrashSentry_Signal_Tests.m in Sources */,
 				008967272486D43700DC48C2 /* BugsnagStackframeTest.m in Sources */,
 				008967302486D43700DC48C2 /* BugsnagStateEventTest.m in Sources */,
@@ -2490,6 +2517,7 @@
 				008966F72486D43700DC48C2 /* RegisterErrorDataTest.m in Sources */,
 				008967152486D43700DC48C2 /* BugsnagCollectionsBSGDictMergeTest.m in Sources */,
 				008967632486D43700DC48C2 /* BugsnagCollectionsBSGDictSetSafeObjectTest.m in Sources */,
+				CB9103662502404000E9D1E2 /* BSGSerializationTest.m in Sources */,
 				008967AB2486D43700DC48C2 /* KSMach_Tests.m in Sources */,
 				0089672A2486D43700DC48C2 /* BugsnagStacktraceTest.m in Sources */,
 				0089678D2486D43700DC48C2 /* KSCrashReportConverter_Tests.m in Sources */,
@@ -2503,6 +2531,7 @@
 				004E353A2487B3B3007FBAE4 /* BugsnagSwiftPublicAPITests.swift in Sources */,
 				008966F12486D43700DC48C2 /* BugsnagMetadataRedactionTest.m in Sources */,
 				008967752486D43700DC48C2 /* XCTestCase+KSCrash.m in Sources */,
+				CB9103642502320A00E9D1E2 /* BugsnagApiClientTest.m in Sources */,
 				008967602486D43700DC48C2 /* BugsnagBreadcrumbsTest.m in Sources */,
 				E701FAA72490EF77008D842F /* ClientApiValidationTest.m in Sources */,
 				008967362486D43700DC48C2 /* BugsnagMetadataTests.m in Sources */,
@@ -2524,6 +2553,7 @@
 				008968E22486DAA700DC48C2 /* BugsnagPluginClient.m in Sources */,
 				008968852486DA9600DC48C2 /* BugsnagNotifier.m in Sources */,
 				008968922486DA9600DC48C2 /* BugsnagError.m in Sources */,
+				CBCF77A725010648004AF22A /* BSGJSONSerialization.m in Sources */,
 				0089687D2486DA9500DC48C2 /* BugsnagBreadcrumb.m in Sources */,
 				008967FB2486DA4500DC48C2 /* BugsnagApiClient.m in Sources */,
 				008967DF2486DA2D00DC48C2 /* BSGConfigurationBuilder.m in Sources */,
@@ -2599,6 +2629,7 @@
 				0089677F2486D43700DC48C2 /* KSLogger_Tests.m in Sources */,
 				008967342486D43700DC48C2 /* BugsnagClientTests.m in Sources */,
 				008967222486D43700DC48C2 /* BugsnagErrorReportSinkTests.m in Sources */,
+				CBCF77AC250142E0004AF22A /* BSGJSONSerializerTest.m in Sources */,
 				0089679A2486D43700DC48C2 /* FileBasedTestCase.m in Sources */,
 				008967912486D43700DC48C2 /* KSJSONCodec_Tests.m in Sources */,
 				008967732486D43700DC48C2 /* KSSysCtl_Tests.m in Sources */,
@@ -2677,6 +2708,7 @@
 				008968E32486DAA700DC48C2 /* BugsnagPluginClient.m in Sources */,
 				008968862486DA9600DC48C2 /* BugsnagNotifier.m in Sources */,
 				008968932486DA9600DC48C2 /* BugsnagError.m in Sources */,
+				CBCF77A825010648004AF22A /* BSGJSONSerialization.m in Sources */,
 				0089687E2486DA9600DC48C2 /* BugsnagBreadcrumb.m in Sources */,
 				008967FC2486DA4500DC48C2 /* BugsnagApiClient.m in Sources */,
 				008967E02486DA2D00DC48C2 /* BSGConfigurationBuilder.m in Sources */,
@@ -2796,6 +2828,7 @@
 				008967A42486D43700DC48C2 /* KSCrashSentry_Signal_Tests.m in Sources */,
 				E701FAB12490EFE8008D842F /* ConfigurationApiValidationTest.m in Sources */,
 				0089677D2486D43700DC48C2 /* RFC3339DateTool_Tests.m in Sources */,
+				CBCF77AD250142E0004AF22A /* BSGJSONSerializerTest.m in Sources */,
 				008967562486D43700DC48C2 /* BugsnagOnCrashTest.m in Sources */,
 				008967A12486D43700DC48C2 /* KSCrashSentry_Tests.m in Sources */,
 				008967442486D43700DC48C2 /* BugsnagSessionTrackerStopTest.m in Sources */,
@@ -2827,6 +2860,7 @@
 				E7462910248907E500F92D67 /* BSG_KSBacktrace.c in Sources */,
 				E7462911248907E500F92D67 /* BSG_KSSysCtl.c in Sources */,
 				E7462912248907E500F92D67 /* BSG_KSMach_x86_64.c in Sources */,
+				CBCF77A925010648004AF22A /* BSGJSONSerialization.m in Sources */,
 				E7462913248907E500F92D67 /* BSG_KSSignalInfo.c in Sources */,
 				E7462914248907E500F92D67 /* BSG_KSString.c in Sources */,
 				E7462915248907E500F92D67 /* BSG_KSObjC.c in Sources */,

--- a/Bugsnag/BSGOutOfMemoryWatchdog.m
+++ b/Bugsnag/BSGOutOfMemoryWatchdog.m
@@ -17,6 +17,7 @@
 #import "Private.h"
 #import "BugsnagErrorTypes.h"
 #import "BSG_RFC3339DateTool.h"
+#import "BSGJSONSerialization.h"
 
 @interface BSGOutOfMemoryWatchdog ()
 @property(nonatomic, getter=isWatching) BOOL watching;
@@ -224,7 +225,7 @@
         bsg_log_err(@"Failed to read oom watchdog file: %@", error);
         return nil;
     }
-    NSDictionary *contents = [NSJSONSerialization JSONObjectWithData:data options:0 error:&error];
+    NSDictionary *contents = [BSGJSONSerialization JSONObjectWithData:data options:0 error:&error];
     if (error) {
         bsg_log_err(@"Failed to read oom watchdog file: %@", error);
         return nil;
@@ -235,11 +236,11 @@
 
 - (void)writeSentinelFile {
     NSError *error = nil;
-    if (![NSJSONSerialization isValidJSONObject:self.cachedFileInfo]) {
+    if (![BSGJSONSerialization isValidJSONObject:self.cachedFileInfo]) {
         bsg_log_err(@"Cached oom watchdog data cannot be written as JSON");
         return;
     }
-    NSData *data = [NSJSONSerialization dataWithJSONObject:self.cachedFileInfo options:0 error:&error];
+    NSData *data = [BSGJSONSerialization dataWithJSONObject:self.cachedFileInfo options:0 error:&error];
     if (error) {
         bsg_log_err(@"Cached oom watchdog data cannot be written as JSON: %@", error);
         return;

--- a/Bugsnag/Client/BugsnagClient.m
+++ b/Bugsnag/Client/BugsnagClient.m
@@ -54,6 +54,7 @@
 #import "BugsnagCollections.h"
 #import "BSG_KSCrashReport.h"
 #import "BSG_KSCrash.h"
+#import "BSGJSONSerialization.h"
 
 #if BSG_PLATFORM_IOS
 #import <UIKit/UIKit.h>
@@ -239,13 +240,13 @@ NSString *BSGOrientationNameFromEnum(UIDeviceOrientation deviceOrientation)
  *  @param destination target location of the data
  */
 void BSSerializeJSONDictionary(NSDictionary *dictionary, char **destination) {
-    if (![NSJSONSerialization isValidJSONObject:dictionary]) {
+    if (![BSGJSONSerialization isValidJSONObject:dictionary]) {
         bsg_log_err(@"could not serialize metadata: is not valid JSON object");
         return;
     }
     @try {
         NSError *error;
-        NSData *json = [NSJSONSerialization dataWithJSONObject:dictionary
+        NSData *json = [BSGJSONSerialization dataWithJSONObject:dictionary
                                                        options:0
                                                          error:&error];
 

--- a/Bugsnag/Delivery/BugsnagApiClient.m
+++ b/Bugsnag/Delivery/BugsnagApiClient.m
@@ -9,6 +9,7 @@
 #import "BugsnagKeys.h"
 #import "BugsnagLogger.h"
 #import "Private.h"
+#import "BSGJSONSerialization.h"
 
 @interface BSGDelayOperation : NSOperation
 @end
@@ -59,7 +60,7 @@
     @try {
         NSError *error = nil;
         NSData *jsonData =
-                [NSJSONSerialization dataWithJSONObject:payload
+                [BSGJSONSerialization dataWithJSONObject:payload
                                                 options:0
                                                   error:&error];
 

--- a/Bugsnag/Helpers/BSGJSONSerialization.h
+++ b/Bugsnag/Helpers/BSGJSONSerialization.h
@@ -1,0 +1,49 @@
+//
+//  BSGJSONSerialization.h
+//  Bugsnag
+//
+//  Created by Karl Stenerud on 03.09.20.
+//  Copyright © 2020 Bugsnag Inc. All rights reserved.
+//
+
+#import <Foundation/Foundation.h>
+
+NS_ASSUME_NONNULL_BEGIN
+
+/* Wraps NSJSONSerialization to trap any exceptions and return them as errors.
+ *
+ * NSJSONSerialization sometimes returns errors and sometimes throws exceptions,
+ * with no specification as to which mechanism will trigger for what kinds of errors.
+ * This wrapper catches all exceptions and forces everything to be returned as an error.
+ */
+@interface BSGJSONSerialization : NSObject
+
+/* Returns YES if the given object can be converted to JSON data, NO otherwise. The object must have the following properties:
+    - Top level object is an NSArray or NSDictionary
+    - All objects are NSString, NSNumber, NSArray, NSDictionary, or NSNull
+    - All dictionary keys are NSStrings
+    - NSNumbers are not NaN or infinity
+ Other rules may apply. Calling this method or attempting a conversion are the definitive ways to tell if a given object can be converted to JSON data.
+ */
++ (BOOL)isValidJSONObject:(id)obj;
+
+/* Generate JSON data from a Foundation object. If the object will not produce valid JSON then an error will be returned. Setting the NSJSONWritingPrettyPrinted option will generate JSON with whitespace designed to make the output more readable. If that option is not set, the most compact possible JSON will be generated. If an error occurs, the error parameter will be set and the return value will be nil. The resulting data is a encoded in UTF-8.
+ */
++ (nullable NSData *)dataWithJSONObject:(id)obj options:(NSJSONWritingOptions)opt error:(NSError **)error;
+
+/* Create a Foundation object from JSON data. Set the NSJSONReadingAllowFragments option if the parser should allow top-level objects that are not an NSArray or NSDictionary. Setting the NSJSONReadingMutableContainers option will make the parser generate mutable NSArrays and NSDictionaries. Setting the NSJSONReadingMutableLeaves option will make the parser generate mutable NSString objects. If an error occurs during the parse, then the error parameter will be set and the result will be nil.
+   The data must be in one of the 5 supported encodings listed in the JSON specification: UTF-8, UTF-16LE, UTF-16BE, UTF-32LE, UTF-32BE. The data may or may not have a BOM. The most efficient encoding to use for parsing is UTF-8, so if you have a choice in encoding the data passed to this method, use UTF-8.
+ */
++ (nullable id)JSONObjectWithData:(NSData *)data options:(NSJSONReadingOptions)opt error:(NSError **)error;
+
+/* Write JSON data into a stream. The stream should be opened and configured. The return value is the number of bytes written to the stream, or 0 on error. All other behavior of this method is the same as the dataWithJSONObject:options:error: method.
+ */
++ (NSInteger)writeJSONObject:(id)obj toStream:(NSOutputStream *)stream options:(NSJSONWritingOptions)opt error:(NSError **)error;
+
+/* Create a JSON object from JSON data stream. The stream should be opened and configured. All other behavior of this method is the same as the JSONObjectWithData:options:error: method.
+ */
++ (nullable id)JSONObjectWithStream:(NSInputStream *)stream options:(NSJSONReadingOptions)opt error:(NSError **)error;
+
+@end
+
+NS_ASSUME_NONNULL_END

--- a/Bugsnag/Helpers/BSGJSONSerialization.m
+++ b/Bugsnag/Helpers/BSGJSONSerialization.m
@@ -1,0 +1,67 @@
+//
+//  BSGJSONSerialization.m
+//  Bugsnag
+//
+//  Created by Karl Stenerud on 03.09.20.
+//  Copyright © 2020 Bugsnag Inc. All rights reserved.
+//
+
+#import "BSGJSONSerialization.h"
+#import "BugsnagLogger.h"
+
+@implementation BSGJSONSerialization
+
+static NSError* wrapException(NSException* exception) {
+    NSDictionary *userInfo = @{
+        NSLocalizedDescriptionKey: exception.description,
+        NSUnderlyingErrorKey: exception,
+    };
+
+    return [NSError errorWithDomain:@"com.bugsnag" code:1 userInfo:userInfo];
+}
+
++ (BOOL)isValidJSONObject:(id)obj {
+    @try {
+        return [NSJSONSerialization isValidJSONObject:obj];
+    } @catch (NSException *exception) {
+        return false;
+    }
+}
+
++ (nullable NSData *)dataWithJSONObject:(id)obj options:(NSJSONWritingOptions)opt error:(NSError **)error {
+    @try {
+        return [NSJSONSerialization dataWithJSONObject:obj options:opt error:error];
+    } @catch (NSException *exception) {
+        *error = wrapException(exception);
+        return nil;
+    }
+}
+
++ (nullable id)JSONObjectWithData:(NSData *)data options:(NSJSONReadingOptions)opt error:(NSError **)error {
+    @try {
+        return [NSJSONSerialization JSONObjectWithData:data options:opt error:error];
+    } @catch (NSException *exception) {
+        *error = wrapException(exception);
+        return nil;
+    }
+}
+
++ (NSInteger)writeJSONObject:(id)obj toStream:(NSOutputStream *)stream options:(NSJSONWritingOptions)opt error:(NSError **)error {
+    @try {
+        return [NSJSONSerialization writeJSONObject:obj toStream:stream options:opt error:error];
+    } @catch (NSException *exception) {
+        *error = wrapException(exception);
+        return 0;
+    }
+}
+
++ (nullable id)JSONObjectWithStream:(NSInputStream *)stream options:(NSJSONReadingOptions)opt error:(NSError **)error {
+    @try {
+        return [NSJSONSerialization JSONObjectWithStream:stream options:opt error:error];
+    } @catch (NSException *exception) {
+        *error = wrapException(exception);
+        return nil;
+    }
+}
+
+@end

--- a/Bugsnag/Helpers/BSGSerialization.m
+++ b/Bugsnag/Helpers/BSGSerialization.m
@@ -1,5 +1,6 @@
 #import "BSGSerialization.h"
 #import "BugsnagLogger.h"
+#import "BSGJSONSerialization.h"
 
 BOOL BSGIsSanitizedType(id obj) {
     static dispatch_once_t onceToken;
@@ -66,7 +67,7 @@ NSDictionary *BSGDeserializeJson(char *json) {
             NSData *data = [str dataUsingEncoding:NSUTF8StringEncoding] ;
             if (data != nil) {
                 NSError *error;
-                NSDictionary *decode = [NSJSONSerialization JSONObjectWithData:data
+                NSDictionary *decode = [BSGJSONSerialization JSONObjectWithData:data
                                                                        options:0
                                                                          error:&error];
                 if (error != nil) {

--- a/Bugsnag/Storage/BugsnagSessionFileStore.m
+++ b/Bugsnag/Storage/BugsnagSessionFileStore.m
@@ -5,6 +5,7 @@
 
 #import "BugsnagSessionFileStore.h"
 #import "BSG_KSLogger.h"
+#import "BSGJSONSerialization.h"
 
 static NSString *const kSessionStoreSuffix = @"-Session-";
 
@@ -25,7 +26,7 @@ static NSString *const kSessionStoreSuffix = @"-Session-";
     NSDictionary *dict = [session toJson];
 
     NSError *error;
-    NSData *json = [NSJSONSerialization dataWithJSONObject:dict options:0 error:&error];
+    NSData *json = [BSGJSONSerialization dataWithJSONObject:dict options:0 error:&error];
 
     if (error != nil || ![json writeToFile:filepath atomically:YES]) {
         BSG_KSLOG_ERROR(@"Failed to write session %@", error);

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,9 @@ Changelog
 
 ### Bug fixes
 
+* Added BSGJSONSerializer, which ensures no exceptions get thrown (NSErrors get returned instead)
+  [791](https://github.com/bugsnag/bugsnag-cocoa/pull/791)
+
 * Quiet some Analyzer false positives
   [#789](https://github.com/bugsnag/bugsnag-cocoa/pull/789)
 

--- a/Tests/BSGJSONSerializerTest.m
+++ b/Tests/BSGJSONSerializerTest.m
@@ -1,0 +1,49 @@
+//
+//  BSGJSONSerializerTest.m
+//  Bugsnag
+//
+//  Created by Karl Stenerud on 03.09.20.
+//  Copyright © 2020 Bugsnag Inc. All rights reserved.
+//
+
+#import <XCTest/XCTest.h>
+#import "BSGJSONSerialization.h"
+
+@interface BSGJSONSerializerTest : XCTestCase
+
+@end
+
+@implementation BSGJSONSerializerTest
+
+- (void)testBadJSONKey {
+    id badDict = @{@123: @"string"};
+    NSData* badJSONData = [@"{123=\"test\"}" dataUsingEncoding:NSUTF8StringEncoding];
+    id result;
+    NSError* error;
+    result = [BSGJSONSerialization dataWithJSONObject:badDict options:0 error:&error];
+    XCTAssertNotNil(error);
+    XCTAssertNil(result);
+    error = nil;
+    
+    result = [BSGJSONSerialization JSONObjectWithData:badJSONData options:0 error:&error];
+    XCTAssertNotNil(error);
+    XCTAssertNil(result);
+    error = nil;
+
+    NSOutputStream* outstream = [NSOutputStream outputStreamToMemory];
+    [outstream open];
+    [BSGJSONSerialization writeJSONObject:badDict toStream:outstream options:0 error:&error];
+    XCTAssertNotNil(error);
+    error = nil;
+    
+    NSInputStream* instream = [NSInputStream inputStreamWithData:badJSONData];
+    [instream open];
+
+    result = [BSGJSONSerialization JSONObjectWithStream:instream options:0 error:&error];
+    XCTAssertNotNil(error);
+    XCTAssertNil(result);
+    error = nil;
+
+}
+
+@end

--- a/Tests/BSGOutOfMemoryWatchdogTests.m
+++ b/Tests/BSGOutOfMemoryWatchdogTests.m
@@ -7,6 +7,10 @@
 #import "BugsnagTestConstants.h"
 
 // Expose private identifiers for testing
+@interface BSGOutOfMemoryWatchdog(Test)
+- (NSDictionary *)readSentinelFile;
+- (void)writeSentinelFile;
+@end
 
 @interface Bugsnag (Testing)
 + (BugsnagClient *)client;
@@ -79,4 +83,18 @@
     XCTAssertEqualObjects([device valueForKey:@"locale"], [[NSLocale currentLocale] localeIdentifier]);
 }
 
+-(void)testBadJSONData {
+    NSString *tempFilePath = [NSTemporaryDirectory() stringByAppendingPathComponent:[[NSUUID UUID] UUIDString]];
+    BugsnagConfiguration *config = [[BugsnagConfiguration alloc] initWithApiKey:DUMMY_APIKEY_32CHAR_1];
+
+    BSGOutOfMemoryWatchdog *watchdog = [[BSGOutOfMemoryWatchdog alloc] initWithSentinelPath:tempFilePath configuration:config];
+    watchdog.cachedFileInfo[@1] = @"a";
+    [watchdog writeSentinelFile];
+    NSError* error;
+    [@"{1=\"a\"" writeToFile:tempFilePath atomically:YES encoding:NSUTF8StringEncoding error:&error];
+    XCTAssertNil(error);
+    [watchdog readSentinelFile];
+}
+
 @end
+

--- a/Tests/BSGSerializationTest.m
+++ b/Tests/BSGSerializationTest.m
@@ -1,0 +1,23 @@
+//
+//  BSGSerializationTest.m
+//  Bugsnag-iOSTests
+//
+//  Created by Karl Stenerud on 04.09.20.
+//  Copyright © 2020 Bugsnag Inc. All rights reserved.
+//
+
+#import <XCTest/XCTest.h>
+#import "BSGSerialization.h"
+
+@interface BSGSerializationTest : XCTestCase
+
+@end
+
+@implementation BSGSerializationTest
+
+- (void)testDeserializeJSONBadData {
+    id dict = BSGDeserializeJson("{2: 1}");
+    XCTAssertNil(dict);
+}
+
+@end

--- a/Tests/BugsnagApiClientTest.m
+++ b/Tests/BugsnagApiClientTest.m
@@ -1,0 +1,27 @@
+//
+//  BugsnagApiClientTest.m
+//  Bugsnag-iOSTests
+//
+//  Created by Karl Stenerud on 04.09.20.
+//  Copyright © 2020 Bugsnag Inc. All rights reserved.
+//
+
+#import <XCTest/XCTest.h>
+#import "BugsnagApiClient.h"
+#import <Bugsnag/Bugsnag.h>
+#import "BugsnagTestConstants.h"
+
+@interface BugsnagApiClientTest : XCTestCase
+
+@end
+
+@implementation BugsnagApiClientTest
+
+- (void)testBadJSON {
+    BugsnagConfiguration *config = [[BugsnagConfiguration alloc] initWithApiKey:DUMMY_APIKEY_32CHAR_1];
+    BugsnagApiClient* client = [[BugsnagApiClient alloc] initWithConfig:config queueName:@"test"];
+    [client sendItems:1 withPayload:@{@1: @"a"} toURL:[NSURL URLWithString:@"file:///dev/null"] headers:@{@1: @"a"} onCompletion:^(NSUInteger reportCount, BOOL success, NSError *error) {
+    }];
+}
+
+@end

--- a/Tests/BugsnagBreadcrumbsTest.m
+++ b/Tests/BugsnagBreadcrumbsTest.m
@@ -89,6 +89,22 @@ BSGBreadcrumbType BSGBreadcrumbTypeFromString(NSString *value);
     XCTAssertEqualObjects(self.crumbs.breadcrumbs[2].message, @"Clear notifications");
 }
 
+- (void)testBreadcrumbsInvalidKey {
+    BugsnagConfiguration *config = [[BugsnagConfiguration alloc] initWithApiKey:DUMMY_APIKEY_32CHAR_1];
+    BugsnagOnBreadcrumbBlock crumbBlock = ^(BugsnagBreadcrumb * _Nonnull crumb) {
+        return YES;
+    };
+    [config addOnBreadcrumbBlock:crumbBlock];
+
+    self.crumbs = [[BugsnagBreadcrumbs alloc] initWithConfiguration:config];
+    [self.crumbs addBreadcrumbWithBlock:^(BugsnagBreadcrumb *_Nonnull crumb) {
+        crumb.type = BSGBreadcrumbTypeState;
+        crumb.message = @"message";
+        crumb.metadata = @{@123 : @"would raise exception"};
+    }];
+    awaitBreadcrumbSync(self.crumbs);
+}
+
 - (void)testEmptyCapacity {
     BugsnagConfiguration *config = [[BugsnagConfiguration alloc] initWithApiKey:DUMMY_APIKEY_32CHAR_1];
     config.maxBreadcrumbs = 0;

--- a/Tests/BugsnagClientTests.m
+++ b/Tests/BugsnagClientTests.m
@@ -43,6 +43,8 @@
 
 NSString *BSGFormatSeverity(BSGSeverity severity);
 
+void BSSerializeJSONDictionary(NSDictionary *dictionary, char **destination);
+
 @implementation BugsnagClientTests
 
 /**
@@ -287,6 +289,12 @@ NSString *BSGFormatSeverity(BSGSeverity severity);
         dict[key] = value;
     }
     return dict;
+}
+
+- (void)testBSSerializeJSONDictionary {
+    // Test that it doesn't raise an exception
+    char* dest = NULL;
+    BSSerializeJSONDictionary(@{@1: @"a"}, &dest);
 }
 
 @end

--- a/Tests/BugsnagMetadataTests.m
+++ b/Tests/BugsnagMetadataTests.m
@@ -181,6 +181,10 @@
     XCTAssertEqual(metadata.dictionary.count, 0);
     XCTAssertFalse(delegateCalled);
     
+    [metadata addMetadata:@{@123 : @"Numeric key is invalid"} toSection:@"invalidKeyTab"];
+    XCTAssertEqual(metadata.dictionary.count, 0);
+    XCTAssertFalse(delegateCalled);
+    
     // Once more with a delegate
     delegateCalled = NO;
     __weak __typeof__(self) weakSelf = self;


### PR DESCRIPTION
## Goal

NSJSONSerialization can sometimes throw an exception, even though the API has an NSError field. We should have a unified way to handle JSON without having to remember to put in try/catch blocks, or manually go through our data to ensure it conforms before attempting to encode, or worry about bad data causing the decoder to freak out.

## Design

BSGJSONSerialization wraps all NSJSONSerialization calls in a try/catch block, turning any resulting exceptions into an NSError.

## Changeset

* Added BSGJSONSerialization
* Updated instances of NSJSONSerialization to use BSGJSONSerialization instead.

## Testing

* Added tests for all components that (de)serialize JSON to ensure they work as expected.
