### PR TITLE
Replace the entire observers list when adding/removing observers in o…

### DIFF
--- a/Bugsnag/Metadata/BugsnagMetadata.m
+++ b/Bugsnag/Metadata/BugsnagMetadata.m
@@ -31,7 +31,7 @@
 #import "BugsnagStateEvent.h"
 
 @interface BugsnagMetadata ()
-@property(nonatomic, readwrite, strong) NSMutableArray *stateEventBlocks;
+@property(atomic, readwrite, strong) NSMutableArray *stateEventBlocks;
 @end
 
 @implementation BugsnagMetadata
@@ -102,11 +102,17 @@
 }
 
 - (void)addObserverWithBlock:(BugsnagObserverBlock _Nonnull)block {
-    [self.stateEventBlocks addObject:[block copy]];
+    // Make a copy to avoid concurrency issues
+    NSMutableArray *newStateEventBlocks = [self.stateEventBlocks mutableCopy];
+    [newStateEventBlocks addObject:[block copy]];
+    self.stateEventBlocks = newStateEventBlocks;
 }
 
 - (void)removeObserverWithBlock:(BugsnagObserverBlock _Nonnull)block {
-    [self.stateEventBlocks removeObject:block];
+    // Make a copy to avoid concurrency issues
+    NSMutableArray *newStateEventBlocks = [self.stateEventBlocks mutableCopy];
+    [newStateEventBlocks removeObject:block];
+    self.stateEventBlocks = newStateEventBlocks;
 }
 
 // MARK: - <NSMutableCopying>

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,9 @@ Changelog
 
 ### Bug fixes
 
+* Copy the metadata observer list rather than mutating it directly.
+  [796](https://github.com/bugsnag/bugsnag-cocoa/pull/796)
+
 * Reorganized the project file
   [793](https://github.com/bugsnag/bugsnag-cocoa/pull/793)
 


### PR DESCRIPTION
## Goal

Fixes https://bugsnag.atlassian.net/browse/PLAT-5007

## Design

Instead of adding/removing observers from the observer list directly, make a copy of the list, modify the copy, then replace the original. This makes concurrency issues (where an observer gets added/removed while the observer list is being walked) impossible.

So long as the list remains small (100 or so entries), the CPU cost is negligible. We don't expect to ever see more than around 10 observers here no matter what future features we add.
