### PR TITLE
docs (contributing): clarify pre-release checks

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -110,20 +110,19 @@ Run the integration tests using `make e2e` (end-to-end)
 * Check the `master` and `next` branches for what changes are intended to be
   released. If any changes on `next` should go out, check out that branch before
   the subsequent steps.
-* Add any missing entries to the CHANGELOG. Update the README.md if appropriate.
+* Add any missing entries to the CHANGELOG. Update the README if appropriate.
 * Create a pull request for a new version by running `make VERSION=[number] 
   prerelease`. Pull request generation depends on [`hub`](https://hub.github.com) 
   (`brew install hub`)
 * Perform preflight checks:
-  - [ ] Have the changelog and README been updated?
+  - [ ] Have the CHANGELOG and README been updated?
   - [ ] Are there pull requests for installation changes on the 
         [dashboard](https://github.com/bugsnag/dashboard-js)?
   - [ ] Are there pull requests for new features/behavior on the 
         [docs site](https://github.com/bugsnag/docs.bugsnag.com)?
-  - [ ] Run `./Tests/prerelease/run_prerelease_checks.sh`
+  - [ ] Run pre-release checks - see [instructions](./Tests/prerelease/README.md)
   
-* The following checks are optional.  Use your judgement to decide if the scope 
-  of the release merits performing any or all of them.
+* Consider the following, additional checks based on changes in the release:
   
   - [ ] Has all new functionality been manually tested on a release build?
   - [ ] Do the [installation instructions](https://docs.bugsnag.com/platforms/ios/#installation) 

--- a/Tests/prerelease/README.md
+++ b/Tests/prerelease/README.md
@@ -1,0 +1,13 @@
+# Pre-release Checks
+
+This section is intended for tests that cannot be performed in the current automated test infrastructure.
+
+## Siri interrupts
+
+1. Open a test app;
+1. Trigger Siri;
+1. Close and open the test app;
+1. Ensure no OOM event is sent.
+
+This was previously automated using the `out_of_memory.feature` in this directory, but it requires work
+for it to run following the introduction of BrowserStack to MazeRunner (ref. PLAT-5040).


### PR DESCRIPTION
## Goal

The pre-release script (Tests/prerelease/run_prerelease_checks.sh) no longer runs with latest MR.

Replaced it with a readme for the manual equivalent, until the check is restored.