### PR TITLE
[PLAT-4366] Disable JSON pretty printing in KSCrash reports

### DIFF
--- a/Bugsnag/KSCrash/Source/KSCrash/Recording/BSG_KSCrashReport.c
+++ b/Bugsnag/KSCrash/Source/KSCrash/Recording/BSG_KSCrashReport.c
@@ -1504,7 +1504,7 @@ void bsg_kscrashreport_writeMinimalReport(
     BSG_KSCrashReportWriter *writer = &concreteWriter;
     bsg_kscrw_i_prepareReportWriter(writer, &jsonContext);
 
-    bsg_ksjsonbeginEncode(bsg_getJsonContext(writer), true,
+    bsg_ksjsonbeginEncode(bsg_getJsonContext(writer), false,
                           bsg_kscrw_i_addJSONData, &fd);
 
     writer->beginObject(writer, BSG_KSCrashField_Report);
@@ -1551,7 +1551,7 @@ void bsg_kscrashreport_writeStandardReport(
     BSG_KSCrashReportWriter *writer = &concreteWriter;
     bsg_kscrw_i_prepareReportWriter(writer, &jsonContext);
 
-    bsg_ksjsonbeginEncode(bsg_getJsonContext(writer), true,
+    bsg_ksjsonbeginEncode(bsg_getJsonContext(writer), false,
                           bsg_kscrw_i_addJSONData, &fd);
 
     // KSCrash report fields are not required for handled errors as

--- a/Bugsnag/KSCrash/Source/KSCrash/Recording/BSG_KSCrashState.m
+++ b/Bugsnag/KSCrash/Source/KSCrash/Recording/BSG_KSCrashState.m
@@ -224,7 +224,7 @@ bool bsg_kscrashstate_i_saveState(const BSG_KSCrash_State *const state,
     }
 
     BSG_KSJSONEncodeContext JSONContext;
-    bsg_ksjsonbeginEncode(&JSONContext, true, bsg_kscrashstate_i_addJSONData,
+    bsg_ksjsonbeginEncode(&JSONContext, false, bsg_kscrashstate_i_addJSONData,
                           &fd);
 
     int result;

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,13 @@
 Changelog
 =========
 
+## TBD
+
+### Enhancements
+
+* Disable JSON pretty-printing in KSCrash reports to save disk space and bandwidth.
+  [802](https://github.com/bugsnag/bugsnag-cocoa/pull/802)
+
 ## 6.1.4 (2020-09-11)
 
 ### Bug fixes


### PR DESCRIPTION
## Goal

This change disables JSON pretty printing for KSCrash reports to reduce the amount of disk space and network bandwidth required for storage and transmission.

Fixes https://bugsnag.atlassian.net/browse/PLAT-4366

## Testing

- [x] I have manually verified that events are still reaching the dashboard
- [x] End-to-end tests have completed successfully