### PR TITLE
[PLAT-3905] Use NS_ENUM and NS_OPTIONS instead of plain enums

### DIFF
--- a/Bugsnag/KSCrash/Source/KSCrash/Recording/BSG_KSCrashDoctor.m
+++ b/Bugsnag/KSCrash/Source/KSCrash/Recording/BSG_KSCrashDoctor.m
@@ -12,13 +12,13 @@
 
 #define BSG_kUserCrashHandler "kscrw_i_callUserCrashHandler"
 
-typedef enum {
+typedef NS_ENUM(NSUInteger, BSG_CPUFamily) {
     BSG_CPUFamilyUnknown,
     BSG_CPUFamilyArm,
     BSG_CPUFamilyArm64,
     BSG_CPUFamilyX86,
     BSG_CPUFamilyX86_64
-} BSG_CPUFamily;
+};
 
 @interface BSG_KSCrashDoctorParam : NSObject
 

--- a/Bugsnag/KSCrash/Source/KSCrash/Recording/BSG_KSCrashType.h
+++ b/Bugsnag/KSCrash/Source/KSCrash/Recording/BSG_KSCrashType.h
@@ -25,6 +25,8 @@
 #ifndef HDR_BSG_KSCrashType_h
 #define HDR_BSG_KSCrashType_h
 
+#include <CoreFoundation/CoreFoundation.h>
+
 /** Different ways an application can crash:
  * - Mach kernel exception
  * - Fatal signal
@@ -32,13 +34,15 @@
  * - Uncaught Objective-C NSException
  * - User reported custom exception
  */
-typedef enum {
+
+
+typedef CF_ENUM(unsigned, BSG_KSCrashType) {
     BSG_KSCrashTypeMachException = 0x01,
     BSG_KSCrashTypeSignal = 0x02,
     BSG_KSCrashTypeCPPException = 0x04,
     BSG_KSCrashTypeNSException = 0x08,
     BSG_KSCrashTypeUserReported = 0x20,
-} BSG_KSCrashType;
+};
 
 #define BSG_KSCrashTypeAll                                                     \
     (BSG_KSCrashTypeMachException | BSG_KSCrashTypeSignal |                    \

--- a/Bugsnag/KSCrash/Source/KSCrash/Recording/Sentry/BSG_KSCrashSentry.h
+++ b/Bugsnag/KSCrash/Source/KSCrash/Recording/Sentry/BSG_KSCrashSentry.h
@@ -37,15 +37,16 @@ extern "C" {
 #include "BSG_KSArchSpecific.h"
 #include "BSG_KSCrashType.h"
 
+#include <CoreFoundation/CoreFoundation.h>
 #include <mach/mach_types.h>
 #include <signal.h>
 #include <stdbool.h>
 
-typedef enum {
+typedef CF_ENUM(unsigned, BSG_KSCrashReservedTheadType) {
     BSG_KSCrashReservedThreadTypeMachPrimary,
     BSG_KSCrashReservedThreadTypeMachSecondary,
     BSG_KSCrashReservedThreadTypeCount
-} BSG_KSCrashReservedTheadType;
+};
 
 typedef struct BSG_KSCrash_SentryContext {
     // Caller defined values. Caller must fill these out prior to installation.

--- a/Bugsnag/KSCrash/Source/KSCrash/Recording/Tools/BSG_KSJSONCodecObjC.h
+++ b/Bugsnag/KSCrash/Source/KSCrash/Recording/Tools/BSG_KSJSONCodecObjC.h
@@ -27,16 +27,16 @@
 #import <Foundation/Foundation.h>
 
 /** Optional behavior when encoding JSON data */
-typedef enum {
+typedef NS_OPTIONS(NSUInteger, BSG_KSJSONEncodeOption) {
     /** Indent 4 spaces per object/array level */
     BSG_KSJSONEncodeOptionPretty = 1,
 
     /** Sort object contents by key name */
     BSG_KSJSONEncodeOptionSorted = 2,
-} BSG_KSJSONEncodeOption;
+};
 
 /** Optional behavior when decoding JSON data */
-typedef enum {
+typedef NS_OPTIONS(NSUInteger, BSG_KSJSONDecodeOption) {
     /** Normally, null elements get stored as [NSNull null].
      * If this option is set, do not store anything when a null element is
      * encountered inside an array.
@@ -54,7 +54,7 @@ typedef enum {
 
     /** If an error is encountered, return the partially decoded object. */
     BSG_KSJSONDecodeOptionKeepPartialObject = 4,
-} BSG_KSJSONDecodeOption;
+};
 
 /**
  * Encodes and decodes UTF-8 JSON data.

--- a/Bugsnag/KSCrash/Source/KSCrash/Recording/Tools/BSG_KSObjC.h
+++ b/Bugsnag/KSCrash/Source/KSCrash/Recording/Tools/BSG_KSObjC.h
@@ -34,14 +34,14 @@ extern "C" {
 #include <CoreFoundation/CoreFoundation.h>
 #include <mach/kern_return.h>
 
-typedef enum {
+typedef CF_ENUM(unsigned, BSG_KSObjCType) {
     BSG_KSObjCTypeUnknown = 0,
     BSG_KSObjCTypeClass,
     BSG_KSObjCTypeObject,
     BSG_KSObjCTypeBlock,
-} BSG_KSObjCType;
+};
 
-typedef enum {
+typedef CF_ENUM(unsigned, BSG_KSObjCClassType) {
     BSG_KSObjCClassTypeUnknown = 0,
     BSG_KSObjCClassTypeString,
     BSG_KSObjCClassTypeDate,
@@ -50,7 +50,7 @@ typedef enum {
     BSG_KSObjCClassTypeDictionary,
     BSG_KSObjCClassTypeNumber,
     BSG_KSObjCClassTypeException,
-} BSG_KSObjCClassType;
+};
 
 //======================================================================
 #pragma mark - Initialization -


### PR DESCRIPTION
## Goal

This improves the consistency of enum declarations, by using `NS_SNUM` and `NS_OPTIONS` where appropriate (falling back to their CoreFoundation counterparts for plain C code.

## Testing

- [x] I have manually verified that events are still reported to the dashboard
- [x] End-to-end tests have passed