### PR TITLE
[PLAT-3596] Incorporate KSCrash mach exception handling improvements

### DIFF
--- a/Bugsnag/KSCrash/Source/KSCrash/Recording/BSG_KSCrashReport.c
+++ b/Bugsnag/KSCrash/Source/KSCrash/Recording/BSG_KSCrashReport.c
@@ -143,8 +143,7 @@ void bsg_kscrw_i_addIntegerElement(const BSG_KSCrashReportWriter *const writer,
 void bsg_kscrw_i_addUIntegerElement(const BSG_KSCrashReportWriter *const writer,
                                     const char *const key,
                                     const unsigned long long value) {
-    bsg_ksjsonaddIntegerElement(bsg_getJsonContext(writer), key,
-                                (long long)value);
+    bsg_ksjsonaddUIntegerElement(bsg_getJsonContext(writer), key, value);
 }
 
 void bsg_kscrw_i_addStringElement(const BSG_KSCrashReportWriter *const writer,
@@ -1181,8 +1180,8 @@ void bsg_kscrw_i_writeError(const BSG_KSCrashReportWriter *const writer,
                             const char *const key,
                             const BSG_KSCrash_SentryContext *const crash) {
     int machExceptionType = 0;
-    kern_return_t machCode = 0;
-    kern_return_t machSubCode = 0;
+    int64_t machCode = 0;
+    int64_t machSubCode = 0;
     int sigNum = 0;
     int sigCode = 0;
     const char *exceptionName = NULL;
@@ -1192,14 +1191,14 @@ void bsg_kscrw_i_writeError(const BSG_KSCrashReportWriter *const writer,
     switch (crash->crashType) {
     case BSG_KSCrashTypeMachException:
         machExceptionType = crash->mach.type;
-        machCode = (kern_return_t)crash->mach.code;
+        machCode = crash->mach.code;
         if (machCode == KERN_PROTECTION_FAILURE && crash->isStackOverflow) {
             // A stack overflow should return KERN_INVALID_ADDRESS, but
             // when a stack blasts through the guard pages at the top of the
             // stack, it generates KERN_PROTECTION_FAILURE. Correct for this.
             machCode = KERN_INVALID_ADDRESS;
         }
-        machSubCode = (kern_return_t)crash->mach.subcode;
+        machSubCode = crash->mach.subcode;
 
         sigNum =
             bsg_kssignal_signalForMachException(machExceptionType, machCode);

--- a/Bugsnag/KSCrash/Source/KSCrash/Recording/Tools/BSG_KSJSONCodec.c
+++ b/Bugsnag/KSCrash/Source/KSCrash/Recording/Tools/BSG_KSJSONCodec.c
@@ -332,6 +332,16 @@ int bsg_ksjsonaddIntegerElement(BSG_KSJSONEncodeContext *const context,
     return addJSONData(context, buff, strlen(buff));
 }
 
+int bsg_ksjsonaddUIntegerElement(BSG_KSJSONEncodeContext *const context,
+                                 const char *const name,
+                                 unsigned long long value) {
+    int result = bsg_ksjsonbeginElement(context, name);
+    unlikely_if(result != BSG_KSJSON_OK) { return result; }
+    char buff[30];
+    sprintf(buff, "%llu", value);
+    return addJSONData(context, buff, (int)strlen(buff));
+}
+
 int bsg_ksjsonaddJSONElement(BSG_KSJSONEncodeContext *const context,
                              const char *restrict const name,
                              const char *restrict const element,

--- a/Bugsnag/KSCrash/Source/KSCrash/Recording/Tools/BSG_KSJSONCodec.h
+++ b/Bugsnag/KSCrash/Source/KSCrash/Recording/Tools/BSG_KSJSONCodec.h
@@ -158,6 +158,19 @@ int bsg_ksjsonaddBooleanElement(BSG_KSJSONEncodeContext *context,
 int bsg_ksjsonaddIntegerElement(BSG_KSJSONEncodeContext *context,
                                 const char *name, long long value);
 
+/** Add an unsigned integer element.
+ *
+ * @param context The encoding context.
+ *
+ * @param name The element's name.
+ *
+ * @param value The element's value.
+ *
+ * @return KSJSON_OK if the process was successful.
+ */
+int bsg_ksjsonaddUIntegerElement(BSG_KSJSONEncodeContext *context,
+                                 const char *name, unsigned long long value);
+
 /** Add a floating point element.
  *
  * @param context The encoding context.


### PR DESCRIPTION
## Goal

This change brings in some improvements to mach exception handling that were made in KSCrash

* https://github.com/kstenerud/KSCrash/pull/349
* https://github.com/kstenerud/KSCrash/pull/350

## Changeset

The core of the change is to specify the `MACH_EXCEPTION_CODES` flag when registering for mach exceptions. This enables handling of 64-bit code and subcode values. The rest of the changes ensure 64-bit values are not truncated.

## Testing

I verified manually, using the example app, that the `EXC_BAD_ACCESS` mach exception is still reported to the dashboard. What is not clear is how to generate codes or subcodes that require the upper 32 bits.