### PR TITLE
[PLAT-3596] Fix reporting of mach exception code and subcode

### DIFF
--- a/Bugsnag/KSCrash/Source/KSCrash/Recording/BSG_KSCrashReport.c
+++ b/Bugsnag/KSCrash/Source/KSCrash/Recording/BSG_KSCrashReport.c
@@ -143,8 +143,7 @@ void bsg_kscrw_i_addIntegerElement(const BSG_KSCrashReportWriter *const writer,
 void bsg_kscrw_i_addUIntegerElement(const BSG_KSCrashReportWriter *const writer,
                                     const char *const key,
                                     const unsigned long long value) {
-    bsg_ksjsonaddIntegerElement(bsg_getJsonContext(writer), key,
-                                (long long)value);
+    bsg_ksjsonaddUIntegerElement(bsg_getJsonContext(writer), key, value);
 }
 
 void bsg_kscrw_i_addStringElement(const BSG_KSCrashReportWriter *const writer,
@@ -1181,8 +1180,8 @@ void bsg_kscrw_i_writeError(const BSG_KSCrashReportWriter *const writer,
                             const char *const key,
                             const BSG_KSCrash_SentryContext *const crash) {
     int machExceptionType = 0;
-    kern_return_t machCode = 0;
-    kern_return_t machSubCode = 0;
+    int64_t machCode = 0;
+    int64_t machSubCode = 0;
     int sigNum = 0;
     int sigCode = 0;
     const char *exceptionName = NULL;
@@ -1192,14 +1191,14 @@ void bsg_kscrw_i_writeError(const BSG_KSCrashReportWriter *const writer,
     switch (crash->crashType) {
     case BSG_KSCrashTypeMachException:
         machExceptionType = crash->mach.type;
-        machCode = (kern_return_t)crash->mach.code;
+        machCode = crash->mach.code;
         if (machCode == KERN_PROTECTION_FAILURE && crash->isStackOverflow) {
             // A stack overflow should return KERN_INVALID_ADDRESS, but
             // when a stack blasts through the guard pages at the top of the
             // stack, it generates KERN_PROTECTION_FAILURE. Correct for this.
             machCode = KERN_INVALID_ADDRESS;
         }
-        machSubCode = (kern_return_t)crash->mach.subcode;
+        machSubCode = crash->mach.subcode;
 
         sigNum =
             bsg_kssignal_signalForMachException(machExceptionType, machCode);

--- a/Bugsnag/KSCrash/Source/KSCrash/Recording/Tools/BSG_KSJSONCodec.c
+++ b/Bugsnag/KSCrash/Source/KSCrash/Recording/Tools/BSG_KSJSONCodec.c
@@ -332,6 +332,16 @@ int bsg_ksjsonaddIntegerElement(BSG_KSJSONEncodeContext *const context,
     return addJSONData(context, buff, strlen(buff));
 }
 
+int bsg_ksjsonaddUIntegerElement(BSG_KSJSONEncodeContext *const context,
+                                 const char *const name,
+                                 unsigned long long value) {
+    int result = bsg_ksjsonbeginElement(context, name);
+    unlikely_if(result != BSG_KSJSON_OK) { return result; }
+    char buff[30];
+    sprintf(buff, "%llu", value);
+    return addJSONData(context, buff, (int)strlen(buff));
+}
+
 int bsg_ksjsonaddJSONElement(BSG_KSJSONEncodeContext *const context,
                              const char *restrict const name,
                              const char *restrict const element,

--- a/Bugsnag/KSCrash/Source/KSCrash/Recording/Tools/BSG_KSJSONCodec.h
+++ b/Bugsnag/KSCrash/Source/KSCrash/Recording/Tools/BSG_KSJSONCodec.h
@@ -158,6 +158,19 @@ int bsg_ksjsonaddBooleanElement(BSG_KSJSONEncodeContext *context,
 int bsg_ksjsonaddIntegerElement(BSG_KSJSONEncodeContext *context,
                                 const char *name, long long value);
 
+/** Add an unsigned integer element.
+ *
+ * @param context The encoding context.
+ *
+ * @param name The element's name.
+ *
+ * @param value The element's value.
+ *
+ * @return KSJSON_OK if the process was successful.
+ */
+int bsg_ksjsonaddUIntegerElement(BSG_KSJSONEncodeContext *context,
+                                 const char *name, unsigned long long value);
+
 /** Add a floating point element.
  *
  * @param context The encoding context.

--- a/Bugsnag/KSCrash/Source/KSCrash/Recording/Tools/BSG_KSMach.c
+++ b/Bugsnag/KSCrash/Source/KSCrash/Recording/Tools/BSG_KSMach.c
@@ -153,6 +153,11 @@ const char *bsg_ksmachkernelReturnCodeName(const kern_return_t returnCode) {
         RETURN_NAME_FOR_ENUM(KERN_NOT_WAITING);
         RETURN_NAME_FOR_ENUM(KERN_OPERATION_TIMED_OUT);
         RETURN_NAME_FOR_ENUM(KERN_CODESIGN_ERROR);
+        // Note: these are only valid for EXC_BAD_ACCESS
+        RETURN_NAME_FOR_ENUM(EXC_ARM_DA_ALIGN);
+        RETURN_NAME_FOR_ENUM(EXC_ARM_DA_DEBUG);
+        RETURN_NAME_FOR_ENUM(EXC_ARM_SP_ALIGN);
+        RETURN_NAME_FOR_ENUM(EXC_ARM_SWP);
     }
     return NULL;
 }

--- a/Bugsnag/KSCrash/Source/KSCrash/Recording/Tools/BSG_KSMachApple.h
+++ b/Bugsnag/KSCrash/Source/KSCrash/Recording/Tools/BSG_KSMachApple.h
@@ -160,6 +160,19 @@ struct dispatch_queue_s {
 #undef pthread_t
 #undef dispatch_queue_s
 
+// ======================================================================
+#pragma mark - xnu-6153.141.1/osfmk/mach/arm/exception.h -
+// ======================================================================
+
+/*
+ *      EXC_BAD_ACCESS
+ *      Note: do not conflict with kern_return_t values returned by vm_fault
+ */
+#define EXC_ARM_DA_ALIGN    0x101    /* Alignment Fault */
+#define EXC_ARM_DA_DEBUG    0x102    /* Debug (watch/break) Fault */
+#define EXC_ARM_SP_ALIGN    0x103    /* SP Alignment Fault */
+#define EXC_ARM_SWP            0x104    /* SWP instruction */
+
 #ifdef __cplusplus
 }
 #endif

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,9 @@ Changelog
 
 ### Bug fixes
 
+* Fix reporting of Mach exception code and subcode.
+  [806](https://github.com/bugsnag/bugsnag-cocoa/pull/806)
+
 * Create date formatters at init time to avoid potential race conditions.
   [807](https://github.com/bugsnag/bugsnag-cocoa/pull/807)
 

--- a/Tests/KSCrash/KSMach_Tests.m
+++ b/Tests/KSCrash/KSMach_Tests.m
@@ -28,6 +28,7 @@
 #import <XCTest/XCTest.h>
 
 #import "BSG_KSMach.h"
+#import "BSG_KSMachApple.h"
 #import <mach/mach_time.h>
 
 
@@ -77,6 +78,14 @@
     NSString* actual = [NSString stringWithCString:bsg_ksmachkernelReturnCodeName(KERN_FAILURE)
                                           encoding:NSUTF8StringEncoding];
     XCTAssertEqualObjects(actual, expected, @"");
+}
+
+- (void) testArmExcBadAccessKernReturnCodeNames
+{
+    XCTAssertEqualObjects(@(bsg_ksmachkernelReturnCodeName(EXC_ARM_DA_ALIGN)), @"EXC_ARM_DA_ALIGN");
+    XCTAssertEqualObjects(@(bsg_ksmachkernelReturnCodeName(EXC_ARM_DA_DEBUG)), @"EXC_ARM_DA_DEBUG");
+    XCTAssertEqualObjects(@(bsg_ksmachkernelReturnCodeName(EXC_ARM_SP_ALIGN)), @"EXC_ARM_SP_ALIGN");
+    XCTAssertEqualObjects(@(bsg_ksmachkernelReturnCodeName(EXC_ARM_SWP)), @"EXC_ARM_SWP");
 }
 
 - (void) testVeryHighKernReturnCodeName

--- a/examples/objective-c-ios/Bugsnag Test App/ViewController.m
+++ b/examples/objective-c-ios/Bugsnag Test App/ViewController.m
@@ -63,7 +63,8 @@
  This method causes a low-level exception from the operating system to terminate the app.  Upon reopening the app this signal should be notified to your Bugsnag dashboard.
  */
 - (IBAction)generateMachException:(id)sender {
-    void (*ptr)(void) = NULL;
+    // This should result in an EXC_BAD_ACCESS mach exception with code = KERN_INVALID_ADDRESS and subcode = 0xDEADBEEF
+    void (* ptr)(void) = (void *)0xDEADBEEF;
     ptr();
 }
 

--- a/features/fixtures/ios-swift-cocoapods/iOSTestApp/scenarios/UnhandledMachExceptionScenario.m
+++ b/features/fixtures/ios-swift-cocoapods/iOSTestApp/scenarios/UnhandledMachExceptionScenario.m
@@ -16,7 +16,7 @@
 }
 
 - (void)run {
-    void (*ptr)(void) = NULL;
+    void (*ptr)(void) = (void *)0xDEADBEEF;
     ptr();
 }
 

--- a/features/unhandled_mach_exception.feature
+++ b/features/unhandled_mach_exception.feature
@@ -8,7 +8,15 @@ Feature: Bugsnag captures an unhandled mach exception
     And I configure Bugsnag for "UnhandledMachExceptionScenario"
     And I wait to receive a request
     Then the request is valid for the error reporting API version "4.0" for the "iOS Bugsnag Notifier" notifier
-    And the event "exceptions.0.message" equals "Attempted to dereference null pointer."
+    And the event "exceptions.0.errorClass" equals "EXC_BAD_ACCESS"
+    And the event "exceptions.0.message" equals "Attempted to dereference garbage pointer 0xdeadbeef."
+    And the event "metaData.error.address" equals "3735928559"
+    And the event "metaData.error.type" equals "mach"
+    And the event "metaData.error.mach.code" equals "1"
+    And the event "metaData.error.mach.code_name" equals "KERN_INVALID_ADDRESS"
+    And the event "metaData.error.mach.exception" equals "1"
+    And the event "metaData.error.mach.exception_name" equals "EXC_BAD_ACCESS"
+    And the event "metaData.error.mach.subcode" equals "3735928559"
     And the event "severity" equals "error"
     And the event "unhandled" is true
     And the event "severityReason.type" equals "unhandledException"

--- a/features/unhandled_mach_exception.feature
+++ b/features/unhandled_mach_exception.feature
@@ -10,13 +10,13 @@ Feature: Bugsnag captures an unhandled mach exception
     Then the request is valid for the error reporting API version "4.0" for the "iOS Bugsnag Notifier" notifier
     And the event "exceptions.0.errorClass" equals "EXC_BAD_ACCESS"
     And the event "exceptions.0.message" equals "Attempted to dereference garbage pointer 0xdeadbeef."
-    And the event "metaData.error.address" equals "3735928559"
+    And the event "metaData.error.address" equals 3735928559
     And the event "metaData.error.type" equals "mach"
-    And the event "metaData.error.mach.code" equals "1"
+    And the event "metaData.error.mach.code" equals 1
     And the event "metaData.error.mach.code_name" equals "KERN_INVALID_ADDRESS"
-    And the event "metaData.error.mach.exception" equals "1"
+    And the event "metaData.error.mach.exception" equals 1
     And the event "metaData.error.mach.exception_name" equals "EXC_BAD_ACCESS"
-    And the event "metaData.error.mach.subcode" equals "3735928559"
+    And the event "metaData.error.mach.subcode" equals 3735928559
     And the event "severity" equals "error"
     And the event "unhandled" is true
     And the event "severityReason.type" equals "unhandledException"

--- a/features/unhandled_mach_exception.feature
+++ b/features/unhandled_mach_exception.feature
@@ -12,8 +12,8 @@ Feature: Bugsnag captures an unhandled mach exception
     And the event "exceptions.0.message" equals "Attempted to dereference garbage pointer 0xdeadbeef."
     And the event "metaData.error.address" equals 3735928559
     And the event "metaData.error.type" equals "mach"
-    And the event "metaData.error.mach.code" equals 1
-    And the event "metaData.error.mach.code_name" equals "KERN_INVALID_ADDRESS"
+    And the event "metaData.error.mach.code" equals 257
+    And the event "metaData.error.mach.code_name" equals "EXC_ARM_DA_ALIGN"
     And the event "metaData.error.mach.exception" equals 1
     And the event "metaData.error.mach.exception_name" equals "EXC_BAD_ACCESS"
     And the event "metaData.error.mach.subcode" equals 3735928559


### PR DESCRIPTION
## Goal

This change brings in some improvements to mach exception handling that were made in KSCrash

* https://github.com/kstenerud/KSCrash/pull/349
* https://github.com/kstenerud/KSCrash/pull/350

These changes fix the parsing of mach exception `code` and `subcode` values.

Prior to these changes, for a `EXC_BAD_ACCESS` exception, the `subcode` did not contain the expected memory address. The exception handler was expecting the kernel to send 64-bit values, but 32-bit values were being sent instead because the `MACH_EXCEPTION_CODES` flag was not specified when registering the exception handler. There was also a struct padding issue (fixed by adding `#pragma pack(4)`) that was causing the exception handler to read values from the wrong offset, resulting in the memory address coming through as `code` and `subcode` to always contain the value `0x8`.

## Testing

I verified manually, using the example app, that the `EXC_BAD_ACCESS` mach exception is reported to the dashboard. The dashboard is now correctly identifying and displaying the memory address that the app tried to access.

<img width="997" alt="Screenshot 2020-09-18 at 08 48 54" src="https://user-images.githubusercontent.com/61777/93571088-dfe02300-f98b-11ea-81c0-dda6471d1bbe.png">
