### PR TITLE
Create date formatters at initialization time rather than at runtime

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,11 @@ Changelog
 * Disable JSON pretty-printing in KSCrash reports to save disk space and bandwidth.
   [802](https://github.com/bugsnag/bugsnag-cocoa/pull/802)
 
+### Bug fixes
+
+* Create date formatters at init time to avoid potential race conditions.
+  [807](https://github.com/bugsnag/bugsnag-cocoa/pull/807)
+
 ## 6.1.4 (2020-09-11)
 
 ### Bug fixes


### PR DESCRIPTION
 We had some null pointer exceptions in code that was using BSG_RFC3339DateTool, which seems to be caused by a nil instance of the date formatter. I couldn't find any definitive culprit, but with this change there's zero possibility of the formatter ever being nil again.

Crash: -[__NSPlaceholderDictionary initWithObjects:forKeys:count:]: attempt to insert nil object from objects[2]

Crashing code: https://github.com/bugsnag/bugsnag-cocoa/blob/v6.1.2/Bugsnag/Delivery/BugsnagSessionTrackingApiClient.m#L74

Potentially problematic code: https://github.com/bugsnag/bugsnag-cocoa/blob/v6.1.2/Bugsnag/Helpers/BSG_RFC3339DateTool.m#L36

Fixes https://bugsnag.atlassian.net/browse/PLAT-5047
