### PR TITLE
Add testing against iOS 14

### DIFF
--- a/.buildkite/pipeline.yml
+++ b/.buildkite/pipeline.yml
@@ -9,6 +9,20 @@ steps:
 
   - wait
 
+  - label: ':ios: iOS 14 end-to-end tests'
+    timeout_in_minutes: 60
+    agents:
+      queue: opensource
+    plugins:
+      artifacts#v1.3.0:
+        download: ["features/fixtures/ios-swift-cocoapods/output/iOSTestApp.ipa"]
+      docker-compose#v3.3.0:
+        run: cocoa-maze-runner
+    env:
+      DEVICE_TYPE: IOS_14
+    concurrency: 10
+    concurrency_group: browserstack-app
+
   - label: ':ios: iOS 13 end-to-end tests'
     timeout_in_minutes: 60
     agents:

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,7 +1,7 @@
 version: '3.6'
 services:
   cocoa-maze-runner:
-    image: 855461928731.dkr.ecr.us-west-1.amazonaws.com/maze-runner:latest-v2-cli
+    image: 855461928731.dkr.ecr.us-west-1.amazonaws.com/maze-runner:master-cli
     command: ["--tags", "not @skip"]
     environment:
       APP_LOCATION: /app/build/iOSTestApp.ipa

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,7 +1,7 @@
 version: '3.6'
 services:
   cocoa-maze-runner:
-    image: 855461928731.dkr.ecr.us-west-1.amazonaws.com/maze-runner:add-more-devices-cli
+    image: 855461928731.dkr.ecr.us-west-1.amazonaws.com/maze-runner:latest-v2-cli
     command: ["--tags", "not @skip"]
     environment:
       APP_LOCATION: /app/build/iOSTestApp.ipa

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,7 +1,7 @@
 version: '3.6'
 services:
   cocoa-maze-runner:
-    image: 855461928731.dkr.ecr.us-west-1.amazonaws.com/maze-runner:latest-v2-cli
+    image: 855461928731.dkr.ecr.us-west-1.amazonaws.com/maze-runner:add-more-devices-cli
     command: ["--tags", "not @skip"]
     environment:
       APP_LOCATION: /app/build/iOSTestApp.ipa

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,7 +1,7 @@
 version: '3.6'
 services:
   cocoa-maze-runner:
-    image: 855461928731.dkr.ecr.us-west-1.amazonaws.com/maze-runner:master-cli
+    image: 855461928731.dkr.ecr.us-west-1.amazonaws.com/maze-runner:latest-v2-cli
     command: ["--tags", "not @skip"]
     environment:
       APP_LOCATION: /app/build/iOSTestApp.ipa

--- a/features/steps/ios_steps.rb
+++ b/features/steps/ios_steps.rb
@@ -183,6 +183,9 @@ Then("the payload field {string} matches the test device model") do |field|
   internal_names = {
       "iPhone 7" => %w[iPhone9,1 iPhone9,2 iPhone9,3 iPhone9,4],
       "iPhone 8" => %w[iPhone10,1 iPhone10,2 iPhone10,4 iPhone10,5],
+      "iPhone 11" => %w[iPhone12,1],
+      "iPhone 11 Pro" => %w[iPhone12,3],
+      "iPhone 11 Pro Max" => %w[iPhone12,5],
       "iPhone X" => %w[iPhone10,3 iPhone10,6],
       "iPhone XR" => ["iPhone11,8"],
       "iPhone XS" => %w[iPhone11,2 iPhone11,4 iPhone11,8]
@@ -223,7 +226,7 @@ Then("the thread information is valid for the event") do
     end
   end
   assert_equal(1, err_thread_count, "Expected errorReportingThread to be reported once for threads #{thread_traces}")
-  
+
   # verify the errorReportingThread stacktrace matches the exception stacktrace
   stack_traces.each_with_index do |frame, index|
     thread_frame = err_thread_trace[index]
@@ -235,7 +238,7 @@ Then("the exception {string} equals one of:") do |keypath, possible_values|
   value = read_key_path(Server.current_request[:body], "events.0.exceptions.0.#{keypath}")
   assert_includes(possible_values.raw.flatten, value)
 end
-  
+
 def wait_for_true
   max_attempts = 300
   attempts = 0


### PR DESCRIPTION
## Goal

Adds testing against iOS 14 to the CI pipeline.

## Design

This is a quick change to make to provide some coverage against iOS 14 in the short term.  As mention to @kstenerud IRL, we do intent to redesign the pipeline longer term.  This may involve the introduction of lighter-weight (but faster) testing for PRs that are not into master whilst also adding tests against MacOS.

## Changeset

Additional step in the CI pipeline, together with the model name mappings needed for the iPhone 11 (which was not in use previously).

## Testing

Verified by a passing CI. 