### PR TITLE
[PLAT-4827] Add +[Bugsnag breadcrumbs]

### DIFF
--- a/Bugsnag/Breadcrumbs/BugsnagBreadcrumbs.h
+++ b/Bugsnag/Breadcrumbs/BugsnagBreadcrumbs.h
@@ -41,6 +41,11 @@ typedef void (^BSGBreadcrumbConfiguration)(BugsnagBreadcrumb *_Nonnull);
 - (NSArray *_Nonnull)arrayValue;
 
 /**
+ * Returns an array containing the current buffer of breadcrumbs.
+ */
+- (NSArray<BugsnagBreadcrumb *> *_Nonnull)getBreadcrumbs;
+
+/**
  * The types of breadcrumbs which will be automatically captured.
  * By default, this is all types.
  */

--- a/Bugsnag/Breadcrumbs/BugsnagBreadcrumbs.m
+++ b/Bugsnag/Breadcrumbs/BugsnagBreadcrumbs.m
@@ -137,4 +137,12 @@
     return contents;
 }
 
+- (NSArray<BugsnagBreadcrumb *> *)getBreadcrumbs {
+    __block NSArray *result = nil;
+    dispatch_barrier_sync(self.readWriteQueue, ^{
+        result = [NSArray arrayWithArray:self.breadcrumbs];
+    });
+    return result;
+}
+
 @end

--- a/Bugsnag/Bugsnag.m
+++ b/Bugsnag/Bugsnag.m
@@ -25,7 +25,9 @@
 //
 
 #import "Bugsnag.h"
+
 #import "BSG_KSCrash.h"
+#import "BugsnagBreadcrumbs.h"
 #import "BugsnagLogger.h"
 #import "BugsnagClient.h"
 #import "BugsnagClientInternal.h"
@@ -187,6 +189,14 @@ static BugsnagClient *bsg_g_bugsnag_client = NULL;
         [self.client leaveBreadcrumbWithMessage:message
                                        metadata:metadata
                                         andType:type];
+    }
+}
+
++ (NSArray<BugsnagBreadcrumb *> *_Nonnull)breadcrumbs {
+    if ([self bugsnagStarted]) {
+        return [self.client.breadcrumbs getBreadcrumbs];
+    } else {
+        return @[];
     }
 }
 

--- a/Bugsnag/Client/BugsnagClient.m
+++ b/Bugsnag/Client/BugsnagClient.m
@@ -299,7 +299,6 @@ void BSGWriteSessionCrashData(BugsnagSession *session) {
 @property (nonatomic, strong) BugsnagPluginClient *pluginClient;
 @property (nonatomic) BOOL appDidCrashLastLaunch;
 @property (nonatomic, strong) BugsnagMetadata *metadata;
-@property(nonatomic, strong) BugsnagBreadcrumbs *breadcrumbs;
 @property (nonatomic) NSString *codeBundleId;
 @property(nonatomic, readwrite, strong) NSMutableArray *stateEventBlocks;
 #if BSG_PLATFORM_IOS

--- a/Bugsnag/Client/BugsnagClientInternal.h
+++ b/Bugsnag/Client/BugsnagClientInternal.h
@@ -10,6 +10,7 @@
 
 #import "BugsnagClient.h"
 
+@class BugsnagBreadcrumbs;
 @class BugsnagClient;
 @class BugsnagSessionTracker;
 @class BugsnagConfiguration;
@@ -18,6 +19,7 @@
 
 @interface BugsnagClient ()
 
+@property(nonatomic, readwrite, retain) BugsnagBreadcrumbs *_Nullable breadcrumbs;
 @property(nonatomic, readwrite, retain) BugsnagConfiguration *_Nullable configuration;
 @property(nonatomic, readwrite, strong) BugsnagMetadata *_Nonnull state;
 @property(nonatomic, readwrite, strong) BugsnagNotifier *_Nonnull notifier;

--- a/Bugsnag/include/Bugsnag/Bugsnag.h
+++ b/Bugsnag/include/Bugsnag/Bugsnag.h
@@ -156,6 +156,13 @@
                            andType:(BSGBreadcrumbType)type
     NS_SWIFT_NAME(leaveBreadcrumb(_:metadata:type:));
 
+/**
+ * Returns the current buffer of breadcrumbs that will be sent with captured events. This
+ * ordered list represents the most recent breadcrumbs to be captured up to the limit
+ * set in `BugsnagConfiguration.maxBreadcrumbs`
+ */
++ (NSArray<BugsnagBreadcrumb *> *_Nonnull)breadcrumbs;
+
 // =============================================================================
 // MARK: - Session
 // =============================================================================

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,9 @@ Changelog
 
 ### Enhancements
 
+* Add `+[Bugsnag breadcrumbs]` to allow apps to fetch the list of breadcrumbs.
+  [813](https://github.com/bugsnag/bugsnag-cocoa/pull/813)
+
 * Disable JSON pretty-printing in KSCrash reports to save disk space and bandwidth.
   [802](https://github.com/bugsnag/bugsnag-cocoa/pull/802)
 

--- a/Tests/BugsnagBreadcrumbsTest.m
+++ b/Tests/BugsnagBreadcrumbsTest.m
@@ -35,7 +35,6 @@
 
 @interface BugsnagClient ()
 - (void)start;
-@property(readonly, strong, nullable) BugsnagBreadcrumbs *breadcrumbs;
 @end
 
 void awaitBreadcrumbSync(BugsnagBreadcrumbs *crumbs) {
@@ -400,6 +399,16 @@ BSGBreadcrumbType BSGBreadcrumbTypeFromString(NSString *value);
     
     XCTAssertEqual([bc1[@"metaData"] count], 0);
     XCTAssertEqual([bc2[@"metaData"] count], 0);
+}
+
+- (void)testGetBreadcrumbs {
+    NSArray<BugsnagBreadcrumb *> *breadcrumbs = [self.crumbs getBreadcrumbs];
+    XCTAssertEqual(breadcrumbs[0].message, @"Launch app");
+    XCTAssertEqual(breadcrumbs[0].type, BSGBreadcrumbTypeManual);
+    XCTAssertEqual(breadcrumbs[1].message, @"Tap button");
+    XCTAssertEqual(breadcrumbs[1].type, BSGBreadcrumbTypeManual);
+    XCTAssertEqual(breadcrumbs[2].message, @"Close tutorial");
+    XCTAssertEqual(breadcrumbs[2].type, BSGBreadcrumbTypeManual);
 }
 
 @end

--- a/Tests/BugsnagClientTests.m
+++ b/Tests/BugsnagClientTests.m
@@ -26,7 +26,6 @@
 @interface BugsnagClient ()
 - (void)orientationChanged:(NSNotification *)notif;
 @property (nonatomic, strong) BugsnagMetadata *metadata;
-@property(nonatomic, strong) BugsnagBreadcrumbs *breadcrumbs;
 @end
 
 @interface BugsnagBreadcrumb ()


### PR DESCRIPTION
## Goal

This adds the `+[Bugsnag breadcrumbs]` public API to allow apps to access the list of breadcrumbs.

This bring the Cocoa notifier in alignment with the [Android version](https://bugsnag.github.io/bugsnag-android/bugsnag-android-core/com.bugsnag.android/-bugsnag/get-breadcrumbs.html).

## Testing

This change is covered by unit tests.