### PR TITLE
[PLAT-4550] Fix SCNetworkReachabilityFlags comparison compiler warning

### DIFF
--- a/Bugsnag/Delivery/BSGConnectivity.m
+++ b/Bugsnag/Delivery/BSGConnectivity.m
@@ -29,9 +29,11 @@
 #import "BSGConnectivity.h"
 #import "Bugsnag.h"
 
+static const SCNetworkReachabilityFlags kSCNetworkReachabilityFlagsUninitialized = UINT32_MAX;
+
 static SCNetworkReachabilityRef bsg_reachability_ref;
 BSGConnectivityChangeBlock bsg_reachability_change_block;
-SCNetworkReachabilityFlags bsg_current_reachability_state = -1;
+static SCNetworkReachabilityFlags bsg_current_reachability_state = kSCNetworkReachabilityFlagsUninitialized;
 
 NSString *const BSGConnectivityCellular = @"cellular";
 NSString *const BSGConnectivityWiFi = @"wifi";
@@ -57,7 +59,7 @@ BOOL BSGConnectivityShouldReportChange(SCNetworkReachabilityFlags flags) {
         // When first subscribing to be notified of changes, the callback is
         // invoked immmediately even if nothing has changed. So this block
         // ignores the very first check, reporting all others.
-        if (bsg_current_reachability_state == -1) {
+        if (bsg_current_reachability_state == kSCNetworkReachabilityFlagsUninitialized) {
             shouldReport = NO;
         }
         // Cache the reachability state to report the previous value representation
@@ -138,7 +140,7 @@ void BSGConnectivityCallback(SCNetworkReachabilityRef target,
         SCNetworkReachabilitySetCallback(bsg_reachability_ref, NULL, NULL);
         SCNetworkReachabilitySetDispatchQueue(bsg_reachability_ref, NULL);
     }
-    bsg_current_reachability_state = -1;
+    bsg_current_reachability_state = kSCNetworkReachabilityFlagsUninitialized;
 }
 
 @end


### PR DESCRIPTION
Fixes the following compiler warning regarding comparison of an unsigned type (`SCNetworkReachabilityFlags`) to `-1`

```
/usr/local/var/buildkite-agent/builds/DU548-1/bugsnag/cocoa-bugsnag-notifier/Bugsnag/Delivery/BSGConnectivity.m:60:44:
 warning: result of comparison of constant 4294967295 with expression of type 'SCNetworkReachabilityFlags'
 (aka 'enum SCNetworkReachabilityFlags') is always false [-Wtautological-constant-out-of-range-compare]
  | if (bsg_current_reachability_state == -1) {
  | ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~ ^  ~~
```
PLAT-4550

# Testing

The build kite logs will reveal whether the warning has been fixed.

There are no unit tests that cover the functionality of `BSGConnectivity`