### PR TITLE
Fix ‘implicit conversion loses integer precision’ warnings

### DIFF
--- a/Bugsnag/KSCrash/Source/KSCrash/Recording/Tools/BSG_KSMach.c
+++ b/Bugsnag/KSCrash/Source/KSCrash/Recording/Tools/BSG_KSMach.c
@@ -100,7 +100,7 @@ const char *bsg_ksmachexceptionName(const exception_type_t exceptionType) {
     return NULL;
 }
 
-const char *bsg_ksmachkernelReturnCodeName(const kern_return_t returnCode) {
+const char *bsg_ksmachkernelReturnCodeName(const unsigned long long returnCode) {
     switch (returnCode) {
         RETURN_NAME_FOR_ENUM(KERN_SUCCESS);
         RETURN_NAME_FOR_ENUM(KERN_INVALID_ADDRESS);

--- a/Bugsnag/KSCrash/Source/KSCrash/Recording/Tools/BSG_KSMach.h
+++ b/Bugsnag/KSCrash/Source/KSCrash/Recording/Tools/BSG_KSMach.h
@@ -87,7 +87,7 @@ const char *bsg_ksmachexceptionName(exception_type_t exceptionType);
  *
  * @return The code's name or NULL if not found.
  */
-const char *bsg_ksmachkernelReturnCodeName(kern_return_t returnCode);
+const char *bsg_ksmachkernelReturnCodeName(unsigned long long returnCode);
 
 // ============================================================================
 #pragma mark - Thread State Info -

--- a/Bugsnag/Payload/BugsnagStackframe.m
+++ b/Bugsnag/Payload/BugsnagStackframe.m
@@ -108,8 +108,10 @@
             symbolName = [string substringWithRange:symbolNameRange];
         }
         
-        unsigned long long address = 0;
-        [[NSScanner scannerWithString:frameAddress] scanHexLongLong:&address];
+        uintptr_t address = 0;
+        if (frameAddress.UTF8String != NULL) {
+            sscanf(frameAddress.UTF8String, "%lx", &address);
+        }
         
         BugsnagStackframe *frame = [BugsnagStackframe new];
         frame.machoFile = imageName;
@@ -118,8 +120,7 @@
         frame.isPc = [frameNumber isEqualToString:@"0"];
         
         Dl_info dl_info;
-        uintptr_t address2 = address;
-        bsg_ksbt_symbolicate(&address2, &dl_info, 1, 0);
+        bsg_ksbt_symbolicate(&address, &dl_info, 1, 0);
         if (dl_info.dli_fname != NULL) {
             frame.machoFile = [NSString stringWithUTF8String:dl_info.dli_fname].lastPathComponent;
         }


### PR DESCRIPTION
## Goal

Fixed some build warnings that were inadvertently introduced with the Mach exception code & subcode handling changes.

## Design

The use of `NSScanner` was dropped in favour of `sscanf` since `NSScanner` does not have a method for scanning an `unsigned long` (to match the `uintptr_t` type)

## Testing

* `+[BugsnagStackframe stackframesWithCallStackSymbols:` is covered by unit tests.
* `bsg_ksmachkernelReturnCodeName` is covered by unit tests and end-to-end tests.