### PR TITLE
Fix warning with -Wpedantic

### DIFF
--- a/Bugsnag/Payload/BugsnagStackframe.m
+++ b/Bugsnag/Payload/BugsnagStackframe.m
@@ -151,7 +151,7 @@
 }
 
 - (NSString *)description {
-    return [NSString stringWithFormat:@"<BugsnagStackframe: %p { %@ %p %@ }>", self,
+    return [NSString stringWithFormat:@"<BugsnagStackframe: %p { %@ %p %@ }>", (void *)self,
             self.machoFile.lastPathComponent, (void *)self.frameAddress.unsignedLongLongValue, self.method];
 }
 


### PR DESCRIPTION
```
Bugsnag/Bugsnag/Payload/BugsnagStackframe.m:154:80: error: format specifies type 'void *' but the argument has type 'BugsnagStackframe *' [-Werror,-Wformat-pedantic]
    return [NSString stringWithFormat:@"<BugsnagStackframe: %p { %@ %p %@ }>", self,
                                                            ~~                 ^~~~
                                                            %@
```

According to https://stackoverflow.com/questions/7555143/nslog-an-objects-memory-address-in-overridden-description-method#comment24364878_7555194 this is also UB otherwise, but I'm not sure that's true