### PR TITLE
[PLAT-3660] Update Framework version when doing a release

### DIFF
--- a/Framework/Info.plist
+++ b/Framework/Info.plist
@@ -15,7 +15,7 @@
 	<key>CFBundlePackageType</key>
 	<string>FMWK</string>
 	<key>CFBundleShortVersionString</key>
-	<string>1.0</string>
+	<string>6.1.6</string>
 	<key>CFBundleVersion</key>
 	<string>1</string>
 </dict>

--- a/Makefile
+++ b/Makefile
@@ -141,6 +141,7 @@ endif
 	@sed -i '' "s/\"tag\": .*/\"tag\": \"v$(VERSION)\"/" Bugsnag.podspec.json
 	@sed -i '' "s/self.version = .*;/self.version = @\"$(VERSION)\";/" Bugsnag/Payload/BugsnagNotifier.m
 	@sed -i '' "s/## TBD/## $(VERSION) ($(shell date '+%Y-%m-%d'))/" CHANGELOG.md
+	@agvtool new-marketing-version $(VERSION)
 
 prerelease: bump ## Generates a PR for the $VERSION release
 ifeq ($(VERSION),)

--- a/Tests/Info.plist
+++ b/Tests/Info.plist
@@ -15,7 +15,7 @@
 	<key>CFBundlePackageType</key>
 	<string>$(PRODUCT_BUNDLE_PACKAGE_TYPE)</string>
 	<key>CFBundleShortVersionString</key>
-	<string>1.0</string>
+	<string>6.1.6</string>
 	<key>CFBundleVersion</key>
 	<string>1</string>
 </dict>


### PR DESCRIPTION
## Goal

This change ensures the Bugsnag framework built by the top-level Xcode project is branded with the version.

## Changeset

Uses Apple's `agvtool` to set the "marketing version" (CFBundleShortVersionString) of Info.plists in the Xcode project.

## Testing

Ran `make bump VERSION=x.y.z` with multiple different version numbers to ensure all the files are updated as expected.