### PR TITLE
Resilient appium driver

### DIFF
--- a/.buildkite/pipeline.yml
+++ b/.buildkite/pipeline.yml
@@ -64,8 +64,6 @@ steps:
       DEVICE_TYPE: IOS_11
     concurrency: 10
     concurrency_group: browserstack-app
-    soft_fail:
-      - exit_status: "*"
 
   - label: ':ios: iOS 10 end-to-end tests'
     timeout_in_minutes: 60
@@ -80,5 +78,3 @@ steps:
       DEVICE_TYPE: IOS_10
     concurrency: 10
     concurrency_group: browserstack-app
-    soft_fail:
-      - exit_status: "*"

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,7 +1,7 @@
 version: '3.6'
 services:
   cocoa-maze-runner:
-    image: 855461928731.dkr.ecr.us-west-1.amazonaws.com/maze-runner:master-cli
+    image: 855461928731.dkr.ecr.us-west-1.amazonaws.com/maze-runner:latest-v2-cli
     command: ["--tags", "not @skip"]
     environment:
       APP_LOCATION: /app/build/iOSTestApp.ipa

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,7 +1,7 @@
 version: '3.6'
 services:
   cocoa-maze-runner:
-    image: 855461928731.dkr.ecr.us-west-1.amazonaws.com/maze-runner:latest-v2-cli
+    image: 855461928731.dkr.ecr.us-west-1.amazonaws.com/maze-runner:restart-failed-driver-5-cli
     command: ["--tags", "not @skip"]
     environment:
       APP_LOCATION: /app/build/iOSTestApp.ipa

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,7 +1,7 @@
 version: '3.6'
 services:
   cocoa-maze-runner:
-    image: 855461928731.dkr.ecr.us-west-1.amazonaws.com/maze-runner:restart-failed-driver-5-cli
+    image: 855461928731.dkr.ecr.us-west-1.amazonaws.com/maze-runner:master-cli
     command: ["--tags", "not @skip"]
     environment:
       APP_LOCATION: /app/build/iOSTestApp.ipa

--- a/features/steps/ios_steps.rb
+++ b/features/steps/ios_steps.rb
@@ -46,11 +46,11 @@ When("I configure Bugsnag for {string}") do |event_type|
 end
 
 When("I send the app to the background") do
-  $driver.background_app(-1)
+  MazeRunner.driver.background_app(-1)
 end
 
 When("I relaunch the app") do
-  $driver.launch_app
+  MazeRunner.driver.launch_app
 end
 
 When("I clear the request queue") do
@@ -68,21 +68,21 @@ end
 # 4: The application is running in the foreground
 Then("The app is running in the foreground") do
   wait_for_true do
-    status = $driver.execute_script('mobile: queryAppState', {bundleId: "com.bugsnag.iOSTestApp"})
+    status = MazeRunner.driver.execute_script('mobile: queryAppState', {bundleId: "com.bugsnag.iOSTestApp"})
     status == 4
   end
 end
 
 Then("The app is running in the background") do
   wait_for_true do
-    status = $driver.execute_script('mobile: queryAppState', {bundleId: "com.bugsnag.iOSTestApp"})
+    status = MazeRunner.driver.execute_script('mobile: queryAppState', {bundleId: "com.bugsnag.iOSTestApp"})
     status == 3
   end
 end
 
 Then("The app is not running") do
   wait_for_true do
-    status = $driver.execute_script('mobile: queryAppState', {bundleId: "com.bugsnag.iOSTestApp"})
+    status = MazeRunner.driver.execute_script('mobile: queryAppState', {bundleId: "com.bugsnag.iOSTestApp"})
     status == 1
   end
 end
@@ -190,7 +190,7 @@ Then("the payload field {string} matches the test device model") do |field|
       "iPhone XR" => ["iPhone11,8"],
       "iPhone XS" => %w[iPhone11,2 iPhone11,4 iPhone11,8]
   }
-  expected_model = Devices::DEVICE_HASH[$driver.device_type]["device"]
+  expected_model = Devices::DEVICE_HASH[MazeRunner.driver.device_type]["device"]
   valid_models = internal_names[expected_model]
   device_model = read_key_path(Server.current_request[:body], field)
   assert_true(valid_models.include?(device_model), "The field #{device_model} did not match any of the list of expected fields")

--- a/features/support/env.rb
+++ b/features/support/env.rb
@@ -10,15 +10,15 @@ $api_key = "12312312312312312312312312312312"
 
 
 After do |scenario|
-  if $driver
+  if MazeRunner.driver
     # [:syslog, :crashlog, :performance, :server, :safariConsole, :safariNetwork]
-    # puts $driver.driver.logs.get(:crashlog)
-    $driver.reset_with_timeout
+    # puts MazeRunner.driver.driver.logs.get(:crashlog)
+    MazeRunner.driver.reset_with_timeout
   end
 end
 
 AfterConfiguration do |config|
-  AppAutomateDriver.new(
+  ResilientAppiumDriver.new(
     bs_username,
     bs_access_key,
     bs_local_id,
@@ -30,12 +30,12 @@ AfterConfiguration do |config|
       'browserstack.appium_version' => '1.15.0' # Temporary fix to allow running on iOS 10
     }
   )
-  $driver.start_driver
+  MazeRunner.driver.start_driver
 end
 
 at_exit do
-  if $driver
-    $driver.close_app
-    $driver.driver_quit
+  if MazeRunner.driver
+    MazeRunner.driver.close_app
+    MazeRunner.driver.driver_quit
   end
 end


### PR DESCRIPTION
## Goal

Switch to using the resilient Appium driver now provided by Maze Runner to run the e2e tests.

## Design

Follows the approach detailed in the MazeRunner changelog.

## Changeset

e2e test steps and soft fail remove from iOS 10 and 11 in the pipeline.

## Testing

CI should now complete without bailing out due to Appium errors (there may be occasional test failures due to known and ticketed issues).