### PR TITLE
[PLAT-5084] Stringify Mach exception code and subcode

### DIFF
--- a/Bugsnag/KSCrash/Source/KSCrash/Recording/BSG_KSCrashReport.c
+++ b/Bugsnag/KSCrash/Source/KSCrash/Recording/BSG_KSCrashReport.c
@@ -1252,20 +1252,25 @@ void bsg_kscrw_i_writeError(const BSG_KSCrashReportWriter *const writer,
         case BSG_KSCrashTypeMachException:
             writer->beginObject(writer, BSG_KSCrashField_Mach);
             {
+                char buffer[20] = {0};
+                
                 writer->addUIntegerElement(writer, BSG_KSCrashField_Exception,
                                            (unsigned)machExceptionType);
                 if (machExceptionName != NULL) {
                     writer->addStringElement(writer, BSG_KSCrashField_ExceptionName,
                                              machExceptionName);
                 }
-                writer->addUIntegerElement(writer, BSG_KSCrashField_Code,
-                                           (unsigned)machCode);
+                
+                snprintf(buffer, sizeof(buffer), "0x%llx", machCode);
+                writer->addStringElement(writer, BSG_KSCrashField_Code, buffer);
+                
                 if (machCodeName != NULL) {
                     writer->addStringElement(writer, BSG_KSCrashField_CodeName,
                                              machCodeName);
                 }
-                writer->addUIntegerElement(writer, BSG_KSCrashField_Subcode,
-                                           (unsigned)machSubCode);
+                
+                snprintf(buffer, sizeof(buffer), "0x%llx", machSubCode);
+                writer->addStringElement(writer, BSG_KSCrashField_Subcode, buffer);
             }
             writer->endContainer(writer);
             writer->addStringElement(writer, BSG_KSCrashField_Type,

--- a/features/unhandled_mach_exception.feature
+++ b/features/unhandled_mach_exception.feature
@@ -12,11 +12,11 @@ Feature: Bugsnag captures an unhandled mach exception
     And the event "exceptions.0.message" equals "Attempted to dereference garbage pointer 0xdeadbeef."
     And the event "metaData.error.address" equals 3735928559
     And the event "metaData.error.type" equals "mach"
-    And the event "metaData.error.mach.code" equals 257
+    And the event "metaData.error.mach.code" equals "0x101"
     And the event "metaData.error.mach.code_name" equals "EXC_ARM_DA_ALIGN"
     And the event "metaData.error.mach.exception" equals 1
     And the event "metaData.error.mach.exception_name" equals "EXC_BAD_ACCESS"
-    And the event "metaData.error.mach.subcode" equals 3735928559
+    And the event "metaData.error.mach.subcode" equals "0xdeadbeef"
     And the event "severity" equals "error"
     And the event "unhandled" is true
     And the event "severityReason.type" equals "unhandledException"


### PR DESCRIPTION
## Goal

Mach exception codes and subcodes are sent by the kernel as 64-bit values.

These can be too large to be faithfully decoded by many JSON decoders and Javascript in particular, meaning they may not be displayed correctly in the dashboard.

## Changeset

This change encodes the Mach exception code and subcode as strings containing hex representations.

## Testing

Manually verified that reports still appear on the dashboard, and that the new values are rendered correctly.

This change is covered by the automated e2e tests, the relevant test case has been amended.