### PR TITLE
[PLAT-5155] Improve BugsnagConfiguration behaviour

### DIFF
--- a/Bugsnag/Client/BugsnagClient.m
+++ b/Bugsnag/Client/BugsnagClient.m
@@ -548,6 +548,8 @@ NSString *const BSGBreadcrumbLoadedMessage = @"Bugsnag loaded";
 }
 
 - (void)start {
+    [configuration validate];
+    
     [self.crashSentry install:self.configuration
                     apiClient:self.errorReportApiClient
                       onCrash:&BSSerializeDataCrashHandler];

--- a/Bugsnag/Configuration/BSGConfigurationBuilder.m
+++ b/Bugsnag/Configuration/BSGConfigurationBuilder.m
@@ -8,19 +8,15 @@ static BOOL BSGValueIsBoolean(id object) {
             && CFGetTypeID((__bridge CFTypeRef)object) == CFBooleanGetTypeID();
 }
 
-@interface BugsnagConfiguration ()
-+ (BOOL)isValidApiKey:(NSString *)apiKey;
-@end
-
 @implementation BSGConfigurationBuilder
 
 + (BugsnagConfiguration *)configurationFromOptions:(NSDictionary *)options {
     NSString *apiKey = options[@"apiKey"];
-    BugsnagConfiguration *config = [[BugsnagConfiguration alloc] initWithApiKey:apiKey];
-
-    if (![BugsnagConfiguration isValidApiKey:apiKey]) {
-        return config;
+    if (apiKey != nil && ![apiKey isKindOfClass:[NSString class]]) {
+        @throw [NSException exceptionWithName:NSInvalidArgumentException reason:@"Bugsnag apiKey must be a string" userInfo:nil];
     }
+
+    BugsnagConfiguration *config = [[BugsnagConfiguration alloc] initWithApiKey:apiKey];
 
     [self loadString:config options:options key:BSGKeyAppType];
     [self loadString:config options:options key:BSGKeyAppVersion];

--- a/Bugsnag/Configuration/BugsnagConfiguration.m
+++ b/Bugsnag/Configuration/BugsnagConfiguration.m
@@ -24,26 +24,11 @@
 // THE SOFTWARE.
 //
 
-#import "BugsnagPlatformConditional.h"
-
 #import "BugsnagConfiguration.h"
-#import "BugsnagKeys.h"
-#import "BSG_RFC3339DateTool.h"
-#import "BugsnagUser.h"
-#import "BugsnagSessionTracker.h"
-#import "BugsnagLogger.h"
-#import "BSGConfigurationBuilder.h"
-#import "BugsnagBreadcrumbs.h"
-#import "BugsnagMetadataStore.h"
-#import "BSGSerialization.h"
-#import "BugsnagEndpointConfiguration.h"
-#import "BugsnagErrorTypes.h"
-#import "BugsnagStateEvent.h"
-#import "BugsnagCollections.h"
-#import "BugsnagMetadataInternal.h"
 
-static NSString *const BSGApiKeyMissingError = @"No Bugsnag API Key set";
-static NSString *const BSGInitError = @"Init is unavailable.  Use [[BugsnagConfiguration alloc] initWithApiKey:] instead.";
+#import "BSGConfigurationBuilder.h"
+#import "Private.h"
+
 static const int BSGApiKeyLength = 32;
 
 // User info persistence keys
@@ -156,29 +141,12 @@ NSString * const kBugsnagUserUserId = @"BugsnagUserUserId";
  * @returns A boolean representing whether the apiKey is valid.
  */
 + (BOOL)isValidApiKey:(NSString *)apiKey {
-    if ([self isApiKeyMissing:apiKey]) {
-        return false;
-    }
-
     NSCharacterSet *chars = [[NSCharacterSet
         characterSetWithCharactersInString:@"0123456789ABCDEF"] invertedSet];
 
     BOOL isHex = (NSNotFound == [[apiKey uppercaseString] rangeOfCharacterFromSet:chars].location);
 
     return isHex && [apiKey length] == BSGApiKeyLength;
-}
-
-/**
- * Check if the API Key is missing, i.e. it's nil, not a string or is empty.
- *
- * This is distinct from 'isValidApiKey' to allow throwing an exception in this case, but not
- * if the API Key is in the wrong format.
- *
- * @param apiKey The API key.
- * @returns A boolean representing whether the API key is nil, of the wrong type or is an empty string
- */
-+ (BOOL)isApiKeyMissing:(NSString *)apiKey {
-    return apiKey == nil || ![apiKey isKindOfClass:[NSString class]] || [apiKey length] == 0;
 }
 
 // -----------------------------------------------------------------------------
@@ -189,7 +157,8 @@ NSString * const kBugsnagUserUserId = @"BugsnagUserUserId";
  * Should not be called, but if it _is_ then fail meaningfully rather than silently
  */
 - (instancetype)init {
-    @throw BSGInitError;
+    @throw [NSException exceptionWithName:NSInternalInconsistencyException reason:
+            @"-[BugsnagConfiguration init] is unavailable.  Use -[BugsnagConfiguration initWithApiKey:] instead." userInfo:nil];
 }
 
 /**
@@ -622,25 +591,18 @@ NSString * const kBugsnagUserUserId = @"BugsnagUserUserId";
 
 // MARK: -
 
-@synthesize apiKey = _apiKey;
-
-- (NSString *)apiKey {
-    return _apiKey;
-}
-
-- (void)setApiKey:(NSString *)apiKey {
-    if ([BugsnagConfiguration isApiKeyMissing:apiKey]) {
-        @throw BSGApiKeyMissingError;
+- (void)validate {
+    if (self.apiKey.length == 0) {
+        @throw [NSException exceptionWithName:NSInvalidArgumentException reason:
+                @"No Bugsnag API key has been provided" userInfo:nil];
     }
 
-    if (![BugsnagConfiguration isValidApiKey:apiKey]) {
-        bsg_log_warn(@"Invalid configuration. apiKey should be a 32-character hexademical string, got \"%@\"", apiKey);
+    if (![BugsnagConfiguration isValidApiKey:self.apiKey]) {
+        bsg_log_warn(@"Invalid Bugsnag apiKey: expected a 32-character hexademical string, got \"%@\"", self.apiKey);
     }
-
-    [self willChangeValueForKey:NSStringFromSelector(@selector(apiKey))];
-    _apiKey = apiKey;
-    [self didChangeValueForKey:NSStringFromSelector(@selector(apiKey))];
 }
+
+// MARK: -
 
 - (void)addPlugin:(id<BugsnagPlugin> _Nonnull)plugin {
     [_plugins addObject:plugin];

--- a/Bugsnag/Private.h
+++ b/Bugsnag/Private.h
@@ -5,21 +5,46 @@
 #ifndef BUGSNAG_PRIVATE_H
 #define BUGSNAG_PRIVATE_H
 
+#import "BSG_RFC3339DateTool.h"
 #import "Bugsnag.h"
 #import "BugsnagBreadcrumb.h"
 #import "BugsnagBreadcrumbs.h"
+#import "BugsnagKeys.h"
+#import "BugsnagLogger.h"
+#import "BugsnagMetadataInternal.h"
+#import "BugsnagPlatformConditional.h"
+
+@class BugsnagConfiguration;
+
+#pragma mark -
+
+@interface BugsnagConfiguration ()
+
+/// Throws an NSInvalidArgumentException if the API key is empty or missing.
+/// Logs a warning message if the API key is not in the expected format.
+- (void)validate;
+
+@end
+
+#pragma mark -
 
 @interface BugsnagBreadcrumb ()
 
 - (NSDictionary *_Nullable)objectValue;
+
 @end
+
+#pragma mark -
 
 @interface BugsnagBreadcrumbs ()
 /**
  * Reads and return breadcrumb data currently stored on disk
  */
 - (NSArray *_Nullable)cachedBreadcrumbs;
+
 @end
+
+#pragma mark -
 
 @interface Bugsnag ()
 

--- a/Bugsnag/include/Bugsnag/Bugsnag.h
+++ b/Bugsnag/include/Bugsnag/Bugsnag.h
@@ -50,19 +50,28 @@
 
 /** Start listening for crashes.
  *
- * This method initializes Bugsnag with the configuration set in your PList. Any uncaught
- * NSExceptions, C++ exceptions, mach exceptions or signals will be logged to
- * disk before your app crashes. The next time your app boots, we send any such
- * reports to Bugsnag.
+ * This method initializes Bugsnag with the configuration set in your Info.plist.
+ *
+ * If a Bugsnag apiKey string has not been added to your Info.plist or is empty, an
+ * NSException will be thrown to indicate that the configuration is not valid.
+ *
+ * Once successfully initialized, NSExceptions, C++ exceptions, Mach exceptions and
+ * signals will be logged to disk before your app crashes. The next time your app
+ * launches, these reports will be sent to your Bugsnag dashboard.
  */
 + (BugsnagClient *_Nonnull)start;
 
 /** Start listening for crashes.
  *
- * This method initializes Bugsnag with the default configuration. Any uncaught
- * NSExceptions, C++ exceptions, mach exceptions or signals will be logged to
- * disk before your app crashes. The next time your app boots, we send any such
- * reports to Bugsnag.
+ * This method initializes Bugsnag with the default configuration and the provided
+ * apiKey.
+ *
+ * If apiKey is nil or is empty, an NSException will be thrown to indicate that the
+ * configuration is not valid.
+ *
+ * Once successfully initialized, NSExceptions, C++ exceptions, Mach exceptions and
+ * signals will be logged to disk before your app crashes. The next time your app
+ * launches, these reports will be sent to your Bugsnag dashboard.
  *
  * @param apiKey  The API key from your Bugsnag dashboard.
  */
@@ -70,10 +79,14 @@
 
 /** Start listening for crashes.
  *
- * This method initializes Bugsnag. Any uncaught NSExceptions, uncaught
- * C++ exceptions, mach exceptions or signals will be logged to disk before
- * your app crashes. The next time your app boots, we send any such
- * reports to Bugsnag.
+ * This method initializes Bugsnag with the provided configuration object.
+ *
+ * If the configuration's apiKey is nil or is empty, an NSException will be thrown
+ * to indicate that the configuration is not valid.
+ *
+ * Once successfully initialized, NSExceptions, C++ exceptions, Mach exceptions and
+ * signals will be logged to disk before your app crashes. The next time your app
+ * launches, these reports will be sent to your Bugsnag dashboard.
  *
  * @param configuration  The configuration to use.
  */

--- a/Bugsnag/include/Bugsnag/BugsnagConfiguration.h
+++ b/Bugsnag/include/Bugsnag/BugsnagConfiguration.h
@@ -37,6 +37,8 @@
 @class BugsnagEndpointConfiguration;
 @class BugsnagErrorTypes;
 
+NS_ASSUME_NONNULL_BEGIN
+
 /**
  * Controls whether Bugsnag should capture and serialize the state of all threads at the time
  * of an error.
@@ -104,7 +106,17 @@ typedef BOOL (^BugsnagOnSessionBlock)(BugsnagSession *_Nonnull session);
  *
  * @return a BugsnagConfiguration containing the options set in the plist file
  */
-+ (instancetype _Nonnull)loadConfig;
++ (instancetype)loadConfig;
+
+/**
+ * Initializes a new configuration object with the provided API key.
+ */
+- (instancetype)initWithApiKey:(NSString *)apiKey NS_DESIGNATED_INITIALIZER NS_SWIFT_NAME(init(_:));
+
+/**
+ * Required declaration to suppress a superclass designated-initializer error
+ */
+- (instancetype)init NS_UNAVAILABLE NS_SWIFT_UNAVAILABLE("Use initWithApiKey:");
 
 // -----------------------------------------------------------------------------
 // MARK: - Properties
@@ -217,18 +229,6 @@ typedef BOOL (^BugsnagOnSessionBlock)(BugsnagSession *_Nonnull session);
 @property BugsnagErrorTypes *_Nonnull enabledErrorTypes;
 
 /**
- * Required declaration to suppress a superclass designated-initializer error
- */
-- (instancetype _Nonnull )init NS_UNAVAILABLE NS_SWIFT_UNAVAILABLE("Use initWithApiKey:");
-
-/**
- * The designated initializer.
- */
-- (instancetype _Nonnull)initWithApiKey:(NSString *_Nonnull)apiKey
-    NS_DESIGNATED_INITIALIZER
-    NS_SWIFT_NAME(init(_:));
-
-/**
  * Set the endpoints to send data to. By default we'll send error reports to
  * https://notify.bugsnag.com, and sessions to https://sessions.bugsnag.com, but you can
  * override this if you are using Bugsnag Enterprise to point to your own Bugsnag endpoint.
@@ -324,3 +324,5 @@ typedef BOOL (^BugsnagOnSessionBlock)(BugsnagSession *_Nonnull session);
 - (void)addPlugin:(id<BugsnagPlugin> _Nonnull)plugin;
 
 @end
+
+NS_ASSUME_NONNULL_END

--- a/Tests/BSGConfigurationBuilderTests.m
+++ b/Tests/BSGConfigurationBuilderTests.m
@@ -1,11 +1,8 @@
 #import <XCTest/XCTest.h>
 
 #import "BSGConfigurationBuilder.h"
-#import "BugsnagConfiguration.h"
 #import "BugsnagTestConstants.h"
-#import "BugsnagEndpointConfiguration.h"
-#import "BugsnagErrorTypes.h"
-#import "BugsnagKeys.h"
+#import "Private.h"
 
 @interface BSGConfigurationBuilderTests : XCTestCase
 @end
@@ -15,8 +12,10 @@
 // MARK: - rejecting invalid plists
 
 - (void)testDecodeEmptyApiKey {
-    XCTAssertThrows([BSGConfigurationBuilder
-                     configurationFromOptions:@{@"apiKey": @""}]);
+    BugsnagConfiguration *configuration;
+    XCTAssertNoThrow(configuration = [BSGConfigurationBuilder configurationFromOptions:@{@"apiKey": @""}]);
+    XCTAssertEqualObjects(configuration.apiKey, @"");
+    XCTAssertThrows([configuration validate]);
 }
 
 - (void)testDecodeInvalidTypeApiKey {
@@ -25,8 +24,11 @@
 }
 
 - (void)testDecodeWithoutApiKey {
-    XCTAssertThrows([BSGConfigurationBuilder
-                     configurationFromOptions:@{@"autoDetectErrors": @NO}]);
+    BugsnagConfiguration *configuration;
+    XCTAssertNoThrow(configuration = [BSGConfigurationBuilder configurationFromOptions:@{@"autoDetectErrors": @NO}]);
+    XCTAssertNil(configuration.apiKey);
+    XCTAssertFalse(configuration.autoDetectErrors);
+    XCTAssertThrows([configuration validate]);
 }
 
 - (void)testDecodeUnknownKeys {
@@ -38,8 +40,7 @@
 }
 
 - (void)testDecodeEmptyOptions {
-    XCTAssertThrows([BSGConfigurationBuilder
-                     configurationFromOptions:@{}]);
+    XCTAssertNoThrow([BSGConfigurationBuilder configurationFromOptions:@{}]);
 }
 
 // MARK: - config loading

--- a/Tests/BugsnagClientTests.m
+++ b/Tests/BugsnagClientTests.m
@@ -126,6 +126,26 @@ void BSSerializeJSONDictionary(NSDictionary *dictionary, char **destination);
     XCTAssertNil([configuration getMetadataFromSection:@"exampleSection3" withKey:@"exampleKey3"]);
 }
 
+- (void)testMissingApiKey {
+    BugsnagConfiguration *configuration = [[BugsnagConfiguration alloc] initWithApiKey:@""];
+    BugsnagClient *client = [[BugsnagClient alloc] initWithConfiguration:configuration];
+    XCTAssertThrowsSpecificNamed([client start], NSException, NSInvalidArgumentException,
+                                 @"An empty apiKey should cause [BugsnagClient start] to throw an exception.");
+    
+#pragma clang diagnostic push
+#pragma clang diagnostic ignored "-Wnonnull"
+    configuration.apiKey = nil;
+#pragma clang diagnostic pop
+    XCTAssertThrowsSpecificNamed([client start], NSException, NSInvalidArgumentException,
+                                 @"A missing apiKey should cause [BugsnagClient start] to throw an exception.");
+}
+
+- (void)testInvalidApiKey {
+    BugsnagConfiguration *configuration = [[BugsnagConfiguration alloc] initWithApiKey:@"INVALID-API-KEY"];
+    BugsnagClient *client = [[BugsnagClient alloc] initWithConfiguration:configuration];
+    XCTAssertNoThrow([client start], @"[BugsnagClient start] should not throw an exception if the apiKey appears to be malformed");
+}
+
 /**
  * Test that user info is stored and retreived correctly
  */

--- a/Tests/BugsnagConfigurationTests.m
+++ b/Tests/BugsnagConfigurationTests.m
@@ -5,13 +5,10 @@
 #import <XCTest/XCTest.h>
 
 #import "BugsnagTestConstants.h"
-#import "Bugsnag.h"
-#import "BugsnagConfiguration.h"
 #import "BugsnagCrashSentry.h"
-#import "BugsnagKeys.h"
 #import "BugsnagSessionTracker.h"
-#import "BugsnagUser.h"
 #import "BSG_KSCrashType.h"
+#import "Private.h"
 
 // =============================================================================
 // MARK: - Required private methods
@@ -635,11 +632,11 @@ NSString * const kBugsnagUserUserId = @"BugsnagUserUserId";
 // MARK: - Other tests
 // =============================================================================
 
-- (void)testInitWithApiKeyThrowsWhenMissing {
+- (void)testValidateThrowsWhenMissingApiKey {
     NSString *nilKey = nil;
 
-    XCTAssertThrows([[BugsnagConfiguration alloc] initWithApiKey:nilKey]);
-    XCTAssertThrows([[BugsnagConfiguration alloc] initWithApiKey:@""]);
+    XCTAssertThrows([[[BugsnagConfiguration alloc] initWithApiKey:nilKey] validate]);
+    XCTAssertThrows([[[BugsnagConfiguration alloc] initWithApiKey:@""] validate]);
 }
 
 /**
@@ -692,30 +689,6 @@ NSString * const kBugsnagUserUserId = @"BugsnagUserUserId";
     XCTAssertEqualObjects(@"123", config.user.id);
     XCTAssertEqualObjects(@"foo", config.user.name);
     XCTAssertEqualObjects(@"test@example.com", config.user.email);
-}
-
-- (void)testApiKeySetter {
-    BugsnagConfiguration *config = [[BugsnagConfiguration alloc] initWithApiKey:DUMMY_APIKEY_32CHAR_1];
-    XCTAssertEqual(DUMMY_APIKEY_32CHAR_1, config.apiKey);
-
-    config.apiKey = DUMMY_APIKEY_32CHAR_1;
-    XCTAssertEqual(DUMMY_APIKEY_32CHAR_1, config.apiKey);
-
-#pragma clang diagnostic push
-#pragma clang diagnostic ignored "-Wnonnull"
-    XCTAssertThrows(config.apiKey = nil);
-#pragma clang diagnostic pop
-
-    XCTAssertEqual(DUMMY_APIKEY_32CHAR_1, config.apiKey);
-
-    XCTAssertThrows(config.apiKey = @"");
-    XCTAssertEqual(DUMMY_APIKEY_32CHAR_1, config.apiKey);
-
-    config.apiKey = DUMMY_APIKEY_16CHAR;
-    XCTAssertEqual(DUMMY_APIKEY_16CHAR, config.apiKey);
-
-    config.apiKey = DUMMY_APIKEY_32CHAR_1;
-    XCTAssertEqual(DUMMY_APIKEY_32CHAR_1, config.apiKey);
 }
 
 -(void)testBSGErrorTypes {


### PR DESCRIPTION
## Goal & changes

This change aims to make the `BugsnagConfiguration` API easier to work with by making the `-initWithApiKey:` initializer more prominent and deferring checks for the presence of an api key until `-[BugsnagClient start]` is called.

It also fixes the throwing of an exception if the api key is missing, by ensuring an `NSException` is thrown rather than a string - which ensures a message is logged in the app developer's Xcode console. As [Apple's documentation](https://developer.apple.com/library/archive/documentation/Cocoa/Conceptual/Exceptions/Tasks/RaisingExceptions.html) says - _"Cocoa applications should @<!-- -->throw only NSException objects"_

## Design

This approach was chosen to avoid making any API breaking changes, and make our APIs more intuitive to work with, as discussed in PLAT-5155

## Testing

This is covered by e2e and unit tests, which have been updated to cater for the changed runtime behaviour.