### PR TITLE
Remove extraneous severity info from unit test

### DIFF
--- a/Tests/BugsnagEventTests.m
+++ b/Tests/BugsnagEventTests.m
@@ -389,7 +389,7 @@
 - (void)testHandledReportSeverity {
     // handled reports should use the serialised depth
     BugsnagHandledState *state = [BugsnagHandledState handledStateWithSeverityReason:HandledException];
-    NSDictionary *dict = @{@"user.state.crash.severity": @"info", @"user.handledState": [state toJson]};
+    NSDictionary *dict = @{@"user.handledState": [state toJson]};
     BugsnagEvent *event = [[BugsnagEvent alloc] initWithKSReport:dict];
     XCTAssertEqual(event.severity, BSGSeverityWarning);
 }


### PR DESCRIPTION
## Goal

"user.state.crash.severity" is neither created nor used in the cocoa client, so it shouldn't be in the test.

## Design

Removed "user.state.crash.severity" from dictionary in `testHandledReportSeverity`

## Testing

Re-ran unit tests on ios, macos, tvos.
