### PR TITLE
Fix duration calculations in iOS.

### DIFF
--- a/Bugsnag/KSCrash/Source/KSCrash/Recording/BSG_KSCrash.m
+++ b/Bugsnag/KSCrash/Source/KSCrash/Recording/BSG_KSCrash.m
@@ -327,6 +327,7 @@ IMPLEMENT_EXCLUSIVE_SHARED_INSTANCE(BSG_KSCrash)
     BSG_KSCrash_State state = crashContext()->state;
     bsg_kscrashstate_updateDurationStats(&state);
     NSMutableDictionary *dict = [NSMutableDictionary new];
+    BSGDictSetSafeObject(dict, @(state.durationSinceLaunch), @BSG_KSCrashField_TimeSinceLaunch);
     BSGDictSetSafeObject(dict, @(state.activeDurationSinceLaunch), @BSG_KSCrashField_ActiveTimeSinceLaunch);
     BSGDictSetSafeObject(dict, @(state.backgroundDurationSinceLaunch), @BSG_KSCrashField_BGTimeSinceLaunch);
     BSGDictSetSafeObject(dict, @(state.applicationIsInForeground), @BSG_KSCrashField_AppInFG);

--- a/Bugsnag/KSCrash/Source/KSCrash/Recording/BSG_KSCrashReport.c
+++ b/Bugsnag/KSCrash/Source/KSCrash/Recording/BSG_KSCrashReport.c
@@ -1365,6 +1365,9 @@ void bsg_kscrw_i_writeAppStats(const BSG_KSCrashReportWriter *const writer,
         writer->addIntegerElement(writer, BSG_KSCrashField_SessionsSinceLaunch,
                                   state->sessionsSinceLaunch);
         writer->addFloatingPointElement(writer,
+                                        BSG_KSCrashField_TimeSinceLaunch,
+                                        state->durationSinceLaunch);
+        writer->addFloatingPointElement(writer,
                                         BSG_KSCrashField_ActiveTimeSinceLaunch,
                                         state->activeDurationSinceLaunch);
         writer->addFloatingPointElement(writer,

--- a/Bugsnag/KSCrash/Source/KSCrash/Recording/BSG_KSCrashReportFields.h
+++ b/Bugsnag/KSCrash/Source/KSCrash/Recording/BSG_KSCrashReportFields.h
@@ -143,6 +143,8 @@
 
 #pragma mark - App Stats -
 
+#define BSG_KSCrashField_TimeSinceCrash "time_since_last_crash"
+#define BSG_KSCrashField_TimeSinceLaunch "time_since_launch"
 #define BSG_KSCrashField_ActiveTimeSinceCrash "active_time_since_last_crash"
 #define BSG_KSCrashField_ActiveTimeSinceLaunch "active_time_since_launch"
 #define BSG_KSCrashField_AppActive "application_active"

--- a/Bugsnag/KSCrash/Source/KSCrash/Recording/BSG_KSCrashState.h
+++ b/Bugsnag/KSCrash/Source/KSCrash/Recording/BSG_KSCrashState.h
@@ -42,6 +42,9 @@ extern "C" {
 typedef struct {
     // Saved data
 
+    /** Total time elapsed since the last crash. */
+    double durationSinceLastCrash;
+
     /** Total active time elapsed since the last crash. */
     double activeDurationSinceLastCrash;
 
@@ -74,9 +77,11 @@ typedef struct {
     /** Timestamp for when the app was launched (mach_absolute_time()) */
     uint64_t appLaunchTime;
 
-    /** Timestamp for when the app state was last changed (active<-> inactive,
-     * background<->foreground) (mach_absolute_time()) */
-    uint64_t appStateTransitionTime;
+    /** Seconds elapsed since app launch */
+    double durationSinceLaunch;
+
+    /** When the app durations were last updated */
+    uint64_t lastDurationUpdate;
 
     /** If true, the application is currently active. */
     bool applicationIsActive;

--- a/Bugsnag/KSCrash/Source/KSCrash/Recording/BSG_KSSystemInfo.h
+++ b/Bugsnag/KSCrash/Source/KSCrash/Recording/BSG_KSSystemInfo.h
@@ -99,6 +99,12 @@
  * YES if the app is currently shown in the foreground
  */
 + (BOOL)isInForeground:(UIApplicationState)state;
+
+/**
+ * YES if the app is currently active
+ */
++ (BOOL)isActive:(UIApplicationState)state;
+
 #endif
 
 @end

--- a/Bugsnag/KSCrash/Source/KSCrash/Recording/BSG_KSSystemInfo.m
+++ b/Bugsnag/KSCrash/Source/KSCrash/Recording/BSG_KSSystemInfo.m
@@ -488,6 +488,10 @@
     return state == UIApplicationStateInactive
         || state == UIApplicationStateActive;
 }
+
++ (BOOL)isActive:(UIApplicationState)state {
+    return state == UIApplicationStateActive;
+}
 #endif
 
 @end

--- a/Bugsnag/Payload/BugsnagAppWithState.m
+++ b/Bugsnag/Payload/BugsnagAppWithState.m
@@ -10,6 +10,7 @@
 #import "BugsnagKeys.h"
 #import "BugsnagConfiguration.h"
 #import "BugsnagCollections.h"
+#import "BSG_KSCrashReportFields.h"
 
 @interface BugsnagApp ()
 + (void)populateFields:(BugsnagApp *)app
@@ -77,12 +78,12 @@
     NSDictionary *stats = system[@"application_stats"];
 
     // convert from seconds to milliseconds
-    NSNumber *activeTimeSinceLaunch = @([stats[@"active_time_since_launch"] longValue] * 1000);
-    NSNumber *backgroundTimeSinceLaunch = @([stats[@"background_time_since_launch"] longValue] * 1000);
+    NSNumber *activeTimeSinceLaunch = @([stats[@BSG_KSCrashField_ActiveTimeSinceLaunch] longValue] * 1000);
+    NSNumber *totalTimeSinceLaunch = @([stats[@BSG_KSCrashField_TimeSinceLaunch] longValue] * 1000);
 
     app.durationInForeground = activeTimeSinceLaunch;
-    app.duration = @([activeTimeSinceLaunch longValue] + [backgroundTimeSinceLaunch longValue]);
-    app.inForeground = [stats[@"application_in_foreground"] boolValue];
+    app.duration = totalTimeSinceLaunch;
+    app.inForeground = [stats[@BSG_KSCrashField_AppInFG] boolValue];
     [BugsnagApp populateFields:app dictionary:event config:config codeBundleId:codeBundleId];
     return app;
 }

--- a/Tests/BugsnagAppTest.m
+++ b/Tests/BugsnagAppTest.m
@@ -44,7 +44,7 @@
             @"system": @{
                     @"application_stats": @{
                             @"active_time_since_launch": @2,
-                            @"background_time_since_launch": @5,
+                            @"time_since_launch": @7,
                             @"application_in_foreground": @YES,
                     },
                     @"CFBundleExecutable": @"MyIosApp",

--- a/Tests/KSCrash/KSCrashState_Tests.m
+++ b/Tests/KSCrash/KSCrashState_Tests.m
@@ -45,7 +45,7 @@
                       &context);
 
     XCTAssertTrue(context.applicationIsInForeground, @"");
-    XCTAssertFalse(context.applicationIsActive, @"");
+    XCTAssertTrue(context.applicationIsActive, @"");
 
     XCTAssertEqual(context.activeDurationSinceLastCrash, 0.0, @"");
     XCTAssertEqual(context.backgroundDurationSinceLastCrash, 0.0, @"");
@@ -65,7 +65,7 @@
                       &context);
 
     XCTAssertTrue(context.applicationIsInForeground, @"");
-    XCTAssertFalse(context.applicationIsActive, @"");
+    XCTAssertTrue(context.applicationIsActive, @"");
 
     XCTAssertEqual(context.activeDurationSinceLastCrash, 0.0, @"");
     XCTAssertEqual(context.backgroundDurationSinceLastCrash, 0.0, @"");
@@ -124,7 +124,7 @@
                       &context);
 
     XCTAssertTrue(context.applicationIsInForeground, @"");
-    XCTAssertFalse(context.applicationIsActive, @"");
+    XCTAssertTrue(context.applicationIsActive, @"");
 
     XCTAssertEqual(context.activeDurationSinceLastCrash, 0.0, @"");
     XCTAssertEqual(context.backgroundDurationSinceLastCrash, 0.0, @"");
@@ -184,7 +184,7 @@
                       &context);
 
     XCTAssertTrue(context.applicationIsInForeground, @"");
-    XCTAssertFalse(context.applicationIsActive, @"");
+    XCTAssertTrue(context.applicationIsActive, @"");
 
     XCTAssertEqual(context.activeDurationSinceLastCrash, 0.0, @"");
     XCTAssertEqual(context.backgroundDurationSinceLastCrash, 0.0, @"");
@@ -268,7 +268,7 @@
                       &context);
 
     XCTAssertTrue(context.applicationIsInForeground, @"");
-    XCTAssertFalse(context.applicationIsActive, @"");
+    XCTAssertTrue(context.applicationIsActive, @"");
 
     XCTAssertEqual(context.activeDurationSinceLastCrash, 0.0, @"");
     XCTAssertEqual(context.backgroundDurationSinceLastCrash, 0.0, @"");
@@ -331,7 +331,7 @@
     BSG_KSCrash_State checkpointR = context;
 
     XCTAssertTrue(checkpointR.applicationIsInForeground, @"");
-    XCTAssertFalse(checkpointR.applicationIsActive, @"");
+    XCTAssertTrue(checkpointR.applicationIsActive, @"");
     XCTAssertEqual(checkpointR.appLaunchTime, 0, @"");
 
     // We don't save after going inactive, so this will still be 0.
@@ -395,7 +395,7 @@
                       &context);
 
     XCTAssertTrue(context.applicationIsInForeground, @"");
-    XCTAssertFalse(context.applicationIsActive, @"");
+    XCTAssertTrue(context.applicationIsActive, @"");
 
     XCTAssertEqual(context.activeDurationSinceLastCrash, 0.0, @"");
     XCTAssertEqual(context.backgroundDurationSinceLastCrash, 0.0, @"");
@@ -460,7 +460,7 @@
     BSG_KSCrash_State checkpointR = context;
 
     XCTAssertTrue(checkpointR.applicationIsInForeground, @"");
-    XCTAssertFalse(checkpointR.applicationIsActive, @"");
+    XCTAssertTrue(checkpointR.applicationIsActive, @"");
 
     XCTAssertTrue(checkpointR.activeDurationSinceLastCrash > 0, @"");
     XCTAssertEqual(checkpointR.backgroundDurationSinceLastCrash, 0.0, @"");
@@ -499,7 +499,7 @@
     BSG_KSCrash_State checkpointR = context;
 
     XCTAssertTrue(checkpointR.applicationIsInForeground, @"");
-    XCTAssertFalse(checkpointR.applicationIsActive, @"");
+    XCTAssertTrue(checkpointR.applicationIsActive, @"");
     XCTAssertEqual(checkpointR.appLaunchTime, 0, @"");
 
     XCTAssertTrue(checkpointR.backgroundDurationSinceLastCrash >
@@ -564,7 +564,7 @@
                       &context);
 
     XCTAssertTrue(context.applicationIsInForeground, @"");
-    XCTAssertFalse(context.applicationIsActive, @"");
+    XCTAssertTrue(context.applicationIsActive, @"");
 
     XCTAssertEqual(context.activeDurationSinceLastCrash, 0.0, @"");
     XCTAssertEqual(context.backgroundDurationSinceLastCrash, 0.0, @"");
@@ -645,7 +645,7 @@
     BSG_KSCrash_State checkpointR = context;
 
     XCTAssertTrue(checkpointR.applicationIsInForeground, @"");
-    XCTAssertFalse(checkpointR.applicationIsActive, @"");
+    XCTAssertTrue(checkpointR.applicationIsActive, @"");
 
     XCTAssertTrue(checkpointR.activeDurationSinceLastCrash > 0, @"");
     // We don't save after going to FG, so this will still be 0.
@@ -712,7 +712,7 @@
                       &context);
 
     XCTAssertTrue(context.applicationIsInForeground, @"");
-    XCTAssertFalse(context.applicationIsActive, @"");
+    XCTAssertTrue(context.applicationIsActive, @"");
 
     XCTAssertEqual(context.activeDurationSinceLastCrash, 0.0, @"");
     XCTAssertEqual(context.backgroundDurationSinceLastCrash, 0.0, @"");

--- a/Tests/report.json
+++ b/Tests/report.json
@@ -9,7 +9,7 @@
         "kernel_version": "Darwin Kernel Version 14.0.0: Fri Sep 19 00:26:44 PDT 2014; root:xnu-2782.1.97~2/RELEASE_X86_64",
         "machine": "x86_64",
         "application_stats": {
-            "background_time_since_last_crash": 2,
+            "time_since_launch": 4,
             "active_time_since_launch": 2,
             "sessions_since_last_crash": 1,
             "launches_since_last_crash": 1,


### PR DESCRIPTION
## Goal

Duration was being calculated as background time + active time, which is incorrect. 

## Design

These changes store the real wall time in addition to background and active time.

Piecing together total time from other times is error prone and fragile. Storing the actual wall time ensures this data is always correct.

## Changeset

KSCrashState and all dependent code required changes to support this.

## Testing

Some unit tests needed to be changed since they worked under the assumption that total duration is a calculated value.
