### PR TITLE
[PLAT-5200] Fix intermittent test failures in features/config_from_plist.feature

### DIFF
--- a/Bugsnag/Configuration/BSGConfigurationBuilder.m
+++ b/Bugsnag/Configuration/BSGConfigurationBuilder.m
@@ -1,4 +1,6 @@
 #import "BSGConfigurationBuilder.h"
+
+#import "BSG_KSLogger.h"
 #import "BugsnagConfiguration.h"
 #import "BugsnagEndpointConfiguration.h"
 #import "BugsnagKeys.h"
@@ -18,6 +20,28 @@ static BOOL BSGValueIsBoolean(id object) {
 
     BugsnagConfiguration *config = [[BugsnagConfiguration alloc] initWithApiKey:apiKey];
 
+    NSArray<NSString *> *validKeys = @[
+        BSGKeyApiKey,
+        BSGKeyAppType,
+        BSGKeyAppVersion,
+        BSGKeyAutoDetectErrors,
+        BSGKeyAutoTrackSessions,
+        BSGKeyBundleVersion,
+        BSGKeyEnabledReleaseStages,
+        BSGKeyEndpoints,
+        BSGKeyMaxBreadcrumbs,
+        BSGKeyPersistUser,
+        BSGKeyRedactedKeys,
+        BSGKeyReleaseStage,
+        BSGKeySendThreads,
+    ];
+    
+    NSMutableSet *unknownKeys = [NSMutableSet setWithArray:options.allKeys];
+    [unknownKeys minusSet:[NSSet setWithArray:validKeys]];
+    if (unknownKeys.count > 0) {
+        BSG_KSLOG_WARN(@"Unknown dictionary keys passed in configuration options: %@", unknownKeys);
+    }
+    
     [self loadString:config options:options key:BSGKeyAppType];
     [self loadString:config options:options key:BSGKeyAppVersion];
     [self loadBoolean:config options:options key:BSGKeyAutoDetectErrors];

--- a/features/app_and_device_attributes.feature
+++ b/features/app_and_device_attributes.feature
@@ -1,7 +1,7 @@
 Feature: App and Device attributes present
 
   Background:
-    Given I clear all UserDefaults data
+    Given I clear all persistent data
 
   Scenario: App and Device info is as expected
     When I run "AppAndDeviceAttributesScenario"

--- a/features/auto_detect_errors.feature
+++ b/features/auto_detect_errors.feature
@@ -3,7 +3,7 @@ Feature: autoDetectErrors flag controls whether errors are captured automaticall
     is false it should only capture handled errors which the user has reported.
 
     Background:
-        Given I clear all UserDefaults data
+        Given I clear all persistent data
 
     Scenario: Uncaught NSException not reported when autoDetectErrors is false
         When I run "AutoDetectFalseHandledScenario"

--- a/features/breadcrumb_callbacks.feature
+++ b/features/breadcrumb_callbacks.feature
@@ -1,7 +1,7 @@
 Feature: Callbacks can access and modify breadcrumb information
 
   Background:
-    Given I clear all UserDefaults data
+    Given I clear all persistent data
 
   Scenario: Returning false in a callback discards breadcrumbs
     When I run "BreadcrumbCallbackDiscardScenario"

--- a/features/breadcrumbs.feature
+++ b/features/breadcrumbs.feature
@@ -4,7 +4,7 @@ Feature: Attaching a series of notable events leading up to errors
   lead the developer to the cause of the event being reported.
 
   Background:
-    Given I clear all UserDefaults data
+    Given I clear all persistent data
 
   Scenario: Manually leaving a breadcrumb of a discarded type and discarding automatic
     When I run "DiscardedBreadcrumbTypeScenario"

--- a/features/config_from_plist.feature
+++ b/features/config_from_plist.feature
@@ -7,13 +7,10 @@ Feature: Loading Bugsnag configuration from Info.plist
 
     Scenario: Specifying config in Info.plist
         When I run "LoadConfigFromFileScenario"
-        # TODO: This should be 2, but until soft-reset code is added, we get a spurious OOM.
-        And I wait to receive 3 requests
+        And I wait to receive 2 requests
         And the "Bugsnag-API-Key" header equals "0192837465afbecd0192837465afbecd"
         And the payload field "notifier.name" equals "iOS Bugsnag Notifier"
         And the payload field "sessions" is not null
-        And I discard the oldest request
-        # TODO: Remove this second discard after adding soft-reset
         And I discard the oldest request
         And the "Bugsnag-API-Key" header equals "0192837465afbecd0192837465afbecd"
         And the payload field "notifier.name" equals "iOS Bugsnag Notifier"
@@ -22,13 +19,10 @@ Feature: Loading Bugsnag configuration from Info.plist
 
     Scenario: Calling Bugsnag.start() with no configuration
         When I run "LoadConfigFromFileAutoScenario"
-        # TODO: This should be 2, but until soft-reset code is added, we get a spurious OOM.
-        And I wait to receive 3 requests
+        And I wait to receive 2 requests
         And the "Bugsnag-API-Key" header equals "0192837465afbecd0192837465afbecd"
         And the payload field "notifier.name" equals "iOS Bugsnag Notifier"
         And the payload field "sessions" is not null
-        And I discard the oldest request
-        # TODO: Remove this second discard after adding soft-reset
         And I discard the oldest request
         And the "Bugsnag-API-Key" header equals "0192837465afbecd0192837465afbecd"
         And the payload field "notifier.name" equals "iOS Bugsnag Notifier"

--- a/features/config_from_plist.feature
+++ b/features/config_from_plist.feature
@@ -3,7 +3,7 @@ Feature: Loading Bugsnag configuration from Info.plist
   writing code for those options.
 
     Background:
-        Given I clear all UserDefaults data
+        Given I clear all persistent data
 
     Scenario: Specifying config in Info.plist
         When I run "LoadConfigFromFileScenario"

--- a/features/context.feature
+++ b/features/context.feature
@@ -1,7 +1,7 @@
 Feature: The context can be automatically and manually set on errors
 
   Background:
-    Given I clear all UserDefaults data
+    Given I clear all persistent data
 
   Scenario: Automatic context from a handled NSError
     When I run "AutoContextNSErrorScenario"

--- a/features/crashprobe.feature
+++ b/features/crashprobe.feature
@@ -1,7 +1,7 @@
 Feature: Reporting crash events
 
   Background:
-    Given I clear all UserDefaults data
+    Given I clear all persistent data
 
   Scenario: Executing privileged instruction
     When I run "PrivilegedInstructionScenario" and relaunch the app

--- a/features/cross_notifier_notify.feature
+++ b/features/cross_notifier_notify.feature
@@ -6,7 +6,7 @@ Feature: Communicating events between notifiers
   using bugsnag-cocoa as the delivery layer.
 
   Background:
-    Given I clear all UserDefaults data
+    Given I clear all persistent data
 
   Scenario: Report a handled event through internalNotify()
   Report a handled exception, including a custom stacktrace and severity.

--- a/features/enabled_error_types.feature
+++ b/features/enabled_error_types.feature
@@ -1,7 +1,7 @@
 Feature: Enabled error types
 
   Background:
-    Given I clear all UserDefaults data
+    Given I clear all persistent data
 
   Scenario: All Crash reporting is disabled
     # Sessions: on, unhandled crashes: off

--- a/features/error_reporting_thread.feature
+++ b/features/error_reporting_thread.feature
@@ -1,7 +1,7 @@
 Feature: Error Reporting Thread
 
   Background:
-    Given I clear all UserDefaults data
+    Given I clear all persistent data
 
   Scenario: Only 1 thread is flagged as the error reporting thread
     When I run "HandledErrorScenario"

--- a/features/event_callbacks.feature
+++ b/features/event_callbacks.feature
@@ -1,7 +1,7 @@
 Feature: Callbacks can access and modify event information
 
   Background:
-    Given I clear all UserDefaults data
+    Given I clear all persistent data
 
   Scenario: Removing an OnSend callback does not affect other OnSend callbacks
     When I run "OnSendCallbackRemovalScenario"

--- a/features/fixtures/ios-swift-cocoapods/iOSTestApp/Base.lproj/Main.storyboard
+++ b/features/fixtures/ios-swift-cocoapods/iOSTestApp/Base.lproj/Main.storyboard
@@ -53,10 +53,10 @@
                             </button>
                             <button opaque="NO" contentMode="scaleToFill" contentHorizontalAlignment="center" contentVerticalAlignment="center" buttonType="roundedRect" lineBreakMode="middleTruncation" translatesAutoresizingMaskIntoConstraints="NO" id="zEv-jB-Vej">
                                 <rect key="frame" x="20" y="343" width="374" height="30"/>
-                                <accessibility key="accessibilityConfiguration" identifier="ClearUserDefaultsButton"/>
-                                <state key="normal" title="Clear User Defaults"/>
+                                <accessibility key="accessibilityConfiguration" identifier="ClearPersistentDataButton"/>
+                                <state key="normal" title="Clear Persistent Data"/>
                                 <connections>
-                                    <action selector="clearUserData:" destination="BYZ-38-t0r" eventType="touchUpInside" id="ZcO-Ew-Mhu"/>
+                                    <action selector="clearPersistentData:" destination="BYZ-38-t0r" eventType="touchUpInside" id="ZcO-Ew-Mhu"/>
                                 </connections>
                             </button>
                             <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="251" text="Manual Testing" textAlignment="center" lineBreakMode="tailTruncation" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" translatesAutoresizingMaskIntoConstraints="NO" id="X9q-4y-UF2">

--- a/features/fixtures/ios-swift-cocoapods/iOSTestApp/Info.plist
+++ b/features/fixtures/ios-swift-cocoapods/iOSTestApp/Info.plist
@@ -75,17 +75,6 @@
 		<string>0192837465afbecd0192837465afbecd</string>
 		<key>releaseStage</key>
 		<string>beta2</string>
-		<key>notifyReleaseStages</key>
-		<array>
-			<string>beta2</string>
-			<string>prod</string>
-		</array>
-		<key>reportOOMs</key>
-		<false/>
-		<key>autoNotify</key>
-		<false/>
-		<key>autoBreadcrumbs</key>
-		<true/>
 		<key>autoTrackSessions</key>
 		<true/>
 	</dict>

--- a/features/fixtures/ios-swift-cocoapods/iOSTestApp/ViewController.swift
+++ b/features/fixtures/ios-swift-cocoapods/iOSTestApp/ViewController.swift
@@ -44,8 +44,12 @@ class ViewController: UIViewController {
         UserDefaults.standard.removePersistentDomain(forName: Bundle.main.bundleIdentifier!)
         do {
             let cachesDirectory = FileManager.default.urls(for: .cachesDirectory, in: .userDomainMask)[0]
-            for url in try FileManager.default.contentsOfDirectory(at: cachesDirectory, includingPropertiesForKeys: []) {
-                try FileManager.default.removeItem(at: url)
+            try FileManager.default.contentsOfDirectory(at: cachesDirectory, includingPropertiesForKeys: []).forEach {
+                do {
+                    try FileManager.default.removeItem(at: $0)
+                } catch {
+                    NSLog("%@", String(describing: error))
+                }
             }
         } catch {
             NSLog("%@", String(describing: error))

--- a/features/fixtures/ios-swift-cocoapods/iOSTestApp/ViewController.swift
+++ b/features/fixtures/ios-swift-cocoapods/iOSTestApp/ViewController.swift
@@ -39,10 +39,10 @@ class ViewController: UIViewController {
         scenario?.startBugsnag()
     }
     
-    @IBAction func clearUserData(_ sender: Any) {
-        NSLog("Clear user defaults")
+    @IBAction func clearPersistentData(_ sender: Any) {
+        NSLog("Clear persistent data")
         UserDefaults.standard.removePersistentDomain(forName: Bundle.main.bundleIdentifier!)
-        do {
+        do { // Delete Bugsnag persistent data to prevent sending of OOMS, old crash reports, or old sessions
             let cachesDirectory = FileManager.default.urls(for: .cachesDirectory, in: .userDomainMask)[0]
             try FileManager.default.contentsOfDirectory(at: cachesDirectory, includingPropertiesForKeys: []).forEach {
                 do {

--- a/features/fixtures/ios-swift-cocoapods/iOSTestApp/ViewController.swift
+++ b/features/fixtures/ios-swift-cocoapods/iOSTestApp/ViewController.swift
@@ -42,6 +42,14 @@ class ViewController: UIViewController {
     @IBAction func clearUserData(_ sender: Any) {
         NSLog("Clear user defaults")
         UserDefaults.standard.removePersistentDomain(forName: Bundle.main.bundleIdentifier!)
+        do {
+            let cachesDirectory = FileManager.default.urls(for: .cachesDirectory, in: .userDomainMask)[0]
+            for url in try FileManager.default.contentsOfDirectory(at: cachesDirectory, includingPropertiesForKeys: []) {
+                try FileManager.default.removeItem(at: url)
+            }
+        } catch {
+            NSLog("%@", String(describing: error))
+        }
     }
     
     internal func prepareScenario() -> Scenario {

--- a/features/handled_errors.feature
+++ b/features/handled_errors.feature
@@ -1,7 +1,7 @@
 Feature: Handled Errors and Exceptions
 
   Background:
-    Given I clear all UserDefaults data
+    Given I clear all persistent data
 
   Scenario: Override errorClass and message from a notifyError() callback, customize report
 

--- a/features/metadata_merging.feature
+++ b/features/metadata_merging.feature
@@ -1,7 +1,7 @@
 Feature: Metadata values are merged in a defined order
 
   Background:
-    Given I clear all UserDefaults data
+    Given I clear all persistent data
 
   Scenario: Merging metadata values
     When I run "MetadataMergeScenario"

--- a/features/metadata_redaction.feature
+++ b/features/metadata_redaction.feature
@@ -2,7 +2,7 @@ Feature: Metadata values can be redacted
   Values added to metadata can be redacted through the use of config.redactedKeys
 
   Background:
-    Given I clear all UserDefaults data
+    Given I clear all persistent data
 
   Scenario: Default behaviour redacts 'password' values after callback is run
     When I run "MetadataRedactionDefaultScenario"

--- a/features/plugin_interface.feature
+++ b/features/plugin_interface.feature
@@ -6,7 +6,7 @@ Feature: Add custom behavior through a plugin interface
   initialization process.
 
   Background:
-    Given I clear all UserDefaults data
+    Given I clear all persistent data
 
   Scenario: Changing payload notifier description
     When I run "CustomPluginNotifierDescriptionScenario" and relaunch the app

--- a/features/release_stage_errors.feature
+++ b/features/release_stage_errors.feature
@@ -1,7 +1,7 @@
 Feature: Discarding reports based on release stage
 
   Background:
-    Given I clear all UserDefaults data
+    Given I clear all persistent data
 
   Scenario: Unhandled error ignored when release stage is not present in enabledReleaseStages
     When I run "UnhandledErrorInvalidReleaseStage" and relaunch the app

--- a/features/release_stage_sessions.feature
+++ b/features/release_stage_sessions.feature
@@ -1,7 +1,7 @@
 Feature: Discarding sessions based on release stage
 
   Background:
-    Given I clear all UserDefaults data
+    Given I clear all persistent data
 
   Scenario: Automatic sessions are only sent when enabledReleaseStages contains the releaseStage
     When I run "EnabledReleaseStageAutoSessionScenario"

--- a/features/runtime_versions.feature
+++ b/features/runtime_versions.feature
@@ -1,7 +1,7 @@
 Feature: Runtime versions are included in all requests
 
   Background:
-    Given I clear all UserDefaults data
+    Given I clear all persistent data
 
   Scenario: Runtime versions included in Cocoa error
     When I run "HandledErrorScenario"

--- a/features/session_callbacks.feature
+++ b/features/session_callbacks.feature
@@ -1,7 +1,7 @@
 Feature: Callbacks can access and modify session information
 
   Background:
-    Given I clear all UserDefaults data
+    Given I clear all persistent data
 
   Scenario: Returning false in a callback discards sessions
     When I run "SessionCallbackDiscardScenario"

--- a/features/session_stopping.feature
+++ b/features/session_stopping.feature
@@ -1,7 +1,7 @@
 Feature: Stopping and resuming sessions
 
   Background:
-    Given I clear all UserDefaults data
+    Given I clear all persistent data
 
   Scenario: When a session is stopped the error has no session information
     When I run "StoppedSessionScenario"

--- a/features/session_tracking.feature
+++ b/features/session_tracking.feature
@@ -1,7 +1,7 @@
 Feature: Session Tracking
 
   Background:
-    Given I clear all UserDefaults data
+    Given I clear all persistent data
 
   Scenario: Launching using the default configuration sends a single session
     When I run "AutoSessionScenario"

--- a/features/steps/ios_steps.rb
+++ b/features/steps/ios_steps.rb
@@ -22,10 +22,10 @@ When("I run {string} and relaunch the app") do |event_type|
   }
 end
 
-When("I clear all UserDefaults data") do
+When("I clear all persistent data") do
   steps %Q{
-    Given the element "ClearUserDefaultsButton" is present
-    And I click the element "ClearUserDefaultsButton"
+    Given the element "ClearPersistentDataButton" is present
+    And I click the element "ClearPersistentDataButton"
   }
 end
 

--- a/features/threads.feature
+++ b/features/threads.feature
@@ -1,7 +1,7 @@
 Feature: Handled Errors and Exceptions
 
   Background:
-    Given I clear all UserDefaults data
+    Given I clear all persistent data
 
   Scenario: Threads are captured for handled errors by default
     When I run "HandledErrorThreadSendAlwaysScenario"

--- a/features/unhandled_cpp_exception.feature
+++ b/features/unhandled_cpp_exception.feature
@@ -1,7 +1,7 @@
 Feature: Thrown C++ exceptions are captured by Bugsnag
 
   Background:
-    Given I clear all UserDefaults data
+    Given I clear all persistent data
 
   Scenario: Throwing a C++ exception
     When I run "CxxExceptionScenario" and relaunch the app

--- a/features/unhandled_mach_exception.feature
+++ b/features/unhandled_mach_exception.feature
@@ -1,7 +1,7 @@
 Feature: Bugsnag captures an unhandled mach exception
 
   Background:
-    Given I clear all UserDefaults data
+    Given I clear all persistent data
 
   Scenario: Trigger a mach exception
     When I run "UnhandledMachExceptionScenario" and relaunch the app

--- a/features/unhandled_nsexception.feature
+++ b/features/unhandled_nsexception.feature
@@ -1,7 +1,7 @@
 Feature: Uncaught NSExceptions are captured by Bugsnag
 
   Background:
-    Given I clear all UserDefaults data
+    Given I clear all persistent data
 
   Scenario: Throw a NSException
     When I run "ObjCExceptionScenario" and relaunch the app

--- a/features/unhandled_signal.feature
+++ b/features/unhandled_signal.feature
@@ -1,7 +1,7 @@
 Feature: Signals are captured as error reports in Bugsnag
 
   Background:
-    Given I clear all UserDefaults data
+    Given I clear all persistent data
 
   Scenario: Triggering SIGABRT
     When I run "AbortScenario" and relaunch the app

--- a/features/user.feature
+++ b/features/user.feature
@@ -1,7 +1,7 @@
 Feature: Reporting User Information
 
   Background:
-    Given I clear all UserDefaults data
+    Given I clear all persistent data
 
   Scenario: Default user information only includes ID
     When I run "UserDefaultInfoScenario"

--- a/features/user_persistence.feature
+++ b/features/user_persistence.feature
@@ -1,7 +1,7 @@
 Feature: Persisting User Information
 
   Background:
-    Given I clear all UserDefaults data
+    Given I clear all persistent data
 
   Scenario: User Info is persisted from config across app runs
     When I run "UserPersistencePersistUserScenario"


### PR DESCRIPTION
## Goal

The test scenarios in `features/config_from_plist.feature` were intermittently failing because the OOM reports were not always sent before the crash reports.

These tests were never intended to be run with OOMs enabled, but the recent changes to allow OOM detection in Debug builds started these being reported after the app is killed by Appium / Browserstack (the e2e tests are run against a [Debug](https://github.com/bugsnag/bugsnag-cocoa/blob/master/features/scripts/export_ios_app.sh#L16) build of the app.)

The test app's `Info.plist` contained keys that were attempting to disable OOMs, but these keys are not actually supported by the notifier. This had gone unnoticed because the notifier was not logging any warnings for unsupported keys, and OOMs were previously disabled in Debug builds.

## Changeset

**OOMs are now prevented**

by clearing out the caches directory (where the previous session state is stored) when a scenario invokes "Given I clear all UserDefaults data" - maybe this should be renamed accordingly?

**Info.plist config keys are now checked.**

A warning will now be logged if there are any unknown config keys in the Bugsnag dictionary, to avoid unexpected behaviour in the future.

## Testing

The OOM disabling mechanism was locally tested by starting and stopping the app from Xcode.

The modified code is covered by e2e tests.