### PR TITLE
Change os_unfair_lock calls to use a dispatch queue instead.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,14 @@
 Changelog
 =========
 
+## TBD
+
+## Bug fixes
+
+* Changed synchronization method when responding to dynamic library image events
+  to a dispatch queue, which is a more bulletproof and battle-hardened approach.
+  [837](https://github.com/bugsnag/bugsnag-cocoa/pull/837)
+
 ## 6.2.0 (2020-10-07)
 
 ### Enhancements


### PR DESCRIPTION
## Goal

https://github.com/bugsnag/bugsnag-cocoa/issues/832 shows a crash in `os_unfair_lock_unlock` that couldn't be traced back to anything user-side. Since we can't repro the issue, we need another way to defend against this.

## Design

`os_unfair_lock` is a relatively new API, so it's not inconceivable that there could still be bugs in it. Dispatch queues, on the other hand, have been battle-hardened over decades. Dispatching to a local queue on a local thread has very low overhead, and will introduce far less latency than calling NSProcessInfo, so this will on the whole run faster.

## Changeset

`bsg_mach_headers_add_image` now uses a dispatch queue rather than `os_unfair_lock` or `OSSpinLock`.

## Testing

Re-ran all unit tests, and did manual tests to ensure end-to-end symbolication.
