### PR TITLE
[PLAT-5204] Fix recording of foregroundDuration

### DIFF
--- a/Bugsnag/KSCrash/Source/KSCrash/Recording/BSG_KSCrash.m
+++ b/Bugsnag/KSCrash/Source/KSCrash/Recording/BSG_KSCrash.m
@@ -327,7 +327,7 @@ IMPLEMENT_EXCLUSIVE_SHARED_INSTANCE(BSG_KSCrash)
     BSG_KSCrash_State state = crashContext()->state;
     bsg_kscrashstate_updateDurationStats(&state);
     NSMutableDictionary *dict = [NSMutableDictionary new];
-    BSGDictSetSafeObject(dict, @(state.activeDurationSinceLaunch), @BSG_KSCrashField_ActiveTimeSinceLaunch);
+    BSGDictSetSafeObject(dict, @(state.foregroundDurationSinceLaunch), @BSG_KSCrashField_ActiveTimeSinceLaunch);
     BSGDictSetSafeObject(dict, @(state.backgroundDurationSinceLaunch), @BSG_KSCrashField_BGTimeSinceLaunch);
     BSGDictSetSafeObject(dict, @(state.applicationIsInForeground), @BSG_KSCrashField_AppInFG);
     return dict;
@@ -364,12 +364,12 @@ IMPLEMENT_EXCLUSIVE_SHARED_INSTANCE(BSG_KSCrash)
     }
 
 BSG_SYNTHESIZE_CRASH_STATE_PROPERTY(NSTimeInterval,
-                                    activeDurationSinceLastCrash)
+                                    foregroundDurationSinceLastCrash)
 BSG_SYNTHESIZE_CRASH_STATE_PROPERTY(NSTimeInterval,
                                     backgroundDurationSinceLastCrash)
 BSG_SYNTHESIZE_CRASH_STATE_PROPERTY(int, launchesSinceLastCrash)
 BSG_SYNTHESIZE_CRASH_STATE_PROPERTY(int, sessionsSinceLastCrash)
-BSG_SYNTHESIZE_CRASH_STATE_PROPERTY(NSTimeInterval, activeDurationSinceLaunch)
+BSG_SYNTHESIZE_CRASH_STATE_PROPERTY(NSTimeInterval, foregroundDurationSinceLaunch)
 BSG_SYNTHESIZE_CRASH_STATE_PROPERTY(NSTimeInterval,
                                     backgroundDurationSinceLaunch)
 BSG_SYNTHESIZE_CRASH_STATE_PROPERTY(int, sessionsSinceLaunch)
@@ -464,11 +464,11 @@ BSG_SYNTHESIZE_CRASH_STATE_PROPERTY(BOOL, crashedLastLaunch)
 // ============================================================================
 
 - (void)applicationDidBecomeActive {
-    bsg_kscrashstate_notifyAppActive(true);
+    bsg_kscrashstate_notifyAppInForeground(true);
 }
 
 - (void)applicationWillResignActive {
-    bsg_kscrashstate_notifyAppActive(false);
+    bsg_kscrashstate_notifyAppInForeground(true);
 }
 
 - (void)applicationDidEnterBackground {

--- a/Bugsnag/KSCrash/Source/KSCrash/Recording/BSG_KSCrashAdvanced.h
+++ b/Bugsnag/KSCrash/Source/KSCrash/Recording/BSG_KSCrashAdvanced.h
@@ -38,7 +38,7 @@
 
 /** Total active time elapsed since the last crash. */
 @property(nonatomic, readonly, assign)
-    NSTimeInterval activeDurationSinceLastCrash;
+    NSTimeInterval foregroundDurationSinceLastCrash;
 
 /** Total time backgrounded elapsed since the last crash. */
 @property(nonatomic, readonly, assign)
@@ -51,7 +51,7 @@
 @property(nonatomic, readonly, assign) int sessionsSinceLastCrash;
 
 /** Total active time elapsed since launch. */
-@property(nonatomic, readonly, assign) NSTimeInterval activeDurationSinceLaunch;
+@property(nonatomic, readonly, assign) NSTimeInterval foregroundDurationSinceLaunch;
 
 /** Total time backgrounded elapsed since launch. */
 @property(nonatomic, readonly, assign)

--- a/Bugsnag/KSCrash/Source/KSCrash/Recording/BSG_KSCrashC.c
+++ b/Bugsnag/KSCrash/Source/KSCrash/Recording/BSG_KSCrashC.c
@@ -151,6 +151,7 @@ void bsg_kscrash_reinstall(const char *const crashReportFilePath,
         BSG_KSLOG_ERROR("Failed to initialize persistent crash state");
     }
     context->state.appLaunchTime = mach_absolute_time();
+    context->state.appStateTransitionTime = mach_absolute_time();
 }
 
 BSG_KSCrashType bsg_kscrash_setHandlingCrashTypes(BSG_KSCrashType crashTypes) {

--- a/Bugsnag/KSCrash/Source/KSCrash/Recording/BSG_KSCrashReport.c
+++ b/Bugsnag/KSCrash/Source/KSCrash/Recording/BSG_KSCrashReport.c
@@ -1351,8 +1351,6 @@ void bsg_kscrw_i_writeAppStats(const BSG_KSCrashReportWriter *const writer,
                                BSG_KSCrash_State *state) {
     writer->beginObject(writer, key);
     {
-        writer->addBooleanElement(writer, BSG_KSCrashField_AppActive,
-                                  state->applicationIsActive);
         writer->addBooleanElement(writer, BSG_KSCrashField_AppInFG,
                                   state->applicationIsInForeground);
 
@@ -1362,7 +1360,7 @@ void bsg_kscrw_i_writeAppStats(const BSG_KSCrashReportWriter *const writer,
                                   state->sessionsSinceLastCrash);
         writer->addFloatingPointElement(writer,
                                         BSG_KSCrashField_ActiveTimeSinceCrash,
-                                        state->activeDurationSinceLastCrash);
+                                        state->foregroundDurationSinceLastCrash);
         writer->addFloatingPointElement(
             writer, BSG_KSCrashField_BGTimeSinceCrash,
             state->backgroundDurationSinceLastCrash);
@@ -1371,7 +1369,7 @@ void bsg_kscrw_i_writeAppStats(const BSG_KSCrashReportWriter *const writer,
                                   state->sessionsSinceLaunch);
         writer->addFloatingPointElement(writer,
                                         BSG_KSCrashField_ActiveTimeSinceLaunch,
-                                        state->activeDurationSinceLaunch);
+                                        state->foregroundDurationSinceLaunch);
         writer->addFloatingPointElement(writer,
                                         BSG_KSCrashField_BGTimeSinceLaunch,
                                         state->backgroundDurationSinceLaunch);

--- a/Bugsnag/KSCrash/Source/KSCrash/Recording/BSG_KSCrashReportFields.h
+++ b/Bugsnag/KSCrash/Source/KSCrash/Recording/BSG_KSCrashReportFields.h
@@ -145,7 +145,6 @@
 
 #define BSG_KSCrashField_ActiveTimeSinceCrash "active_time_since_last_crash"
 #define BSG_KSCrashField_ActiveTimeSinceLaunch "active_time_since_launch"
-#define BSG_KSCrashField_AppActive "application_active"
 #define BSG_KSCrashField_AppInFG "application_in_foreground"
 #define BSG_KSCrashField_BGTimeSinceCrash "background_time_since_last_crash"
 #define BSG_KSCrashField_BGTimeSinceLaunch "background_time_since_launch"

--- a/Bugsnag/KSCrash/Source/KSCrash/Recording/BSG_KSCrashState.h
+++ b/Bugsnag/KSCrash/Source/KSCrash/Recording/BSG_KSCrashState.h
@@ -40,10 +40,11 @@ extern "C" {
 #include "BSG_KSCrashType.h"
 
 typedef struct {
+
     // Saved data
 
-    /** Total active time elapsed since the last crash. */
-    double activeDurationSinceLastCrash;
+    /** Total time elapsed in the foreground since the last crash. */
+    double foregroundDurationSinceLastCrash;
 
     /** Total time backgrounded elapsed since the last crash. */
     double backgroundDurationSinceLastCrash;
@@ -54,8 +55,8 @@ typedef struct {
     /** Number of sessions (launch, resume from suspend) since last crash. */
     int sessionsSinceLastCrash;
 
-    /** Total active time elapsed since launch. */
-    double activeDurationSinceLaunch;
+    /** Total time elapsed in the foreground since launch. */
+    double foregroundDurationSinceLaunch;
 
     /** Total time backgrounded elapsed since launch. */
     double backgroundDurationSinceLaunch;
@@ -74,12 +75,9 @@ typedef struct {
     /** Timestamp for when the app was launched (mach_absolute_time()) */
     uint64_t appLaunchTime;
 
-    /** Timestamp for when the app state was last changed (active<-> inactive,
-     * background<->foreground) (mach_absolute_time()) */
+    /** Timestamp for when the app state was last changed
+     * (background<->foreground) (mach_absolute_time()) */
     uint64_t appStateTransitionTime;
-
-    /** If true, the application is currently active. */
-    bool applicationIsActive;
 
     /** If true, the application is currently in the foreground. */
     bool applicationIsInForeground;
@@ -95,12 +93,6 @@ typedef struct {
  * @return true if initialization was successful.
  */
 bool bsg_kscrashstate_init(const char *stateFilePath, BSG_KSCrash_State *state);
-
-/** Notify the crash reporter of the application active state.
- *
- * @param isActive true if the application is active, otherwise false.
- */
-void bsg_kscrashstate_notifyAppActive(bool isActive);
 
 /** Notify the crash reporter of the application foreground/background state.
  *

--- a/Tests/KSCrash/KSCrashState_Tests.m
+++ b/Tests/KSCrash/KSCrashState_Tests.m
@@ -31,7 +31,8 @@
 #import "BSG_KSCrashC.h"
 
 
-@interface bsg_kscrashstate_Tests : FileBasedTestCase@end
+@interface bsg_kscrashstate_Tests : FileBasedTestCase
+@end
 
 
 @implementation bsg_kscrashstate_Tests
@@ -45,15 +46,14 @@
                       &context);
 
     XCTAssertTrue(context.applicationIsInForeground, @"");
-    XCTAssertFalse(context.applicationIsActive, @"");
 
-    XCTAssertEqual(context.activeDurationSinceLastCrash, 0.0, @"");
+    XCTAssertEqual(context.foregroundDurationSinceLastCrash, 0.0, @"");
     XCTAssertEqual(context.backgroundDurationSinceLastCrash, 0.0, @"");
     XCTAssertEqual(context.launchesSinceLastCrash, 1, @"");
     XCTAssertEqual(context.sessionsSinceLastCrash, 1, @"");
     XCTAssertEqual(context.appLaunchTime, 0, @"");
 
-    XCTAssertEqual(context.activeDurationSinceLaunch, 0.0, @"");
+    XCTAssertEqual(context.foregroundDurationSinceLaunch, 0.0, @"");
     XCTAssertEqual(context.backgroundDurationSinceLaunch, 0.0, @"");
     XCTAssertEqual(context.sessionsSinceLaunch, 1, @"");
 
@@ -65,15 +65,14 @@
                       &context);
 
     XCTAssertTrue(context.applicationIsInForeground, @"");
-    XCTAssertFalse(context.applicationIsActive, @"");
 
-    XCTAssertEqual(context.activeDurationSinceLastCrash, 0.0, @"");
+    XCTAssertEqual(context.foregroundDurationSinceLastCrash, 0.0, @"");
     XCTAssertEqual(context.backgroundDurationSinceLastCrash, 0.0, @"");
     XCTAssertEqual(context.launchesSinceLastCrash, 2, @"");
     XCTAssertEqual(context.sessionsSinceLastCrash, 2, @"");
     XCTAssertEqual(context.appLaunchTime, 0, @"");
 
-    XCTAssertEqual(context.activeDurationSinceLaunch, 0.0, @"");
+    XCTAssertEqual(context.foregroundDurationSinceLaunch, 0.0, @"");
     XCTAssertEqual(context.backgroundDurationSinceLaunch, 0.0, @"");
     XCTAssertEqual(context.sessionsSinceLaunch, 1, @"");
 
@@ -96,12 +95,10 @@
 
     XCTAssertTrue(checkpointC.applicationIsInForeground ==
                  checkpoint0.applicationIsInForeground, @"");
-    XCTAssertTrue(checkpointC.applicationIsActive ==
-                 checkpoint0.applicationIsActive, @"");
     XCTAssertTrue(checkpointC.appLaunchTime == checkpoint0.appLaunchTime, @"");
 
-    XCTAssertTrue(checkpointC.activeDurationSinceLastCrash ==
-                 checkpoint0.activeDurationSinceLastCrash, @"");
+    XCTAssertGreaterThan(checkpointC.foregroundDurationSinceLastCrash,
+                         checkpoint0.foregroundDurationSinceLastCrash);
     XCTAssertTrue(checkpointC.backgroundDurationSinceLastCrash ==
                  checkpoint0.backgroundDurationSinceLastCrash, @"");
     XCTAssertTrue(checkpointC.launchesSinceLastCrash ==
@@ -109,8 +106,8 @@
     XCTAssertTrue(checkpointC.sessionsSinceLastCrash ==
                  checkpoint0.sessionsSinceLastCrash, @"");
 
-    XCTAssertTrue(checkpointC.activeDurationSinceLaunch ==
-                 checkpoint0.activeDurationSinceLaunch, @"");
+    XCTAssertGreaterThan(checkpointC.foregroundDurationSinceLaunch,
+                         checkpoint0.foregroundDurationSinceLaunch);
     XCTAssertTrue(checkpointC.backgroundDurationSinceLaunch ==
                  checkpoint0.backgroundDurationSinceLaunch, @"");
     XCTAssertTrue(checkpointC.sessionsSinceLaunch ==
@@ -124,79 +121,18 @@
                       &context);
 
     XCTAssertTrue(context.applicationIsInForeground, @"");
-    XCTAssertFalse(context.applicationIsActive, @"");
 
-    XCTAssertEqual(context.activeDurationSinceLastCrash, 0.0, @"");
+    XCTAssertEqual(context.foregroundDurationSinceLastCrash, 0.0, @"");
     XCTAssertEqual(context.backgroundDurationSinceLastCrash, 0.0, @"");
     XCTAssertEqual(context.launchesSinceLastCrash, 1, @"");
     XCTAssertEqual(context.sessionsSinceLastCrash, 1, @"");
 
-    XCTAssertEqual(context.activeDurationSinceLaunch, 0.0, @"");
+    XCTAssertEqual(context.foregroundDurationSinceLaunch, 0.0, @"");
     XCTAssertEqual(context.backgroundDurationSinceLaunch, 0.0, @"");
     XCTAssertEqual(context.sessionsSinceLaunch, 1, @"");
 
     XCTAssertFalse(context.crashedThisLaunch, @"");
     XCTAssertTrue(context.crashedLastLaunch, @"");
-}
-
-- (void) testActRelaunch
-{
-    BSG_KSCrash_State context = {0};
-    NSString* stateFile = [self.tempPath stringByAppendingPathComponent:@"state.json"];
-
-    bsg_kscrashstate_init([stateFile cStringUsingEncoding:NSUTF8StringEncoding],
-                      &context);
-    BSG_KSCrash_State checkpoint0 = context;
-
-    usleep(1);
-    bsg_kscrashstate_notifyAppActive(true);
-    BSG_KSCrash_State checkpoint1 = context;
-
-    XCTAssertTrue(checkpoint1.applicationIsInForeground ==
-                 checkpoint0.applicationIsInForeground, @"");
-    XCTAssertTrue(checkpoint1.applicationIsActive !=
-                 checkpoint0.applicationIsActive, @"");
-    XCTAssertTrue(checkpoint1.applicationIsActive, @"");
-    XCTAssertTrue(checkpoint1.appLaunchTime == checkpoint0.appLaunchTime, @"");
-
-    XCTAssertTrue(checkpoint1.activeDurationSinceLastCrash ==
-                 checkpoint0.activeDurationSinceLastCrash, @"");
-    XCTAssertTrue(checkpoint1.backgroundDurationSinceLastCrash ==
-                 checkpoint0.backgroundDurationSinceLastCrash, @"");
-    XCTAssertTrue(checkpoint1.launchesSinceLastCrash ==
-                 checkpoint0.launchesSinceLastCrash, @"");
-    XCTAssertTrue(checkpoint1.sessionsSinceLastCrash ==
-                 checkpoint0.sessionsSinceLastCrash, @"");
-
-    XCTAssertTrue(checkpoint1.activeDurationSinceLaunch ==
-                 checkpoint0.activeDurationSinceLaunch, @"");
-    XCTAssertTrue(checkpoint1.backgroundDurationSinceLaunch ==
-                 checkpoint0.backgroundDurationSinceLaunch, @"");
-    XCTAssertTrue(checkpoint1.sessionsSinceLaunch ==
-                 checkpoint0.sessionsSinceLaunch, @"");
-
-    XCTAssertFalse(checkpoint1.crashedThisLaunch, @"");
-    XCTAssertFalse(checkpoint1.crashedLastLaunch, @"");
-
-    usleep(1);
-    memset(&context, 0, sizeof(context));
-    bsg_kscrashstate_init([stateFile cStringUsingEncoding:NSUTF8StringEncoding],
-                      &context);
-
-    XCTAssertTrue(context.applicationIsInForeground, @"");
-    XCTAssertFalse(context.applicationIsActive, @"");
-
-    XCTAssertEqual(context.activeDurationSinceLastCrash, 0.0, @"");
-    XCTAssertEqual(context.backgroundDurationSinceLastCrash, 0.0, @"");
-    XCTAssertEqual(context.launchesSinceLastCrash, 2, @"");
-    XCTAssertEqual(context.sessionsSinceLastCrash, 2, @"");
-
-    XCTAssertEqual(context.activeDurationSinceLaunch, 0.0, @"");
-    XCTAssertEqual(context.backgroundDurationSinceLaunch, 0.0, @"");
-    XCTAssertEqual(context.sessionsSinceLaunch, 1, @"");
-
-    XCTAssertFalse(context.crashedThisLaunch, @"");
-    XCTAssertFalse(context.crashedLastLaunch, @"");
 }
 
 - (void)testCrashThisLaunchWithUserReported
@@ -223,103 +159,14 @@
     XCTAssertTrue(context.crashedThisLaunch, @"");
 }
 
-- (void) testActCrash
+- (void)testRelaunch
 {
     BSG_KSCrash_State context = {0};
     NSString* stateFile = [self.tempPath stringByAppendingPathComponent:@"state.json"];
 
     bsg_kscrashstate_init([stateFile cStringUsingEncoding:NSUTF8StringEncoding],
                       &context);
-    usleep(1);
-    bsg_kscrashstate_notifyAppActive(true);
-    BSG_KSCrash_State checkpoint0 = context;
-
-    usleep(1);
-    bsg_kscrashstate_notifyAppCrash(BSG_KSCrashTypeSignal);
-    BSG_KSCrash_State checkpointC = context;
-
-    XCTAssertTrue(checkpointC.applicationIsInForeground ==
-                 checkpoint0.applicationIsInForeground, @"");
-    XCTAssertTrue(checkpointC.applicationIsActive ==
-                 checkpoint0.applicationIsActive, @"");
-    XCTAssertTrue(checkpointC.appLaunchTime == checkpoint0.appLaunchTime, @"");
-
-    XCTAssertTrue(checkpointC.activeDurationSinceLastCrash >
-                 checkpoint0.activeDurationSinceLastCrash, @"");
-    XCTAssertTrue(checkpointC.backgroundDurationSinceLastCrash ==
-                 checkpoint0.backgroundDurationSinceLastCrash, @"");
-    XCTAssertTrue(checkpointC.launchesSinceLastCrash ==
-                 checkpoint0.launchesSinceLastCrash, @"");
-    XCTAssertTrue(checkpointC.sessionsSinceLastCrash ==
-                 checkpoint0.sessionsSinceLastCrash, @"");
-
-    XCTAssertTrue(checkpointC.activeDurationSinceLaunch >
-                 checkpoint0.activeDurationSinceLaunch, @"");
-    XCTAssertTrue(checkpointC.backgroundDurationSinceLaunch ==
-                 checkpoint0.backgroundDurationSinceLaunch, @"");
-    XCTAssertTrue(checkpointC.sessionsSinceLaunch ==
-                 checkpoint0.sessionsSinceLaunch, @"");
-
-    XCTAssertTrue(checkpointC.crashedThisLaunch, @"");
-    XCTAssertFalse(checkpointC.crashedLastLaunch, @"");
-
-    memset(&context, 0, sizeof(context));
-    bsg_kscrashstate_init([stateFile cStringUsingEncoding:NSUTF8StringEncoding],
-                      &context);
-
-    XCTAssertTrue(context.applicationIsInForeground, @"");
-    XCTAssertFalse(context.applicationIsActive, @"");
-
-    XCTAssertEqual(context.activeDurationSinceLastCrash, 0.0, @"");
-    XCTAssertEqual(context.backgroundDurationSinceLastCrash, 0.0, @"");
-    XCTAssertEqual(context.launchesSinceLastCrash, 1, @"");
-    XCTAssertEqual(context.sessionsSinceLastCrash, 1, @"");
-
-    XCTAssertEqual(context.activeDurationSinceLaunch, 0.0, @"");
-    XCTAssertEqual(context.backgroundDurationSinceLaunch, 0.0, @"");
-    XCTAssertEqual(context.sessionsSinceLaunch, 1, @"");
-
-    XCTAssertFalse(context.crashedThisLaunch, @"");
-    XCTAssertTrue(context.crashedLastLaunch, @"");
-}
-
-- (void) testActDeactRelaunch
-{
-    BSG_KSCrash_State context = {0};
-    NSString* stateFile = [self.tempPath stringByAppendingPathComponent:@"state.json"];
-
-    bsg_kscrashstate_init([stateFile cStringUsingEncoding:NSUTF8StringEncoding],
-                      &context);
-    usleep(1);
-    bsg_kscrashstate_notifyAppActive(true);
-    BSG_KSCrash_State checkpoint0 = context;
-
-    usleep(1);
-    bsg_kscrashstate_notifyAppActive(false);
     BSG_KSCrash_State checkpoint1 = context;
-
-    XCTAssertTrue(checkpoint1.applicationIsInForeground ==
-                 checkpoint0.applicationIsInForeground, @"");
-    XCTAssertTrue(checkpoint1.applicationIsActive !=
-                 checkpoint0.applicationIsActive, @"");
-    XCTAssertFalse(checkpoint1.applicationIsActive, @"");
-    XCTAssertTrue(checkpoint1.appLaunchTime == checkpoint0.appLaunchTime, @"");
-
-    XCTAssertTrue(checkpoint1.activeDurationSinceLastCrash >
-                 checkpoint0.activeDurationSinceLastCrash, @"");
-    XCTAssertTrue(checkpoint1.backgroundDurationSinceLastCrash ==
-                 checkpoint0.backgroundDurationSinceLastCrash, @"");
-    XCTAssertTrue(checkpoint1.launchesSinceLastCrash ==
-                 checkpoint0.launchesSinceLastCrash, @"");
-    XCTAssertTrue(checkpoint1.sessionsSinceLastCrash ==
-                 checkpoint0.sessionsSinceLastCrash, @"");
-
-    XCTAssertTrue(checkpoint1.activeDurationSinceLaunch >
-                 checkpoint0.activeDurationSinceLaunch, @"");
-    XCTAssertTrue(checkpoint1.backgroundDurationSinceLaunch ==
-                 checkpoint0.backgroundDurationSinceLaunch, @"");
-    XCTAssertTrue(checkpoint1.sessionsSinceLaunch ==
-                 checkpoint0.sessionsSinceLaunch, @"");
 
     XCTAssertFalse(checkpoint1.crashedThisLaunch, @"");
     XCTAssertFalse(checkpoint1.crashedLastLaunch, @"");
@@ -331,16 +178,15 @@
     BSG_KSCrash_State checkpointR = context;
 
     XCTAssertTrue(checkpointR.applicationIsInForeground, @"");
-    XCTAssertFalse(checkpointR.applicationIsActive, @"");
     XCTAssertEqual(checkpointR.appLaunchTime, 0, @"");
 
     // We don't save after going inactive, so this will still be 0.
-    XCTAssertEqual(checkpointR.activeDurationSinceLastCrash, 0.0, @"");
+    XCTAssertEqual(checkpointR.foregroundDurationSinceLastCrash, 0.0, @"");
     XCTAssertEqual(checkpointR.backgroundDurationSinceLastCrash, 0.0, @"");
     XCTAssertEqual(checkpointR.launchesSinceLastCrash, 2, @"");
     XCTAssertEqual(checkpointR.sessionsSinceLastCrash, 2, @"");
 
-    XCTAssertEqual(checkpointR.activeDurationSinceLaunch, 0.0, @"");
+    XCTAssertEqual(checkpointR.foregroundDurationSinceLaunch, 0.0, @"");
     XCTAssertEqual(checkpointR.backgroundDurationSinceLaunch, 0.0, @"");
     XCTAssertEqual(checkpointR.sessionsSinceLaunch, 1, @"");
 
@@ -348,80 +194,15 @@
     XCTAssertFalse(checkpointR.crashedLastLaunch, @"");
 }
 
-- (void) testActDeactCrash
+- (void)testBGRelaunch
 {
     BSG_KSCrash_State context = {0};
     NSString* stateFile = [self.tempPath stringByAppendingPathComponent:@"state.json"];
 
     bsg_kscrashstate_init([stateFile cStringUsingEncoding:NSUTF8StringEncoding],
                       &context);
-    usleep(1);
-    bsg_kscrashstate_notifyAppActive(true);
-    usleep(1);
-    bsg_kscrashstate_notifyAppActive(false);
     BSG_KSCrash_State checkpoint0 = context;
-
-    usleep(1);
-    bsg_kscrashstate_notifyAppCrash(BSG_KSCrashTypeSignal);
-    BSG_KSCrash_State checkpointC = context;
-
-    XCTAssertTrue(checkpointC.applicationIsInForeground ==
-                 checkpoint0.applicationIsInForeground, @"");
-    XCTAssertTrue(checkpointC.applicationIsActive ==
-                 checkpoint0.applicationIsActive, @"");
-    XCTAssertTrue(checkpointC.appLaunchTime == checkpoint0.appLaunchTime, @"");
-
-    XCTAssertTrue(checkpointC.activeDurationSinceLastCrash ==
-                 checkpoint0.activeDurationSinceLastCrash, @"");
-    XCTAssertTrue(checkpointC.backgroundDurationSinceLastCrash ==
-                 checkpoint0.backgroundDurationSinceLastCrash, @"");
-    XCTAssertTrue(checkpointC.launchesSinceLastCrash ==
-                 checkpoint0.launchesSinceLastCrash, @"");
-    XCTAssertTrue(checkpointC.sessionsSinceLastCrash ==
-                 checkpoint0.sessionsSinceLastCrash, @"");
-
-    XCTAssertTrue(checkpointC.activeDurationSinceLaunch ==
-                 checkpoint0.activeDurationSinceLaunch, @"");
-    XCTAssertTrue(checkpointC.backgroundDurationSinceLaunch ==
-                 checkpoint0.backgroundDurationSinceLaunch, @"");
-    XCTAssertTrue(checkpointC.sessionsSinceLaunch ==
-                 checkpoint0.sessionsSinceLaunch, @"");
-
-    XCTAssertTrue(checkpointC.crashedThisLaunch, @"");
-    XCTAssertFalse(checkpointC.crashedLastLaunch, @"");
-
-    memset(&context, 0, sizeof(context));
-    bsg_kscrashstate_init([stateFile cStringUsingEncoding:NSUTF8StringEncoding],
-                      &context);
-
-    XCTAssertTrue(context.applicationIsInForeground, @"");
-    XCTAssertFalse(context.applicationIsActive, @"");
-
-    XCTAssertEqual(context.activeDurationSinceLastCrash, 0.0, @"");
-    XCTAssertEqual(context.backgroundDurationSinceLastCrash, 0.0, @"");
-    XCTAssertEqual(context.launchesSinceLastCrash, 1, @"");
-    XCTAssertEqual(context.sessionsSinceLastCrash, 1, @"");
-
-    XCTAssertEqual(context.activeDurationSinceLaunch, 0.0, @"");
-    XCTAssertEqual(context.backgroundDurationSinceLaunch, 0.0, @"");
-    XCTAssertEqual(context.sessionsSinceLaunch, 1, @"");
-
-    XCTAssertFalse(context.crashedThisLaunch, @"");
-    XCTAssertTrue(context.crashedLastLaunch, @"");
-}
-
-- (void) testActDeactBGRelaunch
-{
-    BSG_KSCrash_State context = {0};
-    NSString* stateFile = [self.tempPath stringByAppendingPathComponent:@"state.json"];
-
-    bsg_kscrashstate_init([stateFile cStringUsingEncoding:NSUTF8StringEncoding],
-                      &context);
-    usleep(1);
-    bsg_kscrashstate_notifyAppActive(true);
-    usleep(1);
-    bsg_kscrashstate_notifyAppActive(false);
-    BSG_KSCrash_State checkpoint0 = context;
+    NSParameterAssert(context.applicationIsInForeground);
 
     usleep(1);
     bsg_kscrashstate_notifyAppInForeground(false);
@@ -429,13 +210,11 @@
 
     XCTAssertTrue(checkpoint1.applicationIsInForeground !=
                  checkpoint0.applicationIsInForeground, @"");
-    XCTAssertTrue(checkpoint1.applicationIsActive ==
-                 checkpoint0.applicationIsActive, @"");
     XCTAssertFalse(checkpoint1.applicationIsInForeground, @"");
     XCTAssertTrue(checkpoint0.appLaunchTime == checkpoint1.appLaunchTime, @"");
 
-    XCTAssertTrue(checkpoint1.activeDurationSinceLastCrash ==
-                 checkpoint0.activeDurationSinceLastCrash, @"");
+    XCTAssertGreaterThan(checkpoint1.foregroundDurationSinceLastCrash,
+                         checkpoint0.foregroundDurationSinceLastCrash);
     XCTAssertTrue(checkpoint1.backgroundDurationSinceLastCrash ==
                  checkpoint0.backgroundDurationSinceLastCrash, @"");
     XCTAssertTrue(checkpoint1.launchesSinceLastCrash ==
@@ -443,8 +222,8 @@
     XCTAssertTrue(checkpoint1.sessionsSinceLastCrash ==
                  checkpoint0.sessionsSinceLastCrash, @"");
 
-    XCTAssertTrue(checkpoint1.activeDurationSinceLaunch ==
-                 checkpoint0.activeDurationSinceLaunch, @"");
+    XCTAssertGreaterThan(checkpoint1.foregroundDurationSinceLaunch,
+                         checkpoint0.foregroundDurationSinceLaunch);
     XCTAssertTrue(checkpoint1.backgroundDurationSinceLaunch ==
                  checkpoint0.backgroundDurationSinceLaunch, @"");
     XCTAssertTrue(checkpoint1.sessionsSinceLaunch ==
@@ -460,14 +239,13 @@
     BSG_KSCrash_State checkpointR = context;
 
     XCTAssertTrue(checkpointR.applicationIsInForeground, @"");
-    XCTAssertFalse(checkpointR.applicationIsActive, @"");
 
-    XCTAssertTrue(checkpointR.activeDurationSinceLastCrash > 0, @"");
+    XCTAssertTrue(checkpointR.foregroundDurationSinceLastCrash > 0, @"");
     XCTAssertEqual(checkpointR.backgroundDurationSinceLastCrash, 0.0, @"");
     XCTAssertEqual(checkpointR.launchesSinceLastCrash, 2, @"");
     XCTAssertEqual(checkpointR.sessionsSinceLastCrash, 2, @"");
 
-    XCTAssertEqual(checkpointR.activeDurationSinceLaunch, 0.0, @"");
+    XCTAssertEqual(checkpointR.foregroundDurationSinceLaunch, 0.0, @"");
     XCTAssertEqual(checkpointR.backgroundDurationSinceLaunch, 0.0, @"");
     XCTAssertEqual(checkpointR.sessionsSinceLaunch, 1, @"");
 
@@ -475,17 +253,14 @@
     XCTAssertFalse(checkpointR.crashedLastLaunch, @"");
 }
 
-- (void) testActDeactBGTerminate
+- (void)testBGTerminate
 {
     BSG_KSCrash_State context = {0};
     NSString* stateFile = [self.tempPath stringByAppendingPathComponent:@"state.json"];
 
     bsg_kscrashstate_init([stateFile cStringUsingEncoding:NSUTF8StringEncoding],
                       &context);
-    usleep(1);
-    bsg_kscrashstate_notifyAppActive(true);
-    usleep(1);
-    bsg_kscrashstate_notifyAppActive(false);
+    NSParameterAssert(context.applicationIsInForeground);
     usleep(1);
     bsg_kscrashstate_notifyAppInForeground(false);
     BSG_KSCrash_State checkpoint0 = context;
@@ -499,7 +274,6 @@
     BSG_KSCrash_State checkpointR = context;
 
     XCTAssertTrue(checkpointR.applicationIsInForeground, @"");
-    XCTAssertFalse(checkpointR.applicationIsActive, @"");
     XCTAssertEqual(checkpointR.appLaunchTime, 0, @"");
 
     XCTAssertTrue(checkpointR.backgroundDurationSinceLastCrash >
@@ -507,7 +281,7 @@
     XCTAssertEqual(checkpointR.launchesSinceLastCrash, 2, @"");
     XCTAssertEqual(checkpointR.sessionsSinceLastCrash, 2, @"");
 
-    XCTAssertEqual(checkpointR.activeDurationSinceLaunch, 0.0, @"");
+    XCTAssertEqual(checkpointR.foregroundDurationSinceLaunch, 0.0, @"");
     XCTAssertEqual(checkpointR.backgroundDurationSinceLaunch, 0.0, @"");
     XCTAssertEqual(checkpointR.sessionsSinceLaunch, 1, @"");
 
@@ -515,7 +289,7 @@
     XCTAssertFalse(checkpointR.crashedLastLaunch, @"");
 }
 
-- (void) testActDeactBGCrash
+- (void)testBGCrash
 {
     BSG_KSCrash_State context = {0};
     NSString* stateFile = [self.tempPath stringByAppendingPathComponent:@"state.json"];
@@ -523,10 +297,7 @@
     bsg_kscrashstate_init([stateFile cStringUsingEncoding:NSUTF8StringEncoding],
                       &context);
     usleep(1);
-    bsg_kscrashstate_notifyAppActive(true);
-    usleep(1);
-    bsg_kscrashstate_notifyAppActive(false);
-    usleep(1);
+    NSParameterAssert(context.applicationIsInForeground);
     bsg_kscrashstate_notifyAppInForeground(false);
     BSG_KSCrash_State checkpoint0 = context;
 
@@ -536,12 +307,10 @@
 
     XCTAssertTrue(checkpointC.applicationIsInForeground ==
                  checkpoint0.applicationIsInForeground, @"");
-    XCTAssertTrue(checkpointC.applicationIsActive ==
-                 checkpoint0.applicationIsActive, @"");
     XCTAssertTrue(checkpointC.appLaunchTime == checkpoint0.appLaunchTime, @"");
 
-    XCTAssertTrue(checkpointC.activeDurationSinceLastCrash ==
-                 checkpoint0.activeDurationSinceLastCrash, @"");
+    XCTAssertTrue(checkpointC.foregroundDurationSinceLastCrash ==
+                 checkpoint0.foregroundDurationSinceLastCrash, @"");
     XCTAssertTrue(checkpointC.backgroundDurationSinceLastCrash >
                  checkpoint0.backgroundDurationSinceLastCrash, @"");
     XCTAssertTrue(checkpointC.launchesSinceLastCrash ==
@@ -549,8 +318,8 @@
     XCTAssertTrue(checkpointC.sessionsSinceLastCrash ==
                  checkpoint0.sessionsSinceLastCrash, @"");
 
-    XCTAssertTrue(checkpointC.activeDurationSinceLaunch ==
-                 checkpoint0.activeDurationSinceLaunch, @"");
+    XCTAssertTrue(checkpointC.foregroundDurationSinceLaunch ==
+                 checkpoint0.foregroundDurationSinceLaunch, @"");
     XCTAssertTrue(checkpointC.backgroundDurationSinceLaunch >
                  checkpoint0.backgroundDurationSinceLaunch, @"");
     XCTAssertTrue(checkpointC.sessionsSinceLaunch ==
@@ -564,14 +333,13 @@
                       &context);
 
     XCTAssertTrue(context.applicationIsInForeground, @"");
-    XCTAssertFalse(context.applicationIsActive, @"");
 
-    XCTAssertEqual(context.activeDurationSinceLastCrash, 0.0, @"");
+    XCTAssertEqual(context.foregroundDurationSinceLastCrash, 0.0, @"");
     XCTAssertEqual(context.backgroundDurationSinceLastCrash, 0.0, @"");
     XCTAssertEqual(context.launchesSinceLastCrash, 1, @"");
     XCTAssertEqual(context.sessionsSinceLastCrash, 1, @"");
 
-    XCTAssertEqual(context.activeDurationSinceLaunch, 0.0, @"");
+    XCTAssertEqual(context.foregroundDurationSinceLaunch, 0.0, @"");
     XCTAssertEqual(context.backgroundDurationSinceLaunch, 0.0, @"");
     XCTAssertEqual(context.sessionsSinceLaunch, 1, @"");
 
@@ -592,17 +360,13 @@
     XCTAssertEqual(34234235534534, context.appLaunchTime);
 }
 
-- (void) testActDeactBGFGRelaunch
+- (void)testBGFGRelaunch
 {
     BSG_KSCrash_State context = {0};
     NSString* stateFile = [self.tempPath stringByAppendingPathComponent:@"state.json"];
 
     bsg_kscrashstate_init([stateFile cStringUsingEncoding:NSUTF8StringEncoding],
                       &context);
-    usleep(1);
-    bsg_kscrashstate_notifyAppActive(true);
-    usleep(1);
-    bsg_kscrashstate_notifyAppActive(false);
     usleep(1);
     bsg_kscrashstate_notifyAppInForeground(false);
     usleep(1);
@@ -614,13 +378,11 @@
 
     XCTAssertTrue(checkpoint1.applicationIsInForeground !=
                  checkpoint0.applicationIsInForeground, @"");
-    XCTAssertTrue(checkpoint1.applicationIsActive ==
-                 checkpoint0.applicationIsActive, @"");
     XCTAssertTrue(checkpoint1.applicationIsInForeground, @"");
     XCTAssertTrue(checkpoint1.appLaunchTime == checkpoint0.appLaunchTime, @"");
 
-    XCTAssertTrue(checkpoint1.activeDurationSinceLastCrash ==
-                 checkpoint0.activeDurationSinceLastCrash, @"");
+    XCTAssertTrue(checkpoint1.foregroundDurationSinceLastCrash ==
+                 checkpoint0.foregroundDurationSinceLastCrash, @"");
     XCTAssertTrue(checkpoint1.backgroundDurationSinceLastCrash >
                  checkpoint0.backgroundDurationSinceLastCrash, @"");
     XCTAssertTrue(checkpoint1.launchesSinceLastCrash ==
@@ -628,8 +390,8 @@
     XCTAssertTrue(checkpoint1.sessionsSinceLastCrash ==
                  checkpoint0.sessionsSinceLastCrash + 1, @"");
 
-    XCTAssertTrue(checkpoint1.activeDurationSinceLaunch ==
-                 checkpoint0.activeDurationSinceLaunch, @"");
+    XCTAssertTrue(checkpoint1.foregroundDurationSinceLaunch ==
+                 checkpoint0.foregroundDurationSinceLaunch, @"");
     XCTAssertTrue(checkpoint1.backgroundDurationSinceLaunch >
                  checkpoint0.backgroundDurationSinceLaunch, @"");
     XCTAssertTrue(checkpoint1.sessionsSinceLaunch ==
@@ -645,15 +407,14 @@
     BSG_KSCrash_State checkpointR = context;
 
     XCTAssertTrue(checkpointR.applicationIsInForeground, @"");
-    XCTAssertFalse(checkpointR.applicationIsActive, @"");
 
-    XCTAssertTrue(checkpointR.activeDurationSinceLastCrash > 0, @"");
+    XCTAssertTrue(checkpointR.foregroundDurationSinceLastCrash > 0, @"");
     // We don't save after going to FG, so this will still be 0.
     XCTAssertEqual(checkpointR.backgroundDurationSinceLastCrash, 0.0, @"");
     XCTAssertEqual(checkpointR.launchesSinceLastCrash, 2, @"");
     XCTAssertEqual(checkpointR.sessionsSinceLastCrash, 2, @"");
 
-    XCTAssertEqual(checkpointR.activeDurationSinceLaunch, 0.0, @"");
+    XCTAssertEqual(checkpointR.foregroundDurationSinceLaunch, 0.0, @"");
     XCTAssertEqual(checkpointR.backgroundDurationSinceLaunch, 0.0, @"");
     XCTAssertEqual(checkpointR.sessionsSinceLaunch, 1, @"");
 
@@ -661,17 +422,13 @@
     XCTAssertFalse(checkpointR.crashedLastLaunch, @"");
 }
 
-- (void) testActDeactBGFGCrash
+- (void)testBGFGCrash
 {
     BSG_KSCrash_State context = {0};
     NSString* stateFile = [self.tempPath stringByAppendingPathComponent:@"state.json"];
 
     bsg_kscrashstate_init([stateFile cStringUsingEncoding:NSUTF8StringEncoding],
                       &context);
-    usleep(1);
-    bsg_kscrashstate_notifyAppActive(true);
-    usleep(1);
-    bsg_kscrashstate_notifyAppActive(false);
     usleep(1);
     bsg_kscrashstate_notifyAppInForeground(false);
     usleep(1);
@@ -684,12 +441,10 @@
 
     XCTAssertTrue(checkpointC.applicationIsInForeground ==
                  checkpoint0.applicationIsInForeground, @"");
-    XCTAssertTrue(checkpointC.applicationIsActive ==
-                 checkpoint0.applicationIsActive, @"");
     XCTAssertTrue(checkpointC.appLaunchTime == checkpoint0.appLaunchTime, @"");
 
-    XCTAssertTrue(checkpointC.activeDurationSinceLastCrash ==
-                 checkpoint0.activeDurationSinceLastCrash, @"");
+    XCTAssertGreaterThan(checkpointC.foregroundDurationSinceLastCrash,
+                         checkpoint0.foregroundDurationSinceLastCrash);
     XCTAssertTrue(checkpointC.backgroundDurationSinceLastCrash ==
                  checkpoint0.backgroundDurationSinceLastCrash, @"");
     XCTAssertTrue(checkpointC.launchesSinceLastCrash ==
@@ -697,8 +452,8 @@
     XCTAssertTrue(checkpointC.sessionsSinceLastCrash ==
                  checkpoint0.sessionsSinceLastCrash, @"");
 
-    XCTAssertTrue(checkpointC.activeDurationSinceLaunch ==
-                 checkpoint0.activeDurationSinceLaunch, @"");
+    XCTAssertGreaterThan(checkpointC.foregroundDurationSinceLaunch,
+                         checkpoint0.foregroundDurationSinceLaunch);
     XCTAssertTrue(checkpointC.backgroundDurationSinceLaunch ==
                  checkpoint0.backgroundDurationSinceLaunch, @"");
     XCTAssertTrue(checkpointC.sessionsSinceLaunch ==
@@ -712,14 +467,13 @@
                       &context);
 
     XCTAssertTrue(context.applicationIsInForeground, @"");
-    XCTAssertFalse(context.applicationIsActive, @"");
 
-    XCTAssertEqual(context.activeDurationSinceLastCrash, 0.0, @"");
+    XCTAssertEqual(context.foregroundDurationSinceLastCrash, 0.0, @"");
     XCTAssertEqual(context.backgroundDurationSinceLastCrash, 0.0, @"");
     XCTAssertEqual(context.launchesSinceLastCrash, 1, @"");
     XCTAssertEqual(context.sessionsSinceLastCrash, 1, @"");
 
-    XCTAssertEqual(context.activeDurationSinceLaunch, 0.0, @"");
+    XCTAssertEqual(context.foregroundDurationSinceLaunch, 0.0, @"");
     XCTAssertEqual(context.backgroundDurationSinceLaunch, 0.0, @"");
     XCTAssertEqual(context.sessionsSinceLaunch, 1, @"");
 


### PR DESCRIPTION
## Goal

This changes the tracking of `foregroundDuration` to include both `UIApplicationStateActive` and `UIApplicationStateInactive` which are both described as "foreground" states in Apple documentation.

Previously only `UIApplicationStateActive` was being counted towards this total duration.

## Design

This simplifies the logic behind duration tracking and makes our APIs more consistent and in line with Apple's documentation.

## Changeset

`BSG_KSCrash_State` now only observes whether the app is in a foreground or background state. Code related to tracking active vs inactive has been removed.

`activeDuration...` struct fields have been renamed to `foregroundDuration...` for clarity

Test cases that only varied the active vs inactive state have been removed.

## Testing

Manually verified that the `duration` and `durationInForeground` values increment as expected in payloads sent to the back-end.

Unit tests and e2e tests passing.