### PR TITLE
[PLAT-5224] Fix test flakes in enabled_error_types.feature

### DIFF
--- a/features/fixtures/ios-swift-cocoapods/iOSTestApp/scenarios/EnabledErrorTypesScenario.m
+++ b/features/fixtures/ios-swift-cocoapods/iOSTestApp/scenarios/EnabledErrorTypesScenario.m
@@ -32,10 +32,8 @@
 
 - (void)run {
     // From null prt scenario
-    dispatch_after(dispatch_time(DISPATCH_TIME_NOW, (int64_t)(2 * NSEC_PER_SEC)), dispatch_get_main_queue(), ^{
-        volatile char *ptr = NULL;
-        (void) *ptr;
-    });
+    volatile char *ptr = NULL;
+    (void) *ptr;
 }
 
 @end
@@ -66,10 +64,8 @@
     [Bugsnag notifyError:[NSError errorWithDomain:@"com.bugsnag" code:833 userInfo:nil]];
 
     // From null prt scenario
-    dispatch_after(dispatch_time(DISPATCH_TIME_NOW, (int64_t)(2 * NSEC_PER_SEC)), dispatch_get_main_queue(), ^{
-        volatile char *ptr = NULL;
-        (void) *ptr;
-    });
+    volatile char *ptr = NULL;
+    (void) *ptr;
 }
 
 @end
@@ -146,9 +142,7 @@
 #pragma clang diagnostic push
 #pragma clang diagnostic ignored "-Winvalid-noreturn"
 - (void)run  __attribute__((noreturn)) {
-    dispatch_after(dispatch_time(DISPATCH_TIME_NOW, (int64_t)(2 * NSEC_PER_SEC)), dispatch_get_main_queue(), ^{
-        raise(SIGINT);
-    });
+    raise(SIGINT);
 }
 #pragma  clang pop
 


### PR DESCRIPTION
## Goal

Occasionally the tests would fail due to a session payload being sent twice.

In these cases the notifier was not receiving the response to its HTTP request before the scenario crashed the app, but the server had received it. When Bugsnag was reinitialised it would re-send the first session since it could not know that it had been already been received by the server.

## Design

By removing the 2 second delay (which is not always enough time to receive the HTTP response) we can be sure the session from the first launch of the app has not been sent, which avoid duplicates.

## Changeset

Removed the delay before crashing the app.

I could not find any comments explaining why the delay had been added in commit d2e04a05ed63bb3ff893d55fd22c5ae2fa536c15

## Testing

I created a separate branch with extra logging and multiple copies of the flakey tests scenario to validate the fix, [results are here](https://buildkite.com/bugsnag/cocoa-bugsnag-notifier/builds/1106)