### PR TITLE
Support duration and durationInForeground on macOS

### DIFF
--- a/Bugsnag/KSCrash/Source/KSCrash/Recording/BSG_KSCrash.m
+++ b/Bugsnag/KSCrash/Source/KSCrash/Recording/BSG_KSCrash.m
@@ -46,6 +46,9 @@
 #if BSG_HAS_UIKIT
 #import <UIKit/UIKit.h>
 #endif
+#if TARGET_OS_OSX
+#import <AppKit/AppKit.h>
+#endif
 
 // ============================================================================
 #pragma mark - Default Constants -
@@ -235,8 +238,8 @@ IMPLEMENT_EXCLUSIVE_SHARED_INSTANCE(BSG_KSCrash)
         return false;
     }
     
-#if BSG_HAS_UIKIT
     NSNotificationCenter *nCenter = [NSNotificationCenter defaultCenter];
+#if BSG_HAS_UIKIT
     [nCenter addObserver:self
                 selector:@selector(applicationDidBecomeActive)
                     name:UIApplicationDidBecomeActiveNotification
@@ -256,6 +259,20 @@ IMPLEMENT_EXCLUSIVE_SHARED_INSTANCE(BSG_KSCrash)
     [nCenter addObserver:self
                 selector:@selector(applicationWillTerminate)
                     name:UIApplicationWillTerminateNotification
+                  object:nil];
+#elif TARGET_OS_OSX
+    // MacOS "active" serves the same purpose as "foreground" in iOS
+    [nCenter addObserver:self
+                selector:@selector(applicationDidEnterBackground)
+                    name:NSApplicationDidResignActiveNotification
+                  object:nil];
+    [nCenter addObserver:self
+                selector:@selector(applicationWillEnterForeground)
+                    name:NSApplicationDidBecomeActiveNotification
+                  object:nil];
+    [nCenter addObserver:self
+                selector:@selector(applicationWillTerminate)
+                    name:NSApplicationWillTerminateNotification
                   object:nil];
 #endif
 


### PR DESCRIPTION
## Goal

Currently, the `duration` and `durationInForeground` fields are always zero on macos because we don't record that information. This PR makes macOS start recording this information so that users can see it in their reports.

## Design

MacOS does record foreground/background state changes, but uses notification names that are confusing when compared to ios. However, they serve purposes that are close enough to be useful for our needs.

**MacOS**:
| Notification | Meaning |
| - | - |
|`NSApplicationDidBecomeActiveNotification`|Application is in foreground |
|`NSApplicationDidResignActiveNotification`|Application is in background |
|`NSApplicationWillTerminateNotification`|Application is shutting down|

**iOS**:
| Notification | Meaning |
| - | - |
|`UIApplicationDidBecomeActiveNotification`|Application is active|
|`UIApplicationWillResignActiveNotification`|Application is interrupted|
|`UIApplicationDidEnterBackgroundNotification`|Application is in background |
|`UIApplicationWillEnterForegroundNotification`|Application is in foreground |
|`UIApplicationWillTerminateNotification`|Application is shutting down|

The approach here simply uses the macOS equivalents to trigger the same handler code as for iOS, allowing existing handlers to do the calculations as they have always done.

## Changeset

Added compile-time-conditional code to add notification handlers for macOS to handle foreground/background and app termination.

## Testing

E2e tests don't exist yet for macos, so I manually triggered events in the macos test apps and verified that durations were recorded on the backend.
