### PR TITLE
Use os_proc_available_memory if available

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,9 @@ Changelog
 
 ## Enhancements
 
+* Use os_proc_available_memory() to get free memory, if available.
+  [851](https://github.com/bugsnag/bugsnag-cocoa/pull/851)
+
 * Reduced the CPU and memory impact of leaving breadcrumbs.
   [853](https://github.com/bugsnag/bugsnag-cocoa/pull/853)
 


### PR DESCRIPTION
## Goal

Apple provides a more accurate measure of usable memory in iOS 13 compared to what we use currently. We should use it when it's available.

## Design

Modified `bsg_ksmachusableMemory()` to call `os_proc_available_memory()` when it's available.

## Testing

Ran all unit tests on all platforms, and did manual tests to verify that the free memory values make sense.
