### PR TITLE
Take maze runner image from releases repository

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,7 +1,7 @@
 version: '3.6'
 services:
   cocoa-maze-runner:
-    image: 855461928731.dkr.ecr.us-west-1.amazonaws.com/maze-runner:latest-v2-cli
+    image: 855461928731.dkr.ecr.us-west-1.amazonaws.com/maze-runner-releases:latest-v2-cli
     command: ["--tags", "not @skip"]
     environment:
       APP_LOCATION: /app/build/iOSTestApp.ipa


### PR DESCRIPTION
## Goal

Take the Maze Runner image from its releases repository.

## Design

maze-runner-releases is a new ECR repository of ours that is dedicated to releases and separate to images built for development branches.  It means that releases will not get swept away as part of our housekeeping policy.

## Changeset

Maze Runner docker file(s).

## Testing

Covered by standard CI.