### PR TITLE
Breadcrumbs tidy up

### DIFF
--- a/Bugsnag/Breadcrumbs/BugsnagBreadcrumbs.h
+++ b/Bugsnag/Breadcrumbs/BugsnagBreadcrumbs.h
@@ -8,8 +8,8 @@
 
 #import <Foundation/Foundation.h>
 
-#import "BugsnagBreadcrumb.h"
-#import "BugsnagConfiguration.h"
+@class BugsnagBreadcrumb;
+@class BugsnagConfiguration;
 
 typedef void (^BSGBreadcrumbConfiguration)(BugsnagBreadcrumb *_Nonnull);
 
@@ -45,12 +45,6 @@ NS_ASSUME_NONNULL_BEGIN
  * Returns the breadcrumb JSON dictionaries stored on disk.
  */
 - (nullable NSArray<NSDictionary *> *)cachedBreadcrumbs;
-
-/**
- * The types of breadcrumbs which will be automatically captured.
- * By default, this is all types.
- */
-@property BSGEnabledBreadcrumbType enabledBreadcrumbTypes;
 
 #pragma mark - Private
 

--- a/Bugsnag/Breadcrumbs/BugsnagBreadcrumbs.h
+++ b/Bugsnag/Breadcrumbs/BugsnagBreadcrumbs.h
@@ -37,11 +37,6 @@ NS_ASSUME_NONNULL_BEGIN
 - (void)addBreadcrumbWithBlock:(BSGBreadcrumbConfiguration)block;
 
 /**
- * Generates an array of dictionaries representing the current buffer of breadcrumbs.
- */
-- (NSArray<NSDictionary *> *)arrayValue;
-
-/**
  * Returns an array containing the current buffer of breadcrumbs.
  */
 - (NSArray<BugsnagBreadcrumb *> *)getBreadcrumbs;

--- a/Bugsnag/Breadcrumbs/BugsnagBreadcrumbs.h
+++ b/Bugsnag/Breadcrumbs/BugsnagBreadcrumbs.h
@@ -13,9 +13,11 @@
 
 typedef void (^BSGBreadcrumbConfiguration)(BugsnagBreadcrumb *_Nonnull);
 
+NS_ASSUME_NONNULL_BEGIN
+
 @interface BugsnagBreadcrumbs : NSObject
 
-- (instancetype _Nonnull)initWithConfiguration:(BugsnagConfiguration *_Nonnull)config;
+- (instancetype _Nonnull)initWithConfiguration:(BugsnagConfiguration *)config;
 
 /**
  * Path where breadcrumbs are persisted on disk
@@ -25,25 +27,29 @@ typedef void (^BSGBreadcrumbConfiguration)(BugsnagBreadcrumb *_Nonnull);
 /**
  * Store a new breadcrumb with a provided message.
  */
-- (void)addBreadcrumb:(NSString *_Nonnull)breadcrumbMessage;
+- (void)addBreadcrumb:(NSString *)breadcrumbMessage;
 
 /**
  *  Store a new breadcrumb configured via block.
  *
  *  @param block configuration block
  */
-- (void)addBreadcrumbWithBlock:
-    (void (^_Nonnull)(BugsnagBreadcrumb *_Nonnull))block;
+- (void)addBreadcrumbWithBlock:(BSGBreadcrumbConfiguration)block;
 
 /**
  * Generates an array of dictionaries representing the current buffer of breadcrumbs.
  */
-- (NSArray *_Nonnull)arrayValue;
+- (NSArray<NSDictionary *> *)arrayValue;
 
 /**
  * Returns an array containing the current buffer of breadcrumbs.
  */
-- (NSArray<BugsnagBreadcrumb *> *_Nonnull)getBreadcrumbs;
+- (NSArray<BugsnagBreadcrumb *> *)getBreadcrumbs;
+
+/**
+ * Returns the breadcrumb JSON dictionaries stored on disk.
+ */
+- (nullable NSArray<NSDictionary *> *)cachedBreadcrumbs;
 
 /**
  * The types of breadcrumbs which will be automatically captured.
@@ -51,4 +57,12 @@ typedef void (^BSGBreadcrumbConfiguration)(BugsnagBreadcrumb *_Nonnull);
  */
 @property BSGEnabledBreadcrumbType enabledBreadcrumbTypes;
 
+#pragma mark - Private
+
+@property (nonatomic, readonly, strong) NSMutableArray<BugsnagBreadcrumb *> *breadcrumbs;
+
+@property (nonatomic, readonly, strong) dispatch_queue_t readWriteQueue;
+
 @end
+
+NS_ASSUME_NONNULL_END

--- a/Bugsnag/Breadcrumbs/BugsnagBreadcrumbs.h
+++ b/Bugsnag/Breadcrumbs/BugsnagBreadcrumbs.h
@@ -17,7 +17,7 @@ NS_ASSUME_NONNULL_BEGIN
 
 @interface BugsnagBreadcrumbs : NSObject
 
-- (instancetype _Nonnull)initWithConfiguration:(BugsnagConfiguration *)config;
+- (instancetype)initWithConfiguration:(BugsnagConfiguration *)config;
 
 /**
  * Path where breadcrumbs are persisted on disk

--- a/Bugsnag/Breadcrumbs/BugsnagBreadcrumbs.m
+++ b/Bugsnag/Breadcrumbs/BugsnagBreadcrumbs.m
@@ -114,28 +114,6 @@
     return [cache isKindOfClass:[NSArray class]] ? cache : nil;
 }
 
-- (NSArray<NSDictionary *> *)arrayValue {
-    __block NSMutableArray *contents;
-    dispatch_barrier_sync(self.readWriteQueue, ^{
-        contents = [[NSMutableArray alloc] initWithCapacity:self.breadcrumbs.count];
-        for (BugsnagBreadcrumb *crumb in self.breadcrumbs) {
-            NSDictionary *objectValue = [crumb objectValue];
-            NSError *error = nil;
-            @try {
-                if (![BSGJSONSerialization isValidJSONObject:objectValue]) {
-                    bsg_log_err(@"Unable to serialize breadcrumb: Not a valid "
-                                @"JSON object");
-                    continue;
-                }
-                [contents addObject:objectValue];
-            } @catch (NSException *exception) {
-              bsg_log_err(@"Unable to serialize breadcrumb: %@", error);
-            }
-        }
-    });
-    return contents;
-}
-
 - (NSArray<BugsnagBreadcrumb *> *)getBreadcrumbs {
     __block NSArray *result = nil;
     dispatch_barrier_sync(self.readWriteQueue, ^{

--- a/Bugsnag/Breadcrumbs/BugsnagBreadcrumbs.m
+++ b/Bugsnag/Breadcrumbs/BugsnagBreadcrumbs.m
@@ -8,7 +8,7 @@
 
 
 #import "BugsnagBreadcrumbs.h"
-#import "BugsnagBreadcrumb.h"
+
 #import "BugsnagLogger.h"
 #import "Private.h"
 #import "BSGJSONSerialization.h"
@@ -25,9 +25,9 @@
 
 @interface BugsnagBreadcrumbs ()
 @property BugsnagConfiguration *config;
-@property(nonatomic, readwrite, strong) NSMutableArray *breadcrumbs;
-@property(nonatomic, readonly, strong) dispatch_queue_t readWriteQueue;
 @end
+
+#pragma mark -
 
 @implementation BugsnagBreadcrumbs
 
@@ -54,8 +54,7 @@
     }];
 }
 
-- (void)addBreadcrumbWithBlock:
-    (void (^_Nonnull)(BugsnagBreadcrumb *_Nonnull))block {
+- (void)addBreadcrumbWithBlock:(BSGBreadcrumbConfiguration)block {
     if (self.config.maxBreadcrumbs == 0) {
         return;
     }
@@ -100,7 +99,7 @@
     return YES;
 }
 
-- (NSArray *)cachedBreadcrumbs {
+- (nullable NSArray<NSDictionary *> *)cachedBreadcrumbs {
     __block NSArray *cache = nil;
     dispatch_barrier_sync(self.readWriteQueue, ^{
         NSError *error = nil;
@@ -115,7 +114,7 @@
     return [cache isKindOfClass:[NSArray class]] ? cache : nil;
 }
 
-- (NSArray *)arrayValue {
+- (NSArray<NSDictionary *> *)arrayValue {
     __block NSMutableArray *contents;
     dispatch_barrier_sync(self.readWriteQueue, ^{
         contents = [[NSMutableArray alloc] initWithCapacity:self.breadcrumbs.count];

--- a/Bugsnag/Client/BugsnagClient.m
+++ b/Bugsnag/Client/BugsnagClient.m
@@ -27,6 +27,8 @@
 #import "BugsnagPlatformConditional.h"
 
 #import "BugsnagClient.h"
+
+#import "BugsnagBreadcrumbs.h"
 #import "BugsnagClientInternal.h"
 #import "BSGConnectivity.h"
 #import "Bugsnag.h"
@@ -361,10 +363,6 @@ void BSGWriteSessionCrashData(BugsnagSession *session) {
 - (instancetype)initWithDictionary:(NSDictionary *)dict;
 - (instancetype)initWithUserId:(NSString *)userId name:(NSString *)name emailAddress:(NSString *)emailAddress;
 - (NSDictionary *)toJson;
-@end
-
-@interface BugsnagBreadcrumbs ()
-@property(nonatomic, readwrite, strong) NSMutableArray *breadcrumbs;
 @end
 
 // =============================================================================

--- a/Bugsnag/Payload/BugsnagEvent.m
+++ b/Bugsnag/Payload/BugsnagEvent.m
@@ -16,6 +16,7 @@
 #import <Foundation/Foundation.h>
 #import "BSGSerialization.h"
 #import "Bugsnag.h"
+#import "BugsnagBreadcrumbs.h"
 #import "BugsnagCollections.h"
 #import "BugsnagHandledState.h"
 #import "BugsnagLogger.h"

--- a/Bugsnag/Private.h
+++ b/Bugsnag/Private.h
@@ -8,7 +8,6 @@
 #import "BSG_RFC3339DateTool.h"
 #import "Bugsnag.h"
 #import "BugsnagBreadcrumb.h"
-#import "BugsnagBreadcrumbs.h"
 #import "BugsnagKeys.h"
 #import "BugsnagLogger.h"
 #import "BugsnagMetadataInternal.h"
@@ -31,16 +30,6 @@
 @interface BugsnagBreadcrumb ()
 
 - (NSDictionary *_Nullable)objectValue;
-
-@end
-
-#pragma mark -
-
-@interface BugsnagBreadcrumbs ()
-/**
- * Reads and return breadcrumb data currently stored on disk
- */
-- (NSArray *_Nullable)cachedBreadcrumbs;
 
 @end
 

--- a/Tests/BugsnagBreadcrumbsTest.m
+++ b/Tests/BugsnagBreadcrumbsTest.m
@@ -225,7 +225,6 @@ BSGBreadcrumbType BSGBreadcrumbTypeFromString(NSString *value);
 - (void)testAlwaysAllowManual {
     BugsnagConfiguration *config = [[BugsnagConfiguration alloc] initWithApiKey:DUMMY_APIKEY_32CHAR_1];
     self.crumbs = [[BugsnagBreadcrumbs alloc] initWithConfiguration:config];
-    self.crumbs.enabledBreadcrumbTypes = 0;
     [self.crumbs addBreadcrumb:@"this is a test"];
     awaitBreadcrumbSync(self.crumbs);
     NSArray *value = [self.crumbs arrayValue];
@@ -241,7 +240,6 @@ BSGBreadcrumbType BSGBreadcrumbTypeFromString(NSString *value);
 - (void)testDiscardByTypeDoesNotApply {
     BugsnagConfiguration *config = [[BugsnagConfiguration alloc] initWithApiKey:DUMMY_APIKEY_32CHAR_1];
     self.crumbs = [[BugsnagBreadcrumbs alloc] initWithConfiguration:config];
-    self.crumbs.enabledBreadcrumbTypes = BSGEnabledBreadcrumbTypeProcess;
     // Don't discard this
     [self.crumbs addBreadcrumbWithBlock:^(BugsnagBreadcrumb *_Nonnull crumb) {
         crumb.type = BSGBreadcrumbTypeState;

--- a/Tests/BugsnagBreadcrumbsTest.m
+++ b/Tests/BugsnagBreadcrumbsTest.m
@@ -24,6 +24,10 @@
 + (instancetype _Nullable)breadcrumbFromDict:(NSDictionary *_Nonnull)dict;
 @end
 
+@interface BugsnagBreadcrumbs (Testing)
+- (NSArray<NSDictionary *> *)arrayValue;
+@end
+
 @interface Bugsnag ()
 + (BugsnagClient *)client;
 @end
@@ -428,6 +432,16 @@ BSGBreadcrumbType BSGBreadcrumbTypeFromString(NSString *value);
     leaveBreadcrumbs();
     
     [self measureBlock:leaveBreadcrumbs];
+}
+
+@end
+
+#pragma mark -
+
+@implementation BugsnagBreadcrumbs (Testing)
+
+- (NSArray<NSDictionary *> *)arrayValue {
+    return [self.breadcrumbs valueForKey:@"objectValue"];
 }
 
 @end

--- a/Tests/BugsnagBreadcrumbsTest.m
+++ b/Tests/BugsnagBreadcrumbsTest.m
@@ -24,11 +24,6 @@
 + (instancetype _Nullable)breadcrumbFromDict:(NSDictionary *_Nonnull)dict;
 @end
 
-@interface BugsnagBreadcrumbs ()
-@property(nonatomic, readwrite, strong) NSMutableArray<BugsnagBreadcrumb *> *breadcrumbs;
-@property(nonatomic, readonly, strong) dispatch_queue_t readWriteQueue;
-@end
-
 @interface Bugsnag ()
 + (BugsnagClient *)client;
 @end

--- a/Tests/BugsnagClientTests.m
+++ b/Tests/BugsnagClientTests.m
@@ -32,10 +32,6 @@
 - (NSDictionary *)objectValue;
 @end
 
-@interface BugsnagBreadcrumbs ()
-@property(nonatomic, readwrite, strong) NSMutableArray *breadcrumbs;
-@end
-
 @interface BugsnagConfiguration ()
 @property(readwrite, retain, nullable) BugsnagMetadata *metadata;
 @end

--- a/Tests/BugsnagOnBreadcrumbTest.m
+++ b/Tests/BugsnagOnBreadcrumbTest.m
@@ -28,10 +28,6 @@
 @property NSMutableArray *onBreadcrumbBlocks;
 @end
 
-@interface BugsnagBreadcrumbs ()
-@property(nonatomic, readwrite, strong) NSMutableArray *breadcrumbs;
-@end
-
 @interface BugsnagOnBreadcrumbTest : XCTestCase
 @end
 

--- a/Tests/BugsnagOnBreadcrumbTest.m
+++ b/Tests/BugsnagOnBreadcrumbTest.m
@@ -12,6 +12,7 @@
 #import "BugsnagConfiguration.h"
 #import "BugsnagTestConstants.h"
 #import "BugsnagBreadcrumbs.h"
+#import "Private.h"
 
 @interface BugsnagClient ()
 @property(nonatomic, readwrite, retain) BugsnagConfiguration *_Nullable configuration;
@@ -186,7 +187,7 @@
     BugsnagClient *client = [[BugsnagClient alloc] initWithConfiguration:config];
     [client start];
     XCTAssertEqual([[config onBreadcrumbBlocks] count], 1);
-    NSDictionary *crumb = [[client.breadcrumbs arrayValue] firstObject];
+    NSDictionary *crumb = [client.breadcrumbs.breadcrumbs.firstObject objectValue];
     XCTAssertEqualObjects(@"Foo", crumb[@"name"]);
 }
 


### PR DESCRIPTION
## Changeset

These changes tidy up `BugsnagBreadcrumbs.h` in preparation for the changes to how storage works.

* Adopted use of `NS_ASSUME_NONNULL_BEGIN` to avoid repetition of `nonnull` or `_Nonnull` declarations.
* `arrayValue` and `enabledBreadcrumbTypes` have been removed as they were completely unused in the rest of the notifier, with only some references in tests.
* The `breadcrumbs` and `readWriteQueue` have been exposed in the header - numerous other files were accessing them anyway through their own definitions.
* The return type of `cachedBreadcrumbs` now makes it clear what's contained in the array.

## Testing

Tested locally by running unit tests.

Covered by end-to-end tests.