### PR TITLE
Implement granular breadcrumb storage

### DIFF
--- a/Bugsnag.xcodeproj/xcshareddata/xcbaselines/00AD1C7A24869B0E00A27979.xcbaseline/AAE3C352-6D5A-468D-8448-CC2EA52E7868.plist
+++ b/Bugsnag.xcodeproj/xcshareddata/xcbaselines/00AD1C7A24869B0E00A27979.xcbaseline/AAE3C352-6D5A-468D-8448-CC2EA52E7868.plist
@@ -11,7 +11,7 @@
 				<key>com.apple.XCTPerformanceMetric_WallClockTime</key>
 				<dict>
 					<key>baselineAverage</key>
-					<real>0.28</real>
+					<real>0.0488</real>
 					<key>baselineIntegrationDisplayName</key>
 					<string>Local Baseline</string>
 				</dict>

--- a/Bugsnag/Breadcrumbs/BugsnagBreadcrumbs.h
+++ b/Bugsnag/Breadcrumbs/BugsnagBreadcrumbs.h
@@ -24,7 +24,7 @@ NS_ASSUME_NONNULL_BEGIN
 /**
  * Path where breadcrumbs are persisted on disk
  */
-@property (readonly, nullable) NSString *cachePath;
+@property (readonly) NSString *cachePath;
 
 /**
  * Store a new breadcrumb with a provided message.

--- a/Bugsnag/Breadcrumbs/BugsnagBreadcrumbs.h
+++ b/Bugsnag/Breadcrumbs/BugsnagBreadcrumbs.h
@@ -19,10 +19,12 @@ NS_ASSUME_NONNULL_BEGIN
 
 - (instancetype)initWithConfiguration:(BugsnagConfiguration *)config;
 
+@property (readonly) NSArray<BugsnagBreadcrumb *> *breadcrumbs;
+
 /**
  * Path where breadcrumbs are persisted on disk
  */
-@property (nonatomic, readonly, strong, nullable) NSString *cachePath;
+@property (readonly, nullable) NSString *cachePath;
 
 /**
  * Store a new breadcrumb with a provided message.
@@ -37,20 +39,14 @@ NS_ASSUME_NONNULL_BEGIN
 - (void)addBreadcrumbWithBlock:(BSGBreadcrumbConfiguration)block;
 
 /**
- * Returns an array containing the current buffer of breadcrumbs.
- */
-- (NSArray<BugsnagBreadcrumb *> *)getBreadcrumbs;
-
-/**
  * Returns the breadcrumb JSON dictionaries stored on disk.
  */
 - (nullable NSArray<NSDictionary *> *)cachedBreadcrumbs;
 
-#pragma mark - Private
-
-@property (nonatomic, readonly, strong) NSMutableArray<BugsnagBreadcrumb *> *breadcrumbs;
-
-@property (nonatomic, readonly, strong) dispatch_queue_t readWriteQueue;
+/**
+ * Removes breadcrumbs from disk and memory.
+ */
+- (void)removeAllBreadcrumbs;
 
 @end
 

--- a/Bugsnag/Breadcrumbs/BugsnagBreadcrumbs.m
+++ b/Bugsnag/Breadcrumbs/BugsnagBreadcrumbs.m
@@ -9,6 +9,7 @@
 
 #import "BugsnagBreadcrumbs.h"
 
+#import "BSGCachesDirectory.h"
 #import "BugsnagLogger.h"
 #import "Private.h"
 #import "BSGJSONSerialization.h"
@@ -49,7 +50,7 @@
     _maxBreadcrumbs = config.maxBreadcrumbs;
     
     NSError *error = nil;
-    NSString *cachesDir = NSSearchPathForDirectoriesInDomains(NSCachesDirectory, NSUserDomainMask, YES).firstObject;
+    NSString *cachesDir = [BSGCachesDirectory cachesDirectory];
     _cachePath = [[cachesDir stringByAppendingPathComponent:@"bugsnag"] stringByAppendingPathComponent:@"breadcrumbs"];
     if (![[NSFileManager defaultManager] createDirectoryAtPath:_cachePath withIntermediateDirectories:YES attributes:nil error:&error]) {
         bsg_log_err(@"Unable to create breadcrumbs directory: %@", error);
@@ -190,7 +191,7 @@
         bsg_log_err(@"Unable to create breadcrumbs directory: %@", error);
     }
 
-    NSString *cachesDir = NSSearchPathForDirectoriesInDomains(NSCachesDirectory, NSUserDomainMask, YES)[0];
+    NSString *cachesDir = [BSGCachesDirectory cachesDirectory];
     NSString *oldBreadcrumbsPath = [cachesDir stringByAppendingPathComponent:@"bugsnag_breadcrumbs.json"];
     [[NSFileManager defaultManager] removeItemAtPath:oldBreadcrumbsPath error:NULL];
 }

--- a/Bugsnag/Breadcrumbs/BugsnagBreadcrumbs.m
+++ b/Bugsnag/Breadcrumbs/BugsnagBreadcrumbs.m
@@ -10,9 +10,9 @@
 #import "BugsnagBreadcrumbs.h"
 
 #import "BSGCachesDirectory.h"
+#import "BSGJSONSerialization.h"
 #import "BugsnagLogger.h"
 #import "Private.h"
-#import "BSGJSONSerialization.h"
 
 @interface BugsnagConfiguration ()
 @property(nonatomic) NSMutableArray *onBreadcrumbBlocks;

--- a/Bugsnag/Bugsnag.m
+++ b/Bugsnag/Bugsnag.m
@@ -203,7 +203,7 @@ static BugsnagClient *bsg_g_bugsnag_client = NULL;
 
 + (NSArray<BugsnagBreadcrumb *> *_Nonnull)breadcrumbs {
     if ([self bugsnagStarted]) {
-        return [self.client.breadcrumbs getBreadcrumbs];
+        return self.client.breadcrumbs.breadcrumbs;
     } else {
         return @[];
     }

--- a/Bugsnag/Client/BugsnagClient.m
+++ b/Bugsnag/Client/BugsnagClient.m
@@ -165,7 +165,8 @@ void BSSerializeDataCrashHandler(const BSG_KSCrashReportWriter *writer, int type
         }
         if (bsg_g_bugsnag_data.breadcrumbsPath) {
             // FIXME: This needs to be updated to cater for new breadcrumb storage scheme
-            writer->addJSONFileElement(writer, "breadcrumbs", bsg_g_bugsnag_data.breadcrumbsPath);
+            // FIXME: addJSONFileElement generates broken JSON if the file cannot be opened
+            // writer->addJSONFileElement(writer, "breadcrumbs", bsg_g_bugsnag_data.breadcrumbsPath);
         }
         if (bsg_g_bugsnag_data.metadataJSON) {
             // The API expects "metaData", capitalised as such.  Elsewhere is is one word.

--- a/Bugsnag/Client/BugsnagClient.m
+++ b/Bugsnag/Client/BugsnagClient.m
@@ -164,6 +164,7 @@ void BSSerializeDataCrashHandler(const BSG_KSCrashReportWriter *writer, int type
             writer->addJSONElement(writer, "state", bsg_g_bugsnag_data.stateJSON);
         }
         if (bsg_g_bugsnag_data.breadcrumbsPath) {
+            // FIXME: This needs to be updated to cater for new breadcrumb storage scheme
             writer->addJSONFileElement(writer, "breadcrumbs", bsg_g_bugsnag_data.breadcrumbsPath);
         }
         if (bsg_g_bugsnag_data.metadataJSON) {
@@ -558,6 +559,7 @@ NSString *const BSGBreadcrumbLoadedMessage = @"Bugsnag loaded";
                     apiClient:self.errorReportApiClient
                       onCrash:&BSSerializeDataCrashHandler];
     [self computeDidCrashLastLaunch];
+    [self.breadcrumbs removeAllBreadcrumbs];
     [self setupConnectivityListener];
     [self updateAutomaticBreadcrumbDetectionSettings];
 
@@ -1613,10 +1615,9 @@ NSString *const BSGBreadcrumbLoadedMessage = @"Bugsnag loaded";
 }
 
 - (NSArray *)collectBreadcrumbs {
-    NSMutableArray *crumbs = self.breadcrumbs.breadcrumbs;
     NSMutableArray *data = [NSMutableArray new];
 
-    for (BugsnagBreadcrumb *crumb in crumbs) {
+    for (BugsnagBreadcrumb *crumb in self.breadcrumbs.breadcrumbs) {
         NSMutableDictionary *crumbData = [[crumb objectValue] mutableCopy];
         // JSON is serialized as 'name', we want as 'message' when passing to RN
         crumbData[@"message"] = crumbData[@"name"];

--- a/Tests/BugsnagClientTests.m
+++ b/Tests/BugsnagClientTests.m
@@ -266,12 +266,11 @@ void BSSerializeJSONDictionary(NSDictionary *dictionary, char **destination);
     BugsnagClient *client = [[BugsnagClient alloc] initWithConfiguration:configuration];
     [client start];
 
-    NSMutableArray *breadcrumbs = client.breadcrumbs.breadcrumbs;
-    XCTAssertEqual(0, [breadcrumbs count]);
+    XCTAssertEqual(client.breadcrumbs.breadcrumbs.count, 0);
 
     // small breadcrumb can be left without issue
     [client leaveBreadcrumbWithMessage:@"Hello World"];
-    XCTAssertEqual(1, [breadcrumbs count]);
+    XCTAssertEqual(client.breadcrumbs.breadcrumbs.count, 1);
 
     // large breadcrumb is also left without issue
     __block NSUInteger crumbSize = 0;
@@ -289,7 +288,7 @@ void BSSerializeJSONDictionary(NSDictionary *dictionary, char **destination);
                               metadata:largeMetadata
                                andType:BSGBreadcrumbTypeManual];
     XCTAssertTrue(crumbSize > 4096); // previous 4kb limit
-    XCTAssertEqual(2, [breadcrumbs count]);
+    XCTAssertEqual(client.breadcrumbs.breadcrumbs.count, 2);
     XCTAssertNotNil(crumb);
     XCTAssertEqualObjects(@"Hello World", crumb.message);
     XCTAssertEqualObjects(largeMetadata, crumb.metadata);
@@ -301,8 +300,7 @@ void BSSerializeJSONDictionary(NSDictionary *dictionary, char **destination);
     BugsnagClient *client = [[BugsnagClient alloc] initWithConfiguration:configuration];
     [client start];
 
-    NSMutableArray *breadcrumbs = client.breadcrumbs.breadcrumbs;
-    XCTAssertEqual(0, [breadcrumbs count]);
+    XCTAssertEqual(client.breadcrumbs.breadcrumbs.count, 0);
 
     id badMetadata = @{
         @"test": @"string key is fine",
@@ -311,7 +309,7 @@ void BSSerializeJSONDictionary(NSDictionary *dictionary, char **destination);
 
     [client leaveBreadcrumbWithMessage:@"test msg" metadata:badMetadata andType:BSGBreadcrumbTypeUser];
 
-    XCTAssertEqual(1, [breadcrumbs count]);
+    XCTAssertEqual(client.breadcrumbs.breadcrumbs.count, 0, @"A breadcrumb with invalid JSON payload should be rejected");
 
     [client notifyError:[NSError errorWithDomain:@"test" code:0 userInfo:badMetadata]];
 }


### PR DESCRIPTION
## Goal

This is the first part of implementing granular breadcrumb storage - handling the writing of breadcrumbs and reading them from disk in the event of an OOM.

Inserting breadcrumbs into KSCrashReports for unhandled errors is to follow in a subsequent PR.

## Changeset

* `breadcrumbs` is now an immutable atomic `NSArray` - this eliminates `mutated while being enumerated` crashes. `getBreadcrumbs` has been removed now that `breadcrumbs` is safe to access.
* Breadcrumbs are now stored in individual files, using an always-incrementing naming scheme, and deleting old files once `maxBreadcrumbs` has been reached.
* Breadcrumbs will no longer be added to the in-memory array if they cannot be serialised.
* `cachedBreadcrumbs` has been updated to read from these individual files.
* `removeAllBreadcrumbs` is called by `BugsnagClient` during start-up to remove breadcrumb files from the previous session.

## Testing

The unit tests have been updated, as some were relying on `breadcrumbs` being a mutable array.

Manually verified that crash reports still reach the dashboard - albeit without any breadcrumbs for unhandled errors (expected at this stage.)

E2E test will fail as a result of missing breadcrumbs in unhandled errors.