### PR TITLE
Adding custom tabs to OOM reports.

### DIFF
--- a/Bugsnag/Client/BugsnagClient.m
+++ b/Bugsnag/Client/BugsnagClient.m
@@ -1562,6 +1562,10 @@ NSString *const BSGBreadcrumbLoadedMessage = @"Bugsnag loaded";
           toSection:(NSString *_Nonnull)sectionName
 {
     [self.metadata addMetadata:metadata withKey:key toSection:sectionName];
+    [self.configuration addOnSendErrorBlock:^BOOL (BugsnagEvent *event) {
+        [event addMetadata:metadata withKey:key toSection:sectionName];
+        return YES;
+    }];
 }
 
 - (id _Nullable)getMetadataFromSection:(NSString *_Nonnull)sectionName


### PR DESCRIPTION
## Goal

Using the metadata client set for showing as new tabs in OOM reports.

## Design

<!-- Why was this approach used? -->

## Changeset

<!-- What changed? -->

## Testing

It was tested in a real project and client set metadata are visible as custom tabs in OOM reports like in other reports.