### PR TITLE
5263 persist default version info

### DIFF
--- a/Bugsnag/Configuration/BugsnagConfiguration.m
+++ b/Bugsnag/Configuration/BugsnagConfiguration.m
@@ -172,7 +172,6 @@ NSString * const kBugsnagUserUserId = @"BugsnagUserUserId";
 
     _metadata = [[BugsnagMetadata alloc] init];
     _config = [[BugsnagMetadata alloc] init];
-    _bundleVersion = NSBundle.mainBundle.infoDictionary[@"CFBundleVersion"];
     _endpoints = [BugsnagEndpointConfiguration new];
     _sessionURL = [NSURL URLWithString:@"https://sessions.bugsnag.com"];
     _autoDetectErrors = YES;
@@ -203,19 +202,30 @@ NSString * const kBugsnagUserUserId = @"BugsnagUserUserId";
             sessionWithConfiguration:[NSURLSessionConfiguration
                                          defaultSessionConfiguration]];
     }
+    
+    NSString *releaseStage = nil;
     #if DEBUG
-        _releaseStage = BSGKeyDevelopment;
+        releaseStage = BSGKeyDevelopment;
     #else
-        _releaseStage = BSGKeyProduction;
+        releaseStage = BSGKeyProduction;
     #endif
 
+    NSString *appType = nil;
     #if BSG_PLATFORM_TVOS
-        _appType = @"tvOS";
+        appType = @"tvOS";
     #elif BSG_PLATFORM_IOS
-        _appType = @"iOS";
+        appType = @"iOS";
     #elif BSG_PLATFORM_OSX
-        _appType = @"macOS";
+        appType = @"macOS";
+    #else
+        appType = @"unknown";
     #endif
+
+    [self setAppType:appType];
+    [self setReleaseStage:releaseStage];
+    [self setAppVersion:NSBundle.mainBundle.infoDictionary[@"CFBundleShortVersionString"]];
+    [self setBundleVersion:NSBundle.mainBundle.infoDictionary[@"CFBundleVersion"]];
+
     return self;
 }
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,10 @@ Changelog
 
 ### Bug fixes
 
+* Fix for incorrect version info during edge case where version info is not
+  manually set, and app version is changed between crashing and reporting the error.
+  [862](https://github.com/bugsnag/bugsnag-cocoa/pull/862)
+
 * Catch and report unexpected exceptions when (de)serializing JSON data rather
   than crashing.
   [856](https://github.com/bugsnag/bugsnag-cocoa/pull/856)


### PR DESCRIPTION
## Goal

When version data is not manually specified, it doesn't get stored to the config metadata JSON buffer, and thus doesn't get stored in any crash events. When loading the event, BugsnagApp tries to fetch the data from the event, then the config, then system data. Since the event data is not present, it ends up fetching current data instead of past data, and gives mismatched values for `app version` and `version` if they happen to change between the last crash and the next launch.

## Design

Force version and app version to be persisted to the config metadata so that it's always available from config no matter how it was initialised.

`ReleaseStage` and `AppType` have also been modified to store their defaults this way.

## Testing

Tested crashing the example app and changing version info before relaunch under the following conditions:

- Don't manually config. Change info.plist version info between launches (where the bug occurred).
- Manually config. Change manually set version info between launches.
- Manually config. Change info.plist between launches (should make no difference to reported version info).
- Manually config. Change info.plist and manually set version info between launches (should show manually set info).
