### PR TITLE
Better checking of TVOS version

### DIFF
--- a/Bugsnag/KSCrash/Source/KSCrash/Recording/Tools/BSG_KSMach.c
+++ b/Bugsnag/KSCrash/Source/KSCrash/Recording/Tools/BSG_KSMach.c
@@ -59,17 +59,24 @@ static pthread_t bsg_g_topThread;
 // ============================================================================
 
 uint64_t bsg_ksmachfreeMemory(void) {
-#if defined(__IPHONE_13_0) && __IPHONE_OS_VERSION_MAX_ALLOWED >= __IPHONE_13_0
-    // Crashes on TVOS, not available on MacOS.
+    size_t mem = 0;
+
+#if BSG_PLATFORM_IOS &&  defined(__IPHONE_13_0) && __IPHONE_OS_VERSION_MAX_ALLOWED >= __IPHONE_13_0
     if (__builtin_available(iOS 13.0, *)) {
-        size_t mem = os_proc_available_memory();
-        // Some versions of iOS always return 0, so fall through
-        // to the old method if this happens.
-        if(mem != 0) {
-            return mem;
-        }
+        mem = os_proc_available_memory();
     }
 #endif
+
+#if BSG_PLATFORM_TVOS &&  defined(__TVOS_13_0) && __TV_OS_VERSION_MAX_ALLOWED >= __TVOS_13_0
+    if (__builtin_available(tvOS 13.0, *)) {
+        mem = os_proc_available_memory();
+    }
+#endif
+
+    // Note: Some broken versions of iOS always return 0.
+    if(mem != 0) {
+        return mem;
+    }
 
     vm_statistics_data_t vmStats;
     vm_size_t pageSize;


### PR DESCRIPTION
## Goal

`os_proc_available_memory` is marked as only available on ios 13+, but it turns out that it's also available on tvos 13+, and that the ios preprocessor version checks also resolve to true on tvos (but not macos). This was causing dynamic linking crashes on tvos <13.

## Design

Add explicit checks individually for ios and for tvos to make sure there's no bleeding across operating systems.

## Testing

Re-ran all unit tests on all platforms at the lowest and highest operating systems available.
