### PR TITLE
[PLAT-5237] Run static analyzer on CI and fix issues

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -8,7 +8,7 @@ install: make bootstrap
 env:
 - TEST_CONFIGURATION=Debug
 
-script: make test
+script: make analyze test
 
 stages:
 - build

--- a/Bugsnag.xcodeproj/project.pbxproj
+++ b/Bugsnag.xcodeproj/project.pbxproj
@@ -3090,6 +3090,7 @@
 				);
 				PRODUCT_BUNDLE_IDENTIFIER = com.bugsnag.Bugsnag;
 				PRODUCT_NAME = Bugsnag;
+				RUN_CLANG_STATIC_ANALYZER = YES;
 				SDKROOT = iphoneos;
 				VERSIONING_SYSTEM = "apple-generic";
 				VERSION_INFO_PREFIX = "";
@@ -3154,6 +3155,7 @@
 				);
 				PRODUCT_BUNDLE_IDENTIFIER = com.bugsnag.Bugsnag;
 				PRODUCT_NAME = Bugsnag;
+				RUN_CLANG_STATIC_ANALYZER = YES;
 				SDKROOT = iphoneos;
 				VALIDATE_PRODUCT = YES;
 				VERSIONING_SYSTEM = "apple-generic";

--- a/Bugsnag/Configuration/BSGConfigurationBuilder.m
+++ b/Bugsnag/Configuration/BSGConfigurationBuilder.m
@@ -13,7 +13,7 @@ static BOOL BSGValueIsBoolean(id object) {
 @implementation BSGConfigurationBuilder
 
 + (BugsnagConfiguration *)configurationFromOptions:(NSDictionary *)options {
-    NSString *apiKey = options[@"apiKey"];
+    NSString *apiKey = options[BSGKeyApiKey];
     if (apiKey != nil && ![apiKey isKindOfClass:[NSString class]]) {
         @throw [NSException exceptionWithName:NSInvalidArgumentException reason:@"Bugsnag apiKey must be a string" userInfo:nil];
     }

--- a/Bugsnag/Configuration/BugsnagConfiguration.m
+++ b/Bugsnag/Configuration/BugsnagConfiguration.m
@@ -164,12 +164,13 @@ NSString * const kBugsnagUserUserId = @"BugsnagUserUserId";
 /**
  * The designated initializer.
  */
-- (instancetype _Nonnull)initWithApiKey:(NSString *_Nonnull)apiKey
-{
-    [self setApiKey:apiKey];
-
-    self = [super init];
-
+- (instancetype)initWithApiKey:(NSString *)apiKey {
+    if (!(self = [super init])) {
+        return nil;
+    }
+    if (apiKey) {
+        [self setApiKey:apiKey];
+    }
     _metadata = [[BugsnagMetadata alloc] init];
     _config = [[BugsnagMetadata alloc] init];
     _endpoints = [BugsnagEndpointConfiguration new];

--- a/Bugsnag/include/Bugsnag/BugsnagConfiguration.h
+++ b/Bugsnag/include/Bugsnag/BugsnagConfiguration.h
@@ -111,7 +111,7 @@ typedef BOOL (^BugsnagOnSessionBlock)(BugsnagSession *_Nonnull session);
 /**
  * Initializes a new configuration object with the provided API key.
  */
-- (instancetype)initWithApiKey:(NSString *)apiKey NS_DESIGNATED_INITIALIZER NS_SWIFT_NAME(init(_:));
+- (instancetype)initWithApiKey:(nullable NSString *)apiKey NS_DESIGNATED_INITIALIZER NS_SWIFT_NAME(init(_:));
 
 /**
  * Required declaration to suppress a superclass designated-initializer error

--- a/Makefile
+++ b/Makefile
@@ -19,7 +19,8 @@
 PLATFORM?=iOS
 OS?=latest
 TEST_CONFIGURATION?=Debug
-BUILD_FLAGS=-project Bugsnag.xcodeproj -scheme Bugsnag-$(PLATFORM) -derivedDataPath build/build-$(PLATFORM)
+DATA_PATH=build/build-$(PLATFORM)
+BUILD_FLAGS=-project Bugsnag.xcodeproj -scheme Bugsnag-$(PLATFORM) -derivedDataPath $(DATA_PATH)
 
 ifeq ($(PLATFORM),macOS)
  SDK?=macosx
@@ -87,6 +88,13 @@ build_swift: ## Build with Swift Package Manager
 #--------------------------------------------------------------------------
 # Testing
 #--------------------------------------------------------------------------
+
+analyze: ## Run static analysis on the build and fail if issues found
+	@rm -rf $(DATA_PATH)/analyzer
+	@$(XCODEBUILD) $(BUILD_FLAGS) $(BUILD_ONLY_FLAGS) analyze \
+		CLANG_ANALYZER_OUTPUT=html \
+		CLANG_ANALYZER_OUTPUT_DIR=$(DATA_PATH)/analyzer $(FORMATTER) \
+		&& [[ -z `find $(DATA_PATH)/analyzer -name "*.html"` ]]
 
 test: ## Run unit tests
 	@$(XCODEBUILD) $(BUILD_FLAGS) $(BUILD_ONLY_FLAGS) test $(FORMATTER)

--- a/Makefile
+++ b/Makefile
@@ -90,10 +90,9 @@ build_swift: ## Build with Swift Package Manager
 #--------------------------------------------------------------------------
 
 analyze: ## Run static analysis on the build and fail if issues found
-	@rm -rf $(DATA_PATH)/analyzer
-	@$(XCODEBUILD) $(BUILD_FLAGS) $(BUILD_ONLY_FLAGS) analyze \
+	@xcodebuild $(BUILD_FLAGS) -quiet $(BUILD_ONLY_FLAGS) analyze \
 		CLANG_ANALYZER_OUTPUT=html \
-		CLANG_ANALYZER_OUTPUT_DIR=$(DATA_PATH)/analyzer $(FORMATTER) \
+		CLANG_ANALYZER_OUTPUT_DIR=$(DATA_PATH)/analyzer \
 		&& [[ -z `find $(DATA_PATH)/analyzer -name "*.html"` ]]
 
 test: ## Run unit tests

--- a/Tests/BugsnagDeviceTest.m
+++ b/Tests/BugsnagDeviceTest.m
@@ -108,7 +108,7 @@ NSNumber *BSGDeviceFreeSpace(NSSearchPathDirectory directory);
     XCTAssertEqualObjects(runtimeVersions, device.runtimeVersions);
 
     // verify stateful fields
-    XCTAssertTrue(device.freeDisk > 0);
+    XCTAssertGreaterThan(device.freeDisk.longLongValue, 0);
     XCTAssertEqualObjects(@742920192, device.freeMemory);
     XCTAssertEqualObjects(@"portrait", device.orientation);
 

--- a/Tests/BugsnagMetadataTests.m
+++ b/Tests/BugsnagMetadataTests.m
@@ -344,8 +344,8 @@
 
     [metadata addObserverWithBlock:firstObserver];
     
-    bool threadShouldQuit = false;
-    if (@available(iOS 10.0, tvOS 10.0, *)) {
+    __block bool threadShouldQuit = false;
+    if (@available(iOS 10.0, tvOS 10.0, macOS 10.12, *)) {
         [NSThread detachNewThreadWithBlock:^{
             while(!threadShouldQuit) {
                 [metadata addObserverWithBlock:secondObserver];


### PR DESCRIPTION
## Goal

We had some static analyzer warnings in our code, but were unaware because our CI was not running the analyzer.

## Design & changeset

The static analyzer is now run just before building and running the unit tests. Because there is no "Treat Static Analyzer Warnings as Errors" build setting in Xcode, we check for output produced by the analyzer and fail the build if there is any. `xcpretty` is skipped because it prevents the static analyzer warnings appearing in Travis' build logs; instead xcodebuild's `-quiet` option is used to suppress the usual torrent of output. For an example of the output we now capture, see this build log - https://travis-ci.com/github/bugsnag/bugsnag-cocoa/jobs/417990124#L779

The `RUN_CLANG_STATIC_ANALYZER` Xcode build setting has been enabled, to run the analyzer (in shallow/quick mode) during regular builds. This adds very little to the build time but ensures we'll know about any issues straight away.

The analyzer warning in BSGConfigurationBuilder.m was due to the fact a nil apiKey could be passed to `-[BugsnagConfiguration initWithApiKey:]`; since the changes in #828 we only throw an exception in the case of a non-nil invalid key. To adapt to this, the apiKey parameter to `-[BugsnagConfiguration initWithApiKey:]` has been marked as `nullable`. Note that the apiKey property is `nonnull` but in some cases the getter may return nil - perhaps we should mark this as `nullable` instead?

There were some analyzer warnings in the unit tests which have now been addressed.

## Testing

All changes have been verified locally, and have E2E / unit test coverage.