### PR TITLE
[PLAT-5252] Prevent onCrashHandler being called for OOMs

### DIFF
--- a/Bugsnag/Client/BugsnagClientInternal.h
+++ b/Bugsnag/Client/BugsnagClientInternal.h
@@ -28,5 +28,7 @@
 @property(readonly) BOOL started;
 
 - (void)start;
-@end
 
+- (BOOL)shouldReportOOM;
+
+@end

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,13 @@
 Changelog
 =========
 
+## TBD
+
+### Bug fixes
+
+* The `onCrashHandler` is no longer called in the event of an OOM.
+  [#874](https://github.com/bugsnag/bugsnag-cocoa/pull/874)
+
 ## 6.2.3 (2020-10-28)
 
 ### Enhancements

--- a/Tests/BugsnagClientMirrorTest.m
+++ b/Tests/BugsnagClientMirrorTest.m
@@ -119,7 +119,9 @@
             @"setBreadcrumbs: v24@0:8@16",
             @"breadcrumbs @16@0:8",
             @"setUser: v24@0:8@16",
+            @"didLikelyOOM B16@0:8",
             @"didLikelyOOM c16@0:8",
+            @"shouldReportOOM B16@0:8",
             @"shouldReportOOM c16@0:8",
             @"systemState @16@0:8",
             @"setSystemState: v24@0:8@16"

--- a/Tests/BugsnagClientMirrorTest.m
+++ b/Tests/BugsnagClientMirrorTest.m
@@ -119,8 +119,8 @@
             @"setBreadcrumbs: v24@0:8@16",
             @"breadcrumbs @16@0:8",
             @"setUser: v24@0:8@16",
-            @"didLikelyOOM B16@0:8",
-            @"shouldReportOOM B16@0:8",
+            @"didLikelyOOM c16@0:8",
+            @"shouldReportOOM c16@0:8",
             @"systemState @16@0:8",
             @"setSystemState: v24@0:8@16"
     ]];

--- a/Tests/BugsnagClientTests.m
+++ b/Tests/BugsnagClientTests.m
@@ -333,8 +333,10 @@ void BSSerializeJSONDictionary(NSDictionary *dictionary, char **destination);
     BSSerializeJSONDictionary(@{@1: @"a"}, &dest);
 }
 
+static BOOL testOnCrashHandlerNotCalledForOOM_didCallOnCrashHandler;
+
 static void testOnCrashHandlerNotCalledForOOM_onCrashHandler(const BSG_KSCrashReportWriter *writer) {
-    XCTFail(@"onCrashHandler should not be called for OOMs");
+    testOnCrashHandlerNotCalledForOOM_didCallOnCrashHandler = YES;
 }
 
 static BOOL testOnCrashHandlerNotCalledForOOM_shouldReportOOM(BugsnagClient *client, SEL _cmd) {
@@ -350,6 +352,7 @@ static BOOL testOnCrashHandlerNotCalledForOOM_shouldReportOOM(BugsnagClient *cli
     void *originalImplementation = method_setImplementation(method, (void *)testOnCrashHandlerNotCalledForOOM_shouldReportOOM);
     [client start];
     method_setImplementation(method, originalImplementation);
+    XCTAssertFalse(testOnCrashHandlerNotCalledForOOM_didCallOnCrashHandler, @"onCrashHandler should not be called for OOMs");
 }
 
 @end


### PR DESCRIPTION
## Goal

The `onCrashHandler` is not supposed to be called for OOMs - it's intended to be called when a crash occurs and not in the following launch of the app.

## Design

Temporarily setting `bsg_g_bugsnag_data.onCrash` to `NULL` was the simplest and least intrusive solution.

The alternative would entail deeper changes in KSCrash to allow `BSSerializeDataCrashHandler` to detect whether the crash is an OOM.

## Changeset

Updated `computeDidCrashLastLaunch` to prevent `onCrashHandler` being invoked.

`#if BSG_PLATFORM_TVOS || BSG_PLATFORM_IOS` was removed to allow the unit test to work on macOS.

## Testing

A unit test case (which reports a failure without the changes to BugsnagClient) has been added to verify this behaviour. It works by replacing the `shouldReportOOM` implementation to trigger an OOM to be sent - we may want to consider the use of a mocking framework such as [OCMock](https://ocmock.org) if we need more of these kinds of tests.