### PR TITLE
[PLAT-5382] Prepare fixtures for running Mac E2E tests

### DIFF
--- a/features/auto_detect_errors.feature
+++ b/features/auto_detect_errors.feature
@@ -13,7 +13,7 @@ Feature: autoDetectErrors flag controls whether errors are captured automaticall
         And the event "unhandled" is false
         And I discard the oldest request
         When I run "AutoDetectFalseNSExceptionScenario" and relaunch the app
-        And I configure Bugsnag for "Scenario"
+        And I configure Bugsnag for "AutoDetectFalseHandledScenario"
         Then I should receive no requests
 
     Scenario: Signal not reported when autoDetectErrors is false
@@ -24,5 +24,5 @@ Feature: autoDetectErrors flag controls whether errors are captured automaticall
         And the event "unhandled" is false
         And I discard the oldest request
         When I run "AutoDetectFalseAbortScenario" and relaunch the app
-        And I configure Bugsnag for "Scenario"
+        And I configure Bugsnag for "AutoDetectFalseHandledScenario"
         Then I should receive no requests

--- a/features/fixtures/ios-swift-cocoapods/iOSTestApp/Base.lproj/Main.storyboard
+++ b/features/fixtures/ios-swift-cocoapods/iOSTestApp/Base.lproj/Main.storyboard
@@ -25,19 +25,19 @@
                             </label>
                             <textField opaque="NO" contentMode="scaleToFill" contentHorizontalAlignment="left" contentVerticalAlignment="center" borderStyle="roundedRect" placeholder="Scenario Name" textAlignment="center" minimumFontSize="17" translatesAutoresizingMaskIntoConstraints="NO" id="5Cz-db-j7f">
                                 <rect key="frame" x="20" y="135" width="374" height="34"/>
-                                <accessibility key="accessibilityConfiguration" identifier="ScenarioNameField"/>
+                                <accessibility key="accessibilityConfiguration" identifier="scenario_name"/>
                                 <fontDescription key="fontDescription" type="system" pointSize="14"/>
                                 <textInputTraits key="textInputTraits"/>
                             </textField>
                             <textField opaque="NO" contentMode="scaleToFill" contentHorizontalAlignment="left" contentVerticalAlignment="center" borderStyle="roundedRect" placeholder="Scenario Metadata" textAlignment="center" minimumFontSize="17" translatesAutoresizingMaskIntoConstraints="NO" id="IN4-CK-eEf">
                                 <rect key="frame" x="20" y="189" width="374" height="34"/>
-                                <accessibility key="accessibilityConfiguration" identifier="ScenarioMetaDataField"/>
+                                <accessibility key="accessibilityConfiguration" identifier="scenario_metadata"/>
                                 <fontDescription key="fontDescription" type="system" pointSize="14"/>
                                 <textInputTraits key="textInputTraits"/>
                             </textField>
                             <button opaque="NO" contentMode="scaleToFill" contentHorizontalAlignment="center" contentVerticalAlignment="center" buttonType="roundedRect" lineBreakMode="middleTruncation" translatesAutoresizingMaskIntoConstraints="NO" id="Oym-db-43x">
                                 <rect key="frame" x="20" y="243" width="374" height="30"/>
-                                <accessibility key="accessibilityConfiguration" identifier="StartScenarioButton"/>
+                                <accessibility key="accessibilityConfiguration" identifier="run_scenario"/>
                                 <state key="normal" title="Start Scenario"/>
                                 <connections>
                                     <action selector="runTestScenario" destination="BYZ-38-t0r" eventType="primaryActionTriggered" id="tlB-VZ-ZdP"/>
@@ -45,7 +45,7 @@
                             </button>
                             <button opaque="NO" contentMode="scaleToFill" contentHorizontalAlignment="center" contentVerticalAlignment="center" buttonType="roundedRect" lineBreakMode="middleTruncation" translatesAutoresizingMaskIntoConstraints="NO" id="2z0-6z-4u6">
                                 <rect key="frame" x="20" y="293" width="374" height="30"/>
-                                <accessibility key="accessibilityConfiguration" identifier="StartBugsnagButton"/>
+                                <accessibility key="accessibilityConfiguration" identifier="start_bugsnag"/>
                                 <state key="normal" title="Start Bugsnag"/>
                                 <connections>
                                     <action selector="startBugsnag" destination="BYZ-38-t0r" eventType="primaryActionTriggered" id="Wv1-OW-OOt"/>
@@ -53,7 +53,7 @@
                             </button>
                             <button opaque="NO" contentMode="scaleToFill" contentHorizontalAlignment="center" contentVerticalAlignment="center" buttonType="roundedRect" lineBreakMode="middleTruncation" translatesAutoresizingMaskIntoConstraints="NO" id="zEv-jB-Vej">
                                 <rect key="frame" x="20" y="343" width="374" height="30"/>
-                                <accessibility key="accessibilityConfiguration" identifier="ClearPersistentDataButton"/>
+                                <accessibility key="accessibilityConfiguration" identifier="clear_persistent_data"/>
                                 <state key="normal" title="Clear Persistent Data"/>
                                 <connections>
                                     <action selector="clearPersistentData:" destination="BYZ-38-t0r" eventType="touchUpInside" id="ZcO-Ew-Mhu"/>
@@ -61,7 +61,7 @@
                             </button>
                             <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="251" text="Manual Testing" textAlignment="center" lineBreakMode="tailTruncation" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" translatesAutoresizingMaskIntoConstraints="NO" id="X9q-4y-UF2">
                                 <rect key="frame" x="20" y="423" width="374" height="21"/>
-                                <accessibility key="accessibilityConfiguration" identifier="CloseKeyboardItem"/>
+                                <accessibility key="accessibilityConfiguration" identifier="close_keyboard"/>
                                 <fontDescription key="fontDescription" type="system" pointSize="17"/>
                                 <nil key="textColor"/>
                                 <nil key="highlightedColor"/>

--- a/features/fixtures/ios-swift-cocoapods/iOSTestApp/Info.plist
+++ b/features/fixtures/ios-swift-cocoapods/iOSTestApp/Info.plist
@@ -22,24 +22,8 @@
 	<true/>
 	<key>NSAppTransportSecurity</key>
 	<dict>
-		<key>NSExceptionDomains</key>
-		<dict>
-			<key>192.168.3.6</key>
-			<dict>
-				<key>NSExceptionAllowsInsecureHTTPLoads</key>
-				<true/>
-			</dict>
-			<key>bs-local.com</key>
-			<dict>
-				<key>NSExceptionAllowsInsecureHTTPLoads</key>
-				<true/>
-			</dict>
-			<key>localhost</key>
-			<dict>
-				<key>NSExceptionAllowsInsecureHTTPLoads</key>
-				<true/>
-			</dict>
-		</dict>
+		<key>NSAllowsArbitraryLoads</key>
+		<true/>
 	</dict>
 	<key>UILaunchStoryboardName</key>
 	<string>LaunchScreen</string>

--- a/features/fixtures/macos/macOSTestApp.xcodeproj/xcshareddata/xcschemes/macOSTestApp.xcscheme
+++ b/features/fixtures/macos/macOSTestApp.xcodeproj/xcshareddata/xcschemes/macOSTestApp.xcscheme
@@ -54,7 +54,7 @@
       </Testables>
    </TestAction>
    <LaunchAction
-      buildConfiguration = "Release"
+      buildConfiguration = "Debug"
       selectedDebuggerIdentifier = ""
       selectedLauncherIdentifier = "Xcode.IDEFoundation.Launcher.PosixSpawn"
       launchStyle = "0"

--- a/features/fixtures/macos/macOSTestApp/Info.plist
+++ b/features/fixtures/macos/macOSTestApp/Info.plist
@@ -4,19 +4,17 @@
 <dict>
 	<key>bugsnag</key>
 	<dict>
-		<key>endpoints</key>
-		<dict>
-			<key>sessions</key>
-			<string>http://bs-local.com:9339</string>
-			<key>notify</key>
-			<string>http://bs-local.com:9339</string>
-		</dict>
 		<key>apiKey</key>
 		<string>0192837465afbecd0192837465afbecd</string>
+		<key>endpoints</key>
+		<dict>
+			<key>notify</key>
+			<string>http://bs-local.com:9339</string>
+			<key>sessions</key>
+			<string>http://bs-local.com:9339</string>
+		</dict>
 		<key>releaseStage</key>
 		<string>beta2</string>
-		<key>autoTrackSessions</key>
-		<true/>
 	</dict>
 	<key>CFBundleDevelopmentRegion</key>
 	<string>en</string>
@@ -33,23 +31,23 @@
 	<key>CFBundlePackageType</key>
 	<string>APPL</string>
 	<key>CFBundleShortVersionString</key>
-	<string>1.0</string>
+	<string>1.0.3</string>
 	<key>CFBundleSignature</key>
 	<string>????</string>
 	<key>CFBundleVersion</key>
-	<string>1</string>
+	<string>5</string>
 	<key>LSMinimumSystemVersion</key>
 	<string>$(MACOSX_DEPLOYMENT_TARGET)</string>
+	<key>NSAppTransportSecurity</key>
+	<dict>
+		<key>NSAllowsArbitraryLoads</key>
+		<true/>
+	</dict>
 	<key>NSHumanReadableCopyright</key>
 	<string>Copyright © 2020 Bugsnac Inc. All rights reserved.</string>
 	<key>NSMainNibFile</key>
 	<string>MainMenu</string>
 	<key>NSPrincipalClass</key>
 	<string>NSApplication</string>
-	<key>NSAppTransportSecurity</key>
-	<dict>
-		<key>NSAllowsArbitraryLoads</key>
-		<true/>
-	</dict>
 </dict>
 </plist>

--- a/features/fixtures/macos/macOSTestApp/MainWindowController.xib
+++ b/features/fixtures/macos/macOSTestApp/MainWindowController.xib
@@ -107,6 +107,7 @@
                             <behavior key="behavior" pushIn="YES" lightByBackground="YES" lightByGray="YES"/>
                             <font key="font" metaFont="system"/>
                         </buttonCell>
+                        <accessibility identifier="clear_persistent_data"/>
                         <connections>
                             <action selector="clearPersistentData:" target="-2" id="p7v-vJ-tOI"/>
                         </connections>

--- a/features/fixtures/macos/macOSTestApp/main.m
+++ b/features/fixtures/macos/macOSTestApp/main.m
@@ -9,5 +9,15 @@
 #import <Cocoa/Cocoa.h>
 
 int main(int argc, const char * argv[]) {
+    [[NSUserDefaults standardUserDefaults] registerDefaults:@{
+        // Disable state restoration to prevent the following dialog being shown after crashes
+        // "The last time you opened macOSTestApp, it unexpectedly quit while reopening windows.
+        //  Do you want to try to reopen its windows again?"
+        // https://developer.apple.com/library/archive/releasenotes/AppKit/RN-AppKitOlderNotes/index.html#10_7StateRestoration
+        @"ApplePersistenceIgnoreState": @YES,
+        // Stop NSApplication swallowing NSExceptions thrown on the main thread.
+        @"NSApplicationCrashOnExceptions": @YES,
+    }];
+    
     return NSApplicationMain(argc, argv);
 }

--- a/features/steps/ios_steps.rb
+++ b/features/steps/ios_steps.rb
@@ -1,16 +1,16 @@
 When("I run {string}") do |event_type|
   steps %Q{
-    Given the element "ScenarioNameField" is present
-    When I send the keys "#{event_type}" to the element "ScenarioNameField"
+    Given the element "scenario_name" is present
+    When I send the keys "#{event_type}" to the element "scenario_name"
     And I close the keyboard
-    And I click the element "StartScenarioButton"
+    And I click the element "run_scenario"
   }
 end
 
 When("I set the app to {string} mode") do |mode|
   steps %Q{
-    Given the element "ScenarioMetaDataField" is present
-    When I send the keys "#{mode}" to the element "ScenarioMetaDataField"
+    Given the element "scenario_metadata" is present
+    When I send the keys "#{mode}" to the element "scenario_metadata"
     And I close the keyboard
   }
 end
@@ -24,24 +24,24 @@ end
 
 When("I clear all persistent data") do
   steps %Q{
-    Given the element "ClearPersistentDataButton" is present
-    And I click the element "ClearPersistentDataButton"
+    Given the element "clear_persistent_data" is present
+    And I click the element "clear_persistent_data"
   }
 end
 
 When("I close the keyboard") do
   steps %Q{
-    Given the element "CloseKeyboardItem" is present
-    And I click the element "CloseKeyboardItem"
+    Given the element "close_keyboard" is present
+    And I click the element "close_keyboard"
   }
 end
 
 When("I configure Bugsnag for {string}") do |event_type|
   steps %Q{
-    Given the element "ScenarioNameField" is present
-    When I send the keys "#{event_type}" to the element "ScenarioNameField"
+    Given the element "scenario_name" is present
+    When I send the keys "#{event_type}" to the element "scenario_name"
     And I close the keyboard
-    And I click the element "StartBugsnagButton"
+    And I click the element "start_bugsnag"
   }
 end
 
@@ -58,7 +58,7 @@ When("I clear the request queue") do
 end
 
 When("derp {string}") do |value|
-  send_keys_to_element("ScenarioNameField", value)
+  send_keys_to_element("scenario_name", value)
 end
 
 # 0: The current application state cannot be determined/is unknown


### PR DESCRIPTION
## Goal

There were some small differences between the test fixtures that were problematic for running the E2E tests on macOS.

## Changeset

* auto_detect_errors.feature contained a bug - it was entering an invalid scenario name resulting the fixture app crashing
* accessibility identifiers have been unified in the iOS and macOS fixtures (following the React Native fixture's naming convention)
* the Mac fixture's Info.plist now matches iOS as some of the test scenarios rely on specific configuration in there
* some Mac changes were required to ensure that the app crashes for uncaught exceptions (NSApplication and other mechanisms have a [tendency to swallow exceptions](https://www.chimehq.com/blog/sad-state-of-exceptions) thrown on the main thread)


## Testing

The iOS E2E tests should continue to run as before.

This branch does not contain all the changes required to run the E2E tests on a Mac - there will be some changes to maze runner and most of the .feature files also require some modifications to cater for multiple platforms.