### PR TITLE
[PLAT-3903] Return instancetype from init and copy methods

### DIFF
--- a/Bugsnag/Client/BugsnagClient.m
+++ b/Bugsnag/Client/BugsnagClient.m
@@ -374,7 +374,7 @@ NSString *_lastOrientation = nil;
 
 @synthesize configuration;
 
-- (id)initWithConfiguration:(BugsnagConfiguration *)initConfiguration {
+- (instancetype)initWithConfiguration:(BugsnagConfiguration *)initConfiguration {
     static NSString *const BSGCrashSentinelFileName = @"bugsnag_handled_crash.txt";
     if ((self = [super init])) {
         // Take a shallow copy of the configuration

--- a/Bugsnag/KSCrash/Source/KSCrash/Recording/BSG_KSCrash.m
+++ b/Bugsnag/KSCrash/Source/KSCrash/Recording/BSG_KSCrash.m
@@ -128,12 +128,12 @@
 
 IMPLEMENT_EXCLUSIVE_SHARED_INSTANCE(BSG_KSCrash)
 
-- (id)init {
+- (instancetype)init {
     return [self
         initWithReportFilesDirectory:BSG_KSCRASH_DefaultReportFilesDirectory];
 }
 
-- (id)initWithReportFilesDirectory:(NSString *)reportFilesDirectory {
+- (instancetype)initWithReportFilesDirectory:(NSString *)reportFilesDirectory {
     if ((self = [super init])) {
         self.bundleName = [[NSBundle mainBundle] infoDictionary][@"CFBundleName"];
 

--- a/Bugsnag/KSCrash/Source/KSCrash/Recording/BSG_KSCrashAdvanced.h
+++ b/Bugsnag/KSCrash/Source/KSCrash/Recording/BSG_KSCrashAdvanced.h
@@ -82,7 +82,7 @@
 #pragma mark - Configuration -
 
 /** Init BSG_KSCrash instance with custom report files directory path. */
-- (id)initWithReportFilesDirectory:(NSString *)reportFilesDirectory;
+- (instancetype)initWithReportFilesDirectory:(NSString *)reportFilesDirectory;
 
 /** Store containing all crash reports. */
 @property(nonatomic, readwrite, retain)

--- a/Bugsnag/KSCrash/Source/KSCrash/Recording/Tools/BSG_KSJSONCodecObjC.m
+++ b/Bugsnag/KSCrash/Source/KSCrash/Recording/Tools/BSG_KSJSONCodecObjC.m
@@ -87,7 +87,7 @@ codecWithEncodeOptions:(BSG_KSJSONEncodeOption)encodeOptions
  *
  * @return The initialized codec.
  */
-- (id)initWithEncodeOptions:(BSG_KSJSONEncodeOption)encodeOptions
+- (instancetype)initWithEncodeOptions:(BSG_KSJSONEncodeOption)encodeOptions
               decodeOptions:(BSG_KSJSONDecodeOption)decodeOptions;
 
 #pragma mark Callbacks
@@ -188,7 +188,7 @@ codecWithEncodeOptions:(BSG_KSJSONEncodeOption)encodeOptions
                                  decodeOptions:decodeOptions];
 }
 
-- (id)initWithEncodeOptions:(BSG_KSJSONEncodeOption)encodeOptions
+- (instancetype)initWithEncodeOptions:(BSG_KSJSONEncodeOption)encodeOptions
               decodeOptions:(BSG_KSJSONDecodeOption)decodeOptions {
     if ((self = [super init])) {
         self.containerStack = [NSMutableArray array];

--- a/Bugsnag/Metadata/BugsnagMetadata.m
+++ b/Bugsnag/Metadata/BugsnagMetadata.m
@@ -36,12 +36,12 @@
 
 @implementation BugsnagMetadata
 
-- (id)init {
+- (instancetype)init {
     NSMutableDictionary *dict = [NSMutableDictionary dictionary];
     return [self initWithDictionary:dict];
 }
 
-- (id)initWithDictionary:(NSDictionary *)dict {
+- (instancetype)initWithDictionary:(NSDictionary *)dict {
     if (self = [super init]) {
         // Ensure that the instantiating dictionary is mutable.
         // Saves checks later.
@@ -117,7 +117,7 @@
 
 // MARK: - <NSMutableCopying>
 
-- (id)mutableCopyWithZone:(NSZone *)zone {
+- (instancetype)mutableCopyWithZone:(NSZone *)zone {
     @synchronized(self) {
         NSMutableDictionary *dict = [self.dictionary mutableCopy];
         return [[BugsnagMetadata alloc] initWithDictionary:dict];
@@ -138,7 +138,7 @@
     }
 }
 
-- (id)deepCopy {
+- (instancetype)deepCopy {
     @synchronized(self) {
         return [[BugsnagMetadata alloc] initWithDictionary:self.dictionary];
     }

--- a/Bugsnag/Metadata/BugsnagMetadataInternal.h
+++ b/Bugsnag/Metadata/BugsnagMetadataInternal.h
@@ -23,7 +23,7 @@ typedef void (^BugsnagObserverBlock)(BugsnagStateEvent *_Nonnull event);
 
 - (NSDictionary *)toDictionary;
 
-- (id)deepCopy;
+- (instancetype)deepCopy;
 
 - (void)addObserverWithBlock:(BugsnagObserverBlock _Nonnull)block;
 

--- a/Bugsnag/Payload/BugsnagEvent.m
+++ b/Bugsnag/Payload/BugsnagEvent.m
@@ -78,7 +78,7 @@ NSDictionary *_Nonnull BSGParseAppMetadata(NSDictionary *_Nonnull event);
 
 @interface BugsnagMetadata ()
 - (NSDictionary *)toDictionary;
-- (id)deepCopy;
+- (instancetype)deepCopy;
 @end
 
 @interface BugsnagStackframe ()

--- a/Bugsnag/Plugins/BugsnagPluginClient.m
+++ b/Bugsnag/Plugins/BugsnagPluginClient.m
@@ -42,7 +42,7 @@ static NSString *const kPluginReactNative = @"BugsnagReactNativePlugin";
 /**
  * Automagically instantiate plugins which Bugsnag uses via class name (e.g. BugsnagReactNativePlugin)
  */
-- (id)instantiateBugsnagPlugin:(NSString *)clzName {
+- (instancetype)instantiateBugsnagPlugin:(NSString *)clzName {
     Class clz = NSClassFromString(clzName);
     if (clz) {
         return [clz new];


### PR DESCRIPTION
## Goal

Modernizes the signature of `init` and copy `method`

## Changeset

Methods now return `instancetype` where appropriate instead of `id`

## Testing

These changes have no effect on runtime behaviour.