### PR TITLE
[PLAT-5354] Add Bugsnag-Integrity HTTP header

### DIFF
--- a/Bugsnag.xcodeproj/project.pbxproj
+++ b/Bugsnag.xcodeproj/project.pbxproj
@@ -660,6 +660,8 @@
 		00E636C224878D84006CBF1A /* BSG_RFC3339DateTool.m in Sources */ = {isa = PBXBuildFile; fileRef = 008969142486DAD000DC48C2 /* BSG_RFC3339DateTool.m */; };
 		014475FD2566844F0018AB94 /* BugsnagApiClientTest.m in Sources */ = {isa = PBXBuildFile; fileRef = CB9103632502320A00E9D1E2 /* BugsnagApiClientTest.m */; };
 		01447605256684500018AB94 /* BugsnagApiClientTest.m in Sources */ = {isa = PBXBuildFile; fileRef = CB9103632502320A00E9D1E2 /* BugsnagApiClientTest.m */; };
+		0187D45C255BD7B700C503D9 /* BugsnagApiClientTest.m in Sources */ = {isa = PBXBuildFile; fileRef = CB9103632502320A00E9D1E2 /* BugsnagApiClientTest.m */; };
+		0187D464255BD7B800C503D9 /* BugsnagApiClientTest.m in Sources */ = {isa = PBXBuildFile; fileRef = CB9103632502320A00E9D1E2 /* BugsnagApiClientTest.m */; };
 		01B14C56251CE55F00118748 /* report-react-native-promise-rejection.json in Resources */ = {isa = PBXBuildFile; fileRef = 01B14C55251CE55F00118748 /* report-react-native-promise-rejection.json */; };
 		01B14C57251CE55F00118748 /* report-react-native-promise-rejection.json in Resources */ = {isa = PBXBuildFile; fileRef = 01B14C55251CE55F00118748 /* report-react-native-promise-rejection.json */; };
 		01B14C58251CE55F00118748 /* report-react-native-promise-rejection.json in Resources */ = {isa = PBXBuildFile; fileRef = 01B14C55251CE55F00118748 /* report-react-native-promise-rejection.json */; };
@@ -2727,6 +2729,7 @@
 				0089675B2486D43700DC48C2 /* BugsnagEnabledBreadcrumbTest.m in Sources */,
 				008966EC2486D43700DC48C2 /* BugsnagDeviceTest.m in Sources */,
 				014475FD2566844F0018AB94 /* BugsnagApiClientTest.m in Sources */,
+				0187D45C255BD7B700C503D9 /* BugsnagApiClientTest.m in Sources */,
 				008967462486D43700DC48C2 /* BugsnagTests.m in Sources */,
 				008967A62486D43700DC48C2 /* KSString_Tests.m in Sources */,
 				004E353D2487B3B8007FBAE4 /* BugsnagSwiftTests.swift in Sources */,
@@ -2937,6 +2940,7 @@
 				00896A422486DBDD00DC48C2 /* BSGConfigurationBuilderTests.m in Sources */,
 				008967682486D43700DC48C2 /* BugsnagNotifierTest.m in Sources */,
 				01447605256684500018AB94 /* BugsnagApiClientTest.m in Sources */,
+				0187D464255BD7B800C503D9 /* BugsnagApiClientTest.m in Sources */,
 				0089676E2486D43700DC48C2 /* BugsnagTestsDummyClass.m in Sources */,
 				008967412486D43700DC48C2 /* BugsnagAppTest.m in Sources */,
 				008967052486D43700DC48C2 /* BugsnagThreadSerializationTest.m in Sources */,

--- a/Bugsnag.xcodeproj/project.pbxproj
+++ b/Bugsnag.xcodeproj/project.pbxproj
@@ -658,9 +658,8 @@
 		00AD1F302486A17900A27979 /* BugsnagSessionTracker.m in Sources */ = {isa = PBXBuildFile; fileRef = 00AD1F012486A17900A27979 /* BugsnagSessionTracker.m */; };
 		00AD1F312486A17900A27979 /* BugsnagSessionTracker.m in Sources */ = {isa = PBXBuildFile; fileRef = 00AD1F012486A17900A27979 /* BugsnagSessionTracker.m */; };
 		00E636C224878D84006CBF1A /* BSG_RFC3339DateTool.m in Sources */ = {isa = PBXBuildFile; fileRef = 008969142486DAD000DC48C2 /* BSG_RFC3339DateTool.m */; };
-		014475FD2566844F0018AB94 /* BugsnagApiClientTest.m in Sources */ = {isa = PBXBuildFile; fileRef = CB9103632502320A00E9D1E2 /* BugsnagApiClientTest.m */; };
+		0140D29A25767C9A00FD0306 /* BugsnagApiClientTest.m in Sources */ = {isa = PBXBuildFile; fileRef = CB9103632502320A00E9D1E2 /* BugsnagApiClientTest.m */; };
 		01447605256684500018AB94 /* BugsnagApiClientTest.m in Sources */ = {isa = PBXBuildFile; fileRef = CB9103632502320A00E9D1E2 /* BugsnagApiClientTest.m */; };
-		0187D45C255BD7B700C503D9 /* BugsnagApiClientTest.m in Sources */ = {isa = PBXBuildFile; fileRef = CB9103632502320A00E9D1E2 /* BugsnagApiClientTest.m */; };
 		0187D464255BD7B800C503D9 /* BugsnagApiClientTest.m in Sources */ = {isa = PBXBuildFile; fileRef = CB9103632502320A00E9D1E2 /* BugsnagApiClientTest.m */; };
 		01B14C56251CE55F00118748 /* report-react-native-promise-rejection.json in Resources */ = {isa = PBXBuildFile; fileRef = 01B14C55251CE55F00118748 /* report-react-native-promise-rejection.json */; };
 		01B14C57251CE55F00118748 /* report-react-native-promise-rejection.json in Resources */ = {isa = PBXBuildFile; fileRef = 01B14C55251CE55F00118748 /* report-react-native-promise-rejection.json */; };
@@ -2712,6 +2711,7 @@
 			buildActionMask = 2147483647;
 			files = (
 				008967882486D43700DC48C2 /* KSCrashSentry_NSException_Tests.m in Sources */,
+				0140D29A25767C9A00FD0306 /* BugsnagApiClientTest.m in Sources */,
 				E701FAA02490EF4A008D842F /* BugsnagApiValidationTest.m in Sources */,
 				008966FB2486D43700DC48C2 /* BugsnagCollectionsBSGDictInsertIfNotNilTest.m in Sources */,
 				0089677F2486D43700DC48C2 /* KSLogger_Tests.m in Sources */,
@@ -2728,8 +2728,6 @@
 				008967132486D43700DC48C2 /* BugsnagEventTests.m in Sources */,
 				0089675B2486D43700DC48C2 /* BugsnagEnabledBreadcrumbTest.m in Sources */,
 				008966EC2486D43700DC48C2 /* BugsnagDeviceTest.m in Sources */,
-				014475FD2566844F0018AB94 /* BugsnagApiClientTest.m in Sources */,
-				0187D45C255BD7B700C503D9 /* BugsnagApiClientTest.m in Sources */,
 				008967462486D43700DC48C2 /* BugsnagTests.m in Sources */,
 				008967A62486D43700DC48C2 /* KSString_Tests.m in Sources */,
 				004E353D2487B3B8007FBAE4 /* BugsnagSwiftTests.swift in Sources */,

--- a/Bugsnag/Delivery/BugsnagApiClient.h
+++ b/Bugsnag/Delivery/BugsnagApiClient.h
@@ -10,6 +10,7 @@ NS_ASSUME_NONNULL_BEGIN
 typedef NSString * BugsnagHTTPHeaderName NS_TYPED_ENUM;
 
 extern BugsnagHTTPHeaderName const BugsnagHTTPHeaderNameApiKey;
+extern BugsnagHTTPHeaderName const BugsnagHTTPHeaderNameIntegrity;
 extern BugsnagHTTPHeaderName const BugsnagHTTPHeaderNamePayloadVersion;
 extern BugsnagHTTPHeaderName const BugsnagHTTPHeaderNameSentAt;
 
@@ -37,6 +38,8 @@ typedef NS_ENUM(NSInteger, BugsnagApiClientDeliveryStatus) {
                 headers:(NSDictionary<BugsnagHTTPHeaderName, NSString *> *)headers
                   toURL:(NSURL *)url
       completionHandler:(void (^)(BugsnagApiClientDeliveryStatus status, NSError * _Nullable error))completionHandler;
+
+- (NSString *)SHA1HashStringWithData:(NSData *)data;
 
 @property(readonly) NSOperationQueue *sendQueue;
 

--- a/Bugsnag/Delivery/BugsnagApiClient.m
+++ b/Bugsnag/Delivery/BugsnagApiClient.m
@@ -4,6 +4,7 @@
 //
 
 #import "BugsnagApiClient.h"
+
 #import "BugsnagConfiguration.h"
 #import "Bugsnag.h"
 #import "BugsnagKeys.h"
@@ -11,7 +12,10 @@
 #import "Private.h"
 #import "BSGJSONSerialization.h"
 
+#import <CommonCrypto/CommonCrypto.h>
+
 BugsnagHTTPHeaderName const BugsnagHTTPHeaderNameApiKey             = @"Bugsnag-Api-Key";
+BugsnagHTTPHeaderName const BugsnagHTTPHeaderNameIntegrity          = @"Bugsnag-Integrity";
 BugsnagHTTPHeaderName const BugsnagHTTPHeaderNamePayloadVersion     = @"Bugsnag-Payload-Version";
 BugsnagHTTPHeaderName const BugsnagHTTPHeaderNameSentAt             = @"Bugsnag-Sent-At";
 
@@ -83,7 +87,10 @@ typedef NS_ENUM(NSInteger, HTTPStatusCode) {
         return completionHandler(BugsnagApiClientDeliveryStatusUndeliverable, error);
     }
     
-    NSMutableURLRequest *request = [self prepareRequest:url headers:headers];
+    NSMutableDictionary<BugsnagHTTPHeaderName, NSString *> *mutableHeaders = [headers mutableCopy];
+    mutableHeaders[BugsnagHTTPHeaderNameIntegrity] = [NSString stringWithFormat:@"sha1 %@", [self SHA1HashStringWithData:data]];
+    
+    NSMutableURLRequest *request = [self prepareRequest:url headers:mutableHeaders];
     
     [[self.session uploadTaskWithRequest:request fromData:data completionHandler:^(NSData *data, NSURLResponse *response, NSError *error) {
         if (![response isKindOfClass:[NSHTTPURLResponse class]]) {
@@ -129,6 +136,19 @@ typedef NS_ENUM(NSInteger, HTTPStatusCode) {
         [request setValue:headers[key] forHTTPHeaderField:key];
     }
     return request;
+}
+
+- (NSString *)SHA1HashStringWithData:(NSData *)data {
+    if (!data) {
+        return nil;
+    }
+    unsigned char md[CC_SHA1_DIGEST_LENGTH];
+    CC_SHA1(data.bytes, (CC_LONG)data.length, md);
+    return [NSString stringWithFormat:@"%02x%02x%02x%02x%02x%02x%02x%02x%02x%02x%02x%02x%02x%02x%02x%02x%02x%02x%02x%02x",
+            md[0], md[1], md[2], md[3], md[4],
+            md[5], md[6], md[7], md[8], md[9],
+            md[10], md[11], md[12], md[13], md[14],
+            md[15], md[16], md[17], md[18], md[19]];
 }
 
 - (void)dealloc {

--- a/Tests/BugsnagApiClientTest.m
+++ b/Tests/BugsnagApiClientTest.m
@@ -80,4 +80,10 @@
     [self waitForExpectationsWithTimeout:1 handler:nil];
 }
 
+- (void)testSHA1HashStringWithData {
+    BugsnagApiClient *client = [[BugsnagApiClient alloc] init];
+    XCTAssertNil([client SHA1HashStringWithData:nil]);
+    XCTAssertEqualObjects([client SHA1HashStringWithData:[@"{\"foo\":\"bar\"}" dataUsingEncoding:NSUTF8StringEncoding]], @"a5e744d0164540d33b1d7ea616c28f2fa97e754a");
+}
+
 @end


### PR DESCRIPTION
## Goal

Implements the new `Bugsnag-Integrity` header as specified in design for ROAD-857

## Design

Apple's CommonCrypto framework is used to generate the SHA1 hash.

## Testing

Added a unit test to validate hash computation against expected output, using the `shasum` command line utility to generate the expected output.

Maze runner [has been updated](https://github.com/bugsnag/maze-runner/pull/159) to verify the correctness of the header, so E2E test will fail if incorrect values are sent.