### PR TITLE
[PLAT-5336] Do not report OOM if the device rebooted

### DIFF
--- a/Bugsnag/BugsnagSystemState.h
+++ b/Bugsnag/BugsnagSystemState.h
@@ -20,6 +20,8 @@
 #define SYSTEMSTATE_APP_BUNDLE_VERSION @"bundleVersion"
 #define SYSTEMSTATE_APP_DEBUGGER_IS_ACTIVE @"debuggerIsActive"
 
+#define SYSTEMSTATE_DEVICE_BOOT_TIME @"bootTime"
+
 #define PLATFORM_WORD_SIZE sizeof(void*)*8
 
 NS_ASSUME_NONNULL_BEGIN

--- a/Bugsnag/BugsnagSystemState.m
+++ b/Bugsnag/BugsnagSystemState.m
@@ -106,6 +106,7 @@ static NSMutableDictionary* initCurrentState(BugsnagKVStore *kvstore, BugsnagCon
     app[SYSTEMSTATE_APP_DEBUGGER_IS_ACTIVE] = @(isBeingDebugged);
 
     NSMutableDictionary *device = [NSMutableDictionary new];
+    device[SYSTEMSTATE_DEVICE_BOOT_TIME] = [BSG_RFC3339DateTool stringFromDate:systemInfo[@BSG_KSSystemField_BootTime]];
     device[@"id"] = systemInfo[@BSG_KSSystemField_DeviceAppHash];
     // device[@"lowMemory"] is initially unset
     device[@"osBuild"] = systemInfo[@BSG_KSSystemField_OSVersion];
@@ -223,6 +224,7 @@ NSDictionary *copyLaunchState(NSDictionary *launchState) {
 - (void)sync {
     NSDictionary *state = self.currentLaunchState;
     NSError *error = nil;
+    NSAssert([BSGJSONSerialization isValidJSONObject:state], @"BugsnagSystemState cannot be converted to JSON data");
     if (![BSGJSONSerialization isValidJSONObject:state]) {
         bsg_log_err(@"System state cannot be written as JSON");
         return;

--- a/Bugsnag/Client/BugsnagClient.m
+++ b/Bugsnag/Client/BugsnagClient.m
@@ -653,7 +653,9 @@ NSString *const BSGBreadcrumbLoadedMessage = @"Bugsnag loaded";
 #if BSGOOMAvailable
     NSDictionary *currAppState = self.systemState.currentLaunchState[SYSTEMSTATE_KEY_APP];
     NSDictionary *prevAppState = self.systemState.lastLaunchState[SYSTEMSTATE_KEY_APP];
-
+    NSDictionary *currentDeviceState = self.systemState.currentLaunchState[SYSTEMSTATE_KEY_DEVICE];
+    NSDictionary *previousDeviceState = self.systemState.lastLaunchState[SYSTEMSTATE_KEY_DEVICE];
+    
     // Disable if a debugger was active, since the development cycle of
     // starting and restarting an app is also an uncatchable kill
     if([prevAppState[SYSTEMSTATE_APP_DEBUGGER_IS_ACTIVE] boolValue]) {
@@ -680,7 +682,14 @@ NSString *const BSGBreadcrumbLoadedMessage = @"Bugsnag loaded";
     if([prevAppState[SYSTEMSTATE_APP_WAS_TERMINATED] boolValue]) {
         return NO;
     }
-
+    
+    id currentBootTime = currentDeviceState[SYSTEMSTATE_DEVICE_BOOT_TIME];
+    id previousBootTime = previousDeviceState[SYSTEMSTATE_DEVICE_BOOT_TIME];
+    BOOL didReboot = currentBootTime && previousBootTime && ![currentBootTime isEqual:previousBootTime];
+    if (didReboot) {
+        return NO;
+    }
+    
     return YES;
 #else
     return NO;


### PR DESCRIPTION
## Goal

Adds boot time to the OOM detection's heuristics, to remove a possible source of false positives.

See feature request #545

## Changeset

A formatted date representation of `sysctl("kern.boottime")` is now stored as `"bootTime"` in `BugsnagSystemState`.

`-[BugsnagClient didLikelyOOM]` uses the current and previous values to determine whether a reboot has occurred, and will not report an OOM if so.

An assert was added to `-[BugsnagSystemState sync]` to make it more obvious when an object that cannot be converted to JSON data has been added to the state.

## Testing

This has been manually tested by triggering an OOM and then rebooting the device before re-launching the test app.

The need for a device reboot to trigger this does not lend itself to automated testing.