### PR TITLE
Improve reliability of testTimeDifferenceInSeconds

### DIFF
--- a/Tests/KSCrash/KSMach_Tests.m
+++ b/Tests/KSCrash/KSMach_Tests.m
@@ -176,10 +176,13 @@
 - (void) testTimeDifferenceInSeconds
 {
     uint64_t startTime = mach_absolute_time();
+    CFAbsoluteTime cfStartTime = CFAbsoluteTimeGetCurrent();
     [NSThread sleepForTimeInterval:0.1];
     uint64_t endTime = mach_absolute_time();
+    CFAbsoluteTime cfEndTime = CFAbsoluteTimeGetCurrent();
     double diff = bsg_ksmachtimeDifferenceInSeconds(endTime, startTime);
-    XCTAssertTrue(diff >= 0.1 && diff < 0.2, @"");
+    double cfDiff = cfEndTime - cfStartTime;
+    XCTAssertEqualWithAccuracy(diff, cfDiff, 0.0001);
 }
 
 // TODO: Disabling this until I figure out what's wrong with queue names.


### PR DESCRIPTION
## Goal

`testTimeDifferenceInSeconds` has been intermittently failing on Travis, and lately has been failing more frequently.
* https://travis-ci.com/github/bugsnag/bugsnag-cocoa/jobs/433368445#L2078
* https://travis-ci.com/github/bugsnag/bugsnag-cocoa/jobs/433368446#L1693
* https://travis-ci.com/github/bugsnag/bugsnag-cocoa/jobs/433089002#L1693
* https://travis-ci.com/github/bugsnag/bugsnag-cocoa/jobs/433083608#L1692

## Changeset

The test was too reliant on the actual amount of time that the thread slept.

This change improves reliability by comparing the result of `bsg_ksmachtimeDifferenceInSeconds()` to a reference obtained using `CFAbsoluteTimeGetCurrent()` (which returns values in seconds.)