### PR TITLE
E2E test tweaks

### DIFF
--- a/.buildkite/pipeline.yml
+++ b/.buildkite/pipeline.yml
@@ -29,6 +29,7 @@ steps:
           - "--access-key=$BROWSER_STACK_ACCESS_KEY"
           - "--resilient"
           - "--appium-version=1.15.0"
+          - "--fail-fast"
     concurrency: 10
     concurrency_group: browserstack-app
 
@@ -49,6 +50,7 @@ steps:
           - "--access-key=$BROWSER_STACK_ACCESS_KEY"
           - "--resilient"
           - "--appium-version=1.15.0"
+          - "--fail-fast"
     concurrency: 10
     concurrency_group: browserstack-app
 
@@ -69,6 +71,7 @@ steps:
           - "--access-key=$BROWSER_STACK_ACCESS_KEY"
           - "--resilient"
           - "--appium-version=1.15.0"
+          - "--fail-fast"
     concurrency: 10
     concurrency_group: browserstack-app
 
@@ -89,6 +92,7 @@ steps:
           - "--access-key=$BROWSER_STACK_ACCESS_KEY"
           - "--resilient"
           - "--appium-version=1.15.0"
+          - "--fail-fast"
     concurrency: 10
     concurrency_group: browserstack-app
     # Soft fail while Browserstack's iOS 11 devices are flakey
@@ -112,5 +116,6 @@ steps:
           - "--access-key=$BROWSER_STACK_ACCESS_KEY"
           - "--resilient"
           - "--appium-version=1.15.0"
+          - "--fail-fast"
     concurrency: 10
     concurrency_group: browserstack-app

--- a/.buildkite/pipeline.yml
+++ b/.buildkite/pipeline.yml
@@ -91,6 +91,9 @@ steps:
           - "--appium-version=1.15.0"
     concurrency: 10
     concurrency_group: browserstack-app
+    # Soft fail while Browserstack's iOS 11 devices are flakey
+    soft_fail:
+      - exit_status: "*"
 
   - label: ':ios: iOS 10 end-to-end tests'
     timeout_in_minutes: 60

--- a/features/fixtures/macos/macOSTestApp.xcodeproj/project.pbxproj
+++ b/features/fixtures/macos/macOSTestApp.xcodeproj/project.pbxproj
@@ -858,10 +858,13 @@
 				CLANG_ENABLE_MODULES = YES;
 				CODE_SIGN_IDENTITY = "-";
 				COMBINE_HIDPI_IMAGES = YES;
+				COPY_PHASE_STRIP = NO;
 				INFOPLIST_FILE = macOSTestApp/Info.plist;
 				LD_RUNPATH_SEARCH_PATHS = "$(inherited) @executable_path/../Frameworks";
 				PRODUCT_BUNDLE_IDENTIFIER = com.bugsnag.macOSTestApp;
 				PRODUCT_NAME = "$(TARGET_NAME)";
+				STRIP_INSTALLED_PRODUCT = NO;
+				STRIP_SWIFT_SYMBOLS = NO;
 				SWIFT_OBJC_BRIDGING_HEADER = "macOSTestApp/macOSTestApp-Bridging-Header.h";
 				SWIFT_OPTIMIZATION_LEVEL = "-Onone";
 				SWIFT_VERSION = 4.2;
@@ -875,10 +878,13 @@
 				CLANG_ENABLE_MODULES = YES;
 				CODE_SIGN_IDENTITY = "-";
 				COMBINE_HIDPI_IMAGES = YES;
+				COPY_PHASE_STRIP = NO;
 				INFOPLIST_FILE = macOSTestApp/Info.plist;
 				LD_RUNPATH_SEARCH_PATHS = "$(inherited) @executable_path/../Frameworks";
 				PRODUCT_BUNDLE_IDENTIFIER = com.bugsnag.macOSTestApp;
 				PRODUCT_NAME = "$(TARGET_NAME)";
+				STRIP_INSTALLED_PRODUCT = NO;
+				STRIP_SWIFT_SYMBOLS = NO;
 				SWIFT_OBJC_BRIDGING_HEADER = "macOSTestApp/macOSTestApp-Bridging-Header.h";
 				SWIFT_VERSION = 4.2;
 			};


### PR DESCRIPTION
## Goal

Fixes some issues related to E2E tests:
* the iOS 11 devices on BrowserStack are currently unreliable and often failing our tests
* the macOSFixture app build was producing a stripped binary, so E2E test that verify symbolication were failing

## Changeset

* iOS 11 devices are now "soft-fail"
* enabled `--fast-fail` so that failures are reported more quickly
* adjusted macOSTestApp build settings to disable symbol stripping