### PR TITLE
iOS 11 model switched for greater stability

### DIFF
--- a/.buildkite/pipeline.yml
+++ b/.buildkite/pipeline.yml
@@ -87,11 +87,11 @@ steps:
         command:
           - "--app=/app/build/iOSTestApp.ipa"
           - "--farm=bs"
-          - "--device=IOS_11"
+          - "--device=IOS_11_0_IPHONE_8_PLUS"
           - "--username=$BROWSER_STACK_USERNAME"
           - "--access-key=$BROWSER_STACK_ACCESS_KEY"
           - "--resilient"
-          - "--appium-version=1.15.0"
+          - "--appium-version=1.16.0"
           - "--fail-fast"
     concurrency: 10
     concurrency_group: browserstack-app

--- a/features/steps/ios_steps.rb
+++ b/features/steps/ios_steps.rb
@@ -181,13 +181,17 @@ end
 
 Then("the payload field {string} matches the test device model") do |field|
   internal_names = {
+      "iPhone 6" => %w[iPhone7,2],
+      "iPhone 6 Plus" => %w[iPhone7,1],
+      "iPhone 6S" => %w[iPhone8,1],
       "iPhone 7" => %w[iPhone9,1 iPhone9,2 iPhone9,3 iPhone9,4],
-      "iPhone 8" => %w[iPhone10,1 iPhone10,2 iPhone10,4 iPhone10,5],
+      "iPhone 8" => %w[iPhone10,1 iPhone10,4],
+      "iPhone 8 Plus" => %w[iPhone10,2 iPhone10,5],
       "iPhone 11" => %w[iPhone12,1],
       "iPhone 11 Pro" => %w[iPhone12,3],
       "iPhone 11 Pro Max" => %w[iPhone12,5],
       "iPhone X" => %w[iPhone10,3 iPhone10,6],
-      "iPhone XR" => ["iPhone11,8"],
+      "iPhone XR" => %w[iPhone11,8],
       "iPhone XS" => %w[iPhone11,2 iPhone11,4 iPhone11,8]
   }
   expected_model = MazeRunner.config.capabilities["device"]


### PR DESCRIPTION
## Goal

Improve stability of tests on iOS 11.

## Design

The change of device type comes after running the tests against all iOS 11 models available on BrowserStack.  Whilst still requiring the "resilient: driver, it does seem to be more stable that the previous choice.  I've left the soft fail on, however, as we never can be too sure with BrowserStack it seems.

## Changeset

Pipeline and test file responsible for mapping iPhone brand names to internal model names, which I've updated based on https://www.theiphonewiki.com/wiki/Models.

## Testing

Covered by CI;