### PR TITLE
Fix crash in -[BugsnagSystemState sync]

### DIFF
--- a/Bugsnag/BugsnagSystemState.h
+++ b/Bugsnag/BugsnagSystemState.h
@@ -29,7 +29,7 @@ NS_ASSUME_NONNULL_BEGIN
 @interface BugsnagSystemState : NSObject
 
 @property(readonly,nonatomic) NSDictionary *lastLaunchState;
-@property(readonly,nonatomic) NSDictionary *currentLaunchState;
+@property(readonly,atomic) NSDictionary *currentLaunchState;
 
 - (instancetype)init NS_UNAVAILABLE;
 - (instancetype)initWithConfiguration:(BugsnagConfiguration *)config;

--- a/Bugsnag/BugsnagSystemState.m
+++ b/Bugsnag/BugsnagSystemState.m
@@ -139,10 +139,10 @@ NSDictionary *copyLaunchState(NSDictionary *launchState) {
 
 @interface BugsnagSystemState ()
 
-@property(readwrite,nonatomic) NSMutableDictionary *currentLaunchStateRW;
-@property(readwrite,nonatomic) NSDictionary *currentLaunchState;
+@property(readonly,nonatomic) NSMutableDictionary *currentLaunchStateRW;
+@property(readwrite,atomic) NSDictionary *currentLaunchState;
 @property(readonly,nonatomic) NSString *persistenceFilePath;
-@property(nonatomic) BugsnagKVStore *kvStore;
+@property(readonly,nonatomic) BugsnagKVStore *kvStore;
 
 @end
 

--- a/Tests/BugsnagOnBreadcrumbTest.m
+++ b/Tests/BugsnagOnBreadcrumbTest.m
@@ -34,6 +34,10 @@
 
 @implementation BugsnagOnBreadcrumbTest
 
+- (void)setUp {
+    [super setUp];
+    [[[BugsnagBreadcrumbs alloc] initWithConfiguration:[[BugsnagConfiguration alloc] initWithApiKey:nil]] removeAllBreadcrumbs];
+}
 
 /**
  * Test that onBreadcrumb blocks get called once added


### PR DESCRIPTION
## Goal

The crash was reported against `-[BugsnagSystemState sync] + 203` ([BugsnagSystemState.m:203](https://github.com/bugsnag/bugsnag-cocoa/blob/v6.2.1/Bugsnag/BugsnagSystemState.m#L203)) which is retaining the `currentLaunchState` property.

```
- (void)sync {
    NSDictionary *state = self.currentLaunchState;
    NSError *error = nil;
    ...
```

This crashed because `currentLaunchState` was declared `nonatomic` but is being set and read from different threads.

## Changeset

* Made the `currentLaunchState` property `atomic` - this ensures the returned object will not be deallocated by a setting thread before the getter completes.
* Marked other `nonatomic` properties as `readonly` where appropriate to avoid similar issues being introduced in the future.

## Testing

N/A