### PR TITLE
[PLAT-5189] HTTP error status code handling

### DIFF
--- a/Bugsnag.xcodeproj/project.pbxproj
+++ b/Bugsnag.xcodeproj/project.pbxproj
@@ -658,12 +658,17 @@
 		00AD1F302486A17900A27979 /* BugsnagSessionTracker.m in Sources */ = {isa = PBXBuildFile; fileRef = 00AD1F012486A17900A27979 /* BugsnagSessionTracker.m */; };
 		00AD1F312486A17900A27979 /* BugsnagSessionTracker.m in Sources */ = {isa = PBXBuildFile; fileRef = 00AD1F012486A17900A27979 /* BugsnagSessionTracker.m */; };
 		00E636C224878D84006CBF1A /* BSG_RFC3339DateTool.m in Sources */ = {isa = PBXBuildFile; fileRef = 008969142486DAD000DC48C2 /* BSG_RFC3339DateTool.m */; };
+		014475FD2566844F0018AB94 /* BugsnagApiClientTest.m in Sources */ = {isa = PBXBuildFile; fileRef = CB9103632502320A00E9D1E2 /* BugsnagApiClientTest.m */; };
+		01447605256684500018AB94 /* BugsnagApiClientTest.m in Sources */ = {isa = PBXBuildFile; fileRef = CB9103632502320A00E9D1E2 /* BugsnagApiClientTest.m */; };
 		01B14C56251CE55F00118748 /* report-react-native-promise-rejection.json in Resources */ = {isa = PBXBuildFile; fileRef = 01B14C55251CE55F00118748 /* report-react-native-promise-rejection.json */; };
 		01B14C57251CE55F00118748 /* report-react-native-promise-rejection.json in Resources */ = {isa = PBXBuildFile; fileRef = 01B14C55251CE55F00118748 /* report-react-native-promise-rejection.json */; };
 		01B14C58251CE55F00118748 /* report-react-native-promise-rejection.json in Resources */ = {isa = PBXBuildFile; fileRef = 01B14C55251CE55F00118748 /* report-react-native-promise-rejection.json */; };
 		01C17AE72542ED7F00C102C9 /* KSCrashReportWriterTests.m in Sources */ = {isa = PBXBuildFile; fileRef = 01C17AE62542ED7F00C102C9 /* KSCrashReportWriterTests.m */; };
 		01C17AE82542ED7F00C102C9 /* KSCrashReportWriterTests.m in Sources */ = {isa = PBXBuildFile; fileRef = 01C17AE62542ED7F00C102C9 /* KSCrashReportWriterTests.m */; };
 		01C17AE92542ED7F00C102C9 /* KSCrashReportWriterTests.m in Sources */ = {isa = PBXBuildFile; fileRef = 01C17AE62542ED7F00C102C9 /* KSCrashReportWriterTests.m */; };
+		01E8765E256684E700F4B70A /* URLSessionMock.m in Sources */ = {isa = PBXBuildFile; fileRef = 01E8765D256684E700F4B70A /* URLSessionMock.m */; };
+		01E8765F256684E700F4B70A /* URLSessionMock.m in Sources */ = {isa = PBXBuildFile; fileRef = 01E8765D256684E700F4B70A /* URLSessionMock.m */; };
+		01E87660256684E700F4B70A /* URLSessionMock.m in Sources */ = {isa = PBXBuildFile; fileRef = 01E8765D256684E700F4B70A /* URLSessionMock.m */; };
 		3A700A9424A63ABC0068CD1B /* BugsnagThread.h in Headers */ = {isa = PBXBuildFile; fileRef = 3A700A8024A63A8E0068CD1B /* BugsnagThread.h */; settings = {ATTRIBUTES = (Public, ); }; };
 		3A700A9524A63AC50068CD1B /* BugsnagSession.h in Headers */ = {isa = PBXBuildFile; fileRef = 3A700A8124A63A8E0068CD1B /* BugsnagSession.h */; settings = {ATTRIBUTES = (Public, ); }; };
 		3A700A9624A63AC60068CD1B /* BugsnagStackframe.h in Headers */ = {isa = PBXBuildFile; fileRef = 3A700A8224A63A8E0068CD1B /* BugsnagStackframe.h */; settings = {ATTRIBUTES = (Public, ); }; };
@@ -1276,6 +1281,8 @@
 		00E636C324878FFC006CBF1A /* Info.plist */ = {isa = PBXFileReference; lastKnownFileType = text.plist.xml; path = Info.plist; sourceTree = "<group>"; };
 		01B14C55251CE55F00118748 /* report-react-native-promise-rejection.json */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = text.json; path = "report-react-native-promise-rejection.json"; sourceTree = "<group>"; };
 		01C17AE62542ED7F00C102C9 /* KSCrashReportWriterTests.m */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.objc; path = KSCrashReportWriterTests.m; sourceTree = "<group>"; };
+		01E8765C256684E700F4B70A /* URLSessionMock.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; path = URLSessionMock.h; sourceTree = "<group>"; };
+		01E8765D256684E700F4B70A /* URLSessionMock.m */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.objc; path = URLSessionMock.m; sourceTree = "<group>"; };
 		3A700A8024A63A8E0068CD1B /* BugsnagThread.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; path = BugsnagThread.h; sourceTree = "<group>"; };
 		3A700A8124A63A8E0068CD1B /* BugsnagSession.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; path = BugsnagSession.h; sourceTree = "<group>"; };
 		3A700A8224A63A8E0068CD1B /* BugsnagStackframe.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; path = BugsnagStackframe.h; sourceTree = "<group>"; };
@@ -1693,6 +1700,8 @@
 				008966AE2486D43500DC48C2 /* Swift Tests */,
 				CBA22499251E429C00B87416 /* TestSupport.h */,
 				CBA2249A251E429C00B87416 /* TestSupport.m */,
+				01E8765C256684E700F4B70A /* URLSessionMock.h */,
+				01E8765D256684E700F4B70A /* URLSessionMock.m */,
 			);
 			path = Tests;
 			sourceTree = "<group>";
@@ -2581,6 +2590,7 @@
 				008967542486D43700DC48C2 /* BugsnagOnCrashTest.m in Sources */,
 				008966F72486D43700DC48C2 /* RegisterErrorDataTest.m in Sources */,
 				008967152486D43700DC48C2 /* BugsnagCollectionsBSGDictMergeTest.m in Sources */,
+				01E8765E256684E700F4B70A /* URLSessionMock.m in Sources */,
 				008967632486D43700DC48C2 /* BugsnagCollectionsBSGDictSetSafeObjectTest.m in Sources */,
 				008967AB2486D43700DC48C2 /* KSMach_Tests.m in Sources */,
 				0089672A2486D43700DC48C2 /* BugsnagStacktraceTest.m in Sources */,
@@ -2708,6 +2718,7 @@
 				008967132486D43700DC48C2 /* BugsnagEventTests.m in Sources */,
 				0089675B2486D43700DC48C2 /* BugsnagEnabledBreadcrumbTest.m in Sources */,
 				008966EC2486D43700DC48C2 /* BugsnagDeviceTest.m in Sources */,
+				014475FD2566844F0018AB94 /* BugsnagApiClientTest.m in Sources */,
 				008967462486D43700DC48C2 /* BugsnagTests.m in Sources */,
 				008967A62486D43700DC48C2 /* KSString_Tests.m in Sources */,
 				004E353D2487B3B8007FBAE4 /* BugsnagSwiftTests.swift in Sources */,
@@ -2750,6 +2761,7 @@
 				008967432486D43700DC48C2 /* BugsnagSessionTrackerStopTest.m in Sources */,
 				008967972486D43700DC48C2 /* KSCrashState_Tests.m in Sources */,
 				008967762486D43700DC48C2 /* XCTestCase+KSCrash.m in Sources */,
+				01E8765F256684E700F4B70A /* URLSessionMock.m in Sources */,
 				008967312486D43700DC48C2 /* BugsnagStateEventTest.m in Sources */,
 				004E35362487AFF2007FBAE4 /* BugsnagHandledStateTest.m in Sources */,
 				01C17AE82542ED7F00C102C9 /* KSCrashReportWriterTests.m in Sources */,
@@ -2891,6 +2903,7 @@
 				0089674A2486D43700DC48C2 /* BugsnagUserTest.m in Sources */,
 				0089673B2486D43700DC48C2 /* BugsnagEventFromKSCrashReportTest.m in Sources */,
 				0089674D2486D43700DC48C2 /* BSGConnectivityTest.m in Sources */,
+				01E87660256684E700F4B70A /* URLSessionMock.m in Sources */,
 				008966F02486D43700DC48C2 /* BugsnagClientPayloadInfoTest.m in Sources */,
 				008967652486D43700DC48C2 /* BugsnagCollectionsBSGDictSetSafeObjectTest.m in Sources */,
 				E701FAA92490EF77008D842F /* ClientApiValidationTest.m in Sources */,
@@ -2915,6 +2928,7 @@
 				01C17AE92542ED7F00C102C9 /* KSCrashReportWriterTests.m in Sources */,
 				00896A422486DBDD00DC48C2 /* BSGConfigurationBuilderTests.m in Sources */,
 				008967682486D43700DC48C2 /* BugsnagNotifierTest.m in Sources */,
+				01447605256684500018AB94 /* BugsnagApiClientTest.m in Sources */,
 				0089676E2486D43700DC48C2 /* BugsnagTestsDummyClass.m in Sources */,
 				008967412486D43700DC48C2 /* BugsnagAppTest.m in Sources */,
 				008967052486D43700DC48C2 /* BugsnagThreadSerializationTest.m in Sources */,

--- a/Bugsnag/BugsnagErrorReportSink.m
+++ b/Bugsnag/BugsnagErrorReportSink.m
@@ -92,10 +92,10 @@
 }
 
 - (void)finishActiveRequest:(NSString *)requestId
-                    success:(BOOL)success
+                  completed:(BOOL)completed
                       error:(NSError *)error
                       block:(BSGOnErrorSentBlock)block {
-    block(requestId, success, error);
+    block(requestId, completed, error);
     @synchronized (self.activeRequests) {
         [self.activeRequests removeObject:requestId];
     }
@@ -123,7 +123,7 @@
         if ([event shouldBeSent] && [self runOnSendBlocks:configuration event:event]) {
             storedEvents[fileKey] = event;
         } else { // delete the report as the user has discarded it
-            [self finishActiveRequest:fileKey success:true error:nil block:block];
+            [self finishActiveRequest:fileKey completed:YES error:nil block:block];
         }
     }
     [self deliverStoredEvents:storedEvents configuration:configuration block:block];
@@ -138,13 +138,11 @@
 
         NSMutableDictionary *apiHeaders = [[configuration errorApiHeaders] mutableCopy];
         BSGDictSetSafeObject(apiHeaders, event.apiKey, BSGHeaderApiKey);
-        [self.apiClient sendItems:1
-                      withPayload:requestPayload
-                            toURL:configuration.notifyURL
-                          headers:apiHeaders
-                     onCompletion:^(NSUInteger reportCount, BOOL success, NSError *error) {
-                         [self finishActiveRequest:filename success:success error:error block:block];
-                     }];
+        [self.apiClient sendJSONPayload:requestPayload headers:apiHeaders toURL:configuration.notifyURL
+                      completionHandler:^(BugsnagApiClientDeliveryStatus status, NSError *error) {
+            BOOL completed = status == BugsnagApiClientDeliveryStatusDelivered || status == BugsnagApiClientDeliveryStatusUndeliverable;
+            [self finishActiveRequest:filename completed:completed error:error block:block];
+        }];
     }
 }
 

--- a/Bugsnag/Client/BugsnagClient.m
+++ b/Bugsnag/Client/BugsnagClient.m
@@ -394,8 +394,7 @@ NSString *_lastOrientation = nil;
         self.extraRuntimeInfo = [NSMutableDictionary new];
         self.metadataLock = [[NSLock alloc] init];
         self.crashSentry = [BugsnagCrashSentry new];
-        self.errorReportApiClient = [[BugsnagErrorReportApiClient alloc] initWithConfig:configuration
-                                                                              queueName:@"Error API queue"];
+        self.errorReportApiClient = [[BugsnagErrorReportApiClient alloc] initWithSession:configuration.session queueName:@"Error API queue"];
         bsg_g_bugsnag_data.onCrash = (void (*)(const BSG_KSCrashReportWriter *))self.configuration.onCrashHandler;
 
         static dispatch_once_t once_t;

--- a/Bugsnag/Delivery/BugsnagApiClient.h
+++ b/Bugsnag/Delivery/BugsnagApiClient.h
@@ -7,7 +7,16 @@
 
 @class BugsnagConfiguration;
 
-typedef void (^RequestCompletion)(NSUInteger reportCount, BOOL success, NSError *error);
+NS_ASSUME_NONNULL_BEGIN
+
+typedef NS_ENUM(NSInteger, BugsnagApiClientDeliveryStatus) {
+    /// The payload was delivered successfully and can be deleted.
+    BugsnagApiClientDeliveryStatusDelivered,
+    /// The payload was not delivered but can be retried, e.g. when there was a loss of connectivity.
+    BugsnagApiClientDeliveryStatusFailed,
+    /// The payload cannot be delivered and should be deleted without attempting to retry.
+    BugsnagApiClientDeliveryStatusUndeliverable,
+};
 
 @interface BugsnagApiClient : NSObject
 
@@ -21,14 +30,14 @@ typedef void (^RequestCompletion)(NSUInteger reportCount, BOOL success, NSError 
 
 - (NSOperation *)deliveryOperation;
 
-- (void)sendItems:(NSUInteger)count
-      withPayload:(NSDictionary *)payload
-            toURL:(NSURL *)url
-          headers:(NSDictionary *)headers
-     onCompletion:(RequestCompletion)onCompletion;
+- (void)sendJSONPayload:(NSDictionary *)payload
+                headers:(NSDictionary<NSString *, NSString *> *)headers
+                  toURL:(NSURL *)url
+      completionHandler:(void (^)(BugsnagApiClientDeliveryStatus status, NSError * _Nullable error))completionHandler;
 
 @property(readonly) NSOperationQueue *sendQueue;
 @property(readonly) BugsnagConfiguration *config;
 
-
 @end
+
+NS_ASSUME_NONNULL_END

--- a/Bugsnag/Delivery/BugsnagApiClient.h
+++ b/Bugsnag/Delivery/BugsnagApiClient.h
@@ -5,8 +5,6 @@
 
 #import <Foundation/Foundation.h>
 
-@class BugsnagConfiguration;
-
 NS_ASSUME_NONNULL_BEGIN
 
 typedef NS_ENUM(NSInteger, BugsnagApiClientDeliveryStatus) {
@@ -20,8 +18,7 @@ typedef NS_ENUM(NSInteger, BugsnagApiClientDeliveryStatus) {
 
 @interface BugsnagApiClient : NSObject
 
-- (instancetype)initWithConfig:(BugsnagConfiguration *)configuration
-                     queueName:(NSString *)queueName;
+- (instancetype)initWithSession:(nullable NSURLSession *)session queueName:(NSString *)queueName;
 
 /**
  * Send outstanding reports
@@ -36,7 +33,6 @@ typedef NS_ENUM(NSInteger, BugsnagApiClientDeliveryStatus) {
       completionHandler:(void (^)(BugsnagApiClientDeliveryStatus status, NSError * _Nullable error))completionHandler;
 
 @property(readonly) NSOperationQueue *sendQueue;
-@property(readonly) BugsnagConfiguration *config;
 
 @end
 

--- a/Bugsnag/Delivery/BugsnagApiClient.m
+++ b/Bugsnag/Delivery/BugsnagApiClient.m
@@ -34,18 +34,15 @@ typedef NS_ENUM(NSInteger, HTTPStatusCode) {
 
 @implementation BugsnagApiClient
 
-- (instancetype)initWithConfig:(BugsnagConfiguration *)configuration
-                     queueName:(NSString *)queueName {
+- (instancetype)initWithSession:(nullable NSURLSession *)session queueName:(NSString *)queueName {
     if (self = [super init]) {
         _sendQueue = [NSOperationQueue new];
         _sendQueue.maxConcurrentOperationCount = 1;
-        _config = configuration;
-        _session = configuration.session ?: [NSURLSession sessionWithConfiguration:[NSURLSessionConfiguration ephemeralSessionConfiguration]];
-
         if ([_sendQueue respondsToSelector:@selector(qualityOfService)]) {
             _sendQueue.qualityOfService = NSQualityOfServiceUtility;
         }
         _sendQueue.name = queueName;
+        _session = session ?: [NSURLSession sessionWithConfiguration:[NSURLSessionConfiguration ephemeralSessionConfiguration]];
     }
     return self;
 }

--- a/Bugsnag/Delivery/BugsnagSessionTrackingApiClient.h
+++ b/Bugsnag/Delivery/BugsnagSessionTrackingApiClient.h
@@ -6,9 +6,12 @@
 #import <Foundation/Foundation.h>
 #import "BugsnagApiClient.h"
 
+@class BugsnagConfiguration;
 @class BugsnagSessionFileStore;
 
 @interface BugsnagSessionTrackingApiClient : BugsnagApiClient
+
+- (instancetype)initWithConfig:(BugsnagConfiguration *)configuration queueName:(NSString *)queueName;
 
 /**
  * Asynchronously delivers sessions written to the store

--- a/Bugsnag/Delivery/BugsnagSessionTrackingApiClient.m
+++ b/Bugsnag/Delivery/BugsnagSessionTrackingApiClient.m
@@ -21,15 +21,16 @@
 @interface BugsnagSessionTrackingApiClient ()
 @property NSMutableSet *activeIds;
 @property(nonatomic) NSString *codeBundleId;
+@property(nonatomic) BugsnagConfiguration *config;
 @end
 
 
 @implementation BugsnagSessionTrackingApiClient
 
-- (instancetype)initWithConfig:(BugsnagConfiguration *)configuration
-                     queueName:(NSString *)queueName {
-    if (self = [super initWithConfig:configuration queueName:queueName]) {
+- (instancetype)initWithConfig:(BugsnagConfiguration *)configuration queueName:(NSString *)queueName {
+    if ((self = [super initWithSession:configuration.session queueName:queueName])) {
         _activeIds = [NSMutableSet new];
+        _config = configuration;
     }
     return self;
 }

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,13 @@
 Changelog
 =========
 
+## TBD
+
+### Bug fixes
+
+* Error and session deliveries that fail with an HTTP error status code will now be retried if appropriate.
+  [#895](https://github.com/bugsnag/bugsnag-cocoa/pull/895)
+
 ## 6.2.5 (2020-11-18)
 
 ### Bug fixes

--- a/Tests/BugsnagApiClientTest.m
+++ b/Tests/BugsnagApiClientTest.m
@@ -10,6 +10,7 @@
 #import "BugsnagApiClient.h"
 #import <Bugsnag/Bugsnag.h>
 #import "BugsnagTestConstants.h"
+#import "URLSessionMock.h"
 
 @interface BugsnagApiClientTest : XCTestCase
 
@@ -18,10 +19,65 @@
 @implementation BugsnagApiClientTest
 
 - (void)testBadJSON {
-    BugsnagConfiguration *config = [[BugsnagConfiguration alloc] initWithApiKey:DUMMY_APIKEY_32CHAR_1];
-    BugsnagApiClient* client = [[BugsnagApiClient alloc] initWithConfig:config queueName:@"test"];
+    BugsnagApiClient *client = [[BugsnagApiClient alloc] initWithSession:nil queueName:@"test"];
     XCTAssertNoThrow([client sendJSONPayload:(id)@{@1: @"a"} headers:(id)@{@1: @"a"} toURL:[NSURL URLWithString:@"file:///dev/null"]
                            completionHandler:^(BugsnagApiClientDeliveryStatus status, NSError * _Nullable error) {}]);
+}
+
+- (void)testHTTPStatusCodes {
+    NSURL *url = [NSURL URLWithString:@"https://example.com"];
+    URLSessionMock *session = [[URLSessionMock alloc] init];
+    BugsnagApiClient *client = [[BugsnagApiClient alloc] initWithSession:(id)session queueName:@""];
+    
+    void (^ test)(NSInteger, BugsnagApiClientDeliveryStatus, BOOL) =
+    ^(NSInteger statusCode, BugsnagApiClientDeliveryStatus expectedDeliveryStatus, BOOL expectError) {
+        XCTestExpectation *expectation = [self expectationWithDescription:@"completionHandler should be called"];
+        id response = [[NSHTTPURLResponse alloc] initWithURL:url statusCode:statusCode HTTPVersion:@"1.1" headerFields:nil];
+        [session mockData:[NSData data] response:response error:nil];
+        [client sendJSONPayload:@{} headers:@{} toURL:url completionHandler:^(BugsnagApiClientDeliveryStatus status, NSError * _Nullable error) {
+            XCTAssertEqual(status, expectedDeliveryStatus);
+            expectError ? XCTAssertNotNil(error) : XCTAssertNil(error);
+            [expectation fulfill];
+        }];
+    };
+    
+    test(200, BugsnagApiClientDeliveryStatusDelivered, NO);
+    
+    // Permanent failures
+    test(400, BugsnagApiClientDeliveryStatusUndeliverable, YES);
+    test(401, BugsnagApiClientDeliveryStatusUndeliverable, YES);
+    test(403, BugsnagApiClientDeliveryStatusUndeliverable, YES);
+    test(404, BugsnagApiClientDeliveryStatusUndeliverable, YES);
+    test(405, BugsnagApiClientDeliveryStatusUndeliverable, YES);
+    test(406, BugsnagApiClientDeliveryStatusUndeliverable, YES);
+    
+    // Transient failures
+    test(402, BugsnagApiClientDeliveryStatusFailed, YES);
+    test(407, BugsnagApiClientDeliveryStatusFailed, YES);
+    test(408, BugsnagApiClientDeliveryStatusFailed, YES);
+    test(429, BugsnagApiClientDeliveryStatusFailed, YES);
+    test(500, BugsnagApiClientDeliveryStatusFailed, YES);
+    
+    [self waitForExpectationsWithTimeout:1 handler:nil];
+}
+
+- (void)testNotConnectedToInternetError {
+    NSURL *url = [NSURL URLWithString:@"https://example.com"];
+    URLSessionMock *session = [[URLSessionMock alloc] init];
+    BugsnagApiClient *client = [[BugsnagApiClient alloc] initWithSession:(id)session queueName:@""];
+    
+    XCTestExpectation *expectation = [self expectationWithDescription:@"completionHandler should be called"];
+    [session mockData:nil response:nil error:[NSError errorWithDomain:NSURLErrorDomain code:NSURLErrorNotConnectedToInternet userInfo:@{
+        NSURLErrorFailingURLErrorKey: url,
+    }]];
+    [client sendJSONPayload:@{} headers:@{} toURL:url completionHandler:^(BugsnagApiClientDeliveryStatus status, NSError * _Nullable error) {
+        XCTAssertEqual(status, BugsnagApiClientDeliveryStatusFailed);
+        XCTAssertNotNil(error);
+        XCTAssertEqualObjects(error.domain, NSURLErrorDomain);
+        [expectation fulfill];
+    }];
+    
+    [self waitForExpectationsWithTimeout:1 handler:nil];
 }
 
 @end

--- a/Tests/BugsnagApiClientTest.m
+++ b/Tests/BugsnagApiClientTest.m
@@ -20,8 +20,8 @@
 - (void)testBadJSON {
     BugsnagConfiguration *config = [[BugsnagConfiguration alloc] initWithApiKey:DUMMY_APIKEY_32CHAR_1];
     BugsnagApiClient* client = [[BugsnagApiClient alloc] initWithConfig:config queueName:@"test"];
-    [client sendItems:1 withPayload:@{@1: @"a"} toURL:[NSURL URLWithString:@"file:///dev/null"] headers:@{@1: @"a"} onCompletion:^(NSUInteger reportCount, BOOL success, NSError *error) {
-    }];
+    XCTAssertNoThrow([client sendJSONPayload:(id)@{@1: @"a"} headers:(id)@{@1: @"a"} toURL:[NSURL URLWithString:@"file:///dev/null"]
+                           completionHandler:^(BugsnagApiClientDeliveryStatus status, NSError * _Nullable error) {}]);
 }
 
 @end

--- a/Tests/URLSessionMock.h
+++ b/Tests/URLSessionMock.h
@@ -1,0 +1,19 @@
+//
+//  URLSessionMock.h
+//  Bugsnag
+//
+//  Created by Nick Dowell on 19/11/2020.
+//  Copyright © 2020 Bugsnag Inc. All rights reserved.
+//
+
+#import <Foundation/Foundation.h>
+
+NS_ASSUME_NONNULL_BEGIN
+
+@interface URLSessionMock : NSObject
+
+- (void)mockData:(nullable NSData *)data response:(nullable NSURLResponse *)response error:(nullable NSError *)error;
+
+@end
+
+NS_ASSUME_NONNULL_END

--- a/Tests/URLSessionMock.m
+++ b/Tests/URLSessionMock.m
@@ -1,0 +1,48 @@
+//
+//  URLSessionMock.m
+//  Bugsnag
+//
+//  Created by Nick Dowell on 19/11/2020.
+//  Copyright © 2020 Bugsnag Inc. All rights reserved.
+//
+
+#import "URLSessionMock.h"
+
+@interface URLSessionUploadTaskMock : NSURLSessionUploadTask
+
+@property dispatch_block_t mock;
+
+@end
+
+#pragma mark -
+
+@implementation URLSessionMock {
+    NSData *_data;
+    NSURLResponse *_response;
+    NSError *_error;
+}
+
+- (void)mockData:(NSData *)data response:(NSURLResponse *)response error:(NSError *)error {
+    _data = data;
+    _response = response;
+    _error = error;
+}
+
+- (NSURLSessionUploadTask *)uploadTaskWithRequest:(NSURLRequest *)request fromData:(NSData *)bodyData
+                                completionHandler:(void (^)(NSData *, NSURLResponse *, NSError *))completionHandler {
+    URLSessionUploadTaskMock *task = [[URLSessionUploadTaskMock alloc] init];
+    task.mock = ^{ completionHandler(self->_data, self->_response, self->_error); };
+    return task;
+}
+
+@end
+
+#pragma mark -
+
+@implementation URLSessionUploadTaskMock
+
+- (void)resume {
+    self.mock();
+}
+
+@end

--- a/features/delivery.feature
+++ b/features/delivery.feature
@@ -1,0 +1,23 @@
+Feature: Delivery of errors
+
+  Background:
+    Given I clear all persistent data
+
+  Scenario: Delivery is retried after an HTTP 500 error
+    When I set the HTTP status code for the next request to 500
+    And I run "HandledExceptionScenario"
+    And I wait to receive a request
+    And I relaunch the app
+    And I clear the request queue
+    And I configure Bugsnag for "HandledExceptionScenario"
+    And I wait to receive a request
+    Then the request is valid for the error reporting API version "4.0" for the "iOS Bugsnag Notifier" notifier
+
+  Scenario: Delivery is not retried after an HTTP 400 error
+    When I set the HTTP status code for the next request to 400
+    And I run "HandledExceptionScenario"
+    And I wait to receive a request
+    And I relaunch the app
+    And I clear the request queue
+    And I configure Bugsnag for "HandledExceptionScenario"
+    Then I should receive no requests


### PR DESCRIPTION
## Goal

Error and session sends that failed with an HTTP error status code were being reported as successful by the `BugsnagApiClient`, resulting in the payloads on disk being deleted and the data lost.

The aim of these changes is to improve the correctness of this behaviour.

## Changeset

`BugsnagApiClient` now examines the HTTP status code when determining the overall result of the operation, which is now expressed by a `BugsnagApiClientDeliveryStatus` enum.

Behaviour was modelled after that of the [Android](https://github.com/bugsnag/bugsnag-android/blob/master/bugsnag-android-core/src/main/java/com/bugsnag/android/DefaultDelivery.kt#L90-L100) [notifier](https://github.com/bugsnag/bugsnag-android/blob/master/bugsnag-android-core/src/main/java/com/bugsnag/android/DeliveryDelegate.java#L83-L99) - with a few exceptions, errors in the 4xx range are treated as permanent failures that indicate a bad payload, and result in the deletion of the payload and no retry.

Other error status codes, e.g. 500 Internal Server Error, will result in a warning being logged and the notifier will try to send it again at the next trigger condition.

The API was cleaned up to remove the unused `count` parameter.

Support for the old `NSURLConnection` API was removed, since we no longer support iOS version 6 or earlier.

## Testing

Tested manually by simulating various HTTP status codes.

Added unit test cases to verify the delivery status reported for various status codes.

Added E2E test scenarios to verify that retries happen in the right cases.