### PR TITLE
[PLAT-5412] Add BugsnagStackframe.type

### DIFF
--- a/Bugsnag.xcodeproj/project.pbxproj
+++ b/Bugsnag.xcodeproj/project.pbxproj
@@ -1274,6 +1274,7 @@
 		00E636C02487031D006CBF1A /* Bugsnag.podspec.json */ = {isa = PBXFileReference; lastKnownFileType = text.json; path = Bugsnag.podspec.json; sourceTree = SOURCE_ROOT; };
 		00E636C12487031D006CBF1A /* docker-compose.yml */ = {isa = PBXFileReference; lastKnownFileType = text.yaml; path = "docker-compose.yml"; sourceTree = SOURCE_ROOT; };
 		00E636C324878FFC006CBF1A /* Info.plist */ = {isa = PBXFileReference; lastKnownFileType = text.plist.xml; path = Info.plist; sourceTree = "<group>"; };
+		0198762E2567D5AB000A7AF3 /* BugsnagStackframe+Private.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; path = "BugsnagStackframe+Private.h"; sourceTree = "<group>"; };
 		01B14C55251CE55F00118748 /* report-react-native-promise-rejection.json */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = text.json; path = "report-react-native-promise-rejection.json"; sourceTree = "<group>"; };
 		01C17AE62542ED7F00C102C9 /* KSCrashReportWriterTests.m */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.objc; path = KSCrashReportWriterTests.m; sourceTree = "<group>"; };
 		3A700A8024A63A8E0068CD1B /* BugsnagThread.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; path = BugsnagThread.h; sourceTree = "<group>"; };
@@ -1795,6 +1796,7 @@
 				008968562486DA9400DC48C2 /* BugsnagSessionTrackingPayload.h */,
 				008968542486DA9400DC48C2 /* BugsnagSessionTrackingPayload.m */,
 				008968532486DA9400DC48C2 /* BugsnagStackframe.m */,
+				0198762E2567D5AB000A7AF3 /* BugsnagStackframe+Private.h */,
 				0089684F2486DA9400DC48C2 /* BugsnagStacktrace.h */,
 				0089685C2486DA9500DC48C2 /* BugsnagStacktrace.m */,
 				008968552486DA9400DC48C2 /* BugsnagStateEvent.h */,

--- a/Bugsnag/Payload/BugsnagError.m
+++ b/Bugsnag/Payload/BugsnagError.m
@@ -7,8 +7,9 @@
 //
 
 #import "BugsnagError.h"
+
 #import "BugsnagKeys.h"
-#import "BugsnagStackframe.h"
+#import "BugsnagStackframe+Private.h"
 #import "BugsnagStacktrace.h"
 #import "BugsnagCollections.h"
 #import "RegisterErrorData.h"
@@ -70,11 +71,6 @@ NSString *BSGParseErrorMessage(NSDictionary *report, NSDictionary *error, NSStri
     }
     return error[BSGKeyReason] ?: @"";
 }
-
-@interface BugsnagStackframe ()
-- (NSDictionary *)toDictionary;
-+ (BugsnagStackframe *)frameFromJson:(NSDictionary *)json;
-@end
 
 @interface BugsnagStacktrace ()
 @property NSMutableArray<BugsnagStackframe *> *trace;

--- a/Bugsnag/Payload/BugsnagEvent.m
+++ b/Bugsnag/Payload/BugsnagEvent.m
@@ -81,17 +81,6 @@ NSDictionary *_Nonnull BSGParseAppMetadata(NSDictionary *_Nonnull event);
 - (instancetype)deepCopy;
 @end
 
-@interface BugsnagStackframe ()
-+ (BugsnagStackframe *)frameFromDict:(NSDictionary *)dict
-                          withImages:(NSArray *)binaryImages;
-@end
-
-@interface BugsnagStackframe ()
-+ (BugsnagStackframe *)frameFromDict:(NSDictionary *)dict
-                          withImages:(NSArray *)binaryImages;
-+ (BugsnagStackframe *)frameFromJson:(NSDictionary *)json;
-@end
-
 @interface BugsnagThread ()
 @property BugsnagStacktrace *trace;
 - (NSDictionary *)toDictionary;

--- a/Bugsnag/Payload/BugsnagStackframe+Private.h
+++ b/Bugsnag/Payload/BugsnagStackframe+Private.h
@@ -1,0 +1,26 @@
+//
+//  BugsnagStackframe+Private.h
+//  Bugsnag
+//
+//  Created by Nick Dowell on 20/11/2020.
+//  Copyright © 2020 Bugsnag Inc. All rights reserved.
+//
+
+#import <Bugsnag/BugsnagStackframe.h>
+
+NS_ASSUME_NONNULL_BEGIN
+
+@interface BugsnagStackframe ()
+
+/// Constructs a stackframe object from a stackframe dictionary and list of images captured by KSCrash.
++ (nullable instancetype)frameFromDict:(NSDictionary<NSString *, id> *)dict withImages:(NSArray<NSDictionary<NSString *, id> *> *)binaryImages;
+
+/// Constructs a stackframe object from a JSON object (typically loaded from disk.)
++ (instancetype)frameFromJson:(NSDictionary<NSString *, id> *)json;
+
+/// Returns a JSON compatible representation of the stackframe.
+- (NSDictionary *)toDictionary;
+
+@end
+
+NS_ASSUME_NONNULL_END

--- a/Bugsnag/Payload/BugsnagStackframe.m
+++ b/Bugsnag/Payload/BugsnagStackframe.m
@@ -6,13 +6,15 @@
 //  Copyright © 2020 Bugsnag. All rights reserved.
 //
 
-#import "BugsnagStackframe.h"
+#import "BugsnagStackframe+Private.h"
 
 #import "BSG_KSBacktrace.h"
 #import "BSG_KSDynamicLinker.h"
 #import "BugsnagCollections.h"
 #import "BugsnagKeys.h"
 #import "BugsnagLogger.h"
+
+BugsnagStackframeType const BugsnagStackframeTypeCocoa = @"cocoa";
 
 @implementation BugsnagStackframe
 
@@ -36,6 +38,7 @@
     frame.frameAddress = [self readInt:json key:BSGKeyFrameAddress];
     frame.symbolAddress = [self readInt:json key:BSGKeySymbolAddr];
     frame.machoLoadAddress = [self readInt:json key:BSGKeyMachoLoadAddr];
+    frame.type = json[BSGKeyType];
     return frame;
 }
 
@@ -183,6 +186,7 @@
     if (self.isLr) {
         BSGDictSetSafeObject(dict, @(self.isLr), BSGKeyIsLR);
     }
+    dict[BSGKeyType] = self.type;
     return dict;
 }
 

--- a/Bugsnag/Payload/BugsnagStacktrace.m
+++ b/Bugsnag/Payload/BugsnagStacktrace.m
@@ -7,15 +7,9 @@
 //
 
 #import "BugsnagStacktrace.h"
-#import "BugsnagStackframe.h"
-#import "BugsnagKeys.h"
 
-@interface BugsnagStackframe ()
-+ (BugsnagStackframe *)frameFromDict:(NSDictionary *)dict
-                          withImages:(NSArray *)binaryImages;
-- (NSDictionary *)toDictionary;
-+ (instancetype)frameFromJson:(NSDictionary *)json;
-@end
+#import "BugsnagKeys.h"
+#import "BugsnagStackframe+Private.h"
 
 @interface BugsnagStacktrace ()
 @property NSMutableArray<BugsnagStackframe *> *trace;

--- a/Bugsnag/Payload/BugsnagThread.m
+++ b/Bugsnag/Payload/BugsnagThread.m
@@ -7,8 +7,9 @@
 //
 
 #import "BugsnagThread.h"
+
 #import "BugsnagCollections.h"
-#import "BugsnagStackframe.h"
+#import "BugsnagStackframe+Private.h"
 #import "BugsnagStacktrace.h"
 #import "BugsnagKeys.h"
 
@@ -27,10 +28,6 @@ NSString *BSGSerializeThreadType(BSGThreadType type) {
 @interface BugsnagStacktrace ()
 + (instancetype)stacktraceFromJson:(NSDictionary *)json;
 @property NSMutableArray<BugsnagStackframe *> *trace;
-@end
-
-@interface BugsnagStackframe ()
-- (NSDictionary *)toDictionary;
 @end
 
 @implementation BugsnagThread

--- a/Bugsnag/include/Bugsnag/BugsnagStackframe.h
+++ b/Bugsnag/include/Bugsnag/BugsnagStackframe.h
@@ -8,6 +8,12 @@
 
 #import <Foundation/Foundation.h>
 
+NS_ASSUME_NONNULL_BEGIN
+
+typedef NSString * BugsnagStackframeType NS_TYPED_ENUM;
+
+FOUNDATION_EXPORT BugsnagStackframeType const BugsnagStackframeTypeCocoa;
+
 /**
  * Represents a single stackframe from a stacktrace.
  */
@@ -59,10 +65,17 @@
 @property BOOL isLr;
 
 /**
+ * The type of the stack frame, if it differs from that of the containing error or event.
+ */
+@property(nullable) BugsnagStackframeType type;
+
+/**
  * Returns an array of stackframe objects representing the provided call stack strings.
  *
  * The call stack strings should follow the format used by `[NSThread callStackSymbols]` and `backtrace_symbols()`.
  */
-+ (NSArray<BugsnagStackframe *> *_Nullable)stackframesWithCallStackSymbols:(NSArray<NSString *> *_Nonnull)callStackSymbols;
++ (nullable NSArray<BugsnagStackframe *> *)stackframesWithCallStackSymbols:(NSArray<NSString *> *)callStackSymbols;
 
 @end
+
+NS_ASSUME_NONNULL_END


### PR DESCRIPTION
## Goal

Adding `type` to `BugsnagStackframe` is a prerequisite for supporting mixed stack traces containing multiple languages.

## Design

The `type` parameter is intended to be `nil` in most cases, and only set if the stack trace contains more than one language - e.g. a `reactnativejs` exception that contains some `cocoa` frames.

Because the existing `BSGErrorType` is an int-based enum and cannot naturally represent a nil value, a new Objective-C style string enum `BugsnagStackframeType` has been created specifically for this property.

In a future notifier update when we are making breaking API changes, we should consider switching all our enums that are serialized as strings to NS_TYPED_ENUMs. 

## Changeset

* Added `type` parameter
* Added `BugsnagStackframe+Private.h` to remove duplicate declarations
* Adopted `NS_ASSUME_NONNULL` for stack frame header

## Testing

* Implemented unit tests to validate expected behaviour of `type` parameter
* Manually verified using a customised version of BugsnagReactNative