### PR TITLE
Add BugsnagHTTPHeaderName

### DIFF
--- a/Bugsnag/BugsnagErrorReportSink.m
+++ b/Bugsnag/BugsnagErrorReportSink.m
@@ -137,7 +137,7 @@
         NSDictionary *requestPayload = [self prepareEventPayload:event];
 
         NSMutableDictionary *apiHeaders = [[configuration errorApiHeaders] mutableCopy];
-        BSGDictSetSafeObject(apiHeaders, event.apiKey, BSGHeaderApiKey);
+        apiHeaders[BugsnagHTTPHeaderNameApiKey] = event.apiKey;
         [self.apiClient sendJSONPayload:requestPayload headers:apiHeaders toURL:configuration.notifyURL
                       completionHandler:^(BugsnagApiClientDeliveryStatus status, NSError *error) {
             BOOL completed = status == BugsnagApiClientDeliveryStatusDelivered || status == BugsnagApiClientDeliveryStatusUndeliverable;

--- a/Bugsnag/Configuration/BugsnagConfiguration.m
+++ b/Bugsnag/Configuration/BugsnagConfiguration.m
@@ -27,6 +27,7 @@
 #import "BugsnagConfiguration.h"
 
 #import "BSGConfigurationBuilder.h"
+#import "BugsnagApiClient.h"
 #import "Private.h"
 
 static const int BSGApiKeyLength = 32;
@@ -306,19 +307,17 @@ NSString * const kBugsnagUserUserId = @"BugsnagUserUserId";
 }
 
 - (NSDictionary *)errorApiHeaders {
-    return @{
-             BSGHeaderApiPayloadVersion: @"4.0",
-             BSGHeaderApiKey: self.apiKey,
-             BSGHeaderApiSentAt: [BSG_RFC3339DateTool stringFromDate:[NSDate new]]
+    return @{BugsnagHTTPHeaderNameApiKey: self.apiKey ?: @"",
+             BugsnagHTTPHeaderNamePayloadVersion: @"4.0",
+             BugsnagHTTPHeaderNameSentAt: [BSG_RFC3339DateTool stringFromDate:[NSDate date]]
     };
 }
 
 - (NSDictionary *)sessionApiHeaders {
-    return @{
-             BSGHeaderApiPayloadVersion: @"1.0",
-             BSGHeaderApiKey: self.apiKey,
-             BSGHeaderApiSentAt: [BSG_RFC3339DateTool stringFromDate:[NSDate new]]
-             };
+    return @{BugsnagHTTPHeaderNameApiKey: self.apiKey ?: @"",
+             BugsnagHTTPHeaderNamePayloadVersion: @"1.0",
+             BugsnagHTTPHeaderNameSentAt: [BSG_RFC3339DateTool stringFromDate:[NSDate date]]
+    };
 }
 
 - (void)setEndpoints:(BugsnagEndpointConfiguration *)endpoints {

--- a/Bugsnag/Delivery/BugsnagApiClient.h
+++ b/Bugsnag/Delivery/BugsnagApiClient.h
@@ -7,6 +7,12 @@
 
 NS_ASSUME_NONNULL_BEGIN
 
+typedef NSString * BugsnagHTTPHeaderName NS_TYPED_ENUM;
+
+extern BugsnagHTTPHeaderName const BugsnagHTTPHeaderNameApiKey;
+extern BugsnagHTTPHeaderName const BugsnagHTTPHeaderNamePayloadVersion;
+extern BugsnagHTTPHeaderName const BugsnagHTTPHeaderNameSentAt;
+
 typedef NS_ENUM(NSInteger, BugsnagApiClientDeliveryStatus) {
     /// The payload was delivered successfully and can be deleted.
     BugsnagApiClientDeliveryStatusDelivered,
@@ -28,7 +34,7 @@ typedef NS_ENUM(NSInteger, BugsnagApiClientDeliveryStatus) {
 - (NSOperation *)deliveryOperation;
 
 - (void)sendJSONPayload:(NSDictionary *)payload
-                headers:(NSDictionary<NSString *, NSString *> *)headers
+                headers:(NSDictionary<BugsnagHTTPHeaderName, NSString *> *)headers
                   toURL:(NSURL *)url
       completionHandler:(void (^)(BugsnagApiClientDeliveryStatus status, NSError * _Nullable error))completionHandler;
 

--- a/Bugsnag/Delivery/BugsnagApiClient.m
+++ b/Bugsnag/Delivery/BugsnagApiClient.m
@@ -11,6 +11,10 @@
 #import "Private.h"
 #import "BSGJSONSerialization.h"
 
+BugsnagHTTPHeaderName const BugsnagHTTPHeaderNameApiKey             = @"Bugsnag-Api-Key";
+BugsnagHTTPHeaderName const BugsnagHTTPHeaderNamePayloadVersion     = @"Bugsnag-Payload-Version";
+BugsnagHTTPHeaderName const BugsnagHTTPHeaderNameSentAt             = @"Bugsnag-Sent-At";
+
 typedef NS_ENUM(NSInteger, HTTPStatusCode) {
     /// 402 Payment Required: a nonstandard client error status response code that is reserved for future use.
     ///
@@ -63,7 +67,7 @@ typedef NS_ENUM(NSInteger, HTTPStatusCode) {
 #pragma mark - Delivery
 
 - (void)sendJSONPayload:(NSDictionary *)payload
-                headers:(NSDictionary<NSString *, NSString *> *)headers
+                headers:(NSDictionary<BugsnagHTTPHeaderName, NSString *> *)headers
                   toURL:(NSURL *)url
       completionHandler:(void (^)(BugsnagApiClientDeliveryStatus status, NSError * _Nullable error))completionHandler {
     

--- a/Bugsnag/Delivery/BugsnagSessionTrackingApiClient.m
+++ b/Bugsnag/Delivery/BugsnagSessionTrackingApiClient.m
@@ -70,9 +70,9 @@
                     codeBundleId:self.codeBundleId];
             NSMutableDictionary *data = [payload toJson];
             NSDictionary *HTTPHeaders = @{
-                    @"Bugsnag-Payload-Version": @"1.0",
-                    @"Bugsnag-API-Key": apiKey,
-                    @"Bugsnag-Sent-At": [BSG_RFC3339DateTool stringFromDate:[NSDate new]]
+                BugsnagHTTPHeaderNameApiKey: apiKey ?: @"",
+                BugsnagHTTPHeaderNamePayloadVersion: @"1.0",
+                BugsnagHTTPHeaderNameSentAt: [BSG_RFC3339DateTool stringFromDate:[NSDate date]]
             };
             [self sendJSONPayload:data headers:HTTPHeaders toURL:sessionURL
                 completionHandler:^(BugsnagApiClientDeliveryStatus status, NSError *error) {

--- a/Bugsnag/Helpers/BugsnagKeys.h
+++ b/Bugsnag/Helpers/BugsnagKeys.h
@@ -101,9 +101,6 @@ extern NSString *const BSGKeyUser;
 extern NSString *const BSGKeyUuid;
 extern NSString *const BSGKeyVersion;
 extern NSString *const BSGKeyWarning;
-extern NSString *const BSGHeaderApiKey;
-extern NSString *const BSGHeaderApiPayloadVersion;
-extern NSString *const BSGHeaderApiSentAt;
 
 #define BSGKeyHwCputype "hw.cputype"
 #define BSGKeyHwCpusubtype "hw.cpusubtype"

--- a/Bugsnag/Helpers/BugsnagKeys.m
+++ b/Bugsnag/Helpers/BugsnagKeys.m
@@ -97,6 +97,3 @@ NSString *const BSGKeyUser = @"user";
 NSString *const BSGKeyUuid = @"uuid";
 NSString *const BSGKeyVersion = @"version";
 NSString *const BSGKeyWarning = @"warning";
-NSString *const BSGHeaderApiKey = @"Bugsnag-Api-Key";
-NSString *const BSGHeaderApiPayloadVersion = @"Bugsnag-Payload-Version";
-NSString *const BSGHeaderApiSentAt = @"Bugsnag-Sent-At";


### PR DESCRIPTION
## Goal

In preparation for adding the new `Bugsnag-Stacktrace-Types` header, this change cleans up the definition of HTTP header names.

## Changeset

Added a `BugsnagHTTPHeaderName` typed enum to collect all HTTP header names in a single place.

## Testing

There is unit test coverage that validates the header names.