### PR TITLE
[PLAT-5471] Fix crash in BugsnagClient.m line 818

### DIFF
--- a/Bugsnag/Client/BugsnagClient.m
+++ b/Bugsnag/Client/BugsnagClient.m
@@ -823,11 +823,9 @@ NSString *const BSGBreadcrumbLoadedMessage = @"Bugsnag loaded";
             [strongSelf flushPendingReports];
         }
 
-        [self addAutoBreadcrumbOfType:BSGBreadcrumbTypeState
-                          withMessage:@"Connectivity changed"
-                          andMetadata:@{
-                              @"type"  :  connectionType
-                          }];
+        [strongSelf addAutoBreadcrumbOfType:BSGBreadcrumbTypeState
+                                withMessage:@"Connectivity changed"
+                                andMetadata:@{@"type": connectionType}];
     }];
 }
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,9 @@ Changelog
 * Error and session deliveries that fail with an HTTP error status code will now be retried if appropriate.
   [#895](https://github.com/bugsnag/bugsnag-cocoa/pull/895)
 
+* Fixed a rare crash in BugsnagClient's network connectivity observer block.
+  [#904](https://github.com/bugsnag/bugsnag-cocoa/pull/904)
+
 ## 6.2.5 (2020-11-18)
 
 ### Bug fixes


### PR DESCRIPTION
## Goal

Two types of crashes were seen in `__42-[BugsnagClient setupConnectivityListener]_block_invoke (BugsnagClient.m:818:9)`:

```
NSInvalidArgumentException: -[NSOperationQueue addAutoBreadcrumbOfType:withMessage:andMetadata:]: unrecognized selector sent to instance 0x107e18e50

0  CoreFoundation          ___exceptionPreprocess
1  libobjc.A.dylib         _objc_exception_throw
2  CoreFoundation          -[NSObject(NSObject) doesNotRecognizeSelector:]
3  CoreFoundation          ____forwarding___
4  CoreFoundation          ___forwarding_prep_0___
5  App                     __42-[BugsnagClient setupConnectivityListener]_block_invoke (BugsnagClient.m:818:9)
6  App                     BSGConnectivityCallback (BSGConnectivity.m:97:9)
```

```
EXC_BAD_ACCESS: Attempted to dereference garbage pointer 0x646e616d6d6f63.

0  libobjc.A.dylib         _objc_msgSend
1  App                     __42-[BugsnagClient setupConnectivityListener]_block_invoke (BugsnagClient.m:818:9)
2  App                     BSGConnectivityCallback (BSGConnectivity.m:97:9)
```

Note: line numbers differ slightly because the reports were for v6.2.3

Both point to the fact that the `self` pointer inside the block was invalid, and `strongSelf` should have been used instead.