### PR TITLE
Add private headers for error, event & thread

### DIFF
--- a/Bugsnag.xcodeproj/project.pbxproj
+++ b/Bugsnag.xcodeproj/project.pbxproj
@@ -1279,6 +1279,9 @@
 		00E636C02487031D006CBF1A /* Bugsnag.podspec.json */ = {isa = PBXFileReference; lastKnownFileType = text.json; path = Bugsnag.podspec.json; sourceTree = SOURCE_ROOT; };
 		00E636C12487031D006CBF1A /* docker-compose.yml */ = {isa = PBXFileReference; lastKnownFileType = text.yaml; path = "docker-compose.yml"; sourceTree = SOURCE_ROOT; };
 		00E636C324878FFC006CBF1A /* Info.plist */ = {isa = PBXFileReference; lastKnownFileType = text.plist.xml; path = Info.plist; sourceTree = "<group>"; };
+		0134524A256BCF7C0088C548 /* BugsnagError+Private.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; path = "BugsnagError+Private.h"; sourceTree = "<group>"; };
+		0134524B256BD00A0088C548 /* BugsnagThread+Private.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; path = "BugsnagThread+Private.h"; sourceTree = "<group>"; };
+		0195FC3B256BC81400DE6646 /* BugsnagEvent+Private.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; path = "BugsnagEvent+Private.h"; sourceTree = "<group>"; };
 		0198762E2567D5AB000A7AF3 /* BugsnagStackframe+Private.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; path = "BugsnagStackframe+Private.h"; sourceTree = "<group>"; };
 		01B14C55251CE55F00118748 /* report-react-native-promise-rejection.json */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = text.json; path = "report-react-native-promise-rejection.json"; sourceTree = "<group>"; };
 		01C17AE62542ED7F00C102C9 /* KSCrashReportWriterTests.m */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.objc; path = KSCrashReportWriterTests.m; sourceTree = "<group>"; };
@@ -1795,7 +1798,9 @@
 				008968482486DA9400DC48C2 /* BugsnagDevice.m */,
 				0089685A2486DA9500DC48C2 /* BugsnagDeviceWithState.m */,
 				008968512486DA9400DC48C2 /* BugsnagError.m */,
+				0134524A256BCF7C0088C548 /* BugsnagError+Private.h */,
 				008968462486DA9300DC48C2 /* BugsnagEvent.m */,
+				0195FC3B256BC81400DE6646 /* BugsnagEvent+Private.h */,
 				0089684E2486DA9400DC48C2 /* BugsnagHandledState.h */,
 				008968522486DA9400DC48C2 /* BugsnagHandledState.m */,
 				008968622486DA9500DC48C2 /* BugsnagNotifier.h */,
@@ -1811,6 +1816,7 @@
 				008968552486DA9400DC48C2 /* BugsnagStateEvent.h */,
 				008968582486DA9500DC48C2 /* BugsnagStateEvent.m */,
 				008968612486DA9500DC48C2 /* BugsnagThread.m */,
+				0134524B256BD00A0088C548 /* BugsnagThread+Private.h */,
 				0089685F2486DA9500DC48C2 /* BugsnagUser.m */,
 			);
 			path = Payload;

--- a/Bugsnag/Bugsnag.m
+++ b/Bugsnag/Bugsnag.m
@@ -52,10 +52,6 @@ static BugsnagClient *bsg_g_bugsnag_client = NULL;
 - (NSDictionary *)BSG_mergedInto:(NSDictionary *)dest;
 @end
 
-@interface BugsnagEvent ()
-@property(readwrite) NSUInteger depth;
-@end
-
 @interface BugsnagClient ()
 - (void)startListeningForStateChangeNotification:(NSString *_Nonnull)notificationName;
 - (void)addBreadcrumbWithBlock:(void (^_Nonnull)(BugsnagBreadcrumb *_Nonnull))block;

--- a/Bugsnag/BugsnagErrorReportSink.m
+++ b/Bugsnag/BugsnagErrorReportSink.m
@@ -25,14 +25,16 @@
 //
 
 #import "BugsnagErrorReportSink.h"
+
+#import "BSG_KSSystemInfo.h"
 #import "Bugsnag.h"
-#import "BugsnagLogger.h"
-#import "BugsnagCollections.h"
 #import "BugsnagClient.h"
 #import "BugsnagClientInternal.h"
+#import "BugsnagCollections.h"
+#import "BugsnagEvent+Private.h"
 #import "BugsnagKeys.h"
+#import "BugsnagLogger.h"
 #import "BugsnagNotifier.h"
-#import "BSG_KSSystemInfo.h"
 #import "Private.h"
 
 // This is private in Bugsnag, but really we want package private so define
@@ -43,13 +45,6 @@
 
 @interface BugsnagNotifier ()
 - (NSDictionary *)toDict;
-@end
-
-@interface BugsnagEvent ()
-- (NSDictionary *_Nonnull)toJson;
-- (BOOL)shouldBeSent;
-- (instancetype _Nonnull)initWithKSReport:(NSDictionary *_Nonnull)report;
-@property NSSet<NSString *> *redactedKeys;
 @end
 
 @interface BugsnagConfiguration ()

--- a/Bugsnag/Client/BugsnagClient.m
+++ b/Bugsnag/Client/BugsnagClient.m
@@ -28,35 +28,38 @@
 
 #import "BugsnagClient.h"
 
+#import "BSGConnectivity.h"
+#import "BSGJSONSerialization.h"
+#import "BSGSerialization.h"
+#import "BSG_KSCrash.h"
+#import "BSG_KSCrashC.h"
+#import "BSG_KSCrashReport.h"
+#import "BSG_KSCrashState.h"
+#import "BSG_KSCrashType.h"
+#import "BSG_KSMach.h"
+#import "BSG_KSSystemInfo.h"
+#import "BSG_RFC3339DateTool.h"
+#import "Bugsnag.h"
+#import "Bugsnag.h"
 #import "BugsnagBreadcrumbs.h"
 #import "BugsnagClientInternal.h"
-#import "BSGConnectivity.h"
-#import "Bugsnag.h"
-#import "Private.h"
+#import "BugsnagCollections.h"
 #import "BugsnagCrashSentry.h"
+#import "BugsnagError+Private.h"
+#import "BugsnagErrorTypes.h"
+#import "BugsnagEvent+Private.h"
 #import "BugsnagHandledState.h"
-#import "BugsnagLogger.h"
 #import "BugsnagKeys.h"
+#import "BugsnagLogger.h"
+#import "BugsnagMetadataInternal.h"
+#import "BugsnagNotifier.h"
+#import "BugsnagPluginClient.h"
 #import "BugsnagSessionTracker.h"
 #import "BugsnagSessionTrackingApiClient.h"
-#import "BugsnagPluginClient.h"
-#import "BugsnagSystemState.h"
-#import "BSG_RFC3339DateTool.h"
-#import "BSG_KSCrashC.h"
-#import "BSG_KSCrashType.h"
-#import "BSG_KSCrashState.h"
-#import "BSG_KSSystemInfo.h"
-#import "BSG_KSMach.h"
-#import "BSGSerialization.h"
-#import "Bugsnag.h"
-#import "BugsnagErrorTypes.h"
-#import "BugsnagNotifier.h"
-#import "BugsnagMetadataInternal.h"
 #import "BugsnagStateEvent.h"
-#import "BugsnagCollections.h"
-#import "BSG_KSCrashReport.h"
-#import "BSG_KSCrash.h"
-#import "BSGJSONSerialization.h"
+#import "BugsnagSystemState.h"
+#import "BugsnagThread+Private.h"
+#import "Private.h"
 
 #if BSG_PLATFORM_IOS || BSG_PLATFORM_TVOS
 #define BSGOOMAvailable 1
@@ -119,10 +122,6 @@ NSDictionary *BSGParseDeviceMetadata(NSDictionary *event);
 @interface BugsnagSession ()
 @property NSUInteger unhandledCount;
 @property NSUInteger handledCount;
-@end
-
-@interface BugsnagThread ()
-+ (NSMutableArray *)serializeThreads:(NSArray<BugsnagThread *> *)threads;
 @end
 
 @interface BugsnagAppWithState ()
@@ -324,31 +323,6 @@ void BSGWriteSessionCrashData(BugsnagSession *session) {
 @property(readwrite, retain, nullable) BugsnagMetadata *metadata;
 @property(readwrite, retain, nullable) BugsnagMetadata *config;
 - (BOOL)shouldRecordBreadcrumbType:(BSGBreadcrumbType)type;
-@end
-
-@interface BugsnagEvent ()
-@property(readonly, copy, nonnull) NSDictionary *overrides;
-@property(readwrite) NSUInteger depth;
-@property(readonly, nonnull) BugsnagHandledState *handledState;
-@property (nonatomic, strong) BugsnagMetadata *metadata;
-- (void)setOverrideProperty:(NSString *)key value:(id)value;
-- (NSDictionary *)toJson;
-- (instancetype)initWithApp:(BugsnagAppWithState *)app
-                     device:(BugsnagDeviceWithState *)device
-               handledState:(BugsnagHandledState *)handledState
-                       user:(BugsnagUser *)user
-                   metadata:(BugsnagMetadata *)metadata
-                breadcrumbs:(NSArray<BugsnagBreadcrumb *> *)breadcrumbs
-                     errors:(NSArray<BugsnagError *> *)errors
-                    threads:(NSArray<BugsnagThread *> *)threads
-                    session:(BugsnagSession *)session;
-@end
-
-@interface BugsnagError ()
-- (instancetype)initWithErrorClass:(NSString *)errorClass
-                      errorMessage:(NSString *)errorMessage
-                         errorType:(BSGErrorType)errorType
-                        stacktrace:(NSArray<BugsnagStackframe *> *)stacktrace;
 @end
 
 @interface BugsnagSessionTracker ()

--- a/Bugsnag/KSCrash/Source/KSCrash/Recording/BSG_KSCrash.m
+++ b/Bugsnag/KSCrash/Source/KSCrash/Recording/BSG_KSCrash.m
@@ -36,7 +36,7 @@
 
 //#define BSG_KSLogger_LocalLevel TRACE
 #import "BSG_KSLogger.h"
-#import "BugsnagThread.h"
+#import "BugsnagThread+Private.h"
 #import "BSGJSONSerialization.h"
 #import "BSGSerialization.h"
 #import "Bugsnag.h"
@@ -73,13 +73,6 @@
 // ============================================================================
 #pragma mark - Globals -
 // ============================================================================
-
-@interface BugsnagThread ()
-+ (NSMutableArray<BugsnagThread *> *)threadsFromArray:(NSArray *)threads
-                                         binaryImages:(NSArray *)binaryImages
-                                                depth:(NSUInteger)depth
-                                            errorType:(NSString *)errorType;
-@end
 
 @interface BSG_KSCrash ()
 

--- a/Bugsnag/Payload/BugsnagError+Private.h
+++ b/Bugsnag/Payload/BugsnagError+Private.h
@@ -1,0 +1,34 @@
+//
+//  BugsnagError+Private.h
+//  Bugsnag
+//
+//  Created by Nick Dowell on 23/11/2020.
+//  Copyright © 2020 Bugsnag Inc. All rights reserved.
+//
+
+#import <Bugsnag/BugsnagError.h>
+
+NS_ASSUME_NONNULL_BEGIN
+
+@class BugsnagThread;
+
+@interface BugsnagError ()
+
+- (instancetype)initWithEvent:(NSDictionary *)event errorReportingThread:(nullable BugsnagThread *)thread;
+
+- (instancetype)initWithErrorClass:(NSString *)errorClass
+                      errorMessage:(NSString *)errorMessage
+                         errorType:(BSGErrorType)errorType
+                        stacktrace:(nullable NSArray<BugsnagStackframe *> *)stacktrace;
+
++ (BugsnagError *)errorFromJson:(NSDictionary *)json;
+
+- (NSDictionary *)toDictionary;
+
+@end
+
+BSGErrorType BSGParseErrorType(NSString *errorType);
+
+NSString *BSGSerializeErrorType(BSGErrorType errorType);
+
+NS_ASSUME_NONNULL_END

--- a/Bugsnag/Payload/BugsnagEvent+Private.h
+++ b/Bugsnag/Payload/BugsnagEvent+Private.h
@@ -1,0 +1,70 @@
+//
+//  BugsnagEvent+Private.h
+//  Bugsnag
+//
+//  Created by Nick Dowell on 23/11/2020.
+//  Copyright © 2020 Bugsnag Inc. All rights reserved.
+//
+
+#import <Bugsnag/BugsnagEvent.h>
+
+NS_ASSUME_NONNULL_BEGIN
+
+@interface BugsnagEvent ()
+
+@property (copy, nonatomic) NSString *codeBundleId;
+
+/// User-provided exception metadata.
+@property (readwrite, copy, nullable, nonatomic) NSDictionary *customException;
+
+/// Number of frames to discard at the top of the generated stacktrace. Stacktraces from raised exceptions are unaffected.
+@property NSUInteger depth;
+
+/// A unique hash identifying this device for the application or vendor.
+@property (readwrite, copy, nullable, nonatomic) NSString *deviceAppHash;
+
+/// The release stages used to notify at the time this report is captured.
+@property (readwrite, copy, nullable) NSArray *enabledReleaseStages;
+
+/// Raw error data added to metadata.
+@property (readwrite, copy, nullable) NSDictionary *error;
+
+/// The event state (whether the error is handled/unhandled.)
+@property (readonly) BugsnagHandledState *handledState;
+
+@property (strong, nonatomic) BugsnagMetadata *metadata;
+
+/// Property overrides.
+@property (readonly, copy) NSDictionary *overrides;
+
+@property NSSet<NSString *> *redactedKeys;
+
+/// The release stage of the application
+@property (readwrite, copy, nullable) NSString *releaseStage;
+
+@property (strong, nullable, nonatomic) BugsnagSession *session;
+
+- (instancetype)initWithApp:(nullable BugsnagAppWithState *)app
+                     device:(nullable BugsnagDeviceWithState *)device
+               handledState:(BugsnagHandledState *)handledState
+                       user:(nullable BugsnagUser *)user
+                   metadata:(nullable BugsnagMetadata *)metadata
+                breadcrumbs:(NSArray<BugsnagBreadcrumb *> *)breadcrumbs
+                     errors:(NSArray<BugsnagError *> *)errors
+                    threads:(NSArray<BugsnagThread *> *)threads
+                    session:(nullable BugsnagSession *)session;
+
+- (instancetype)initWithKSReport:(NSDictionary *)KSReport;
+
+- (instancetype)initWithUserData:(NSDictionary *)event;
+
+/// Whether this report should be sent, based on release stage information cached at crash time and within the application currently.
+- (BOOL)shouldBeSent;
+
+- (void)setOverrideProperty:(NSString *)key value:(id)value;
+
+- (NSDictionary *)toJson;
+
+@end
+
+NS_ASSUME_NONNULL_END

--- a/Bugsnag/Payload/BugsnagEvent.m
+++ b/Bugsnag/Payload/BugsnagEvent.m
@@ -14,22 +14,25 @@
 #endif
 
 #import <Foundation/Foundation.h>
+
 #import "BSGSerialization.h"
+#import "BSG_KSCrashReportFields.h"
+#import "BSG_RFC3339DateTool.h"
 #import "Bugsnag.h"
 #import "BugsnagBreadcrumbs.h"
 #import "BugsnagCollections.h"
+#import "BugsnagError+Private.h"
+#import "BugsnagEvent+Private.h"
 #import "BugsnagHandledState.h"
-#import "BugsnagLogger.h"
 #import "BugsnagKeys.h"
+#import "BugsnagLogger.h"
 #import "BugsnagSession.h"
-#import "Private.h"
-#import "BSG_RFC3339DateTool.h"
-#import "BugsnagStacktrace.h"
-#import "BugsnagThread.h"
-#import "RegisterErrorData.h"
 #import "BugsnagSessionInternal.h"
+#import "BugsnagStacktrace.h"
+#import "BugsnagThread+Private.h"
 #import "BugsnagUser.h"
-#import "BSG_KSCrashReportFields.h"
+#import "Private.h"
+#import "RegisterErrorData.h"
 
 static NSString *const DEFAULT_EXCEPTION_TYPE = @"cocoa";
 
@@ -81,44 +84,12 @@ NSDictionary *_Nonnull BSGParseAppMetadata(NSDictionary *_Nonnull event);
 - (instancetype)deepCopy;
 @end
 
-@interface BugsnagThread ()
-@property BugsnagStacktrace *trace;
-- (NSDictionary *)toDictionary;
-
-- (instancetype)initWithThread:(NSDictionary *)thread
-                  binaryImages:(NSArray *)binaryImages;
-
-+ (NSMutableArray<BugsnagThread *> *)threadsFromArray:(NSArray *)threads
-                                         binaryImages:(NSArray *)binaryImages
-                                                depth:(NSUInteger)depth
-                                            errorType:(NSString *)errorType;
-
-+ (NSMutableArray *)serializeThreads:(NSArray<BugsnagThread *> *)threads;
-@end
-
 @interface BugsnagStacktrace ()
 - (NSArray *)toArray;
 @end
 
-@interface BugsnagThread ()
-- (instancetype)initWithThread:(NSDictionary *)thread
-                  binaryImages:(NSArray *)binaryImages;
-
-+ (NSMutableArray<BugsnagThread *> *)threadsFromArray:(NSArray *)threads
-                                         binaryImages:(NSArray *)binaryImages
-                                                depth:(NSUInteger)depth
-                                            errorType:(NSString *)errorType;
-+ (instancetype)threadFromJson:(NSDictionary *)json;
-@end
-
 @interface BugsnagStacktrace ()
 - (NSArray *)toArray;
-@end
-
-@interface BugsnagError ()
-- (NSDictionary *)toDictionary;
-- (instancetype)initWithEvent:(NSDictionary *)event errorReportingThread:(BugsnagThread *)thread;
-+ (BugsnagError *)errorFromJson:(NSDictionary *)json;
 @end
 
 // MARK: - KSCrashReport parsing
@@ -231,66 +202,6 @@ NSDictionary *BSGParseCustomException(NSDictionary *report,
 @interface BugsnagUser ()
 - (instancetype)initWithDictionary:(NSDictionary *)dict;
 - (instancetype)initWithUserId:(NSString *)userId name:(NSString *)name emailAddress:(NSString *)emailAddress;
-@end
-
-@interface BugsnagEvent ()
-
-/**
- *  A unique hash identifying this device for the application or vendor
- */
-@property(nonatomic, readwrite, copy, nullable) NSString *deviceAppHash;
-/**
- *  User-provided exception metadata
- */
-@property(nonatomic, readwrite, copy, nullable) NSDictionary *customException;
-@property(nonatomic, strong) BugsnagSession *session;
-
-/**
- *  The event state (whether the error is handled/unhandled)
- */
-@property(readonly, nonnull) BugsnagHandledState *handledState;
-
-- (NSDictionary *_Nonnull)toJson;
-
-/**
- *  Whether this report should be sent, based on release stage information
- *  cached at crash time and within the application currently
- *
- *  @return YES if the report should be sent
- */
-- (BOOL)shouldBeSent;
-
-/**
- *  The release stages used to notify at the time this report is captured
- */
-@property(readwrite, copy, nullable) NSArray *enabledReleaseStages;
-
-/**
- *  Property overrides
- */
-@property(readonly, copy, nonnull) NSDictionary *overrides;
-
-/**
- *  Number of frames to discard at the top of the generated stacktrace.
- *  Stacktraces from raised exceptions are unaffected.
- */
-@property(readwrite) NSUInteger depth;
-
-@property (nonatomic, strong) BugsnagMetadata *metadata;
-
-/**
- *  Raw error data added to metadata
- */
-@property(readwrite, copy, nullable) NSDictionary *error;
-
-/**
- *  The release stage of the application
- */
-@property(readwrite, copy, nullable) NSString *releaseStage;
-
-@property NSSet<NSString *> *redactedKeys;
-
-@property(nonatomic) NSString *codeBundleId;
 @end
 
 @implementation BugsnagEvent

--- a/Bugsnag/Payload/BugsnagThread+Private.h
+++ b/Bugsnag/Payload/BugsnagThread+Private.h
@@ -1,0 +1,40 @@
+//
+//  BugsnagThread+Private.h
+//  Bugsnag
+//
+//  Created by Nick Dowell on 23/11/2020.
+//  Copyright © 2020 Bugsnag Inc. All rights reserved.
+//
+
+#import <Bugsnag/BugsnagThread.h>
+
+NS_ASSUME_NONNULL_BEGIN
+
+@interface BugsnagThread ()
+
+@property BugsnagStacktrace *trace;
+
+- (instancetype)initWithThread:(NSDictionary *)thread binaryImages:(NSArray *)binaryImages;
+
++ (instancetype)threadFromJson:(NSDictionary *)json;
+
++ (NSDictionary *)enhanceThreadInfo:(NSDictionary *)thread
+                              depth:(NSUInteger)depth
+                          errorType:(nullable NSString *)errorType;
+
++ (NSMutableArray *)serializeThreads:(NSArray<BugsnagThread *> *)threads;
+
++ (NSMutableArray<BugsnagThread *> *)threadsFromArray:(NSArray *)threads
+                                         binaryImages:(NSArray *)binaryImages
+                                                depth:(NSUInteger)depth
+                                            errorType:(nullable NSString *)errorType;
+
+- (NSDictionary *)toDictionary;
+
+@end
+
+BSGThreadType BSGParseThreadType(NSString *type);
+
+NSString *BSGSerializeThreadType(BSGThreadType type);
+
+NS_ASSUME_NONNULL_END

--- a/Tests/BugsnagErrorReportSinkTests.m
+++ b/Tests/BugsnagErrorReportSinkTests.m
@@ -14,6 +14,7 @@
 #import "Bugsnag.h"
 #import "BugsnagHandledState.h"
 #import "BugsnagErrorReportSink.h"
+#import "BugsnagEvent+Private.h"
 #import "BugsnagTestConstants.h"
 
 @interface BugsnagErrorReportSinkTests : XCTestCase
@@ -27,20 +28,6 @@
 
 @interface BugsnagClient ()
 - (void)start;
-@end
-
-@interface BugsnagEvent ()
-- (instancetype)initWithKSReport:(NSDictionary *)report;
-
-- (instancetype)initWithApp:(BugsnagAppWithState *)app
-                     device:(BugsnagDeviceWithState *)device
-               handledState:(BugsnagHandledState *)handledState
-                       user:(BugsnagUser *)user
-                   metadata:(BugsnagMetadata *)metadata
-                breadcrumbs:(NSArray<BugsnagBreadcrumb *> *)breadcrumbs
-                     errors:(NSArray<BugsnagError *> *)errors
-                    threads:(NSArray<BugsnagThread *> *)threads
-                    session:(BugsnagSession *)session;
 @end
 
 @interface BugsnagErrorReportSink ()

--- a/Tests/BugsnagErrorTest.m
+++ b/Tests/BugsnagErrorTest.m
@@ -9,26 +9,13 @@
 #import <XCTest/XCTest.h>
 
 #import "BugsnagKeys.h"
-#import "BugsnagError.h"
+#import "BugsnagError+Private.h"
 #import "BugsnagStackframe.h"
-#import "BugsnagThread.h"
+#import "BugsnagThread+Private.h"
 
 NSString *_Nonnull BSGParseErrorClass(NSDictionary *error, NSString *errorType);
 
 NSString *BSGParseErrorMessage(NSDictionary *report, NSDictionary *error, NSString *errorType);
-
-@interface BugsnagError ()
-- (instancetype)initWithEvent:(NSDictionary *)event errorReportingThread:(BugsnagThread *)thread;
-
-- (NSDictionary *)toDictionary;
-@end
-
-@interface BugsnagThread ()
-+ (NSMutableArray<BugsnagThread *> *)threadsFromArray:(NSArray *)threads
-                                         binaryImages:(NSArray *)binaryImages
-                                                depth:(NSUInteger)depth
-                                            errorType:(NSString *)errorType;
-@end
 
 @interface BugsnagErrorTest : XCTestCase
 @property NSDictionary *event;

--- a/Tests/BugsnagEventFromKSCrashReportTest.m
+++ b/Tests/BugsnagEventFromKSCrashReportTest.m
@@ -7,7 +7,9 @@
 //
 
 @import XCTest;
-#import "Bugsnag.h"
+
+#import <Bugsnag/Bugsnag.h>
+#import "BugsnagEvent+Private.h"
 
 @interface Bugsnag ()
 + (BugsnagConfiguration *)configuration;
@@ -15,14 +17,6 @@
 
 @interface BugsnagEventFromKSCrashReportTest : XCTestCase
 @property BugsnagEvent *event;
-@end
-
-@interface BugsnagEvent ()
-- (NSDictionary *_Nonnull)toJson;
-- (BOOL)shouldBeSent;
-- (instancetype)initWithKSReport:(NSDictionary *)event;
-@property(readwrite, copy, nullable) NSArray *enabledReleaseStages;
-@property(readwrite) NSUInteger depth;
 @end
 
 @implementation BugsnagEventFromKSCrashReportTest

--- a/Tests/BugsnagEventPersistLoadTest.m
+++ b/Tests/BugsnagEventPersistLoadTest.m
@@ -7,7 +7,8 @@
 //
 
 #import <XCTest/XCTest.h>
-#import "BugsnagEvent.h"
+
+#import "BugsnagEvent+Private.h"
 #import "BugsnagAppWithState.h"
 #import "BugsnagUser.h"
 #import "BugsnagDeviceWithState.h"
@@ -16,17 +17,9 @@
 #import "BugsnagBreadcrumb.h"
 #import "BugsnagHandledState.h"
 #import "Bugsnag.h"
-
 #import "BugsnagError.h"
 #import "BugsnagStackframe.h"
 #import "BugsnagThread.h"
-
-@interface BugsnagEvent ()
-- (instancetype)initWithKSReport:(NSDictionary *)report;
-- (NSDictionary *)toJson;
-@property(readonly, nonnull) BugsnagHandledState *handledState;
-@property BugsnagSession *session;
-@end
 
 @interface BugsnagDeviceWithState ()
 @property (nonatomic, readonly) NSDateFormatter *formatter;

--- a/Tests/BugsnagEventTests.m
+++ b/Tests/BugsnagEventTests.m
@@ -11,6 +11,7 @@
 
 #import "BSG_RFC3339DateTool.h"
 #import "Bugsnag.h"
+#import "BugsnagEvent+Private.h"
 #import "BugsnagHandledState.h"
 #import "BugsnagSession.h"
 #import "BugsnagSessionInternal.h"
@@ -30,27 +31,6 @@
 
 @interface Bugsnag ()
 + (BugsnagConfiguration *)configuration;
-@end
-
-@interface BugsnagEvent ()
-- (NSDictionary *_Nonnull)toJson;
-- (BOOL)shouldBeSent;
-- (instancetype)initWithUserData:(NSDictionary *)event;
-- (instancetype)initWithKSReport:(NSDictionary *)report;
-- (instancetype)initWithApp:(BugsnagAppWithState *)app
-                     device:(BugsnagDeviceWithState *)device
-               handledState:(BugsnagHandledState *)handledState
-                       user:(BugsnagUser *)user
-                   metadata:(BugsnagMetadata *)metadata
-                breadcrumbs:(NSArray<BugsnagBreadcrumb *> *)breadcrumbs
-                     errors:(NSArray<BugsnagError *> *)errors
-                    threads:(NSArray<BugsnagThread *> *)threads
-                    session:(BugsnagSession *)session;
-@property (nonatomic, strong) BugsnagMetadata *metadata;
-@property(readwrite) NSUInteger depth;
-@property NSString *releaseStage;
-@property NSArray *enabledReleaseStages;
-@property BugsnagSession *session;
 @end
 
 @interface BugsnagMetadata ()

--- a/Tests/BugsnagMetadataRedactionTest.m
+++ b/Tests/BugsnagMetadataRedactionTest.m
@@ -7,13 +7,8 @@
 //
 
 #import <XCTest/XCTest.h>
-#import "BugsnagEvent.h"
 
-@interface BugsnagEvent ()
-- (NSDictionary *)toJson;
-- (instancetype)initWithKSReport:(NSDictionary *)report;
-@property NSSet<NSString *> *redactedKeys;
-@end
+#import "BugsnagEvent+Private.h"
 
 @interface BugsnagMetadataRedactionTest : XCTestCase
 

--- a/Tests/BugsnagOnCrashTest.m
+++ b/Tests/BugsnagOnCrashTest.m
@@ -9,10 +9,7 @@
 #import <XCTest/XCTest.h>
 
 #import <Bugsnag/Bugsnag.h>
-
-@interface BugsnagEvent ()
-- (instancetype)initWithKSReport:(NSDictionary *)report;
-@end
+#import "BugsnagEvent+Private.h"
 
 @interface BugsnagOnCrashTest : XCTestCase
 

--- a/Tests/BugsnagTests.m
+++ b/Tests/BugsnagTests.m
@@ -7,11 +7,13 @@
 //
 // Unit tests of global Bugsnag behaviour
 
+#import <XCTest/XCTest.h>
+
 #import "Bugsnag.h"
 #import "BugsnagClient.h"
+#import "BugsnagEvent+Private.h"
 #import "BugsnagTestConstants.h"
 #import "BugsnagNotifier.h"
-#import <XCTest/XCTest.h>
 
 // MARK: - BugsnagTests
 
@@ -30,10 +32,6 @@
 @property(readwrite, retain, nullable) BugsnagMetadata *metadata;
 - (void)start;
 @property BugsnagConfiguration *configuration;
-@end
-
-@interface BugsnagEvent ()
-@property (nonatomic, strong) BugsnagMetadata *metadata;
 @end
 
 @interface BugsnagTests : XCTestCase

--- a/Tests/BugsnagThreadSerializationTest.m
+++ b/Tests/BugsnagThreadSerializationTest.m
@@ -3,17 +3,11 @@
 // Copyright (c) 2018 Bugsnag. All rights reserved.
 //
 
-#import <Foundation/Foundation.h>
 #import <XCTest/XCTest.h>
 
-#import "BugsnagEvent.h"
+#import "BugsnagEvent+Private.h"
 
 @interface BugsnagThreadSerializationTest : XCTestCase
-@end
-
-@interface BugsnagEvent ()
-- (NSDictionary *)toJson;
-- (instancetype)initWithKSReport:(NSDictionary *)report;
 @end
 
 @implementation BugsnagThreadSerializationTest

--- a/Tests/BugsnagThreadTest.m
+++ b/Tests/BugsnagThreadTest.m
@@ -9,17 +9,7 @@
 #import <XCTest/XCTest.h>
 
 #import "BugsnagStackframe.h"
-#import "BugsnagThread.h"
-
-@interface BugsnagThread ()
-- (NSDictionary *)toDictionary;
-
-- (instancetype)initWithThread:(NSDictionary *)thread binaryImages:(NSArray *)binaryImages;
-
-+ (NSDictionary *)enhanceThreadInfo:(NSDictionary *)thread
-                              depth:(NSUInteger)depth
-                          errorType:(NSString *)errorType;
-@end
+#import "BugsnagThread+Private.h"
 
 @interface BugsnagThreadTest : XCTestCase
 @property NSArray *binaryImages;

--- a/Tests/BugsnagUserTest.m
+++ b/Tests/BugsnagUserTest.m
@@ -9,20 +9,12 @@
 #import <XCTest/XCTest.h>
 
 #import "BugsnagUser.h"
-#import "BugsnagEvent.h"
-
-@interface BugsnagEvent ()
-- (instancetype)initWithKSReport:(NSDictionary *)report;
-@end
+#import "BugsnagEvent+Private.h"
 
 @interface BugsnagUser ()
 - (instancetype)initWithDictionary:(NSDictionary *)dict;
 - (instancetype)initWithUserId:(NSString *)userId name:(NSString *)name emailAddress:(NSString *)emailAddress;
 - (NSDictionary *)toJson;
-@end
-
-@interface BugsnagEvent ()
-- (instancetype)initWithKSReport:(NSDictionary *)report;
 @end
 
 @interface BugsnagUserTest : XCTestCase

--- a/Tests/EventApiValidationTest.m
+++ b/Tests/EventApiValidationTest.m
@@ -7,11 +7,9 @@
 //
 
 #import <XCTest/XCTest.h>
-#import <Bugsnag/Bugsnag.h>
 
-@interface BugsnagEvent ()
-- (instancetype)initWithKSReport:(NSDictionary *)event;
-@end
+#import <Bugsnag/Bugsnag.h>
+#import "BugsnagEvent+Private.h"
 
 /**
 * Validates that the Event API interface handles any invalid input gracefully.


### PR DESCRIPTION
## Goal

The private interfaces for `BugsnagError` `BugsnagEvent` and `BugsnagThread` need to be amended in order to implement the new `Bugsnag-Stacktrace-Types` HTTP header.

The private interfaces were redeclared throughout the codebase by the classes that needed to access them, leaving a maintenance problem. The goal here is to provide a single definition of the private interface in dedicated header files.

## Changeset

Removed all the private `@interface` declarations from .m files and copied them to individual header files that are not accessible publicly since they are not in the "include" folder.

In some files I sorted the list of imports alphabetically, which makes it easer to scan and know where to put new statements.

## Testing

Ran the unit tests and static analyzer locally.