### PR TITLE
[PLAT-5421] Implement Bugsnag-Stacktrace-Types HTTP header

### DIFF
--- a/Bugsnag/BugsnagErrorReportSink.m
+++ b/Bugsnag/BugsnagErrorReportSink.m
@@ -133,6 +133,7 @@
 
         NSMutableDictionary *apiHeaders = [[configuration errorApiHeaders] mutableCopy];
         apiHeaders[BugsnagHTTPHeaderNameApiKey] = event.apiKey;
+        apiHeaders[BugsnagHTTPHeaderNameStacktraceTypes] = [event.stacktraceTypes componentsJoinedByString:@","];
         [self.apiClient sendJSONPayload:requestPayload headers:apiHeaders toURL:configuration.notifyURL
                       completionHandler:^(BugsnagApiClientDeliveryStatus status, NSError *error) {
             BOOL completed = status == BugsnagApiClientDeliveryStatusDelivered || status == BugsnagApiClientDeliveryStatusUndeliverable;

--- a/Bugsnag/Delivery/BugsnagApiClient.h
+++ b/Bugsnag/Delivery/BugsnagApiClient.h
@@ -12,6 +12,7 @@ typedef NSString * BugsnagHTTPHeaderName NS_TYPED_ENUM;
 extern BugsnagHTTPHeaderName const BugsnagHTTPHeaderNameApiKey;
 extern BugsnagHTTPHeaderName const BugsnagHTTPHeaderNamePayloadVersion;
 extern BugsnagHTTPHeaderName const BugsnagHTTPHeaderNameSentAt;
+extern BugsnagHTTPHeaderName const BugsnagHTTPHeaderNameStacktraceTypes;
 
 typedef NS_ENUM(NSInteger, BugsnagApiClientDeliveryStatus) {
     /// The payload was delivered successfully and can be deleted.

--- a/Bugsnag/Delivery/BugsnagApiClient.m
+++ b/Bugsnag/Delivery/BugsnagApiClient.m
@@ -14,6 +14,7 @@
 BugsnagHTTPHeaderName const BugsnagHTTPHeaderNameApiKey             = @"Bugsnag-Api-Key";
 BugsnagHTTPHeaderName const BugsnagHTTPHeaderNamePayloadVersion     = @"Bugsnag-Payload-Version";
 BugsnagHTTPHeaderName const BugsnagHTTPHeaderNameSentAt             = @"Bugsnag-Sent-At";
+BugsnagHTTPHeaderName const BugsnagHTTPHeaderNameStacktraceTypes    = @"Bugsnag-Stacktrace-Types";
 
 typedef NS_ENUM(NSInteger, HTTPStatusCode) {
     /// 402 Payment Required: a nonstandard client error status response code that is reserved for future use.

--- a/Bugsnag/Payload/BugsnagEvent+Private.h
+++ b/Bugsnag/Payload/BugsnagEvent+Private.h
@@ -44,6 +44,9 @@ NS_ASSUME_NONNULL_BEGIN
 
 @property (strong, nullable, nonatomic) BugsnagSession *session;
 
+/// An array of string representations of BSGErrorType describing the types of stackframe / stacktrace in this error.
+@property (readonly, nonatomic) NSArray<NSString *> *stacktraceTypes;
+
 - (instancetype)initWithApp:(nullable BugsnagAppWithState *)app
                      device:(nullable BugsnagDeviceWithState *)device
                handledState:(BugsnagHandledState *)handledState

--- a/Tests/BugsnagEventTests.m
+++ b/Tests/BugsnagEventTests.m
@@ -15,6 +15,7 @@
 #import "BugsnagHandledState.h"
 #import "BugsnagSession.h"
 #import "BugsnagSessionInternal.h"
+#import "BugsnagStackframe+Private.h"
 #import "BugsnagStateEvent.h"
 #import "BugsnagTestConstants.h"
 #import "BugsnagTestsDummyClass.h"
@@ -537,6 +538,47 @@
         XCTAssertEqual(event.apiKey, DUMMY_APIKEY_32CHAR_1);
         return true;
     }];
+}
+
+- (void)testStacktraceTypes {
+    BugsnagEvent *event = [[BugsnagEvent alloc] init];
+    XCTAssertEqualObjects(event.stacktraceTypes, @[]);
+    
+    BugsnagError *error = [[BugsnagError alloc] init];
+    event.errors = @[error];
+    error.type = BSGErrorTypeCocoa;
+    XCTAssertEqualObjects(event.stacktraceTypes, @[@"cocoa"]);
+    
+    error.type = BSGErrorTypeReactNativeJs;
+    XCTAssertEqualObjects(event.stacktraceTypes, @[@"reactnativejs"]);
+    
+    NSArray *(^ sorted)(NSArray *) = ^(NSArray *array) { return [array sortedArrayUsingSelector:@selector(compare:)]; };
+    
+    error.stacktrace = @[
+        [BugsnagStackframe frameFromJson:@{}],
+        [BugsnagStackframe frameFromJson:@{@"type": @"cocoa"}],
+        [BugsnagStackframe frameFromJson:@{@"type": @"reactnativejs"}],
+    ];
+    XCTAssertEqualObjects(sorted(event.stacktraceTypes), (@[@"cocoa", @"reactnativejs"]));
+    
+    event.errors = @[[[BugsnagError alloc] init]];
+    
+    BugsnagThread *thread1 = [[BugsnagThread alloc] init];
+    thread1.stacktrace = @[
+        [BugsnagStackframe frameFromJson:@{@"type": @"c"}],
+        [BugsnagStackframe frameFromJson:@{@"type": @"java"}],
+    ];
+    thread1.type = BSGThreadTypeCocoa;
+    event.threads = @[thread1];
+    XCTAssertEqualObjects(sorted(event.stacktraceTypes), (@[@"c", @"cocoa", @"java"]));
+
+    BugsnagThread *thread2 = [[BugsnagThread alloc] init];
+    thread2.stacktrace = @[
+        [BugsnagStackframe frameFromJson:@{@"type": @"csharp"}],
+        [BugsnagStackframe frameFromJson:@{@"type": @"android"}],
+    ];
+    event.threads = @[thread1, thread2];
+    XCTAssertEqualObjects(sorted(event.stacktraceTypes), (@[@"android", @"c", @"cocoa", @"csharp", @"java"]));
 }
 
 // MARK: - Metadata interface


### PR DESCRIPTION
## Goal

The new `Bugsnag-Stacktrace-Types` HTTP header informs the back-end about the contents of the payload without having to parse it.

## Changeset

`BugnagErrorReportSink` sets the new HTTP header on outgoing requests.

Added a `stacktraceTypes` computed property on BugsnagEvent to make the logic testable.

Note that since (cocoa) threads are captured by default, all React Native errors will contain `reactnativejs` and `cocoa` types.

## Testing

Added unit tests to verify the expected types are returned for different kinds of events.

Manually verified the changes when used with BugsnagReactNative.