### PR TITLE
Don't error on first launch

### DIFF
--- a/Bugsnag/KSCrash/Source/KSCrash/Recording/BSG_KSCrashState.m
+++ b/Bugsnag/KSCrash/Source/KSCrash/Recording/BSG_KSCrashState.m
@@ -180,7 +180,9 @@ bool bsg_kscrashstate_i_loadState(BSG_KSCrash_State *const context,
     NSError *error = nil;
     NSData *data = [NSData dataWithContentsOfFile:[NSString stringWithUTF8String:path] options:0 error:&error];
     if (error != nil) {
-        BSG_KSLOG_ERROR(@"%s: Could not load file: %@", path, error);
+        if (!(error.domain == NSCocoaErrorDomain && error.code == NSFileReadNoSuchFileError)) {
+            BSG_KSLOG_ERROR(@"%s: Could not load file: %@", path, error);
+        }
         return false;
     }
     id objectContext = [BSG_KSJSONCodec decode:data options:0 error:&error];


### PR DESCRIPTION
## Goal

On first launch, the state file won't be present (because it hasn't been created yet). Printing an error because of this is poor UX.

## Design

Check if the error is "file not found" and if so, don't print an error.

## Testing

Manually tested by wiping a device and running multiple times.
