### PR TITLE
[PLAT-5450] Add missing app and device data to OOM events

### DIFF
--- a/Bugsnag/BugsnagSystemState.h
+++ b/Bugsnag/BugsnagSystemState.h
@@ -34,7 +34,15 @@ NS_ASSUME_NONNULL_BEGIN
 - (instancetype)init NS_UNAVAILABLE;
 - (instancetype)initWithConfiguration:(BugsnagConfiguration *)config;
 
+- (void)recordAppUUID;
+
+- (void)setBatteryCharging:(BOOL)charging;
+
+- (void)setBatteryLevel:(NSNumber *)batteryLevel;
+
 - (void)setCodeBundleID:(NSString*)codeBundleID;
+
+- (void)setOrientation:(NSString *)orientation;
 
 /**
  * Purge all stored system state.

--- a/Bugsnag/BugsnagSystemState.m
+++ b/Bugsnag/BugsnagSystemState.m
@@ -27,6 +27,10 @@
 #define STATE_DIR @"bugsnag/state"
 #define STATE_FILE @"system_state.json"
 
+#if BSG_PLATFORM_IOS
+NSString *BSGOrientationNameFromEnum(UIDeviceOrientation deviceOrientation);
+#endif
+
 static NSDictionary* loadPreviousState(BugsnagKVStore *kvstore, NSString *jsonPath) {
     NSData *data = [NSData dataWithContentsOfFile:jsonPath];
     if(data == nil) {
@@ -127,6 +131,12 @@ static NSMutableDictionary* initCurrentState(BugsnagKVStore *kvstore, BugsnagCon
     device[@"simulator"] = @NO;
 #endif
     device[@"totalMemory"] = systemInfo[@BSG_KSSystemField_Memory][@"usable"];
+#if BSG_PLATFORM_IOS
+    device[BSGKeyBatteryLevel] = @([UIDevice currentDevice].batteryLevel);
+    UIDeviceBatteryState batteryState = [UIDevice currentDevice].batteryState;
+    device[BSGKeyCharging] = @(batteryState == UIDeviceBatteryStateCharging || batteryState == UIDeviceBatteryStateFull);
+    device[BSGKeyOrientation] = BSGOrientationNameFromEnum([UIDevice currentDevice].orientation);
+#endif
 
     NSMutableDictionary *state = [NSMutableDictionary new];
     state[BSGKeyApp] = app;

--- a/Bugsnag/BugsnagSystemState.m
+++ b/Bugsnag/BugsnagSystemState.m
@@ -231,18 +231,18 @@ NSDictionary *copyLaunchState(NSDictionary *launchState) {
 }
 
 - (void)setValue:(id)value forAppKey:(NSString *)key {
-    [self setValue:value forKey:key inDictionary:SYSTEMSTATE_KEY_APP];
+    [self setValue:value forKey:key inSection:SYSTEMSTATE_KEY_APP];
 }
 
 - (void)setValue:(id)value forDeviceKey:(NSString *)key {
-    [self setValue:value forKey:key inDictionary:SYSTEMSTATE_KEY_DEVICE];
+    [self setValue:value forKey:key inSection:SYSTEMSTATE_KEY_DEVICE];
 }
 
-- (void)setValue:(id)value forKey:(NSString *)key inDictionary:(NSString *)dictionary {
+- (void)setValue:(id)value forKey:(NSString *)key inSection:(NSString *)section {
     // Run on a BG thread so we don't monopolize the notification queue.
     dispatch_async(dispatch_get_global_queue( DISPATCH_QUEUE_PRIORITY_DEFAULT, 0), ^(void){
         @synchronized (self) {
-            self.currentLaunchStateRW[dictionary][key] = value;
+            self.currentLaunchStateRW[section][key] = value;
             // User-facing state should never mutate from under them.
             self.currentLaunchState = copyLaunchState(self.currentLaunchStateRW);
         }

--- a/Bugsnag/BugsnagSystemState.m
+++ b/Bugsnag/BugsnagSystemState.m
@@ -117,11 +117,16 @@ static NSMutableDictionary* initCurrentState(BugsnagKVStore *kvstore, BugsnagCon
     device[@"modelNumber"] = systemInfo[@ BSG_KSSystemField_Model];
     device[@"wordSize"] = @(PLATFORM_WORD_SIZE);
     device[@"locale"] = [[NSLocale currentLocale] localeIdentifier];
+    device[@"runtimeVersions"] = @{
+        @"clangVersion": systemInfo[@BSG_KSSystemField_ClangVersion] ?: @"",
+        @"osBuild": systemInfo[@BSG_KSSystemField_OSVersion] ?: @""
+    };
 #if BSG_PLATFORM_SIMULATOR
     device[@"simulator"] = @YES;
 #else
     device[@"simulator"] = @NO;
 #endif
+    device[@"totalMemory"] = systemInfo[@BSG_KSSystemField_Memory][@"usable"];
 
     NSMutableDictionary *state = [NSMutableDictionary new];
     state[BSGKeyApp] = app;
@@ -167,11 +172,11 @@ NSDictionary *copyLaunchState(NSDictionary *launchState) {
         // MacOS "active" serves the same purpose as "foreground" in iOS
         [center addObserverForName:NSApplicationDidBecomeActiveNotification object:nil queue:nil usingBlock:^(NSNotification * _Nonnull note) {
             [weakSelf.kvStore setBoolean:YES forKey:SYSTEMSTATE_APP_IS_IN_FOREGROUND];
-            [weakSelf bgSetAppValue:@YES forKey:SYSTEMSTATE_APP_IS_IN_FOREGROUND];
+            [weakSelf setValue:@YES forAppKey:SYSTEMSTATE_APP_IS_IN_FOREGROUND];
         }];
         [center addObserverForName:NSApplicationDidResignActiveNotification object:nil queue:nil usingBlock:^(NSNotification * _Nonnull note) {
             [weakSelf.kvStore setBoolean:NO forKey:SYSTEMSTATE_APP_IS_IN_FOREGROUND];
-            [weakSelf bgSetAppValue:@NO forKey:SYSTEMSTATE_APP_IS_IN_FOREGROUND];
+            [weakSelf setValue:@NO forAppKey:SYSTEMSTATE_APP_IS_IN_FOREGROUND];
         }];
 #else
         [center addObserverForName:UIApplicationWillTerminateNotification object:nil queue:nil usingBlock:^(NSNotification * _Nonnull note) {
@@ -180,46 +185,70 @@ NSDictionary *copyLaunchState(NSDictionary *launchState) {
         }];
         [center addObserverForName:UIApplicationWillEnterForegroundNotification object:nil queue:nil usingBlock:^(NSNotification * _Nonnull note) {
             [weakSelf.kvStore setBoolean:YES forKey:SYSTEMSTATE_APP_IS_IN_FOREGROUND];
-            [weakSelf bgSetAppValue:@YES forKey:SYSTEMSTATE_APP_IS_IN_FOREGROUND];
+            [weakSelf setValue:@YES forAppKey:SYSTEMSTATE_APP_IS_IN_FOREGROUND];
         }];
         [center addObserverForName:UIApplicationDidEnterBackgroundNotification object:nil queue:nil usingBlock:^(NSNotification * _Nonnull note) {
             [weakSelf.kvStore setBoolean:NO forKey:SYSTEMSTATE_APP_IS_IN_FOREGROUND];
-            [weakSelf bgSetAppValue:@NO forKey:SYSTEMSTATE_APP_IS_IN_FOREGROUND];
+            [weakSelf setValue:@NO forAppKey:SYSTEMSTATE_APP_IS_IN_FOREGROUND];
         }];
         [center addObserverForName:UIApplicationDidBecomeActiveNotification object:nil queue:nil usingBlock:^(NSNotification * _Nonnull note) {
             [weakSelf.kvStore setBoolean:YES forKey:SYSTEMSTATE_APP_IS_ACTIVE];
-            [weakSelf bgSetAppValue:@YES forKey:SYSTEMSTATE_APP_IS_ACTIVE];
+            [weakSelf setValue:@YES forAppKey:SYSTEMSTATE_APP_IS_ACTIVE];
         }];
         [center addObserverForName:UIApplicationWillResignActiveNotification object:nil queue:nil usingBlock:^(NSNotification * _Nonnull note) {
             [weakSelf.kvStore setBoolean:NO forKey:SYSTEMSTATE_APP_IS_ACTIVE];
-            [weakSelf bgSetAppValue:@NO forKey:SYSTEMSTATE_APP_IS_ACTIVE];
+            [weakSelf setValue:@NO forAppKey:SYSTEMSTATE_APP_IS_ACTIVE];
         }];
         [center addObserverForName:UIApplicationDidReceiveMemoryWarningNotification object:nil queue:nil usingBlock:^(NSNotification * _Nonnull note) {
             NSString *date = [BSG_RFC3339DateTool stringFromDate:[NSDate date]];
             [weakSelf.kvStore setString:date forKey:SYSTEMSTATE_APP_LAST_LOW_MEMORY_WARNING];
-            [weakSelf bgSetAppValue:date forKey:SYSTEMSTATE_APP_LAST_LOW_MEMORY_WARNING];
+            [weakSelf setValue:date forAppKey:SYSTEMSTATE_APP_LAST_LOW_MEMORY_WARNING];
         }];
 #endif
     }
     return self;
 }
 
-- (void)setCodeBundleID:(NSString*)codeBundleID {
-    [self bgSetAppValue:codeBundleID forKey:BSGKeyCodeBundleId];
+- (void)recordAppUUID {
+    // [BSG_KSSystemInfo appUUID] returns nil until we have called _dyld_register_func_for_add_image()
+    [self setValue:[BSG_KSSystemInfo appUUID] forAppKey:BSGKeyMachoUUID];
 }
 
-- (void)bgSetAppValue:(id)value forKey:(NSString*)key {
+- (void)setBatteryCharging:(BOOL)charging {
+    [self setValue:@(charging) forDeviceKey:BSGKeyCharging];
+}
+
+- (void)setBatteryLevel:(NSNumber *)batteryLevel {
+    [self setValue:batteryLevel forDeviceKey:BSGKeyBatteryLevel];
+}
+
+- (void)setCodeBundleID:(NSString*)codeBundleID {
+    [self setValue:codeBundleID forAppKey:BSGKeyCodeBundleId];
+}
+
+- (void)setOrientation:(NSString *)orientation {
+    [self setValue:orientation forDeviceKey:BSGKeyOrientation];
+}
+
+- (void)setValue:(id)value forAppKey:(NSString *)key {
+    [self setValue:value forKey:key inDictionary:SYSTEMSTATE_KEY_APP];
+}
+
+- (void)setValue:(id)value forDeviceKey:(NSString *)key {
+    [self setValue:value forKey:key inDictionary:SYSTEMSTATE_KEY_DEVICE];
+}
+
+- (void)setValue:(id)value forKey:(NSString *)key inDictionary:(NSString *)dictionary {
     // Run on a BG thread so we don't monopolize the notification queue.
     dispatch_async(dispatch_get_global_queue( DISPATCH_QUEUE_PRIORITY_DEFAULT, 0), ^(void){
         @synchronized (self) {
-            self.currentLaunchStateRW[SYSTEMSTATE_KEY_APP][key] = value;
+            self.currentLaunchStateRW[dictionary][key] = value;
             // User-facing state should never mutate from under them.
             self.currentLaunchState = copyLaunchState(self.currentLaunchStateRW);
         }
         [self sync];
     });
 }
-
 
 - (void)sync {
     NSDictionary *state = self.currentLaunchState;

--- a/Bugsnag/Client/BugsnagClient.m
+++ b/Bugsnag/Client/BugsnagClient.m
@@ -560,6 +560,7 @@ NSString *const BSGBreadcrumbLoadedMessage = @"Bugsnag loaded";
     [[UIDevice currentDevice] beginGeneratingDeviceOrientationNotifications];
 
     [self batteryChanged:nil];
+    [self orientationChanged:nil];
     [self addTerminationObserver:UIApplicationWillTerminateNotification];
 
 #elif BSG_PLATFORM_OSX

--- a/Bugsnag/Client/BugsnagClient.m
+++ b/Bugsnag/Client/BugsnagClient.m
@@ -523,6 +523,7 @@ NSString *const BSGBreadcrumbLoadedMessage = @"Bugsnag loaded";
     [self.crashSentry install:self.configuration
                     apiClient:self.errorReportApiClient
                       onCrash:&BSSerializeDataCrashHandler];
+    [self.systemState recordAppUUID]; // Needs to be called after crashSentry installed but before -computeDidCrashLastLaunch
     [self computeDidCrashLastLaunch];
     [self.breadcrumbs removeAllBreadcrumbs];
     [self setupConnectivityListener];
@@ -1173,6 +1174,10 @@ NSString *const BSGBreadcrumbLoadedMessage = @"Bugsnag loaded";
     [self.state addMetadata:charging ? @YES : @NO
                     withKey:BSGKeyCharging
                   toSection:BSGKeyDeviceState];
+    
+    [self.systemState setBatteryLevel:batteryLevel];
+    
+    [self.systemState setBatteryCharging:charging];
 }
 
 /**
@@ -1194,6 +1199,8 @@ NSString *const BSGBreadcrumbLoadedMessage = @"Bugsnag loaded";
     [self.state addMetadata:orientation
                     withKey:BSGKeyOrientation
                   toSection:BSGKeyDeviceState];
+    
+    [self.systemState setOrientation:orientation];
 
     // Short-circuit the exit if we don't have enough info to record a full breadcrumb
     // or the orientation hasn't changed (false positive).

--- a/Bugsnag/KSCrash/Source/KSCrash/Recording/BSG_KSSystemInfo.h
+++ b/Bugsnag/KSCrash/Source/KSCrash/Recording/BSG_KSSystemInfo.h
@@ -74,6 +74,12 @@
  */
 + (NSDictionary *)systemInfo;
 
+/** Get this application's UUID.
+ *
+ * @return The UUID.
+ */
++ (NSString *)appUUID;
+
 /**
  * The build version of the OS
  */
@@ -99,6 +105,7 @@
  * YES if the app is currently shown in the foreground
  */
 + (BOOL)isInForeground:(UIApplicationState)state;
+
 #endif
 
 @end

--- a/Bugsnag/Payload/BugsnagAppWithState.m
+++ b/Bugsnag/Payload/BugsnagAppWithState.m
@@ -59,6 +59,7 @@
 {
     BugsnagAppWithState *app = [BugsnagAppWithState new];
     app.id = event[@"id"];
+    app.dsymUuid = event[BSGKeyMachoUUID];
     app.releaseStage = event[@"releaseStage"];
     app.version = event[@"version"];
     app.bundleVersion = event[@"bundleVersion"];

--- a/Bugsnag/Payload/BugsnagDeviceWithState.m
+++ b/Bugsnag/Payload/BugsnagDeviceWithState.m
@@ -15,7 +15,7 @@
 #import "BugsnagSystemState.h"
 #import "Bugsnag.h"
 
-NSDictionary *BSGParseDeviceMetadata(NSDictionary *event) {
+NSMutableDictionary *BSGParseDeviceMetadata(NSDictionary *event) {
     NSMutableDictionary *device = [NSMutableDictionary new];
     NSDictionary *state = [event valueForKeyPath:@"user.state.deviceState"];
     [device addEntriesFromDictionary:state];
@@ -95,9 +95,13 @@ NSNumber *BSGDeviceFreeSpace(NSSearchPathDirectory directory) {
     device.id = data[@"id"];
     device.osVersion = data[@"osVersion"];
     device.osName = data[@"osName"];
+    device.manufacturer = @"Apple";
     device.model = data[@"model"];
     device.modelNumber = data[@"modelNumber"];
+    device.orientation = data[@"orientation"];
     device.locale = data[@"locale"];
+    device.runtimeVersions = data[@"runtimeVersions"];
+    device.totalMemory = data[@"totalMemory"];
     return device;
 }
 

--- a/Bugsnag/Payload/BugsnagEvent.m
+++ b/Bugsnag/Payload/BugsnagEvent.m
@@ -38,7 +38,7 @@ static NSString *const DEFAULT_EXCEPTION_TYPE = @"cocoa";
 
 // MARK: - Accessing hidden methods/properties
 
-NSDictionary *_Nonnull BSGParseDeviceMetadata(NSDictionary *_Nonnull event);
+NSMutableDictionary *_Nonnull BSGParseDeviceMetadata(NSDictionary *_Nonnull event);
 NSDictionary *_Nonnull BSGParseAppMetadata(NSDictionary *_Nonnull event);
 
 @interface BugsnagAppWithState ()
@@ -296,7 +296,12 @@ NSDictionary *BSGParseCustomException(NSDictionary *report,
     }
     BugsnagMetadata *metadata = [BugsnagMetadata new];
     // Cocoa-specific, non-spec., device and app data
-    [metadata addMetadata:BSGParseDeviceMetadata(event) toSection:BSGKeyDevice];
+    NSMutableDictionary *deviceMetadata = BSGParseDeviceMetadata(event);
+    // This can be removed once metadata is being persisted to disk
+    deviceMetadata[BSGKeyBatteryLevel]  = [event valueForKeyPath:@"user.state.oom.device.batteryLevel"];
+    deviceMetadata[BSGKeyCharging]      = [event valueForKeyPath:@"user.state.oom.device.charging"];
+    deviceMetadata[BSGKeyOrientation]   = [event valueForKeyPath:@"user.state.oom.device.orientation"];
+    [metadata addMetadata:deviceMetadata toSection:BSGKeyDevice];
     [metadata addMetadata:BSGParseAppMetadata(event) toSection:BSGKeyApp];
 
     BugsnagEvent *obj = [self initWithApp:[BugsnagAppWithState appWithOomData:[event valueForKeyPath:@"user.state.oom.app"]]

--- a/features/out_of_memory.feature
+++ b/features/out_of_memory.feature
@@ -24,6 +24,9 @@ Feature: Out of memory errors
 
     # Ensure the basic data from OOMs are present
     And the event "device.jailbroken" is false
+    And the event "metaData.device.batteryLevel" is not null
+    And the event "metaData.device.charging" is not null
+    And the event "metaData.device.orientation" is not null
     And the event "metaData.device.timezone" is not null
     And the event "metaData.device.simulator" is false
     And the event "metaData.device.wordSize" is not null
@@ -32,7 +35,12 @@ Feature: Out of memory errors
     And the event "app.inForeground" is true
     And the event "app.type" equals "iOS"
     And the event "app.bundleVersion" is not null
+    And the event "app.dsymUUIDs" is not null
     And the event "app.version" is not null
+    And the event "device.manufacturer" equals "Apple"
+    And the event "device.orientation" is not null
+    And the event "device.runtimeVersions" is not null
+    And the event "device.totalMemory" is not null
 
     # Ensure breadcrumbs are carried over
     And the event has a "manual" breadcrumb named "OOMLoadScenarioBreadcrumb"


### PR DESCRIPTION
## Goal

Out Of Memory errors have been missing some of the information present in other types of errors reported by Bugsnag.

The aim of this PR is to add the following data:

* `batteryLevel`
* `charging`
* `dsymUUIDs`
* `manufacturer`
* `orientation`
* `runtimeVersions`
* `totalMemory`

## Design

The additional information is captured in `BugnagSystemState` as this information is already being used to generate the OOM error payload.

## Changeset

`BugnagSystemState` has been amended to capture additional information.

`BugsnagAppWithState`, `BugsnagDeviceWithState` and `BugsnagEvent` have been updated to read this new information. 

## Testing

Manually tested and verified by examining the payloads sent to the notify endpoint.