### PR TITLE
Allow overriding the unhandled flag in non-fatal errors.

### DIFF
--- a/Bugsnag/Client/BugsnagClient.m
+++ b/Bugsnag/Client/BugsnagClient.m
@@ -1017,12 +1017,16 @@ NSString *const BSGBreadcrumbLoadedMessage = @"Bugsnag loaded";
         [event.metadata addMetadata:deviceFields toSection:BSGKeyDevice];
     }
 
+    BOOL originalUnhandledValue = event.unhandled;
     @try {
         if (block != nil && !block(event)) { // skip notifying if callback false
             return;
         }
     } @catch (NSException *exception) {
         bsg_log_err(@"Error from onError callback: %@", exception);
+    }
+    if (event.unhandled != originalUnhandledValue) {
+        [event notifyUnhandledOverridden];
     }
 
     if (event.handledState.unhandled) {

--- a/Bugsnag/Helpers/BugsnagKeys.h
+++ b/Bugsnag/Helpers/BugsnagKeys.h
@@ -96,6 +96,7 @@ extern NSString *const BSGKeyThreads;
 extern NSString *const BSGKeyTimestamp;
 extern NSString *const BSGKeyType;
 extern NSString *const BSGKeyUnhandled;
+extern NSString *const BSGKeyUnhandledOverridden;
 extern NSString *const BSGKeyUrl;
 extern NSString *const BSGKeyUser;
 extern NSString *const BSGKeyUuid;

--- a/Bugsnag/Helpers/BugsnagKeys.m
+++ b/Bugsnag/Helpers/BugsnagKeys.m
@@ -92,6 +92,7 @@ NSString *const BSGKeyThreads = @"threads";
 NSString *const BSGKeyTimestamp = @"timestamp";
 NSString *const BSGKeyType = @"type";
 NSString *const BSGKeyUnhandled = @"unhandled";
+NSString *const BSGKeyUnhandledOverridden = @"unhandledOverridden";
 NSString *const BSGKeyUrl = @"url";
 NSString *const BSGKeyUser = @"user";
 NSString *const BSGKeyUuid = @"uuid";

--- a/Bugsnag/Payload/BugsnagEvent+Private.h
+++ b/Bugsnag/Payload/BugsnagEvent+Private.h
@@ -68,6 +68,8 @@ NS_ASSUME_NONNULL_BEGIN
 
 - (NSDictionary *)toJson;
 
+- (void)notifyUnhandledOverridden;
+
 @end
 
 NS_ASSUME_NONNULL_END

--- a/Bugsnag/Payload/BugsnagEvent.m
+++ b/Bugsnag/Payload/BugsnagEvent.m
@@ -658,6 +658,10 @@ NSDictionary *BSGParseCustomException(NSDictionary *report,
     }
 }
 
+- (void)notifyUnhandledOverridden {
+    self.handledState.unhandledOverridden = YES;
+}
+
 - (NSDictionary *)toJson {
     NSMutableDictionary *event = [NSMutableDictionary dictionary];
 
@@ -691,6 +695,7 @@ NSDictionary *BSGParseCustomException(NSDictionary *report,
 
 
     BSGDictSetSafeObject(event, @(self.handledState.unhandled), BSGKeyUnhandled);
+    BSGDictSetSafeObject(event, @(self.handledState.unhandledOverridden), BSGKeyUnhandledOverridden);
 
     // serialize handled/unhandled into payload
     NSMutableDictionary *severityReason = [NSMutableDictionary new];
@@ -783,6 +788,10 @@ NSDictionary *BSGParseCustomException(NSDictionary *report,
     return self.handledState.unhandled;
 }
 
+- (void)setUnhandled:(BOOL)unhandled {
+    self.handledState.unhandled = unhandled;
+}
+
 // MARK: - <BugsnagMetadataStore>
 
 - (void)addMetadata:(NSDictionary *_Nonnull)metadata
@@ -818,10 +827,6 @@ NSDictionary *BSGParseCustomException(NSDictionary *report,
                        withKey:(NSString *_Nonnull)key
 {
     [self.metadata clearMetadataFromSection:sectionName withKey:key];
-}
-
-- (void)updateUnhandled:(BOOL)val {
-    self.handledState.unhandled = val;
 }
 
 #pragma mark -

--- a/Bugsnag/Payload/BugsnagHandledState.h
+++ b/Bugsnag/Payload/BugsnagHandledState.h
@@ -43,6 +43,7 @@ NSString *BSGFormatSeverity(BSGSeverity severity);
 @interface BugsnagHandledState : NSObject
 
 @property(nonatomic) BOOL unhandled;
+@property(nonatomic) BOOL unhandledOverridden;
 @property(nonatomic, readonly) SeverityReasonType severityReasonType;
 @property(nonatomic, readonly) BSGSeverity originalSeverity;
 @property(nonatomic) BSGSeverity currentSeverity;
@@ -66,6 +67,7 @@ NSString *BSGFormatSeverity(BSGSeverity severity);
 - (instancetype)initWithSeverityReason:(SeverityReasonType)severityReason
                               severity:(BSGSeverity)severity
                              unhandled:(BOOL)unhandled
+                   unhandledOverridden:(BOOL)unhandledOverridden
                              attrValue:(NSString *)attrValue;
 
 - (NSDictionary *)toJson;

--- a/Bugsnag/Payload/BugsnagHandledState.m
+++ b/Bugsnag/Payload/BugsnagHandledState.m
@@ -29,6 +29,7 @@ NSString *BSGFormatSeverity(BSGSeverity severity) {
 }
 
 static NSString *const kUnhandled = @"unhandled";
+static NSString *const kUnhandledOverridden = @"unhandledOverridden";
 static NSString *const kSeverityReasonType = @"severityReasonType";
 static NSString *const kOriginalSeverity = @"originalSeverity";
 static NSString *const kCurrentSeverity = @"currentSeverity";
@@ -49,6 +50,7 @@ static NSString *const kUserCallbackSetSeverity = @"userCallbackSetSeverity";
 
 + (instancetype)handledStateFromJson:(NSDictionary *)json {
     BOOL unhandled = [json[@"unhandled"] boolValue];
+    BOOL unhandledOverridden = [json[@"unhandledOverridden"] boolValue];
     NSDictionary *data = json[@"severityReason"];
     BSGSeverity severity = BSGParseSeverity(json[@"severity"]);
 
@@ -62,6 +64,7 @@ static NSString *const kUserCallbackSetSeverity = @"userCallbackSetSeverity";
     return [[BugsnagHandledState alloc] initWithSeverityReason:reason
                                                       severity:severity
                                                      unhandled:unhandled
+                                           unhandledOverridden:unhandledOverridden
                                                      attrValue:attrValue];
 }
 
@@ -77,6 +80,7 @@ static NSString *const kUserCallbackSetSeverity = @"userCallbackSetSeverity";
                                       severity:(BSGSeverity)severity
                                      attrValue:(NSString *)attrValue {
     BOOL unhandled = NO;
+    BOOL unhandledOverridden = NO;
 
     switch (severityReason) {
     case PromiseRejection:
@@ -107,18 +111,21 @@ static NSString *const kUserCallbackSetSeverity = @"userCallbackSetSeverity";
     return [[BugsnagHandledState alloc] initWithSeverityReason:severityReason
                                                       severity:severity
                                                      unhandled:unhandled
+                                           unhandledOverridden:unhandledOverridden
                                                      attrValue:attrValue];
 }
 
 - (instancetype)initWithSeverityReason:(SeverityReasonType)severityReason
                               severity:(BSGSeverity)severity
                              unhandled:(BOOL)unhandled
+                   unhandledOverridden:(BOOL)unhandledOverridden
                              attrValue:(NSString *)attrValue {
     if (self = [super init]) {
         _severityReasonType = severityReason;
         _currentSeverity = severity;
         _originalSeverity = severity;
         _unhandled = unhandled;
+        _unhandledOverridden = unhandledOverridden;
 
         if (severityReason == Signal) {
             _attrValue = attrValue;
@@ -199,6 +206,9 @@ static NSString *const kUserCallbackSetSeverity = @"userCallbackSetSeverity";
 - (NSDictionary *)toJson {
     NSMutableDictionary *dict = [NSMutableDictionary new];
     dict[kUnhandled] = @(self.unhandled);
+    if(self.unhandledOverridden) {
+        dict[kUnhandledOverridden] = @(self.unhandledOverridden);
+    }
     dict[kSeverityReasonType] =
         [BugsnagHandledState stringFromSeverityReason:self.severityReasonType];
     dict[kOriginalSeverity] = BSGFormatSeverity(self.originalSeverity);

--- a/Bugsnag/include/Bugsnag/BugsnagEvent.h
+++ b/Bugsnag/include/Bugsnag/BugsnagEvent.h
@@ -81,7 +81,7 @@ typedef NS_ENUM(NSUInteger, BSGSeverity) {
  * Whether the event was a crash (i.e. unhandled) or handled error in which the system
  * continued running.
  */
-@property(readonly) BOOL unhandled;
+@property(readwrite) BOOL unhandled;
 
 /**
  * Thread traces for the error that occurred, if collection was enabled.

--- a/Tests/BugsnagErrorReportSinkTests.m
+++ b/Tests/BugsnagErrorReportSinkTests.m
@@ -121,6 +121,7 @@
                            @"severityReason",
                            @"threads",
                            @"unhandled",
+                           @"unhandledOverridden",
                            @"user",
                            ];
     XCTAssertEqualObjects(actualKeys, eventKeys);
@@ -352,6 +353,38 @@
     [BugsnagHandledState stringFromSeverityReason:HandledException];
     XCTAssertEqualObjects(expected, severityReason[@"type"]);
     XCTAssertNil(severityReason[@"attributes"]);
+}
+
+- (void)testHandledOverriddenSerialization {
+    BugsnagHandledState *state =
+    [BugsnagHandledState handledStateWithSeverityReason:HandledException];
+    state.unhandled = YES;
+    state.unhandledOverridden = YES;
+    NSDictionary *payload = [self reportFromHandledState:state];
+    
+    XCTAssertTrue([payload[@"unhandled"] boolValue]);
+    XCTAssertTrue([payload[@"unhandledOverridden"] boolValue]);
+
+    state.unhandled = YES;
+    state.unhandledOverridden = NO;
+    payload = [self reportFromHandledState:state];
+    
+    XCTAssertTrue([payload[@"unhandled"] boolValue]);
+    XCTAssertFalse([payload[@"unhandledOverridden"] boolValue]);
+
+    state.unhandled = NO;
+    state.unhandledOverridden = YES;
+    payload = [self reportFromHandledState:state];
+    
+    XCTAssertFalse([payload[@"unhandled"] boolValue]);
+    XCTAssertTrue([payload[@"unhandledOverridden"] boolValue]);
+
+    state.unhandled = NO;
+    state.unhandledOverridden = NO;
+    payload = [self reportFromHandledState:state];
+    
+    XCTAssertFalse([payload[@"unhandled"] boolValue]);
+    XCTAssertFalse([payload[@"unhandledOverridden"] boolValue]);
 }
 
 - (void)testUnhandledSerialization {

--- a/Tests/BugsnagEventTests.m
+++ b/Tests/BugsnagEventTests.m
@@ -757,6 +757,41 @@
     XCTAssertTrue(event.unhandled);
 }
 
+- (void)testUnhandledOverride {
+    BugsnagConfiguration *config = [[BugsnagConfiguration alloc] initWithApiKey:DUMMY_APIKEY_32CHAR_1];
+    BugsnagClient *client = [[BugsnagClient alloc] initWithConfiguration:config];
+    [client start];
+
+    NSException *ex = [[NSException alloc] initWithName:@"myName" reason:@"myReason1" userInfo:nil];
+    __block BugsnagEvent *eventRef = nil;
+
+    // No change to unhandled.
+    [client notify:ex block:^BOOL(BugsnagEvent * _Nonnull event) {
+        eventRef = event;
+        return true;
+    }];
+    XCTAssertEqual(eventRef.unhandled, NO);
+    XCTAssertEqual(eventRef.handledState.unhandledOverridden, NO);
+
+    // Change unhandled from NO to YES.
+    [client notify:ex block:^BOOL(BugsnagEvent * _Nonnull event) {
+        eventRef = event;
+        event.unhandled = YES;
+        return true;
+    }];
+    XCTAssertEqual(eventRef.unhandled, YES);
+    XCTAssertEqual(eventRef.handledState.unhandledOverridden, YES);
+
+    // Set unhandled to NO, but was already NO.
+    [client notify:ex block:^BOOL(BugsnagEvent * _Nonnull event) {
+        eventRef = event;
+        event.unhandled = NO;
+        return true;
+    }];
+    XCTAssertEqual(eventRef.unhandled, NO);
+    XCTAssertEqual(eventRef.handledState.unhandledOverridden, NO);
+}
+
 - (void)testMetadataMutability {
     BugsnagEvent *event = [[BugsnagEvent alloc] initWithKSReport:@{@"dummy" : @"value"}];
 

--- a/Tests/report.json
+++ b/Tests/report.json
@@ -2083,6 +2083,7 @@
         },
         "handledState":{
             "unhandled":false,
+            "unhandledOverridden":false,
             "currentSeverity":"info",
             "severityReasonType":"handledError",
             "originalSeverity":"warning"

--- a/features/cross_notifier_notify.feature
+++ b/features/cross_notifier_notify.feature
@@ -66,6 +66,7 @@ Feature: Communicating events between notifiers
     And the "file" of stack frame 2 is null
     And the "lineNumber" of stack frame 2 is null
     And the event "unhandled" is true
+    And the event "unhandledOverridden" is true
 
     And the payload field "events" is an array with 1 elements
     And the payload field "events.0.session.events.handled" equals 0

--- a/features/event_callbacks.feature
+++ b/features/event_callbacks.feature
@@ -22,6 +22,36 @@ Feature: Callbacks can access and modify event information
     And the event "user.id" equals "customId"
     And the event "user.email" equals "customEmail"
     And the event "user.name" equals "customName"
+    And the event "unhandled" is false
+
+  Scenario: An OnErrorCallback can overwrite unhandled (true) for a handled error
+    When I run "OnErrorOverwriteUnhandledTrueScenario"
+    And I wait to receive a request
+    Then the request is valid for the error reporting API version "4.0" for the "iOS Bugsnag Notifier" notifier
+    And the event "app.id" equals "customAppId"
+    And the event "context" equals "customContext"
+    And the event "device.id" equals "customDeviceId"
+    And the event "groupingHash" equals "customGroupingHash"
+    And the event "severity" equals "info"
+    And the event "user.id" equals "customId"
+    And the event "user.email" equals "customEmail"
+    And the event "user.name" equals "customName"
+    And the event "unhandled" is true
+    And the event "unhandledOverridden" is true
+
+  Scenario: An OnErrorCallback can overwrite unhandled (false) for a handled error
+    When I run "OnErrorOverwriteUnhandledFalseScenario"
+    And I wait to receive a request
+    Then the request is valid for the error reporting API version "4.0" for the "iOS Bugsnag Notifier" notifier
+    And the event "app.id" equals "customAppId"
+    And the event "context" equals "customContext"
+    And the event "device.id" equals "customDeviceId"
+    And the event "groupingHash" equals "customGroupingHash"
+    And the event "severity" equals "info"
+    And the event "user.id" equals "customId"
+    And the event "user.email" equals "customEmail"
+    And the event "user.name" equals "customName"
+    And the event "unhandled" is false
 
   Scenario: An OnSend callback can overwrite information for an unhandled error
     When I run "SwiftAssertion" and relaunch the app

--- a/features/fixtures/ios-swift-cocoapods/iOSTestApp.xcodeproj/project.pbxproj
+++ b/features/fixtures/ios-swift-cocoapods/iOSTestApp.xcodeproj/project.pbxproj
@@ -48,6 +48,8 @@
 		A1117E592535B29800014FDA /* OOMEnabledErrorTypesScenario.swift in Sources */ = {isa = PBXBuildFile; fileRef = A1117E582535B29800014FDA /* OOMEnabledErrorTypesScenario.swift */; };
 		A1117E5B2536036400014FDA /* OOMSessionScenario.swift in Sources */ = {isa = PBXBuildFile; fileRef = A1117E5A2536036400014FDA /* OOMSessionScenario.swift */; };
 		C4D0B5FF8E60C0835B86DFE9 /* Pods_iOSTestApp.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = 4994F05E0421A0B037DD2CC5 /* Pods_iOSTestApp.framework */; };
+		CBE1C9242574F532004B8B5B /* OnErrorOverwriteUnhandledFalseScenario.swift in Sources */ = {isa = PBXBuildFile; fileRef = CBE1C9222574F532004B8B5B /* OnErrorOverwriteUnhandledFalseScenario.swift */; };
+		CBE1C9252574F532004B8B5B /* OnErrorOverwriteUnhandledTrueScenario.swift in Sources */ = {isa = PBXBuildFile; fileRef = CBE1C9232574F532004B8B5B /* OnErrorOverwriteUnhandledTrueScenario.swift */; };
 		E700EE48247D1158008CFFB6 /* UserEventOverrideScenario.swift in Sources */ = {isa = PBXBuildFile; fileRef = E700EE47247D1158008CFFB6 /* UserEventOverrideScenario.swift */; };
 		E700EE4A247D1164008CFFB6 /* UserSessionOverrideScenario.swift in Sources */ = {isa = PBXBuildFile; fileRef = E700EE49247D1164008CFFB6 /* UserSessionOverrideScenario.swift */; };
 		E700EE4C247D12E4008CFFB6 /* UserFromConfigEventScenario.swift in Sources */ = {isa = PBXBuildFile; fileRef = E700EE4B247D12E4008CFFB6 /* UserFromConfigEventScenario.swift */; };
@@ -203,6 +205,8 @@
 		A1117E562535B22300014FDA /* OOMAutoDetectErrorsScenario.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = OOMAutoDetectErrorsScenario.swift; sourceTree = "<group>"; };
 		A1117E582535B29800014FDA /* OOMEnabledErrorTypesScenario.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = OOMEnabledErrorTypesScenario.swift; sourceTree = "<group>"; };
 		A1117E5A2536036400014FDA /* OOMSessionScenario.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = OOMSessionScenario.swift; sourceTree = "<group>"; };
+		CBE1C9222574F532004B8B5B /* OnErrorOverwriteUnhandledFalseScenario.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = OnErrorOverwriteUnhandledFalseScenario.swift; sourceTree = "<group>"; };
+		CBE1C9232574F532004B8B5B /* OnErrorOverwriteUnhandledTrueScenario.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = OnErrorOverwriteUnhandledTrueScenario.swift; sourceTree = "<group>"; };
 		E700EE47247D1158008CFFB6 /* UserEventOverrideScenario.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = UserEventOverrideScenario.swift; sourceTree = "<group>"; };
 		E700EE49247D1164008CFFB6 /* UserSessionOverrideScenario.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = UserSessionOverrideScenario.swift; sourceTree = "<group>"; };
 		E700EE4B247D12E4008CFFB6 /* UserFromConfigEventScenario.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = UserFromConfigEventScenario.swift; sourceTree = "<group>"; };
@@ -411,6 +415,8 @@
 			children = (
 				E753F24524927409001FB671 /* NotifyCallbackCrashScenario.swift */,
 				E700EE52247D31EA008CFFB6 /* OnErrorOverwriteScenario.swift */,
+				CBE1C9222574F532004B8B5B /* OnErrorOverwriteUnhandledFalseScenario.swift */,
+				CBE1C9232574F532004B8B5B /* OnErrorOverwriteUnhandledTrueScenario.swift */,
 				E700EE54247D3204008CFFB6 /* OnSendOverwriteScenario.swift */,
 				E700EE58247D321B008CFFB6 /* OriginalErrorNSErrorScenario.swift */,
 				E700EE5A247D3224008CFFB6 /* OriginalErrorNSExceptionScenario.swift */,
@@ -891,8 +897,10 @@
 				A1117E572535B22300014FDA /* OOMAutoDetectErrorsScenario.swift in Sources */,
 				E75040B424782597005D33BD /* ReleaseStageSessionScenario.swift in Sources */,
 				E700EE75247D7A0C008CFFB6 /* SIGFPEScenario.m in Sources */,
+				CBE1C9242574F532004B8B5B /* OnErrorOverwriteUnhandledFalseScenario.swift in Sources */,
 				A1117E5B2536036400014FDA /* OOMSessionScenario.swift in Sources */,
 				8AF8FCAE22BD23BA00A967CA /* HandledInternalNotifyScenario.swift in Sources */,
+				CBE1C9252574F532004B8B5B /* OnErrorOverwriteUnhandledTrueScenario.swift in Sources */,
 				8A42FD35225DEE04007AE561 /* SessionOOMScenario.m in Sources */,
 				E7A324EF247E9DBC008B0052 /* BreadcrumbCallbackCrashScenario.swift in Sources */,
 				F4295CEAD7C915EFA04898A5 /* Scenario.m in Sources */,

--- a/features/fixtures/shared/scenarios/AttachCustomStacktraceHook.h
+++ b/features/fixtures/shared/scenarios/AttachCustomStacktraceHook.h
@@ -11,5 +11,4 @@
 
 @interface BugsnagEvent ()
 - (void)attachCustomStacktrace:(NSArray *)frames withType:(NSString *)type;
-- (void)updateUnhandled:(BOOL)val;
 @end

--- a/features/fixtures/shared/scenarios/OnErrorOverwriteUnhandledFalseScenario.swift
+++ b/features/fixtures/shared/scenarios/OnErrorOverwriteUnhandledFalseScenario.swift
@@ -1,0 +1,33 @@
+//
+//  OnErrorOverwriteUnhandledFalseScenario.swift
+//  iOSTestApp
+//
+//  Created by Jamie Lynch on 26/05/2020.
+//  Copyright © 2020 Bugsnag. All rights reserved.
+//
+
+import Foundation
+
+/**
+ * Verifies that an OnErrorCallback can overwrite unhandled for a handled error
+ */
+class OnErrorOverwriteUnhandledFalseScenario : Scenario {
+    override func startBugsnag() {
+        self.config.autoTrackSessions = false;
+        super.startBugsnag()
+    }
+
+    override func run() {
+        let error = NSError(domain: "HandledErrorScenario", code: 100, userInfo: nil)
+        Bugsnag.notifyError(error) { (event) -> Bool in
+            event.app.id = "customAppId"
+            event.context = "customContext"
+            event.device.id = "customDeviceId"
+            event.groupingHash = "customGroupingHash"
+            event.severity = .info
+            event.setUser("customId", withEmail: "customEmail", andName: "customName")
+            event.unhandled = false
+            return true
+        }
+    }
+}

--- a/features/fixtures/shared/scenarios/OnErrorOverwriteUnhandledTrueScenario.swift
+++ b/features/fixtures/shared/scenarios/OnErrorOverwriteUnhandledTrueScenario.swift
@@ -1,0 +1,33 @@
+//
+//  OnErrorOverwriteUnhandledTrueScenario.swift
+//  iOSTestApp
+//
+//  Created by Jamie Lynch on 26/05/2020.
+//  Copyright © 2020 Bugsnag. All rights reserved.
+//
+
+import Foundation
+
+/**
+ * Verifies that an OnErrorCallback can overwrite unhandled for a handled error
+ */
+class OnErrorOverwriteUnhandledTrueScenario : Scenario {
+    override func startBugsnag() {
+        self.config.autoTrackSessions = false;
+        super.startBugsnag()
+    }
+
+    override func run() {
+        let error = NSError(domain: "HandledErrorScenario", code: 100, userInfo: nil)
+        Bugsnag.notifyError(error) { (event) -> Bool in
+            event.app.id = "customAppId"
+            event.context = "customContext"
+            event.device.id = "customDeviceId"
+            event.groupingHash = "customGroupingHash"
+            event.severity = .info
+            event.setUser("customId", withEmail: "customEmail", andName: "customName")
+            event.unhandled = true
+            return true
+        }
+    }
+}

--- a/features/fixtures/shared/scenarios/UnhandledInternalNotifyScenario.swift
+++ b/features/fixtures/shared/scenarios/UnhandledInternalNotifyScenario.swift
@@ -16,7 +16,7 @@ import Foundation
                 ["method":"is_done()"]
             ]
             event.severity = .info
-            event.updateUnhandled(true)
+            event.unhandled = true
             event.attachCustomStacktrace(frames, withType: "fake")
             return true
         }

--- a/features/steps/ios_steps.rb
+++ b/features/steps/ios_steps.rb
@@ -252,6 +252,7 @@ Then("the error is an OOM event") do
     And the event "severity" equals "error"
     And the event "severityReason.type" equals "outOfMemory"
     And the event "unhandled" is true
+    And the event "unhandledOverridden" is false
   }
 end
 


### PR DESCRIPTION
## Goal

Make the `unhandled` property of `BugsnagEvent` writable, and trace if it has been changed.

## Design

See ROAD-732

## Changeset

The existing `unhandled` property of `BugsnagEvent` will be made readwrite and `-[BugsnagEvent setUnhandled:]` will be implemented to propagate the value to `BugsnagHandledState.unhandled`

* A new `unhandledOverridden` property will be added to `BugsnagHandledState`
* `-[BugsnagEvent toJson]` will be updated to include `unhandledOverridden`
* `+[BugsnagHandledState handledStateFromJson:]` will be updated to restore the saved value of `unhandledOverridden`
* `-[BugsnagClient notifyInternal:block:]` will be updated to track whether the `unhandled` value has changed by the `OnErrorBlock` and set `unhandledOverridden` if so.

## Testing

Added unit tests:

* Run code that triggers `unhandled` setters.
* Verify that `[BugsnagClient notifyInternal:block:]` properly updates `unhandledOverridden` when `unhandled` changes
* Verify that serde functions properly deal with `unhandledOverridden`
