### PR TITLE
Fix "double-quoted include in framework header" warning in Xcode 10

### DIFF
--- a/Bugsnag.xcodeproj/project.pbxproj
+++ b/Bugsnag.xcodeproj/project.pbxproj
@@ -637,9 +637,9 @@
 		00AD1F142486A17900A27979 /* BugsnagErrorReportSink.m in Sources */ = {isa = PBXBuildFile; fileRef = 00AD1EF92486A17700A27979 /* BugsnagErrorReportSink.m */; };
 		00AD1F152486A17900A27979 /* BugsnagErrorReportSink.m in Sources */ = {isa = PBXBuildFile; fileRef = 00AD1EF92486A17700A27979 /* BugsnagErrorReportSink.m */; };
 		00AD1F162486A17900A27979 /* BugsnagErrorReportSink.m in Sources */ = {isa = PBXBuildFile; fileRef = 00AD1EF92486A17700A27979 /* BugsnagErrorReportSink.m */; };
-		00AD1F172486A17900A27979 /* Private.h in Headers */ = {isa = PBXBuildFile; fileRef = 00AD1EFA2486A17700A27979 /* Private.h */; settings = {ATTRIBUTES = (Private, ); }; };
-		00AD1F182486A17900A27979 /* Private.h in Headers */ = {isa = PBXBuildFile; fileRef = 00AD1EFA2486A17700A27979 /* Private.h */; settings = {ATTRIBUTES = (Private, ); }; };
-		00AD1F192486A17900A27979 /* Private.h in Headers */ = {isa = PBXBuildFile; fileRef = 00AD1EFA2486A17700A27979 /* Private.h */; settings = {ATTRIBUTES = (Private, ); }; };
+		00AD1F172486A17900A27979 /* Private.h in Headers */ = {isa = PBXBuildFile; fileRef = 00AD1EFA2486A17700A27979 /* Private.h */; };
+		00AD1F182486A17900A27979 /* Private.h in Headers */ = {isa = PBXBuildFile; fileRef = 00AD1EFA2486A17700A27979 /* Private.h */; };
+		00AD1F192486A17900A27979 /* Private.h in Headers */ = {isa = PBXBuildFile; fileRef = 00AD1EFA2486A17700A27979 /* Private.h */; };
 		00AD1F212486A17900A27979 /* BugsnagErrorReportSink.h in Headers */ = {isa = PBXBuildFile; fileRef = 00AD1EFD2486A17800A27979 /* BugsnagErrorReportSink.h */; };
 		00AD1F222486A17900A27979 /* BugsnagErrorReportSink.h in Headers */ = {isa = PBXBuildFile; fileRef = 00AD1EFD2486A17800A27979 /* BugsnagErrorReportSink.h */; };
 		00AD1F232486A17900A27979 /* Bugsnag.m in Sources */ = {isa = PBXBuildFile; fileRef = 00AD1EFE2486A17800A27979 /* Bugsnag.m */; };

--- a/Tests/KSCrash/KSMach_Tests.m
+++ b/Tests/KSCrash/KSMach_Tests.m
@@ -182,7 +182,7 @@
     CFAbsoluteTime cfEndTime = CFAbsoluteTimeGetCurrent();
     double diff = bsg_ksmachtimeDifferenceInSeconds(endTime, startTime);
     double cfDiff = cfEndTime - cfStartTime;
-    XCTAssertEqualWithAccuracy(diff, cfDiff, 0.0001);
+    XCTAssertEqualWithAccuracy(diff, cfDiff, 0.001);
 }
 
 // TODO: Disabling this until I figure out what's wrong with queue names.


### PR DESCRIPTION
## Goal

#870 fixed the "double-quoted include in framework header" warning for the latest versions of Xcode, but Xcode 10 was still emitting the error for the header file `Private.h`

These warnings can be seen in Travis: https://travis-ci.com/github/bugsnag/bugsnag-cocoa/jobs/448655702#L873

## Changeset

Changed `Private.h` from "Private" to "Project" (the default) which stops Xcode treating it as a framework header.

Also addressed flakey `-[bsg_ksmachTests testTimeDifferenceInSeconds]` because that failed the first build of this branch...

## Testing

Ran unit tests locally.