### PR TITLE
[PLAT-5449] Include metadata in OOM events

### DIFF
--- a/Bugsnag/BugsnagSystemState.h
+++ b/Bugsnag/BugsnagSystemState.h
@@ -36,13 +36,7 @@ NS_ASSUME_NONNULL_BEGIN
 
 - (void)recordAppUUID;
 
-- (void)setBatteryCharging:(BOOL)charging;
-
-- (void)setBatteryLevel:(NSNumber *)batteryLevel;
-
 - (void)setCodeBundleID:(NSString*)codeBundleID;
-
-- (void)setOrientation:(NSString *)orientation;
 
 /**
  * Purge all stored system state.

--- a/Bugsnag/BugsnagSystemState.m
+++ b/Bugsnag/BugsnagSystemState.m
@@ -27,10 +27,6 @@
 #define STATE_DIR @"bugsnag/state"
 #define STATE_FILE @"system_state.json"
 
-#if BSG_PLATFORM_IOS
-NSString *BSGOrientationNameFromEnum(UIDeviceOrientation deviceOrientation);
-#endif
-
 static NSDictionary* loadPreviousState(BugsnagKVStore *kvstore, NSString *jsonPath) {
     NSData *data = [NSData dataWithContentsOfFile:jsonPath];
     if(data == nil) {
@@ -131,12 +127,6 @@ static NSMutableDictionary* initCurrentState(BugsnagKVStore *kvstore, BugsnagCon
     device[@"simulator"] = @NO;
 #endif
     device[@"totalMemory"] = systemInfo[@BSG_KSSystemField_Memory][@"usable"];
-#if BSG_PLATFORM_IOS
-    device[BSGKeyBatteryLevel] = @([UIDevice currentDevice].batteryLevel);
-    UIDeviceBatteryState batteryState = [UIDevice currentDevice].batteryState;
-    device[BSGKeyCharging] = @(batteryState == UIDeviceBatteryStateCharging || batteryState == UIDeviceBatteryStateFull);
-    device[BSGKeyOrientation] = BSGOrientationNameFromEnum([UIDevice currentDevice].orientation);
-#endif
 
     NSMutableDictionary *state = [NSMutableDictionary new];
     state[BSGKeyApp] = app;
@@ -224,28 +214,12 @@ NSDictionary *copyLaunchState(NSDictionary *launchState) {
     [self setValue:[BSG_KSSystemInfo appUUID] forAppKey:BSGKeyMachoUUID];
 }
 
-- (void)setBatteryCharging:(BOOL)charging {
-    [self setValue:@(charging) forDeviceKey:BSGKeyCharging];
-}
-
-- (void)setBatteryLevel:(NSNumber *)batteryLevel {
-    [self setValue:batteryLevel forDeviceKey:BSGKeyBatteryLevel];
-}
-
 - (void)setCodeBundleID:(NSString*)codeBundleID {
     [self setValue:codeBundleID forAppKey:BSGKeyCodeBundleId];
 }
 
-- (void)setOrientation:(NSString *)orientation {
-    [self setValue:orientation forDeviceKey:BSGKeyOrientation];
-}
-
 - (void)setValue:(id)value forAppKey:(NSString *)key {
     [self setValue:value forKey:key inSection:SYSTEMSTATE_KEY_APP];
-}
-
-- (void)setValue:(id)value forDeviceKey:(NSString *)key {
-    [self setValue:value forKey:key inSection:SYSTEMSTATE_KEY_DEVICE];
 }
 
 - (void)setValue:(id)value forKey:(NSString *)key inSection:(NSString *)section {

--- a/Bugsnag/Client/BugsnagClient+Private.h
+++ b/Bugsnag/Client/BugsnagClient+Private.h
@@ -32,6 +32,8 @@ NS_ASSUME_NONNULL_BEGIN
 
 @property (readonly) NSString *configMetadataFile;
 
+@property (nullable) NSDictionary *configMetadataFromLastLaunch;
+
 @property (nullable, retain, nonatomic) BugsnagConfiguration *configuration;
 
 @property (strong, nonatomic) BugsnagCrashSentry *crashSentry;
@@ -48,6 +50,8 @@ NS_ASSUME_NONNULL_BEGIN
 
 @property (readonly) NSString *metadataFile;
 
+@property (nullable) NSDictionary *metadataFromLastLaunch;
+
 @property (strong, nonatomic) BugsnagNotifier *notifier; // Used in BugsnagReactNative
 
 @property (strong, nonatomic) BugsnagPluginClient *pluginClient;
@@ -61,6 +65,8 @@ NS_ASSUME_NONNULL_BEGIN
 @property (strong, nonatomic) NSMutableArray *stateEventBlocks;
 
 @property (readonly) NSString *stateMetadataFile;
+
+@property (nullable) NSDictionary *stateMetadataFromLastLaunch;
 
 @property (strong, nonatomic) BugsnagSystemState *systemState;
 

--- a/Bugsnag/Client/BugsnagClient+Private.h
+++ b/Bugsnag/Client/BugsnagClient+Private.h
@@ -30,6 +30,8 @@ NS_ASSUME_NONNULL_BEGIN
 
 @property (nullable, nonatomic) NSString *codeBundleId;
 
+@property (readonly) NSString *configMetadataFile;
+
 @property (nullable, retain, nonatomic) BugsnagConfiguration *configuration;
 
 @property (strong, nonatomic) BugsnagCrashSentry *crashSentry;
@@ -44,7 +46,7 @@ NS_ASSUME_NONNULL_BEGIN
 
 @property (strong, nonatomic) BugsnagMetadata *metadata; // Used in BugsnagReactNative
 
-@property (strong, nonatomic) NSLock *metadataLock;
+@property (readonly) NSString *metadataFile;
 
 @property (strong, nonatomic) BugsnagNotifier *notifier; // Used in BugsnagReactNative
 
@@ -57,6 +59,8 @@ NS_ASSUME_NONNULL_BEGIN
 @property (strong, nonatomic) BugsnagMetadata *state;
 
 @property (strong, nonatomic) NSMutableArray *stateEventBlocks;
+
+@property (readonly) NSString *stateMetadataFile;
 
 @property (strong, nonatomic) BugsnagSystemState *systemState;
 

--- a/Bugsnag/Client/BugsnagClient.m
+++ b/Bugsnag/Client/BugsnagClient.m
@@ -1124,10 +1124,6 @@ NSString *const BSGBreadcrumbLoadedMessage = @"Bugsnag loaded";
     [self.state addMetadata:charging ? @YES : @NO
                     withKey:BSGKeyCharging
                   toSection:BSGKeyDeviceState];
-    
-    [self.systemState setBatteryLevel:batteryLevel];
-    
-    [self.systemState setBatteryCharging:charging];
 }
 
 /**
@@ -1149,8 +1145,6 @@ NSString *const BSGBreadcrumbLoadedMessage = @"Bugsnag loaded";
     [self.state addMetadata:orientation
                     withKey:BSGKeyOrientation
                   toSection:BSGKeyDeviceState];
-    
-    [self.systemState setOrientation:orientation];
 
     // Short-circuit the exit if we don't have enough info to record a full breadcrumb
     // or the orientation hasn't changed (false positive).

--- a/Bugsnag/Client/BugsnagClient.m
+++ b/Bugsnag/Client/BugsnagClient.m
@@ -82,12 +82,12 @@ static struct {
     // Contains the state of the event (handled/unhandled)
     char *handledState;
     // Contains the user-specified metadata, including the user tab from config.
-    char metadataPath[PATH_MAX];
+    char *metadataPath;
     // Contains the Bugsnag configuration, all under the "config" tab.
-    char configPath[PATH_MAX];
+    char *configPath;
     // Contains notifier state, under "deviceState" and crash-specific
     // information under "crash".
-    char statePath[PATH_MAX];
+    char *statePath;
     // Contains properties in the Bugsnag payload overridden by the user before
     // it was sent
     char *userOverridesJSON;
@@ -100,7 +100,7 @@ static NSDictionary *notificationNameMap;
 static char *sessionId[128];
 static char *sessionStartDate[128];
 static char *watchdogSentinelPath = NULL;
-static char crashSentinelPath[PATH_MAX];
+static char *crashSentinelPath;
 static NSUInteger handledCount;
 static NSUInteger unhandledCount;
 static bool hasRecordedSessions;
@@ -301,18 +301,18 @@ NSString *_lastOrientation = nil;
         [[NSFileManager defaultManager] createDirectoryAtPath:bugsnagDir withIntermediateDirectories:YES attributes:nil error:nil];
         
         NSString *crashPath = [cachesDir stringByAppendingPathComponent:@"bugsnag_handled_crash.txt"];
-        [crashPath getFileSystemRepresentation:crashSentinelPath maxLength:sizeof(crashSentinelPath)];
+        crashSentinelPath = strdup(crashPath.fileSystemRepresentation);
         
         _configMetadataFile = [bugsnagDir stringByAppendingPathComponent:@"config.json"];
-        [_configMetadataFile getFileSystemRepresentation:bsg_g_bugsnag_data.configPath maxLength:sizeof(bsg_g_bugsnag_data.configPath)];
+        bsg_g_bugsnag_data.configPath = strdup(_configMetadataFile.fileSystemRepresentation);
         _configMetadataFromLastLaunch = [BSGJSONSerialization JSONObjectWithContentsOfFile:_configMetadataFile options:0 error:nil];
         
         _metadataFile = [bugsnagDir stringByAppendingPathComponent:@"metadata.json"];
-        [_metadataFile getFileSystemRepresentation:bsg_g_bugsnag_data.metadataPath maxLength:sizeof(bsg_g_bugsnag_data.metadataPath)];
+        bsg_g_bugsnag_data.metadataPath = strdup(_metadataFile.fileSystemRepresentation);
         _metadataFromLastLaunch = [BSGJSONSerialization JSONObjectWithContentsOfFile:_metadataFile options:0 error:nil];
         
         _stateMetadataFile = [bugsnagDir stringByAppendingPathComponent:@"state.json"];
-        [_stateMetadataFile getFileSystemRepresentation:bsg_g_bugsnag_data.statePath maxLength:sizeof(bsg_g_bugsnag_data.statePath)];
+        bsg_g_bugsnag_data.statePath = strdup(_stateMetadataFile.fileSystemRepresentation);
         _stateMetadataFromLastLaunch = [BSGJSONSerialization JSONObjectWithContentsOfFile:_stateMetadataFile options:0 error:nil];
 
         self.stateEventBlocks = [NSMutableArray new];

--- a/Bugsnag/Helpers/BSGJSONSerialization.h
+++ b/Bugsnag/Helpers/BSGJSONSerialization.h
@@ -44,6 +44,8 @@ NS_ASSUME_NONNULL_BEGIN
  */
 + (nullable id)JSONObjectWithStream:(NSInputStream *)stream options:(NSJSONReadingOptions)opt error:(NSError **)error;
 
++ (BOOL)writeJSONObject:(id)JSONObject toFile:(NSString *)file options:(NSJSONWritingOptions)options error:(NSError **)errorPtr;
+
 @end
 
 NS_ASSUME_NONNULL_END

--- a/Bugsnag/Helpers/BSGJSONSerialization.h
+++ b/Bugsnag/Helpers/BSGJSONSerialization.h
@@ -46,6 +46,8 @@ NS_ASSUME_NONNULL_BEGIN
 
 + (BOOL)writeJSONObject:(id)JSONObject toFile:(NSString *)file options:(NSJSONWritingOptions)options error:(NSError **)errorPtr;
 
++ (nullable id)JSONObjectWithContentsOfFile:(NSString *)file options:(NSJSONReadingOptions)options error:(NSError **)errorPtr;
+
 @end
 
 NS_ASSUME_NONNULL_END

--- a/Bugsnag/Helpers/BSGJSONSerialization.m
+++ b/Bugsnag/Helpers/BSGJSONSerialization.m
@@ -17,14 +17,14 @@ static NSError* wrapException(NSException* exception) {
         NSUnderlyingErrorKey: exception,
     };
 
-    return [NSError errorWithDomain:@"com.bugsnag" code:1 userInfo:userInfo];
+    return [NSError errorWithDomain:@"BSGJSONSerializationErrorDomain" code:1 userInfo:userInfo];
 }
 
 + (BOOL)isValidJSONObject:(id)obj {
     @try {
         return [NSJSONSerialization isValidJSONObject:obj];
     } @catch (NSException *exception) {
-        return false;
+        return NO;
     }
 }
 
@@ -32,7 +32,9 @@ static NSError* wrapException(NSException* exception) {
     @try {
         return [NSJSONSerialization dataWithJSONObject:obj options:opt error:error];
     } @catch (NSException *exception) {
-        *error = wrapException(exception);
+        if (error) {
+            *error = wrapException(exception);
+        }
         return nil;
     }
 }
@@ -41,7 +43,9 @@ static NSError* wrapException(NSException* exception) {
     @try {
         return [NSJSONSerialization JSONObjectWithData:data options:opt error:error];
     } @catch (NSException *exception) {
-        *error = wrapException(exception);
+        if (error) {
+            *error = wrapException(exception);
+        }
         return nil;
     }
 }
@@ -50,7 +54,9 @@ static NSError* wrapException(NSException* exception) {
     @try {
         return [NSJSONSerialization writeJSONObject:obj toStream:stream options:opt error:error];
     } @catch (NSException *exception) {
-        *error = wrapException(exception);
+        if (error) {
+            *error = wrapException(exception);
+        }
         return 0;
     }
 }
@@ -59,9 +65,23 @@ static NSError* wrapException(NSException* exception) {
     @try {
         return [NSJSONSerialization JSONObjectWithStream:stream options:opt error:error];
     } @catch (NSException *exception) {
-        *error = wrapException(exception);
+        if (error) {
+            *error = wrapException(exception);
+        }
         return nil;
     }
+}
+
++ (BOOL)writeJSONObject:(id)JSONObject toFile:(NSString *)file options:(NSJSONWritingOptions)options error:(NSError **)errorPtr {
+    if (![BSGJSONSerialization isValidJSONObject:JSONObject]) {
+        if (errorPtr) {
+            *errorPtr = [NSError errorWithDomain:@"BSGJSONSerializationErrorDomain" code:0 userInfo:@{
+                NSLocalizedDescriptionKey: @"Not a valid JSON object"}];
+        }
+        return NO;
+    }
+    NSData *data = [BSGJSONSerialization dataWithJSONObject:JSONObject options:options error:errorPtr];
+    return [data writeToFile:file options:NSDataWritingAtomic error:errorPtr];
 }
 
 @end

--- a/Bugsnag/Helpers/BSGJSONSerialization.m
+++ b/Bugsnag/Helpers/BSGJSONSerialization.m
@@ -84,4 +84,12 @@ static NSError* wrapException(NSException* exception) {
     return [data writeToFile:file options:NSDataWritingAtomic error:errorPtr];
 }
 
++ (nullable id)JSONObjectWithContentsOfFile:(NSString *)file options:(NSJSONReadingOptions)options error:(NSError **)errorPtr {
+    NSData *data = [NSData dataWithContentsOfFile:file options:0 error:errorPtr];
+    if (!data) {
+        return nil;
+    }
+    return [BSGJSONSerialization JSONObjectWithData:data options:options error:errorPtr];
+}
+
 @end

--- a/Bugsnag/Payload/BugsnagEvent.m
+++ b/Bugsnag/Payload/BugsnagEvent.m
@@ -283,7 +283,6 @@ NSDictionary *BSGParseCustomException(NSDictionary *report,
  * @return a BugsnagEvent containing the parsed information
  */
 - (instancetype)initWithOOMData:(NSDictionary *)event {
-    // no threads or metadata captured for OOMs
     NSDictionary *sessionData = [event valueForKeyPath:@"user.state.oom.session"];
     BugsnagSession *session;
     BugsnagUser *user;
@@ -294,14 +293,13 @@ NSDictionary *BSGParseCustomException(NSDictionary *report,
             user = session.user;
         }
     }
-    BugsnagMetadata *metadata = [BugsnagMetadata new];
+    NSDictionary *metaData = [event valueForKeyPath:@"user.metaData"];
+    if (!metaData) {
+        bsg_log_err(@"user.metaData was missing from the OOM KSCrashReport");
+    }
+    BugsnagMetadata *metadata = [[BugsnagMetadata alloc] initWithDictionary:metaData ?: @{}];
     // Cocoa-specific, non-spec., device and app data
-    NSMutableDictionary *deviceMetadata = BSGParseDeviceMetadata(event);
-    // This can be removed once metadata is being persisted to disk
-    deviceMetadata[BSGKeyBatteryLevel]  = [event valueForKeyPath:@"user.state.oom.device.batteryLevel"];
-    deviceMetadata[BSGKeyCharging]      = [event valueForKeyPath:@"user.state.oom.device.charging"];
-    deviceMetadata[BSGKeyOrientation]   = [event valueForKeyPath:@"user.state.oom.device.orientation"];
-    [metadata addMetadata:deviceMetadata toSection:BSGKeyDevice];
+    [metadata addMetadata:BSGParseDeviceMetadata(event) toSection:BSGKeyDevice];
     [metadata addMetadata:BSGParseAppMetadata(event) toSection:BSGKeyApp];
 
     BugsnagEvent *obj = [self initWithApp:[BugsnagAppWithState appWithOomData:[event valueForKeyPath:@"user.state.oom.app"]]

--- a/Tests/BSGJSONSerializerTest.m
+++ b/Tests/BSGJSONSerializerTest.m
@@ -43,7 +43,37 @@
     XCTAssertNotNil(error);
     XCTAssertNil(result);
     error = nil;
+}
 
+- (void)testJSONFileSerialization {
+    id validJSON = @{@"foo": @"bar"};
+    id invalidJSON = @{@"foo": [NSDate date]};
+    
+    NSString *file = [NSTemporaryDirectory() stringByAppendingPathComponent:@(__PRETTY_FUNCTION__)];
+    
+    XCTAssertTrue([BSGJSONSerialization writeJSONObject:validJSON toFile:file options:0 error:nil]);
+
+    XCTAssertEqualObjects([BSGJSONSerialization JSONObjectWithContentsOfFile:file options:0 error:nil], @{@"foo": @"bar"});
+    
+    [[NSFileManager defaultManager] removeItemAtPath:file error:nil];
+    
+    NSError *error = nil;
+    XCTAssertFalse([BSGJSONSerialization writeJSONObject:invalidJSON toFile:file options:0 error:&error]);
+    XCTAssertNotNil(error);
+    
+    error = nil;
+    XCTAssertNil([BSGJSONSerialization JSONObjectWithContentsOfFile:file options:0 error:&error]);
+    XCTAssertNotNil(error);
+
+    NSString *unwritablePath = @"/System/Library/foobar";
+    
+    error = nil;
+    XCTAssertFalse([BSGJSONSerialization writeJSONObject:validJSON toFile:unwritablePath options:0 error:&error]);
+    XCTAssertNotNil(error);
+    
+    error = nil;
+    XCTAssertNil([BSGJSONSerialization JSONObjectWithContentsOfFile:unwritablePath options:0 error:&error]);
+    XCTAssertNotNil(error);
 }
 
 @end

--- a/Tests/BugsnagClientMirrorTest.m
+++ b/Tests/BugsnagClientMirrorTest.m
@@ -40,7 +40,6 @@
             @"setSessionTracker: v24@0:8@16",
             @"addTerminationObserver: v24@0:8@16",
             @"setLastOrientation: v24@0:8@16",
-            @"metadataLock @16@0:8",
             @"oomWatchdog @16@0:8",
             @"initializeNotificationNameMap v16@0:8",
             @"notifyOutOfMemoryEvent v16@0:8",
@@ -124,7 +123,10 @@
             @"shouldReportOOM B16@0:8",
             @"shouldReportOOM c16@0:8",
             @"systemState @16@0:8",
-            @"setSystemState: v24@0:8@16"
+            @"setSystemState: v24@0:8@16",
+            @"stateMetadataFile @16@0:8",
+            @"metadataFile @16@0:8",
+            @"configMetadataFile @16@0:8",
     ]];
 
     // the following methods are implemented on Bugsnag but do not need to

--- a/Tests/BugsnagClientMirrorTest.m
+++ b/Tests/BugsnagClientMirrorTest.m
@@ -124,9 +124,15 @@
             @"shouldReportOOM c16@0:8",
             @"systemState @16@0:8",
             @"setSystemState: v24@0:8@16",
-            @"stateMetadataFile @16@0:8",
-            @"metadataFile @16@0:8",
             @"configMetadataFile @16@0:8",
+            @"configMetadataFromLastLaunch @16@0:8",
+            @"metadataFile @16@0:8",
+            @"metadataFromLastLaunch @16@0:8",
+            @"setConfigMetadataFromLastLaunch: v24@0:8@16",
+            @"setMetadataFromLastLaunch: v24@0:8@16",
+            @"setStateMetadataFromLastLaunch: v24@0:8@16",
+            @"stateMetadataFile @16@0:8",
+            @"stateMetadataFromLastLaunch @16@0:8",
     ]];
 
     // the following methods are implemented on Bugsnag but do not need to

--- a/Tests/BugsnagClientTests.m
+++ b/Tests/BugsnagClientTests.m
@@ -34,8 +34,6 @@
 
 NSString *BSGFormatSeverity(BSGSeverity severity);
 
-void BSSerializeJSONDictionary(NSDictionary *dictionary, char **destination);
-
 @implementation BugsnagClientTests
 
 /**
@@ -319,12 +317,6 @@ void BSSerializeJSONDictionary(NSDictionary *dictionary, char **destination);
         dict[key] = value;
     }
     return dict;
-}
-
-- (void)testBSSerializeJSONDictionary {
-    // Test that it doesn't raise an exception
-    char* dest = NULL;
-    BSSerializeJSONDictionary(@{@1: @"a"}, &dest);
 }
 
 static BOOL testOnCrashHandlerNotCalledForOOM_didCallOnCrashHandler;

--- a/Tests/BugsnagEventTests.m
+++ b/Tests/BugsnagEventTests.m
@@ -399,8 +399,10 @@
 
     BugsnagEvent *report1 = [[BugsnagEvent alloc] initWithKSReport:dict];
     XCTAssertNotNil(report1.metadata);
-    XCTAssertEqual([[report1.metadata toDictionary] count], 2);
     XCTAssertEqualObjects([report1.metadata getMetadataFromSection:@"app" withKey:@"name"], @"TestAppNAme");
+    XCTAssertEqualObjects([report1.metadata getMetadataFromSection:@"Custom" withKey:@"Foo"], @"Bar");
+    XCTAssertNotNil([report1.metadata getMetadataFromSection:@"device" withKey:@"simulator"]);
+    XCTAssertNotNil([report1.metadata getMetadataFromSection:@"device" withKey:@"wordSize"]);
 
     // OOM metadata is set from the session user data.
     [metadata addMetadata:@"OOMuser" withKey:@"id" toSection:@"user"];

--- a/features/fixtures/shared/scenarios/OOMLoadScenario.swift
+++ b/features/fixtures/shared/scenarios/OOMLoadScenario.swift
@@ -15,6 +15,7 @@ class OOMLoadScenario: Scenario {
         config = BugsnagConfiguration.loadConfig()
         config.autoTrackSessions = false
         config.addMetadata(["bar": "foo"], section: "custom")
+        config.setUser("foobar", withEmail: "foobar@example.com", andName: "Foo Bar")
         Bugsnag.start(with: config)
     }
 

--- a/features/fixtures/shared/scenarios/OOMLoadScenario.swift
+++ b/features/fixtures/shared/scenarios/OOMLoadScenario.swift
@@ -14,6 +14,7 @@ class OOMLoadScenario: Scenario {
     override func startBugsnag() {
         config = BugsnagConfiguration.loadConfig()
         config.autoTrackSessions = false
+        config.addMetadata(["bar": "foo"], section: "custom")
         Bugsnag.start(with: config)
     }
 

--- a/features/out_of_memory.feature
+++ b/features/out_of_memory.feature
@@ -40,6 +40,7 @@ Feature: Out of memory errors
     And the event "device.manufacturer" equals "Apple"
     And the event "device.runtimeVersions" is not null
     And the event "device.totalMemory" is not null
+    And the event "metaData.custom.bar" equals "foo"
 
     # Ensure breadcrumbs are carried over
     And the event has a "manual" breadcrumb named "OOMLoadScenarioBreadcrumb"

--- a/features/out_of_memory.feature
+++ b/features/out_of_memory.feature
@@ -38,7 +38,6 @@ Feature: Out of memory errors
     And the event "app.dsymUUIDs" is not null
     And the event "app.version" is not null
     And the event "device.manufacturer" equals "Apple"
-    And the event "device.orientation" is not null
     And the event "device.runtimeVersions" is not null
     And the event "device.totalMemory" is not null
 

--- a/features/out_of_memory.feature
+++ b/features/out_of_memory.feature
@@ -41,6 +41,9 @@ Feature: Out of memory errors
     And the event "device.runtimeVersions" is not null
     And the event "device.totalMemory" is not null
     And the event "metaData.custom.bar" equals "foo"
+    And the event "user.id" equals "foobar"
+    And the event "user.email" equals "foobar@example.com"
+    And the event "user.name" equals "Foo Bar"
 
     # Ensure breadcrumbs are carried over
     And the event has a "manual" breadcrumb named "OOMLoadScenarioBreadcrumb"


### PR DESCRIPTION
## Goal

OOM events were missing some important data that are present in other types of error:

* custom metadata provided by the app developer
* user information

The changes in this PR add this information to OOMs.

## Design

See the design document on Confluence.

## Changeset

Metadata is now written to files on disk and read from there when constructing a KSCrashReport.

`-[BugsnagEvent initWithOOMData:]` has been amended to use this newly available information.

The device data being captured in `BugsnagSystemState` becomes redundant as it exists in the "state" metadata, so has been removed.

`out_of_memory.feature` no longer checks for `device.orientation` because that is not present in other types of error.

## Testing

Manually verified by triggering OOMs and examining payload.

Updated `out_of_memory.feature` to verify that custom metadata and user information is present and in the expected location within the payload.