### PR TITLE
Update travis to include latest Xcode, and cull unsupported ios,tvos versions

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -25,6 +25,16 @@ jobs:
   # Unit Tests - Mac
   # ----------------------------------------------------------------------------
 
+  - osx_image: xcode12.2 # macos 10.15.7
+    name: macOS 10.15.7 unit tests
+    stage: macOS unit tests
+    env: PLATFORM=macOS
+
+  - osx_image: xcode11.6 # macos 10.15.5
+    name: macOS 10.15.5 unit tests
+    stage: macOS unit tests
+    env: PLATFORM=macOS
+
   - osx_image: xcode10.2 # macos 10.14
     name: macOS 10.14 unit tests
     stage: macOS unit tests
@@ -39,18 +49,29 @@ jobs:
   # Unit Tests - iOS
   # ----------------------------------------------------------------------------
 
-  - osx_image: xcode11
-    name: iOS 13.x unit tests
+  - osx_image: xcode12.2
+    name: iOS 11-14 unit tests
     stage: unit tests
-    # Xcode 11+ no longer ships with all device combinations premade
-    before_script: xcrun simctl create "13-xs" "iPhone XS" com.apple.CoreSimulator.SimRuntime.iOS-13-0
     env:
     - PLATFORM=iOS
-    - OS=13.0
-    - DEVICE="iPhone XS"
+    - DEVICE="iPhone 8"
+    script:
+    - make test OS=14.1
+    - make test OS=13.5
+    - make test OS=12.4
+    - make test OS=11.4
+
+  - osx_image: xcode11
+    name: iOS 10 unit tests
+    stage: unit tests
+    env:
+    - PLATFORM=iOS
+    - DEVICE="iPhone 7"
+    script:
+    - make test OS=10.3.1
 
   - osx_image: xcode10.2
-    name: iOS 9-12 unit tests
+    name: iOS 9 unit tests
     stage: unit tests
     env: PLATFORM=iOS
     before_script:
@@ -59,26 +80,35 @@ jobs:
     script:
     - make test OS=9.3
     - make test OS=9.3 TEST_CONFIGURATION=Release
-    - make test OS=12.2
-    - make test OS=12.1
-    - make test OS=11.4
-    - make test OS=10.3.1
 
   # ----------------------------------------------------------------------------
   # Unit Tests - tvOS
   # ----------------------------------------------------------------------------
 
-  - osx_image: xcode10.2
-    name: tvOS 9-12 unit tests
+  - osx_image: xcode12.2
+    name: tvOS 11-14 unit tests
     stage: unit tests
     env: PLATFORM=tvOS
     script:
-    - make test OS=12.2
-    - make test OS=12.1
+    - make test OS=14.0
+    - make test OS=13.3
+    - make test OS=12.4
     - make test OS=11.4
-    - make test OS=10.2
-    - make test OS=9.2
     
+  - osx_image: xcode11
+    name: tvOS 10 unit tests
+    stage: unit tests
+    env: PLATFORM=tvOS
+    script:
+    - make test OS=10.2
+
+  - osx_image: xcode10.2
+    name: tvOS 9 unit tests
+    stage: unit tests
+    env: PLATFORM=tvOS
+    script:
+    - make test OS=9.2
+
   # ----------------------------------------------------------------------------
   # Static framework, Carthage and Swift Package Manager builds
   # ----------------------------------------------------------------------------
@@ -99,7 +129,7 @@ jobs:
   # Doc Generation
   # ----------------------------------------------------------------------------
 
-  - osx_image: xcode10.2
+  - osx_image: xcode11
     stage: deploy
     before_deploy: make doc
     script: skip


### PR DESCRIPTION
## Goal

Travis is currently building test environments using xcode versions that can no longer submit apps to the app store. Since effectively nobody can use these xcode versions anymore, we shouldn't be wasting resources running tests with them.

## Changeset

Modified the test runs to:

| OS | Xcode |
| -- | -- |
| macos 10.15.7 | 12.2 |
| macos 10.15.5 | 11.6 |
| macos 10.14 | 10.2 |
| macos 10.13 | 9.4 |
| ios 11-14 | 12.2 |
| ios 10 | 11 |
| ios 9 | 10.2 |
| tvos 11-14 | 12.2 |
| tvos 10 | 11 |
| tvos 9 | 10.2 |

## Testing

Ran all of the tests on Travis (see testing report below)
