### PR TITLE
Update NSException-disabled e2e test to account for SIGABRT

### DIFF
--- a/features/enabled_error_types.feature
+++ b/features/enabled_error_types.feature
@@ -24,12 +24,12 @@ Feature: Enabled error types
   Scenario: NSException Crash Reporting is disabled
     When I run "DisableNSExceptionScenario" and relaunch the app
     And I configure Bugsnag for "DisableNSExceptionScenario"
-
-    # This received request is confirmation the scenario is running through
     And I wait to receive a request
     Then the request is valid for the error reporting API version "4.0" for the "iOS Bugsnag Notifier" notifier
-    And the event "unhandled" is false
-    And the payload field "events.0.exceptions.0.message" equals "DisableNSExceptionScenario - Handled"
+    And the event "severity" equals "error"
+    And the event "unhandled" is true
+    And the event "severityReason.type" equals "signal"
+    And the event "severityReason.attributes.signalType" equals "SIGABRT"
 
   Scenario: CPP Crash Reporting is disabled
     When I run "EnabledErrorTypesCxxScenario" and relaunch the app

--- a/features/fixtures/shared/scenarios/EnabledErrorTypesScenario.m
+++ b/features/fixtures/shared/scenarios/EnabledErrorTypesScenario.m
@@ -87,15 +87,8 @@
 #pragma clang diagnostic push
 #pragma clang diagnostic ignored "-Winvalid-noreturn"
 - (void)run  __attribute__((noreturn)) {
-    // Send a handled exception to confirm the scenario is running.
-    [Bugsnag notify:[NSException exceptionWithName:NSGenericException reason:@"DisableNSExceptionScenario - Handled"
-                                                 userInfo:@{NSLocalizedDescriptionKey: @""}]];
-
-    // From ObjCExceptionScenario.  Wait 1 seconds before throwing.
-    dispatch_after(dispatch_time(DISPATCH_TIME_NOW, (int64_t)(1 * NSEC_PER_SEC)), dispatch_get_main_queue(), ^{
-        @throw [NSException exceptionWithName:NSGenericException reason:@"An uncaught exception! SCREAM."
-                                    userInfo:@{NSLocalizedDescriptionKey: @"I'm in your program, catching your exceptions!"}];
-    });
+    @throw [NSException exceptionWithName:NSGenericException reason:@"An uncaught exception! SCREAM."
+                                userInfo:@{NSLocalizedDescriptionKey: @"I'm in your program, catching your exceptions!"}];
 }
 #pragma clang diagnostic pop
 


### PR DESCRIPTION
## Goal

When NSException handling is disabled, the default handler calls `abort()`, which generates a `SIGABRT` signal. The current test doesn't account for this.

## Design

Update the DisableNSExceptionScenario test to look for a `SIGABRT` signal. I've also removed the `dispatch_after` call because it's unreliable as to whether the test rig will capture it properly or not (and also it's not needed in this case).

## Testing

Re-ran e2e test multiple times to make sure the test no longer flakes.
