### PR TITLE
Provide the ability for use without UIKit

### DIFF
--- a/Bugsnag.xcodeproj/project.pbxproj
+++ b/Bugsnag.xcodeproj/project.pbxproj
@@ -656,6 +656,8 @@
 		00AD1F312486A17900A27979 /* BugsnagSessionTracker.m in Sources */ = {isa = PBXBuildFile; fileRef = 00AD1F012486A17900A27979 /* BugsnagSessionTracker.m */; };
 		00E636C224878D84006CBF1A /* BSG_RFC3339DateTool.m in Sources */ = {isa = PBXBuildFile; fileRef = 008969142486DAD000DC48C2 /* BSG_RFC3339DateTool.m */; };
 		0140D29A25767C9A00FD0306 /* BugsnagApiClientTest.m in Sources */ = {isa = PBXBuildFile; fileRef = CB9103632502320A00E9D1E2 /* BugsnagApiClientTest.m */; };
+		012482A325627B51003F7243 /* UIKitTests.m in Sources */ = {isa = PBXBuildFile; fileRef = 012482A225627B51003F7243 /* UIKitTests.m */; };
+		014475FD2566844F0018AB94 /* BugsnagApiClientTest.m in Sources */ = {isa = PBXBuildFile; fileRef = CB9103632502320A00E9D1E2 /* BugsnagApiClientTest.m */; };
 		01447605256684500018AB94 /* BugsnagApiClientTest.m in Sources */ = {isa = PBXBuildFile; fileRef = CB9103632502320A00E9D1E2 /* BugsnagApiClientTest.m */; };
 		0187D464255BD7B800C503D9 /* BugsnagApiClientTest.m in Sources */ = {isa = PBXBuildFile; fileRef = CB9103632502320A00E9D1E2 /* BugsnagApiClientTest.m */; };
 		01B14C56251CE55F00118748 /* report-react-native-promise-rejection.json in Resources */ = {isa = PBXBuildFile; fileRef = 01B14C55251CE55F00118748 /* report-react-native-promise-rejection.json */; };
@@ -1274,8 +1276,10 @@
 		00E636C02487031D006CBF1A /* Bugsnag.podspec.json */ = {isa = PBXFileReference; lastKnownFileType = text.json; path = Bugsnag.podspec.json; sourceTree = SOURCE_ROOT; };
 		00E636C12487031D006CBF1A /* docker-compose.yml */ = {isa = PBXFileReference; lastKnownFileType = text.yaml; path = "docker-compose.yml"; sourceTree = SOURCE_ROOT; };
 		00E636C324878FFC006CBF1A /* Info.plist */ = {isa = PBXFileReference; lastKnownFileType = text.plist.xml; path = Info.plist; sourceTree = "<group>"; };
+		012482A225627B51003F7243 /* UIKitTests.m */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.objc; path = UIKitTests.m; sourceTree = "<group>"; };
 		0134524A256BCF7C0088C548 /* BugsnagError+Private.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; path = "BugsnagError+Private.h"; sourceTree = "<group>"; };
 		0134524B256BD00A0088C548 /* BugsnagThread+Private.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; path = "BugsnagThread+Private.h"; sourceTree = "<group>"; };
+		0140D24725765F8F00FD0306 /* BSGUIKit.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; path = BSGUIKit.h; sourceTree = "<group>"; };
 		0195FC3B256BC81400DE6646 /* BugsnagEvent+Private.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; path = "BugsnagEvent+Private.h"; sourceTree = "<group>"; };
 		0198762E2567D5AB000A7AF3 /* BugsnagStackframe+Private.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; path = "BugsnagStackframe+Private.h"; sourceTree = "<group>"; };
 		01B14C55251CE55F00118748 /* report-react-native-promise-rejection.json */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = text.json; path = "report-react-native-promise-rejection.json"; sourceTree = "<group>"; };
@@ -1701,6 +1705,7 @@
 				CBA2249A251E429C00B87416 /* TestSupport.m */,
 				01E8765C256684E700F4B70A /* URLSessionMock.h */,
 				01E8765D256684E700F4B70A /* URLSessionMock.m */,
+				012482A225627B51003F7243 /* UIKitTests.m */,
 			);
 			path = Tests;
 			sourceTree = "<group>";
@@ -1762,6 +1767,7 @@
 				CBCF77A225010648004AF22A /* BSGJSONSerialization.m */,
 				008968112486DA5600DC48C2 /* BSGSerialization.h */,
 				008968162486DA5600DC48C2 /* BSGSerialization.m */,
+				0140D24725765F8F00FD0306 /* BSGUIKit.h */,
 				008968102486DA5600DC48C2 /* BugsnagCollections.h */,
 				008968172486DA5600DC48C2 /* BugsnagCollections.m */,
 				008968152486DA5600DC48C2 /* BugsnagKeys.h */,
@@ -2552,6 +2558,7 @@
 				0089678A2486D43700DC48C2 /* KSCrashReportStore_Tests.m in Sources */,
 				E701FAAB2490EFD9008D842F /* EventApiValidationTest.m in Sources */,
 				0089677E2486D43700DC48C2 /* KSLogger_Tests.m in Sources */,
+				012482A325627B51003F7243 /* UIKitTests.m in Sources */,
 				008967482486D43700DC48C2 /* BugsnagUserTest.m in Sources */,
 				008967962486D43700DC48C2 /* KSCrashState_Tests.m in Sources */,
 				0089675D2486D43700DC48C2 /* BugsnagSessionTrackingPayloadTest.m in Sources */,
@@ -3184,6 +3191,7 @@
 		00AD1C8724869B0E00A27979 /* Debug */ = {
 			isa = XCBuildConfiguration;
 			buildSettings = {
+				CLANG_MODULES_AUTOLINK = NO;
 				CODE_SIGN_STYLE = Automatic;
 				DEFINES_MODULE = YES;
 				DYLIB_COMPATIBILITY_VERSION = 1;
@@ -3206,6 +3214,7 @@
 		00AD1C8824869B0E00A27979 /* Release */ = {
 			isa = XCBuildConfiguration;
 			buildSettings = {
+				CLANG_MODULES_AUTOLINK = NO;
 				CODE_SIGN_STYLE = Automatic;
 				DEFINES_MODULE = YES;
 				DYLIB_COMPATIBILITY_VERSION = 1;

--- a/Bugsnag/BugsnagSystemState.m
+++ b/Bugsnag/BugsnagSystemState.m
@@ -10,7 +10,7 @@
 #if TARGET_OS_OSX
 #import <AppKit/AppKit.h>
 #else
-#import <UIKit/UIKit.h>
+#import "BSGUIKit.h"
 #endif
 
 #import "BugsnagSystemState.h"

--- a/Bugsnag/Client/BugsnagClient.m
+++ b/Bugsnag/Client/BugsnagClient.m
@@ -68,7 +68,7 @@
 #endif
 
 #if BSG_PLATFORM_IOS
-#import <UIKit/UIKit.h>
+#import "BSGUIKit.h"
 #elif BSG_PLATFORM_OSX
 #import <AppKit/AppKit.h>
 #endif
@@ -359,7 +359,7 @@ NSString *_lastOrientation = nil;
                                                                   client:self];
 
 #if BSG_PLATFORM_IOS
-        _lastOrientation = BSGOrientationNameFromEnum([UIDevice currentDevice].orientation);
+        _lastOrientation = BSGOrientationNameFromEnum([UIDEVICE currentDevice].orientation);
 #endif
         _user = self.configuration.user;
 
@@ -507,8 +507,8 @@ NSString *const BSGBreadcrumbLoadedMessage = @"Bugsnag loaded";
                    name:UIApplicationDidReceiveMemoryWarningNotification
                  object:nil];
 
-    [UIDevice currentDevice].batteryMonitoringEnabled = YES;
-    [[UIDevice currentDevice] beginGeneratingDeviceOrientationNotifications];
+    [UIDEVICE currentDevice].batteryMonitoringEnabled = YES;
+    [[UIDEVICE currentDevice] beginGeneratingDeviceOrientationNotifications];
 
     [self batteryChanged:nil];
     [self orientationChanged:nil];
@@ -681,8 +681,8 @@ NSString *const BSGBreadcrumbLoadedMessage = @"Bugsnag loaded";
     [BSGConnectivity stopMonitoring];
 
 #if BSG_PLATFORM_IOS
-    [UIDevice currentDevice].batteryMonitoringEnabled = NO;
-    [[UIDevice currentDevice] endGeneratingDeviceOrientationNotifications];
+    [UIDEVICE currentDevice].batteryMonitoringEnabled = NO;
+    [[UIDEVICE currentDevice] endGeneratingDeviceOrientationNotifications];
 #endif
 }
 
@@ -1114,9 +1114,9 @@ NSString *const BSGBreadcrumbLoadedMessage = @"Bugsnag loaded";
  */
 #if BSG_PLATFORM_IOS
 - (void)batteryChanged:(NSNotification *)notification {
-    NSNumber *batteryLevel = @([UIDevice currentDevice].batteryLevel);
-    BOOL charging = [UIDevice currentDevice].batteryState == UIDeviceBatteryStateCharging ||
-                    [UIDevice currentDevice].batteryState == UIDeviceBatteryStateFull;
+    NSNumber *batteryLevel = @([UIDEVICE currentDevice].batteryLevel);
+    BOOL charging = [UIDEVICE currentDevice].batteryState == UIDeviceBatteryStateCharging ||
+                    [UIDEVICE currentDevice].batteryState == UIDeviceBatteryStateFull;
 
     [self.state addMetadata:batteryLevel
                     withKey:BSGKeyBatteryLevel
@@ -1134,7 +1134,7 @@ NSString *const BSGBreadcrumbLoadedMessage = @"Bugsnag loaded";
  * @param notification The orientation-change notification
  */
 - (void)orientationChanged:(NSNotification *)notification {
-    UIDeviceOrientation currentDeviceOrientation = [UIDevice currentDevice].orientation;
+    UIDeviceOrientation currentDeviceOrientation = [UIDEVICE currentDevice].orientation;
     NSString *orientation = BSGOrientationNameFromEnum(currentDeviceOrientation);
 
     // No orientation, nothing  to be done

--- a/Bugsnag/Helpers/BSGUIKit.h
+++ b/Bugsnag/Helpers/BSGUIKit.h
@@ -1,0 +1,40 @@
+//
+//  BSGUIKit.h
+//  Bugsnag
+//
+//  Created by Nick Dowell on 01/12/2020.
+//  Copyright © 2020 Bugsnag Inc. All rights reserved.
+//
+
+#import <UIKit/UIKit.h>
+
+// When used in some memory constrained contexts such as a file provider extension, linking to UIKit is problematic.
+// These macros exist to allow the use of UIKit without adding a link-time dependency on it.
+
+#define UIAPPLICATION                                       NSClassFromString(@"UIApplication")
+#define UIDEVICE                                            NSClassFromString(@"UIDevice")
+
+#define UIApplicationDidBecomeActiveNotification            @"UIApplicationDidBecomeActiveNotification"
+#define UIApplicationDidEnterBackgroundNotification         @"UIApplicationDidEnterBackgroundNotification"
+#define UIApplicationDidReceiveMemoryWarningNotification    @"UIApplicationDidReceiveMemoryWarningNotification"
+#define UIApplicationUserDidTakeScreenshotNotification      @"UIApplicationUserDidTakeScreenshotNotification"
+#define UIApplicationWillEnterForegroundNotification        @"UIApplicationWillEnterForegroundNotification"
+#define UIApplicationWillResignActiveNotification           @"UIApplicationWillResignActiveNotification"
+#define UIApplicationWillTerminateNotification              @"UIApplicationWillTerminateNotification"
+#define UIDeviceBatteryLevelDidChangeNotification           @"UIDeviceBatteryLevelDidChangeNotification"
+#define UIDeviceBatteryStateDidChangeNotification           @"UIDeviceBatteryStateDidChangeNotification"
+#define UIDeviceOrientationDidChangeNotification            @"UIDeviceOrientationDidChangeNotification"
+#define UIKeyboardDidHideNotification                       @"UIKeyboardDidHideNotification"
+#define UIKeyboardDidShowNotification                       @"UIKeyboardDidShowNotification"
+#define UIMenuControllerDidHideMenuNotification             @"UIMenuControllerDidHideMenuNotification"
+#define UIMenuControllerDidShowMenuNotification             @"UIMenuControllerDidShowMenuNotification"
+#define UIScreenBrightnessDidChangeNotification             @"UIScreenBrightnessDidChangeNotification"
+#define UITableViewSelectionDidChangeNotification           @"UITableViewSelectionDidChangeNotification"
+#define UITextFieldTextDidBeginEditingNotification          @"UITextFieldTextDidBeginEditingNotification"
+#define UITextFieldTextDidEndEditingNotification            @"UITextFieldTextDidEndEditingNotification"
+#define UITextViewTextDidBeginEditingNotification           @"UITextViewTextDidBeginEditingNotification"
+#define UITextViewTextDidEndEditingNotification             @"UITextViewTextDidEndEditingNotification"
+#define UIWindowDidBecomeHiddenNotification                 @"UIWindowDidBecomeHiddenNotification"
+#define UIWindowDidBecomeKeyNotification                    @"UIWindowDidBecomeKeyNotification"
+#define UIWindowDidBecomeVisibleNotification                @"UIWindowDidBecomeVisibleNotification"
+#define UIWindowDidResignKeyNotification                    @"UIWindowDidResignKeyNotification"

--- a/Bugsnag/KSCrash/Source/KSCrash/Recording/BSG_KSCrash.m
+++ b/Bugsnag/KSCrash/Source/KSCrash/Recording/BSG_KSCrash.m
@@ -43,7 +43,7 @@
 #import "BSG_KSCrashReportFields.h"
 
 #if BSG_HAS_UIKIT
-#import <UIKit/UIKit.h>
+#import "BSGUIKit.h"
 #endif
 #if TARGET_OS_OSX
 #import <AppKit/AppKit.h>

--- a/Bugsnag/KSCrash/Source/KSCrash/Recording/BSG_KSCrashState.m
+++ b/Bugsnag/KSCrash/Source/KSCrash/Recording/BSG_KSCrashState.m
@@ -36,7 +36,7 @@
 #include "BSG_KSLogger.h"
 
 #if (TARGET_OS_TV || TARGET_OS_IPHONE || TARGET_IPHONE_SIMULATOR)
-#import <UIKit/UIKit.h>
+#import "BSGUIKit.h"
 #endif
 #include <errno.h>
 #include <fcntl.h>

--- a/Bugsnag/KSCrash/Source/KSCrash/Recording/BSG_KSSystemInfo.h
+++ b/Bugsnag/KSCrash/Source/KSCrash/Recording/BSG_KSSystemInfo.h
@@ -60,7 +60,7 @@
 #import "BugsnagPlatformConditional.h"
 
 #if BSG_PLATFORM_IOS || BSG_PLATFORM_TVOS
-#import <UIKit/UIKit.h>
+#import "BSGUIKit.h"
 #endif
 
 /**

--- a/Bugsnag/KSCrash/Source/KSCrash/Recording/BSG_KSSystemInfo.m
+++ b/Bugsnag/KSCrash/Source/KSCrash/Recording/BSG_KSSystemInfo.m
@@ -42,7 +42,7 @@
 
 #import <CommonCrypto/CommonDigest.h>
 #if BSG_PLATFORM_IOS || BSG_PLATFORM_TVOS
-#import <UIKit/UIKit.h>
+#import "BSGUIKit.h"
 #endif
 
 @implementation BSG_KSSystemInfo
@@ -176,10 +176,10 @@
     NSMutableData *data = nil;
 
 #if BSG_HAS_UIDEVICE
-    if ([[UIDevice currentDevice]
+    if ([[UIDEVICE currentDevice]
             respondsToSelector:@selector(identifierForVendor)]) {
         data = [NSMutableData dataWithLength:16];
-        [[UIDevice currentDevice].identifierForVendor
+        [[UIDEVICE currentDevice].identifierForVendor
             getUUIDBytes:data.mutableBytes];
     } else
 #endif
@@ -354,8 +354,8 @@
     BSGDictSetSafeObject(sysInfo, @__clang_version__, @BSG_KSSystemField_ClangVersion);
 #endif
 #if BSG_HAS_UIDEVICE
-    BSGDictSetSafeObject(sysInfo, [UIDevice currentDevice].systemName, @BSG_KSSystemField_SystemName);
-    BSGDictSetSafeObject(sysInfo, [UIDevice currentDevice].systemVersion, @BSG_KSSystemField_SystemVersion);
+    BSGDictSetSafeObject(sysInfo, [UIDEVICE currentDevice].systemName, @BSG_KSSystemField_SystemName);
+    BSGDictSetSafeObject(sysInfo, [UIDEVICE currentDevice].systemVersion, @BSG_KSSystemField_SystemVersion);
 #else
     BSGDictSetSafeObject(sysInfo, @"Mac OS", @BSG_KSSystemField_SystemName);
     NSOperatingSystemVersion version =
@@ -458,7 +458,7 @@
         // Calling this API indirectly to avoid a compile-time check that
         // [UIApplication sharedApplication] is not called from app extensions
         // (which is handled above)
-        UIApplication *app = [UIApplication performSelector:@selector(sharedApplication)];
+        UIApplication *app = [UIAPPLICATION performSelector:@selector(sharedApplication)];
         return [app applicationState];
     };
 

--- a/Bugsnag/Payload/BugsnagEvent.m
+++ b/Bugsnag/Payload/BugsnagEvent.m
@@ -9,7 +9,7 @@
 #import "BugsnagPlatformConditional.h"
 
 #if BSG_PLATFORM_IOS
-#import <UIKit/UIKit.h>
+#import "BSGUIKit.h"
 #include <sys/utsname.h>
 #endif
 

--- a/Tests/UIKitTests.m
+++ b/Tests/UIKitTests.m
@@ -1,0 +1,48 @@
+//
+//  UIKitTests.m
+//  Bugsnag-iOSTests
+//
+//  Created by Nick Dowell on 16/11/2020.
+//  Copyright © 2020 Bugsnag Inc. All rights reserved.
+//
+
+#import <UIKit/UIKit.h>
+#import <XCTest/XCTest.h>
+
+@interface UIKitTests : XCTestCase
+
+@end
+
+@implementation UIKitTests
+
+- (void)testNotificationNames {
+    // The notifier uses hard-coded notification names so that it can avoid linking
+    // to UIKit. These tests ensure that the hard-coded names match the SDK.
+    #define ASSERT_NOTIFICATION_NAME(name) XCTAssertEqualObjects(name, @#name)
+    ASSERT_NOTIFICATION_NAME(UIApplicationDidBecomeActiveNotification);
+    ASSERT_NOTIFICATION_NAME(UIApplicationDidEnterBackgroundNotification);
+    ASSERT_NOTIFICATION_NAME(UIApplicationDidReceiveMemoryWarningNotification);
+    ASSERT_NOTIFICATION_NAME(UIApplicationUserDidTakeScreenshotNotification);
+    ASSERT_NOTIFICATION_NAME(UIApplicationWillEnterForegroundNotification);
+    ASSERT_NOTIFICATION_NAME(UIApplicationWillResignActiveNotification);
+    ASSERT_NOTIFICATION_NAME(UIApplicationWillTerminateNotification);
+    ASSERT_NOTIFICATION_NAME(UIDeviceBatteryLevelDidChangeNotification);
+    ASSERT_NOTIFICATION_NAME(UIDeviceBatteryStateDidChangeNotification);
+    ASSERT_NOTIFICATION_NAME(UIDeviceOrientationDidChangeNotification);
+    ASSERT_NOTIFICATION_NAME(UIKeyboardDidHideNotification);
+    ASSERT_NOTIFICATION_NAME(UIKeyboardDidShowNotification);
+    ASSERT_NOTIFICATION_NAME(UIMenuControllerDidHideMenuNotification);
+    ASSERT_NOTIFICATION_NAME(UIMenuControllerDidShowMenuNotification);
+    ASSERT_NOTIFICATION_NAME(UIScreenBrightnessDidChangeNotification);
+    ASSERT_NOTIFICATION_NAME(UITableViewSelectionDidChangeNotification);
+    ASSERT_NOTIFICATION_NAME(UITextFieldTextDidBeginEditingNotification);
+    ASSERT_NOTIFICATION_NAME(UITextFieldTextDidEndEditingNotification);
+    ASSERT_NOTIFICATION_NAME(UITextViewTextDidBeginEditingNotification);
+    ASSERT_NOTIFICATION_NAME(UITextViewTextDidEndEditingNotification);
+    ASSERT_NOTIFICATION_NAME(UIWindowDidBecomeHiddenNotification);
+    ASSERT_NOTIFICATION_NAME(UIWindowDidBecomeKeyNotification);
+    ASSERT_NOTIFICATION_NAME(UIWindowDidBecomeVisibleNotification);
+    ASSERT_NOTIFICATION_NAME(UIWindowDidResignKeyNotification);
+}
+
+@end


### PR DESCRIPTION
## Goal

Some types of app extensions have such severe memory limits (e.g. 30MB for a file provider extension) that linking UIKit is undesirable.

These changes make it possible to use Bugsnag without linking UIKit.

## Design

The approach used here to avoid the use of any UIKit symbols - i.e. Objective-C classes, function names or symbols like NSNotification names.

We can still `#import <UIKit/UIKit.h>` because Clang's autolinking works on the basis of the symbols referenced by code.

_Note: this is contrary to the Quick Help Summary show in Xcode:_

> Automatically link SDK frameworks that are referenced using `#import` or `#include`. This feature requires also enabling support for modules. This build setting only applies to C-family languages.

_Even with `CLANG_MODULES_AUTOLINK = YES` (the default) `otool -L` shows that removing the use of all UIKit symbols from our code also removes the linker dependency._

We can also still send messages to UIKit objects in the normal way as this does not introduce any link-time dependencies.

## Changeset

* `CLANG_MODULES_AUTOLINK` has been set to `NO` in the top-level Bugsnag project - this will cause a build failure if we reintroduce a link-time dependency on UIKit e.g. `Undefined symbol: _OBJC_CLASS_$_UIDevice`
* Messages to UIKit classes now use `NSClassFromString()` to avoid linking against the class symbol
* Notification names are now hardcoded

## Testing

* Added a unit test case to verify that the hard-coded notification names match those used by the OS.
* Manually verified that Bugsnag works when used in a file provider extension without UIKit.