### PR TITLE
Auto retry for lost agents

### DIFF
--- a/.buildkite/pipeline.yml
+++ b/.buildkite/pipeline.yml
@@ -32,6 +32,10 @@ steps:
           - "--fail-fast"
     concurrency: 10
     concurrency_group: browserstack-app
+    retry:
+      automatic:
+        - exit_status: -1  # Agent was lost
+          limit: 2
 
   - label: ':ios: iOS 13 end-to-end tests'
     timeout_in_minutes: 60
@@ -53,6 +57,10 @@ steps:
           - "--fail-fast"
     concurrency: 10
     concurrency_group: browserstack-app
+    retry:
+      automatic:
+        - exit_status: -1  # Agent was lost
+          limit: 2
 
   - label: ':ios: iOS 12 end-to-end tests'
     timeout_in_minutes: 60
@@ -74,6 +82,10 @@ steps:
           - "--fail-fast"
     concurrency: 10
     concurrency_group: browserstack-app
+    retry:
+      automatic:
+        - exit_status: -1  # Agent was lost
+          limit: 2
 
   - label: ':ios: iOS 11 end-to-end tests'
     timeout_in_minutes: 60
@@ -95,9 +107,10 @@ steps:
           - "--fail-fast"
     concurrency: 10
     concurrency_group: browserstack-app
-    # Soft fail while Browserstack's iOS 11 devices are flakey
-    soft_fail:
-      - exit_status: "*"
+    retry:
+      automatic:
+        - exit_status: -1  # Agent was lost
+          limit: 2
 
   - label: ':ios: iOS 10 end-to-end tests'
     timeout_in_minutes: 60
@@ -119,3 +132,7 @@ steps:
           - "--fail-fast"
     concurrency: 10
     concurrency_group: browserstack-app
+    retry:
+      automatic:
+        - exit_status: -1  # Agent was lost
+          limit: 2


### PR DESCRIPTION
## Goal

Auto-retry steps susceptible to agents being lost (spot instances reclaimed by AWS in our case).

## Design

Taken directly from the [Buildkite docs](https://buildkite.com/docs/pipelines/command-step#automatic-retry-attributes).

## Changeset

Retry added to pipeline steps.  Also removed the soft fail on iOS 11 as it appears to be more stable now and I'd be nervous of missing a genuine issue (or fixable flake).

## Testing

As it happened I lost an agent on the build for this PR and so saw it in action.  Forcibly killing an agent didn't result in an auto-retry for some reason, but it's safe enough to leave the the config in and I have posed a question in the Buidlkite community Slack.