### PR TITLE
[PLAT-5477] Update appium version for iOS 12+ end to end tests

### DIFF
--- a/.buildkite/pipeline.yml
+++ b/.buildkite/pipeline.yml
@@ -91,7 +91,7 @@ steps:
           - "--username=$BROWSER_STACK_USERNAME"
           - "--access-key=$BROWSER_STACK_ACCESS_KEY"
           - "--resilient"
-          - "--appium-version=1.17.0"
+          - "--appium-version=1.16.0"
           - "--fail-fast"
     concurrency: 10
     concurrency_group: browserstack-app

--- a/.buildkite/pipeline.yml
+++ b/.buildkite/pipeline.yml
@@ -28,7 +28,7 @@ steps:
           - "--username=$BROWSER_STACK_USERNAME"
           - "--access-key=$BROWSER_STACK_ACCESS_KEY"
           - "--resilient"
-          - "--appium-version=1.15.0"
+          - "--appium-version=1.17.0"
           - "--fail-fast"
     concurrency: 10
     concurrency_group: browserstack-app
@@ -49,7 +49,7 @@ steps:
           - "--username=$BROWSER_STACK_USERNAME"
           - "--access-key=$BROWSER_STACK_ACCESS_KEY"
           - "--resilient"
-          - "--appium-version=1.15.0"
+          - "--appium-version=1.17.0"
           - "--fail-fast"
     concurrency: 10
     concurrency_group: browserstack-app
@@ -70,7 +70,7 @@ steps:
           - "--username=$BROWSER_STACK_USERNAME"
           - "--access-key=$BROWSER_STACK_ACCESS_KEY"
           - "--resilient"
-          - "--appium-version=1.15.0"
+          - "--appium-version=1.17.0"
           - "--fail-fast"
     concurrency: 10
     concurrency_group: browserstack-app
@@ -91,7 +91,7 @@ steps:
           - "--username=$BROWSER_STACK_USERNAME"
           - "--access-key=$BROWSER_STACK_ACCESS_KEY"
           - "--resilient"
-          - "--appium-version=1.16.0"
+          - "--appium-version=1.17.0"
           - "--fail-fast"
     concurrency: 10
     concurrency_group: browserstack-app


### PR DESCRIPTION
## Goal
This should clear up a persistent error present in the appium logs.

Unfortunately iOS 10 only supports up to Appium v1.15, and through looking at the test runs iOS 11 seems to struggle beyond iOS 1.16.