### PR TITLE
Reduce browserstack concurrency to 9

### DIFF
--- a/.buildkite/pipeline.yml
+++ b/.buildkite/pipeline.yml
@@ -30,7 +30,7 @@ steps:
           - "--resilient"
           - "--appium-version=1.17.0"
           - "--fail-fast"
-    concurrency: 10
+    concurrency: 9
     concurrency_group: browserstack-app
 
   - label: ':ios: iOS 13 end-to-end tests'
@@ -51,7 +51,7 @@ steps:
           - "--resilient"
           - "--appium-version=1.17.0"
           - "--fail-fast"
-    concurrency: 10
+    concurrency: 9
     concurrency_group: browserstack-app
 
   - label: ':ios: iOS 12 end-to-end tests'
@@ -72,7 +72,7 @@ steps:
           - "--resilient"
           - "--appium-version=1.17.0"
           - "--fail-fast"
-    concurrency: 10
+    concurrency: 9
     concurrency_group: browserstack-app
 
   - label: ':ios: iOS 11 end-to-end tests'
@@ -93,7 +93,7 @@ steps:
           - "--resilient"
           - "--appium-version=1.16.0"
           - "--fail-fast"
-    concurrency: 10
+    concurrency: 9
     concurrency_group: browserstack-app
     # Soft fail while Browserstack's iOS 11 devices are flakey
     soft_fail:
@@ -117,5 +117,5 @@ steps:
           - "--resilient"
           - "--appium-version=1.15.0"
           - "--fail-fast"
-    concurrency: 10
+    concurrency: 9
     concurrency_group: browserstack-app


### PR DESCRIPTION
## Goal

Reduces the browserstack concurrency from 10 to 9. This makes one device slot will always be available for running local tests, which speeds up the feedback loop without dramatically slowing down CI times.