### PR TITLE
[PLAT-5523] Fix exception thrown when started without apiKey

### DIFF
--- a/Bugsnag/Configuration/BugsnagConfiguration.m
+++ b/Bugsnag/Configuration/BugsnagConfiguration.m
@@ -96,7 +96,7 @@ NSString * const kBugsnagUserUserId = @"BugsnagUserUserId";
  * @param zone This parameter is ignored. Memory zones are no longer used by Objective-C.
  */
 - (nonnull id)copyWithZone:(nullable NSZone *)zone {
-    BugsnagConfiguration *copy = [[BugsnagConfiguration alloc] initWithApiKey:[NSMutableString stringWithString:self.apiKey]];
+    BugsnagConfiguration *copy = [[BugsnagConfiguration alloc] initWithApiKey:[self.apiKey copy]];
     // Omit apiKey - it's set explicitly in the line above
     [copy setAppType:self.appType];
     [copy setAppVersion:self.appVersion];


### PR DESCRIPTION
## Goal

An unexpected exception was being thrown when trying to start Bugsnag without an API key.

The expected behaviour is for a descriptive exception to be thrown when calling `[Bugsnag start]`

<img width="619" alt="Screenshot 2020-12-08 at 11 55 36" src="https://user-images.githubusercontent.com/61777/101480993-5e75ac80-394c-11eb-9f37-f4187b17e732.png">

Instead of this NSMutableArray was throwing an exception due to being passed a `nil` argument.

## Changeset

The `apiKey` is now copied in a more straightforward way.

## Testing

Manually verified by creating a new empty project using Bugsnag and trying to run app before configuring the API key.