### PR TITLE
Fix some flaky tests

### DIFF
--- a/features/enabled_error_types.feature
+++ b/features/enabled_error_types.feature
@@ -4,28 +4,19 @@ Feature: Enabled error types
     Given I clear all persistent data
 
   Scenario: All Crash reporting is disabled
-    # Sessions: on, unhandled crashes: off
+    # enabledErrorTypes = None, Generate a manual notification, crash
     When I run "DisableAllExceptManualExceptionsAndCrashScenario" and relaunch the app
     And I configure Bugsnag for "DisableAllExceptManualExceptionsAndCrashScenario"
-    # Give ignored report time to be processed
-    And I wait for 2 seconds
-    And I wait to receive 2 requests
-    Then the request is valid for the session reporting API version "1.0" for the "iOS Bugsnag Notifier" notifier
-    And I discard the oldest request
-    Then the request is valid for the session reporting API version "1.0" for the "iOS Bugsnag Notifier" notifier
-
-  Scenario: All Crash reporting is disabled but manual notification works
-    # enabledErrorTypes = None, Generate a manual notification, crash
-    When I run "DisableAllExceptManualExceptionsSendManualAndCrashScenario" and relaunch the app
-    And I configure Bugsnag for "DisableAllExceptManualExceptionsSendManualAndCrashScenario"
     And I wait to receive a request
     Then the request is valid for the error reporting API version "4.0" for the "iOS Bugsnag Notifier" notifier
+    And the event "unhandled" is false
 
   Scenario: NSException Crash Reporting is disabled
     When I run "DisableNSExceptionScenario" and relaunch the app
     And I configure Bugsnag for "DisableNSExceptionScenario"
     And I wait to receive a request
     Then the request is valid for the error reporting API version "4.0" for the "iOS Bugsnag Notifier" notifier
+    # Default NSException handler calls abort()
     And the event "severity" equals "error"
     And the event "unhandled" is true
     And the event "severityReason.type" equals "signal"
@@ -34,26 +25,21 @@ Feature: Enabled error types
   Scenario: CPP Crash Reporting is disabled
     When I run "EnabledErrorTypesCxxScenario" and relaunch the app
     And I configure Bugsnag for "EnabledErrorTypesCxxScenario"
-    # Give ignored SIGABRT report time to be processed
-    And I wait for 2 seconds
-    And I wait to receive 2 requests
-    Then the request is valid for the session reporting API version "1.0" for the "iOS Bugsnag Notifier" notifier
-    And I discard the oldest request
-    Then the request is valid for the session reporting API version "1.0" for the "iOS Bugsnag Notifier" notifier
+    And I wait to receive a request
+    Then the request is valid for the error reporting API version "4.0" for the "iOS Bugsnag Notifier" notifier
+    And the event "unhandled" is false
 
   Scenario: Mach Crash Reporting is disabled
     When I run "DisableMachExceptionScenario"
     And I relaunch the app
     And I configure Bugsnag for "DisableMachExceptionScenario"
-    # Give ignored SIGSEGV report time to be processed
-    And I wait for 2 seconds
-    And I wait to receive 2 requests
-    Then the request is valid for the session reporting API version "1.0" for the "iOS Bugsnag Notifier" notifier
-    And I discard the oldest request
-    Then the request is valid for the session reporting API version "1.0" for the "iOS Bugsnag Notifier" notifier
+    And I wait to receive a request
+    Then the request is valid for the error reporting API version "4.0" for the "iOS Bugsnag Notifier" notifier
+    And the event "unhandled" is false
 
   Scenario: Signals Crash Reporting is disabled
     When I run "DisableSignalsExceptionScenario" and relaunch the app
     And I configure Bugsnag for "DisableSignalsExceptionScenario"
-    And I wait for 5 seconds
-    And I should receive no requests
+    And I wait to receive a request
+    Then the request is valid for the error reporting API version "4.0" for the "iOS Bugsnag Notifier" notifier
+    And the event "unhandled" is false

--- a/features/fixtures/shared/scenarios/EnabledErrorTypesCxxScenario.mm
+++ b/features/fixtures/shared/scenarios/EnabledErrorTypesCxxScenario.mm
@@ -20,6 +20,7 @@ const char *disabled_cxx_reporting_kaboom_exception::what() const throw() {
     errorTypes.cppExceptions = false;
     errorTypes.ooms = false;
     self.config.enabledErrorTypes = errorTypes;
+    self.config.autoTrackSessions = false;
     [self.config addOnSendErrorBlock:^BOOL(BugsnagEvent * _Nonnull event) {
         // std::exception terminates with abort() by default, therefore discard SIGABRT
         return ![@"SIGABRT" isEqualToString:event.errors[0].errorClass];
@@ -32,6 +33,9 @@ const char *disabled_cxx_reporting_kaboom_exception::what() const throw() {
 }
 
 - (void)crash __attribute__((noreturn)) {
+    // Notify error so that mazerunner sees something
+    [Bugsnag notifyError:[NSError errorWithDomain:@"com.bugsnag" code:833 userInfo:nil]];
+
     throw new disabled_cxx_reporting_kaboom_exception;
 }
 

--- a/features/fixtures/shared/scenarios/EnabledErrorTypesScenario.m
+++ b/features/fixtures/shared/scenarios/EnabledErrorTypesScenario.m
@@ -26,41 +26,12 @@
     errorTypes.signals = false;
     errorTypes.ooms = false;
     self.config.enabledErrorTypes = errorTypes;
-    self.config.autoTrackSessions = YES;
-    [super startBugsnag];
-}
-
-- (void)run {
-    // From null prt scenario
-    volatile char *ptr = NULL;
-    (void) *ptr;
-}
-
-@end
-
-// MARK: -
-
-
-/**
- * Disable all crash reporting (except, implicitly, manual), send a manual report
- * and crash the app (one session request with 2 sessions and 1 report should be sent)
- */
-@implementation DisableAllExceptManualExceptionsSendManualAndCrashScenario
-
-- (void)startBugsnag {
-    BugsnagErrorTypes *errorTypes = [BugsnagErrorTypes new];
-    errorTypes.cppExceptions = false;
-    errorTypes.machExceptions = false;
-    errorTypes.unhandledExceptions = false;
-    errorTypes.signals = false;
-    errorTypes.ooms = false;
-    self.config.enabledErrorTypes = errorTypes;
     self.config.autoTrackSessions = NO;
     [super startBugsnag];
 }
 
 - (void)run {
-    // Manual crash
+    // Notify error so that mazerunner sees something
     [Bugsnag notifyError:[NSError errorWithDomain:@"com.bugsnag" code:833 userInfo:nil]];
 
     // From null prt scenario
@@ -103,6 +74,7 @@
     errorTypes.machExceptions = false;
     errorTypes.ooms = false;
     self.config.enabledErrorTypes = errorTypes;
+    self.config.autoTrackSessions = NO;
     [self.config addOnSendErrorBlock:^BOOL(BugsnagEvent * _Nonnull event) {
         // Suppress the SIGSEGV caused by EXC_BAD_ACCESS (https://flylib.com/books/en/3.126.1.110/1/)
         return ![@"SIGSEGV" isEqualToString:event.errors[0].errorClass];
@@ -113,6 +85,9 @@
 #pragma clang diagnostic push
 #pragma clang diagnostic ignored "-Winvalid-noreturn"
 - (void)run  __attribute__((noreturn)) {
+    // Notify error so that mazerunner sees something
+    [Bugsnag notifyError:[NSError errorWithDomain:@"com.bugsnag" code:833 userInfo:nil]];
+
     strcmp(0, ""); // Generate EXC_BAD_ACCESS (see e.g. https://stackoverflow.com/q/22488358/2431627)
 }
 #pragma clang diagnostic pop
@@ -135,6 +110,9 @@
 #pragma clang diagnostic push
 #pragma clang diagnostic ignored "-Winvalid-noreturn"
 - (void)run  __attribute__((noreturn)) {
+    // Notify error so that mazerunner sees something
+    [Bugsnag notifyError:[NSError errorWithDomain:@"com.bugsnag" code:833 userInfo:nil]];
+
     raise(SIGINT);
 }
 #pragma  clang pop


### PR DESCRIPTION
## Goal

Tests that relied upon session tracking to detect the non-sending of events can sometimes flake.

## Design

If we manually send a handled error, we can just check for only that error being received. This is already used elsewhere in the tests.

## Changeset

Modified affected tests to disable session tracking, and only expect one request.

## Testing

Re-ran e2e tests.
