### PR TITLE
Fix unhandledOverride

### DIFF
--- a/Bugsnag/Payload/BugsnagEvent.m
+++ b/Bugsnag/Payload/BugsnagEvent.m
@@ -646,12 +646,12 @@ NSDictionary *BSGParseCustomException(NSDictionary *report,
     event[BSGKeyGroupingHash] = self.groupingHash;
 
     event[BSGKeyUnhandled] = @(self.handledState.unhandled);
-    if (self.handledState.unhandledOverridden) {
-        event[BSGKeyUnhandledOverridden] = @(self.handledState.unhandledOverridden);
-    }
 
     // serialize handled/unhandled into payload
     NSMutableDictionary *severityReason = [NSMutableDictionary new];
+    if (self.handledState.unhandledOverridden) {
+        severityReason[BSGKeyUnhandledOverridden] = @(self.handledState.unhandledOverridden);
+    }
     NSString *reasonType = [BugsnagHandledState
         stringFromSeverityReason:self.handledState.calculateSeverityReasonType];
     severityReason[BSGKeyType] = reasonType;

--- a/Bugsnag/Payload/BugsnagHandledState.m
+++ b/Bugsnag/Payload/BugsnagHandledState.m
@@ -49,18 +49,18 @@ static NSString *const kUserCallbackSetSeverity = @"userCallbackSetSeverity";
 @implementation BugsnagHandledState
 
 + (instancetype)handledStateFromJson:(NSDictionary *)json {
-    BOOL unhandled = [json[@"unhandled"] boolValue];
-    BOOL unhandledOverridden = [json[@"unhandledOverridden"] boolValue];
-    NSDictionary *data = json[@"severityReason"];
-    BSGSeverity severity = BSGParseSeverity(json[@"severity"]);
+    BOOL unhandled = [json[BSGKeyUnhandled] boolValue];
+    NSDictionary *severityReason = json[BSGKeySeverityReason];
+    BOOL unhandledOverridden = [severityReason[BSGKeyUnhandledOverridden] boolValue];
+    BSGSeverity severity = BSGParseSeverity(json[BSGKeySeverity]);
 
     NSString *attrValue = nil;
-    NSDictionary *attrs = data[@"attributes"];
+    NSDictionary *attrs = severityReason[BSGKeyAttributes];
 
     if (attrs != nil && [attrs count] == 1) { // only 1 attrValue is ever present
         attrValue = [attrs allValues][0];
     }
-    SeverityReasonType reason = [BugsnagHandledState severityReasonFromString:data[@"type"]];
+    SeverityReasonType reason = [BugsnagHandledState severityReasonFromString:severityReason[BSGKeyType]];
     return [[BugsnagHandledState alloc] initWithSeverityReason:reason
                                                       severity:severity
                                                      unhandled:unhandled

--- a/Tests/BugsnagErrorReportSinkTests.m
+++ b/Tests/BugsnagErrorReportSinkTests.m
@@ -354,7 +354,7 @@
     NSDictionary *payload = [self reportFromHandledState:state];
     
     XCTAssertTrue([payload[@"unhandled"] boolValue]);
-    XCTAssertTrue([payload[@"unhandledOverridden"] boolValue]);
+    XCTAssertTrue([payload[@"severityReason"][@"unhandledOverridden"] boolValue]);
 
     state.unhandled = YES;
     state.unhandledOverridden = NO;
@@ -368,7 +368,7 @@
     payload = [self reportFromHandledState:state];
     
     XCTAssertFalse([payload[@"unhandled"] boolValue]);
-    XCTAssertTrue([payload[@"unhandledOverridden"] boolValue]);
+    XCTAssertTrue([payload[@"severityReason"][@"unhandledOverridden"] boolValue]);
 
     state.unhandled = NO;
     state.unhandledOverridden = NO;

--- a/features/cross_notifier_notify.feature
+++ b/features/cross_notifier_notify.feature
@@ -66,7 +66,7 @@ Feature: Communicating events between notifiers
     And the "file" of stack frame 2 is null
     And the "lineNumber" of stack frame 2 is null
     And the event "unhandled" is true
-    And the event "unhandledOverridden" is true
+    And the event "severityReason.unhandledOverridden" is true
 
     And the payload field "events" is an array with 1 elements
     And the payload field "events.0.session.events.handled" equals 0

--- a/features/event_callbacks.feature
+++ b/features/event_callbacks.feature
@@ -37,7 +37,7 @@ Feature: Callbacks can access and modify event information
     And the event "user.email" equals "customEmail"
     And the event "user.name" equals "customName"
     And the event "unhandled" is true
-    And the event "unhandledOverridden" is true
+    And the event "severityReason.unhandledOverridden" is true
 
   Scenario: An OnErrorCallback can overwrite unhandled (false) for a handled error
     When I run "OnErrorOverwriteUnhandledFalseScenario"

--- a/features/unhandled_cpp_exception.feature
+++ b/features/unhandled_cpp_exception.feature
@@ -25,5 +25,5 @@ Feature: Thrown C++ exceptions are captured by Bugsnag
     And the payload field "events.0.exceptions.0.stacktrace" is an array with 0 elements
     And the event "severity" equals "error"
     And the event "unhandled" is false
-    And the event "unhandledOverridden" is true
+    And the event "severityReason.unhandledOverridden" is true
     And the event "severityReason.type" equals "unhandledException"

--- a/features/unhandled_mach_exception.feature
+++ b/features/unhandled_mach_exception.feature
@@ -37,5 +37,5 @@ Feature: Bugsnag captures an unhandled mach exception
     And the event "metaData.error.mach.subcode" equals "0xdeadbeef"
     And the event "severity" equals "error"
     And the event "unhandled" is false
-    And the event "unhandledOverridden" is true
+    And the event "severityReason.unhandledOverridden" is true
     And the event "severityReason.type" equals "unhandledException"

--- a/features/unhandled_nsexception.feature
+++ b/features/unhandled_nsexception.feature
@@ -31,5 +31,5 @@ Feature: Uncaught NSExceptions are captured by Bugsnag
     And the payload field "events.0.device.time" is a date
     And the event "severity" equals "error"
     And the event "unhandled" is false
-    And the event "unhandledOverridden" is true
+    And the event "severityReason.unhandledOverridden" is true
     And the event "severityReason.type" equals "unhandledException"

--- a/features/unhandled_signal.feature
+++ b/features/unhandled_signal.feature
@@ -32,7 +32,7 @@ Feature: Signals are captured as error reports in Bugsnag
     And the "method" of stack frame 3 equals "-[AbortOverrideScenario run]"
     And the event "severity" equals "error"
     And the event "unhandled" is false
-    And the event "unhandledOverridden" is true
+    And the event "severityReason.unhandledOverridden" is true
     And the event "severityReason.type" equals "signal"
     And the event "severityReason.attributes.signalType" equals "SIGABRT"
 


### PR DESCRIPTION
## Goal

The last unhandled override PR incorrectly placed `unhandledOverride` at the top level, when it should have been inside of `severityReason`.

## Changeset

Update JSON serializer and deserializer code to place it at the correct level, and update tests to match.

## Testing

Re-ran unit tests and e2e tests.
