### PR TITLE
5371 max persisted sessions

### DIFF
--- a/Bugsnag/BugsnagSessionTracker.m
+++ b/Bugsnag/BugsnagSessionTracker.m
@@ -58,7 +58,8 @@ NSString *const BSGSessionUpdateNotification = @"BugsnagSessionChanged";
         if (!storePath) {
             BSG_KSLOG_ERROR(@"Failed to initialize session store.");
         }
-        _sessionStore = [BugsnagSessionFileStore storeWithPath:storePath];
+
+        _sessionStore = [BugsnagSessionFileStore storeWithPath:storePath maxPersistedSessions:config.maxPersistedSessions];
         _extraRuntimeInfo = [NSMutableDictionary new];
     }
     return self;

--- a/Bugsnag/Configuration/BSGConfigurationBuilder.m
+++ b/Bugsnag/Configuration/BSGConfigurationBuilder.m
@@ -31,6 +31,7 @@ static BOOL BSGValueIsBoolean(id object) {
         BSGKeyEndpoints,
         BSGKeyMaxBreadcrumbs,
         BSGKeyMaxPersistedEvents,
+        BSGKeyMaxPersistedSessions,
         BSGKeyPersistUser,
         BSGKeyRedactedKeys,
         BSGKeyReleaseStage,
@@ -57,6 +58,7 @@ static BOOL BSGValueIsBoolean(id object) {
 
     [self loadNumber:config options:options key:BSGKeyMaxBreadcrumbs];
     [self loadNumber:config options:options key:BSGKeyMaxPersistedEvents];
+    [self loadNumber:config options:options key:BSGKeyMaxPersistedSessions];
     [self loadSendThreads:config options:options];
     return config;
 }

--- a/Bugsnag/Configuration/BugsnagConfiguration.m
+++ b/Bugsnag/Configuration/BugsnagConfiguration.m
@@ -85,6 +85,7 @@ NSString * const kBugsnagUserUserId = @"BugsnagUserUserId";
     copy.discardClasses = self.discardClasses;
     [copy setRedactedKeys:self.redactedKeys];
     [copy setMaxPersistedEvents:self.maxPersistedEvents];
+    [copy setMaxPersistedSessions:self.maxPersistedSessions];
     [copy setMaxBreadcrumbs:self.maxBreadcrumbs];
     copy->_metadata = [[BugsnagMetadata alloc] initWithDictionary:[[self.metadata toDictionary] mutableCopy]];
     [copy setEndpoints:self.endpoints];
@@ -162,6 +163,7 @@ NSString * const kBugsnagUserUserId = @"BugsnagUserUserId";
     _redactedKeys = [NSSet setWithArray:@[@"password"]];
     _enabledBreadcrumbTypes = BSGEnabledBreadcrumbTypeAll;
     _maxPersistedEvents = 12;
+    _maxPersistedSessions = 32;
     _maxBreadcrumbs = 25;
     _autoTrackSessions = YES;
     _sendThreads = BSGThreadSendPolicyAlways;
@@ -434,6 +436,26 @@ NSString * const kBugsnagUserUserId = @"BugsnagUserUserId";
             bsg_log_err(@"Invalid configuration value detected. Option maxPersistedEvents "
                         "should be an integer between 1-100. Supplied value is %lu",
                         (unsigned long) maxPersistedEvents);
+        }
+    }
+}
+
+@synthesize maxPersistedSessions = _maxPersistedSessions;
+
+- (NSUInteger)maxPersistedSessions {
+    @synchronized (self) {
+        return _maxPersistedSessions;
+    }
+}
+
+- (void)setMaxPersistedSessions:(NSUInteger)maxPersistedSessions {
+    @synchronized (self) {
+        if (maxPersistedSessions >= 1 && maxPersistedSessions <= 100) {
+            _maxPersistedSessions = maxPersistedSessions;
+        } else {
+            bsg_log_err(@"Invalid configuration value detected. Option maxPersistedSessions "
+                        "should be an integer between 1-100. Supplied value is %lu",
+                        (unsigned long) maxPersistedSessions);
         }
     }
 }

--- a/Bugsnag/Helpers/BugsnagKeys.h
+++ b/Bugsnag/Helpers/BugsnagKeys.h
@@ -64,6 +64,7 @@ extern NSString *const BSGKeyMachoUUID;
 extern NSString *const BSGKeyMachoVMAddress;
 extern NSString *const BSGKeyMaxBreadcrumbs;
 extern NSString *const BSGKeyMaxPersistedEvents;
+extern NSString *const BSGKeyMaxPersistedSessions;
 extern NSString *const BSGKeyMessage;
 extern NSString *const BSGKeyMetadata;
 extern NSString *const BSGKeyMethod;

--- a/Bugsnag/Helpers/BugsnagKeys.m
+++ b/Bugsnag/Helpers/BugsnagKeys.m
@@ -60,6 +60,7 @@ NSString *const BSGKeyMachoUUID = @"machoUUID";
 NSString *const BSGKeyMachoVMAddress = @"machoVMAddress";
 NSString *const BSGKeyMaxBreadcrumbs = @"maxBreadcrumbs";
 NSString *const BSGKeyMaxPersistedEvents = @"maxPersistedEvents";
+NSString *const BSGKeyMaxPersistedSessions = @"maxPersistedSessions";
 NSString *const BSGKeyMessage = @"message";
 NSString *const BSGKeyMetadata = @"metaData";
 NSString *const BSGKeyMethod = @"method";

--- a/Bugsnag/Storage/BugsnagSessionFileStore.h
+++ b/Bugsnag/Storage/BugsnagSessionFileStore.h
@@ -9,7 +9,8 @@
 #import "BugsnagSession.h"
 
 @interface BugsnagSessionFileStore : BugsnagFileStore
-+ (BugsnagSessionFileStore *)storeWithPath:(NSString *)path;
++ (BugsnagSessionFileStore *)storeWithPath:(NSString *)path
+                      maxPersistedSessions:(NSUInteger)maxPersistedSessions;
 
 - (void)write:(BugsnagSession *)session;
 

--- a/Bugsnag/Storage/BugsnagSessionFileStore.m
+++ b/Bugsnag/Storage/BugsnagSessionFileStore.m
@@ -11,11 +11,27 @@
 
 static NSString *const kSessionStoreSuffix = @"-Session-";
 
+@interface BugsnagSessionFileStore ()
+
+@property NSUInteger maxPersistedSessions;
+
+@end
+
 @implementation BugsnagSessionFileStore
 
-+ (BugsnagSessionFileStore *)storeWithPath:(NSString *)path {
++ (BugsnagSessionFileStore *)storeWithPath:(NSString *)path
+                      maxPersistedSessions:(NSUInteger)maxPersistedSessions {
     return [[self alloc] initWithPath:path
-                       filenameSuffix:kSessionStoreSuffix];
+                 maxPersistedSessions:maxPersistedSessions];
+}
+
+- (instancetype) initWithPath:(NSString *)path
+         maxPersistedSessions:(NSUInteger)maxPersistedSessions {
+    if ((self = [super initWithPath:path
+                     filenameSuffix:kSessionStoreSuffix])) {
+        _maxPersistedSessions = maxPersistedSessions;
+    }
+    return self;
 }
 
 - (void)write:(BugsnagSession *)session {
@@ -30,6 +46,8 @@ static NSString *const kSessionStoreSuffix = @"-Session-";
         BSG_KSLOG_ERROR(@"Failed to write session %@", error);
         return;
     }
+    
+    [self pruneFilesLeaving:(int)self.maxPersistedSessions];
 }
 
 

--- a/Bugsnag/include/Bugsnag/BugsnagConfiguration.h
+++ b/Bugsnag/include/Bugsnag/BugsnagConfiguration.h
@@ -227,6 +227,14 @@ typedef BOOL (^BugsnagOnSessionBlock)(BugsnagSession *_Nonnull session);
 @property (nonatomic) NSUInteger maxPersistedEvents;
 
 /**
+ * Sets the maximum number of sessions which will be stored. Once the threshold is reached,
+ * the oldest sessions will be deleted.
+ *
+ * By default, 32 sessions are stored: this can be amended up to a maximum of 100.
+ */
+@property (nonatomic) NSUInteger maxPersistedSessions;
+
+/**
  * Sets the maximum number of breadcrumbs which will be stored. Once the threshold is reached,
  * the oldest breadcrumbs will be deleted.
  *

--- a/Tests/BSGConfigurationBuilderTests.m
+++ b/Tests/BSGConfigurationBuilderTests.m
@@ -56,6 +56,7 @@
     XCTAssertTrue(config.autoDetectErrors);
     XCTAssertTrue(config.autoTrackSessions);
     XCTAssertEqual(12, config.maxPersistedEvents);
+    XCTAssertEqual(32, config.maxPersistedSessions);
     XCTAssertEqual(25, config.maxBreadcrumbs);
     XCTAssertTrue(config.persistUser);
     XCTAssertEqualObjects(@[@"password"], [config.redactedKeys allObjects]);
@@ -94,6 +95,7 @@
                     },
                     @"enabledReleaseStages": @[@"beta2", @"prod"],
                     @"maxPersistedEvents": @29,
+                    @"maxPersistedSessions": @19,
                     @"maxBreadcrumbs": @27,
                     @"persistUser": @NO,
                     @"redactedKeys": @[@"foo"],
@@ -108,6 +110,7 @@
     XCTAssertFalse(config.autoTrackSessions);
     XCTAssertEqualObjects(@"7.22", config.bundleVersion);
     XCTAssertEqual(29, config.maxPersistedEvents);
+    XCTAssertEqual(19, config.maxPersistedSessions);
     XCTAssertEqual(27, config.maxBreadcrumbs);
     XCTAssertFalse(config.persistUser);
     XCTAssertEqualObjects(@[@"foo"], config.redactedKeys);
@@ -142,6 +145,7 @@
                     @"enabledReleaseStages": @[@"beta2", @"prod"],
                     @"enabledErrorTypes": @[@"ooms", @"signals"],
                     @"maxPersistedEvents": @29,
+                    @"maxPersistedSessions": @19,
                     @"maxBreadcrumbs": @27,
                     @"persistUser": @"pomelo",
                     @"redactedKeys": @[@77],

--- a/Tests/BugsnagClientTests.m
+++ b/Tests/BugsnagClientTests.m
@@ -188,6 +188,7 @@ NSString *BSGFormatSeverity(BSGSeverity severity);
     XCTAssertEqualObjects(expected.endpoints.notify, actual.endpoints.notify);
     XCTAssertEqualObjects(expected.endpoints.sessions, actual.endpoints.sessions);
     XCTAssertEqual(expected.maxPersistedEvents, actual.maxPersistedEvents);
+    XCTAssertEqual(expected.maxPersistedSessions, actual.maxPersistedSessions);
     XCTAssertEqual(expected.maxBreadcrumbs, actual.maxBreadcrumbs);
     XCTAssertEqual(expected.persistUser, actual.persistUser);
     XCTAssertEqual([expected.redactedKeys count], [actual.redactedKeys count]);
@@ -211,12 +212,14 @@ NSString *BSGFormatSeverity(BSGSeverity severity);
     // Modify some arbitrary properties
     config.persistUser = !config.persistUser;
     config.maxPersistedEvents = config.maxPersistedEvents * 2;
+    config.maxPersistedSessions = config.maxPersistedSessions * 2;
     config.maxBreadcrumbs = config.maxBreadcrumbs * 2;
     config.appVersion = @"99.99.99";
 
     // Ensure the changes haven't been reflected in our copy
     XCTAssertNotEqual(initialConfig.persistUser, config.persistUser);
     XCTAssertNotEqual(initialConfig.maxPersistedEvents, config.maxPersistedEvents);
+    XCTAssertNotEqual(initialConfig.maxPersistedSessions, config.maxPersistedSessions);
     XCTAssertNotEqual(initialConfig.maxBreadcrumbs, config.maxBreadcrumbs);
     XCTAssertNotEqualObjects(initialConfig.appVersion, config.appVersion);
 
@@ -235,6 +238,7 @@ NSString *BSGFormatSeverity(BSGSeverity severity);
     updatedConfig.persistUser = !initialConfig.persistUser;
     updatedConfig.maxBreadcrumbs = initialConfig.maxBreadcrumbs * 2;
     updatedConfig.maxPersistedEvents = initialConfig.maxPersistedEvents * 2;
+    updatedConfig.maxPersistedSessions = initialConfig.maxPersistedSessions * 2;
     updatedConfig.appVersion = @"99.99.99";
 
     [Bugsnag startWithConfiguration:updatedConfig];

--- a/Tests/BugsnagConfigurationTests.m
+++ b/Tests/BugsnagConfigurationTests.m
@@ -562,6 +562,38 @@ NSString * const kBugsnagUserUserId = @"BugsnagUserUserId";
 }
 
 // =============================================================================
+// MARK: - Max Persisted Sessions
+// =============================================================================
+
+- (void)testMaxPersistedSessions {
+    BugsnagConfiguration *config = [[BugsnagConfiguration alloc] initWithApiKey:DUMMY_APIKEY_32CHAR_1];
+    XCTAssertEqual(32, config.maxPersistedSessions);
+
+    // alter to valid value
+    config.maxPersistedSessions = 10;
+    XCTAssertEqual(10, config.maxPersistedSessions);
+
+    // alter to max value
+    config.maxPersistedSessions = 100;
+    XCTAssertEqual(100, config.maxPersistedSessions);
+
+    // alter to min value
+    config.maxPersistedSessions = 1;
+    XCTAssertEqual(1, config.maxPersistedSessions);
+
+    config.maxPersistedSessions = 0;
+    XCTAssertEqual(1, config.maxPersistedSessions);
+
+    // alter to negative value
+    config.maxPersistedSessions = -1;
+    XCTAssertEqual(1, config.maxPersistedSessions);
+
+    // alter to > max value
+    config.maxPersistedSessions = 500;
+    XCTAssertEqual(1, config.maxPersistedSessions);
+}
+
+// =============================================================================
 // MARK: - Max Breadcrumb
 // =============================================================================
 

--- a/Tests/ConfigurationApiValidationTest.m
+++ b/Tests/ConfigurationApiValidationTest.m
@@ -147,6 +147,25 @@
     XCTAssertEqual(1, self.config.maxPersistedEvents);
 }
 
+- (void)testValidMaxPersistedSessions {
+    self.config.maxPersistedSessions = 1;
+    XCTAssertEqual(1, self.config.maxPersistedSessions);
+    self.config.maxPersistedSessions = 100;
+    XCTAssertEqual(100, self.config.maxPersistedSessions);
+    self.config.maxPersistedSessions = 40;
+    XCTAssertEqual(40, self.config.maxPersistedSessions);
+}
+
+- (void)testInvalidMaxPersistedSessions {
+    self.config.maxPersistedSessions = 1;
+    self.config.maxPersistedSessions = 0;
+    XCTAssertEqual(1, self.config.maxPersistedSessions);
+    self.config.maxPersistedSessions = -1;
+    XCTAssertEqual(1, self.config.maxPersistedSessions);
+    self.config.maxPersistedSessions = 590;
+    XCTAssertEqual(1, self.config.maxPersistedSessions);
+}
+
 - (void)testValidMaxBreadcrumbs {
     self.config.maxBreadcrumbs = 0;
     XCTAssertEqual(0, self.config.maxBreadcrumbs);


### PR DESCRIPTION
## Goal

Adding max persisted sessions config option to bring the library in line with the current notifier spec (PLAT-5371)

## Testing

- New unit tests

E2E tests are not possible because all persisted sessions are queued for sending immediately upon creating a new session. I was able to verify that only the configured number of sessions are persisted, and all others are deleted.
