### PR TITLE
Wait for network connectivity before running E2E scenario

### DIFF
--- a/features/fixtures/shared/scenarios/Scenario.h
+++ b/features/fixtures/shared/scenarios/Scenario.h
@@ -18,6 +18,11 @@ void markErrorHandledCallback(const BSG_KSCrashReportWriter * _Nonnull writer);
 - (instancetype _Nonnull)initWithConfig:(BugsnagConfiguration *_Nonnull)config;
 
 /**
+ * Blocks the calling thread until network connectivity to the notify endpoint has been verified.
+ */
+- (void)waitForNetworkConnectivity;
+
+/**
  * Executes the test case
  */
 - (void)run;
@@ -27,4 +32,5 @@ void markErrorHandledCallback(const BSG_KSCrashReportWriter * _Nonnull writer);
 - (void)didEnterBackgroundNotification;
 
 @property (nonatomic, strong, nullable) NSString *eventMode;
+
 @end

--- a/features/fixtures/shared/scenarios/Scenario.m
+++ b/features/fixtures/shared/scenarios/Scenario.m
@@ -45,10 +45,36 @@ void markErrorHandledCallback(const BSG_KSCrashReportWriter *writer) {
     return self;
 }
 
+- (void)waitForNetworkConnectivity {
+    NSDictionary *proxySettings = (__bridge_transfer NSDictionary *)CFNetworkCopySystemProxySettings();
+    NSLog(@"*** Proxy settings = %@", proxySettings);
+    
+    // This check uses HTTP rather than sockets because connectivity is commonly provided via an HTTP proxy.
+    
+    NSURL *url = [NSURL URLWithString:self.config.endpoints.notify];
+    NSURLRequest *request = [NSURLRequest requestWithURL:url cachePolicy:NSURLRequestReloadIgnoringLocalCacheData timeoutInterval:3];
+    NSLog(@"*** Checking for connectivity to %@", url);
+    while (1) {
+        NSURLResponse *response = nil;
+        NSError *error = nil;
+#pragma clang diagnostic push
+#pragma clang diagnostic ignored "-Wdeprecated-declarations"
+        [NSURLConnection sendSynchronousRequest:request returningResponse:&response error:&error];
+#pragma clang diagnostic pop
+        if ([response isKindOfClass:[NSHTTPURLResponse class]] && ((NSHTTPURLResponse *)response).statusCode / 100 == 2) {
+            NSLog(@"*** Received response from notify endpoint.");
+            break;
+        }
+        NSLog(@"*** No response from notify endpoint, retrying in 1 second...");
+        [NSThread sleepForTimeInterval:1];
+    }
+}
+
 - (void)run {
 }
 
 - (void)startBugsnag {
+    [self waitForNetworkConnectivity];
     [Bugsnag startWithConfiguration:self.config];
 }
 


### PR DESCRIPTION
## Goal

A small proportion of E2E test runs fail to receive a request payload when running the first scenario.

This change aims to make it easier to diagnose these failures by checking for connectivity to Maze Runner before running each test scenario, and including relevant messages in the device logs.

## Design

The pre-flight step works by performing an HTTP GET request on the notify endpoint, and retrying indefinitely until a success status code is received.

The GET request is not logged by Maze Runner and so does not get added to its lists of requests that would alter the test scenarios.

An earlier implementation using low-level TCP sockets failed because connectivity is provided through an HTTP proxy.

## Changeset

Added a pre-flight step that runs before each scenario.

In normal conditions this does not measurably impact the running time of the tests.

## Testing

Running E2E tests