### PR TITLE
[PLAT-5624] Add E2E barebone tests

### DIFF
--- a/features/barebone_tests.feature
+++ b/features/barebone_tests.feature
@@ -1,0 +1,177 @@
+Feature: Barebone tests
+
+  Background:
+    Given I clear all persistent data
+
+  Scenario: Barebone test: handled errors
+    When I run "BareboneTestHandledScenario"
+    And I wait to receive 3 requests
+  
+    Then the request is valid for the session reporting API version "1.0" for the "iOS Bugsnag Notifier" notifier
+    And the payload field "sessions.0.id" is not null
+    And the session "user.id" equals "foobar"
+    And the session "user.email" equals "foobar@example.com"
+    And the session "user.name" equals "Foo Bar"
+
+    And I discard the oldest request
+
+    Then the request is valid for the error reporting API version "4.0" for the "iOS Bugsnag Notifier" notifier
+    And the event "app.bundleVersion" equals "12301"
+    And the event "app.id" equals "com.bugsnag.iOSTestApp"
+    And the event "app.inForeground" is true
+    And the event "app.releaseStage" equals "development"
+    And the event "app.type" equals "iOS"
+    And the event "app.version" equals "12.3"
+    And the event "breadcrumbs.0.name" equals "Running BareboneTestHandledScenario"
+    And the event "breadcrumbs.1.name" equals "This is super <redacted>"
+    And the event "device.id" is not null
+    And the event "device.jailbroken" is false
+    And the event "device.locale" is not null
+    And the event "device.manufacturer" equals "Apple"
+    And the event "device.modelNumber" is not null
+    And the event "device.osName" equals "iOS"
+    And the event "device.osVersion" matches "\d+\.\d+"
+    And the event "device.runtimeVersions.clangVersion" is not null
+    And the event "device.runtimeVersions.osBuild" is not null
+    And the event "device.time" is a timestamp
+    And the event "metaData.device.batteryLevel" is not null
+    And the event "metaData.device.charging" is not null
+    And the event "metaData.device.orientation" is not null
+    And the event "metaData.device.simulator" is false
+    And the event "metaData.device.timezone" is not null
+    And the event "metaData.device.wordSize" is not null
+    And the event "metaData.Exception.info" equals "Some error specific information"
+    And the event "metaData.Flags.Testing" is true
+    And the event "metaData.Other.password" equals "[REDACTED]"
+    And the event "severity" equals "warning"
+    And the event "severityReason.type" equals "handledException"
+    And the event "severityReason.unhandledOverridden" is true
+    And the event "unhandled" is true
+    And the event "user.email" equals "foobar@example.com"
+    And the event "user.id" equals "foobar"
+    And the event "user.name" equals "Foo Bar"
+    And the exception "errorClass" equals "NSRangeException"
+    And the exception "message" equals "-[__NSSingleObjectArrayI objectAtIndex:]: index 1 beyond bounds [0 .. 0]"
+    And the exception "type" equals "cocoa"
+    And the payload field "events.0.app.dsymUUIDs" is a non-empty array
+    And the payload field "events.0.app.duration" is a number
+    And the payload field "events.0.app.durationInForeground" is a number
+    And the payload field "events.0.device.freeDisk" is an integer
+    And the payload field "events.0.device.freeMemory" is an integer
+    And the payload field "events.0.device.model" matches the test device model
+    And the payload field "events.0.device.totalMemory" is an integer
+
+    And I discard the oldest request
+
+    Then the request is valid for the error reporting API version "4.0" for the "iOS Bugsnag Notifier" notifier
+    And the event "breadcrumbs.2.name" equals "NSRangeException"
+    And the event "breadcrumbs.2.type" equals "error"
+    And the event "breadcrumbs.3.name" equals "About to decode a payload..."
+    And the event "metaData.nserror.code" equals 4864
+    And the event "metaData.nserror.domain" equals "NSCocoaErrorDomain"
+    And the event "metaData.nserror.reason" equals "The data isn’t in the correct format."
+    And the event "severity" equals "warning"
+    And the event "severityReason.type" equals "handledError"
+    And the event "severityReason.unhandledOverridden" is null
+    And the event "unhandled" is false
+    And the exception "errorClass" equals "__SwiftNativeNSError"
+    And the exception "message" equals "The data couldn’t be read because it isn’t in the correct format."
+    And the exception "type" equals "cocoa"
+
+  Scenario: Smoke test: unhandled error
+    When I run "BareboneTestUnhandledErrorScenario" and relaunch the app
+    And I set the app to "report" mode
+    And I configure Bugsnag for "BareboneTestUnhandledErrorScenario"
+    And I wait to receive a request
+
+    Then the request is valid for the error reporting API version "4.0" for the "iOS Bugsnag Notifier" notifier
+    And the event "app.bundleVersion" equals "12301"
+    And the event "app.inForeground" is true
+    And the event "app.releaseStage" equals "development"
+    And the event "app.type" equals "iOS"
+    And the event "app.version" equals "12.3"
+    And the event "breadcrumbs.0.name" equals "Bugsnag loaded"
+    And the event "breadcrumbs.1.name" is null
+    And the event "device.id" is not null
+    And the event "device.jailbroken" is false
+    And the event "device.locale" is not null
+    And the event "device.manufacturer" equals "Apple"
+    And the event "device.modelNumber" is not null
+    And the event "device.osName" equals "iOS"
+    And the event "device.osVersion" matches "\d+\.\d+"
+    And the event "device.runtimeVersions.clangVersion" is not null
+    And the event "device.runtimeVersions.osBuild" is not null
+    And the event "device.time" is a timestamp
+    And the event "metaData.error.mach.code_name" equals "KERN_INVALID_ADDRESS"
+    And the event "metaData.error.mach.code" equals "0x1"
+    And the event "metaData.error.mach.exception_name" equals "EXC_BREAKPOINT"
+    And the event "severity" equals "error"
+    And the event "severityReason.type" equals "unhandledException"
+    And the event "severityReason.unhandledOverridden" is null
+    And the event "unhandled" is true
+    And the event "user.email" equals "barfoo@example.com"
+    And the event "user.id" equals "barfoo"
+    And the event "user.name" equals "Bar Foo"
+    And the exception "errorClass" equals "Fatal error"
+    # This can be uncommented once Swift fatal error message reporting is fixed.
+    # And the exception "message" equals "iOSTestApp/BareboneTestScenarios.swift | Unexpectedly found nil while implicitly unwrapping an Optional value"
+    And the exception "type" equals "cocoa"
+    And the payload field "events.0.app.dsymUUIDs" is a non-empty array
+    And the payload field "events.0.app.duration" is a number
+    And the payload field "events.0.app.durationInForeground" is a number
+    And the payload field "events.0.device.freeDisk" is an integer
+    And the payload field "events.0.device.freeMemory" is an integer
+    And the payload field "events.0.device.model" matches the test device model
+    And the payload field "events.0.device.totalMemory" is an integer
+
+  Scenario: Barebone test: Out Of Memory
+    When I run "OOMLoadScenario"
+    And I wait to receive a request
+
+    Then the "Bugsnag-API-Key" header equals "0192837465afbecd0192837465afbecd"
+    And the event "unhandled" is false
+    And the exception "message" equals "OOMLoadScenario"
+    And the event has a "manual" breadcrumb named "OOMLoadScenarioBreadcrumb"
+    And I discard the oldest request
+
+    When I relaunch the app
+    And I configure Bugsnag for "OOMLoadScenario"
+    And I wait to receive a request
+
+    Then the "Bugsnag-API-Key" header equals "0192837465afbecd0192837465afbecd"
+    And the error is an OOM event
+    And the event "app.bundleVersion" is not null
+    And the event "app.dsymUUIDs" is not null
+    And the event "app.id" equals "com.bugsnag.iOSTestApp"
+    And the event "app.inForeground" is true
+    And the event "app.type" equals "iOS"
+    And the event "app.version" is not null
+    And the event "device.id" is not null
+    And the event "device.jailbroken" is false
+    And the event "device.locale" is not null
+    And the event "device.manufacturer" equals "Apple"
+    And the event "device.modelNumber" is not null
+    And the event "device.osName" equals "iOS"
+    And the event "device.osVersion" matches "\d+\.\d+"
+    And the event "device.runtimeVersions.clangVersion" is not null
+    And the event "device.runtimeVersions.osBuild" is not null
+    And the event "device.time" is null
+    And the event "device.totalMemory" is not null
+    And the event "metaData.app.name" equals "iOSTestApp"
+    And the event "metaData.custom.bar" equals "foo"
+    And the event "metaData.device.batteryLevel" is not null
+    And the event "metaData.device.charging" is not null
+    And the event "metaData.device.orientation" is not null
+    And the event "metaData.device.simulator" is false
+    And the event "metaData.device.timezone" is not null
+    And the event "metaData.device.wordSize" is not null
+    And the event "user.email" equals "foobar@example.com"
+    And the event "user.id" equals "foobar"
+    And the event "user.name" equals "Foo Bar"
+    And the payload field "events.0.app.dsymUUIDs" is a non-empty array
+    And the payload field "events.0.app.duration" is null
+    And the payload field "events.0.app.durationInForeground" is null
+    And the payload field "events.0.device.freeDisk" is null
+    And the payload field "events.0.device.freeMemory" is null
+    And the payload field "events.0.device.model" matches the test device model
+    And the payload field "events.0.device.totalMemory" is an integer

--- a/features/fixtures/ios-swift-cocoapods/iOSTestApp.xcodeproj/project.pbxproj
+++ b/features/fixtures/ios-swift-cocoapods/iOSTestApp.xcodeproj/project.pbxproj
@@ -17,6 +17,7 @@
 		00507A64242BFE5600EF1B87 /* EnabledBreadcrumbTypesIsNilScenario.swift in Sources */ = {isa = PBXBuildFile; fileRef = 00507A63242BFE5600EF1B87 /* EnabledBreadcrumbTypesIsNilScenario.swift */; };
 		00CEB60D24080C690004793D /* EnabledErrorTypesScenario.m in Sources */ = {isa = PBXBuildFile; fileRef = 00CEB60C24080C690004793D /* EnabledErrorTypesScenario.m */; };
 		0163BFA72583B3CF008DC28B /* DiscardClassesScenarios.swift in Sources */ = {isa = PBXBuildFile; fileRef = 0163BFA62583B3CF008DC28B /* DiscardClassesScenarios.swift */; };
+		01AF6A53258A112F00FFC803 /* BareboneTestScenarios.swift in Sources */ = {isa = PBXBuildFile; fileRef = 01AF6A52258A112F00FFC803 /* BareboneTestScenarios.swift */; };
 		6526A0D4248A83350002E2C9 /* LoadConfigFromFileAutoScenario.swift in Sources */ = {isa = PBXBuildFile; fileRef = 6526A0D3248A83350002E2C9 /* LoadConfigFromFileAutoScenario.swift */; };
 		8A14F0F62282D4AE00337B05 /* (null) in Sources */ = {isa = PBXBuildFile; };
 		8A32DB8222424E3000EDD92F /* NSExceptionShiftScenario.m in Sources */ = {isa = PBXBuildFile; fileRef = 8A32DB8122424E3000EDD92F /* NSExceptionShiftScenario.m */; };
@@ -161,6 +162,7 @@
 		00CEB60B24080C690004793D /* EnabledErrorTypesScenario.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; path = EnabledErrorTypesScenario.h; sourceTree = "<group>"; };
 		00CEB60C24080C690004793D /* EnabledErrorTypesScenario.m */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.objc; path = EnabledErrorTypesScenario.m; sourceTree = "<group>"; };
 		0163BFA62583B3CF008DC28B /* DiscardClassesScenarios.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = DiscardClassesScenarios.swift; sourceTree = "<group>"; };
+		01AF6A52258A112F00FFC803 /* BareboneTestScenarios.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = BareboneTestScenarios.swift; sourceTree = "<group>"; };
 		4994F05E0421A0B037DD2CC5 /* Pods_iOSTestApp.framework */ = {isa = PBXFileReference; explicitFileType = wrapper.framework; includeInIndex = 0; path = Pods_iOSTestApp.framework; sourceTree = BUILT_PRODUCTS_DIR; };
 		6526A0D3248A83350002E2C9 /* LoadConfigFromFileAutoScenario.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = LoadConfigFromFileAutoScenario.swift; sourceTree = "<group>"; };
 		8A32DB8022424E3000EDD92F /* NSExceptionShiftScenario.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = NSExceptionShiftScenario.h; sourceTree = "<group>"; };
@@ -551,6 +553,7 @@
 				F49695A3243EF7B600105DA9 /* OOMs */,
 				F49695AE2445476700105DA9 /* Plugin */,
 				0037410E2473CF2300BE41AA /* AppAndDeviceAttributesScenario.swift */,
+				01AF6A52258A112F00FFC803 /* BareboneTestScenarios.swift */,
 				0163BFA62583B3CF008DC28B /* DiscardClassesScenarios.swift */,
 				8AB1081823301FE600672818 /* ReleaseStageScenarios.swift */,
 				F4295ABA693D273D52AA9F6B /* Scenario.h */,
@@ -884,6 +887,7 @@
 				E700EE69247D73F8008CFFB6 /* UnhandledMachExceptionScenario.m in Sources */,
 				E75040B12478214F005D33BD /* MetadataRedactionRegexScenario.swift in Sources */,
 				E700EE5B247D3224008CFFB6 /* OriginalErrorNSExceptionScenario.swift in Sources */,
+				01AF6A53258A112F00FFC803 /* BareboneTestScenarios.swift in Sources */,
 				8AEFC73120F8D1A000A78779 /* AutoSessionWithUserScenario.m in Sources */,
 				8AB1081923301FE600672818 /* ReleaseStageScenarios.swift in Sources */,
 				8AF6FD7A225E3FA00056EF9E /* ResumeSessionOOMScenario.m in Sources */,

--- a/features/fixtures/macos/macOSTestApp.xcodeproj/project.pbxproj
+++ b/features/fixtures/macos/macOSTestApp.xcodeproj/project.pbxproj
@@ -16,6 +16,7 @@
 		0176C0B6254AE81B0066E0F3 /* MainMenu.xib in Resources */ = {isa = PBXBuildFile; fileRef = 0176C0B4254AE81B0066E0F3 /* MainMenu.xib */; };
 		017FBFB8254B09C300809042 /* MainWindowController.m in Sources */ = {isa = PBXBuildFile; fileRef = 017FBFB6254B09C300809042 /* MainWindowController.m */; };
 		017FBFB9254B09C300809042 /* MainWindowController.xib in Resources */ = {isa = PBXBuildFile; fileRef = 017FBFB7254B09C300809042 /* MainWindowController.xib */; };
+		01AF6A50258A00DE00FFC803 /* BareboneTestScenarios.swift in Sources */ = {isa = PBXBuildFile; fileRef = 01AF6A4F258A00DE00FFC803 /* BareboneTestScenarios.swift */; };
 		01F47CC4254B1B3100B184AD /* OriginalErrorNSExceptionScenario.swift in Sources */ = {isa = PBXBuildFile; fileRef = 01F47C21254B1B2C00B184AD /* OriginalErrorNSExceptionScenario.swift */; };
 		01F47CC5254B1B3100B184AD /* LoadConfigFromFileAutoScenario.swift in Sources */ = {isa = PBXBuildFile; fileRef = 01F47C23254B1B2C00B184AD /* LoadConfigFromFileAutoScenario.swift */; };
 		01F47CC6254B1B3100B184AD /* HandledExceptionScenario.swift in Sources */ = {isa = PBXBuildFile; fileRef = 01F47C28254B1B2C00B184AD /* HandledExceptionScenario.swift */; };
@@ -158,6 +159,7 @@
 		017FBFB5254B09C300809042 /* MainWindowController.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; path = MainWindowController.h; sourceTree = "<group>"; };
 		017FBFB6254B09C300809042 /* MainWindowController.m */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.objc; path = MainWindowController.m; sourceTree = "<group>"; };
 		017FBFB7254B09C300809042 /* MainWindowController.xib */ = {isa = PBXFileReference; lastKnownFileType = file.xib; path = MainWindowController.xib; sourceTree = "<group>"; };
+		01AF6A4F258A00DE00FFC803 /* BareboneTestScenarios.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = BareboneTestScenarios.swift; sourceTree = "<group>"; };
 		01F47C21254B1B2C00B184AD /* OriginalErrorNSExceptionScenario.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = OriginalErrorNSExceptionScenario.swift; sourceTree = "<group>"; };
 		01F47C22254B1B2C00B184AD /* ThreadScenarios.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = ThreadScenarios.h; sourceTree = "<group>"; };
 		01F47C23254B1B2C00B184AD /* LoadConfigFromFileAutoScenario.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = LoadConfigFromFileAutoScenario.swift; sourceTree = "<group>"; };
@@ -367,6 +369,7 @@
 				01F47CB8254B1B3000B184AD /* AutoSessionUnhandledScenario.m */,
 				01F47C2E254B1B2D00B184AD /* AutoSessionWithUserScenario.h */,
 				01F47C98254B1B2F00B184AD /* AutoSessionWithUserScenario.m */,
+				01AF6A4F258A00DE00FFC803 /* BareboneTestScenarios.swift */,
 				01F47C2F254B1B2D00B184AD /* BreadcrumbCallbackCrashScenario.swift */,
 				01F47C79254B1B2F00B184AD /* BreadcrumbCallbackDiscardScenario.swift */,
 				01F47C7A254B1B2F00B184AD /* BreadcrumbCallbackOrderScenario.swift */,
@@ -643,6 +646,7 @@
 				01F47D15254B1B3100B184AD /* UndefinedInstructionScenario.m in Sources */,
 				01F47D1E254B1B3100B184AD /* SIGPIPEScenario.m in Sources */,
 				01F47CCF254B1B3100B184AD /* ObjCExceptionScenario.m in Sources */,
+				01AF6A50258A00DE00FFC803 /* BareboneTestScenarios.swift in Sources */,
 				01F47CED254B1B3100B184AD /* ResumedSessionScenario.swift in Sources */,
 				01F47CE8254B1B3100B184AD /* AppAndDeviceAttributesScenario.swift in Sources */,
 				01F47D1A254B1B3100B184AD /* ThreadScenarios.m in Sources */,

--- a/features/fixtures/shared/scenarios/BareboneTestScenarios.swift
+++ b/features/fixtures/shared/scenarios/BareboneTestScenarios.swift
@@ -1,0 +1,109 @@
+//
+//  BareboneTestScenarios.swift
+//  macOSTestApp
+//
+//  Created by Nick Dowell on 16/12/2020.
+//  Copyright © 2020 Bugsnag Inc. All rights reserved.
+//
+
+class BareboneTestHandledScenario: Scenario {
+    
+    var onBreadcrumbCount = 0
+    var onSendErrorCount = 0
+    var onSessionCount = 0
+    
+    override func startBugsnag() {
+        config.addOnBreadcrumb {
+            NSLog("OnBreadcrumb: \"\($0.message)\"")
+            self.onBreadcrumbCount += 1
+            if $0.message.contains("secret") {
+                $0.message = $0.message.replacingOccurrences(of: "secret", with: "<redacted>")
+            }
+            return true
+        }
+        config.addOnSendError {
+            NSLog("OnSendError: \"\($0.errors[0].errorClass ?? "")\" \"\($0.errors[0].errorMessage ?? "")\"")
+            self.onSendErrorCount += 1
+            return true
+        }
+        config.addOnSession {
+            NSLog("OnSession: \($0.id) started at \($0.startedAt)")
+            self.onSessionCount += 1
+            return true
+        }
+        config.enabledBreadcrumbTypes = [.error]
+        config.addMetadata(["Testing": true], section: "Flags")
+        config.addMetadata(["password": "123456"], section: "Other")
+        config.sendThreads = .unhandledOnly
+        config.setUser("foobar", withEmail: "foobar@example.com", andName: "Foo Bar")
+        config.appVersion = "12.3"
+        config.bundleVersion = "12301"
+        super.startBugsnag()
+    }
+    
+    override func run() {
+        precondition(onSessionCount == 1)
+        
+        Bugsnag.leaveBreadcrumb(withMessage: "Running BareboneTestHandledScenario")
+        
+        precondition(onBreadcrumbCount == 1)
+        
+        Bugsnag.notify(NSException(name: .genericException, reason: nil)) { _ in
+            return false
+        }
+        
+        Bugsnag.leaveBreadcrumb(withMessage: "This is super secret")
+        
+        Bugsnag.notify(NSException(name: .rangeException, reason: "-[__NSSingleObjectArrayI objectAtIndex:]: index 1 beyond bounds [0 .. 0]")) {
+            $0.addMetadata(["info": "Some error specific information"], section: "Exception")
+            $0.unhandled = true
+            return true
+        }
+        
+        // There is a delay between notify() and an error being sent.
+        RunLoop.current.run(until: .init(timeIntervalSinceNow: 2))
+        precondition(onSendErrorCount == 1)
+        
+        Bugsnag.leaveBreadcrumb(withMessage: "About to decode a payload...")
+        
+        do {
+            _ = try JSONDecoder().decode(Payload.self, from: Data())
+        } catch {
+            Bugsnag.notifyError(error)
+        }
+    }
+}
+
+// MARK: -
+
+class BareboneTestUnhandledErrorScenario: Scenario {
+    
+    private var payload: Payload!
+    
+    override func startBugsnag() {
+        config.autoTrackSessions = false
+        if eventMode == "report" {
+            // The version of the app at report time.
+            config.appVersion = "23.4"
+            config.bundleVersion = "23401"
+        } else {
+            // The version of the app at crash time.
+            config.appVersion = "12.3"
+            config.bundleVersion = "12301"
+        }
+        super.startBugsnag()
+    }
+    
+    override func run() {
+        Bugsnag.setUser("barfoo", withEmail: "barfoo@example.com", andName: "Bar Foo")
+        
+        // Triggers "Fatal error: Unexpectedly found nil while implicitly unwrapping an Optional value: ..."
+        print(payload.name)
+    }
+}
+
+// MARK: -
+
+private struct Payload: Decodable {
+    let name: String
+}


### PR DESCRIPTION
## Goal

Add E2E smoke tests that can run quickly to validate basic functionality.

## Design

The tests are designed to verify a number of different areas of functionality within each scenario.

3 types of error are tested, since each type has a separate code path in the notifier:
* Handled
* Unhandled
* OOM

The areas of functionality covered:
* Sessions contain custom user ID
* Overriding app version in config
* Metadata from config and in OnError block
* Metadata redaction
* Presence of all app & device fields
* Overriding unhandled flag (for handled errors only)
* Leaving breadcrumbs
* Modifying breadcrumbs in an OnBreadcrumb block
* OnBreadcrumb, OnSendError and OnSession blocks are called as expected
* Rejection of error in OnError block

## Changeset

Added 3 new scenarios.

## Testing

See BuildKite