### PR TITLE
[PLAT-5628] Remove use of [Bugsnag configuration] and [Bugsnag client]

### DIFF
--- a/Bugsnag/BugsnagCrashSentry.h
+++ b/Bugsnag/BugsnagCrashSentry.h
@@ -12,10 +12,13 @@
 #import "BugsnagConfiguration.h"
 #import "BugsnagErrorReportApiClient.h"
 
+@class BugsnagNotifier;
+
 @interface BugsnagCrashSentry : NSObject
 
 - (void)install:(BugsnagConfiguration *)config
       apiClient:(BugsnagErrorReportApiClient *)apiClient
+       notifier:(BugsnagNotifier *)notifier
         onCrash:(BSGReportCallback)onCrash;
 
 - (void)reportUserException:(NSString *)reportName

--- a/Bugsnag/BugsnagCrashSentry.m
+++ b/Bugsnag/BugsnagCrashSentry.m
@@ -22,7 +22,7 @@
       apiClient:(BugsnagErrorReportApiClient *)apiClient
         onCrash:(BSGReportCallback)onCrash
 {
-    BugsnagErrorReportSink *sink = [[BugsnagErrorReportSink alloc] initWithApiClient:apiClient];
+    BugsnagErrorReportSink *sink = [[BugsnagErrorReportSink alloc] initWithApiClient:apiClient configuration:config];
     BSG_KSCrash *ksCrash = [BSG_KSCrash sharedInstance];
     ksCrash.sink = sink;
     ksCrash.introspectMemory = YES;

--- a/Bugsnag/BugsnagCrashSentry.m
+++ b/Bugsnag/BugsnagCrashSentry.m
@@ -20,9 +20,10 @@
 
 - (void)install:(BugsnagConfiguration *)config
       apiClient:(BugsnagErrorReportApiClient *)apiClient
+       notifier:(BugsnagNotifier *)notifier
         onCrash:(BSGReportCallback)onCrash
 {
-    BugsnagErrorReportSink *sink = [[BugsnagErrorReportSink alloc] initWithApiClient:apiClient configuration:config];
+    BugsnagErrorReportSink *sink = [[BugsnagErrorReportSink alloc] initWithApiClient:apiClient configuration:config notifier:notifier];
     BSG_KSCrash *ksCrash = [BSG_KSCrash sharedInstance];
     ksCrash.sink = sink;
     ksCrash.introspectMemory = YES;

--- a/Bugsnag/BugsnagErrorReportSink+Private.h
+++ b/Bugsnag/BugsnagErrorReportSink+Private.h
@@ -8,6 +8,8 @@
 
 #import "BugsnagErrorReportSink.h"
 
+@class BugsnagEvent;
+
 NS_ASSUME_NONNULL_BEGIN
 
 @interface BugsnagErrorReportSink ()

--- a/Bugsnag/BugsnagErrorReportSink.h
+++ b/Bugsnag/BugsnagErrorReportSink.h
@@ -25,16 +25,21 @@
 //
 
 #import <Foundation/Foundation.h>
-#import "BSG_KSCrash.h"
-#import "BugsnagErrorReportApiClient.h"
+
+#import "BSGOnErrorSentBlock.h"
+
+@class BugsnagConfiguration;
+@class BugsnagErrorReportApiClient;
 
 NS_ASSUME_NONNULL_BEGIN
 
 @interface BugsnagErrorReportSink : NSObject
 
-@property(nonatomic, strong) BugsnagErrorReportApiClient *apiClient;
+- (instancetype)initWithApiClient:(BugsnagErrorReportApiClient *)apiClient configuration:(BugsnagConfiguration *)configuration;
 
-- (instancetype)initWithApiClient:(BugsnagErrorReportApiClient *)apiClient;
+@property (strong, nonatomic) BugsnagErrorReportApiClient *apiClient;
+
+@property (strong, nonatomic) BugsnagConfiguration *configuration;
 
 /**
  * Invoked when reports stored by KSCrash need to be delivered.

--- a/Bugsnag/BugsnagErrorReportSink.h
+++ b/Bugsnag/BugsnagErrorReportSink.h
@@ -30,16 +30,21 @@
 
 @class BugsnagConfiguration;
 @class BugsnagErrorReportApiClient;
+@class BugsnagNotifier;
 
 NS_ASSUME_NONNULL_BEGIN
 
 @interface BugsnagErrorReportSink : NSObject
 
-- (instancetype)initWithApiClient:(BugsnagErrorReportApiClient *)apiClient configuration:(BugsnagConfiguration *)configuration;
+- (instancetype)initWithApiClient:(BugsnagErrorReportApiClient *)apiClient
+                    configuration:(BugsnagConfiguration *)configuration
+                         notifier:(BugsnagNotifier *)notifier;
 
 @property (strong, nonatomic) BugsnagErrorReportApiClient *apiClient;
 
 @property (strong, nonatomic) BugsnagConfiguration *configuration;
+
+@property (strong, nonatomic) BugsnagNotifier *notifier;
 
 /**
  * Invoked when reports stored by KSCrash need to be delivered.

--- a/Bugsnag/BugsnagErrorReportSink.m
+++ b/Bugsnag/BugsnagErrorReportSink.m
@@ -155,6 +155,9 @@
         // Use current value for crashes from older notifier versions that didn't persist config.appType
         event.app.type = self.configuration.appType;
     }
+    if (!event.apiKey) {
+        event.apiKey = self.configuration.apiKey;
+    }
     NSMutableDictionary *data = [[NSMutableDictionary alloc] init];
     data[BSGKeyNotifier] = [self.notifier toDict];
     data[BSGKeyApiKey] = event.apiKey;

--- a/Bugsnag/BugsnagErrorReportSink.m
+++ b/Bugsnag/BugsnagErrorReportSink.m
@@ -31,6 +31,7 @@
 #import "BugsnagClient+Private.h"
 #import "BugsnagCollections.h"
 #import "BugsnagConfiguration+Private.h"
+#import "BugsnagErrorReportApiClient.h"
 #import "BugsnagEvent+Private.h"
 #import "BugsnagKeys.h"
 #import "BugsnagLogger.h"
@@ -42,10 +43,11 @@
 
 @implementation BugsnagErrorReportSink
 
-- (instancetype)initWithApiClient:(BugsnagErrorReportApiClient *)apiClient {
-    if (self = [super init]) {
-        self.apiClient = apiClient;
-        self.activeRequests = [NSMutableSet new];
+- (instancetype)initWithApiClient:(BugsnagErrorReportApiClient *)apiClient configuration:(BugsnagConfiguration *)configuration {
+    if ((self = [super init])) {
+        _apiClient = apiClient;
+        _activeRequests = [NSMutableSet new];
+        _configuration = configuration;
     }
     return self;
 }
@@ -86,7 +88,6 @@
     // 4. When a request has completed and deleted the file, remove the files from the dictionary
     NSArray<NSString *> *keys = [self prepareNewRequests:[ksCrashReports allKeys]];
     NSMutableDictionary<NSString *, BugsnagEvent *>* storedEvents = [NSMutableDictionary new];
-    BugsnagConfiguration *configuration = [Bugsnag configuration];
 
     // run user callbacks on events before enqueueing any requests, as
     // this way events can be discarded quickly. This frees up disk
@@ -94,35 +95,33 @@
     for (NSString *fileKey in keys) {
         NSDictionary *report = ksCrashReports[fileKey];
         BugsnagEvent *event = [[BugsnagEvent alloc] initWithKSReport:report];
-        event.redactedKeys = configuration.redactedKeys;
+        event.redactedKeys = self.configuration.redactedKeys;
         
         NSString *errorClass = event.errors.firstObject.errorClass;
-        if ([configuration shouldDiscardErrorClass:errorClass]) {
+        if ([self.configuration shouldDiscardErrorClass:errorClass]) {
             bsg_log_info(@"Discarding event because errorClass \"%@\" matched configuration.discardClasses", errorClass);
             [self finishActiveRequest:fileKey completed:YES error:nil block:block];
             continue;
         }
-
-        if ([event shouldBeSent] && [self runOnSendBlocks:configuration event:event]) {
+        
+        if (self.configuration.shouldSendReports && [event shouldBeSent] && [self runOnSendBlocksForEvent:event]) {
             storedEvents[fileKey] = event;
         } else { // delete the report as the user has discarded it
             [self finishActiveRequest:fileKey completed:YES error:nil block:block];
         }
     }
-    [self deliverStoredEvents:storedEvents configuration:configuration block:block];
+    [self deliverStoredEvents:storedEvents block:block];
 }
 
-- (void)deliverStoredEvents:(NSMutableDictionary<NSString *, BugsnagEvent *> *)storedEvents
-              configuration:(BugsnagConfiguration *)configuration
-                      block:(BSGOnErrorSentBlock)block {
+- (void)deliverStoredEvents:(NSMutableDictionary<NSString *, BugsnagEvent *> *)storedEvents block:(BSGOnErrorSentBlock)block {
     for (NSString *filename in storedEvents) {
         BugsnagEvent *event = storedEvents[filename];
         NSDictionary *requestPayload = [self prepareEventPayload:event];
 
-        NSMutableDictionary *apiHeaders = [[configuration errorApiHeaders] mutableCopy];
+        NSMutableDictionary *apiHeaders = [self.configuration.errorApiHeaders mutableCopy];
         apiHeaders[BugsnagHTTPHeaderNameApiKey] = event.apiKey;
         apiHeaders[BugsnagHTTPHeaderNameStacktraceTypes] = [event.stacktraceTypes componentsJoinedByString:@","];
-        [self.apiClient sendJSONPayload:requestPayload headers:apiHeaders toURL:configuration.notifyURL
+        [self.apiClient sendJSONPayload:requestPayload headers:apiHeaders toURL:self.configuration.notifyURL
                       completionHandler:^(BugsnagApiClientDeliveryStatus status, NSError *error) {
             BOOL completed = status == BugsnagApiClientDeliveryStatusDelivered || status == BugsnagApiClientDeliveryStatusUndeliverable;
             [self finishActiveRequest:filename completed:completed error:error block:block];
@@ -130,9 +129,8 @@
     }
 }
 
-- (BOOL)runOnSendBlocks:(BugsnagConfiguration *)configuration
-                  event:(BugsnagEvent *)event {
-    for (BugsnagOnSendErrorBlock onSendErrorBlock in configuration.onSendBlocks) {
+- (BOOL)runOnSendBlocksForEvent:(BugsnagEvent *)event {
+    for (BugsnagOnSendErrorBlock onSendErrorBlock in self.configuration.onSendBlocks) {
         @try {
             if (!onSendErrorBlock(event)) {
                 return false;
@@ -150,6 +148,10 @@
  * @return an Error Reporting API payload represented as a serializable dictionary
  */
 - (NSDictionary *)prepareEventPayload:(BugsnagEvent *)event {
+    if (!event.app.type) {
+        // Use current value for crashes from older notifier versions that didn't persist config.appType
+        event.app.type = self.configuration.appType;
+    }
     NSMutableDictionary *data = [[NSMutableDictionary alloc] init];
     data[BSGKeyNotifier] = [[Bugsnag client].notifier toDict];
     data[BSGKeyApiKey] = event.apiKey;

--- a/Bugsnag/BugsnagErrorReportSink.m
+++ b/Bugsnag/BugsnagErrorReportSink.m
@@ -43,11 +43,14 @@
 
 @implementation BugsnagErrorReportSink
 
-- (instancetype)initWithApiClient:(BugsnagErrorReportApiClient *)apiClient configuration:(BugsnagConfiguration *)configuration {
+- (instancetype)initWithApiClient:(BugsnagErrorReportApiClient *)apiClient
+                    configuration:(BugsnagConfiguration *)configuration
+                         notifier:(BugsnagNotifier *)notifier {
     if ((self = [super init])) {
         _apiClient = apiClient;
         _activeRequests = [NSMutableSet new];
         _configuration = configuration;
+        _notifier = notifier;
     }
     return self;
 }
@@ -153,7 +156,7 @@
         event.app.type = self.configuration.appType;
     }
     NSMutableDictionary *data = [[NSMutableDictionary alloc] init];
-    data[BSGKeyNotifier] = [[Bugsnag client].notifier toDict];
+    data[BSGKeyNotifier] = [self.notifier toDict];
     data[BSGKeyApiKey] = event.apiKey;
     data[BSGKeyPayloadVersion] = @"4.0";
     data[BSGKeyEvents] = @[[event toJson]];

--- a/Bugsnag/BugsnagSessionTracker.m
+++ b/Bugsnag/BugsnagSessionTracker.m
@@ -9,7 +9,7 @@
 #import "BugsnagSessionTracker+Private.h"
 
 #import "BugsnagApp+Private.h"
-#import "BugsnagClient.h"
+#import "BugsnagClient+Private.h"
 #import "BugsnagConfiguration+Private.h"
 #import "BugsnagDevice+Private.h"
 #import "BugsnagSessionFileStore.h"
@@ -51,7 +51,7 @@ NSString *const BSGSessionUpdateNotification = @"BugsnagSessionChanged";
     if (self = [super init]) {
         _config = config;
         _client = client;
-        _apiClient = [[BugsnagSessionTrackingApiClient alloc] initWithConfig:config queueName:@"Session API queue"];
+        _apiClient = [[BugsnagSessionTrackingApiClient alloc] initWithConfig:config queueName:@"Session API queue" notifier:client.notifier];
         _callback = callback;
 
         NSString *storePath = [BugsnagFileStore findReportStorePath:@"Sessions"];

--- a/Bugsnag/Client/BugsnagClient.m
+++ b/Bugsnag/Client/BugsnagClient.m
@@ -349,9 +349,7 @@ NSString *_lastOrientation = nil;
 
 - (void)start {
     [self.configuration validate];
-    [self.crashSentry install:self.configuration
-                    apiClient:self.errorReportApiClient
-                      onCrash:&BSSerializeDataCrashHandler];
+    [self.crashSentry install:self.configuration apiClient:self.errorReportApiClient notifier:self.notifier onCrash:&BSSerializeDataCrashHandler];
     [self.systemState recordAppUUID]; // Needs to be called after crashSentry installed but before -computeDidCrashLastLaunch
     [self computeDidCrashLastLaunch];
     [self.breadcrumbs removeAllBreadcrumbs];

--- a/Bugsnag/Configuration/BugsnagConfiguration.m
+++ b/Bugsnag/Configuration/BugsnagConfiguration.m
@@ -228,6 +228,7 @@ static NSUserDefaults *userDefaults;
     if (!(self = [super init])) {
         return nil;
     }
+    _appType = metadata[BSGKeyAppType];
     _appVersion = metadata[BSGKeyAppVersion];
     _context = metadata[BSGKeyContext];
     _bundleVersion = metadata[BSGKeyBundleVersion];
@@ -614,6 +615,23 @@ static NSUserDefaults *userDefaults;
         [self.config addMetadata:newContext
                          withKey:BSGKeyContext
                        toSection:BSGKeyConfig];
+    }
+}
+
+// MARK: -
+
+@synthesize appType = _appType;
+
+- (NSString *)appType {
+    @synchronized (self) {
+        return _appType;
+    }
+}
+
+- (void)setAppType:(NSString *)appType {
+    @synchronized (self) {
+        _appType = [appType copy];
+        [self.config addMetadata:appType withKey:BSGKeyAppType toSection:BSGKeyConfig];
     }
 }
 

--- a/Bugsnag/Configuration/BugsnagConfiguration.m
+++ b/Bugsnag/Configuration/BugsnagConfiguration.m
@@ -99,7 +99,7 @@ static NSUserDefaults *userDefaults;
     [copy setPersistUser:self.persistUser];
     [copy setPlugins:[self.plugins copy]];
     [copy setReleaseStage:self.releaseStage];
-    [copy setSession:[self.session copy]];
+    copy.session = self.session; // NSURLSession does not declare conformance to NSCopying
     [copy setSendThreads:self.sendThreads];
     [copy setUser:self.user.id
         withEmail:self.user.email

--- a/Bugsnag/Delivery/BugsnagErrorReportApiClient.m
+++ b/Bugsnag/Delivery/BugsnagErrorReportApiClient.m
@@ -7,11 +7,14 @@
 //
 
 #import "BugsnagErrorReportApiClient.h"
+
+#import "BSG_KSCrash.h"
 #import "Bugsnag.h"
-#import "BugsnagLogger.h"
 #import "BugsnagClient.h"
 #import "BugsnagErrorReportSink.h"
 #import "BugsnagKeys.h"
+#import "BugsnagLogger.h"
+
 
 @interface BSGDeliveryOperation : NSOperation
 @end

--- a/Bugsnag/Delivery/BugsnagSessionTrackingApiClient.h
+++ b/Bugsnag/Delivery/BugsnagSessionTrackingApiClient.h
@@ -7,11 +7,12 @@
 #import "BugsnagApiClient.h"
 
 @class BugsnagConfiguration;
+@class BugsnagNotifier;
 @class BugsnagSessionFileStore;
 
 @interface BugsnagSessionTrackingApiClient : BugsnagApiClient
 
-- (instancetype)initWithConfig:(BugsnagConfiguration *)configuration queueName:(NSString *)queueName;
+- (instancetype)initWithConfig:(BugsnagConfiguration *)configuration queueName:(NSString *)queueName notifier:(BugsnagNotifier *)notifier;
 
 /**
  * Asynchronously delivers sessions written to the store
@@ -21,5 +22,7 @@
 - (void)deliverSessionsInStore:(BugsnagSessionFileStore *)store;
 
 @property (copy) NSString *codeBundleId;
+
+@property BugsnagNotifier *notifier;
 
 @end

--- a/Bugsnag/Delivery/BugsnagSessionTrackingApiClient.m
+++ b/Bugsnag/Delivery/BugsnagSessionTrackingApiClient.m
@@ -5,7 +5,6 @@
 
 #import "BugsnagSessionTrackingApiClient.h"
 
-#import "Bugsnag+Private.h"
 #import "BugsnagConfiguration+Private.h"
 #import "BugsnagSessionTrackingPayload.h"
 #import "BugsnagSessionFileStore.h"
@@ -22,10 +21,11 @@
 
 @implementation BugsnagSessionTrackingApiClient
 
-- (instancetype)initWithConfig:(BugsnagConfiguration *)configuration queueName:(NSString *)queueName {
+- (instancetype)initWithConfig:(BugsnagConfiguration *)configuration queueName:(NSString *)queueName notifier:(BugsnagNotifier *)notifier {
     if ((self = [super initWithSession:configuration.session queueName:queueName])) {
         _activeIds = [NSMutableSet new];
         _config = configuration;
+        _notifier = notifier;
     }
     return self;
 }
@@ -62,7 +62,8 @@
             BugsnagSessionTrackingPayload *payload = [[BugsnagSessionTrackingPayload alloc]
                 initWithSessions:@[session]
                           config:self.config
-                    codeBundleId:self.codeBundleId];
+                    codeBundleId:self.codeBundleId
+                        notifier:self.notifier];
             NSMutableDictionary *data = [payload toJson];
             NSDictionary *HTTPHeaders = @{
                 BugsnagHTTPHeaderNameApiKey: apiKey ?: @"",

--- a/Bugsnag/Delivery/BugsnagSessionTrackingApiClient.m
+++ b/Bugsnag/Delivery/BugsnagSessionTrackingApiClient.m
@@ -61,7 +61,7 @@
         [self.sendQueue addOperationWithBlock:^{
             BugsnagSessionTrackingPayload *payload = [[BugsnagSessionTrackingPayload alloc]
                 initWithSessions:@[session]
-                          config:[Bugsnag configuration]
+                          config:self.config
                     codeBundleId:self.codeBundleId];
             NSMutableDictionary *data = [payload toJson];
             NSDictionary *HTTPHeaders = @{

--- a/Bugsnag/Payload/BugsnagEvent.m
+++ b/Bugsnag/Payload/BugsnagEvent.m
@@ -358,9 +358,6 @@ NSDictionary *BSGParseCustomException(NSDictionary *report,
     BugsnagUser *user = [self parseUser:event deviceAppHash:deviceAppHash deviceId:device.id];
     BugsnagConfiguration *config = [[BugsnagConfiguration alloc] initWithMetadata:[event valueForKeyPath:@"user.config"]];
     BugsnagAppWithState *app = [BugsnagAppWithState appWithDictionary:event config:config codeBundleId:self.codeBundleId];
-    if (!app.type) { // Configuration.type does not get stored in the crash report at the time of writing.
-        app.type = [Bugsnag configuration].appType;
-    }
     BugsnagEvent *obj = [self initWithApp:app
                                    device:device
                              handledState:handledState
@@ -496,8 +493,7 @@ NSDictionary *BSGParseCustomException(NSDictionary *report,
 
 - (BOOL)shouldBeSent {
     return [self.enabledReleaseStages containsObject:self.releaseStage] ||
-           (self.enabledReleaseStages.count == 0 &&
-            [[Bugsnag configuration] shouldSendReports]);
+           (self.enabledReleaseStages.count == 0);
 }
 
 - (NSArray *)serializeBreadcrumbs {

--- a/Bugsnag/Payload/BugsnagSessionTrackingPayload.h
+++ b/Bugsnag/Payload/BugsnagSessionTrackingPayload.h
@@ -10,6 +10,7 @@
 #import "BugsnagSession.h"
 
 @class BugsnagConfiguration;
+@class BugsnagNotifier;
 
 @interface BugsnagSessionTrackingPayload : NSObject
 
@@ -17,7 +18,8 @@
 
 - (instancetype)initWithSessions:(NSArray<BugsnagSession *> *)sessions
                           config:(BugsnagConfiguration *)config
-                    codeBundleId:(NSString *)codeBundleId;
+                    codeBundleId:(NSString *)codeBundleId
+                        notifier:(BugsnagNotifier *)notifier;
 
 - (NSMutableDictionary *)toJson;
 

--- a/Bugsnag/Payload/BugsnagSessionTrackingPayload.m
+++ b/Bugsnag/Payload/BugsnagSessionTrackingPayload.m
@@ -23,6 +23,7 @@
 @interface BugsnagSessionTrackingPayload ()
 @property (nonatomic) BugsnagConfiguration *config;
 @property(nonatomic, copy) NSString *codeBundleId;
+@property (nonatomic) BugsnagNotifier *notifier;
 @end
 
 @implementation BugsnagSessionTrackingPayload
@@ -30,11 +31,13 @@
 - (instancetype)initWithSessions:(NSArray<BugsnagSession *> *)sessions
                           config:(BugsnagConfiguration *)config
                     codeBundleId:(NSString *)codeBundleId
+                        notifier:(BugsnagNotifier *)notifier
 {
     if (self = [super init]) {
         _sessions = sessions;
         _config = config;
         _codeBundleId = codeBundleId;
+        _notifier = notifier;
     }
     return self;
 }
@@ -48,7 +51,7 @@
         [sessionData addObject:[session toDictionary]];
     }
     dict[@"sessions"] = sessionData;
-    dict[BSGKeyNotifier] = [[Bugsnag client].notifier toDict];
+    dict[BSGKeyNotifier] = [self.notifier toDict];
 
     // app/device data collection relies on KSCrash reports,
     // need to mimic the JSON structure here

--- a/Tests/BSGConnectivityTest.m
+++ b/Tests/BSGConnectivityTest.m
@@ -43,8 +43,4 @@
                   usingCallback:block];
 }
 
-- (void)simulateConnectivityChangeTo:(SCNetworkReachabilityFlags) flags {
-    BSGConnectivityCallback(nil, flags, NULL);
-}
-
 @end

--- a/Tests/BugsnagApiClientTest.m
+++ b/Tests/BugsnagApiClientTest.m
@@ -82,7 +82,10 @@
 
 - (void)testSHA1HashStringWithData {
     BugsnagApiClient *client = [[BugsnagApiClient alloc] init];
+#pragma clang diagnostic push
+#pragma clang diagnostic ignored "-Wnonnull"
     XCTAssertNil([client SHA1HashStringWithData:nil]);
+#pragma clang diagnostic pop
     XCTAssertEqualObjects([client SHA1HashStringWithData:[@"{\"foo\":\"bar\"}" dataUsingEncoding:NSUTF8StringEncoding]], @"a5e744d0164540d33b1d7ea616c28f2fa97e754a");
 }
 

--- a/Tests/BugsnagErrorReportSinkTests.m
+++ b/Tests/BugsnagErrorReportSinkTests.m
@@ -49,7 +49,12 @@
     [client start];
     BugsnagEvent *report =
             [[BugsnagEvent alloc] initWithKSReport:self.rawReportData];
-    self.processedData = [[BugsnagErrorReportSink new] prepareEventPayload:report];
+    
+    BugsnagErrorReportSink *sink = [[BugsnagErrorReportSink alloc] initWithApiClient:client.errorReportApiClient
+                                                                       configuration:client.configuration
+                                                                            notifier:client.notifier];
+    
+    self.processedData = [sink prepareEventPayload:report];
 }
 
 - (void)tearDown {

--- a/Tests/BugsnagSessionTrackingPayloadTest.m
+++ b/Tests/BugsnagSessionTrackingPayloadTest.m
@@ -9,11 +9,12 @@
 #import <XCTest/XCTest.h>
 
 #import "BugsnagApp+Private.h"
-#import "BugsnagDevice+Private.h"
-#import "BugsnagSessionTrackingPayload.h"
 #import "BugsnagConfiguration+Private.h"
-#import "BugsnagTestConstants.h"
+#import "BugsnagDevice+Private.h"
+#import "BugsnagNotifier.h"
 #import "BugsnagSession+Private.h"
+#import "BugsnagSessionTrackingPayload.h"
+#import "BugsnagTestConstants.h"
 
 @interface BugsnagSessionTrackingPayloadTest : XCTestCase
 @property NSDictionary *payload;
@@ -29,15 +30,19 @@
 
     BugsnagConfiguration *config = [[BugsnagConfiguration alloc] initWithApiKey:DUMMY_APIKEY_32CHAR_1];
     config.releaseStage = @"beta";
-    BugsnagSessionTrackingPayload *data = [[BugsnagSessionTrackingPayload alloc] initWithSessions:@[] config:config codeBundleId:nil];
+    
+    BugsnagSessionTrackingPayload *payload = [[BugsnagSessionTrackingPayload alloc] initWithSessions:@[]
+                                                                                              config:config
+                                                                                        codeBundleId:nil
+                                                                                            notifier:[[BugsnagNotifier alloc] init]];
     BugsnagSession *session = [[BugsnagSession alloc] initWithId:@"test"
                                                        startDate:[NSDate date]
                                                             user:nil
                                                     autoCaptured:NO
                                                              app:self.app
                                                           device:self.device];
-    data.sessions = @[session];
-    self.payload = [data toJson];
+    payload.sessions = @[session];
+    self.payload = [payload toJson];
 }
 
 - (BugsnagApp *)generateApp {


### PR DESCRIPTION
## Goal

Accessing the `Bugsnag` class methods from within the implementation causes problems for unit testing, and contributes to the inability to run BugsnagErrorReportSinkTests and KSMachLinker_Test in isolation as the previously executed tests leave some global state upon which later test rely.

## Design

Replaced instances of `[Bugsnag configuration]` and `[Bugsnag client]` with parameters and / or properties configured by the creators of those objects.

`Configuration.appType` is now stored in the persisted metadata to allow it to be accessed when parsing a KSCrashReport.

Fixed an issue that prevented BugsnagErrorReportSinkTests from being run in isolation.

Fixed some analyzer warnings.

## Testing

Ran unit tests locally.