### PR TITLE
[PLAT-5649] Fix flake in BareboneTestHandledScenario

### DIFF
--- a/features/barebone_tests.feature
+++ b/features/barebone_tests.feature
@@ -78,7 +78,7 @@ Feature: Barebone tests
     And the exception "message" equals "The data couldn’t be read because it isn’t in the correct format."
     And the exception "type" equals "cocoa"
 
-  Scenario: Smoke test: unhandled error
+  Scenario: Barebone test: unhandled error
     When I run "BareboneTestUnhandledErrorScenario" and relaunch the app
     And I set the app to "report" mode
     And I configure Bugsnag for "BareboneTestUnhandledErrorScenario"


### PR DESCRIPTION
## Goal

This scenario was flaking due to a timing issue.

## Changeset

Replaced fixed-length "sleep" with a block-based approach that removes timing sensitivity.

## Testing

Ran the scenario manually.