### PR TITLE
Replace BugsnagConfiguration `config` with `dictionaryRepresentation`

### DIFF
--- a/Bugsnag/Client/BugsnagClient.m
+++ b/Bugsnag/Client/BugsnagClient.m
@@ -281,6 +281,8 @@ NSString *_lastOrientation = nil;
 
         self.breadcrumbs = [[BugsnagBreadcrumbs alloc] initWithConfiguration:self.configuration];
 
+        [BSGJSONSerialization writeJSONObject:configuration.dictionaryRepresentation toFile:_configMetadataFile options:0 error:nil];
+        
         // Start with a copy of the configuration metadata
         self.metadata = [[configuration metadata] deepCopy];
         // add metadata about app/device
@@ -289,7 +291,6 @@ NSString *_lastOrientation = nil;
         [self.metadata addMetadata:BSGParseDeviceMetadata(@{@"system": systemInfo}) toSection:BSGKeyDevice];
         // sync initial state
         [self metadataChanged:self.metadata];
-        [self metadataChanged:self.configuration.config];
         [self metadataChanged:self.state];
 
         // add observers for future metadata changes
@@ -301,7 +302,6 @@ NSString *_lastOrientation = nil;
             [weakSelf metadataChanged:event.data];
         };
         [self.metadata addObserverWithBlock:observer];
-        [self.configuration.config addObserverWithBlock:observer];
         [self.state addObserverWithBlock:observer];
 
         self.pluginClient = [[BugsnagPluginClient alloc] initWithPlugins:self.configuration.plugins
@@ -920,7 +920,7 @@ NSString *_lastOrientation = nil;
                         callbackOverrides:event.overrides
                            eventOverrides:eventOverrides
                                  metadata:[event.metadata toDictionary]
-                                   config:[self.configuration.config toDictionary]];
+                                   config:self.configuration.dictionaryRepresentation];
 
     // A basic set of event metadata
     NSMutableDictionary *metadata = [@{
@@ -973,8 +973,6 @@ NSString *_lastOrientation = nil;
     @synchronized(metadata) {
         if (metadata == self.metadata) {
             [BSGJSONSerialization writeJSONObject:[metadata toDictionary] toFile:self.metadataFile options:0 error:nil];
-        } else if (metadata == self.configuration.config) {
-            [BSGJSONSerialization writeJSONObject:[metadata getMetadataFromSection:BSGKeyConfig] toFile:self.configMetadataFile options:0 error:nil];
         } else if (metadata == self.state) {
             [BSGJSONSerialization writeJSONObject:[metadata toDictionary] toFile:self.stateMetadataFile options:0 error:nil];
         }

--- a/Bugsnag/Configuration/BugsnagConfiguration+Private.h
+++ b/Bugsnag/Configuration/BugsnagConfiguration+Private.h
@@ -14,16 +14,14 @@ NS_ASSUME_NONNULL_BEGIN
 
 #pragma mark Initializers
 
-/// Initializes the configuration with values previously stored in metadata.
-- (instancetype)initWithMetadata:(NSDictionary *)JSONObject NS_DESIGNATED_INITIALIZER;
+- (instancetype)initWithDictionaryRepresentation:(NSDictionary<NSString *, id> *)JSONObject NS_DESIGNATED_INITIALIZER;
 
 #pragma mark Properties
 
 /// The user defaults database to use for persistence of user information.
 @property (class, nonatomic) NSUserDefaults *userDefaults;
 
-/// Meta-information about the state of Bugsnag
-@property (retain, nullable) BugsnagMetadata *config;
+@property (readonly) NSDictionary<NSString *, id> *dictionaryRepresentation;
 
 @property (readonly) NSDictionary<NSString *, id> *errorApiHeaders;
 

--- a/Bugsnag/Payload/BugsnagEvent.m
+++ b/Bugsnag/Payload/BugsnagEvent.m
@@ -356,7 +356,7 @@ NSDictionary *BSGParseCustomException(NSDictionary *report,
     NSString *deviceAppHash = [event valueForKeyPath:@"system.device_app_hash"];
     BugsnagDeviceWithState *device = [BugsnagDeviceWithState deviceWithDictionary:event];
     BugsnagUser *user = [self parseUser:event deviceAppHash:deviceAppHash deviceId:device.id];
-    BugsnagConfiguration *config = [[BugsnagConfiguration alloc] initWithMetadata:[event valueForKeyPath:@"user.config"]];
+    BugsnagConfiguration *config = [[BugsnagConfiguration alloc] initWithDictionaryRepresentation:[event valueForKeyPath:@"user.config"]];
     BugsnagAppWithState *app = [BugsnagAppWithState appWithDictionary:event config:config codeBundleId:self.codeBundleId];
     BugsnagEvent *obj = [self initWithApp:app
                                    device:device

--- a/Tests/BugsnagAppTest.m
+++ b/Tests/BugsnagAppTest.m
@@ -45,7 +45,7 @@
             }
     };
 
-    self.config = [[BugsnagConfiguration alloc] initWithMetadata:self.data[@"user"][@"config"]];
+    self.config = [[BugsnagConfiguration alloc] initWithDictionaryRepresentation:self.data[@"user"][@"config"]];
     self.config.appType = @"iOS";
     self.config.bundleVersion = nil;
     self.config.appVersion = @"3.14.159";

--- a/Tests/BugsnagConfigurationTests.m
+++ b/Tests/BugsnagConfigurationTests.m
@@ -671,6 +671,29 @@ NSString * const kBugsnagUserUserId = @"BugsnagUserUserId";
 // MARK: - Other tests
 // =============================================================================
 
+- (void)testDictionaryRepresentation {
+    BugsnagConfiguration *configuration = [[BugsnagConfiguration alloc] initWithApiKey:DUMMY_APIKEY_32CHAR_1];
+    XCTAssertNotNil(configuration.dictionaryRepresentation[@"appType"]);
+    XCTAssertNotNil(configuration.dictionaryRepresentation[@"releaseStage"]);
+    
+    configuration.appVersion = @"1.2.3";
+    XCTAssertEqualObjects(configuration.dictionaryRepresentation[@"appVersion"], @"1.2.3");
+    
+    configuration.bundleVersion = @"2001";
+    XCTAssertEqualObjects(configuration.dictionaryRepresentation[@"bundleVersion"], @"2001");
+    
+    XCTAssertNil(configuration.dictionaryRepresentation[@"context"]);
+    configuration.context = @"lorem ipsum";
+    XCTAssertEqualObjects(configuration.dictionaryRepresentation[@"context"], @"lorem ipsum");
+    
+    configuration.releaseStage = @"release";
+    XCTAssertEqualObjects(configuration.dictionaryRepresentation[@"releaseStage"], @"release");
+    
+    XCTAssertNil(configuration.dictionaryRepresentation[@"enabledReleaseStages"]);
+    configuration.enabledReleaseStages = [NSSet setWithArray:@[@"release"]];
+    XCTAssertEqualObjects(configuration.dictionaryRepresentation[@"enabledReleaseStages"], @[@"release"]);
+}
+
 - (void)testValidateThrowsWhenMissingApiKey {
     NSString *nilKey = nil;
 

--- a/Tests/BugsnagSessionTest.m
+++ b/Tests/BugsnagSessionTest.m
@@ -51,7 +51,7 @@
             }
     };
 
-    BugsnagConfiguration *config = [[BugsnagConfiguration alloc] initWithMetadata:appData[@"user"][@"config"]];
+    BugsnagConfiguration *config = [[BugsnagConfiguration alloc] initWithDictionaryRepresentation:appData[@"user"][@"config"]];
     config.appType = @"iOS";
     config.bundleVersion = nil;
     return [BugsnagApp appWithDictionary:appData config:config codeBundleId:@"bundle-123"];

--- a/Tests/BugsnagSessionTrackingPayloadTest.m
+++ b/Tests/BugsnagSessionTrackingPayloadTest.m
@@ -66,7 +66,7 @@
             }
     };
 
-    BugsnagConfiguration *config = [[BugsnagConfiguration alloc] initWithMetadata:appData[@"user"][@"config"]];
+    BugsnagConfiguration *config = [[BugsnagConfiguration alloc] initWithDictionaryRepresentation:appData[@"user"][@"config"]];
     config.appType = @"iOS";
     config.bundleVersion = nil;
     return [BugsnagApp appWithDictionary:appData config:config codeBundleId:@"bundle-123"];


### PR DESCRIPTION
## Goal

This change simplifies the implementation of the `BugsnagConfiguration` configuration code.

A `BugsnagMetadata` object was being used to capture the state of the following properties:
* `appType`
* `appVersion`
* `bundleVersion`
* `context`
* `enabledReleaseStages`
* `releaseStage`

This was an overly complicated solution since BugsnagMetadata's observation functionality was not being used; the configuration does not be change once Bugsnag is started.

It also required custom getters and setters to be implemented for these properties, adding further complexity and maintenance burden.

Replacing this with a more straightforward approach makes the code easier to understand.

## Changeset

* Replaced the `BugsnagMetadata *config` property with a read-only `NSDictionary *dictionaryRepresentation`.
* Renamed `initWithMetadata:` to `initWithDictionaryRepresentation:` for consistency.

## Testing

Added unit test coverage for the 