### PR TITLE
Remove BugsnagClient from BugsnagErrorReportSinkTests

### DIFF
--- a/Bugsnag/Payload/BugsnagEvent.m
+++ b/Bugsnag/Payload/BugsnagEvent.m
@@ -472,12 +472,8 @@ NSDictionary *BSGParseCustomException(NSDictionary *report,
 @synthesize apiKey = _apiKey;
 
 - (NSString *)apiKey {
-    if (! _apiKey) {
-        _apiKey = Bugsnag.configuration.apiKey;
-    }
     return _apiKey;
 }
-
 
 - (void)setApiKey:(NSString *)apiKey {
     if ([BugsnagConfiguration isValidApiKey:apiKey]) {

--- a/Bugsnag/include/Bugsnag/BugsnagEvent.h
+++ b/Bugsnag/include/Bugsnag/BugsnagEvent.h
@@ -62,7 +62,7 @@ typedef NS_ENUM(NSUInteger, BSGSeverity) {
 
 /**
  * A per-event override for the apiKey.
- * - Reads default to the BugsnagConfiguration apiKey value unless explicitly set.
+ * - The default value of nil results in the BugsnagConfiguration apiKey being used.
  * - Writes are not persisted to BugsnagConfiguration.
  */
 @property(readwrite, copy, nullable) NSString *apiKey;

--- a/Tests/BugsnagErrorReportSinkTests.m
+++ b/Tests/BugsnagErrorReportSinkTests.m
@@ -8,15 +8,16 @@
 
 #import "BugsnagPlatformConditional.h"
 
-#import <Foundation/Foundation.h>
+#import <Bugsnag/Bugsnag.h>
 #import <XCTest/XCTest.h>
 
-#import "Bugsnag.h"
-#import "BugsnagClient+Private.h"
-#import "BugsnagHandledState.h"
+#import "BugsnagErrorReportApiClient.h"
 #import "BugsnagErrorReportSink+Private.h"
 #import "BugsnagEvent+Private.h"
+#import "BugsnagHandledState.h"
+#import "BugsnagNotifier.h"
 #import "BugsnagTestConstants.h"
+#import "URLSessionMock.h"
 
 @interface BugsnagErrorReportSinkTests : XCTestCase
 @property NSDictionary *rawReportData;
@@ -27,6 +28,7 @@
 
 - (void)setUp {
     [super setUp];
+    
     NSBundle *bundle = [NSBundle bundleForClass:[self class]];
     NSString *path = [bundle pathForResource:@"report" ofType:@"json"];
     NSString *contents = [NSString stringWithContentsOfFile:path
@@ -41,20 +43,18 @@
     // This value should not appear in the assertions, as it is not equal to
     // the release stage in the serialized report
     config.releaseStage = @"MagicalTestingTime";
-
-    // set a dummy endpoint, avoid hitting production
-    config.endpoints = [[BugsnagEndpointConfiguration alloc] initWithNotify:@"http://localhost:1234"
-                                                                   sessions:@"http://localhost:1234"];
-    BugsnagClient *client = [[BugsnagClient alloc] initWithConfiguration:config];
-    [client start];
-    BugsnagEvent *report =
-            [[BugsnagEvent alloc] initWithKSReport:self.rawReportData];
     
-    BugsnagErrorReportSink *sink = [[BugsnagErrorReportSink alloc] initWithApiClient:client.errorReportApiClient
-                                                                       configuration:client.configuration
-                                                                            notifier:client.notifier];
+    id session = [[URLSessionMock alloc] init];
     
-    self.processedData = [sink prepareEventPayload:report];
+    BugsnagErrorReportApiClient *apiClient = [[BugsnagErrorReportApiClient alloc] initWithSession:session queueName:@""];
+    
+    BugsnagNotifier *notifier = [[BugsnagNotifier alloc] init];
+    
+    BugsnagEvent *event = [[BugsnagEvent alloc] initWithKSReport:self.rawReportData];
+    
+    BugsnagErrorReportSink *sink = [[BugsnagErrorReportSink alloc] initWithApiClient:apiClient configuration:config notifier:notifier];
+    
+    self.processedData = [sink prepareEventPayload:event];
 }
 
 - (void)tearDown {


### PR DESCRIPTION
## Goal

Updates `BugsnagErrorReportSinkTests` to stop relying on `BugsnagClient`, and removes an uncaught use of the `Bugsnag.configuration` global that could cause intermittent failures depending on the order tests are run.

This makes the tests more independent, run faster, and reduces the number of side-effects such as writing data to disk or attempting to make network connections.

## Changeset

Constructs the various objects required by `BugsnagErrorReportSink` instead of taking them from a `BugsnagClient`.

Passes in a mock/stub for `NSURLSession` to prevent any possible network activity.

The `BugsnagEvent.apiKey` no longer falls back to `Bugsnag.configuration.apiKey` - `-[BugsnagErrorReportSink prepareEventPayload:]` will use the configuration's apiKey if required, when sending.

## Testing

Tested by running unit tests.