### PR TITLE
[PLAT-4174] Add [Bugsnag] prefix to log messages

### DIFF
--- a/Bugsnag/BugsnagSessionTracker.m
+++ b/Bugsnag/BugsnagSessionTracker.m
@@ -8,18 +8,17 @@
 
 #import "BugsnagSessionTracker+Private.h"
 
+#import "BSG_KSSystemInfo.h"
 #import "BugsnagApp+Private.h"
 #import "BugsnagClient+Private.h"
+#import "BugsnagCollections.h"
 #import "BugsnagConfiguration+Private.h"
 #import "BugsnagDevice+Private.h"
-#import "BugsnagSessionFileStore.h"
-#import "BSG_KSLogger.h"
-#import "BugsnagSessionTrackingPayload.h"
-#import "BugsnagSessionTrackingApiClient.h"
 #import "BugsnagLogger.h"
 #import "BugsnagSession+Private.h"
-#import "BSG_KSSystemInfo.h"
-#import "BugsnagCollections.h"
+#import "BugsnagSessionFileStore.h"
+#import "BugsnagSessionTrackingApiClient.h"
+#import "BugsnagSessionTrackingPayload.h"
 
 /**
  Number of seconds in background required to make a new session
@@ -56,7 +55,7 @@ NSString *const BSGSessionUpdateNotification = @"BugsnagSessionChanged";
 
         NSString *storePath = [BugsnagFileStore findReportStorePath:@"Sessions"];
         if (!storePath) {
-            BSG_KSLOG_ERROR(@"Failed to initialize session store.");
+            bsg_log_err(@"Failed to initialize session store.");
         }
 
         _sessionStore = [BugsnagSessionFileStore storeWithPath:storePath maxPersistedSessions:config.maxPersistedSessions];

--- a/Bugsnag/Configuration/BSGConfigurationBuilder.m
+++ b/Bugsnag/Configuration/BSGConfigurationBuilder.m
@@ -1,9 +1,9 @@
 #import "BSGConfigurationBuilder.h"
 
-#import "BSG_KSLogger.h"
 #import "BugsnagConfiguration.h"
 #import "BugsnagEndpointConfiguration.h"
 #import "BugsnagKeys.h"
+#import "BugsnagLogger.h"
 
 static BOOL BSGValueIsBoolean(id object) {
     return object != nil && [object isKindOfClass:[NSNumber class]]
@@ -41,7 +41,7 @@ static BOOL BSGValueIsBoolean(id object) {
     NSMutableSet *unknownKeys = [NSMutableSet setWithArray:options.allKeys];
     [unknownKeys minusSet:[NSSet setWithArray:validKeys]];
     if (unknownKeys.count > 0) {
-        BSG_KSLOG_WARN(@"Unknown dictionary keys passed in configuration options: %@", unknownKeys);
+        bsg_log_warn(@"Unknown dictionary keys passed in configuration options: %@", unknownKeys);
     }
     
     [self loadString:config options:options key:BSGKeyAppType];

--- a/Bugsnag/Configuration/BugsnagConfiguration.m
+++ b/Bugsnag/Configuration/BugsnagConfiguration.m
@@ -574,7 +574,7 @@ static NSUserDefaults *userDefaults;
     }
 
     if (![BugsnagConfiguration isValidApiKey:self.apiKey]) {
-        bsg_log_warn(@"Invalid Bugsnag apiKey: expected a 32-character hexademical string, got \"%@\"", self.apiKey);
+        bsg_log_warn(@"Invalid apiKey: expected a 32-character hexademical string, got \"%@\"", self.apiKey);
     }
 }
 

--- a/Bugsnag/Delivery/BugsnagSessionTrackingApiClient.m
+++ b/Bugsnag/Delivery/BugsnagSessionTrackingApiClient.m
@@ -74,14 +74,14 @@
                 completionHandler:^(BugsnagApiClientDeliveryStatus status, NSError *error) {
                 switch (status) {
                     case BugsnagApiClientDeliveryStatusDelivered:
-                        bsg_log_info(@"Sent session %@ to Bugsnag", session.id);
+                        bsg_log_info(@"Sent session %@", session.id);
                         [store deleteFileWithId:fileId];
                         break;
                     case BugsnagApiClientDeliveryStatusFailed:
-                        bsg_log_warn(@"Failed to send sessions to Bugsnag: %@", error);
+                        bsg_log_warn(@"Failed to send sessions: %@", error);
                         break;
                     case BugsnagApiClientDeliveryStatusUndeliverable:
-                        bsg_log_warn(@"Failed to send sessions to Bugsnag: %@", error);
+                        bsg_log_warn(@"Failed to send sessions: %@", error);
                         [store deleteFileWithId:fileId];
                         break;
                 }

--- a/Bugsnag/Helpers/BSGCachesDirectory.m
+++ b/Bugsnag/Helpers/BSGCachesDirectory.m
@@ -7,7 +7,8 @@
 //
 
 #import "BSGCachesDirectory.h"
-#import "BSG_KSLogger.h"
+
+#import "BugsnagLogger.h"
 
 @implementation BSGCachesDirectory
 
@@ -21,12 +22,12 @@ static NSString* g_cachesPath = nil;
     dispatch_once(&onceToken, ^{
         NSArray *dirs = NSSearchPathForDirectoriesInDomains(NSCachesDirectory, NSUserDomainMask, YES);
         if ([dirs count] == 0) {
-            BSG_KSLOG_ERROR(@"Could not locate cache directory path.");
+            bsg_log_err(@"Could not locate cache directory path.");
             return;
         }
 
         if ([dirs[0] length] == 0) {
-            BSG_KSLOG_ERROR(@"Could not locate cache directory path.");
+            bsg_log_err(@"Could not locate cache directory path.");
             return;
         }
         cachesPath = dirs[0];
@@ -42,7 +43,7 @@ static NSString* g_cachesPath = nil;
     NSFileManager *fileManager = [NSFileManager defaultManager];
     NSError *error = nil;
     if(![fileManager createDirectoryAtPath:subdirPath withIntermediateDirectories:YES attributes:nil error:&error]) {
-        BSG_KSLOG_ERROR(@"Could not create caches subdir %@: %@", subdirPath, error);
+        bsg_log_err(@"Could not create caches subdir %@: %@", subdirPath, error);
         // Make the best of it, just return the top-level caches dir.
         return cachesDir;
     }

--- a/Bugsnag/Helpers/BugsnagLogger.h
+++ b/Bugsnag/Helpers/BugsnagLogger.h
@@ -24,9 +24,6 @@
  *       That file includes this one.  No further configuration is required.
  */
 
-#ifndef BugsnagLogger_h
-#define BugsnagLogger_h
-
 #define BSG_LOGLEVEL_NONE 0
 #define BSG_LOGLEVEL_ERR 10
 #define BSG_LOGLEVEL_WARN 20
@@ -38,28 +35,32 @@
 #define BSG_LOG_LEVEL BSG_LOGLEVEL_INFO
 #endif
 
+#ifdef __OBJC__
+
+#import <Foundation/Foundation.h>
+
 #if BSG_LOG_LEVEL >= BSG_LOGLEVEL_ERR
-#define bsg_log_err NSLog
+#define bsg_log_err(...) NSLog(@"[Bugsnag] [ERROR] " __VA_ARGS__)
 #else
 #define bsg_log_err(format, ...)
 #endif
 
 #if BSG_LOG_LEVEL >= BSG_LOGLEVEL_WARN
-#define bsg_log_warn NSLog
+#define bsg_log_warn(...) NSLog(@"[Bugsnag] [WARN] " __VA_ARGS__)
 #else
 #define bsg_log_warn(format, ...)
 #endif
 
 #if BSG_LOG_LEVEL >= BSG_LOGLEVEL_INFO
-#define bsg_log_info NSLog
+#define bsg_log_info(...) NSLog(@"[Bugsnag] [INFO] " __VA_ARGS__)
 #else
 #define bsg_log_info(format, ...)
 #endif
 
 #if BSG_LOG_LEVEL >= BSG_LOGLEVEL_DEBUG
-#define bsg_log_debug NSLog
+#define bsg_log_debug(...) NSLog(@"[Bugsnag] [DEBUG] " __VA_ARGS__)
 #else
 #define bsg_log_debug(format, ...)
 #endif
 
-#endif /* BugsnagLogger_h */
+#endif

--- a/Bugsnag/KSCrash/Source/KSCrash/Recording/Tools/BSG_KSLogger.h
+++ b/Bugsnag/KSCrash/Source/KSCrash/Recording/Tools/BSG_KSLogger.h
@@ -356,6 +356,24 @@ bool bsg_kslog_setLogFilename(const char *filename, bool overwrite);
 #undef BSG_KSLOG_BAK_TRACE
 #endif
 
+#ifdef __OBJC__
+
+#pragma mark - Redirect BSG_KSLOG_* to bsg_log_* so that logging output has a unified format.
+
+#undef BSG_KSLOG_ERROR
+#undef BSG_KSLOG_WARN
+#undef BSG_KSLOG_INFO
+#undef BSG_KSLOG_DEBUG
+#undef BSG_KSLOG_TRACE
+
+#define BSG_KSLOG_ERROR bsg_log_err
+#define BSG_KSLOG_WARN  bsg_log_warn
+#define BSG_KSLOG_INFO  bsg_log_info
+#define BSG_KSLOG_DEBUG bsg_log_debug
+#define BSG_KSLOG_TRACE bsg_log_debug
+
+#endif // __OBJC__
+
 #ifdef __cplusplus
 }
 #endif

--- a/Bugsnag/Storage/BugsnagFileStore.m
+++ b/Bugsnag/Storage/BugsnagFileStore.m
@@ -4,11 +4,12 @@
 //
 
 #import "BugsnagFileStore.h"
+
+#import "BSGCachesDirectory.h"
 #import "BSG_KSCrashReportFields.h"
 #import "BSG_KSJSONCodecObjC.h"
+#import "BugsnagLogger.h"
 #import "NSError+BSG_SimpleConstructor.h"
-#import "BSG_KSLogger.h"
-#import "BSGCachesDirectory.h"
 
 #pragma mark - Meta Data
 
@@ -90,7 +91,7 @@
     NSFileManager *fm = [NSFileManager defaultManager];
     NSArray *filenames = [fm contentsOfDirectoryAtPath:self.path error:&error];
     if (filenames == nil) {
-        BSG_KSLOG_ERROR(@"Could not get contents of directory %@: %@",
+        bsg_log_err(@"Could not get contents of directory %@: %@",
                 self.path, error);
         return nil;
     }
@@ -105,7 +106,7 @@
             NSDictionary *fileAttribs =
                     [fm attributesOfItemAtPath:fullPath error:&error];
             if (fileAttribs == nil) {
-                BSG_KSLOG_ERROR(@"Could not read file attributes for %@: %@",
+                bsg_log_err(@"Could not read file attributes for %@: %@",
                         fullPath, error);
             } else {
                 FileStoreInfo *info = [FileStoreInfo fileStoreInfoWithId:fileId
@@ -165,11 +166,11 @@
     NSMutableDictionary *fileContents =
             [self readFile:[self pathToFileWithId:fileId] error:&error];
     if (error != nil) {
-        BSG_KSLOG_ERROR(@"Encountered error loading file %@: %@",
+        bsg_log_err(@"Encountered error loading file %@: %@",
                 fileId, error);
     }
     if (fileContents == nil) {
-        BSG_KSLOG_ERROR(@"Could not load file");
+        bsg_log_err(@"Could not load file");
         return nil;
     }
     return fileContents;
@@ -181,7 +182,7 @@
 
     [[NSFileManager defaultManager] removeItemAtPath:filename error:&error];
     if (error != nil) {
-        BSG_KSLOG_ERROR(@"Could not delete file %@: %@", filename, error);
+        bsg_log_err(@"Could not delete file %@: %@", filename, error);
     }
 }
 
@@ -195,11 +196,11 @@
             [[BSGCachesDirectory cachesDirectory] stringByAppendingPathComponent:storePathEnd];
 
     if ([storePath length] == 0) {
-        BSG_KSLOG_ERROR(@"Could not determine report files path.");
+        bsg_log_err(@"Could not determine report files path.");
         return nil;
     }
     if (![self ensureDirectoryExists:storePath]) {
-        BSG_KSLOG_ERROR(@"Store Directory does not exist.");
+        bsg_log_err(@"Store Directory does not exist.");
         return nil;
     }
     return storePath;
@@ -214,7 +215,7 @@
            withIntermediateDirectories:YES
                             attributes:nil
                                  error:&error]) {
-            BSG_KSLOG_ERROR(@"Could not create directory %@: %@.", path, error);
+            bsg_log_err(@"Could not create directory %@: %@.", path, error);
             return NO;
         }
     }
@@ -229,7 +230,7 @@
               operation:(void (^)(id parent, id field))operation
            okIfNotFound:(BOOL)isOkIfNotFound {
     if (fieldPath.count == 0) {
-        BSG_KSLOG_ERROR(@"Unexpected end of field path");
+        bsg_log_err(@"Unexpected end of field path");
         return;
     }
 
@@ -244,7 +245,7 @@
     id field = file[currentField];
     if (field == nil) {
         if (!isOkIfNotFound) {
-            BSG_KSLOG_ERROR(@"%@: No such field in file. Candidates are: %@",
+            bsg_log_err(@"%@: No such field in file. Candidates are: %@",
                     currentField, file.allKeys);
         }
         return;
@@ -300,7 +301,7 @@
                               error:error];
     if (error != nil && *error != nil) {
 
-        BSG_KSLOG_ERROR(@"Error decoding JSON data from %@: %@", path, *error);
+        bsg_log_err(@"Error decoding JSON data from %@: %@", path, *error);
         fileContents[@BSG_KSCrashField_Incomplete] = @YES;
     }
     return fileContents;

--- a/Bugsnag/Storage/BugsnagSessionFileStore.m
+++ b/Bugsnag/Storage/BugsnagSessionFileStore.m
@@ -5,8 +5,8 @@
 
 #import "BugsnagSessionFileStore.h"
 
-#import "BSG_KSLogger.h"
 #import "BSGJSONSerialization.h"
+#import "BugsnagLogger.h"
 #import "BugsnagSession+Private.h"
 
 static NSString *const kSessionStoreSuffix = @"-Session-";
@@ -43,7 +43,7 @@ static NSString *const kSessionStoreSuffix = @"-Session-";
     NSData *json = [BSGJSONSerialization dataWithJSONObject:dict options:0 error:&error];
 
     if (error != nil || ![json writeToFile:filepath atomically:YES]) {
-        BSG_KSLOG_ERROR(@"Failed to write session %@", error);
+        bsg_log_err(@"Failed to write session %@", error);
         return;
     }
     

--- a/Tests/KSCrash/KSLogger_Tests.m
+++ b/Tests/KSCrash/KSLogger_Tests.m
@@ -58,11 +58,6 @@
     BSG_KSLOG_ERROR(@"TEST");
 }
 
-- (void) testLogErrorNull
-{
-    BSG_KSLOG_ERROR(nil);
-}
-
 - (void) testLogAlways
 {
     BSG_KSLOG_ALWAYS(@"TEST");


### PR DESCRIPTION
## Goal

Improves the consistency of and ability to search / filter Bugsnag log messages.

Improves the ability to diagnose E2E test failures by sending all possible message to NSLog so that they are captured in device logs by BrowserStack.

## Changeset

The `bsg_log_` macros have been updated to include a prefix indicating the source (Bugsnag) and level, e.g.
* `[Bugsnag] [WARN] Invalid apiKey: expected a 32-character hexademical string, got "YOUR-API-KEY"`
* `[Bugsnag] [INFO] Sent session E8FE313F-042B-458F-97E6-067A52F86C23`
* `[Bugsnag] [INFO] Sending 1 crash reports`

Code outside the KSCrash subdirectory has been updated to use the `bsg_log_*` macros from BugsnagLogger.h - these should be used in preference to those declared in BSG_KSLogger.h

Code inside KSCrash continues to use the `BSG_KSLOG_*` macros (there are > 200 usages) but they now redirect to `bsg_log_*` when used in Objective-C code. This felt like a less disruptive / churny solution than replacing all uses of the old macro.

## Testing

Tested locally by running unit tests and example apps.