### PR TITLE
[PLAT-5451] Fix missing session information in OOM events

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,13 @@
 Changelog
 =========
 
+## TBD
+
+### Bug fixes
+
+* Fix missing session information in OOM events.
+  [#963](https://github.com/bugsnag/bugsnag-cocoa/pull/963)
+
 ## 6.5.0 (2021-01-06)
 
 ### Enhancements
@@ -17,7 +24,7 @@ Changelog
 * Bugsnag log messages are now prefixed with `[Bugsnag]` for easier searching & filtering.
   [#955](https://github.com/bugsnag/bugsnag-cocoa/pull/955)
 
-## Bug fixes
+### Bug fixes
 
 * Fix reliability of Swift fatal error message reporting.
   [#948](https://github.com/bugsnag/bugsnag-cocoa/pull/948)

--- a/features/barebone_tests.feature
+++ b/features/barebone_tests.feature
@@ -126,9 +126,11 @@ Feature: Barebone tests
 
   Scenario: Barebone test: Out Of Memory
     When I run "OOMLoadScenario"
-    And I wait to receive a request
+    And I wait to receive 2 requests
 
-    Then the "Bugsnag-API-Key" header equals "0192837465afbecd0192837465afbecd"
+    Then the request is valid for the session reporting API version "1.0" for the "iOS Bugsnag Notifier" notifier
+    And I discard the oldest request
+
     And the event "unhandled" is false
     And the exception "message" equals "OOMLoadScenario"
     And the event has a "manual" breadcrumb named "OOMLoadScenarioBreadcrumb"
@@ -136,9 +138,11 @@ Feature: Barebone tests
 
     When I relaunch the app
     And I configure Bugsnag for "OOMLoadScenario"
-    And I wait to receive a request
+    And I wait to receive 2 requests
 
-    Then the "Bugsnag-API-Key" header equals "0192837465afbecd0192837465afbecd"
+    Then the request is valid for the session reporting API version "1.0" for the "iOS Bugsnag Notifier" notifier
+    And I discard the oldest request
+
     And the error is an OOM event
     And the event "app.bundleVersion" is not null
     And the event "app.dsymUUIDs" is not null
@@ -165,6 +169,11 @@ Feature: Barebone tests
     And the event "metaData.device.simulator" is false
     And the event "metaData.device.timezone" is not null
     And the event "metaData.device.wordSize" is not null
+    And the event "session.id" is not null
+    And the event "session.startedAt" is not null
+    And the event "session.events.handled" equals 1
+    And the event "session.events.unhandled" equals 1
+    And the event "unhandled" is true
     And the event "user.email" equals "foobar@example.com"
     And the event "user.id" equals "foobar"
     And the event "user.name" equals "Foo Bar"

--- a/features/fixtures/shared/scenarios/OOMLoadScenario.swift
+++ b/features/fixtures/shared/scenarios/OOMLoadScenario.swift
@@ -12,8 +12,8 @@ import Bugsnag
 class OOMLoadScenario: Scenario {
 
     override func startBugsnag() {
-        config = BugsnagConfiguration.loadConfig()
-        config.autoTrackSessions = false
+        config.autoTrackSessions = true
+        config.enabledErrorTypes.ooms = true
         config.addMetadata(["bar": "foo"], section: "custom")
         config.setUser("foobar", withEmail: "foobar@example.com", andName: "Foo Bar")
         Bugsnag.start(with: config)

--- a/features/out_of_memory.feature
+++ b/features/out_of_memory.feature
@@ -9,8 +9,11 @@ Feature: Out of memory errors
 
   Scenario: Out of memory errors are enabled when loading configuration
     When I run "OOMLoadScenario"
-    And I wait to receive a request
-    Then the "Bugsnag-API-Key" header equals "0192837465afbecd0192837465afbecd"
+    And I wait to receive 2 requests
+
+    Then the request is valid for the session reporting API version "1.0" for the "iOS Bugsnag Notifier" notifier
+    And I discard the oldest request
+
     And the event "unhandled" is false
     And the exception "message" equals "OOMLoadScenario"
     And the event has a "manual" breadcrumb named "OOMLoadScenarioBreadcrumb"
@@ -18,8 +21,11 @@ Feature: Out of memory errors
 
     When I relaunch the app
     And I configure Bugsnag for "OOMLoadScenario"
-    And I wait to receive a request
-    Then the "Bugsnag-API-Key" header equals "0192837465afbecd0192837465afbecd"
+    And I wait to receive 2 requests
+
+    Then the request is valid for the session reporting API version "1.0" for the "iOS Bugsnag Notifier" notifier
+    And I discard the oldest request
+
     And the error is an OOM event
 
     # Ensure the basic data from OOMs are present
@@ -41,6 +47,11 @@ Feature: Out of memory errors
     And the event "device.runtimeVersions" is not null
     And the event "device.totalMemory" is not null
     And the event "metaData.custom.bar" equals "foo"
+    And the event "session.id" is not null
+    And the event "session.startedAt" is not null
+    And the event "session.events.handled" equals 1
+    And the event "session.events.unhandled" equals 1
+    And the event "unhandled" is true
     And the event "user.id" equals "foobar"
     And the event "user.email" equals "foobar@example.com"
     And the event "user.name" equals "Foo Bar"


### PR DESCRIPTION
## Goal

OOM events used to contain session information, but this was inadvertently removed by a regression introduced in v6.2.0.

These changes reintroduce the session information in OOM events and add verification of this in the E2E tests.

## Changeset

`BugsnagSystemState` now records the session information when a BSGSessionUpdateNotification is posted, just like `BSGOutOfMemoryWatchdog` used to.

`-[BugsnagEvent initWithOOMData:]` still contains the code to read the session information from the data stored by `BugsnagSystemState`.

## Testing

Tested manually using the example app, and by amending & running the E2E tests.