### PR TITLE
CI: Add environment variable to trigger full CI build

### DIFF
--- a/.buildkite/pipeline_trigger.sh
+++ b/.buildkite/pipeline_trigger.sh
@@ -4,7 +4,8 @@ if [[ "$BUILDKITE_MESSAGE" == *"[barebones ci]"* ]]; then
   echo "Running barebones build due to commit message\n"
 elif [[ "$BUILDKITE_MESSAGE" == *"[full ci]"* ||
   "$BUILDKITE_PULL_REQUEST_BASE_BRANCH" == "master" ||
-  "$BUILDKITE_BRANCH" == "master" ]]; then
+  "$BUILDKITE_BRANCH" == "master" ||
+  ! -z "$FULL_SCHEDULED_BUILD" ]]; then
   echo "Running full build"
   buildkite-agent pipeline upload .buildkite/pipeline.quick.yml
   buildkite-agent pipeline upload .buildkite/pipeline.full.yml


### PR DESCRIPTION
## Goal

Adds an environmental trigger that will allow the full tests to be run on a scheduled build.

This results in the scheduled build looking like: https://buildkite.com/bugsnag/bugsnag-cocoa/builds/1617

Note: Once this is merged I need to make a tweak to the scheduled job to target the `next` branch