### PR TITLE
Allow 75 minutes for E2E test run

### DIFF
--- a/.buildkite/pipeline.full.yml
+++ b/.buildkite/pipeline.full.yml
@@ -2,7 +2,7 @@ steps:
   - label: ':ios: iOS 13 end-to-end tests'
     depends_on:
       - cocoa_fixture
-    timeout_in_minutes: 60
+    timeout_in_minutes: 75
     agents:
       queue: opensource
     plugins:
@@ -27,7 +27,7 @@ steps:
   - label: ':ios: iOS 12 end-to-end tests'
     depends_on:
       - cocoa_fixture
-    timeout_in_minutes: 60
+    timeout_in_minutes: 75
     agents:
       queue: opensource
     plugins:

--- a/.buildkite/pipeline.quick.yml
+++ b/.buildkite/pipeline.quick.yml
@@ -143,7 +143,7 @@ steps:
   - label: ':ios: iOS 14 full end-to-end tests'
     depends_on:
       - cocoa_fixture
-    timeout_in_minutes: 60
+    timeout_in_minutes: 75
     agents:
       queue: opensource
     plugins:
@@ -168,7 +168,7 @@ steps:
   - label: ':ios: iOS 10 full end-to-end tests'
     depends_on:
       - cocoa_fixture
-    timeout_in_minutes: 60
+    timeout_in_minutes: 75
     agents:
       queue: opensource
     plugins:

--- a/.buildkite/pipeline.yml
+++ b/.buildkite/pipeline.yml
@@ -119,7 +119,7 @@ steps:
   - label: ':ios: iOS 14 barebones end-to-end tests'
     depends_on:
       - cocoa_fixture
-    timeout_in_minutes: 60
+    timeout_in_minutes: 10
     agents:
       queue: opensource
     plugins:
@@ -145,7 +145,7 @@ steps:
   - label: ':ios: iOS 10 barebones end-to-end tests'
     depends_on:
       - cocoa_fixture
-    timeout_in_minutes: 60
+    timeout_in_minutes: 10
     agents:
       queue: opensource
     plugins:


### PR DESCRIPTION
## Goal

The full E2E test runs sometimes fail due to not completing within the 60 minutes allowed.

E.g. iOS 12 & 13 in https://buildkite.com/bugsnag/bugsnag-cocoa/builds/1647

## Changeset

* Increases the timeout to 75 minutes for full E2E
* Makes all unit test jobs use a 10 minute timeout