### PR TITLE
[PLAT-5682] Make max persisted events/sessions spec compliant

### DIFF
--- a/Bugsnag/Configuration/BugsnagConfiguration.m
+++ b/Bugsnag/Configuration/BugsnagConfiguration.m
@@ -174,9 +174,9 @@ static NSUserDefaults *userDefaults;
     _enabledReleaseStages = nil;
     _redactedKeys = [NSSet setWithArray:@[@"password"]];
     _enabledBreadcrumbTypes = BSGEnabledBreadcrumbTypeAll;
-    _maxPersistedEvents = 12;
-    _maxPersistedSessions = 32;
     _maxBreadcrumbs = 25;
+    _maxPersistedEvents = 32;
+    _maxPersistedSessions = 128;
     _autoTrackSessions = YES;
     _sendThreads = BSGThreadSendPolicyAlways;
     // Default to recording all error types
@@ -441,41 +441,25 @@ static NSUserDefaults *userDefaults;
 // MARK: - Properties: Getters and Setters
 // -----------------------------------------------------------------------------
 
-@synthesize maxPersistedEvents = _maxPersistedEvents;
-
-- (NSUInteger)maxPersistedEvents {
-    @synchronized (self) {
-        return _maxPersistedEvents;
-    }
-}
-
 - (void)setMaxPersistedEvents:(NSUInteger)maxPersistedEvents {
     @synchronized (self) {
-        if (maxPersistedEvents >= 1 && maxPersistedEvents <= 100) {
+        if (maxPersistedEvents >= 1) {
             _maxPersistedEvents = maxPersistedEvents;
         } else {
             bsg_log_err(@"Invalid configuration value detected. Option maxPersistedEvents "
-                        "should be an integer between 1-100. Supplied value is %lu",
+                        "should be a non-zero integer. Supplied value is %lu",
                         (unsigned long) maxPersistedEvents);
         }
     }
 }
 
-@synthesize maxPersistedSessions = _maxPersistedSessions;
-
-- (NSUInteger)maxPersistedSessions {
-    @synchronized (self) {
-        return _maxPersistedSessions;
-    }
-}
-
 - (void)setMaxPersistedSessions:(NSUInteger)maxPersistedSessions {
     @synchronized (self) {
-        if (maxPersistedSessions >= 1 && maxPersistedSessions <= 100) {
+        if (maxPersistedSessions >= 1) {
             _maxPersistedSessions = maxPersistedSessions;
         } else {
             bsg_log_err(@"Invalid configuration value detected. Option maxPersistedSessions "
-                        "should be an integer between 1-100. Supplied value is %lu",
+                        "should be a non-zero integer. Supplied value is %lu",
                         (unsigned long) maxPersistedSessions);
         }
     }

--- a/Bugsnag/include/Bugsnag/BugsnagConfiguration.h
+++ b/Bugsnag/include/Bugsnag/BugsnagConfiguration.h
@@ -222,7 +222,7 @@ typedef BOOL (^BugsnagOnSessionBlock)(BugsnagSession *_Nonnull session);
  * Sets the maximum number of events which will be stored. Once the threshold is reached,
  * the oldest events will be deleted.
  *
- * By default, 12 events are stored: this can be amended up to a maximum of 100.
+ * By default, 32 events are persisted.
  */
 @property (nonatomic) NSUInteger maxPersistedEvents;
 
@@ -230,7 +230,7 @@ typedef BOOL (^BugsnagOnSessionBlock)(BugsnagSession *_Nonnull session);
  * Sets the maximum number of sessions which will be stored. Once the threshold is reached,
  * the oldest sessions will be deleted.
  *
- * By default, 32 sessions are stored: this can be amended up to a maximum of 100.
+ * By default, 128 sessions are persisted.
  */
 @property (nonatomic) NSUInteger maxPersistedSessions;
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,8 @@ Changelog
 
 * Fix missing session information in OOM events.
   [#963](https://github.com/bugsnag/bugsnag-cocoa/pull/963)
+* Make `maxPersistedEvents` and `maxPersistedSessions` comply with the specification, with defaults of 32 and 128 respectively.
+  [#966](https://github.com/bugsnag/bugsnag-cocoa/pull/966)
 
 ## 6.5.0 (2021-01-06)
 

--- a/Tests/BSGConfigurationBuilderTests.m
+++ b/Tests/BSGConfigurationBuilderTests.m
@@ -55,9 +55,9 @@
     XCTAssertNil(config.appVersion);
     XCTAssertTrue(config.autoDetectErrors);
     XCTAssertTrue(config.autoTrackSessions);
-    XCTAssertEqual(12, config.maxPersistedEvents);
-    XCTAssertEqual(32, config.maxPersistedSessions);
-    XCTAssertEqual(25, config.maxBreadcrumbs);
+    XCTAssertEqual(config.maxPersistedEvents, 32);
+    XCTAssertEqual(config.maxPersistedSessions, 128);
+    XCTAssertEqual(config.maxBreadcrumbs, 25);
     XCTAssertTrue(config.persistUser);
     XCTAssertEqualObjects(@[@"password"], [config.redactedKeys allObjects]);
     XCTAssertEqual(BSGThreadSendPolicyAlways, config.sendThreads);

--- a/Tests/BugsnagConfigurationTests.m
+++ b/Tests/BugsnagConfigurationTests.m
@@ -535,30 +535,19 @@ NSString * const kBugsnagUserUserId = @"BugsnagUserUserId";
 
 - (void)testMaxPersistedEvents {
     BugsnagConfiguration *config = [[BugsnagConfiguration alloc] initWithApiKey:DUMMY_APIKEY_32CHAR_1];
-    XCTAssertEqual(12, config.maxPersistedEvents);
+    XCTAssertEqual(config.maxPersistedEvents, 32, @"maxPersistedEvents should default to 32");
 
-    // alter to valid value
     config.maxPersistedEvents = 10;
-    XCTAssertEqual(10, config.maxPersistedEvents);
+    XCTAssertEqual(config.maxPersistedEvents, 10, @"Valid values should be accepted");
 
-    // alter to max value
-    config.maxPersistedEvents = 100;
-    XCTAssertEqual(100, config.maxPersistedEvents);
+    config.maxPersistedEvents = 1000;
+    XCTAssertEqual(config.maxPersistedEvents, 1000, @"No maximum bound should be applied");
 
-    // alter to min value
     config.maxPersistedEvents = 1;
-    XCTAssertEqual(1, config.maxPersistedEvents);
+    XCTAssertEqual(config.maxPersistedEvents, 1, @"A value of 1 should be accepted");
 
     config.maxPersistedEvents = 0;
-    XCTAssertEqual(1, config.maxPersistedEvents);
-
-    // alter to negative value
-    config.maxPersistedEvents = -1;
-    XCTAssertEqual(1, config.maxPersistedEvents);
-
-    // alter to > max value
-    config.maxPersistedEvents = 500;
-    XCTAssertEqual(1, config.maxPersistedEvents);
+    XCTAssertEqual(config.maxPersistedEvents, 1, @"Setting to zero should have no effect");
 }
 
 // =============================================================================
@@ -567,30 +556,19 @@ NSString * const kBugsnagUserUserId = @"BugsnagUserUserId";
 
 - (void)testMaxPersistedSessions {
     BugsnagConfiguration *config = [[BugsnagConfiguration alloc] initWithApiKey:DUMMY_APIKEY_32CHAR_1];
-    XCTAssertEqual(32, config.maxPersistedSessions);
+    XCTAssertEqual(config.maxPersistedSessions, 128, @"maxPersistedSessions should default to 128");
 
-    // alter to valid value
     config.maxPersistedSessions = 10;
-    XCTAssertEqual(10, config.maxPersistedSessions);
+    XCTAssertEqual(config.maxPersistedSessions, 10, @"Valid values should be accepted");
 
-    // alter to max value
-    config.maxPersistedSessions = 100;
-    XCTAssertEqual(100, config.maxPersistedSessions);
+    config.maxPersistedSessions = 1000;
+    XCTAssertEqual(config.maxPersistedSessions, 1000, @"No maximum bound should be applied");
 
-    // alter to min value
     config.maxPersistedSessions = 1;
-    XCTAssertEqual(1, config.maxPersistedSessions);
+    XCTAssertEqual(config.maxPersistedSessions, 1, @"A value of 1 should be accepted");
 
     config.maxPersistedSessions = 0;
-    XCTAssertEqual(1, config.maxPersistedSessions);
-
-    // alter to negative value
-    config.maxPersistedSessions = -1;
-    XCTAssertEqual(1, config.maxPersistedSessions);
-
-    // alter to > max value
-    config.maxPersistedSessions = 500;
-    XCTAssertEqual(1, config.maxPersistedSessions);
+    XCTAssertEqual(config.maxPersistedSessions, 1, @"Setting to zero should have no effect");
 }
 
 // =============================================================================

--- a/Tests/ConfigurationApiValidationTest.m
+++ b/Tests/ConfigurationApiValidationTest.m
@@ -137,16 +137,6 @@
     XCTAssertEqual(40, self.config.maxPersistedEvents);
 }
 
-- (void)testInvalidMaxPersistedEvents {
-    self.config.maxPersistedEvents = 1;
-    self.config.maxPersistedEvents = 0;
-    XCTAssertEqual(1, self.config.maxPersistedEvents);
-    self.config.maxPersistedEvents = -1;
-    XCTAssertEqual(1, self.config.maxPersistedEvents);
-    self.config.maxPersistedEvents = 590;
-    XCTAssertEqual(1, self.config.maxPersistedEvents);
-}
-
 - (void)testValidMaxPersistedSessions {
     self.config.maxPersistedSessions = 1;
     XCTAssertEqual(1, self.config.maxPersistedSessions);
@@ -154,16 +144,6 @@
     XCTAssertEqual(100, self.config.maxPersistedSessions);
     self.config.maxPersistedSessions = 40;
     XCTAssertEqual(40, self.config.maxPersistedSessions);
-}
-
-- (void)testInvalidMaxPersistedSessions {
-    self.config.maxPersistedSessions = 1;
-    self.config.maxPersistedSessions = 0;
-    XCTAssertEqual(1, self.config.maxPersistedSessions);
-    self.config.maxPersistedSessions = -1;
-    XCTAssertEqual(1, self.config.maxPersistedSessions);
-    self.config.maxPersistedSessions = 590;
-    XCTAssertEqual(1, self.config.maxPersistedSessions);
 }
 
 - (void)testValidMaxBreadcrumbs {


### PR DESCRIPTION
## Goal

Make `maxPersistedEvents` and `maxPersistedSessions` more closely follow the specification
* Defaults of 32 and 128, respectively
* No upper limit

## Changeset

Adjusted the implementation and documentation to closely follow the specification and [Android implementation](https://github.com/bugsnag/bugsnag-android/blob/v5.5.0/bugsnag-android-core/src/main/java/com/bugsnag/android/Configuration.java#L478-L528).

Removed the custom getters - these are no longer required since the properties are now `nonatomic`.

Adjusted the unit tests.

Note when using `XCTAssert` macros that the expected value should be passed as the second argument, as demonstrated in [Apple's documentation](https://developer.apple.com/documentation/xctest/defining_test_cases_and_test_methods). Many of our existing tests do not follow this convention, but new code should.

## Testing

Manually ran the unit tests.