### PR TITLE
Build status badge: replace Travis with BuildKite

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,7 +2,7 @@
 [![iOS Documentation](https://img.shields.io/badge/ios_documentation-latest-blue.svg)](http://docs.bugsnag.com/platforms/ios/)
 [![tvOS Documentation](https://img.shields.io/badge/tvos_documentation-latest-blue.svg)](http://docs.bugsnag.com/platforms/tvos/)
 [![macOS Documentation](https://img.shields.io/badge/macos_documentation-latest-blue.svg)](http://docs.bugsnag.com/platforms/macos/)
-[![Build status](https://travis-ci.com/bugsnag/bugsnag-cocoa.svg?branch=master)](https://travis-ci.com/bugsnag/bugsnag-cocoa)
+[![Build status](https://badge.buildkite.com/bc15523ca2dc56d1a9fd61a1c0e93b99adba62f229a1c3379b.svg?branch=master)](https://buildkite.com/bugsnag/bugsnag-cocoa)
 
 The Bugsnag crash reporter for Cocoa library automatically detects crashes and fatal signals in your iOS 9.3+, macOS 10.11+ and tvOS 9.2+ applications, collecting diagnostic information and immediately notifying your development team, helping you to understand and resolve issues as fast as possible. Learn more about [iOS crash reporting with Bugsnag](https://www.bugsnag.com/platforms/ios-crash-reporting/).
 


### PR DESCRIPTION
## Goal

We no longer use Travis, so its build status badge no longer reflects the status of our builds.
