### PR TITLE
[PLAT-5704] Fix "Update documentation page" build step on CI

### DIFF
--- a/.buildkite/pipeline.full.yml
+++ b/.buildkite/pipeline.full.yml
@@ -77,7 +77,7 @@ steps:
           limit: 2
 
   - label: 'Update documentation page'
-    if: build.tag =~ /^v[2-9]\.[0-9]+\.[0-9]+\$/ && build.branch == "master"
+    if: build.branch == "master"
     agents:
       queue: opensource-mac-cocoa
     concurrency: 3

--- a/Makefile
+++ b/Makefile
@@ -181,17 +181,14 @@ doc: ## Generate html documentation
 	@mv docs/masterTOC.html docs/index.html
 
 update-docs: ## Update and upload docs to Github
-ifeq ($(BUILDKITE),)
+ifneq ($(BUILDKITE_BRANCH), master)
 	@$(error Docs deployment is handled by CI, and shouldn't be run locally)
-endif
-ifeq ($(BUILDKITE_TAG),)
-	@$(error Docs deployments should only occur on a tagged release)
 endif
 	@git clone --single-branch --branch=gh-pages git@github.com:bugsnag/bugsnag-cocoa.git docs
 	@make doc
 	@cd docs
 	@git add .
-	@git commit -m "Docs update for $BUILDKITE_TAG release"
+	@git commit -m "Docs update for $(PRESET_VERSION) release"
 	@git push --force-with-lease
 
 help: ## Show help text


### PR DESCRIPTION
## Goal

The "Update documentation page" build step is currently not being run on BuildKite, because when the build triggers there is no Git tag associated with the branch (merges onto `master` happen via GitHub PRs, tags get created by the developer running `make release` some time afterwards.)

## Changeset

Removes the `build.tag` condition.

## Testing

Not tested. Will need to validate this during the next release.