### PR TITLE
[PLAT-5702] Capture NSError userInfo

### DIFF
--- a/Bugsnag.xcodeproj/project.pbxproj
+++ b/Bugsnag.xcodeproj/project.pbxproj
@@ -46,9 +46,9 @@
 		008967122486D43700DC48C2 /* BugsnagEventTests.m in Sources */ = {isa = PBXBuildFile; fileRef = 008966B32486D43500DC48C2 /* BugsnagEventTests.m */; };
 		008967132486D43700DC48C2 /* BugsnagEventTests.m in Sources */ = {isa = PBXBuildFile; fileRef = 008966B32486D43500DC48C2 /* BugsnagEventTests.m */; };
 		008967142486D43700DC48C2 /* BugsnagEventTests.m in Sources */ = {isa = PBXBuildFile; fileRef = 008966B32486D43500DC48C2 /* BugsnagEventTests.m */; };
-		008967152486D43700DC48C2 /* BugsnagCollectionsBSGDictMergeTest.m in Sources */ = {isa = PBXBuildFile; fileRef = 008966B42486D43500DC48C2 /* BugsnagCollectionsBSGDictMergeTest.m */; };
-		008967162486D43700DC48C2 /* BugsnagCollectionsBSGDictMergeTest.m in Sources */ = {isa = PBXBuildFile; fileRef = 008966B42486D43500DC48C2 /* BugsnagCollectionsBSGDictMergeTest.m */; };
-		008967172486D43700DC48C2 /* BugsnagCollectionsBSGDictMergeTest.m in Sources */ = {isa = PBXBuildFile; fileRef = 008966B42486D43500DC48C2 /* BugsnagCollectionsBSGDictMergeTest.m */; };
+		008967152486D43700DC48C2 /* BugsnagCollectionsTests.m in Sources */ = {isa = PBXBuildFile; fileRef = 008966B42486D43500DC48C2 /* BugsnagCollectionsTests.m */; };
+		008967162486D43700DC48C2 /* BugsnagCollectionsTests.m in Sources */ = {isa = PBXBuildFile; fileRef = 008966B42486D43500DC48C2 /* BugsnagCollectionsTests.m */; };
+		008967172486D43700DC48C2 /* BugsnagCollectionsTests.m in Sources */ = {isa = PBXBuildFile; fileRef = 008966B42486D43500DC48C2 /* BugsnagCollectionsTests.m */; };
 		008967182486D43700DC48C2 /* BugsnagErrorTest.m in Sources */ = {isa = PBXBuildFile; fileRef = 008966B52486D43500DC48C2 /* BugsnagErrorTest.m */; };
 		008967192486D43700DC48C2 /* BugsnagErrorTest.m in Sources */ = {isa = PBXBuildFile; fileRef = 008966B52486D43500DC48C2 /* BugsnagErrorTest.m */; };
 		0089671A2486D43700DC48C2 /* BugsnagErrorTest.m in Sources */ = {isa = PBXBuildFile; fileRef = 008966B52486D43500DC48C2 /* BugsnagErrorTest.m */; };
@@ -1056,7 +1056,7 @@
 		008966B02486D43500DC48C2 /* BugsnagSwiftPublicAPITests.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = BugsnagSwiftPublicAPITests.swift; sourceTree = "<group>"; };
 		008966B12486D43500DC48C2 /* BugsnagSwiftConfigurationTests.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = BugsnagSwiftConfigurationTests.swift; sourceTree = "<group>"; };
 		008966B32486D43500DC48C2 /* BugsnagEventTests.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; path = BugsnagEventTests.m; sourceTree = "<group>"; };
-		008966B42486D43500DC48C2 /* BugsnagCollectionsBSGDictMergeTest.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; path = BugsnagCollectionsBSGDictMergeTest.m; sourceTree = "<group>"; };
+		008966B42486D43500DC48C2 /* BugsnagCollectionsTests.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; path = BugsnagCollectionsTests.m; sourceTree = "<group>"; };
 		008966B52486D43500DC48C2 /* BugsnagErrorTest.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; path = BugsnagErrorTest.m; sourceTree = "<group>"; };
 		008966B62486D43500DC48C2 /* BugsnagSessionTest.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; path = BugsnagSessionTest.m; sourceTree = "<group>"; };
 		008966B72486D43500DC48C2 /* report.json */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = text.json; path = report.json; sourceTree = "<group>"; };
@@ -1669,7 +1669,7 @@
 				008966CA2486D43600DC48C2 /* BugsnagClientMirrorTest.m */,
 				008966A52486D43400DC48C2 /* BugsnagClientPayloadInfoTest.m */,
 				008966BE2486D43500DC48C2 /* BugsnagClientTests.m */,
-				008966B42486D43500DC48C2 /* BugsnagCollectionsBSGDictMergeTest.m */,
+				008966B42486D43500DC48C2 /* BugsnagCollectionsTests.m */,
 				00896A432486DBF000DC48C2 /* BugsnagConfigurationTests.m */,
 				008966A42486D43400DC48C2 /* BugsnagDeviceTest.m */,
 				008966CB2486D43600DC48C2 /* BugsnagEnabledBreadcrumbTest.m */,
@@ -2619,7 +2619,7 @@
 				008967332486D43700DC48C2 /* BugsnagClientTests.m in Sources */,
 				004E353F2487B3BD007FBAE4 /* BugsnagSwiftConfigurationTests.swift in Sources */,
 				008967542486D43700DC48C2 /* BugsnagOnCrashTest.m in Sources */,
-				008967152486D43700DC48C2 /* BugsnagCollectionsBSGDictMergeTest.m in Sources */,
+				008967152486D43700DC48C2 /* BugsnagCollectionsTests.m in Sources */,
 				01E8765E256684E700F4B70A /* URLSessionMock.m in Sources */,
 				008967AB2486D43700DC48C2 /* KSMach_Tests.m in Sources */,
 				0089672A2486D43700DC48C2 /* BugsnagStacktraceTest.m in Sources */,
@@ -2754,7 +2754,7 @@
 				004E353D2487B3B8007FBAE4 /* BugsnagSwiftTests.swift in Sources */,
 				008967192486D43700DC48C2 /* BugsnagErrorTest.m in Sources */,
 				016875C7258D003200DFFF69 /* NSUserDefaultsStub.m in Sources */,
-				008967162486D43700DC48C2 /* BugsnagCollectionsBSGDictMergeTest.m in Sources */,
+				008967162486D43700DC48C2 /* BugsnagCollectionsTests.m in Sources */,
 				008967582486D43700DC48C2 /* BugsnagClientMirrorTest.m in Sources */,
 				0089676A2486D43700DC48C2 /* BugsnagSessionTrackerTest.m in Sources */,
 				008967792486D43700DC48C2 /* KSMachHeader_Tests.m in Sources */,
@@ -2913,7 +2913,7 @@
 				008967472486D43700DC48C2 /* BugsnagTests.m in Sources */,
 				008967A72486D43700DC48C2 /* KSString_Tests.m in Sources */,
 				0089671A2486D43700DC48C2 /* BugsnagErrorTest.m in Sources */,
-				008967172486D43700DC48C2 /* BugsnagCollectionsBSGDictMergeTest.m in Sources */,
+				008967172486D43700DC48C2 /* BugsnagCollectionsTests.m in Sources */,
 				008967532486D43700DC48C2 /* BSGOutOfMemoryTests.m in Sources */,
 				008967592486D43700DC48C2 /* BugsnagClientMirrorTest.m in Sources */,
 				0089676B2486D43700DC48C2 /* BugsnagSessionTrackerTest.m in Sources */,

--- a/Bugsnag/Client/BugsnagClient.m
+++ b/Bugsnag/Client/BugsnagClient.m
@@ -741,12 +741,14 @@ NSString *_lastOrientation = nil;
                     block:(BugsnagOnErrorBlock)block
                     event:(BugsnagEvent *)event {
     event.originalError = error;
-    [event addMetadata:@{
-                            @"code" : @(error.code),
-                            @"domain" : error.domain,
-                            BSGKeyReason : error.localizedFailureReason ?: @""
-                        }
-             toSection:@"nserror"];
+
+    NSMutableDictionary *metadata = [NSMutableDictionary dictionary];
+    metadata[@"code"] = @(error.code);
+    metadata[@"domain"] = error.domain;
+    metadata[BSGKeyReason] = error.localizedFailureReason;
+    metadata[@"userInfo"] = BSGJSONDictionary(error.userInfo);
+    [event addMetadata:metadata toSection:@"nserror"];
+
     if (event.context == nil) { // set context as error domain
          event.context = [NSString stringWithFormat:@"%@ (%ld)", error.domain, (long)error.code];
     }
@@ -754,7 +756,7 @@ NSString *_lastOrientation = nil;
     if (block) {
         return block(event);
     }
-    return true;
+    return YES;
 }
 
 - (void)notify:(NSException *_Nonnull)exception {

--- a/Bugsnag/Helpers/BugsnagCollections.h
+++ b/Bugsnag/Helpers/BugsnagCollections.h
@@ -28,3 +28,8 @@
  *  @param destination a dictionary or nil
  */
 NSDictionary *BSGDictMerge(NSDictionary *source, NSDictionary *destination);
+
+/// Returns a representation of the dictionary that contains only valid JSON.
+/// Any dictionary keys that are not strings will be ignored.
+/// Any values that are not valid JSON will be replaced by a string description.
+NSDictionary * BSGJSONDictionary(NSDictionary *dictionary);

--- a/Bugsnag/Helpers/BugsnagCollections.m
+++ b/Bugsnag/Helpers/BugsnagCollections.m
@@ -21,6 +21,8 @@
 
 #import "BugsnagCollections.h"
 
+#import "BSGJSONSerialization.h"
+
 NSDictionary *BSGDictMerge(NSDictionary *source, NSDictionary *destination) {
     if ([destination count] == 0) {
         return source;
@@ -40,4 +42,28 @@ NSDictionary *BSGDictMerge(NSDictionary *source, NSDictionary *destination) {
         dict[key] = srcEntry;
     }
     return dict;
+}
+
+NSDictionary * BSGJSONDictionary(NSDictionary *dictionary) {
+    if (!dictionary) {
+        return nil;
+    }
+    if ([BSGJSONSerialization isValidJSONObject:dictionary]) {
+        return dictionary;
+    }
+    NSMutableDictionary *json = [NSMutableDictionary dictionary];
+    for (id key in dictionary) {
+        if (![key isKindOfClass:[NSString class]]) {
+            continue;
+        }
+        const id value = dictionary[key];
+        if ([BSGJSONSerialization isValidJSONObject:@{key: value}]) {
+            json[key] = value;
+        } else if ([value isKindOfClass:[NSDictionary class]]) {
+            json[key] = BSGJSONDictionary(value);
+        } else {
+            json[key] = ((NSObject *)value).description;
+        }
+    }
+    return json;
 }

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,12 +1,20 @@
 Changelog
 =========
 
+## TBD
+
+### Enhancements
+
+* The NSError's `userInfo` property is now included in reports.
+  [#974](https://github.com/bugsnag/bugsnag-cocoa/pull/974)
+
 ## 6.5.1 (2021-01-13)
 
 ### Bug fixes
 
 * Fix a regression where OOM events were missing session information.
   [#963](https://github.com/bugsnag/bugsnag-cocoa/pull/963)
+
 * Make `maxPersistedEvents` and `maxPersistedSessions` comply with the specification, with defaults of 32 and 128 respectively.
   [#966](https://github.com/bugsnag/bugsnag-cocoa/pull/966)
 

--- a/Tests/BugsnagCollectionsTests.m
+++ b/Tests/BugsnagCollectionsTests.m
@@ -1,5 +1,5 @@
 //
-//  BugsnagCollectionsBSGDictMergeTest.m
+//  BugsnagCollectionsTests.m
 //  Tests
 //
 //  Created by Paul Zabelin on 7/1/19.
@@ -9,10 +9,15 @@
 @import XCTest;
 #import "BugsnagCollections.h"
 
-@interface BugsnagCollectionsBSGDictMergeTest : XCTestCase
+@interface BugsnagCollectionsTests : XCTestCase
 @end
 
-@implementation BugsnagCollectionsBSGDictMergeTest
+@interface BugsnagCollectionsTests_DummyObject : NSObject
+@end
+
+@implementation BugsnagCollectionsTests
+
+// MARK: BSGDictMergeTest
 
 - (void)testBasicMerge {
     NSDictionary *combined = @{@"a": @"one",
@@ -56,6 +61,45 @@
     NSDictionary* expected = @{@"a": @{@"x": @"blah",
                                        @"y": @"something"}};
     XCTAssertEqualObjects(expected, BSGDictMerge(src, dst), @"should combine");
+}
+
+// MARK: BSGJSONDictionary
+
+- (void)testBSGJSONDictionary {
+    XCTAssertNil(BSGJSONDictionary(nil));
+    
+    id validDictionary = @{
+        @"name": @"foobar",
+        @"count": @1,
+        @"userInfo": @{@"extra": @"hello"}
+    };
+    XCTAssertEqualObjects(BSGJSONDictionary(validDictionary), validDictionary);
+    
+    id invalidDictionary = @{
+        @123: @"invalid key; should be ignored",
+        @[]: @"this is backwards",
+        @{}: @""
+    };
+    XCTAssertEqualObjects(BSGJSONDictionary(invalidDictionary), @{});
+    
+    id mixedDictionary = @{
+        @"count": @42,
+        @"dict": @{@"object": [[BugsnagCollectionsTests_DummyObject alloc] init]},
+        @123: @"invalid key; should be ignored"
+    };
+    XCTAssertEqualObjects(BSGJSONDictionary(mixedDictionary),
+                          (@{@"count": @42,
+                             @"dict": @{@"object": @"Dummy object"}}));
+}
+
+@end
+
+// MARK: -
+
+@implementation BugsnagCollectionsTests_DummyObject
+
+- (NSString *)description {
+    return @"Dummy object";
 }
 
 @end

--- a/features/barebone_tests.feature
+++ b/features/barebone_tests.feature
@@ -70,6 +70,9 @@ Feature: Barebone tests
     And the event "metaData.nserror.code" equals 4864
     And the event "metaData.nserror.domain" equals "NSCocoaErrorDomain"
     And the event "metaData.nserror.reason" equals "The data isn’t in the correct format."
+    And the event "metaData.nserror.userInfo.NSCodingPath" is not null
+    And the event "metaData.nserror.userInfo.NSDebugDescription" equals "The given data was not valid JSON."
+    And the event "metaData.nserror.userInfo.NSUnderlyingError" matches "Error Domain=NSCocoaErrorDomain Code=3840"
     And the event "severity" equals "warning"
     And the event "severityReason.type" equals "handledError"
     And the event "severityReason.unhandledOverridden" is null


### PR DESCRIPTION
## Goal

Include the NSError's userInfo in error reports.

## Design

The `nserror` metaData now includes a `userInfo` value which contains a sanitised version of the NSError's userInfo property.

Since it is a dictionary, it is fully searchable in the dashboard.

## Changeset

`-[BugsnagClient appendNSErrorInfo:block:event:]` now includes `userInfo` in the `nserror` metadata.

Added `BSGJSONDictionary()` function to create a JSON sanitised JSON version of userInfo.

## Testing

Manually tested using example app.

Added new unit test for `BSGJSONDictionary()`

Updated barebones test to verify presence of `nserror.userInfo`