### PR TITLE
[PLAT-5720] Expose private interfaces for BugsnagReactNative

### DIFF
--- a/Bugsnag/Bugsnag+Private.h
+++ b/Bugsnag/Bugsnag+Private.h
@@ -23,9 +23,15 @@ NS_ASSUME_NONNULL_BEGIN
 
 #pragma mark Methods
 
++ (void)addRuntimeVersionInfo:(NSString *)info withKey:(NSString *)key; // Used in BugsnagReactNative
+
++ (void)notifyInternal:(BugsnagEvent *)event block:(BOOL (^)(BugsnagEvent *))block; // Used in BugsnagReactNative
+
 + (void)purge;
 
 + (void)removeOnBreadcrumbBlock:(BugsnagOnBreadcrumbBlock)block;
+
++ (void)updateCodeBundleId:(NSString *)codeBundleId; // Used in BugsnagReactNative
 
 @end
 

--- a/Bugsnag/Client/BugsnagClient+Private.h
+++ b/Bugsnag/Client/BugsnagClient+Private.h
@@ -8,6 +8,8 @@
 
 #import <Bugsnag/BugsnagClient.h>
 
+#import "BugsnagMetadata+Private.h" // For BugsnagObserverBlock
+
 @class BugsnagBreadcrumbs;
 @class BugsnagConfiguration;
 @class BugsnagCrashSentry;
@@ -76,6 +78,8 @@ NS_ASSUME_NONNULL_BEGIN
 
 - (void)addBreadcrumbWithBlock:(void (^)(BugsnagBreadcrumb *))block;
 
+- (void)addObserverWithBlock:(BugsnagObserverBlock)block; // Used in BugsnagReactNative
+
 - (void)addRuntimeVersionInfo:(NSString *)info withKey:(NSString *)key;
 
 - (NSDictionary *)collectAppWithState; // Used in BugsnagReactNative
@@ -87,6 +91,8 @@ NS_ASSUME_NONNULL_BEGIN
 - (NSArray *)collectThreads:(BOOL)unhandled; // Used in BugsnagReactNative
 
 - (void)notifyInternal:(BugsnagEvent *)event block:(BugsnagOnErrorBlock)block;
+
+- (void)removeObserverWithBlock:(BugsnagObserverBlock)block; // Used in BugsnagReactNative
 
 - (BOOL)shouldReportOOM;
 

--- a/Bugsnag/Payload/BugsnagEvent+Private.h
+++ b/Bugsnag/Payload/BugsnagEvent+Private.h
@@ -61,6 +61,8 @@ NS_ASSUME_NONNULL_BEGIN
 
 - (instancetype)initWithUserData:(NSDictionary *)event;
 
+- (void)attachCustomStacktrace:(NSArray *)frames withType:(NSString *)type; // Used in BugsnagReactNative
+
 /// Whether this report should be sent, based on release stage information cached at crash time and within the application currently.
 - (BOOL)shouldBeSent;
 


### PR DESCRIPTION
## Goal

Allows BugsnagReactNative to remove its remaining private `@interface Bugsnag* ()` declarations and rely on the +Private.h header files instead.

## Testing

Tested manually using BugsnagReactNative's Xcode project.