### PR TITLE
[PLAT-5695] Remove lowMemory key, assert lowMemoryWarning key

### DIFF
--- a/Bugsnag/BugsnagSystemState.h
+++ b/Bugsnag/BugsnagSystemState.h
@@ -15,7 +15,6 @@
 #define SYSTEMSTATE_APP_WAS_TERMINATED @"wasTerminated"
 #define SYSTEMSTATE_APP_IS_ACTIVE @"isActive"
 #define SYSTEMSTATE_APP_IS_IN_FOREGROUND @"inForeground"
-#define SYSTEMSTATE_APP_LAST_LOW_MEMORY_WARNING @"lowMemory"
 #define SYSTEMSTATE_APP_VERSION @"version"
 #define SYSTEMSTATE_APP_BUNDLE_VERSION @"bundleVersion"
 #define SYSTEMSTATE_APP_DEBUGGER_IS_ACTIVE @"debuggerIsActive"

--- a/Bugsnag/BugsnagSystemState.m
+++ b/Bugsnag/BugsnagSystemState.m
@@ -53,7 +53,6 @@ static NSDictionary* loadPreviousState(BugsnagKVStore *kvstore, NSString *jsonPa
     NSMutableDictionary *app = state[SYSTEMSTATE_KEY_APP];
 
     // KV-store versions of these are authoritative
-    app[SYSTEMSTATE_APP_LAST_LOW_MEMORY_WARNING] = [kvstore stringForKey:SYSTEMSTATE_APP_LAST_LOW_MEMORY_WARNING defaultValue:@""];
     app[SYSTEMSTATE_APP_WAS_TERMINATED] = [kvstore NSBooleanForKey:SYSTEMSTATE_APP_WAS_TERMINATED defaultValue:false];
     app[SYSTEMSTATE_APP_IS_ACTIVE] = [kvstore NSBooleanForKey:SYSTEMSTATE_APP_IS_ACTIVE defaultValue:false];
     app[SYSTEMSTATE_APP_IS_IN_FOREGROUND] = [kvstore NSBooleanForKey:SYSTEMSTATE_APP_IS_IN_FOREGROUND defaultValue:false];
@@ -84,7 +83,6 @@ static NSMutableDictionary* initCurrentState(BugsnagKVStore *kvstore, BugsnagCon
     isActive = appState == UIApplicationStateActive;
 #endif
     
-    [kvstore deleteKey:SYSTEMSTATE_APP_LAST_LOW_MEMORY_WARNING];
     [kvstore deleteKey:SYSTEMSTATE_APP_WAS_TERMINATED];
     [kvstore setBoolean:isActive forKey:SYSTEMSTATE_APP_IS_ACTIVE];
     [kvstore setBoolean:isInForeground forKey:SYSTEMSTATE_APP_IS_IN_FOREGROUND];
@@ -110,7 +108,6 @@ static NSMutableDictionary* initCurrentState(BugsnagKVStore *kvstore, BugsnagCon
     NSMutableDictionary *device = [NSMutableDictionary new];
     device[SYSTEMSTATE_DEVICE_BOOT_TIME] = [BSG_RFC3339DateTool stringFromDate:systemInfo[@BSG_KSSystemField_BootTime]];
     device[@"id"] = systemInfo[@BSG_KSSystemField_DeviceAppHash];
-    // device[@"lowMemory"] is initially unset
     device[@"osBuild"] = systemInfo[@BSG_KSSystemField_OSVersion];
     device[@"osVersion"] = systemInfo[@BSG_KSSystemField_SystemVersion];
     device[@"osName"] = systemInfo[@BSG_KSSystemField_SystemName];
@@ -209,12 +206,6 @@ static NSDictionary *copyDictionary(NSDictionary *launchState) {
             __strong __typeof__(self) strongSelf = weakSelf;
             [strongSelf.kvStore setBoolean:NO forKey:SYSTEMSTATE_APP_IS_ACTIVE];
             [strongSelf setValue:@NO forAppKey:SYSTEMSTATE_APP_IS_ACTIVE];
-        }];
-        [center addObserverForName:UIApplicationDidReceiveMemoryWarningNotification object:nil queue:nil usingBlock:^(NSNotification * _Nonnull note) {
-            __strong __typeof__(self) strongSelf = weakSelf;
-            NSString *date = [BSG_RFC3339DateTool stringFromDate:[NSDate date]];
-            [strongSelf.kvStore setString:date forKey:SYSTEMSTATE_APP_LAST_LOW_MEMORY_WARNING];
-            [strongSelf setValue:date forAppKey:SYSTEMSTATE_APP_LAST_LOW_MEMORY_WARNING];
         }];
 #endif
         [center addObserver:self selector:@selector(sessionUpdateNotification:) name:BSGSessionUpdateNotification object:nil];

--- a/features/barebone_tests.feature
+++ b/features/barebone_tests.feature
@@ -128,19 +128,17 @@ Feature: Barebone tests
     And the payload field "events.0.device.totalMemory" is an integer
 
   Scenario: Barebone test: Out Of Memory
-    When I run "OOMLoadScenario"
-    And I wait to receive 2 requests
+    When I run "OOMScenario"
 
+    And I wait to receive 1 requests
     Then the request is valid for the session reporting API version "1.0" for the "iOS Bugsnag Notifier" notifier
     And I discard the oldest request
 
-    And the event "unhandled" is false
-    And the exception "message" equals "OOMLoadScenario"
-    And the event has a "manual" breadcrumb named "OOMLoadScenarioBreadcrumb"
-    And I discard the oldest request
+    # Wait for app to be killed for using too much memory
+    And I wait for 5 seconds
 
-    When I relaunch the app
-    And I configure Bugsnag for "OOMLoadScenario"
+    And I relaunch the app
+    And I configure Bugsnag for "OOMScenario"
     And I wait to receive 2 requests
 
     Then the request is valid for the session reporting API version "1.0" for the "iOS Bugsnag Notifier" notifier
@@ -153,6 +151,8 @@ Feature: Barebone tests
     And the event "app.inForeground" is true
     And the event "app.type" equals "iOS"
     And the event "app.version" is not null
+    And the event "breadcrumbs.0.name" equals "Bugsnag loaded"
+    And the event "breadcrumbs.1.name" equals "Memory Warning"
     And the event "device.id" is not null
     And the event "device.jailbroken" is false
     And the event "device.locale" is not null
@@ -168,13 +168,14 @@ Feature: Barebone tests
     And the event "metaData.custom.bar" equals "foo"
     And the event "metaData.device.batteryLevel" is not null
     And the event "metaData.device.charging" is not null
+    And the event "metaData.device.lowMemoryWarning" is not null
     And the event "metaData.device.orientation" is not null
     And the event "metaData.device.simulator" is false
     And the event "metaData.device.timezone" is not null
     And the event "metaData.device.wordSize" is not null
     And the event "session.id" is not null
     And the event "session.startedAt" is not null
-    And the event "session.events.handled" equals 1
+    And the event "session.events.handled" equals 0
     And the event "session.events.unhandled" equals 1
     And the event "unhandled" is true
     And the event "user.email" equals "foobar@example.com"

--- a/features/fixtures/ios-swift-cocoapods/iOSTestApp.xcodeproj/project.pbxproj
+++ b/features/fixtures/ios-swift-cocoapods/iOSTestApp.xcodeproj/project.pbxproj
@@ -19,6 +19,7 @@
 		0104085F258CA0A100933C60 /* DispatchCrashScenario.swift in Sources */ = {isa = PBXBuildFile; fileRef = 0104085E258CA0A100933C60 /* DispatchCrashScenario.swift */; };
 		0163BFA72583B3CF008DC28B /* DiscardClassesScenarios.swift in Sources */ = {isa = PBXBuildFile; fileRef = 0163BFA62583B3CF008DC28B /* DiscardClassesScenarios.swift */; };
 		01AF6A53258A112F00FFC803 /* BareboneTestScenarios.swift in Sources */ = {isa = PBXBuildFile; fileRef = 01AF6A52258A112F00FFC803 /* BareboneTestScenarios.swift */; };
+		01E5EAD225B713990066EA8A /* OOMScenario.m in Sources */ = {isa = PBXBuildFile; fileRef = 01E5EAD125B713990066EA8A /* OOMScenario.m */; };
 		6526A0D4248A83350002E2C9 /* LoadConfigFromFileAutoScenario.swift in Sources */ = {isa = PBXBuildFile; fileRef = 6526A0D3248A83350002E2C9 /* LoadConfigFromFileAutoScenario.swift */; };
 		8A14F0F62282D4AE00337B05 /* (null) in Sources */ = {isa = PBXBuildFile; };
 		8A32DB8222424E3000EDD92F /* NSExceptionShiftScenario.m in Sources */ = {isa = PBXBuildFile; fileRef = 8A32DB8122424E3000EDD92F /* NSExceptionShiftScenario.m */; };
@@ -165,6 +166,8 @@
 		0104085E258CA0A100933C60 /* DispatchCrashScenario.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = DispatchCrashScenario.swift; sourceTree = "<group>"; };
 		0163BFA62583B3CF008DC28B /* DiscardClassesScenarios.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = DiscardClassesScenarios.swift; sourceTree = "<group>"; };
 		01AF6A52258A112F00FFC803 /* BareboneTestScenarios.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = BareboneTestScenarios.swift; sourceTree = "<group>"; };
+		01E5EAD025B713990066EA8A /* OOMScenario.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; path = OOMScenario.h; sourceTree = "<group>"; };
+		01E5EAD125B713990066EA8A /* OOMScenario.m */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.objc; path = OOMScenario.m; sourceTree = "<group>"; };
 		4994F05E0421A0B037DD2CC5 /* Pods_iOSTestApp.framework */ = {isa = PBXFileReference; explicitFileType = wrapper.framework; includeInIndex = 0; path = Pods_iOSTestApp.framework; sourceTree = BUILT_PRODUCTS_DIR; };
 		6526A0D3248A83350002E2C9 /* LoadConfigFromFileAutoScenario.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = LoadConfigFromFileAutoScenario.swift; sourceTree = "<group>"; };
 		8A32DB8022424E3000EDD92F /* NSExceptionShiftScenario.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = NSExceptionShiftScenario.h; sourceTree = "<group>"; };
@@ -557,6 +560,8 @@
 				0037410E2473CF2300BE41AA /* AppAndDeviceAttributesScenario.swift */,
 				01AF6A52258A112F00FFC803 /* BareboneTestScenarios.swift */,
 				0163BFA62583B3CF008DC28B /* DiscardClassesScenarios.swift */,
+				01E5EAD025B713990066EA8A /* OOMScenario.h */,
+				01E5EAD125B713990066EA8A /* OOMScenario.m */,
 				8AB1081823301FE600672818 /* ReleaseStageScenarios.swift */,
 				F4295ABA693D273D52AA9F6B /* Scenario.h */,
 				F42954E8B66F3FB7F5333CF7 /* Scenario.m */,
@@ -921,6 +926,7 @@
 				E7A324EF247E9DBC008B0052 /* BreadcrumbCallbackCrashScenario.swift in Sources */,
 				F4295CEAD7C915EFA04898A5 /* Scenario.m in Sources */,
 				F4295836C8AF75547C675E8D /* ReleasedObjectScenario.m in Sources */,
+				01E5EAD225B713990066EA8A /* OOMScenario.m in Sources */,
 				8A530CCC22FDDBF000F0C108 /* ManyConcurrentNotifyScenario.m in Sources */,
 				F42958881D3F34A76CADE4EC /* SwiftCrash.swift in Sources */,
 				E7A324EA247E9DA5008B0052 /* BreadcrumbCallbackOverrideScenario.swift in Sources */,

--- a/features/fixtures/shared/scenarios/OOMScenario.h
+++ b/features/fixtures/shared/scenarios/OOMScenario.h
@@ -1,0 +1,17 @@
+//
+//  OOMScenario.h
+//  iOSTestApp
+//
+//  Created by Nick Dowell on 19/01/2021.
+//  Copyright © 2021 Bugsnag. All rights reserved.
+//
+
+#import "Scenario.h"
+
+NS_ASSUME_NONNULL_BEGIN
+
+@interface OOMScenario : Scenario
+
+@end
+
+NS_ASSUME_NONNULL_END

--- a/features/fixtures/shared/scenarios/OOMScenario.m
+++ b/features/fixtures/shared/scenarios/OOMScenario.m
@@ -1,0 +1,37 @@
+//
+//  OOMScenario.m
+//  iOSTestApp
+//
+//  Created by Nick Dowell on 19/01/2021.
+//  Copyright © 2021 Bugsnag. All rights reserved.
+//
+
+#import "OOMScenario.h"
+
+@implementation OOMScenario
+
+- (void)startBugsnag {
+    self.config.autoTrackSessions = YES;
+    self.config.enabledErrorTypes.ooms = YES;
+    [self.config addMetadata:@{@"bar": @"foo"} toSection:@"custom"];
+    [self.config setUser:@"foobar" withEmail:@"foobar@example.com" andName:@"Foo Bar"];
+    [super startBugsnag];
+}
+
+- (void)run {
+    // Delay to allow session payload to be sent
+    dispatch_after(dispatch_time(DISPATCH_TIME_NOW, (int64_t)(2 * NSEC_PER_SEC)), dispatch_get_global_queue(QOS_CLASS_USER_INITIATED, 0), ^{
+        NSLog(@"*** Consuming all available memory...");
+        const int blocksize = 1024 * 1024;
+        const int pagesize = (int)NSPageSize();
+        const int npages = blocksize / pagesize;
+        while (1) {
+            volatile char *ptr = malloc(blocksize);
+            for (int i = 0; i < npages; i++) {
+                ptr[i * pagesize] = 42; // Dirty each page
+            }
+        }
+    });
+}
+
+@end


### PR DESCRIPTION
## Goal

The `"lowMemory"` value was included in OOM event payloads by the notifier prior to v6.

In v6 this was inadvertently lost during refactoring.

In v6.3.0 the general improvements to OOM metadata meant the `"lowMemoryWarning"` value is now included in OOM payloads.

This pull request removes the code that writes `"lowMemory"` as it is redundant.

## Testing

Manually tested using the example app.

Amended E2E tests to trigger a real OOM and verify the presence of the `"lowMemoryWarning"` value as well as a `"Memory Warning"` breadcrumb.