### PR TITLE
[PLAT-5731] Improve Header docs readability

### DIFF
--- a/.buildkite/pipeline.full.yml
+++ b/.buildkite/pipeline.full.yml
@@ -75,12 +75,3 @@ steps:
       automatic:
         - exit_status: -1  # Agent was lost
           limit: 2
-
-  - label: 'Update documentation page'
-    if: build.branch == "master"
-    agents:
-      queue: opensource-mac-cocoa
-    concurrency: 3
-    concurrency_group: cocoa-unit-tests
-    command:
-      - make update-docs

--- a/.github/workflows/update_docs.yml
+++ b/.github/workflows/update_docs.yml
@@ -1,8 +1,7 @@
 name: "Update Docs"
 on:
-  push:
-    branches:
-      - master
+  release:
+    types: [published]
 
 jobs:
   build:

--- a/.github/workflows/update_docs.yml
+++ b/.github/workflows/update_docs.yml
@@ -1,0 +1,45 @@
+name: "Update Docs"
+on:
+  push:
+    branches:
+      - master
+
+jobs:
+  build:
+    runs-on: macos-latest
+    steps:
+      - name: Checkout bugsnag-cocoa
+        uses: actions/checkout@v2
+
+      - name: Checkout docs branch
+        uses: actions/checkout@v2
+        with:
+          ref: gh-pages
+          path: docs
+
+      - name: Configure docs branch
+        working-directory: docs
+        run: |
+          git config user.name "Bugsnag Bot"
+          git config user.email notifiers@bugsnag.com
+
+      - uses: actions/cache@v2
+        with:
+          path: vendor/bundle
+          key: ${{ runner.os }}-gems-${{ hashFiles('**/Gemfile.lock') }}
+          restore-keys: |
+            ${{ runner.os }}-gems-
+
+      - name: Bundle install
+        run: |
+          bundle config path vendor/bundle
+          bundle install --jobs 4 --retry 3
+
+      - name: Update docs
+        run: make docs
+
+      - name: Push changes
+        working-directory: docs
+        run: |
+          git status
+          git push

--- a/.gitignore
+++ b/.gitignore
@@ -25,4 +25,5 @@ Podfile.lock
 .build
 .swiftpm
 Package.resolved
+/docs/
 /infer-out

--- a/.jazzy.yaml
+++ b/.jazzy.yaml
@@ -1,6 +1,6 @@
 author_url: "https://www.bugsnag.com"
 author: "Bugsnag Inc"
-clean: true
+clean: false # avoid deleting docs/.git
 framework_root: "Bugsnag"
 github_file_prefix: "https://github.com/bugsnag/bugsnag-cocoa/tree/v6.6.0"
 github_url: "https://github.com/bugsnag/bugsnag-cocoa"

--- a/.jazzy.yaml
+++ b/.jazzy.yaml
@@ -1,0 +1,16 @@
+author_url: "https://www.bugsnag.com"
+author: "Bugsnag Inc"
+clean: true
+framework_root: "Bugsnag"
+github_file_prefix: "https://github.com/bugsnag/bugsnag-cocoa/tree/v6.6.0"
+github_url: "https://github.com/bugsnag/bugsnag-cocoa"
+hide_documentation_coverage: true
+module: "Bugsnag"
+module_version: "6.6.0"
+objc: true
+output: "docs"
+readme: "README.md"
+root_url: "https://bugsnag.github.io/bugsnag-cocoa"
+source_directory: "Bugsnag"
+theme: "apple"
+umbrella_header: "Bugsnag/include/Bugsnag/Bugsnag.h"

--- a/Bugsnag/include/Bugsnag/BSG_KSCrashReportWriter.h
+++ b/Bugsnag/include/Bugsnag/BSG_KSCrashReportWriter.h
@@ -42,7 +42,8 @@ extern "C" {
  * Encapsulates report writing functionality.
  */
 typedef struct BSG_KSCrashReportWriter {
-    /** Add a boolean element to the report.
+    /**
+     * Add a boolean element to the report.
      *
      * @param writer This writer.
      *
@@ -53,7 +54,8 @@ typedef struct BSG_KSCrashReportWriter {
     void (*addBooleanElement)(const struct BSG_KSCrashReportWriter *writer,
                               const char *name, bool value);
 
-    /** Add a floating point element to the report.
+    /**
+     * Add a floating point element to the report.
      *
      * @param writer This writer.
      *
@@ -65,7 +67,8 @@ typedef struct BSG_KSCrashReportWriter {
         const struct BSG_KSCrashReportWriter *writer, const char *name,
         double value);
 
-    /** Add an integer element to the report.
+    /**
+     * Add an integer element to the report.
      *
      * @param writer This writer.
      *
@@ -76,7 +79,8 @@ typedef struct BSG_KSCrashReportWriter {
     void (*addIntegerElement)(const struct BSG_KSCrashReportWriter *writer,
                               const char *name, long long value);
 
-    /** Add an unsigned integer element to the report.
+    /**
+     * Add an unsigned integer element to the report.
      *
      * @param writer This writer.
      *
@@ -87,7 +91,8 @@ typedef struct BSG_KSCrashReportWriter {
     void (*addUIntegerElement)(const struct BSG_KSCrashReportWriter *writer,
                                const char *name, unsigned long long value);
 
-    /** Add a string element to the report.
+    /**
+     * Add a string element to the report.
      *
      * @param writer This writer.
      *
@@ -98,7 +103,8 @@ typedef struct BSG_KSCrashReportWriter {
     void (*addStringElement)(const struct BSG_KSCrashReportWriter *writer,
                              const char *name, const char *value);
 
-    /** Add a string element from a text file to the report.
+    /**
+     * Add a string element from a text file to the report.
      *
      * @param writer This writer.
      *
@@ -109,7 +115,8 @@ typedef struct BSG_KSCrashReportWriter {
     void (*addTextFileElement)(const struct BSG_KSCrashReportWriter *writer,
                                const char *name, const char *filePath);
 
-    /** Add a JSON element from a text file to the report.
+    /**
+     * Add a JSON element from a text file to the report.
      *
      * @param writer This writer.
      *
@@ -120,7 +127,8 @@ typedef struct BSG_KSCrashReportWriter {
     void (*addJSONFileElement)(const struct BSG_KSCrashReportWriter *writer,
                                const char *name, const char *filePath);
 
-    /** Add a hex encoded data element to the report.
+    /**
+     * Add a hex encoded data element to the report.
      *
      * @param writer This writer.
      *
@@ -134,7 +142,8 @@ typedef struct BSG_KSCrashReportWriter {
                            const char *name, const char *value,
                            const size_t length);
 
-    /** Begin writing a hex encoded data element to the report.
+    /**
+     * Begin writing a hex encoded data element to the report.
      *
      * @param writer This writer.
      *
@@ -143,7 +152,8 @@ typedef struct BSG_KSCrashReportWriter {
     void (*beginDataElement)(const struct BSG_KSCrashReportWriter *writer,
                              const char *name);
 
-    /** Append hex encoded data to the current data element in the report.
+    /**
+     * Append hex encoded data to the current data element in the report.
      *
      * @param writer This writer.
      *
@@ -154,13 +164,15 @@ typedef struct BSG_KSCrashReportWriter {
     void (*appendDataElement)(const struct BSG_KSCrashReportWriter *writer,
                               const char *value, const size_t length);
 
-    /** Complete writing a hex encoded data element to the report.
+    /**
+     * Complete writing a hex encoded data element to the report.
      *
      * @param writer This writer.
      */
     void (*endDataElement)(const struct BSG_KSCrashReportWriter *writer);
 
-    /** Add a UUID element to the report.
+    /**
+     * Add a UUID element to the report.
      *
      * @param writer This writer.
      *
@@ -171,7 +183,8 @@ typedef struct BSG_KSCrashReportWriter {
     void (*addUUIDElement)(const struct BSG_KSCrashReportWriter *writer,
                            const char *name, const unsigned char *value);
 
-    /** Add a preformatted JSON element to the report.
+    /**
+     * Add a preformatted JSON element to the report.
      *
      * @param writer This writer.
      *
@@ -182,7 +195,8 @@ typedef struct BSG_KSCrashReportWriter {
     void (*addJSONElement)(const struct BSG_KSCrashReportWriter *writer,
                            const char *name, const char *jsonElement);
 
-    /** Begin a new object container.
+    /**
+     * Begin a new object container.
      *
      * @param writer This writer.
      *
@@ -191,7 +205,8 @@ typedef struct BSG_KSCrashReportWriter {
     void (*beginObject)(const struct BSG_KSCrashReportWriter *writer,
                         const char *name);
 
-    /** Begin a new array container.
+    /**
+     * Begin a new array container.
      *
      * @param writer This writer.
      *
@@ -200,7 +215,8 @@ typedef struct BSG_KSCrashReportWriter {
     void (*beginArray)(const struct BSG_KSCrashReportWriter *writer,
                        const char *name);
 
-    /** Leave the current container, returning to the next higher level
+    /**
+     * Leave the current container, returning to the next higher level
      *  container.
      *
      * @param writer This writer.

--- a/Bugsnag/include/Bugsnag/Bugsnag.h
+++ b/Bugsnag/include/Bugsnag/Bugsnag.h
@@ -41,6 +41,9 @@
 #import <Bugsnag/BugsnagStackframe.h>
 #import <Bugsnag/BugsnagThread.h>
 
+/**
+ * Static access to a Bugsnag Client, the easiest way to use Bugsnag in your app.
+ */
 @interface Bugsnag : NSObject <BugsnagClassLevelMetadataStore>
 
 /**
@@ -48,7 +51,8 @@
  */
 - (instancetype _Nonnull )init NS_UNAVAILABLE NS_SWIFT_UNAVAILABLE("Use class methods to initialise Bugsnag.");
 
-/** Start listening for crashes.
+/**
+ * Start listening for crashes.
  *
  * This method initializes Bugsnag with the configuration set in your Info.plist.
  *
@@ -61,7 +65,8 @@
  */
 + (BugsnagClient *_Nonnull)start;
 
-/** Start listening for crashes.
+/**
+ * Start listening for crashes.
  *
  * This method initializes Bugsnag with the default configuration and the provided
  * apiKey.
@@ -77,7 +82,8 @@
  */
 + (BugsnagClient *_Nonnull)startWithApiKey:(NSString *_Nonnull)apiKey;
 
-/** Start listening for crashes.
+/**
+ * Start listening for crashes.
  *
  * This method initializes Bugsnag with the provided configuration object.
  *
@@ -101,7 +107,8 @@
 // MARK: - Notify
 // =============================================================================
 
-/** Send a custom or caught exception to Bugsnag.
+/**
+ * Send a custom or caught exception to Bugsnag.
  *
  * The exception will be sent to Bugsnag in the background allowing your
  * app to continue running.

--- a/Bugsnag/include/Bugsnag/BugsnagBreadcrumb.h
+++ b/Bugsnag/include/Bugsnag/BugsnagBreadcrumb.h
@@ -33,6 +33,9 @@
 #endif
 #endif
 
+/**
+ * Types of breadcrumbs
+ */
 typedef NS_ENUM(NSUInteger, BSGBreadcrumbType) {
     /**
      *  Any breadcrumb sent via Bugsnag.leaveBreadcrumb()
@@ -89,14 +92,33 @@ typedef NS_OPTIONS(NSUInteger, BSGEnabledBreadcrumbType) {
                                 | BSGEnabledBreadcrumbTypeError,
 };
 
+/**
+ * A short log message, representing an action that occurred in your app, to aid with debugging.
+ */
 @class BugsnagBreadcrumb;
 
 @interface BugsnagBreadcrumb : NSObject
 
+/**
+ * The date when the breadcrumb was left
+ */
 @property(readonly, nullable) NSDate *timestamp;
+
+/**
+ * The type of breadcrumb
+ */
 @property(readwrite) BSGBreadcrumbType type;
+
+/**
+ * The description of the breadcrumb
+ */
 @property(readwrite, copy, nonnull) NSString *message;
+
+/**
+ * Diagnostic data relating to the breadcrumb.
+ * 
+ * The dictionary should be a valid JSON object.
+ */
 @property(readwrite, copy, nonnull) NSDictionary *metadata;
+
 @end
-
-

--- a/Bugsnag/include/Bugsnag/BugsnagClient.h
+++ b/Bugsnag/include/Bugsnag/BugsnagClient.h
@@ -32,8 +32,16 @@
 
 @class BugsnagSessionTracker;
 
+/**
+ * The BugsnagClient is not intended to be used directly.
+ * 
+ * Use the static access provided by the Bugsnag class instead.
+ */
 @interface BugsnagClient : NSObject<BugsnagMetadataStore>
 
+/**
+ * Initializes the client with the provided configuration.
+ */
 - (instancetype _Nonnull)initWithConfiguration:(BugsnagConfiguration *_Nonnull)configuration;
 
 // =============================================================================

--- a/Bugsnag/include/Bugsnag/BugsnagConfiguration.h
+++ b/Bugsnag/include/Bugsnag/BugsnagConfiguration.h
@@ -98,6 +98,9 @@ typedef BOOL (^BugsnagOnSessionBlock)(BugsnagSession *_Nonnull session);
 // MARK: - BugsnagConfiguration
 // =============================================================================
 
+/**
+ * Contains user-provided configuration, including API key and endpoints.
+ */
 @interface BugsnagConfiguration : NSObject <BugsnagMetadataStore>
 
 /**

--- a/Bugsnag/include/Bugsnag/BugsnagError.h
+++ b/Bugsnag/include/Bugsnag/BugsnagError.h
@@ -10,6 +10,9 @@
 
 @class BugsnagStackframe;
 
+/**
+ * Denote which platform or runtime the Error occurred in.
+ */
 typedef NS_OPTIONS(NSUInteger, BSGErrorType) {
     BSGErrorTypeCocoa NS_SWIFT_NAME(cocoa), // Swift won't bring in the zeroeth option by default
     BSGErrorTypeC NS_SWIFT_NAME(c), // Fix Swift auto-capitalisation

--- a/Bugsnag/include/Bugsnag/BugsnagErrorTypes.h
+++ b/Bugsnag/include/Bugsnag/BugsnagErrorTypes.h
@@ -8,6 +8,9 @@
 
 #import <Foundation/Foundation.h>
 
+/**
+ * The types of error that should be reported.
+ */
 @interface BugsnagErrorTypes : NSObject
 
 /**
@@ -53,4 +56,3 @@
 @property BOOL unhandledRejections;
 
 @end
-

--- a/Bugsnag/include/Bugsnag/BugsnagEvent.h
+++ b/Bugsnag/include/Bugsnag/BugsnagEvent.h
@@ -21,12 +21,18 @@
 @class BugsnagError;
 @class BugsnagUser;
 
+/**
+ * Represents the importance of a particular event.
+ */
 typedef NS_ENUM(NSUInteger, BSGSeverity) {
     BSGSeverityError,
     BSGSeverityWarning,
     BSGSeverityInfo,
 };
 
+/**
+ * Represents an occurrence of an error, along with information about the state of the app and device.
+ */
 @interface BugsnagEvent : NSObject <BugsnagMetadataStore>
 
 // -----------------------------------------------------------------------------

--- a/Bugsnag/include/Bugsnag/BugsnagMetadata.h
+++ b/Bugsnag/include/Bugsnag/BugsnagMetadata.h
@@ -28,6 +28,7 @@
 
 #import <Bugsnag/BugsnagMetadataStore.h>
 
+/// :nodoc:
 @interface BugsnagMetadata : NSObject <BugsnagMetadataStore>
 - (instancetype _Nonnull)initWithDictionary:(NSDictionary *_Nonnull)dict;
 @end

--- a/Bugsnag/include/Bugsnag/BugsnagPlugin.h
+++ b/Bugsnag/include/Bugsnag/BugsnagPlugin.h
@@ -7,7 +7,7 @@
 @class BugsnagClient;
 
 /**
- * Internal interface for adding custom behavior
+ * Internal interface for adding custom behavior :nodoc:
  */
 @protocol BugsnagPlugin <NSObject>
 

--- a/Bugsnag/include/Bugsnag/BugsnagSession.h
+++ b/Bugsnag/include/Bugsnag/BugsnagSession.h
@@ -12,6 +12,9 @@
 #import <Bugsnag/BugsnagDevice.h>
 #import <Bugsnag/BugsnagUser.h>
 
+/**
+ * Represents a session of user interaction with your app.
+ */
 @interface BugsnagSession : NSObject
 
 @property NSString *_Nonnull id;

--- a/Bugsnag/include/Bugsnag/BugsnagUser.h
+++ b/Bugsnag/include/Bugsnag/BugsnagUser.h
@@ -8,6 +8,9 @@
 
 #import <Foundation/Foundation.h>
 
+/**
+ * Information about the current user of your application.
+ */
 @interface BugsnagUser : NSObject
 
 @property(readonly) NSString *id;

--- a/Gemfile
+++ b/Gemfile
@@ -2,6 +2,7 @@ source 'https://rubygems.org'
 
 gem 'cocoapods'
 gem 'danger'
+gem 'jazzy'
 gem 'xcpretty'
 
 # A reference to Maze Runner is only needed for running tests locally and if committed it must be

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -144,17 +144,28 @@ GEM
     httpclient (2.8.3)
     i18n (1.8.7)
       concurrent-ruby (~> 1.0)
+    jazzy (0.13.6)
+      cocoapods (~> 1.5)
+      mustache (~> 1.1)
+      open4
+      redcarpet (~> 3.4)
+      rouge (>= 2.0.6, < 4.0)
+      sassc (~> 2.1)
+      sqlite3 (~> 1.3)
+      xcinvoke (~> 0.3.0)
     json (2.5.1)
     kramdown (2.3.0)
       rexml
     kramdown-parser-gfm (1.1.0)
       kramdown (~> 2.0)
+    liferaft (0.0.6)
     mini_portile2 (2.5.0)
     minitest (5.14.3)
     molinillo (0.6.6)
     multi_json (1.15.0)
     multi_test (0.1.2)
     multipart-post (2.1.1)
+    mustache (1.1.1)
     nanaimo (0.3.0)
     nap (1.1.0)
     netrc (0.11.0)
@@ -173,17 +184,21 @@ GEM
     racc (1.5.2)
     rake (12.3.3)
     rchardet (1.8.0)
+    redcarpet (3.5.1)
     rexml (3.2.4)
     rouge (2.0.7)
     ruby-macho (1.4.0)
     ruby2_keywords (0.0.4)
     rubyzip (2.3.0)
+    sassc (2.4.0)
+      ffi (~> 1.9)
     sawyer (0.8.2)
       addressable (>= 2.3.5)
       faraday (> 0.8, < 2.0)
     selenium-webdriver (3.142.7)
       childprocess (>= 0.5, < 4.0)
       rubyzip (>= 1.2.2)
+    sqlite3 (1.4.2)
     terminal-table (1.8.0)
       unicode-display_width (~> 1.1, >= 1.1.1)
     test-unit (3.3.9)
@@ -198,6 +213,8 @@ GEM
     websocket-driver (0.7.3)
       websocket-extensions (>= 0.1.0)
     websocket-extensions (0.1.5)
+    xcinvoke (0.3.0)
+      liferaft (~> 0.0.6)
     xcodeproj (1.19.0)
       CFPropertyList (>= 2.3.3, < 4.0)
       atomos (~> 0.1.3)
@@ -214,6 +231,7 @@ DEPENDENCIES
   bugsnag-maze-runner!
   cocoapods
   danger
+  jazzy
   xcpretty
 
 BUNDLED WITH

--- a/Makefile
+++ b/Makefile
@@ -47,7 +47,7 @@ all: build
 # A phony target is one that is not really the name of a file; rather it is just a name for a recipe to be executed when you make an explicit request.
 # There are two reasons to use a phony target: to avoid a conflict with a file of the same name, and to improve performance.
 
-.PHONY: all analyze archive bootstrap build build_carthage build_ios_static build_swift bump clean doc help infer prerelease release test test-fixtures update-docs
+.PHONY: all analyze archive bootstrap build build_carthage build_ios_static build_swift bump clean docs help infer prerelease release test test-fixtures update-docs
 
 #--------------------------------------------------------------------------
 # Build
@@ -152,6 +152,7 @@ endif
 	@sed -i '' "s/\"tag\": .*/\"tag\": \"v$(VERSION)\"/" Bugsnag.podspec.json
 	@sed -i '' "s/self.version = .*;/self.version = @\"$(VERSION)\";/" Bugsnag/Payload/BugsnagNotifier.m
 	@sed -i '' "s/## TBD/## $(VERSION) ($(shell date '+%Y-%m-%d'))/" CHANGELOG.md
+	@sed -i '' -E "s/[0-9]+.[0-9]+.[0-9]+/$(VERSION)/g" .jazzy.yaml
 	@agvtool new-marketing-version $(VERSION)
 
 prerelease: bump ## Generates a PR for the $VERSION release
@@ -175,17 +176,15 @@ clean: ## Clean build artifacts
 
 archive: build/Bugsnag-$(PLATFORM)-$(PRESET_VERSION).zip
 
-doc: ## Generate html documentation
-	@headerdoc2html -N -o docs $(shell ruby -e "require 'json'; print Dir.glob(JSON.parse(File.read('Bugsnag.podspec.json'))['public_header_files']).join(' ')") -j
-	@gatherheaderdoc docs
-	@mv docs/masterTOC.html docs/index.html
+docs: ## Generate HTML documentation
+	@bundle exec jazzy
 
-update-docs: ## Update and upload docs to Github
+update-docs: ## Update and upload docs to GitHub
 ifneq ($(BUILDKITE_BRANCH), master)
 	@$(error Docs deployment is handled by CI, and shouldn't be run locally)
 endif
 	@git clone --single-branch --branch=gh-pages git@github.com:bugsnag/bugsnag-cocoa.git docs
-	@make doc
+	@make docs
 	@cd docs
 	@git add .
 	@git commit -m "Docs update for $(PRESET_VERSION) release"

--- a/Makefile
+++ b/Makefile
@@ -47,7 +47,7 @@ all: build
 # A phony target is one that is not really the name of a file; rather it is just a name for a recipe to be executed when you make an explicit request.
 # There are two reasons to use a phony target: to avoid a conflict with a file of the same name, and to improve performance.
 
-.PHONY: all analyze archive bootstrap build build_carthage build_ios_static build_swift bump clean docs help infer prerelease release test test-fixtures update-docs
+.PHONY: all analyze archive bootstrap build build_carthage build_ios_static build_swift bump clean docs help infer prerelease release test test-fixtures
 
 #--------------------------------------------------------------------------
 # Build
@@ -176,19 +176,12 @@ clean: ## Clean build artifacts
 
 archive: build/Bugsnag-$(PLATFORM)-$(PRESET_VERSION).zip
 
-docs: ## Generate HTML documentation
+docs: ## Generate or update HTML documentation
+	@rm -rf docs/*
 	@bundle exec jazzy
-
-update-docs: ## Update and upload docs to GitHub
-ifneq ($(BUILDKITE_BRANCH), master)
-	@$(error Docs deployment is handled by CI, and shouldn't be run locally)
+ifneq ($(wildcard docs/.git),)
+	@cd docs && git add --all . && git commit -m "Docs update for $(PRESET_VERSION) release"
 endif
-	@git clone --single-branch --branch=gh-pages git@github.com:bugsnag/bugsnag-cocoa.git docs
-	@make docs
-	@cd docs
-	@git add .
-	@git commit -m "Docs update for $(PRESET_VERSION) release"
-	@git push --force-with-lease
 
 help: ## Show help text
 	@grep -E '^[a-zA-Z0-9_-]+:.*?## .*$$' $(MAKEFILE_LIST) | sort | awk 'BEGIN {FS = ":.*?## "}; {printf "\033[36m%-30s\033[0m %s\n", $$1, $$2}'

--- a/README.md
+++ b/README.md
@@ -1,4 +1,4 @@
-# Bugsnag exception reporter for iOS and macOS
+# Bugsnag exception reporter for iOS, macOS and tvOS
 [![iOS Documentation](https://img.shields.io/badge/ios_documentation-latest-blue.svg)](http://docs.bugsnag.com/platforms/ios/)
 [![tvOS Documentation](https://img.shields.io/badge/tvos_documentation-latest-blue.svg)](http://docs.bugsnag.com/platforms/tvos/)
 [![macOS Documentation](https://img.shields.io/badge/macos_documentation-latest-blue.svg)](http://docs.bugsnag.com/platforms/macos/)


### PR DESCRIPTION
## Goal

The [Header docs](http://bugsnag.github.io/bugsnag-cocoa/Bugsnag_h/index.html) for bugsnag-cocoa have readability issues when it comes to Objective-C properties.

The tool being used to generate them no longer appears to be maintained so it is necessary to find a better alternative.

## Design

[Jazzy](https://github.com/realm/jazzy) is a documentation generation tool created and actively maintained by Realm. It is used by several popular open-source libraries, including for documenting [Realm's own library](https://realm.io/docs/swift/latest/api/).

The documentation it generates can shows Objective-C and Swift versions of each symbol, similar to Apple's documentation.

## Other tools considered

* [appledoc](https://github.com/tomaz/appledoc) is no longer actively maintained
* [Doxygen](https://www.doxygen.nl/index.html) is popular but is not focused on Objective-C / Swift and would not be able to show Swift generated interfaces. Its default theme is also not as smart as Jazzy's.

## Changeset

Some of the header files were updated to add missing documentation for classes, and fix the formatting of some existing ones to be parsed more correctly by Jazzy.

### Note

The "Header docs" link on https://docs.bugsnag.com/platforms/ios/ will need to be updated after deploying new documentation, since Jazzy uses a different file naming convention and `Bugsnag_h/index.html` will no longer exist.

## Testing

Tested by running `make docs` locally and opening `docs/index.html`.

Note that a `bundle install` is required before running `make docs`.

Generated output attached below for convenience.

## Demo

<img width="1145" alt="Screenshot 2021-01-20 at 15 24 59" src="https://user-images.githubusercontent.com/61777/105196643-c0245b80-5b33-11eb-8d86-fd7b71fee8a7.png">

[docs.zip](https://github.com/bugsnag/bugsnag-cocoa/files/5843452/docs.zip)
