### PR TITLE
[PLAT-5055] Adds basic pipeline support for running Cocoa tests on MacOS

### DIFF
--- a/.buildkite/pipeline.full.yml
+++ b/.buildkite/pipeline.full.yml
@@ -87,7 +87,7 @@ steps:
         download: ["features/fixtures/macos/output/macOSTestApp.zip"]
     commands:
       - bundle install
-      - bundle exec bugsnag-maze-runner
+      - bundle exec maze-runner
         --farm=local
         --os=macos
         --os-version=10.14

--- a/.buildkite/pipeline.full.yml
+++ b/.buildkite/pipeline.full.yml
@@ -75,3 +75,22 @@ steps:
       automatic:
         - exit_status: -1  # Agent was lost
           limit: 2
+
+  - label: ':apple: macOS 10.14 full end-to-end tests'
+    depends_on:
+      - cocoa_fixture
+    timeout_in_minutes: 60
+    agents:
+      queue: opensource-mac-cocoa-10.14
+    plugins:
+      artifacts#v1.3.0:
+        download: ["features/fixtures/macos/output/macOSTestApp.zip"]
+    commands:
+      - bundle install
+      - bundle exec bugsnag-maze-runner
+        --farm=local
+        --os=macos
+        --os-version=10.14
+        --app=macOSTestApp
+        --tags='not @skip_macos'
+        --fail-fast

--- a/.buildkite/pipeline.full.yml
+++ b/.buildkite/pipeline.full.yml
@@ -76,6 +76,25 @@ steps:
         - exit_status: -1  # Agent was lost
           limit: 2
 
+  - label: ':apple: macOS 11.0 full end-to-end tests'
+    depends_on:
+      - cocoa_fixture
+    timeout_in_minutes: 60
+    agents:
+      queue: opensource-mac-cocoa-11
+    plugins:
+      artifacts#v1.3.0:
+        download: ["features/fixtures/macos/output/macOSTestApp.zip"]
+    commands:
+      - bundle install
+      - bundle exec maze-runner
+        --farm=local
+        --os=macos
+        --os-version=11.0
+        --app=macOSTestApp
+        --tags='not @skip_macos'
+        --fail-fast
+
   - label: ':apple: macOS 10.14 full end-to-end tests'
     depends_on:
       - cocoa_fixture

--- a/.buildkite/pipeline.quick.yml
+++ b/.buildkite/pipeline.quick.yml
@@ -151,7 +151,7 @@ steps:
         download: ["features/fixtures/macos/output/macOSTestApp.zip"]
     commands:
       - bundle install
-      - bundle exec bugsnag-maze-runner
+      - bundle exec maze-runner
         --farm=local
         --os=macos
         --os-version=10.15

--- a/.buildkite/pipeline.quick.yml
+++ b/.buildkite/pipeline.quick.yml
@@ -140,6 +140,25 @@ steps:
       - make bootstrap
       - make test
 
+  - label: ':apple: macOS 10.15 full end-to-end tests'
+    depends_on:
+      - cocoa_fixture
+    timeout_in_minutes: 60
+    agents:
+      queue: opensource-mac-cocoa
+    plugins:
+      artifacts#v1.3.0:
+        download: ["features/fixtures/macos/output/macOSTestApp.zip"]
+    commands:
+      - bundle install
+      - bundle exec bugsnag-maze-runner
+        --farm=local
+        --os=macos
+        --os-version=10.15
+        --app=macOSTestApp
+        --tags='not @skip_macos'
+        --fail-fast
+
   - label: ':ios: iOS 14 full end-to-end tests'
     depends_on:
       - cocoa_fixture

--- a/.buildkite/pipeline.yml
+++ b/.buildkite/pipeline.yml
@@ -179,7 +179,7 @@ steps:
         download: ["features/fixtures/macos/output/macOSTestApp.zip"]
     commands:
       - bundle install
-      - bundle exec bugsnag-maze-runner
+      - bundle exec maze-runner
         features/barebone_tests.feature
         --farm=local
         --os=macos

--- a/.buildkite/pipeline.yml
+++ b/.buildkite/pipeline.yml
@@ -187,7 +187,6 @@ steps:
         --app=macOSTestApp
         --tags='not @skip_macos'
         --fail-fast
-        --verbose
 
   - label: 'Conditionally trigger full set of tests'
     command: sh -c .buildkite/pipeline_trigger.sh

--- a/.buildkite/pipeline.yml
+++ b/.buildkite/pipeline.yml
@@ -168,5 +168,26 @@ steps:
         - exit_status: -1  # Agent was lost
           limit: 2
 
+  - label: ':apple: macOS 10.15 barebones end-to-end tests'
+    depends_on:
+      - cocoa_fixture
+    timeout_in_minutes: 60
+    agents:
+      queue: opensource-mac-cocoa
+    plugins:
+      artifacts#v1.3.0:
+        download: ["features/fixtures/macos/output/macOSTestApp.zip"]
+      docker-compose#v3.3.0:
+        run: cocoa-maze-runner
+        command:
+          - "features/barebone_tests.feature"
+          - "--farm=local"
+          - "--os=macos"
+          - "--os-version=10.15"
+          - "--app=macOSTestApp"
+          - "--tags"
+          - "'not @skip_macos'"
+          - "--fail-fast"
+
   - label: 'Conditionally trigger full set of tests'
     command: sh -c .buildkite/pipeline_trigger.sh

--- a/.buildkite/pipeline.yml
+++ b/.buildkite/pipeline.yml
@@ -177,17 +177,17 @@ steps:
     plugins:
       artifacts#v1.3.0:
         download: ["features/fixtures/macos/output/macOSTestApp.zip"]
-      docker-compose#v3.3.0:
-        run: cocoa-maze-runner
-        command:
-          - "features/barebone_tests.feature"
-          - "--farm=local"
-          - "--os=macos"
-          - "--os-version=10.15"
-          - "--app=macOSTestApp"
-          - "--tags"
-          - "'not @skip_macos'"
-          - "--fail-fast"
+    commands:
+      - bundle install
+      - bundle exec bugsnag-maze-runner
+        features/barebone_tests.feature
+        --farm=local
+        --os=macos
+        --os-version=10.15
+        --app=macOSTestApp
+        --tags='not @skip_macos'
+        --fail-fast
+        --verbose
 
   - label: 'Conditionally trigger full set of tests'
     command: sh -c .buildkite/pipeline_trigger.sh

--- a/Gemfile
+++ b/Gemfile
@@ -10,4 +10,4 @@ gem 'xcpretty'
 gem 'bugsnag-maze-runner', git: 'https://github.com/bugsnag/maze-runner', tag: 'v4.4.0'
 
 # Locally, you can run against Maze Runner branches and uncommitted changes:
-# gem 'bugsnag-maze-runner', path: '/Users/amoinet/Desktop/bugsnag-tools/maze-runner'
+# gem 'bugsnag-maze-runner', path: '../maze-runner'

--- a/Gemfile
+++ b/Gemfile
@@ -10,4 +10,4 @@ gem 'xcpretty'
 gem 'bugsnag-maze-runner', git: 'https://github.com/bugsnag/maze-runner', tag: 'v4.4.0'
 
 # Locally, you can run against Maze Runner branches and uncommitted changes:
-#gem 'bugsnag-maze-runner', path: '/Users/amoinet/Desktop/bugsnag-tools/maze-runner'
+# gem 'bugsnag-maze-runner', path: '/Users/amoinet/Desktop/bugsnag-tools/maze-runner'

--- a/Gemfile
+++ b/Gemfile
@@ -10,4 +10,4 @@ gem 'xcpretty'
 gem 'bugsnag-maze-runner', git: 'https://github.com/bugsnag/maze-runner', tag: 'v4.4.0'
 
 # Locally, you can run against Maze Runner branches and uncommitted changes:
-#gem 'bugsnag-maze-runner', path: '../maze-runner'
+#gem 'bugsnag-maze-runner', path: '/Users/amoinet/Desktop/bugsnag-tools/maze-runner'

--- a/features/support/env.rb
+++ b/features/support/env.rb
@@ -1,6 +1,28 @@
+require 'fileutils'
+
 # Set this explicitly
 $api_key = "12312312312312312312312312312312"
 
 AfterConfiguration do |_config|
   Maze.config.receive_no_requests_wait = 15
+end
+
+# Additional require MacOS configuration
+if MazeRunner.config.os == 'macos'
+  fixture_dir = 'features/fixtures/macos/output'
+  app_dir = '/Applications'
+  zip_name = "#{MazeRunner.config.app}.zip"
+  app_name = "#{MazeRunner.config.app}.app"
+
+  # If built app file already exists, skip unzip
+  unless File.exists?("#{fixture_dir}/#{app_name}")
+    raise Exception, 'Test fixture build archive not found' unless File.file?("#{fixture_dir}/#{zip_name}")
+    `unzip #{fixture_dir}/#{zip_name}`
+  end
+
+  FileUtils.mv("#{fixture_dir}/#{app_name}", "#{app_dir}/#{app_name}")
+
+  at_exit do
+    FileUtils.rm_rf("#{app_dir}/#{app_name}")
+  end
 end

--- a/features/support/env.rb
+++ b/features/support/env.rb
@@ -8,11 +8,11 @@ AfterConfiguration do |_config|
 end
 
 # Additional require MacOS configuration
-if MazeRunner.config.os == 'macos'
+if Maze.config.os == 'macos'
   fixture_dir = 'features/fixtures/macos/output'
   app_dir = '/Applications'
-  zip_name = "#{MazeRunner.config.app}.zip"
-  app_name = "#{MazeRunner.config.app}.app"
+  zip_name = "#{Maze.config.app}.zip"
+  app_name = "#{Maze.config.app}.app"
 
   # If built app file already exists, skip unzip
   unless File.exist?("#{fixture_dir}/#{app_name}")

--- a/features/support/env.rb
+++ b/features/support/env.rb
@@ -15,9 +15,9 @@ if MazeRunner.config.os == 'macos'
   app_name = "#{MazeRunner.config.app}.app"
 
   # If built app file already exists, skip unzip
-  unless File.exists?("#{fixture_dir}/#{app_name}")
+  unless File.exist?("#{fixture_dir}/#{app_name}")
     raise Exception, 'Test fixture build archive not found' unless File.file?("#{fixture_dir}/#{zip_name}")
-    `unzip #{fixture_dir}/#{zip_name}`
+    `cd #{fixture_dir} && unzip #{zip_name}`
   end
 
   FileUtils.mv("#{fixture_dir}/#{app_name}", "#{app_dir}/#{app_name}")


### PR DESCRIPTION
## Goal

Will retarget `next` once #981 is merged

Adds:
- MacOS 10.15 barebones tests to the barebones pipeline
- MacOS 10.15 full tests to the quick pipeline
- MacOS 10.14 full tests to the full pipeline

TODO in this PR:
- Update to Maze-runner v4 once #981 is updated to use it
- Target tests at MacOS 11 (requires infrastructure changes)

TODO elsewhere:
- Target tests at MacOS 10.13 (currently failing due to issues that need debugging separately)