### PR TITLE
[PLAT-5721] Run OCLint static analysis tool

### DIFF
--- a/.github/workflows/pull_request.yml
+++ b/.github/workflows/pull_request.yml
@@ -6,31 +6,24 @@ jobs:
     runs-on: macos-latest
     steps:
       - name: Checkout base branch
-        uses: actions/checkout@v1
+        uses: actions/checkout@v2
         with:
           ref: ${{ github.base_ref }}
-          clean: false
 
       - name: Build framework
+        # Base branch may not have the latest Makefile, so cannot use `make` here
         run: |
           xcodebuild -project Bugsnag.xcodeproj -configuration Release -scheme Bugsnag-iOS -destination generic/platform=iOS -derivedDataPath DerivedData -quiet clean build VALID_ARCHS=arm64
           eval $(stat -s DerivedData/Build/Products/Release-iphoneos/Bugsnag.framework/Bugsnag)
           echo $st_size > .size_before
+          rm -rf DerivedData
 
       - name: Checkout PR branch
-        uses: actions/checkout@v1
+        uses: actions/checkout@v2
         with:
           ref: ${{ github.ref }}
+          fetch-depth: 0
           clean: false
-
-      - name: Build framework
-        run: |
-          xcodebuild -project Bugsnag.xcodeproj -configuration Release -scheme Bugsnag-iOS -destination generic/platform=iOS -derivedDataPath DerivedData -quiet clean build VALID_ARCHS=arm64
-          eval $(stat -s DerivedData/Build/Products/Release-iphoneos/Bugsnag.framework/Bugsnag)
-          echo $st_size > .size_after
-      
-      - name: Infer
-        run: make infer
 
       - uses: actions/cache@v2
         with:
@@ -43,6 +36,18 @@ jobs:
         run: |
           bundle config path vendor/bundle
           bundle install --jobs 4 --retry 3
+
+      - name: Build framework
+        run: |
+          make compile_commands.json
+          eval $(stat -s DerivedData/Build/Products/Release-iphoneos/Bugsnag.framework/Bugsnag)
+          echo $st_size > .size_after
+      
+      - name: Infer
+        run: make infer
+      
+      - name: OCLint
+        run: make oclint
 
       - name: Danger
         run: bundle exec danger

--- a/.gitignore
+++ b/.gitignore
@@ -25,5 +25,7 @@ Podfile.lock
 .build
 .swiftpm
 Package.resolved
+/compile_commands.json
 /docs/
 /infer-out
+/oclint.json

--- a/.oclint
+++ b/.oclint
@@ -1,0 +1,33 @@
+# vim: set ft=yaml
+
+disable-rules:
+  - BitwiseOperatorInConditional    # Used quite a bit in KSCrash
+  - CollapsibleIfStatements         # Fixing violations would churn a lot of code
+  - ConstantConditionalOperator     # False positive for e.g. strncpy()
+  - EmptyDoWhileStatement           # False positive for e.g. NSAssert()
+  - GotoStatement                   # KSCrash uses gotos extensively
+  - HighCyclomaticComplexity
+  - HighNcssMethod
+  - HighNPathComplexity
+  - InvertedLogic                   # Triggers on e.g. `if (old != new)`
+  - MissingDefaultStatement         # Rule not smart enough to only trigger for missing cases
+  - ParameterReassignment
+  - PreferEarlyExit                 # Fixing violations would churn a lot of code
+  - ShortVariableName
+  - UnnecessaryElseStatement        # Fixing violations would churn a lot of code
+  - UnusedMethodParameter           # Quite common for notification handlers
+  - UselessParentheses              # False positive for e.g. ULONG_MAX
+
+rule-configurations:
+  - key: LONG_LINE
+    # GitHub's PR viewer allows 150 characters before scrolling
+    value: 150
+  - key: LONG_METHOD
+    value: 159
+  - key: LONG_VARIABLE_NAME
+    value: 50
+  - key: NESTED_BLOCK_DEPTH
+    value: 6
+  - key: TOO_MANY_METHODS
+    # We have several very large classses (BugsnagConfiguration, BugsnagClient)
+    value: 110

--- a/Bugsnag/Breadcrumbs/BSGNotificationBreadcrumbs.m
+++ b/Bugsnag/Breadcrumbs/BSGNotificationBreadcrumbs.m
@@ -148,11 +148,12 @@ NSString * const BSGNotificationBreadcrumbsMessageAppWillTerminate = @"App Will 
         NSWindowWillMiniaturizeNotification,
     ];
 #endif
-    return nil;
 }
 
 - (NSArray<NSNotificationName> *)automaticBreadcrumbControlEvents {
-#if TARGET_OS_IOS
+#if TARGET_OS_TV
+    return nil;
+#elif TARGET_OS_IOS
     return @[
         UITextFieldTextDidBeginEditingNotification,
         UITextFieldTextDidEndEditingNotification,
@@ -165,7 +166,6 @@ NSString * const BSGNotificationBreadcrumbsMessageAppWillTerminate = @"App Will 
         NSControlTextDidEndEditingNotification
     ];
 #endif
-    return nil;
 }
 
 - (NSArray<NSNotificationName> *)automaticBreadcrumbTableItemEvents {
@@ -174,7 +174,6 @@ NSString * const BSGNotificationBreadcrumbsMessageAppWillTerminate = @"App Will 
 #elif TARGET_OS_OSX
     return @[ NSTableViewSelectionDidChangeNotification ];
 #endif
-    return nil;
 }
 
 - (NSArray<NSNotificationName> *)automaticBreadcrumbMenuItemEvents {

--- a/Bugsnag/BugsnagSystemState.m
+++ b/Bugsnag/BugsnagSystemState.m
@@ -146,6 +146,7 @@ static NSDictionary *copyDictionary(NSDictionary *launchState) {
 
 @property(readonly,nonatomic) NSMutableDictionary *currentLaunchStateRW;
 @property(readwrite,atomic) NSDictionary *currentLaunchState;
+@property(readwrite,nonatomic) NSDictionary *lastLaunchState;
 @property(readonly,nonatomic) NSString *persistenceFilePath;
 @property(readonly,nonatomic) BugsnagKVStore *kvStore;
 
@@ -276,7 +277,7 @@ static NSDictionary *copyDictionary(NSDictionary *launchState) {
         bsg_log_err(@"Could not remove persistence file: %@", error);
     }
     [self.kvStore purge];
-    self->_lastLaunchState = loadPreviousState(self.kvStore, self.persistenceFilePath);
+    self.lastLaunchState = loadPreviousState(self.kvStore, self.persistenceFilePath);
 }
 
 @end

--- a/Bugsnag/Client/BugsnagClient+Private.h
+++ b/Bugsnag/Client/BugsnagClient+Private.h
@@ -60,7 +60,7 @@ NS_ASSUME_NONNULL_BEGIN
 
 @property (strong, nonatomic) BugsnagSessionTracker *sessionTracker; // Used in BugsnagReactNative
 
-@property (readonly, nonatomic) BOOL started;
+@property (nonatomic) BOOL started;
 
 @property (strong, nonatomic) BugsnagMetadata *state;
 

--- a/Bugsnag/Client/BugsnagClient+Private.h
+++ b/Bugsnag/Client/BugsnagClient+Private.h
@@ -60,7 +60,7 @@ NS_ASSUME_NONNULL_BEGIN
 
 @property (strong, nonatomic) BugsnagSessionTracker *sessionTracker; // Used in BugsnagReactNative
 
-@property (nonatomic) BOOL started;
+@property (readonly, nonatomic) BOOL started;
 
 @property (strong, nonatomic) BugsnagMetadata *state;
 

--- a/Bugsnag/Client/BugsnagClient.m
+++ b/Bugsnag/Client/BugsnagClient.m
@@ -397,7 +397,7 @@ NSString *_lastOrientation = nil;
     [self addTerminationObserver:NSApplicationWillTerminateNotification];
 #endif
 
-    _started = YES;
+    self.started = YES;
 
     [self.sessionTracker startNewSessionIfAutoCaptureEnabled];
 
@@ -926,7 +926,7 @@ NSString *_lastOrientation = nil;
 
     // Only include the eventMessage if it contains something
     NSString *eventMessage = event.errors[0].errorMessage;
-    if (eventMessage && [eventMessage length] > 0) {
+    if (eventMessage.length) {
         [metadata setValue:eventMessage forKey:BSGKeyName];
     }
 
@@ -1017,7 +1017,7 @@ NSString *_lastOrientation = nil;
     // Short-circuit the exit if we don't have enough info to record a full breadcrumb
     // or the orientation hasn't changed (false positive).
     if (!_lastOrientation || [orientation isEqualToString:_lastOrientation]) {
-        _lastOrientation = orientation;
+        self.lastOrientation = orientation;
         return;
     }
 
@@ -1031,7 +1031,7 @@ NSString *_lastOrientation = nil;
                           @"to" : orientation
                       }];
 
-    _lastOrientation = orientation;
+    self.lastOrientation = orientation;
 }
 
 - (void)lowMemoryWarning:(NSNotification *)notif {

--- a/Bugsnag/Client/BugsnagClient.m
+++ b/Bugsnag/Client/BugsnagClient.m
@@ -535,6 +535,10 @@ NSString *_lastOrientation = nil;
     self.sessionTracker.codeBundleId = codeBundleId;
 }
 
+- (void)setStarted:(BOOL)started {
+    _started = started;
+}
+
 /**
  * Removes observers and listeners to prevent allocations when the app is terminated
  */

--- a/Bugsnag/Configuration/BugsnagConfiguration+Private.h
+++ b/Bugsnag/Configuration/BugsnagConfiguration+Private.h
@@ -25,7 +25,7 @@ NS_ASSUME_NONNULL_BEGIN
 
 @property (readonly) NSDictionary<NSString *, id> *errorApiHeaders;
 
-@property (readonly, nonatomic) BugsnagMetadata *metadata;
+@property (readonly, copy, nonatomic) BugsnagMetadata *metadata;
 
 @property (nullable, nonatomic) NSURL *notifyURL;
 

--- a/Bugsnag/Configuration/BugsnagConfiguration+Private.h
+++ b/Bugsnag/Configuration/BugsnagConfiguration+Private.h
@@ -27,7 +27,7 @@ NS_ASSUME_NONNULL_BEGIN
 
 @property (readonly, nonatomic) BugsnagMetadata *metadata;
 
-@property (readonly, nullable, nonatomic) NSURL *notifyURL;
+@property (nullable, nonatomic) NSURL *notifyURL;
 
 @property (nonatomic) NSMutableArray<BugsnagOnBreadcrumbBlock> *onBreadcrumbBlocks;
 
@@ -42,7 +42,9 @@ NS_ASSUME_NONNULL_BEGIN
 
 @property (readonly) NSDictionary<NSString *, id> *sessionApiHeaders;
 
-@property (readonly, nullable, nonatomic) NSURL *sessionURL;
+@property (nullable, nonatomic) NSURL *sessionURL;
+
+@property (readwrite, retain, nonnull, nonatomic) BugsnagUser *user;
 
 #pragma mark Methods
 

--- a/Bugsnag/Configuration/BugsnagConfiguration+Private.h
+++ b/Bugsnag/Configuration/BugsnagConfiguration+Private.h
@@ -27,7 +27,7 @@ NS_ASSUME_NONNULL_BEGIN
 
 @property (readonly, copy, nonatomic) BugsnagMetadata *metadata;
 
-@property (nullable, nonatomic) NSURL *notifyURL;
+@property (readonly, nullable, nonatomic) NSURL *notifyURL;
 
 @property (nonatomic) NSMutableArray<BugsnagOnBreadcrumbBlock> *onBreadcrumbBlocks;
 
@@ -42,7 +42,7 @@ NS_ASSUME_NONNULL_BEGIN
 
 @property (readonly) NSDictionary<NSString *, id> *sessionApiHeaders;
 
-@property (nullable, nonatomic) NSURL *sessionURL;
+@property (readonly, nullable, nonatomic) NSURL *sessionURL;
 
 @property (readwrite, retain, nonnull, nonatomic) BugsnagUser *user;
 

--- a/Bugsnag/Configuration/BugsnagConfiguration.m
+++ b/Bugsnag/Configuration/BugsnagConfiguration.m
@@ -489,6 +489,14 @@ static NSUserDefaults *userDefaults;
     _metadata = [metadata deepCopy];
 }
 
+- (void)setNotifyURL:(NSURL *)notifyURL {
+    _notifyURL = notifyURL;
+}
+
+- (void)setSessionURL:(NSURL *)sessionURL {
+    _sessionURL = sessionURL;
+}
+
 - (BOOL)shouldDiscardErrorClass:(NSString *)errorClass {
     for (id obj in self.discardClasses) {
         if ([obj isKindOfClass:[NSString class]]) {

--- a/Bugsnag/Configuration/BugsnagConfiguration.m
+++ b/Bugsnag/Configuration/BugsnagConfiguration.m
@@ -92,7 +92,7 @@ static NSUserDefaults *userDefaults;
     [copy setMaxPersistedEvents:self.maxPersistedEvents];
     [copy setMaxPersistedSessions:self.maxPersistedSessions];
     [copy setMaxBreadcrumbs:self.maxBreadcrumbs];
-    copy->_metadata = [[BugsnagMetadata alloc] initWithDictionary:[[self.metadata toDictionary] mutableCopy]];
+    copy->_metadata = [[BugsnagMetadata alloc] initWithDictionary:[[self.metadata toDictionary] mutableCopy]]; //!OCLINT
     [copy setEndpoints:self.endpoints];
     [copy setOnCrashHandler:self.onCrashHandler];
     [copy setPersistUser:self.persistUser];
@@ -263,7 +263,7 @@ static NSUserDefaults *userDefaults;
 - (void)setUser:(NSString *_Nullable)userId
       withEmail:(NSString *_Nullable)email
         andName:(NSString *_Nullable)name {
-    _user = [[BugsnagUser alloc] initWithUserId:userId name:name emailAddress:email];
+    self.user = [[BugsnagUser alloc] initWithUserId:userId name:name emailAddress:email];
 
     // Persist the user
     if (self.persistUser) {
@@ -338,14 +338,14 @@ static NSUserDefaults *userDefaults;
 
 - (void)setEndpoints:(BugsnagEndpointConfiguration *)endpoints {
     _endpoints = endpoints;
-    _notifyURL = [NSURL URLWithString:endpoints.notify];
-    _sessionURL = [NSURL URLWithString:endpoints.sessions];
+    self.notifyURL = [NSURL URLWithString:endpoints.notify];
+    self.sessionURL = [NSURL URLWithString:endpoints.sessions];
 
     // This causes a crash under DEBUG but is ignored in production
     NSAssert([self isValidUrl:_notifyURL], @"Invalid URL supplied for notify endpoint");
 
     if (![self isValidUrl:_sessionURL]) {
-        _sessionURL = nil;
+        self.sessionURL = nil;
     }
 }
 

--- a/Bugsnag/Configuration/BugsnagConfiguration.m
+++ b/Bugsnag/Configuration/BugsnagConfiguration.m
@@ -92,7 +92,7 @@ static NSUserDefaults *userDefaults;
     [copy setMaxPersistedEvents:self.maxPersistedEvents];
     [copy setMaxPersistedSessions:self.maxPersistedSessions];
     [copy setMaxBreadcrumbs:self.maxBreadcrumbs];
-    copy->_metadata = [[BugsnagMetadata alloc] initWithDictionary:[[self.metadata toDictionary] mutableCopy]]; //!OCLINT
+    [copy setMetadata:self.metadata];
     [copy setEndpoints:self.endpoints];
     [copy setOnCrashHandler:self.onCrashHandler];
     [copy setPersistUser:self.persistUser];
@@ -483,6 +483,10 @@ static NSUserDefaults *userDefaults;
                         (unsigned long) maxBreadcrumbs);
         }
     }
+}
+
+- (void)setMetadata:(BugsnagMetadata *)metadata {
+    _metadata = [metadata deepCopy];
 }
 
 - (BOOL)shouldDiscardErrorClass:(NSString *)errorClass {

--- a/Bugsnag/KSCrash/Source/KSCrash/Recording/BSG_KSCrash.m
+++ b/Bugsnag/KSCrash/Source/KSCrash/Recording/BSG_KSCrash.m
@@ -212,7 +212,7 @@
 
 - (BOOL)install {
 
-    _handlingCrashTypes = bsg_kscrash_install(
+    self.handlingCrashTypes = bsg_kscrash_install(
         [self.crashReportPath UTF8String], [self.recrashReportPath UTF8String],
         [self.stateFilePath UTF8String], [self.nextCrashID UTF8String]);
     if (self.handlingCrashTypes == 0) {

--- a/Bugsnag/KSCrash/Source/KSCrash/Recording/BSG_KSCrashReportStore.m
+++ b/Bugsnag/KSCrash/Source/KSCrash/Recording/BSG_KSCrashReportStore.m
@@ -136,7 +136,7 @@ static NSString *const kCrashReportSuffix = @"-CrashReport-";
 
     NSDictionary *dstDict = report[dstKey];
     if (dstDict == nil) {
-        dstDict = [NSDictionary dictionary];
+        dstDict = @{};
     }
     if (![dstDict isKindOfClass:[NSDictionary class]]) {
         BSG_KSLOG_ERROR(@"'%@' should be a dictionary, not %@", dstKey,

--- a/Bugsnag/KSCrash/Source/KSCrash/Recording/Tools/BSG_KSJSONCodec.c
+++ b/Bugsnag/KSCrash/Source/KSCrash/Recording/Tools/BSG_KSJSONCodec.c
@@ -185,6 +185,7 @@ int bsg_ksjsoncodec_i_appendEscapedString(
             } else {
                 *dst++ = *src;
             }
+            break;
         }
     }
     size_t encLength = (size_t)(dst - workBuffer);

--- a/Bugsnag/KSCrash/Source/KSCrash/Recording/Tools/BSG_KSString.c
+++ b/Bugsnag/KSCrash/Source/KSCrash/Recording/Tools/BSG_KSString.c
@@ -132,7 +132,7 @@ bool bsg_ksstring_extractHexValue(const char *string, size_t stringLength,
                 accum += nybble;
             }
             *result = accum;
-            return true;
+            return true; //!OCLINT
         }
     }
     return false;

--- a/Bugsnag/KSCrash/Source/KSCrash/Recording/Tools/BSG_KSString.c
+++ b/Bugsnag/KSCrash/Source/KSCrash/Recording/Tools/BSG_KSString.c
@@ -111,31 +111,34 @@ static const unsigned int bsg_g_hexConversion[] = {
 
 bool bsg_ksstring_extractHexValue(const char *string, size_t stringLength,
                                   uint64_t *const result) {
-    if (stringLength > 0) {
-        const unsigned char *current = (const unsigned char *)string;
-        const unsigned char *const end = current + stringLength;
-        for (;;) {
-            current = (const unsigned char *)strnstr(
-                (const char *)current, "0x", (size_t)(end - current));
-            unlikely_if(!current) { return false; }
-            current += 2;
-
-            // Must have at least one valid digit after "0x".
-            unlikely_if(bsg_g_hexConversion[*current] == INV) { continue; }
-
-            uint64_t accum = 0;
-            unsigned int nybble = 0;
-            while (current < end) {
-                nybble = bsg_g_hexConversion[*current++];
-                unlikely_if(nybble == INV) { break; }
-                accum <<= 4;
-                accum += nybble;
-            }
-            *result = accum;
-            return true; //!OCLINT
-        }
+    if (!stringLength) {
+        return false;
     }
-    return false;
+    
+    const char *value = strnstr(string, "0x", stringLength);
+    if (!value) {
+        return false;
+    }
+    
+    value += 2;
+    
+    // Must have at least one valid digit after "0x".
+    unlikely_if (bsg_g_hexConversion[*(uint8_t *)value] == INV) {
+        return false;
+    }
+    
+    uint64_t accum = 0;
+    unsigned int nybble = 0;
+    while (value < string + stringLength) {
+        nybble = bsg_g_hexConversion[*(uint8_t *)value++];
+        unlikely_if (nybble == INV) {
+            break;
+        }
+        accum <<= 4;
+        accum += nybble;
+    }
+    *result = accum;
+    return true;
 }
 
 void bsg_ksstring_replace(const char **dest, const char *replacement) {

--- a/Bugsnag/KSCrash/Source/KSCrash/Recording/Tools/BSG_KSString.c
+++ b/Bugsnag/KSCrash/Source/KSCrash/Recording/Tools/BSG_KSString.c
@@ -116,7 +116,7 @@ bool bsg_ksstring_extractHexValue(const char *string, size_t stringLength,
     }
     
     const char *value = strnstr(string, "0x", stringLength);
-    if (!value) {
+    unlikely_if (!value) {
         return false;
     }
     

--- a/Bugsnag/Payload/BugsnagAppWithState.m
+++ b/Bugsnag/Payload/BugsnagAppWithState.m
@@ -19,12 +19,12 @@
     BugsnagAppWithState *app = [BugsnagAppWithState new];
 
     id duration = json[@"duration"];
-    if (duration && [duration isKindOfClass:[NSNumber class]]) {
+    if ([duration isKindOfClass:[NSNumber class]]) {
         app.duration = duration;
     }
 
     id durationInForeground = json[@"durationInForeground"];
-    if (durationInForeground && [durationInForeground isKindOfClass:[NSNumber class]]) {
+    if ([durationInForeground isKindOfClass:[NSNumber class]]) {
         app.durationInForeground = durationInForeground;
     }
 
@@ -35,7 +35,7 @@
 
     NSArray *dsyms = json[@"dsymUUIDs"];
 
-    if (dsyms && [dsyms count] > 0) {
+    if (dsyms.count) {
         app.dsymUuid = dsyms[0];
     }
 

--- a/Bugsnag/Payload/BugsnagDeviceWithState.m
+++ b/Bugsnag/Payload/BugsnagDeviceWithState.m
@@ -38,7 +38,6 @@ NSMutableDictionary *BSGParseDeviceMetadata(NSDictionary *event) {
  * @return free space in the number of bytes, or nil if this information could not be found
  */
 NSNumber *BSGDeviceFreeSpace(NSSearchPathDirectory directory) {
-    NSNumber *freeBytes = nil;
     NSFileManager *fileManager = [NSFileManager defaultManager];
     NSArray *searchPaths = NSSearchPathForDirectoriesInDomains(directory, NSUserDomainMask, true);
     NSString *path = [searchPaths lastObject];
@@ -47,12 +46,10 @@ NSNumber *BSGDeviceFreeSpace(NSSearchPathDirectory directory) {
     NSDictionary *fileSystemAttrs =
             [fileManager attributesOfFileSystemForPath:path error:&error];
 
-    if (error) {
+    if (!fileSystemAttrs) {
         bsg_log_warn(@"Failed to read free disk space: %@", error);
-    } else {
-        freeBytes = [fileSystemAttrs objectForKey:NSFileSystemFreeSize];
     }
-    return freeBytes;
+    return fileSystemAttrs[NSFileSystemFreeSize];
 }
 
 @implementation BugsnagDeviceWithState
@@ -78,7 +75,7 @@ NSNumber *BSGDeviceFreeSpace(NSSearchPathDirectory directory) {
     }
 
     id time = json[@"time"];
-    if (time && [time isKindOfClass:[NSString class]]) {
+    if ([time isKindOfClass:[NSString class]]) {
         device.time = [BSG_RFC3339DateTool dateFromString:time];
     }
     return device;

--- a/Bugsnag/Payload/BugsnagError.m
+++ b/Bugsnag/Payload/BugsnagError.m
@@ -25,8 +25,6 @@ NSString *_Nonnull BSGSerializeErrorType(BSGErrorType errorType) {
             return @"c";
         case BSGErrorTypeReactNativeJs:
             return @"reactnativejs";
-        default:
-            return nil;
     }
 }
 

--- a/Bugsnag/Payload/BugsnagEvent+Private.h
+++ b/Bugsnag/Payload/BugsnagEvent+Private.h
@@ -47,6 +47,8 @@ NS_ASSUME_NONNULL_BEGIN
 /// An array of string representations of BSGErrorType describing the types of stackframe / stacktrace in this error.
 @property (readonly, nonatomic) NSArray<NSString *> *stacktraceTypes;
 
+@property (readwrite, nonatomic, nonnull) BugsnagUser *user;
+
 - (instancetype)initWithApp:(nullable BugsnagAppWithState *)app
                      device:(nullable BugsnagDeviceWithState *)device
                handledState:(BugsnagHandledState *)handledState

--- a/Bugsnag/Payload/BugsnagEvent.m
+++ b/Bugsnag/Payload/BugsnagEvent.m
@@ -499,7 +499,7 @@ NSDictionary *BSGParseCustomException(NSDictionary *report,
 }
 
 - (NSArray *)serializeBreadcrumbs {
-    return [[self breadcrumbs] valueForKeyPath:NSStringFromSelector(@selector(objectValue))];;
+    return [[self breadcrumbs] valueForKeyPath:NSStringFromSelector(@selector(objectValue))];
 }
 
 @synthesize releaseStage = _releaseStage;
@@ -556,7 +556,7 @@ NSDictionary *BSGParseCustomException(NSDictionary *report,
 - (void)setUser:(NSString *_Nullable)userId
       withEmail:(NSString *_Nullable)email
         andName:(NSString *_Nullable)name {
-    _user = [[BugsnagUser alloc] initWithUserId:userId name:name emailAddress:email];
+    self.user = [[BugsnagUser alloc] initWithUserId:userId name:name emailAddress:email];
 }
 
 /**
@@ -604,7 +604,7 @@ NSDictionary *BSGParseCustomException(NSDictionary *report,
         } else {
             [metadata removeObjectForKey:key];
         }
-        _overrides = metadata;
+        self.overrides = metadata;
     }
 }
 

--- a/Bugsnag/Payload/BugsnagSession+Private.h
+++ b/Bugsnag/Payload/BugsnagSession+Private.h
@@ -45,6 +45,8 @@ NS_ASSUME_NONNULL_BEGIN
 
 @property NSUInteger unhandledCount;
 
+@property (readwrite, nonnull, nonatomic) BugsnagUser *user;
+
 #pragma mark Methods
 
 - (void)resume;

--- a/Bugsnag/Payload/BugsnagSession.m
+++ b/Bugsnag/Payload/BugsnagSession.m
@@ -131,7 +131,7 @@ static NSString *const kBugsnagUser = @"user";
 - (void)setUser:(NSString *_Nullable)userId
       withEmail:(NSString *_Nullable)email
         andName:(NSString *_Nullable)name {
-    _user = [[BugsnagUser alloc] initWithUserId:userId name:name emailAddress:email];
+    self.user = [[BugsnagUser alloc] initWithUserId:userId name:name emailAddress:email];
 }
 
 @end

--- a/Bugsnag/Payload/BugsnagStacktrace+Private.h
+++ b/Bugsnag/Payload/BugsnagStacktrace+Private.h
@@ -14,7 +14,7 @@ NS_ASSUME_NONNULL_BEGIN
 
 + (instancetype)stacktraceFromJson:(NSDictionary *)json;
 
-@property (readonly, nonatomic) NSMutableArray<BugsnagStackframe *> *trace;
+@property (nonatomic) NSMutableArray<BugsnagStackframe *> *trace;
 
 @end
 

--- a/Bugsnag/Payload/BugsnagStacktrace.m
+++ b/Bugsnag/Payload/BugsnagStacktrace.m
@@ -26,7 +26,7 @@
             }
         }
     }
-    trace->_trace = data;
+    trace.trace = data;
     return trace;
 }
 

--- a/Bugsnag/Storage/BSGFileLocations.m
+++ b/Bugsnag/Storage/BSGFileLocations.m
@@ -77,15 +77,15 @@ static NSString *getAndCreateSubdir(NSString *rootPath, NSString *relativePath) 
 - (instancetype)initWithVersion1 {
     if (self = [super init]) {
         NSString *root = rootDirectory(@"v1");
-        self->_sessions = getAndCreateSubdir(root, @"sessions");
-        self->_breadcrumbs = getAndCreateSubdir(root, @"breadcrumbs");
-        self->_kscrashReports = getAndCreateSubdir(root, @"KSCrashReports");
-        self->_kvStore = getAndCreateSubdir(root, @"kvstore");
-        self->_flagHandledCrash = [root stringByAppendingPathComponent:@"bugsnag_handled_crash.txt"];
-        self->_configuration = [root stringByAppendingPathComponent:@"config.json"];
-        self->_metadata = [root stringByAppendingPathComponent:@"metadata.json"];
-        self->_state = [root stringByAppendingPathComponent:@"state.json"];
-        self->_systemState = [root stringByAppendingPathComponent:@"system_state.json"];
+        _sessions = getAndCreateSubdir(root, @"sessions");
+        _breadcrumbs = getAndCreateSubdir(root, @"breadcrumbs");
+        _kscrashReports = getAndCreateSubdir(root, @"KSCrashReports");
+        _kvStore = getAndCreateSubdir(root, @"kvstore");
+        _flagHandledCrash = [root stringByAppendingPathComponent:@"bugsnag_handled_crash.txt"];
+        _configuration = [root stringByAppendingPathComponent:@"config.json"];
+        _metadata = [root stringByAppendingPathComponent:@"metadata.json"];
+        _state = [root stringByAppendingPathComponent:@"state.json"];
+        _systemState = [root stringByAppendingPathComponent:@"system_state.json"];
     }
     return self;
 }

--- a/Bugsnag/Storage/BSGFileLocations.m
+++ b/Bugsnag/Storage/BSGFileLocations.m
@@ -71,19 +71,23 @@ static NSString *getAndCreateSubdir(NSString *rootPath, NSString *relativePath) 
 }
 
 + (instancetype) v1 {
-    NSString *root = rootDirectory(@"v1");
-    BSGFileLocations *inst = [[BSGFileLocations alloc] init];
-    inst->_sessions = getAndCreateSubdir(root, @"sessions");
-    inst->_breadcrumbs = getAndCreateSubdir(root, @"breadcrumbs");
-    inst->_kscrashReports = getAndCreateSubdir(root, @"KSCrashReports");
-    inst->_kvStore = getAndCreateSubdir(root, @"kvstore");
-    inst->_flagHandledCrash = [root stringByAppendingPathComponent:@"bugsnag_handled_crash.txt"];
-    inst->_configuration = [root stringByAppendingPathComponent:@"config.json"];
-    inst->_metadata = [root stringByAppendingPathComponent:@"metadata.json"];
-    inst->_state = [root stringByAppendingPathComponent:@"state.json"];
-    inst->_systemState = [root stringByAppendingPathComponent:@"system_state.json"];
+    return [[BSGFileLocations alloc] initWithVersion1];
+}
 
-    return inst;
+- (instancetype)initWithVersion1 {
+    if (self = [super init]) {
+        NSString *root = rootDirectory(@"v1");
+        self->_sessions = getAndCreateSubdir(root, @"sessions");
+        self->_breadcrumbs = getAndCreateSubdir(root, @"breadcrumbs");
+        self->_kscrashReports = getAndCreateSubdir(root, @"KSCrashReports");
+        self->_kvStore = getAndCreateSubdir(root, @"kvstore");
+        self->_flagHandledCrash = [root stringByAppendingPathComponent:@"bugsnag_handled_crash.txt"];
+        self->_configuration = [root stringByAppendingPathComponent:@"config.json"];
+        self->_metadata = [root stringByAppendingPathComponent:@"metadata.json"];
+        self->_state = [root stringByAppendingPathComponent:@"state.json"];
+        self->_systemState = [root stringByAppendingPathComponent:@"system_state.json"];
+    }
+    return self;
 }
 
 @end

--- a/Bugsnag/Storage/BugsnagFileStore.m
+++ b/Bugsnag/Storage/BugsnagFileStore.m
@@ -139,12 +139,8 @@
     NSMutableDictionary *files =
     [NSMutableDictionary dictionaryWithCapacity:[fileIds count]];
     for (NSString *fileId in fileIds) {
-        NSDictionary *fileContents = [self fileWithId:fileId];
-        if (fileContents != nil) {
-            [files setObject:fileContents forKey:fileId];
-        }
+        files[fileId] = [self fileWithId:fileId];
     }
-
     return files;
 }
 

--- a/Tests/BugsnagClientMirrorTest.m
+++ b/Tests/BugsnagClientMirrorTest.m
@@ -132,6 +132,8 @@
             @"setConfigMetadataFromLastLaunch: v24@0:8@16",
             @"setMetadataFromLastLaunch: v24@0:8@16",
             @"setNotificationBreadcrumbs: v24@0:8@16",
+            @"setStarted: v20@0:8B16",
+            @"setStarted: v20@0:8c16",
             @"setStateMetadataFromLastLaunch: v24@0:8@16",
             @"stateMetadataFile @16@0:8",
             @"stateMetadataFromLastLaunch @16@0:8",
@@ -163,8 +165,8 @@
     [clientMethods minusSet:bugsnagMethods];
     [clientMethods minusSet:self.clientMethodsNotRequiredOnBugsnag];
 
-    if ([clientMethods count] > 0) {
-        XCTFail(@"Missing the following methods on Bugsnag %@", clientMethods);
+    for (NSString *method in clientMethods) {
+        XCTFail(@"The \"Bugsnag\" class should implement +%@", method);
     }
 }
 
@@ -177,8 +179,8 @@
     [bugsnagMethods minusSet:clientMethods];
     [bugsnagMethods minusSet:self.bugsnagMethodsNotRequiredOnClient];
 
-    if ([bugsnagMethods count] > 0) {
-        XCTFail(@"Missing the following methods on Client %@", bugsnagMethods);
+    for (NSString *method in bugsnagMethods) {
+        XCTFail(@"The \"BugsnagClient\" class should implement -%@", method);
     }
 }
 

--- a/Tests/KSCrash/KSString_Tests.m
+++ b/Tests/KSCrash/KSString_Tests.m
@@ -109,6 +109,13 @@
     XCTAssertFalse(success, @"");
 }
 
+- (void) testExtractHexValueInvalid3
+{
+    const char *string = "A string with nothing after 0x";
+    uint64_t result = 0;
+    XCTAssertFalse(bsg_ksstring_extractHexValue(string, strlen(string), &result));
+}
+
 - (void) testIsNullTerminatedUTF8String
 {
     const char* string = "A string";


### PR DESCRIPTION
## Goal

Integrates the [OCLint](http://oclint.org/) static analytics tool into the CI workflow.

## Design

Integrated into the same GitHub Action that runs Infer and reports results via Danger, so that all results are shown in the same PR comment.

## Changeset

The GH push_request action has been refactored to generate `compile_commands.json` before running Infer and OCLint (which requires that file, unlike Infer where it's optional.)

A number of rules have been disabled due to false positives or flagging relatively harmless issues whose fixes would create a lot of whitespace changes that would reduce the effectiveness of `git blame` 👉 see `.oclint` for details.

Warnings raised for remaining rules have been fixed in this PR.

## Testing

Tested by running locally - `make oclint` and verifying the results reported in the PR.

To see the issues reported by OCLint, view the older version of the Danger PR comment

<img width="695" alt="Screenshot 2021-01-25 at 09 27 53" src="https://user-images.githubusercontent.com/61777/105686889-b0b86000-5eef-11eb-9a31-c1f8080aba21.png">
