### PR TITLE
Improve reliability of OOM scenario

### DIFF
--- a/examples/objective-c-ios/Bugsnag Test App/OutOfMemoryController.m
+++ b/examples/objective-c-ios/Bugsnag Test App/OutOfMemoryController.m
@@ -1,6 +1,18 @@
 #import "OutOfMemoryController.h"
 
-@implementation OutOfMemoryController
+#define PRINT_STATS 0
+
+#if PRINT_STATS
+#import <mach/mach_init.h>
+#import <mach/task_info.h>
+#import <mach/task.h>
+#endif
+
+#define MEGABYTE 0x100000
+
+@implementation OutOfMemoryController {
+    NSUInteger _blockSize;
+}
 
 - (void)viewDidLoad {
     [super viewDidLoad];
@@ -15,32 +27,52 @@
 - (void)viewDidAppear:(BOOL)animated {
     [super viewDidAppear:animated];
     
-    [NSThread detachNewThreadSelector:@selector(consumeMemory) toTarget:self withObject:nil];
+    NSUInteger physicalMemory = (NSUInteger)NSProcessInfo.processInfo.physicalMemory;
+    NSUInteger megabytes = physicalMemory / MEGABYTE;
+    NSLog(@"*** Physical memory = %lu MB", (unsigned long)megabytes);
+    
+    // The ActiveHard limit varies between devices
+    //
+    // Device       iOS     Total   Limit
+    // ========================================
+    // iPad3,19      9       987     700  (70%)
+    // iPhone12,1   14      3859    2098  (54%)
+    // iPhone12,8   14      2965    2095  (70%)
+    // iPhone13,1   14      3718    2098  (57%)
+    //
+    NSUInteger limit = MIN(2098, megabytes * 70 / 100);
+    
+    NSUInteger initial = limit * 95 / 100;
+    NSLog(@"*** Dirtying an initial block of %lu MB", (unsigned long)initial);
+    [self consumeMegabytes:initial];
+    
+    _blockSize = limit <= 1024 ? 1 : 2;
+    NSLog(@"*** Dirtying remaining memory in %lu MB blocks", (unsigned long)_blockSize);
+    // This should take around 2 seconds to trigger an OOM kill
+    [NSTimer scheduledTimerWithTimeInterval:0.03 target:self selector:@selector(timerFired) userInfo:nil repeats:YES];
 }
 
-- (void)consumeMemory {
-    NSLog(@"*** Consuming all available memory...");
-    __block BOOL pause = NO;
-    [NSNotificationCenter.defaultCenter addObserverForName:UIApplicationDidReceiveMemoryWarningNotification object:nil
-                                                     queue:nil usingBlock:^(NSNotification * _Nonnull note) {
-        pause = YES;
-    }];
-    const int blocksize = 1024 * 1024;
-    const int pagesize = (int)NSPageSize();
-    const int npages = blocksize / pagesize;
-    while (1) {
-        volatile char *ptr = malloc(blocksize);
-        for (int i = 0; i < npages; i++) {
-            ptr[i * pagesize] = 42; // Dirty each page
-            
-            if (pause) {
-                pause = NO;
-                NSLog(@"*** Pausing memory consumption to allow Bugsnag to write breadcrumbs and metadata");
-                [NSThread sleepForTimeInterval:0.5];
-                NSLog(@"*** Resuming memory consumption...");
-            }
+- (void)timerFired {
+    [self consumeMegabytes:_blockSize];
+}
+
+- (void)consumeMegabytes:(NSUInteger)megabytes {
+    for (NSUInteger i = 0; i < megabytes; i++) {
+        const NSUInteger pagesize = NSPageSize();
+        const NSUInteger npages = MEGABYTE / pagesize;
+        volatile char *ptr = malloc(MEGABYTE);
+        for (NSUInteger page = 0; page < npages; page++) {
+            ptr[page * pagesize] = 42; // Dirty each page
         }
     }
+#if PRINT_STATS
+    task_vm_info_data_t info;
+    mach_msg_type_number_t count = TASK_VM_INFO_COUNT;
+    kern_return_t result = task_info(mach_task_self(), TASK_VM_INFO, (task_info_t) &info, &count);
+    assert(result == KERN_SUCCESS);
+    unsigned long long physicalMemory = NSProcessInfo.processInfo.physicalMemory;
+    NSLog(@"%4llu / %4llu MB (%llu%%)", info.phys_footprint / MEGABYTE, physicalMemory / MEGABYTE, info.phys_footprint * 100 / physicalMemory);
+#endif
 }
 
 @end


### PR DESCRIPTION
## Goal

Observed another [OOM flake](https://buildkite.com/bugsnag/bugsnag-cocoa/builds/1803#f501b03a-a674-4e39-94fb-5d83c654cffa) where it appears the low memory warning was not received / processed despite the previous changes. This PR aims to improve reliability of the test.

## Design

The scenario will now consume a large amount of memory (enough to trigger a warning) very quickly, and then consume the remainder in a slower fashion.

Everything now happens on the main thread, using a timer for the second phase of allocations to ensure that the run loop has a chance to run and process any memory warnings.

## Testing

Tested locally with 3 different devices, and by [repeatedly running the barebones tests](https://buildkite.com/bugsnag/bugsnag-cocoa/builds?branch=nickdowell%2Fimprove-oom-scenario-reliability) (which run OOMScenario)