### PR TITLE
[PLAT-5849] Improve logging for E2E tests

### DIFF
--- a/Bugsnag/BugsnagCrashSentry.m
+++ b/Bugsnag/BugsnagCrashSentry.m
@@ -6,15 +6,16 @@
 //
 //
 
-#import "BSG_KSCrashAdvanced.h"
-#import "BSG_KSCrashC.h"
 
 #import "BugsnagCrashSentry.h"
-#import "BugsnagLogger.h"
-#import "BugsnagErrorReportSink.h"
-#import "BugsnagConfiguration.h"
+
+#import "BSG_KSCrashAdvanced.h"
+#import "BSG_KSCrashC.h"
 #import "Bugsnag.h"
+#import "BugsnagConfiguration.h"
+#import "BugsnagErrorReportSink.h"
 #import "BugsnagErrorTypes.h"
+#import "BugsnagLogger.h"
 
 @implementation BugsnagCrashSentry
 
@@ -85,6 +86,9 @@
                                        eventOverrides:eventOverrides
                                              metadata:metadata
                                                config:config];
+    
+    bsg_log_debug(@"Saved KSCrashReport for \"%@\" \"%@\"", handledState[@"severityReasonType"],
+                  [[eventOverrides[@"exceptions"] firstObject] valueForKey:@"errorClass"]);
 }
 
 @end

--- a/Bugsnag/Delivery/BugsnagApiClient.m
+++ b/Bugsnag/Delivery/BugsnagApiClient.m
@@ -91,9 +91,11 @@ typedef NS_ENUM(NSInteger, HTTPStatusCode) {
     mutableHeaders[BugsnagHTTPHeaderNameIntegrity] = [NSString stringWithFormat:@"sha1 %@", [self SHA1HashStringWithData:data]];
     
     NSMutableURLRequest *request = [self prepareRequest:url headers:mutableHeaders];
+    bsg_log_debug(@"Sending %lu byte payload to %@", (unsigned long)data.length, url);
     
     [[self.session uploadTaskWithRequest:request fromData:data completionHandler:^(NSData *data, NSURLResponse *response, NSError *error) {
         if (![response isKindOfClass:[NSHTTPURLResponse class]]) {
+            bsg_log_debug(@"Request to %@ completed with error %@", url, error);
             return completionHandler(BugsnagApiClientDeliveryStatusFailed, error ?:
                                      [NSError errorWithDomain:@"BugsnagApiClientErrorDomain" code:0 userInfo:@{
                                          NSLocalizedDescriptionKey: @"Request failed: no response was received",
@@ -101,6 +103,7 @@ typedef NS_ENUM(NSInteger, HTTPStatusCode) {
         }
         
         NSInteger statusCode = ((NSHTTPURLResponse *)response).statusCode;
+        bsg_log_debug(@"Request to %@ completed with status code %ld", url, (long)statusCode);
         
         if (statusCode / 100 == 2) {
             return completionHandler(BugsnagApiClientDeliveryStatusDelivered, nil);

--- a/Bugsnag/Delivery/BugsnagApiClient.m
+++ b/Bugsnag/Delivery/BugsnagApiClient.m
@@ -114,6 +114,9 @@ typedef NS_ENUM(NSInteger, HTTPStatusCode) {
                                         (long)statusCode, [NSHTTPURLResponse localizedStringForStatusCode:statusCode]],
             NSURLErrorFailingURLErrorKey: url }];
         
+        bsg_log_debug(@"Response headers: %@", ((NSHTTPURLResponse *)response).allHeaderFields);
+        bsg_log_debug(@"Response body: %.*s", (int)data.length, data.bytes);
+        
         if (statusCode / 100 == 4 &&
             statusCode != HTTPStatusCodePaymentRequired &&
             statusCode != HTTPStatusCodeProxyAuthenticationRequired &&

--- a/Bugsnag/KSCrash/Source/KSCrash/Recording/BSG_KSCrash.m
+++ b/Bugsnag/KSCrash/Source/KSCrash/Recording/BSG_KSCrash.m
@@ -264,17 +264,21 @@
     [self.crashReportStore pruneFilesLeaving:self.maxStoredReports];
 
     NSDictionary *reports = [self allReportsByFilename];
+    if (!reports.count) {
+        return;
+    }
 
     BSG_KSLOG_INFO(@"Sending %lu crash reports", (unsigned long)reports.count);
 
     [self sendReports:reports
             withBlock:^(NSString *filename, BOOL completed,
                     NSError *error) {
-                BSG_KSLOG_DEBUG(@"Process finished with completion: %d", completed);
+                BSG_KSLOG_DEBUG(@"Sending finished with completion: %d", completed);
                 if (error != nil) {
                     BSG_KSLOG_ERROR(@"Failed to send reports: %@", error);
                 }
                 if (completed && filename != nil) {
+                    BSG_KSLOG_DEBUG(@"Deleting KSCrashReport %@", filename);
                     [self.crashReportStore deleteFileWithId:filename];
                 }
             }];

--- a/features/fixtures/ios-swift-cocoapods/Podfile
+++ b/features/fixtures/ios-swift-cocoapods/Podfile
@@ -11,3 +11,13 @@ target 'iOSTestApp' do
   pod 'Bugsnag', path: '../../..'
 
 end
+
+post_install do |installer|
+  installer.pods_project.targets.each do |target|
+    if target.name == "Bugsnag"
+      target.build_configurations.each do |config|
+        config.build_settings['GCC_PREPROCESSOR_DEFINITIONS'] ||= ['$(inherited)', 'BSG_LOG_LEVEL=BSG_LOGLEVEL_DEBUG']
+      end
+    end
+  end
+end


### PR DESCRIPTION
## Goal

More detailed logs to help diagnose E2E test failures and flakes.

## Changeset

* Enabled debug-level logging for the iOS test fixture.
* Added debug log statements related to saving and deleting KSCrashReports.
* Added debug log statements related to HTTP requests for events and sessions.

## Testing

Tested locally using example app, and by examining device logs on BrowserStack to verify expected messages are included ([example](https://app-automate.browserstack.com/s3-upload/bs-selenium-logs-usw/s3.us-west-1/e6e6e87a967a90464340ff48363c721a8f0b1ca5/e6e6e87a967a90464340ff48363c721a8f0b1ca5-device-logs.txt?X-Amz-Algorithm=AWS4-HMAC-SHA256&X-Amz-Credential=AKIA2XUQHUQMNUFLEXQQ%2F20210127%2Fus-west-1%2Fs3%2Faws4_request&X-Amz-Date=20210127T114032Z&X-Amz-Expires=604800&X-Amz-SignedHeaders=host&X-Amz-Signature=7de44782acd842938f874abc09e3f5bfe657f76efa791f856157640ee91b0dc4))