### PR TITLE
[PLAT-5729 ] Fix malformed NSError from BSGJSONSerialization

### DIFF
--- a/Bugsnag.xcodeproj/project.pbxproj
+++ b/Bugsnag.xcodeproj/project.pbxproj
@@ -789,9 +789,9 @@
 		CBCF77A725010648004AF22A /* BSGJSONSerialization.m in Sources */ = {isa = PBXBuildFile; fileRef = CBCF77A225010648004AF22A /* BSGJSONSerialization.m */; };
 		CBCF77A825010648004AF22A /* BSGJSONSerialization.m in Sources */ = {isa = PBXBuildFile; fileRef = CBCF77A225010648004AF22A /* BSGJSONSerialization.m */; };
 		CBCF77A925010648004AF22A /* BSGJSONSerialization.m in Sources */ = {isa = PBXBuildFile; fileRef = CBCF77A225010648004AF22A /* BSGJSONSerialization.m */; };
-		CBCF77AB250142E0004AF22A /* BSGJSONSerializerTest.m in Sources */ = {isa = PBXBuildFile; fileRef = CBCF77AA250142E0004AF22A /* BSGJSONSerializerTest.m */; };
-		CBCF77AC250142E0004AF22A /* BSGJSONSerializerTest.m in Sources */ = {isa = PBXBuildFile; fileRef = CBCF77AA250142E0004AF22A /* BSGJSONSerializerTest.m */; };
-		CBCF77AD250142E0004AF22A /* BSGJSONSerializerTest.m in Sources */ = {isa = PBXBuildFile; fileRef = CBCF77AA250142E0004AF22A /* BSGJSONSerializerTest.m */; };
+		CBCF77AB250142E0004AF22A /* BSGJSONSerializationTests.m in Sources */ = {isa = PBXBuildFile; fileRef = CBCF77AA250142E0004AF22A /* BSGJSONSerializationTests.m */; };
+		CBCF77AC250142E0004AF22A /* BSGJSONSerializationTests.m in Sources */ = {isa = PBXBuildFile; fileRef = CBCF77AA250142E0004AF22A /* BSGJSONSerializationTests.m */; };
+		CBCF77AD250142E0004AF22A /* BSGJSONSerializationTests.m in Sources */ = {isa = PBXBuildFile; fileRef = CBCF77AA250142E0004AF22A /* BSGJSONSerializationTests.m */; };
 		CBDD6D0725AC3EFF00A2E12B /* BSGStorageMigratorTests.m in Sources */ = {isa = PBXBuildFile; fileRef = CB6419AA25A73E8C00613D25 /* BSGStorageMigratorTests.m */; };
 		CBDD6D0F25AC3EFF00A2E12B /* BSGStorageMigratorTests.m in Sources */ = {isa = PBXBuildFile; fileRef = CB6419AA25A73E8C00613D25 /* BSGStorageMigratorTests.m */; };
 		CBE9062A25A34DAB0045B965 /* BSGStorageMigratorV0V1.h in Headers */ = {isa = PBXBuildFile; fileRef = CBE9062825A34DAB0045B965 /* BSGStorageMigratorV0V1.h */; };
@@ -1333,7 +1333,7 @@
 		CBCAF6F925A457F90095771F /* BSGFileLocations.m */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.objc; path = BSGFileLocations.m; sourceTree = "<group>"; };
 		CBCF77A125010648004AF22A /* BSGJSONSerialization.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; path = BSGJSONSerialization.h; sourceTree = "<group>"; };
 		CBCF77A225010648004AF22A /* BSGJSONSerialization.m */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.objc; path = BSGJSONSerialization.m; sourceTree = "<group>"; };
-		CBCF77AA250142E0004AF22A /* BSGJSONSerializerTest.m */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.objc; path = BSGJSONSerializerTest.m; sourceTree = "<group>"; };
+		CBCF77AA250142E0004AF22A /* BSGJSONSerializationTests.m */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.objc; path = BSGJSONSerializationTests.m; sourceTree = "<group>"; };
 		CBE9062825A34DAB0045B965 /* BSGStorageMigratorV0V1.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; path = BSGStorageMigratorV0V1.h; sourceTree = "<group>"; };
 		CBE9062925A34DAB0045B965 /* BSGStorageMigratorV0V1.m */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.objc; path = BSGStorageMigratorV0V1.m; sourceTree = "<group>"; };
 		E701FA9E2490EF4A008D842F /* BugsnagApiValidationTest.m */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.objc; path = BugsnagApiValidationTest.m; sourceTree = "<group>"; };
@@ -1664,7 +1664,7 @@
 			children = (
 				00896A3F2486DBDD00DC48C2 /* BSGConfigurationBuilderTests.m */,
 				008966C62486D43600DC48C2 /* BSGConnectivityTest.m */,
-				CBCF77AA250142E0004AF22A /* BSGJSONSerializerTest.m */,
+				CBCF77AA250142E0004AF22A /* BSGJSONSerializationTests.m */,
 				008966C82486D43600DC48C2 /* BSGOutOfMemoryTests.m */,
 				CB6419AA25A73E8C00613D25 /* BSGStorageMigratorTests.m */,
 				CB9103632502320A00E9D1E2 /* BugsnagApiClientTest.m */,
@@ -2581,7 +2581,7 @@
 				008967722486D43700DC48C2 /* KSSysCtl_Tests.m in Sources */,
 				0089676C2486D43700DC48C2 /* BugsnagTestsDummyClass.m in Sources */,
 				008966EB2486D43700DC48C2 /* BugsnagDeviceTest.m in Sources */,
-				CBCF77AB250142E0004AF22A /* BSGJSONSerializerTest.m in Sources */,
+				CBCF77AB250142E0004AF22A /* BSGJSONSerializationTests.m in Sources */,
 				008967A22486D43700DC48C2 /* KSCrashSentry_Signal_Tests.m in Sources */,
 				008967272486D43700DC48C2 /* BugsnagStackframeTest.m in Sources */,
 				008967302486D43700DC48C2 /* BugsnagStateEventTest.m in Sources */,
@@ -2748,7 +2748,7 @@
 				008967342486D43700DC48C2 /* BugsnagClientTests.m in Sources */,
 				008967222486D43700DC48C2 /* BugsnagErrorReportSinkTests.m in Sources */,
 				CB10E540250BA8DF00AF5824 /* BugsnagKVStoreTest.m in Sources */,
-				CBCF77AC250142E0004AF22A /* BSGJSONSerializerTest.m in Sources */,
+				CBCF77AC250142E0004AF22A /* BSGJSONSerializationTests.m in Sources */,
 				0089679A2486D43700DC48C2 /* FileBasedTestCase.m in Sources */,
 				008967912486D43700DC48C2 /* KSJSONCodec_Tests.m in Sources */,
 				008967732486D43700DC48C2 /* KSSysCtl_Tests.m in Sources */,
@@ -2955,7 +2955,7 @@
 				008967A42486D43700DC48C2 /* KSCrashSentry_Signal_Tests.m in Sources */,
 				E701FAB12490EFE8008D842F /* ConfigurationApiValidationTest.m in Sources */,
 				0089677D2486D43700DC48C2 /* RFC3339DateTool_Tests.m in Sources */,
-				CBCF77AD250142E0004AF22A /* BSGJSONSerializerTest.m in Sources */,
+				CBCF77AD250142E0004AF22A /* BSGJSONSerializationTests.m in Sources */,
 				0163BF5B25823D8D008DC28B /* NotificationBreadcrumbTests.m in Sources */,
 				008967562486D43700DC48C2 /* BugsnagOnCrashTest.m in Sources */,
 				008967A12486D43700DC48C2 /* KSCrashSentry_Tests.m in Sources */,

--- a/Bugsnag/Helpers/BSGJSONSerialization.m
+++ b/Bugsnag/Helpers/BSGJSONSerialization.m
@@ -12,12 +12,9 @@
 @implementation BSGJSONSerialization
 
 static NSError* wrapException(NSException* exception) {
-    NSDictionary *userInfo = @{
-        NSLocalizedDescriptionKey: exception.description,
-        NSUnderlyingErrorKey: exception,
-    };
-
-    return [NSError errorWithDomain:@"BSGJSONSerializationErrorDomain" code:1 userInfo:userInfo];
+    return [NSError errorWithDomain:@"BSGJSONSerializationErrorDomain" code:1 userInfo:@{
+        NSLocalizedDescriptionKey: [NSString stringWithFormat:@"%@: %@", exception.name, exception.reason]
+    }];
 }
 
 + (BOOL)isValidJSONObject:(id)obj {

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,8 @@ Changelog
 
 * Fix compiler warnings when importing Bugsnag from Objective-C sources that do not use ARC.
   [#985](https://github.com/bugsnag/bugsnag-cocoa/pull/985)
+* Fix a rare crash that could occur in the event of JSON parsing failures.
+  [#987](https://github.com/bugsnag/bugsnag-cocoa/pull/987)
 
 ## 6.6.0 (2021-01-20)
 

--- a/Tests/BSGJSONSerializationTests.m
+++ b/Tests/BSGJSONSerializationTests.m
@@ -1,5 +1,5 @@
 //
-//  BSGJSONSerializerTest.m
+//  BSGJSONSerializationTests.m
 //  Bugsnag
 //
 //  Created by Karl Stenerud on 03.09.20.
@@ -7,13 +7,13 @@
 //
 
 #import <XCTest/XCTest.h>
+
 #import "BSGJSONSerialization.h"
 
-@interface BSGJSONSerializerTest : XCTestCase
-
+@interface BSGJSONSerializationTests : XCTestCase
 @end
 
-@implementation BSGJSONSerializerTest
+@implementation BSGJSONSerializationTests
 
 - (void)testBadJSONKey {
     id badDict = @{@123: @"string"};
@@ -74,6 +74,17 @@
     error = nil;
     XCTAssertNil([BSGJSONSerialization JSONObjectWithContentsOfFile:unwritablePath options:0 error:&error]);
     XCTAssertNotNil(error);
+}
+
+- (void)testExceptionHandling {
+    NSError *error = nil;
+#pragma clang diagnostic push
+#pragma clang diagnostic ignored "-Wnonnull"
+    XCTAssertNil([BSGJSONSerialization JSONObjectWithData:nil options:0 error:&error]);
+#pragma clang diagnostic pop
+    XCTAssertNotNil(error);
+    id underlyingError = error.userInfo[NSUnderlyingErrorKey];
+    XCTAssert(!underlyingError || [underlyingError isKindOfClass:[NSError class]], @"The value of %@ should be an NSError", NSUnderlyingErrorKey);
 }
 
 @end


### PR DESCRIPTION
## Goal

Fixes a low-occurrence crash observed in a customer dashboard

```
NSInvalidArgumentException: -[NSException domain]: unrecognized selector sent to instance 0x29b7d8930

0  CoreFoundation    ___exceptionPreprocess
1  libobjc.A.dylib   _objc_exception_throw
2  CoreFoundation    -[NSObject(NSObject) doesNotRecognizeSelector:]
3  CoreFoundation    ____forwarding___
4  CoreFoundation    ___forwarding_prep_0___
5  CoreFoundation    _CFErrorGetDomain
6  CoreFoundation    __CFErrorCopyUserInfoKeyFromCallBack
7  CoreFoundation    __CFErrorFormatDebugDescriptionAux
8  CoreFoundation    _userInfoKeyValueShow
9  CoreFoundation    -[__NSDictionaryI __apply:context:]
10 CoreFoundation    __CFErrorFormatDebugDescriptionAux
11 CoreFoundation    __CFErrorCreateDebugDescription
12 Foundation        -[NSError description]
13 CoreFoundation    -[NSObject(NSObject) _copyDescription]
14 CoreFoundation    _CFCopyDescription
15 CoreFoundation    ___CFStringAppendFormatCore
16 CoreFoundation    __CFStringCreateWithFormatAndArgumentsAux2
17 App               bsg_i_kslog_logObjC (BSG_KSLogger.m:259:29)
18 App               -[BSG_KSCrash captureThreads:depth:recordAllThreads:] (BSG_KSCrash.m:348:9)
19 App               -[BugsnagClient notify:handledState:block:] (BugsnagClient.m:980:24)
20 App               -[BugsnagClient notifyError:block:] (BugsnagClient.m:870:5)
21 App               +[Bugsnag notifyError:block:] (Bugsnag.m:132:9)
```

I was not able to reproduce the crash in a test case, but the root cause was an `NSException` being asked for its `domain` (which it doesn't have) so something that was expecting to be passed an `NSError` was being passed an `NSException`.

From the involvement of `-[BSG_KSCrash captureThreads:depth:recordAllThreads:]` it can be seen that the error being logged came from `[BSGJSONSerialization JSONObjectWithData:options:error:]`

So the root cause is an [exception object being passed as the value for NSUnderlyingErrorKey](https://github.com/bugsnag/bugsnag-cocoa/blob/v6.6.0/Bugsnag/Helpers/BSGJSONSerialization.m#L17) and the system libraries trying to interpret it as an NSError in accordance with the documentation;

```objc
// Key in userInfo. A recommended standard way to embed NSErrors from underlying calls.
// The value of this key should be an NSError.
FOUNDATION_EXPORT NSErrorUserInfoKey const NSUnderlyingErrorKey;
```

## Changeset

* Removed offending value for `NSUnderlyingErrorKey`
* Added test case and renamed test class / file to match convention (`<ClassBeingTested>Tests`)

## Testing

Was not able to reproduce the crash.

Added test case to verify that NSUnderlyingErrorKey is an NSError, if provided.
