### PR TITLE
Review Appium version use on iOS 10 and 11

### DIFF
--- a/.buildkite/pipeline.full.yml
+++ b/.buildkite/pipeline.full.yml
@@ -1,5 +1,5 @@
 steps:
-  - label: ':ios: iOS 13 end-to-end tests'
+  - label: ':ios: iOS 13 full end-to-end tests'
     depends_on:
       - cocoa_fixture
     timeout_in_minutes: 120
@@ -24,7 +24,7 @@ steps:
         - exit_status: -1  # Agent was lost
           limit: 2
 
-  - label: ':ios: iOS 12 end-to-end tests'
+  - label: ':ios: iOS 12 full end-to-end tests'
     depends_on:
       - cocoa_fixture
     timeout_in_minutes: 120
@@ -49,7 +49,7 @@ steps:
         - exit_status: -1  # Agent was lost
           limit: 2
 
-  - label: ':ios: iOS 11 end-to-end tests'
+  - label: ':ios: iOS 11 full end-to-end tests'
     depends_on:
       - cocoa_fixture
     # More time than other steps as the BrowserStack iOS 11 devices seem particularly unstable and
@@ -66,8 +66,7 @@ steps:
           - "--app=/app/build/iOSTestApp.ipa"
           - "--farm=bs"
           - "--device=IOS_11_0_IPHONE_8_PLUS"
-          - "--resilient"
-          - "--appium-version=1.16.0"
+          - "--appium-version=1.7.0"
           - "--fail-fast"
     concurrency: 9
     concurrency_group: browserstack-app

--- a/.buildkite/pipeline.quick.yml
+++ b/.buildkite/pipeline.quick.yml
@@ -199,8 +199,7 @@ steps:
           - "--app=/app/build/iOSTestApp.ipa"
           - "--farm=bs"
           - "--device=IOS_10"
-          - "--resilient"
-          - "--appium-version=1.15.0"
+          - "--appium-version=1.7.0"
           - "--fail-fast"
     concurrency: 9
     concurrency_group: browserstack-app

--- a/.buildkite/pipeline.quick.yml
+++ b/.buildkite/pipeline.quick.yml
@@ -184,10 +184,10 @@ steps:
         - exit_status: -1  # Agent was lost
           limit: 2
 
-  - label: ':ios: iOS 10 full end-to-end tests'
+  - label: ':ios: iOS 10 full end-to-end tests - batch 1'
     depends_on:
       - cocoa_fixture
-    timeout_in_minutes: 120
+    timeout_in_minutes: 60
     agents:
       queue: opensource
     plugins:
@@ -201,6 +201,34 @@ steps:
           - "--device=IOS_10"
           - "--appium-version=1.7.0"
           - "--fail-fast"
+          - "-e"
+          - "features/[o-z].*.feature"
+    concurrency: 9
+    concurrency_group: browserstack-app
+    retry:
+      automatic:
+        - exit_status: -1  # Agent was lost
+          limit: 2
+
+  - label: ':ios: iOS 10 full end-to-end tests - batch 2'
+    depends_on:
+      - cocoa_fixture
+    timeout_in_minutes: 60
+    agents:
+      queue: opensource
+    plugins:
+      artifacts#v1.3.0:
+        download: ["features/fixtures/ios-swift-cocoapods/output/iOSTestApp.ipa"]
+      docker-compose#v3.3.0:
+        run: cocoa-maze-runner
+        command:
+          - "--app=/app/build/iOSTestApp.ipa"
+          - "--farm=bs"
+          - "--device=IOS_10"
+          - "--appium-version=1.7.0"
+          - "--fail-fast"
+          - "-e"
+          - "features/[a-n].*.feature"
     concurrency: 9
     concurrency_group: browserstack-app
     retry:

--- a/.buildkite/pipeline.yml
+++ b/.buildkite/pipeline.yml
@@ -158,8 +158,7 @@ steps:
           - "--app=/app/build/iOSTestApp.ipa"
           - "--farm=bs"
           - "--device=IOS_10"
-          - "--resilient"
-          - "--appium-version=1.15.0"
+          - "--appium-version=1.7.0"
           - "--fail-fast"
     concurrency: 9
     concurrency_group: browserstack-app

--- a/features/steps/ios_steps.rb
+++ b/features/steps/ios_steps.rb
@@ -29,12 +29,19 @@ When('I clear all persistent data') do
   )
 end
 
+def click_if_present(element)
+  return false unless Maze.driver.wait_for_element(element, 1)
+
+  Maze.driver.click_element(element)
+  true
+rescue Selenium::WebDriver::Error::NoSuchElementError
+  # Ignore - we have seen clicks fail like this despite having just checked for the element's presence
+  false
+end
+
 When('I close the keyboard') do
   unless Maze.driver.capabilities['platformName'].eql?('Mac')
-    steps %(
-      Given the element "close_keyboard" is present
-      And I click the element "close_keyboard"
-    )
+    click_if_present 'close_keyboard'
   end
 end
 


### PR DESCRIPTION
## Goal

Use an earlier version of Appium (1.7.0) on iOS 10 and 11 to avoid a bug in 1.15/1.16 that causes session instability.

## Changeset

During testing some devices showed errors closing the keyboard, so I've relaxed the behaviour to ignore any cases of the keyboard not being present in the first place.

I've removed use of the resilient driver on iOS 10/11 to allow us more readily form a picture of how the change performs over a series of scheduled overnight builds.

## Testing

Covered by CI.  Running with Appium 1.7.0 against all 11 iOS devices available on BrowserStack yielded good results, although we will continue to monitor the situation,