### PR TITLE
[PLAT-5892] Implement lastRunInfo & consecutiveLaunchCrashes

### DIFF
--- a/Bugsnag.xcodeproj/project.pbxproj
+++ b/Bugsnag.xcodeproj/project.pbxproj
@@ -660,6 +660,13 @@
 		01C17AE72542ED7F00C102C9 /* KSCrashReportWriterTests.m in Sources */ = {isa = PBXBuildFile; fileRef = 01C17AE62542ED7F00C102C9 /* KSCrashReportWriterTests.m */; };
 		01C17AE82542ED7F00C102C9 /* KSCrashReportWriterTests.m in Sources */ = {isa = PBXBuildFile; fileRef = 01C17AE62542ED7F00C102C9 /* KSCrashReportWriterTests.m */; };
 		01C17AE92542ED7F00C102C9 /* KSCrashReportWriterTests.m in Sources */ = {isa = PBXBuildFile; fileRef = 01C17AE62542ED7F00C102C9 /* KSCrashReportWriterTests.m */; };
+		01CCAEEA25D414D60057268D /* BugsnagLastRunInfo.h in Headers */ = {isa = PBXBuildFile; fileRef = 01CCAEE825D414D60057268D /* BugsnagLastRunInfo.h */; settings = {ATTRIBUTES = (Public, ); }; };
+		01CCAEEB25D414D60057268D /* BugsnagLastRunInfo.h in Headers */ = {isa = PBXBuildFile; fileRef = 01CCAEE825D414D60057268D /* BugsnagLastRunInfo.h */; settings = {ATTRIBUTES = (Public, ); }; };
+		01CCAEEC25D414D60057268D /* BugsnagLastRunInfo.h in Headers */ = {isa = PBXBuildFile; fileRef = 01CCAEE825D414D60057268D /* BugsnagLastRunInfo.h */; settings = {ATTRIBUTES = (Public, ); }; };
+		01CCAEED25D414D60057268D /* BugsnagLastRunInfo.m in Sources */ = {isa = PBXBuildFile; fileRef = 01CCAEE925D414D60057268D /* BugsnagLastRunInfo.m */; };
+		01CCAEEE25D414D60057268D /* BugsnagLastRunInfo.m in Sources */ = {isa = PBXBuildFile; fileRef = 01CCAEE925D414D60057268D /* BugsnagLastRunInfo.m */; };
+		01CCAEEF25D414D60057268D /* BugsnagLastRunInfo.m in Sources */ = {isa = PBXBuildFile; fileRef = 01CCAEE925D414D60057268D /* BugsnagLastRunInfo.m */; };
+		01CCAEF025D414D60057268D /* BugsnagLastRunInfo.m in Sources */ = {isa = PBXBuildFile; fileRef = 01CCAEE925D414D60057268D /* BugsnagLastRunInfo.m */; };
 		01E8765E256684E700F4B70A /* URLSessionMock.m in Sources */ = {isa = PBXBuildFile; fileRef = 01E8765D256684E700F4B70A /* URLSessionMock.m */; };
 		01E8765F256684E700F4B70A /* URLSessionMock.m in Sources */ = {isa = PBXBuildFile; fileRef = 01E8765D256684E700F4B70A /* URLSessionMock.m */; };
 		01E87660256684E700F4B70A /* URLSessionMock.m in Sources */ = {isa = PBXBuildFile; fileRef = 01E8765D256684E700F4B70A /* URLSessionMock.m */; };
@@ -1294,6 +1301,9 @@
 		0198762E2567D5AB000A7AF3 /* BugsnagStackframe+Private.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; path = "BugsnagStackframe+Private.h"; sourceTree = "<group>"; };
 		01B14C55251CE55F00118748 /* report-react-native-promise-rejection.json */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = text.json; path = "report-react-native-promise-rejection.json"; sourceTree = "<group>"; };
 		01C17AE62542ED7F00C102C9 /* KSCrashReportWriterTests.m */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.objc; path = KSCrashReportWriterTests.m; sourceTree = "<group>"; };
+		01CCAEE825D414D60057268D /* BugsnagLastRunInfo.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; path = BugsnagLastRunInfo.h; sourceTree = "<group>"; };
+		01CCAEE925D414D60057268D /* BugsnagLastRunInfo.m */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.objc; path = BugsnagLastRunInfo.m; sourceTree = "<group>"; };
+		01CCAEFF25D4151C0057268D /* BugsnagLastRunInfo+Private.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; path = "BugsnagLastRunInfo+Private.h"; sourceTree = "<group>"; };
 		01D8EC3C256FC6C3006F2A2D /* BugsnagConfiguration+Private.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; path = "BugsnagConfiguration+Private.h"; sourceTree = "<group>"; };
 		01E8765C256684E700F4B70A /* URLSessionMock.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; path = URLSessionMock.h; sourceTree = "<group>"; };
 		01E8765D256684E700F4B70A /* URLSessionMock.m */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.objc; path = URLSessionMock.m; sourceTree = "<group>"; };
@@ -1639,6 +1649,8 @@
 				00AD1EFD2486A17800A27979 /* BugsnagErrorReportSink.h */,
 				00AD1EF92486A17700A27979 /* BugsnagErrorReportSink.m */,
 				01937D01257A7E0E00F2DE31 /* BugsnagErrorReportSink+Private.h */,
+				01CCAEE925D414D60057268D /* BugsnagLastRunInfo.m */,
+				01CCAEFF25D4151C0057268D /* BugsnagLastRunInfo+Private.h */,
 				00AD1EF82486A17700A27979 /* BugsnagSessionTracker.h */,
 				00AD1F012486A17900A27979 /* BugsnagSessionTracker.m */,
 				01937D09257A7ED000F2DE31 /* BugsnagSessionTracker+Private.h */,
@@ -1914,6 +1926,7 @@
 				3A700A9124A63A8E0068CD1B /* BugsnagError.h */,
 				3A700A8724A63A8E0068CD1B /* BugsnagErrorTypes.h */,
 				3A700A8824A63A8E0068CD1B /* BugsnagEvent.h */,
+				01CCAEE825D414D60057268D /* BugsnagLastRunInfo.h */,
 				3A700A9324A63A8E0068CD1B /* BugsnagMetadata.h */,
 				3A700A8324A63A8E0068CD1B /* BugsnagMetadataStore.h */,
 				3A700A8E24A63A8E0068CD1B /* BugsnagPlugin.h */,
@@ -2029,6 +2042,7 @@
 				008969962486DAD100DC48C2 /* BSG_KSBacktrace_Private.h in Headers */,
 				00896A112486DAD100DC48C2 /* BSG_KSCrashSentry_CPPException.h in Headers */,
 				008969ED2486DAD100DC48C2 /* BSG_KSCrashDoctor.h in Headers */,
+				01CCAEEA25D414D60057268D /* BugsnagLastRunInfo.h in Headers */,
 				01468F5225876DC1002B0519 /* BSGNotificationBreadcrumbs.h in Headers */,
 				008968ED2486DAB800DC48C2 /* BugsnagFileStore.h in Headers */,
 				00896A292486DAD100DC48C2 /* BSG_KSCrashType.h in Headers */,
@@ -2127,6 +2141,7 @@
 				00896A122486DAD100DC48C2 /* BSG_KSCrashSentry_CPPException.h in Headers */,
 				008969EE2486DAD100DC48C2 /* BSG_KSCrashDoctor.h in Headers */,
 				01468F5325876DC1002B0519 /* BSGNotificationBreadcrumbs.h in Headers */,
+				01CCAEEB25D414D60057268D /* BugsnagLastRunInfo.h in Headers */,
 				008968EE2486DAB800DC48C2 /* BugsnagFileStore.h in Headers */,
 				00896A2A2486DAD100DC48C2 /* BSG_KSCrashType.h in Headers */,
 				008969DC2486DAD100DC48C2 /* BSG_KSCrash.h in Headers */,
@@ -2225,6 +2240,7 @@
 				00896A132486DAD100DC48C2 /* BSG_KSCrashSentry_CPPException.h in Headers */,
 				008969EF2486DAD100DC48C2 /* BSG_KSCrashDoctor.h in Headers */,
 				01468F5425876DC1002B0519 /* BSGNotificationBreadcrumbs.h in Headers */,
+				01CCAEEC25D414D60057268D /* BugsnagLastRunInfo.h in Headers */,
 				008968EF2486DAB800DC48C2 /* BugsnagFileStore.h in Headers */,
 				00896A2B2486DAD100DC48C2 /* BSG_KSCrashType.h in Headers */,
 				008969DD2486DAD100DC48C2 /* BSG_KSCrash.h in Headers */,
@@ -2505,6 +2521,7 @@
 				008968912486DA9600DC48C2 /* BugsnagError.m in Sources */,
 				0089687C2486DA9500DC48C2 /* BugsnagBreadcrumb.m in Sources */,
 				008967FA2486DA4500DC48C2 /* BugsnagApiClient.m in Sources */,
+				01CCAEED25D414D60057268D /* BugsnagLastRunInfo.m in Sources */,
 				CBCAF6FD25A457F90095771F /* BSGFileLocations.m in Sources */,
 				008967DE2486DA2D00DC48C2 /* BSGConfigurationBuilder.m in Sources */,
 				008968C72486DA9600DC48C2 /* BugsnagApp.m in Sources */,
@@ -2671,6 +2688,7 @@
 				0089687D2486DA9500DC48C2 /* BugsnagBreadcrumb.m in Sources */,
 				008967FB2486DA4500DC48C2 /* BugsnagApiClient.m in Sources */,
 				008967DF2486DA2D00DC48C2 /* BSGConfigurationBuilder.m in Sources */,
+				01CCAEEE25D414D60057268D /* BugsnagLastRunInfo.m in Sources */,
 				CBCAF6FE25A457F90095771F /* BSGFileLocations.m in Sources */,
 				008968C82486DA9600DC48C2 /* BugsnagApp.m in Sources */,
 				00AD1F242486A17900A27979 /* Bugsnag.m in Sources */,
@@ -2835,6 +2853,7 @@
 				0089687E2486DA9600DC48C2 /* BugsnagBreadcrumb.m in Sources */,
 				008967FC2486DA4500DC48C2 /* BugsnagApiClient.m in Sources */,
 				008967E02486DA2D00DC48C2 /* BSGConfigurationBuilder.m in Sources */,
+				01CCAEEF25D414D60057268D /* BugsnagLastRunInfo.m in Sources */,
 				CBCAF6FF25A457F90095771F /* BSGFileLocations.m in Sources */,
 				008968C92486DA9600DC48C2 /* BugsnagApp.m in Sources */,
 				00AD1F252486A17900A27979 /* Bugsnag.m in Sources */,
@@ -2998,6 +3017,7 @@
 				E7462913248907E500F92D67 /* BSG_KSSignalInfo.c in Sources */,
 				E7462914248907E500F92D67 /* BSG_KSString.c in Sources */,
 				E7462915248907E500F92D67 /* BSG_KSObjC.c in Sources */,
+				01CCAEF025D414D60057268D /* BugsnagLastRunInfo.m in Sources */,
 				E7462916248907E500F92D67 /* BSG_KSCrashType.c in Sources */,
 				E7462917248907E500F92D67 /* BSG_KSCrashSentry_User.c in Sources */,
 				E7462918248907E500F92D67 /* BSG_KSCrashSentry_Signal.c in Sources */,

--- a/Bugsnag.xcodeproj/project.pbxproj
+++ b/Bugsnag.xcodeproj/project.pbxproj
@@ -657,6 +657,7 @@
 		01B14C56251CE55F00118748 /* report-react-native-promise-rejection.json in Resources */ = {isa = PBXBuildFile; fileRef = 01B14C55251CE55F00118748 /* report-react-native-promise-rejection.json */; };
 		01B14C57251CE55F00118748 /* report-react-native-promise-rejection.json in Resources */ = {isa = PBXBuildFile; fileRef = 01B14C55251CE55F00118748 /* report-react-native-promise-rejection.json */; };
 		01B14C58251CE55F00118748 /* report-react-native-promise-rejection.json in Resources */ = {isa = PBXBuildFile; fileRef = 01B14C55251CE55F00118748 /* report-react-native-promise-rejection.json */; };
+		01B6BB7E25D5777F00FC4DE6 /* BugsnagSwiftPublicAPITests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 008966B02486D43500DC48C2 /* BugsnagSwiftPublicAPITests.swift */; };
 		01C17AE72542ED7F00C102C9 /* KSCrashReportWriterTests.m in Sources */ = {isa = PBXBuildFile; fileRef = 01C17AE62542ED7F00C102C9 /* KSCrashReportWriterTests.m */; };
 		01C17AE82542ED7F00C102C9 /* KSCrashReportWriterTests.m in Sources */ = {isa = PBXBuildFile; fileRef = 01C17AE62542ED7F00C102C9 /* KSCrashReportWriterTests.m */; };
 		01C17AE92542ED7F00C102C9 /* KSCrashReportWriterTests.m in Sources */ = {isa = PBXBuildFile; fileRef = 01C17AE62542ED7F00C102C9 /* KSCrashReportWriterTests.m */; };
@@ -2946,6 +2947,7 @@
 				008967592486D43700DC48C2 /* BugsnagClientMirrorTest.m in Sources */,
 				0089676B2486D43700DC48C2 /* BugsnagSessionTrackerTest.m in Sources */,
 				E701FAA12490EF4A008D842F /* BugsnagApiValidationTest.m in Sources */,
+				01B6BB7E25D5777F00FC4DE6 /* BugsnagSwiftPublicAPITests.swift in Sources */,
 				0089677A2486D43700DC48C2 /* KSMachHeader_Tests.m in Sources */,
 				0089675F2486D43700DC48C2 /* BugsnagSessionTrackingPayloadTest.m in Sources */,
 				008967AA2486D43700DC48C2 /* KSCrashIdentifierTests.m in Sources */,

--- a/Bugsnag/Bugsnag.m
+++ b/Bugsnag/Bugsnag.m
@@ -100,6 +100,13 @@ static BugsnagClient *bsg_g_bugsnag_client = NULL;
     return NO;
 }
 
++ (BugsnagLastRunInfo *)lastRunInfo {
+    if ([self bugsnagStarted]) {
+        return self.client.lastRunInfo;
+    }
+    return nil;
+}
+
 + (void)markLaunchCompleted {
     if ([self bugsnagStarted]) {
         [self.client markLaunchCompleted];

--- a/Bugsnag/BugsnagLastRunInfo+Private.h
+++ b/Bugsnag/BugsnagLastRunInfo+Private.h
@@ -1,0 +1,17 @@
+//
+//  BugsnagLastRunInfo+Private.h
+//  Bugsnag
+//
+//  Created by Nick Dowell on 10/02/2021.
+//  Copyright © 2021 Bugsnag Inc. All rights reserved.
+//
+
+#include "BugsnagLastRunInfo.h"
+
+@interface BugsnagLastRunInfo ()
+
+- (instancetype)initWithConsecutiveLaunchCrashes:(NSUInteger)consecutiveLaunchCrashes
+                                         crashed:(BOOL)crashed
+                             crashedDuringLaunch:(BOOL)crashedDuringLaunch;
+
+@end

--- a/Bugsnag/BugsnagLastRunInfo.m
+++ b/Bugsnag/BugsnagLastRunInfo.m
@@ -1,0 +1,24 @@
+//
+//  BugsnagLastRunInfo.m
+//  Bugsnag
+//
+//  Created by Nick Dowell on 10/02/2021.
+//  Copyright © 2021 Bugsnag Inc. All rights reserved.
+//
+
+#import "BugsnagLastRunInfo+Private.h"
+
+@implementation BugsnagLastRunInfo
+
+- (instancetype)initWithConsecutiveLaunchCrashes:(NSUInteger)consecutiveLaunchCrashes
+                                         crashed:(BOOL)crashed
+                             crashedDuringLaunch:(BOOL)crashedDuringLaunch {
+    if (self = [super init]) {
+        _consecutiveLaunchCrashes = consecutiveLaunchCrashes;
+        _crashed = crashed;
+        _crashedDuringLaunch = crashedDuringLaunch;
+    }
+    return self;
+}
+
+@end

--- a/Bugsnag/BugsnagSystemState.h
+++ b/Bugsnag/BugsnagSystemState.h
@@ -7,6 +7,7 @@
 //
 
 #import <Foundation/Foundation.h>
+
 #import "BugsnagConfiguration.h"
 
 #define SYSTEMSTATE_KEY_APP @"app"
@@ -36,6 +37,8 @@ NS_ASSUME_NONNULL_BEGIN
 - (void)recordAppUUID;
 
 - (void)setCodeBundleID:(NSString*)codeBundleID;
+
+@property (nonatomic) NSUInteger consecutiveLaunchCrashes;
 
 /**
  * Purge all stored system state.

--- a/Bugsnag/BugsnagSystemState.m
+++ b/Bugsnag/BugsnagSystemState.m
@@ -29,6 +29,9 @@
 #import "BugsnagSessionTracker.h"
 #import "BugsnagSystemState.h"
 
+static NSString * const ConsecutiveLaunchCrashesKey = @"consecutiveLaunchCrashes";
+static NSString * const InternalKey = @"internal";
+
 static NSDictionary* loadPreviousState(BugsnagKVStore *kvstore, NSString *jsonPath) {
     NSData *data = [NSData dataWithContentsOfFile:jsonPath];
     if(data == nil) {
@@ -161,6 +164,7 @@ static NSDictionary *copyDictionary(NSDictionary *launchState) {
         _lastLaunchState = loadPreviousState(_kvStore, _persistenceFilePath);
         _currentLaunchStateRW = initCurrentState(_kvStore, config);
         _currentLaunchState = [_currentLaunchStateRW copy];
+        _consecutiveLaunchCrashes = [_lastLaunchState[InternalKey][ConsecutiveLaunchCrashesKey] unsignedIntegerValue];
         [self sync];
 
         __weak __typeof__(self) weakSelf = self;
@@ -233,13 +237,21 @@ static NSDictionary *copyDictionary(NSDictionary *launchState) {
     [self setValue:codeBundleID forAppKey:BSGKeyCodeBundleId];
 }
 
+- (void)setConsecutiveLaunchCrashes:(NSUInteger)consecutiveLaunchCrashes {
+    [self setValue:@(_consecutiveLaunchCrashes = consecutiveLaunchCrashes) forKey:ConsecutiveLaunchCrashesKey inSection:InternalKey];
+}
+
 - (void)setValue:(id)value forAppKey:(NSString *)key {
     [self setValue:value forKey:key inSection:SYSTEMSTATE_KEY_APP];
 }
 
 - (void)setValue:(id)value forKey:(NSString *)key inSection:(NSString *)section {
     [self mutateLaunchState:^(NSMutableDictionary *state) {
-        state[section][key] = value;
+        if (state[section]) {
+            state[section][key] = value;
+        } else {
+            state[section] = [NSMutableDictionary dictionaryWithObjectsAndKeys:value, key, nil];
+        }
     }];
 }
 

--- a/Bugsnag/include/Bugsnag/Bugsnag.h
+++ b/Bugsnag/include/Bugsnag/Bugsnag.h
@@ -35,6 +35,7 @@
 #import <Bugsnag/BugsnagError.h>
 #import <Bugsnag/BugsnagErrorTypes.h>
 #import <Bugsnag/BugsnagEvent.h>
+#import <Bugsnag/BugsnagLastRunInfo.h>
 #import <Bugsnag/BugsnagMetadata.h>
 #import <Bugsnag/BugsnagPlugin.h>
 #import <Bugsnag/BugsnagSession.h>
@@ -101,7 +102,12 @@
 /**
  * @return YES if Bugsnag has been started and the previous launch crashed
  */
-+ (BOOL)appDidCrashLastLaunch;
++ (BOOL)appDidCrashLastLaunch __attribute__((deprecated("use 'lastRunInfo.crashed' instead")));
+
+/**
+ * Information about the last run of the app, and whether it crashed.
+ */
+@property (class, readonly, nullable) BugsnagLastRunInfo *lastRunInfo;
 
 /**
  * Tells Bugsnag that your app has finished launching.

--- a/Bugsnag/include/Bugsnag/BugsnagClient.h
+++ b/Bugsnag/include/Bugsnag/BugsnagClient.h
@@ -27,6 +27,7 @@
 #import <Foundation/Foundation.h>
 
 #import <Bugsnag/BugsnagConfiguration.h>
+#import <Bugsnag/BugsnagLastRunInfo.h>
 #import <Bugsnag/BugsnagMetadata.h>
 #import <Bugsnag/BugsnagMetadataStore.h>
 
@@ -209,7 +210,12 @@ NS_SWIFT_NAME(leaveBreadcrumb(_:metadata:type:));
 /**
  * @return YES if Bugsnag has been started and the previous launch crashed
  */
-- (BOOL)appDidCrashLastLaunch;
+- (BOOL)appDidCrashLastLaunch __attribute__((deprecated("use 'lastRunInfo.crashed' instead")));
+
+/**
+ * Information about the last run of the app, and whether it crashed.
+ */
+@property (readonly, nullable, nonatomic) BugsnagLastRunInfo *lastRunInfo;
 
 /**
  * Tells Bugsnag that your app has finished launching.

--- a/Bugsnag/include/Bugsnag/BugsnagLastRunInfo.h
+++ b/Bugsnag/include/Bugsnag/BugsnagLastRunInfo.h
@@ -1,0 +1,39 @@
+//
+//  BugsnagLastRunInfo.h
+//  Bugsnag
+//
+//  Created by Nick Dowell on 10/02/2021.
+//  Copyright © 2021 Bugsnag Inc. All rights reserved.
+//
+
+#import <Foundation/Foundation.h>
+
+NS_ASSUME_NONNULL_BEGIN
+
+/**
+ * Contains information about the last run of the app.
+ */
+@interface BugsnagLastRunInfo : NSObject
+
+/**
+ * The number of consecutive runs that have ended with a crash while launching.
+ *
+ * See `BugsnagConfiguration.launchDurationMillis` for more information.
+ */
+@property (readonly, nonatomic) NSUInteger consecutiveLaunchCrashes;
+
+/**
+ * True if the previous run crashed.
+ */
+@property (readonly, nonatomic) BOOL crashed;
+
+/**
+ * True if the previous run crashed while launching.
+ *
+ * See `BugsnagConfiguration.launchDurationMillis` for more information.
+ */
+@property (readonly, nonatomic) BOOL crashedDuringLaunch;
+
+@end
+
+NS_ASSUME_NONNULL_END

--- a/Tests/BugsnagApiValidationTest.m
+++ b/Tests/BugsnagApiValidationTest.m
@@ -27,7 +27,7 @@
 
 - (void)testAppDidCrashLastLaunch {
     [TestSupport purgePersistentData];
-    XCTAssertFalse([Bugsnag appDidCrashLastLaunch]);
+    XCTAssertFalse(Bugsnag.lastRunInfo.crashed);
 }
 
 - (void)testValidNotify {
@@ -88,7 +88,7 @@
 }
 
 - (void)testValidAppDidCrashLastLaunch {
-    XCTAssertFalse(Bugsnag.appDidCrashLastLaunch);
+    XCTAssertFalse(Bugsnag.lastRunInfo.crashed);
 }
 
 - (void)testValidUser {

--- a/Tests/BugsnagClientMirrorTest.m
+++ b/Tests/BugsnagClientMirrorTest.m
@@ -133,6 +133,7 @@
             @"notificationBreadcrumbs @16@0:8",
             @"setAppLaunchTimer: v24@0:8@16",
             @"setConfigMetadataFromLastLaunch: v24@0:8@16",
+            @"setLastRunInfo: v24@0:8@16",
             @"setMetadataFromLastLaunch: v24@0:8@16",
             @"setNotificationBreadcrumbs: v24@0:8@16",
             @"setStarted: v20@0:8B16",

--- a/Tests/ClientApiValidationTest.m
+++ b/Tests/ClientApiValidationTest.m
@@ -85,7 +85,7 @@
 }
 
 - (void)testValidAppDidCrashLastLaunch {
-    XCTAssertFalse(self.client.appDidCrashLastLaunch);
+    XCTAssertFalse(self.client.lastRunInfo.crashed);
 }
 
 - (void)testValidUser {

--- a/Tests/Swift Tests/BugsnagSwiftPublicAPITests.swift
+++ b/Tests/Swift Tests/BugsnagSwiftPublicAPITests.swift
@@ -49,7 +49,7 @@ class BugsnagSwiftPublicAPITests: XCTestCase {
         Bugsnag.start(withApiKey: apiKey);
         Bugsnag.start(with: BugsnagConfiguration(apiKey))
         
-        let _ = Bugsnag.appDidCrashLastLaunch()
+        let _ = Bugsnag.lastRunInfo?.crashed
         
         Bugsnag.notify(ex)
         Bugsnag.notify(ex) { (event) -> Bool in return false }
@@ -268,7 +268,7 @@ class BugsnagSwiftPublicAPITests: XCTestCase {
         client.context = ""
         _ = client.context
         
-        let _ = client.appDidCrashLastLaunch()
+        let _ = client.lastRunInfo?.crashed
         
         client.setUser("me", withEmail: "memail@foo.com", andName: "you")
         let _ = client.user()

--- a/features/barebone_tests.feature
+++ b/features/barebone_tests.feature
@@ -127,6 +127,9 @@ Feature: Barebone tests
     And the event "metaData.error.mach.code_name" equals "KERN_INVALID_ADDRESS"
     And the event "metaData.error.mach.code" equals "0x1"
     And the event "metaData.error.mach.exception_name" is not null
+    And the event "metaData.lastRunInfo.consecutiveLaunchCrashes" equals 1
+    And the event "metaData.lastRunInfo.crashed" is true
+    And the event "metaData.lastRunInfo.crashedDuringLaunch" is true
     And the event "severity" equals "error"
     And the event "severityReason.type" equals "unhandledException"
     And the event "severityReason.unhandledOverridden" is null
@@ -210,6 +213,9 @@ Feature: Barebone tests
     And the event "metaData.device.simulator" is false
     And the event "metaData.device.timezone" is not null
     And the event "metaData.device.wordSize" is not null
+    And the event "metaData.lastRunInfo.consecutiveLaunchCrashes" equals 1
+    And the event "metaData.lastRunInfo.crashed" is true
+    And the event "metaData.lastRunInfo.crashedDuringLaunch" is true
     And the event "session.id" is not null
     And the event "session.startedAt" is not null
     And the event "session.events.handled" equals 0

--- a/features/fixtures/ios-swift-cocoapods/iOSTestApp.xcodeproj/project.pbxproj
+++ b/features/fixtures/ios-swift-cocoapods/iOSTestApp.xcodeproj/project.pbxproj
@@ -19,6 +19,7 @@
 		0104085F258CA0A100933C60 /* DispatchCrashScenario.swift in Sources */ = {isa = PBXBuildFile; fileRef = 0104085E258CA0A100933C60 /* DispatchCrashScenario.swift */; };
 		0163BFA72583B3CF008DC28B /* DiscardClassesScenarios.swift in Sources */ = {isa = PBXBuildFile; fileRef = 0163BFA62583B3CF008DC28B /* DiscardClassesScenarios.swift */; };
 		01AF6A53258A112F00FFC803 /* BareboneTestScenarios.swift in Sources */ = {isa = PBXBuildFile; fileRef = 01AF6A52258A112F00FFC803 /* BareboneTestScenarios.swift */; };
+		01B6BB7525D5748800FC4DE6 /* LastRunInfoScenarios.swift in Sources */ = {isa = PBXBuildFile; fileRef = 01B6BB7425D5748800FC4DE6 /* LastRunInfoScenarios.swift */; };
 		01E5EAD225B713990066EA8A /* OOMScenario.m in Sources */ = {isa = PBXBuildFile; fileRef = 01E5EAD125B713990066EA8A /* OOMScenario.m */; };
 		6526A0D4248A83350002E2C9 /* LoadConfigFromFileAutoScenario.swift in Sources */ = {isa = PBXBuildFile; fileRef = 6526A0D3248A83350002E2C9 /* LoadConfigFromFileAutoScenario.swift */; };
 		8A14F0F62282D4AE00337B05 /* (null) in Sources */ = {isa = PBXBuildFile; };
@@ -166,6 +167,7 @@
 		0104085E258CA0A100933C60 /* DispatchCrashScenario.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = DispatchCrashScenario.swift; sourceTree = "<group>"; };
 		0163BFA62583B3CF008DC28B /* DiscardClassesScenarios.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = DiscardClassesScenarios.swift; sourceTree = "<group>"; };
 		01AF6A52258A112F00FFC803 /* BareboneTestScenarios.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = BareboneTestScenarios.swift; sourceTree = "<group>"; };
+		01B6BB7425D5748800FC4DE6 /* LastRunInfoScenarios.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = LastRunInfoScenarios.swift; sourceTree = "<group>"; };
 		01E5EAD025B713990066EA8A /* OOMScenario.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; path = OOMScenario.h; sourceTree = "<group>"; };
 		01E5EAD125B713990066EA8A /* OOMScenario.m */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.objc; path = OOMScenario.m; sourceTree = "<group>"; };
 		4994F05E0421A0B037DD2CC5 /* Pods_iOSTestApp.framework */ = {isa = PBXFileReference; explicitFileType = wrapper.framework; includeInIndex = 0; path = Pods_iOSTestApp.framework; sourceTree = BUILT_PRODUCTS_DIR; };
@@ -565,6 +567,7 @@
 				8AB1081823301FE600672818 /* ReleaseStageScenarios.swift */,
 				F4295ABA693D273D52AA9F6B /* Scenario.h */,
 				F42954E8B66F3FB7F5333CF7 /* Scenario.m */,
+				01B6BB7425D5748800FC4DE6 /* LastRunInfoScenarios.swift */,
 				CBB7878F2578FC0C0071BDE4 /* MarkUnhandledHandledScenario.h */,
 				CBB787902578FC0C0071BDE4 /* MarkUnhandledHandledScenario.m */,
 				E7A324D4247E707D008B0052 /* Session Callbacks */,
@@ -881,6 +884,7 @@
 				F42955E0916B8851F074D9B3 /* UserEmailScenario.swift in Sources */,
 				E700EE4C247D12E4008CFFB6 /* UserFromConfigEventScenario.swift in Sources */,
 				8A3B5F292407F66700CE4A3A /* ModifyBreadcrumbScenario.swift in Sources */,
+				01B6BB7525D5748800FC4DE6 /* LastRunInfoScenarios.swift in Sources */,
 				E75040A2247801A8005D33BD /* AutoDetectFalseNSExceptionScenario.swift in Sources */,
 				F4295968571A4118D6A4606A /* UserEnabledScenario.swift in Sources */,
 				E700EE7E247D7A61008CFFB6 /* SIGSYSScenario.m in Sources */,

--- a/features/fixtures/macos/macOSTestApp.xcodeproj/project.pbxproj
+++ b/features/fixtures/macos/macOSTestApp.xcodeproj/project.pbxproj
@@ -18,6 +18,7 @@
 		017FBFB9254B09C300809042 /* MainWindowController.xib in Resources */ = {isa = PBXBuildFile; fileRef = 017FBFB7254B09C300809042 /* MainWindowController.xib */; };
 		01AF6A50258A00DE00FFC803 /* BareboneTestScenarios.swift in Sources */ = {isa = PBXBuildFile; fileRef = 01AF6A4F258A00DE00FFC803 /* BareboneTestScenarios.swift */; };
 		01AF6A84258BB38A00FFC803 /* DispatchCrashScenario.swift in Sources */ = {isa = PBXBuildFile; fileRef = 01AF6A83258BB38A00FFC803 /* DispatchCrashScenario.swift */; };
+		01B6BB7225D56CBF00FC4DE6 /* LastRunInfoScenarios.swift in Sources */ = {isa = PBXBuildFile; fileRef = 01B6BB7125D56CBF00FC4DE6 /* LastRunInfoScenarios.swift */; };
 		01ECBCF425A7522000FC0678 /* OnErrorOverwriteUnhandledFalseScenario.swift in Sources */ = {isa = PBXBuildFile; fileRef = 01ECBCF225A7522000FC0678 /* OnErrorOverwriteUnhandledFalseScenario.swift */; };
 		01ECBCF525A7522000FC0678 /* OnErrorOverwriteUnhandledTrueScenario.swift in Sources */ = {isa = PBXBuildFile; fileRef = 01ECBCF325A7522000FC0678 /* OnErrorOverwriteUnhandledTrueScenario.swift */; };
 		01F47CC4254B1B3100B184AD /* OriginalErrorNSExceptionScenario.swift in Sources */ = {isa = PBXBuildFile; fileRef = 01F47C21254B1B2C00B184AD /* OriginalErrorNSExceptionScenario.swift */; };
@@ -164,6 +165,7 @@
 		017FBFB7254B09C300809042 /* MainWindowController.xib */ = {isa = PBXFileReference; lastKnownFileType = file.xib; path = MainWindowController.xib; sourceTree = "<group>"; };
 		01AF6A4F258A00DE00FFC803 /* BareboneTestScenarios.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = BareboneTestScenarios.swift; sourceTree = "<group>"; };
 		01AF6A83258BB38A00FFC803 /* DispatchCrashScenario.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = DispatchCrashScenario.swift; sourceTree = "<group>"; };
+		01B6BB7125D56CBF00FC4DE6 /* LastRunInfoScenarios.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = LastRunInfoScenarios.swift; sourceTree = "<group>"; };
 		01ECBCF225A7522000FC0678 /* OnErrorOverwriteUnhandledFalseScenario.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = OnErrorOverwriteUnhandledFalseScenario.swift; sourceTree = "<group>"; };
 		01ECBCF325A7522000FC0678 /* OnErrorOverwriteUnhandledTrueScenario.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = OnErrorOverwriteUnhandledTrueScenario.swift; sourceTree = "<group>"; };
 		01F47C21254B1B2C00B184AD /* OriginalErrorNSExceptionScenario.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = OriginalErrorNSExceptionScenario.swift; sourceTree = "<group>"; };
@@ -404,6 +406,7 @@
 				01F47C4E254B1B2D00B184AD /* HandledErrorScenario.swift */,
 				01F47C28254B1B2C00B184AD /* HandledExceptionScenario.swift */,
 				01F47C55254B1B2E00B184AD /* HandledInternalNotifyScenario.swift */,
+				01B6BB7125D56CBF00FC4DE6 /* LastRunInfoScenarios.swift */,
 				01F47C23254B1B2C00B184AD /* LoadConfigFromFileAutoScenario.swift */,
 				01F47C94254B1B2F00B184AD /* LoadConfigFromFileScenario.swift */,
 				01F47C3B254B1B2D00B184AD /* ManualContextClientScenario.swift */,
@@ -752,6 +755,7 @@
 				01F47CF4254B1B3100B184AD /* OOMSessionScenario.swift in Sources */,
 				01F47D21254B1B3100B184AD /* SIGFPEScenario.m in Sources */,
 				01F47CEB254B1B3100B184AD /* AutoSessionHandledEventsScenario.m in Sources */,
+				01B6BB7225D56CBF00FC4DE6 /* LastRunInfoScenarios.swift in Sources */,
 				01F47CF7254B1B3100B184AD /* OnSendErrorCallbackCrashScenario.swift in Sources */,
 				01F47CDF254B1B3100B184AD /* AbortScenario.m in Sources */,
 				01F47CD1254B1B3100B184AD /* ManualContextClientScenario.swift in Sources */,

--- a/features/fixtures/macos/macOSTestApp/MainWindowController.m
+++ b/features/fixtures/macos/macOSTestApp/MainWindowController.m
@@ -51,11 +51,13 @@
 }
 
 - (IBAction)runScenario:(id)sender {
-    self.scenario = [Scenario createScenarioNamed:self.scenarioName withConfig:[self configuration]];
-    self.scenario.eventMode = self.scenarioMetadata;
+    if (!self.scenario) {
+        self.scenario = [Scenario createScenarioNamed:self.scenarioName withConfig:[self configuration]];
+        self.scenario.eventMode = self.scenarioMetadata;
 
-    NSLog(@"Starting Bugsnag for scenario: %@", self.scenario);
-    [self.scenario startBugsnag];
+        NSLog(@"Starting Bugsnag for scenario: %@", self.scenario);
+        [self.scenario startBugsnag];
+    }
 
     NSLog(@"Running scenario: %@", self.scenario);
     // Using dispatch_async to prevent AppleEvents swallowing exceptions.

--- a/features/fixtures/shared/scenarios/BareboneTestScenarios.swift
+++ b/features/fixtures/shared/scenarios/BareboneTestScenarios.swift
@@ -97,6 +97,16 @@ class BareboneTestUnhandledErrorScenario: Scenario {
             // The version of the app at report time.
             config.appVersion = "23.4"
             config.bundleVersion = "23401"
+            config.addOnSendError { [weak self] in
+                if let lastRunInfo = self?.client?.lastRunInfo {
+                    $0.addMetadata(
+                        ["consecutiveLaunchCrashes": lastRunInfo.consecutiveLaunchCrashes,
+                         "crashed": lastRunInfo.crashed,
+                         "crashedDuringLaunch": lastRunInfo.crashedDuringLaunch
+                        ], section: "lastRunInfo")
+                }
+                return true
+            }
         } else {
             // The version of the app at crash time.
             config.appVersion = "12.3"

--- a/features/fixtures/shared/scenarios/DiscardClassesScenarios.swift
+++ b/features/fixtures/shared/scenarios/DiscardClassesScenarios.swift
@@ -43,7 +43,7 @@ class DiscardClassesUnhandledExceptionScenario: Scenario {
         }
         super.startBugsnag()
         
-        if Bugsnag.appDidCrashLastLaunch() {
+        if Bugsnag.lastRunInfo?.crashed == true {
             Bugsnag.notify(NSException(name: .notDiscarded, reason: "This exception should not be discarded"))
         }
     }
@@ -66,7 +66,7 @@ class DiscardClassesUnhandledCrashScenario: Scenario {
         }
         super.startBugsnag()
         
-        if Bugsnag.appDidCrashLastLaunch() {
+        if Bugsnag.lastRunInfo?.crashed == true {
             Bugsnag.notify(NSException(name: .notDiscarded, reason: "This exception should not be discarded"))
         }
     }

--- a/features/fixtures/shared/scenarios/LastRunInfoScenarios.swift
+++ b/features/fixtures/shared/scenarios/LastRunInfoScenarios.swift
@@ -1,0 +1,28 @@
+//
+//  LastRunInfoScenarios.swift
+//  macOSTestApp
+//
+//  Created by Nick Dowell on 11/02/2021.
+//  Copyright © 2021 Bugsnag Inc. All rights reserved.
+//
+
+class LastRunInfoConsecutiveLaunchCrashesScenario: Scenario {
+    
+    override func startBugsnag() {
+        config.addOnSendError { [weak self] in
+            if let lastRunInfo = self?.client?.lastRunInfo {
+                $0.addMetadata(
+                    ["consecutiveLaunchCrashes": lastRunInfo.consecutiveLaunchCrashes,
+                     "crashed": lastRunInfo.crashed,
+                     "crashedDuringLaunch": lastRunInfo.crashedDuringLaunch
+                    ], section: "lastRunInfo")
+            }
+            return true
+        }
+        super.startBugsnag()
+    }
+    
+    override func run() {
+        fatalError("Oh no, the app crashed!")
+    }
+}

--- a/features/fixtures/shared/scenarios/OOMScenario.m
+++ b/features/fixtures/shared/scenarios/OOMScenario.m
@@ -19,8 +19,20 @@
 - (void)startBugsnag {
     self.config.autoTrackSessions = YES;
     self.config.enabledErrorTypes.ooms = YES;
+    self.config.launchDurationMillis = 0; // Ensure isLaunching will be true for the OOM, no matter how long it takes to occur.
     [self.config addMetadata:@{@"bar": @"foo"} toSection:@"custom"];
     [self.config setUser:@"foobar" withEmail:@"foobar@example.com" andName:@"Foo Bar"];
+    __weak typeof(self) weakSelf = self;
+    [self.config addOnSendErrorBlock:^BOOL(BugsnagEvent *event) {
+        BugsnagLastRunInfo *lastRunInfo = weakSelf.client.lastRunInfo;
+        if (lastRunInfo) {
+            [event addMetadata:@{@"consecutiveLaunchCrashes": @(lastRunInfo.consecutiveLaunchCrashes),
+                                 @"crashed": @(lastRunInfo.crashed),
+                                 @"crashedDuringLaunch": @(lastRunInfo.crashedDuringLaunch)}
+                     toSection:@"lastRunInfo"];
+        }
+        return true;
+    }];
     [super startBugsnag];
 }
 

--- a/features/fixtures/shared/scenarios/Scenario.h
+++ b/features/fixtures/shared/scenarios/Scenario.h
@@ -12,6 +12,8 @@ void markErrorHandledCallback(const BSG_KSCrashReportWriter * _Nonnull writer);
 
 @property (strong, nonatomic, nonnull) BugsnagConfiguration *config;
 
+@property (readonly, nullable, nonatomic) BugsnagClient *client;
+
 + (Scenario *_Nonnull)createScenarioNamed:(NSString *_Nonnull)className
                                withConfig:(BugsnagConfiguration *_Nonnull)config;
 

--- a/features/fixtures/shared/scenarios/Scenario.m
+++ b/features/fixtures/shared/scenarios/Scenario.m
@@ -76,7 +76,7 @@ void markErrorHandledCallback(const BSG_KSCrashReportWriter *writer) {
 - (void)startBugsnag {
     // TODO: PLAT-5827
     // [self waitForNetworkConnectivity]; // Disabled for now because MR v4 does not listen on /
-    [Bugsnag startWithConfiguration:self.config];
+    _client = [Bugsnag startWithConfiguration:self.config];
 }
 
 - (void)didEnterBackgroundNotification {

--- a/features/last_run_info.feature
+++ b/features/last_run_info.feature
@@ -1,0 +1,39 @@
+Feature: Launch detection
+
+  Background:
+    Given I clear all persistent data
+
+  Scenario: LastRunInfo consecutiveLaunchCrashes increments when isLaunching is true
+    When I run "LastRunInfoConsecutiveLaunchCrashesScenario"
+    And I relaunch the app
+    And I configure Bugsnag for "LastRunInfoConsecutiveLaunchCrashesScenario"
+    And I wait to receive an error
+    And the event "metaData.lastRunInfo.consecutiveLaunchCrashes" equals 1
+    And the event "metaData.lastRunInfo.crashed" is true
+    And the event "metaData.lastRunInfo.crashedDuringLaunch" is true
+    And I discard the oldest error
+
+    And I click the element "run_scenario"
+    And I wait for 1 seconds
+    And I relaunch the app
+    And I configure Bugsnag for "LastRunInfoConsecutiveLaunchCrashesScenario"
+    And I wait to receive an error
+    And the event "metaData.lastRunInfo.consecutiveLaunchCrashes" equals 2
+    And I discard the oldest error
+
+    And I click the element "run_scenario"
+    And I relaunch the app
+    And I configure Bugsnag for "LastRunInfoConsecutiveLaunchCrashesScenario"
+    And I wait to receive an error
+    And the event "metaData.lastRunInfo.consecutiveLaunchCrashes" equals 3
+    And I discard the oldest error
+
+    And I wait for 5 seconds
+
+    And I click the element "run_scenario"
+    And I relaunch the app
+    And I configure Bugsnag for "LastRunInfoConsecutiveLaunchCrashesScenario"
+    And I wait to receive an error
+    And the event "metaData.lastRunInfo.consecutiveLaunchCrashes" equals 0
+    And the event "metaData.lastRunInfo.crashed" is true
+    And the event "metaData.lastRunInfo.crashedDuringLaunch" is false


### PR DESCRIPTION
## Goal

Implements the `lastRunInfo` property and associated object, along with storage necessary to implement it.

## Design

Following the engineering design, uses `BugsnagSystemState` to store the value of `consecutiveLaunchCrashes`.

## Changeset

* Adds `Bugsnag.lastRunInfo` and `BugsnagClient.lastRunInfo`
* Marks `Bugsnag.appDidCrashLastLaunch` and `BugsnagClient.appDidCrashLastLaunch` as deprecated.
* Implements `BugsnagLastRunInfo`

## Testing

Tested manually using a sample app.

Added / updated E2E scenarios to verify the behaviour of lastRunInfo and ran them locally on iOS and macOS.