### PR TITLE
Use dispatch_semaphore instead of NSCondition

### DIFF
--- a/Bugsnag/Client/BugsnagClient.m
+++ b/Bugsnag/Client/BugsnagClient.m
@@ -438,13 +438,13 @@ NSString *_lastOrientation = nil;
         return;
     }
     bsg_log_info(@"Sending launch crash synchronously.");
-    NSDate *deadline = [NSDate dateWithTimeIntervalSinceNow:2];
-    NSCondition *sentLaunchCrash = [[NSCondition alloc] init];
+    dispatch_time_t deadline = dispatch_time(DISPATCH_TIME_NOW, 2 * NSEC_PER_SEC);
+    dispatch_semaphore_t semaphore = dispatch_semaphore_create(0);
     [[BSG_KSCrash sharedInstance] sendLatestReport:^{
         bsg_log_debug(@"Sent launch crash.");
-        [sentLaunchCrash signal];
+        dispatch_semaphore_signal(semaphore);
     }];
-    if (![sentLaunchCrash waitUntilDate:deadline]) {
+    if (dispatch_semaphore_wait(semaphore, deadline)) {
         bsg_log_debug(@"Timed out waiting for launch crash to be sent.");
     }
 }


### PR DESCRIPTION
## Goal

Fixes the following issue observed in device logs for older iOS versions:

```
*** -[NSCondition dealloc]: condition (<NSCondition: 0x17411c200> '(null)') deallocated while still in use
*** Break on _NSLockError() to debug.
```

Also fixes an issue which can arise if the callback is called before `waitUntilDate:` - this does not work as expected with an NSCondition and results in a 2 second timeout.

GCD semaphores fix both of these issues.

## Testing

Verified manually using example app.