### PR TITLE
[PLAT-6112] Fix possible deadlock when recording threads

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,9 @@ Changelog
 
 ### Bug fixes
 
+* Fix possible deadlock when recording thread information for handled errors.
+  [1011](https://github.com/bugsnag/bugsnag-cocoa/pull/1011)
+
 * Fix Swift 5.4 fatal error message parsing.
   [1010](https://github.com/bugsnag/bugsnag-cocoa/pull/1010)
 


### PR DESCRIPTION
## Goal

There was the possibility of a deadlock when recording all threads (for a handled event) due to use of the Objective-C runtime while other threads were suspended.

This issue was manifesting as an intermittent failure of the unit tests to complete within their timeout.

This issue was introduced in release v6.2.3 by https://github.com/bugsnag/bugsnag-cocoa/pull/992

## Changeset

`backtrace_for_callstack()` was being called while threads were suspended, and accepted an `NSArray` resulting in the Objective-C runtime being called for reference counting, reading the array items and their values.

Refactored the methods and functions to ensure the `callStackReturnAddresses` `NSArray` is converted to a plain C struct before any mach thread related calls are made.

## Testing

Tested by running unit tests locally.