### PR TITLE
[PLAT-6113] Fix possible deadlock in bsg_ksmachfreeMemory

### DIFF
--- a/Bugsnag/KSCrash/Source/KSCrash/Recording/Tools/BSG_KSMach.c
+++ b/Bugsnag/KSCrash/Source/KSCrash/Recording/Tools/BSG_KSMach.c
@@ -37,8 +37,9 @@
 #include <mach-o/arch.h>
 #include <mach/mach_time.h>
 #include <sys/sysctl.h>
-#if defined(__IPHONE_13_0) && __IPHONE_OS_VERSION_MAX_ALLOWED >= __IPHONE_13_0
-#import <os/proc.h>
+
+#if __has_include(<os/proc.h>) && TARGET_OS_IPHONE
+#include <os/proc.h>
 #endif
 
 // Avoiding static functions due to linker issues.
@@ -60,26 +61,33 @@ static pthread_t bsg_g_topThread;
 #pragma mark - General Information -
 // ============================================================================
 
+/**
+ * A pointer to `os_proc_available_memory` if it is available and usable.
+ *
+ * We cannot use the `__builtin_available` check at runtime because its
+ * implementation uses malloc() which is not async-signal-safe and can result in
+ * a deadlock if called from a crash handler or while threads are suspended.
+ */
+static size_t (* get_available_memory)(void);
+
+static void bsg_ksmachfreeMemory_init(void) {
+#if __has_include(<os/proc.h>) && TARGET_OS_IPHONE
+    if (__builtin_available(iOS 13.0, tvOS 13.0, watchOS 6.0, *)) {
+        // Only use `os_proc_available_memory` if it appears to be working.
+        // 0 is returned if the calling process is not an app or is running
+        // on a Simulator, and may also erroneously be returned by some early
+        // implementations like iOS 13.0.
+        if (os_proc_available_memory()) {
+            get_available_memory = os_proc_available_memory;
+        }
+    }
+#endif
+}
+
 uint64_t bsg_ksmachfreeMemory(void) {
-    size_t mem = 0;
-
-#if BSG_PLATFORM_IOS &&  defined(__IPHONE_13_0) && __IPHONE_OS_VERSION_MAX_ALLOWED >= __IPHONE_13_0
-    if (__builtin_available(iOS 13.0, *)) {
-        mem = os_proc_available_memory();
+    if (get_available_memory) {
+        return get_available_memory();
     }
-#endif
-
-#if BSG_PLATFORM_TVOS &&  defined(__TVOS_13_0) && __TV_OS_VERSION_MAX_ALLOWED >= __TVOS_13_0
-    if (__builtin_available(tvOS 13.0, *)) {
-        mem = os_proc_available_memory();
-    }
-#endif
-
-    // Note: Some broken versions of iOS always return 0.
-    if(mem != 0) {
-        return mem;
-    }
-
     vm_statistics_data_t vmStats;
     vm_size_t pageSize;
     if (bsg_ksmachi_VMStats(&vmStats, &pageSize)) {
@@ -227,6 +235,9 @@ void bsg_ksmach_init(void) {
         }
         vm_deallocate(thisTask, (vm_address_t)threads,
                       sizeof(thread_t) * numThreads);
+        
+        bsg_ksmachfreeMemory_init();
+        
         initialized = true;
     }
 }

--- a/Bugsnag/KSCrash/Source/KSCrash/Recording/Tools/BSG_KSMach.h
+++ b/Bugsnag/KSCrash/Source/KSCrash/Recording/Tools/BSG_KSMach.h
@@ -46,8 +46,8 @@ extern "C" {
 // ============================================================================
 
 /** Initializes KSMach.
- * Some functions (currently only bsg_ksmachpthreadFromMachThread) require
- * initialization before use.
+ * Some functions (currently only bsg_ksmachpthreadFromMachThread and
+ * bsg_ksmachfreeMemory) require initialization before use.
  */
 void bsg_ksmach_init(void);
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,13 @@
 Changelog
 =========
 
+## TBD
+
+### Bug fixes
+
+*  Fix a possible deadlock when writing crash reports for unhandled errors.
+  [#1013](https://github.com/bugsnag/bugsnag-cocoa/pull/1013)
+
 ## 6.6.4 (2021-02-24)
 
 ### Bug fixes

--- a/features/crashprobe.feature
+++ b/features/crashprobe.feature
@@ -156,6 +156,12 @@ Feature: Reporting crash events
     # |pthread_getname_np|
       | -[AsyncSafeThreadScenario run] |
 
+  Scenario: Trigger a crash with simulated malloc() lock held
+    When I run "AsyncSafeMallocScenario" and relaunch the app
+    And I configure Bugsnag for "AsyncSafeMallocScenario"
+    And I wait to receive an error
+    And the exception "errorClass" equals "SIGABRT"
+
   Scenario: Read a garbage pointer
     When I run "ReadGarbagePointerScenario" and relaunch the app
     And I configure Bugsnag for "ReadGarbagePointerScenario"

--- a/features/fixtures/ios-swift-cocoapods/iOSTestApp.xcodeproj/project.pbxproj
+++ b/features/fixtures/ios-swift-cocoapods/iOSTestApp.xcodeproj/project.pbxproj
@@ -16,6 +16,7 @@
 		00432CC4240912A100826D05 /* EnabledErrorTypesCxxScenario.mm in Sources */ = {isa = PBXBuildFile; fileRef = 00432CC2240912A000826D05 /* EnabledErrorTypesCxxScenario.mm */; };
 		00507A64242BFE5600EF1B87 /* EnabledBreadcrumbTypesIsNilScenario.swift in Sources */ = {isa = PBXBuildFile; fileRef = 00507A63242BFE5600EF1B87 /* EnabledBreadcrumbTypesIsNilScenario.swift */; };
 		00CEB60D24080C690004793D /* EnabledErrorTypesScenario.m in Sources */ = {isa = PBXBuildFile; fileRef = 00CEB60C24080C690004793D /* EnabledErrorTypesScenario.m */; };
+		01018BA025E40ADD000312C6 /* AsyncSafeMallocScenario.m in Sources */ = {isa = PBXBuildFile; fileRef = 01018B9F25E40ADD000312C6 /* AsyncSafeMallocScenario.m */; };
 		0104085F258CA0A100933C60 /* DispatchCrashScenario.swift in Sources */ = {isa = PBXBuildFile; fileRef = 0104085E258CA0A100933C60 /* DispatchCrashScenario.swift */; };
 		0163BFA72583B3CF008DC28B /* DiscardClassesScenarios.swift in Sources */ = {isa = PBXBuildFile; fileRef = 0163BFA62583B3CF008DC28B /* DiscardClassesScenarios.swift */; };
 		01AF6A53258A112F00FFC803 /* BareboneTestScenarios.swift in Sources */ = {isa = PBXBuildFile; fileRef = 01AF6A52258A112F00FFC803 /* BareboneTestScenarios.swift */; };
@@ -163,6 +164,7 @@
 		00A98315240DBB7A0016A57E /* out_of_memory.feature */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = text; name = out_of_memory.feature; path = ../../../out_of_memory.feature; sourceTree = "<group>"; };
 		00CEB60B24080C690004793D /* EnabledErrorTypesScenario.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; path = EnabledErrorTypesScenario.h; sourceTree = "<group>"; };
 		00CEB60C24080C690004793D /* EnabledErrorTypesScenario.m */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.objc; path = EnabledErrorTypesScenario.m; sourceTree = "<group>"; };
+		01018B9F25E40ADD000312C6 /* AsyncSafeMallocScenario.m */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.objc; path = AsyncSafeMallocScenario.m; sourceTree = "<group>"; };
 		0104085E258CA0A100933C60 /* DispatchCrashScenario.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = DispatchCrashScenario.swift; sourceTree = "<group>"; };
 		0163BFA62583B3CF008DC28B /* DiscardClassesScenarios.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = DiscardClassesScenarios.swift; sourceTree = "<group>"; };
 		01AF6A52258A112F00FFC803 /* BareboneTestScenarios.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = BareboneTestScenarios.swift; sourceTree = "<group>"; };
@@ -603,6 +605,7 @@
 				F429534164257A2BE23ED72D /* AbortScenario.m */,
 				F42956707AEC06754D9C2208 /* AccessNonObjectScenario.h */,
 				F4295A20DE438C2B28167714 /* AccessNonObjectScenario.m */,
+				01018B9F25E40ADD000312C6 /* AsyncSafeMallocScenario.m */,
 				F429556E677F030F72C4C5D0 /* AsyncSafeThreadScenario.h */,
 				F4295CA6B6792DECA15C450B /* AsyncSafeThreadScenario.m */,
 				F4295E2979ED53A2E82017CF /* BuiltinTrapScenario.h */,
@@ -877,6 +880,7 @@
 				8AB8866620404DD30003E444 /* ViewController.swift in Sources */,
 				8AB8866420404DD30003E444 /* AppDelegate.swift in Sources */,
 				00507A64242BFE5600EF1B87 /* EnabledBreadcrumbTypesIsNilScenario.swift in Sources */,
+				01018BA025E40ADD000312C6 /* AsyncSafeMallocScenario.m in Sources */,
 				8A98400320FD11BF0023ECD1 /* AutoSessionCustomVersionScenario.m in Sources */,
 				F42955E0916B8851F074D9B3 /* UserEmailScenario.swift in Sources */,
 				E700EE4C247D12E4008CFFB6 /* UserFromConfigEventScenario.swift in Sources */,

--- a/features/fixtures/macos/macOSTestApp.xcodeproj/project.pbxproj
+++ b/features/fixtures/macos/macOSTestApp.xcodeproj/project.pbxproj
@@ -7,6 +7,7 @@
 	objects = {
 
 /* Begin PBXBuildFile section */
+		01018BAB25E417EC000312C6 /* AsyncSafeMallocScenario.m in Sources */ = {isa = PBXBuildFile; fileRef = 01018BAA25E417EC000312C6 /* AsyncSafeMallocScenario.m */; };
 		01452354254AFD7C00D436AA /* Bugsnag.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = 01452353254AFD7C00D436AA /* Bugsnag.framework */; };
 		01452355254AFD7C00D436AA /* Bugsnag.framework in Embed Frameworks */ = {isa = PBXBuildFile; fileRef = 01452353254AFD7C00D436AA /* Bugsnag.framework */; settings = {ATTRIBUTES = (CodeSignOnCopy, RemoveHeadersOnCopy, ); }; };
 		0163BF9B2583AF2A008DC28B /* DiscardClassesScenarios.swift in Sources */ = {isa = PBXBuildFile; fileRef = 0163BF9A2583AF2A008DC28B /* DiscardClassesScenarios.swift */; };
@@ -149,6 +150,7 @@
 /* End PBXCopyFilesBuildPhase section */
 
 /* Begin PBXFileReference section */
+		01018BAA25E417EC000312C6 /* AsyncSafeMallocScenario.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; path = AsyncSafeMallocScenario.m; sourceTree = "<group>"; };
 		01452353254AFD7C00D436AA /* Bugsnag.framework */ = {isa = PBXFileReference; explicitFileType = wrapper.framework; path = Bugsnag.framework; sourceTree = BUILT_PRODUCTS_DIR; };
 		01452360254AFEA700D436AA /* macOSTestApp-Bridging-Header.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; path = "macOSTestApp-Bridging-Header.h"; sourceTree = "<group>"; };
 		0163BF9A2583AF2A008DC28B /* DiscardClassesScenarios.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = DiscardClassesScenarios.swift; sourceTree = "<group>"; };
@@ -353,6 +355,7 @@
 				01F47C4A254B1B2D00B184AD /* AccessNonObjectScenario.h */,
 				01F47C5B254B1B2E00B184AD /* AccessNonObjectScenario.m */,
 				01F47C60254B1B2E00B184AD /* AppAndDeviceAttributesScenario.swift */,
+				01018BAA25E417EC000312C6 /* AsyncSafeMallocScenario.m */,
 				01F47C73254B1B2E00B184AD /* AsyncSafeThreadScenario.h */,
 				01F47C40254B1B2D00B184AD /* AsyncSafeThreadScenario.m */,
 				01F47CBE254B1B3000B184AD /* AttachCustomStacktraceHook.h */,
@@ -689,6 +692,7 @@
 				01F47D32254B1B3100B184AD /* ResumeSessionOOMScenario.m in Sources */,
 				01F47D13254B1B3100B184AD /* UserPersistenceScenarios.m in Sources */,
 				01F47CF9254B1B3100B184AD /* BreadcrumbCallbackDiscardScenario.swift in Sources */,
+				01018BAB25E417EC000312C6 /* AsyncSafeMallocScenario.m in Sources */,
 				01F47CE6254B1B3100B184AD /* HandledErrorOverrideScenario.swift in Sources */,
 				01F47D26254B1B3100B184AD /* PrivilegedInstructionScenario.m in Sources */,
 				01F47D18254B1B3100B184AD /* SIGBUSScenario.m in Sources */,

--- a/features/fixtures/shared/scenarios/AsyncSafeMallocScenario.m
+++ b/features/fixtures/shared/scenarios/AsyncSafeMallocScenario.m
@@ -1,0 +1,44 @@
+//
+//  AsyncSafeMallocScenario.m
+//  iOSTestApp
+//
+//  Created by Nick Dowell on 22/02/2021.
+//  Copyright © 2021 Bugsnag. All rights reserved.
+//
+
+#import "Scenario.h"
+
+#include <libkern/OSSpinLockDeprecated.h>
+#include <mach/mach_init.h>
+#include <mach/vm_map.h>
+#include <malloc/malloc.h>
+
+static void * customMalloc(struct _malloc_zone_t *zone, size_t size) {
+    static OSSpinLock spinLock = OS_SPINLOCK_INIT;
+    OSSpinLockLock(&spinLock);
+    OSSpinLockLock(&spinLock);
+    return NULL;
+}
+
+static void installCustomMalloc() {
+    malloc_zone_t *zone = malloc_default_zone();
+    vm_protect(mach_task_self(), (uintptr_t)zone, sizeof(malloc_zone_t), 0, VM_PROT_READ | VM_PROT_WRITE);
+    zone->malloc = customMalloc;
+    vm_protect(mach_task_self(), (uintptr_t)zone, sizeof(malloc_zone_t), 0, VM_PROT_READ);
+}
+
+@interface AsyncSafeMallocScenario : Scenario
+
+@end
+
+@implementation AsyncSafeMallocScenario
+
+- (void)run {
+    // Override malloc() with an implementation that will cause a deadlock for any thread that calls malloc()
+    installCustomMalloc();
+    
+    // If the signal handler calls malloc(), the app will hang instead of terminating immediately.
+    abort();
+}
+
+@end


### PR DESCRIPTION
## Goal

Fixes a deadlock that can occur because the implementation of `__builtin_available()` uses `malloc()` and is therefore not async-signal-safe.

This was observed when investigating potential causes of deadlocks in the crash handling code.

<img width="964" alt="Screenshot 2021-02-22 at 16 38 27" src="https://user-images.githubusercontent.com/61777/109134990-8821c100-774e-11eb-9075-418145ed4ab7.png">

## Design / Changeset

The availability of `os_proc_available_memory()` is now determined at initialization time rather than in the implementation of `bsg_ksmachfreeMemory()`

A function pointer is used to avoid the need for `#pragma clang diagnostic` statements in `bsg_ksmachfreeMemory()`

## Testing

Manually verified by running example apps and adding log statements to confirm that `os_proc_available_memory()` is used on the relevant platforms.

Added an E2E scenario that could consistently produce a deadlock in `bsg_ksmachfreeMemory()` prior to the fix, and confirmed that it passes with the fix in place.