### PR TITLE
Upload MacOS fixture test logs

### DIFF
--- a/.buildkite/pipeline.full.yml
+++ b/.buildkite/pipeline.full.yml
@@ -84,6 +84,7 @@ steps:
     plugins:
       artifacts#v1.3.0:
         download: ["features/fixtures/macos/output/macOSTestApp.zip"]
+        upload: ["macOSTestApp.log"]
     commands:
       - bundle install
       - bundle exec maze-runner
@@ -103,6 +104,7 @@ steps:
     plugins:
       artifacts#v1.3.0:
         download: ["features/fixtures/macos/output/macOSTestApp.zip"]
+        upload: ["macOSTestApp.log"]
     commands:
       - bundle install
       - bundle exec maze-runner

--- a/.buildkite/pipeline.quick.yml
+++ b/.buildkite/pipeline.quick.yml
@@ -149,6 +149,7 @@ steps:
     plugins:
       artifacts#v1.3.0:
         download: ["features/fixtures/macos/output/macOSTestApp.zip"]
+        upload: ["macOSTestApp.log"]
     commands:
       - bundle install
       - bundle exec maze-runner

--- a/.buildkite/pipeline.yml
+++ b/.buildkite/pipeline.yml
@@ -176,6 +176,7 @@ steps:
     plugins:
       artifacts#v1.3.0:
         download: ["features/fixtures/macos/output/macOSTestApp.zip"]
+        upload: ["macOSTestApp.log"]
     commands:
       - bundle install
       - bundle exec maze-runner

--- a/Gemfile
+++ b/Gemfile
@@ -7,7 +7,7 @@ gem 'xcpretty'
 
 # A reference to Maze Runner is only needed for running tests locally and if committed it must be
 # portable for CI, e.g. a specific release.  However, leaving it commented out would mean quicker CI.
-gem 'bugsnag-maze-runner', git: 'https://github.com/bugsnag/maze-runner', tag: 'v4.4.0'
+gem 'bugsnag-maze-runner', git: 'https://github.com/bugsnag/maze-runner', branch: 'macos-app-logs'
 
 # Locally, you can run against Maze Runner branches and uncommitted changes:
 # gem 'bugsnag-maze-runner', path: '../maze-runner'

--- a/Gemfile
+++ b/Gemfile
@@ -7,7 +7,7 @@ gem 'xcpretty'
 
 # A reference to Maze Runner is only needed for running tests locally and if committed it must be
 # portable for CI, e.g. a specific release.  However, leaving it commented out would mean quicker CI.
-gem 'bugsnag-maze-runner', git: 'https://github.com/bugsnag/maze-runner', branch: 'macos-app-logs'
+gem 'bugsnag-maze-runner', git: 'https://github.com/bugsnag/maze-runner', tag: 'v4.11.1'
 
 # Locally, you can run against Maze Runner branches and uncommitted changes:
 # gem 'bugsnag-maze-runner', path: '../maze-runner'

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -1,9 +1,9 @@
 GIT
   remote: https://github.com/bugsnag/maze-runner
-  revision: d813563b6fcaca5d1c583b878d3516a35dd316eb
-  branch: macos-app-logs
+  revision: b5925737b0c3db49ac38a5a68e6bfe38026ef508
+  tag: v4.11.1
   specs:
-    bugsnag-maze-runner (4.10.1)
+    bugsnag-maze-runner (4.11.1)
       appium_lib (~> 11.2.0)
       boring (~> 0.1.0)
       cucumber (~> 3.1.2)

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -1,6 +1,6 @@
 GIT
   remote: https://github.com/bugsnag/maze-runner
-  revision: 0d80bf9ef1f50889092775cfba39ec531c9117d9
+  revision: 420d9b00661e7a8ef36187a9da6b3c772facdafb
   branch: macos-app-logs
   specs:
     bugsnag-maze-runner (4.10.1)

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -1,6 +1,6 @@
 GIT
   remote: https://github.com/bugsnag/maze-runner
-  revision: 420d9b00661e7a8ef36187a9da6b3c772facdafb
+  revision: d813563b6fcaca5d1c583b878d3516a35dd316eb
   branch: macos-app-logs
   specs:
     bugsnag-maze-runner (4.10.1)

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -1,10 +1,10 @@
 GIT
   remote: https://github.com/bugsnag/maze-runner
-  revision: acdffd98a16ecf7b32c4efbb9f38583e3a0c06ab
-  tag: v4.4.0
+  revision: 8dea04f256db383ae84364f054f144da28e7ed1a
+  branch: macos-app-logs
   specs:
-    bugsnag-maze-runner (4.4.0)
-      appium_lib (~> 10.2)
+    bugsnag-maze-runner (4.10.1)
+      appium_lib (~> 11.2.0)
       boring (~> 0.1.0)
       cucumber (~> 3.1.2)
       cucumber-expressions (~> 6.0.0)
@@ -31,11 +31,11 @@ GEM
     algoliasearch (1.27.5)
       httpclient (~> 2.8, >= 2.8.3)
       json (>= 1.5.1)
-    appium_lib (10.6.0)
-      appium_lib_core (~> 3.3)
+    appium_lib (11.2.0)
+      appium_lib_core (~> 4.1)
       nokogiri (~> 1.8, >= 1.8.1)
       tomlrb (~> 1.1)
-    appium_lib_core (3.11.1)
+    appium_lib_core (4.4.1)
       faye-websocket (~> 0.11.0)
       selenium-webdriver (~> 3.14, >= 3.14.1)
     atomos (0.1.3)
@@ -160,7 +160,7 @@ GEM
       kramdown (~> 2.0)
     liferaft (0.0.6)
     mini_portile2 (2.5.0)
-    minitest (5.14.3)
+    minitest (5.14.4)
     molinillo (0.6.6)
     multi_json (1.15.0)
     multi_test (0.1.2)

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -1,6 +1,6 @@
 GIT
   remote: https://github.com/bugsnag/maze-runner
-  revision: 8dea04f256db383ae84364f054f144da28e7ed1a
+  revision: 0d80bf9ef1f50889092775cfba39ec531c9117d9
   branch: macos-app-logs
   specs:
     bugsnag-maze-runner (4.10.1)


### PR DESCRIPTION
## Goal

Generates and attaches MacOS test fixture logs to the run step.

Depends on https://github.com/bugsnag/maze-runner/pull/230, and will need to be updated on next MR release.
