### PR TITLE
[PLAT-6132] Fix incorrect freeMemory for handled errors

### DIFF
--- a/Bugsnag/BugsnagSessionTracker.m
+++ b/Bugsnag/BugsnagSessionTracker.m
@@ -123,7 +123,7 @@ NSString *const BSGSessionUpdateNotification = @"BugsnagSessionChanged";
     BugsnagApp *app = [BugsnagApp appWithDictionary:@{@"system": systemInfo}
                                              config:self.config
                                        codeBundleId:self.codeBundleId];
-    BugsnagDevice *device = [BugsnagDevice deviceWithDictionary:@{@"system": systemInfo}];
+    BugsnagDevice *device = [BugsnagDevice deviceWithKSCrashReport:@{@"system": systemInfo}];
     [device appendRuntimeInfo:self.extraRuntimeInfo];
 
     BugsnagSession *newSession = [[BugsnagSession alloc] initWithId:[[NSUUID UUID] UUIDString]

--- a/Bugsnag/Client/BugsnagClient.m
+++ b/Bugsnag/Client/BugsnagClient.m
@@ -1163,7 +1163,7 @@ NSString *_lastOrientation = nil;
 }
 
 - (BugsnagDeviceWithState *)generateDeviceWithState:(NSDictionary *)systemInfo {
-    BugsnagDeviceWithState *device = [BugsnagDeviceWithState deviceWithDictionary:@{@"system": systemInfo}];
+    BugsnagDeviceWithState *device = [BugsnagDeviceWithState deviceWithKSCrashReport:@{@"system": systemInfo}];
     device.time = [NSDate date]; // default to current time for handled errors
     [device appendRuntimeInfo:self.extraRuntimeInfo];
     device.orientation = _lastOrientation;

--- a/Bugsnag/KSCrash/Source/KSCrash/Recording/BSG_KSSystemInfo.m
+++ b/Bugsnag/KSCrash/Source/KSCrash/Recording/BSG_KSSystemInfo.m
@@ -429,11 +429,11 @@ static inline bool is_jailbroken() {
     sysInfo[@BSG_KSSystemField_DeviceAppHash] = [self deviceAndAppHash];
     sysInfo[@BSG_KSSystemField_BuildType] = [BSG_KSSystemInfo buildType];
 
-    NSDictionary *memory = @{
-            @BSG_KSSystemField_Size: [self int64Sysctl:@"hw.memsize"],
-            @BSG_KSCrashField_Usable: @(bsg_ksmachusableMemory())
+    sysInfo[@(BSG_KSSystemField_Memory)] = @{
+        @(BSG_KSCrashField_Free): @(bsg_ksmachfreeMemory()),
+        @(BSG_KSCrashField_Usable): @(bsg_ksmachusableMemory()),
+        @(BSG_KSSystemField_Size): [self int64Sysctl:@"hw.memsize"]
     };
-    sysInfo[@BSG_KSSystemField_Memory] = memory;
 
     NSDictionary *statsInfo = [[BSG_KSCrash sharedInstance] captureAppStats];
     sysInfo[@BSG_KSCrashField_AppStats] = statsInfo;

--- a/Bugsnag/Payload/BugsnagDevice+Private.h
+++ b/Bugsnag/Payload/BugsnagDevice+Private.h
@@ -12,7 +12,7 @@ NS_ASSUME_NONNULL_BEGIN
 
 @interface BugsnagDevice ()
 
-+ (instancetype)deviceWithDictionary:(NSDictionary *)event;
++ (instancetype)deviceWithKSCrashReport:(NSDictionary *)event;
 
 + (instancetype)deserializeFromJson:(NSDictionary *)json;
 

--- a/Bugsnag/Payload/BugsnagDevice.m
+++ b/Bugsnag/Payload/BugsnagDevice.m
@@ -29,7 +29,7 @@
     return device;
 }
 
-+ (BugsnagDevice *)deviceWithDictionary:(NSDictionary *)event {
++ (BugsnagDevice *)deviceWithKSCrashReport:(NSDictionary *)event {
     BugsnagDevice *device = [BugsnagDevice new];
     [self populateFields:device dictionary:event];
     return device;

--- a/Bugsnag/Payload/BugsnagDeviceWithState+Private.h
+++ b/Bugsnag/Payload/BugsnagDeviceWithState+Private.h
@@ -16,7 +16,7 @@ NS_ASSUME_NONNULL_BEGIN
 
 + (instancetype)deviceFromJson:(NSDictionary *)json;
 
-+ (instancetype)deviceWithDictionary:(NSDictionary *)event;
++ (instancetype)deviceWithKSCrashReport:(NSDictionary *)event;
 
 + (instancetype)deviceWithOomData:(NSDictionary *)data;
 

--- a/Bugsnag/Payload/BugsnagDeviceWithState.m
+++ b/Bugsnag/Payload/BugsnagDeviceWithState.m
@@ -101,7 +101,7 @@ NSNumber *BSGDeviceFreeSpace(NSSearchPathDirectory directory) {
     BugsnagDeviceWithState *device = [BugsnagDeviceWithState new];
     [self populateFields:device dictionary:event];
     device.orientation = [event valueForKeyPath:@"user.state.deviceState.orientation"];
-    device.freeMemory = [event valueForKeyPath:@"system.memory.free"] ?: [event valueForKeyPath:@"system.memory.usable"];
+    device.freeMemory = [event valueForKeyPath:@"system.memory.free"];
     device.freeDisk = BSGDeviceFreeSpace(NSCachesDirectory);
 
     NSString *val = [event valueForKeyPath:@"report.timestamp"];

--- a/Bugsnag/Payload/BugsnagDeviceWithState.m
+++ b/Bugsnag/Payload/BugsnagDeviceWithState.m
@@ -97,7 +97,7 @@ NSNumber *BSGDeviceFreeSpace(NSSearchPathDirectory directory) {
     return device;
 }
 
-+ (BugsnagDeviceWithState *)deviceWithDictionary:(NSDictionary *)event {
++ (BugsnagDeviceWithState *)deviceWithKSCrashReport:(NSDictionary *)event {
     BugsnagDeviceWithState *device = [BugsnagDeviceWithState new];
     [self populateFields:device dictionary:event];
     device.orientation = [event valueForKeyPath:@"user.state.deviceState.orientation"];

--- a/Bugsnag/Payload/BugsnagEvent.m
+++ b/Bugsnag/Payload/BugsnagEvent.m
@@ -360,7 +360,7 @@ NSDictionary *BSGParseCustomException(NSDictionary *report,
         }
     }
     NSString *deviceAppHash = [event valueForKeyPath:@"system.device_app_hash"];
-    BugsnagDeviceWithState *device = [BugsnagDeviceWithState deviceWithDictionary:event];
+    BugsnagDeviceWithState *device = [BugsnagDeviceWithState deviceWithKSCrashReport:event];
     BugsnagUser *user = [self parseUser:event deviceAppHash:deviceAppHash deviceId:device.id];
     BugsnagConfiguration *config = [[BugsnagConfiguration alloc] initWithDictionaryRepresentation:[event valueForKeyPath:@"user.config"]];
     BugsnagAppWithState *app = [BugsnagAppWithState appWithDictionary:event config:config codeBundleId:self.codeBundleId];

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,13 @@
 Changelog
 =========
 
+## TBD
+
+### Bug fixes
+
+* Fix incorrect `freeMemory` for errors reported via `notify()`
+  [#1021](https://github.com/bugsnag/bugsnag-cocoa/pull/1021)
+
 ## 6.7.0 (2021-03-03)
 
 ### Enhancements

--- a/Tests/BugsnagDeviceTest.m
+++ b/Tests/BugsnagDeviceTest.m
@@ -49,7 +49,7 @@
 }
 
 - (void)testDevice {
-    BugsnagDevice *device = [BugsnagDevice deviceWithDictionary:self.data];
+    BugsnagDevice *device = [BugsnagDevice deviceWithKSCrashReport:self.data];
 
     // verify stateless fields
     XCTAssertTrue(device.jailbroken);
@@ -69,7 +69,7 @@
 }
 
 - (void)testDeviceWithState {
-    BugsnagDeviceWithState *device = [BugsnagDeviceWithState deviceWithDictionary:self.data];
+    BugsnagDeviceWithState *device = [BugsnagDeviceWithState deviceWithKSCrashReport:self.data];
 
     // verify stateless fields
     XCTAssertTrue(device.jailbroken);
@@ -99,7 +99,7 @@
 }
 
 - (void)testDeviceToDict {
-    BugsnagDevice *device = [BugsnagDevice deviceWithDictionary:self.data];
+    BugsnagDevice *device = [BugsnagDevice deviceWithKSCrashReport:self.data];
     device.locale = @"en-US";
     NSDictionary *dict = [device toDictionary];
 
@@ -122,7 +122,7 @@
 }
 
 - (void)testDeviceWithStateToDict {
-    BugsnagDeviceWithState *device = [BugsnagDeviceWithState deviceWithDictionary:self.data];
+    BugsnagDeviceWithState *device = [BugsnagDeviceWithState deviceWithKSCrashReport:self.data];
     device.locale = @"en-US";
     NSDictionary *dict = [device toDictionary];
 
@@ -185,7 +185,7 @@
 }
 
 - (void)testDeviceRuntimeInfoAppended {
-    BugsnagDevice *device = [BugsnagDevice deviceWithDictionary:self.data];
+    BugsnagDevice *device = [BugsnagDevice deviceWithKSCrashReport:self.data];
     XCTAssertEqual(2, [device.runtimeVersions count]);
     XCTAssertEqualObjects(@"14B25", device.runtimeVersions[@"osBuild"]);
     XCTAssertEqualObjects(@"10.0.0 (clang-1000.11.45.5)", device.runtimeVersions[@"clangVersion"]);

--- a/Tests/BugsnagDeviceTest.m
+++ b/Tests/BugsnagDeviceTest.m
@@ -7,10 +7,10 @@
 //
 
 #import <XCTest/XCTest.h>
-#import "BugsnagConfiguration.h"
-#import "BugsnagDeviceWithState+Private.h"
+
+#import "BSG_KSSystemInfo.h"
 #import "BugsnagDevice+Private.h"
-#import "BugsnagTestConstants.h"
+#import "BugsnagDeviceWithState+Private.h"
 
 @interface BugsnagDeviceTest : XCTestCase
 @property NSDictionary *data;
@@ -96,6 +96,12 @@
     formatter.dateFormat = @"yyyy'-'MM'-'dd'T'HH':'mm':'ssZZZ";
     formatter.timeZone = [NSTimeZone timeZoneForSecondsFromGMT:0];
     XCTAssertEqualObjects([formatter dateFromString:@"2014-12-02T01:56:13Z"], device.time);
+}
+
+- (void)testDeviceWithRealSystemInfo {
+    NSDictionary *systemInfo = [BSG_KSSystemInfo systemInfo];
+    BugsnagDeviceWithState *device = [BugsnagDeviceWithState deviceWithKSCrashReport:@{@"system": systemInfo}];
+    XCTAssertLessThan(device.freeMemory.unsignedLongLongValue, device.totalMemory.unsignedLongLongValue);
 }
 
 - (void)testDeviceToDict {

--- a/Tests/BugsnagSessionTest.m
+++ b/Tests/BugsnagSessionTest.m
@@ -84,7 +84,7 @@
                     }
             }
     };
-    BugsnagDevice *device = [BugsnagDevice deviceWithDictionary:deviceData];
+    BugsnagDevice *device = [BugsnagDevice deviceWithKSCrashReport:deviceData];
     device.locale = @"en-US";
     return device;
 }

--- a/Tests/BugsnagSessionTrackingPayloadTest.m
+++ b/Tests/BugsnagSessionTrackingPayloadTest.m
@@ -99,7 +99,7 @@
                     }
             }
     };
-    BugsnagDevice *device = [BugsnagDevice deviceWithDictionary:deviceData];
+    BugsnagDevice *device = [BugsnagDevice deviceWithKSCrashReport:deviceData];
     device.locale = @"en-US";
     return device;
 }

--- a/features/app_and_device_attributes.feature
+++ b/features/app_and_device_attributes.feature
@@ -35,6 +35,7 @@ Feature: App and Device attributes present
       | ios   | @not_null |
       | macos | @null     |
     And the error payload field "events.0.device.time" is a date
+    And the event "device.freeMemory" is less than the event "device.totalMemory"
 
     # App
 

--- a/features/barebone_tests.feature
+++ b/features/barebone_tests.feature
@@ -28,6 +28,7 @@ Feature: Barebone tests
     And the event "app.version" equals "12.3"
     And the event "breadcrumbs.0.name" equals "Running BareboneTestHandledScenario"
     And the event "breadcrumbs.1.name" equals "This is super <redacted>"
+    And the event "device.freeMemory" is less than the event "device.totalMemory"
     And the event "device.id" is not null
     And the event "device.jailbroken" is false
     And the event "device.locale" is not null
@@ -119,6 +120,7 @@ Feature: Barebone tests
     And the event "app.version" equals "12.3"
     And the event "breadcrumbs.0.name" equals "Bugsnag loaded"
     And the event "breadcrumbs.1.name" is null
+    And the event "device.freeMemory" is less than the event "device.totalMemory"
     And the event "device.id" is not null
     And the event "device.jailbroken" is false
     And the event "device.locale" is not null

--- a/features/steps/ios_steps.rb
+++ b/features/steps/ios_steps.rb
@@ -169,6 +169,14 @@ Then('the event {string} is between {int} and {int}') do |field, lower, upper|
   assert_true(lower <= value && value <= upper, "Expected a value between #{lower} and #{upper}, but received #{value}")
 end
 
+Then('the event {string} is less than the event {string}') do |field1, field2|
+  value1 = Maze::Helper.read_key_path(Maze::Server.errors.current[:body], "events.0.#{field1}")
+  assert_not_nil(value1, 'Expected a value')
+  value2 = Maze::Helper.read_key_path(Maze::Server.errors.current[:body], "events.0.#{field2}")
+  assert_not_nil(value2, 'Expected a value')
+  assert_true(value1 < value2, "Expected value to be less than #{value2}, but received #{value1}")
+end
+
 Then('the event breadcrumbs contain {string} with type {string}') do |string, type|
   crumbs = Maze::Helper.read_key_path(find_request(0)[:body], 'events.0.breadcrumbs')
   assert_not_equal(0, crumbs.length, 'There are no breadcrumbs on this event')


### PR DESCRIPTION
## Goal

Fixes a bug where handled errors (those reported via `notify()`) included an incorrect value for `freeMemory`

## Changeset

The root cause was `-[BSG_KSSystemInfo systemInfo]` not including `bsg_ksmachfreeMemory()` and `BugsnagDeviceWithState` incorrectly falling back to the "usable" value instead.

## Testing

Added E2E and unit test cases that replicate the problem, and verified they pass after the fix.

Manually verified that handled errors now contain `freeMemory < totalMemory`