### PR TITLE
[PLAT-6136] Fix missing / invalid device info when UIKit is not available

### DIFF
--- a/Bugsnag/Client/BugsnagClient.m
+++ b/Bugsnag/Client/BugsnagClient.m
@@ -1031,6 +1031,10 @@ NSString *_lastOrientation = nil;
  */
 #if BSG_PLATFORM_IOS
 - (void)batteryChanged:(NSNotification *)notification {
+    if (![UIDEVICE currentDevice]) {
+        return;
+    }
+
     NSNumber *batteryLevel = @([UIDEVICE currentDevice].batteryLevel);
     BOOL charging = [UIDEVICE currentDevice].batteryState == UIDeviceBatteryStateCharging ||
                     [UIDEVICE currentDevice].batteryState == UIDeviceBatteryStateFull;

--- a/Bugsnag/KSCrash/Source/KSCrash/Recording/BSG_KSSystemInfo.m
+++ b/Bugsnag/KSCrash/Source/KSCrash/Recording/BSG_KSSystemInfo.m
@@ -371,11 +371,19 @@ static inline bool is_jailbroken() {
 #ifdef __clang_version__
     sysInfo[@BSG_KSSystemField_ClangVersion] = @__clang_version__;
 #endif
-#if BSG_HAS_UIDEVICE
-    sysInfo[@BSG_KSSystemField_SystemName] = [UIDEVICE currentDevice].systemName;
-    sysInfo[@BSG_KSSystemField_SystemVersion] = [UIDEVICE currentDevice].systemVersion;
-#else
+#if TARGET_OS_IOS
+    // Note: This does not match UIDevice.currentDevice.systemName for versions
+    // prior to (and some versions of) iOS 9 where the systemName was reported
+    // as "iPhone OS". UIDevice gets its data from MobileGestalt which is a
+    // private API. /System/Library/CoreServices/SystemVersion.plist contains
+    // the information we need but will contain the macOS information when
+    // running on the Simulator.
+    sysInfo[@BSG_KSSystemField_SystemName] = @"iOS";
+#elif TARGET_OS_OSX
     sysInfo[@BSG_KSSystemField_SystemName] = @"Mac OS";
+#elif TARGET_OS_TV
+    sysInfo[@BSG_KSSystemField_SystemName] = @"tvOS";
+#endif
     NSOperatingSystemVersion version =
         [NSProcessInfo processInfo].operatingSystemVersion;
     NSString *systemVersion;
@@ -389,7 +397,7 @@ static inline bool is_jailbroken() {
                              version.minorVersion, version.patchVersion];
     }
     sysInfo[@BSG_KSSystemField_SystemVersion] = systemVersion;
-#endif
+
     if ([self isSimulatorBuild]) {
         NSString *model = [NSProcessInfo processInfo]
                               .environment[BSGKeySimulatorModelId];

--- a/Bugsnag/KSCrash/Source/KSCrash/Recording/BSG_KSSystemInfo.m
+++ b/Bugsnag/KSCrash/Source/KSCrash/Recording/BSG_KSSystemInfo.m
@@ -389,12 +389,13 @@ static inline bool is_jailbroken() {
     NSString *systemVersion;
     if (version.patchVersion == 0) {
         systemVersion =
-            [NSString stringWithFormat:@"%ld.%ld", version.majorVersion,
-                                       version.minorVersion];
+        [NSString stringWithFormat:@"%ld.%ld",
+         (long)version.majorVersion, (long)version.minorVersion];
     } else {
-        systemVersion = [NSString
-            stringWithFormat:@"%ld.%ld.%ld", version.majorVersion,
-                             version.minorVersion, version.patchVersion];
+        systemVersion =
+        [NSString stringWithFormat:@"%ld.%ld.%ld",
+         (long)version.majorVersion, (long)version.minorVersion,
+         (long)version.patchVersion];
     }
     sysInfo[@BSG_KSSystemField_SystemVersion] = systemVersion;
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,13 @@
 Changelog
 =========
 
+## TBD
+
+### Bug fixes
+
+* Fix missing `osName` and `osVersion` for errors reported from app extensions that do not link against UIKit.
+  [#1022](https://github.com/bugsnag/bugsnag-cocoa/pull/1022)
+
 ## 6.7.0 (2021-03-03)
 
 ### Enhancements


### PR DESCRIPTION
## Goal

Fixes missing `osName` and `osVersion` device fields for errors reported from app extensions that do not link against UIKit.

Also stops invalid `batteryLevel` and `charging` values being sent.

## Changeset

`BSG_KSSystemInfo` now reads `NSOperatingSystemVersion` (that was used on macOS) on iOS and tvOS.

Hard-coded strings are now used for each OS name.

## Testing

E2E tests have coverage of osName.

Manually tested with an app extension.

Manually verified that osVersion matches `-[UIDevice systemVersion]` on iOS 14.5 beta.