### PR TITLE
Fix detection of app hangs in UITableView callbacks

### DIFF
--- a/Bugsnag/Helpers/BSGAppHangDetector.m
+++ b/Bugsnag/Helpers/BSGAppHangDetector.m
@@ -105,7 +105,11 @@
         }
     };
     
-    self.observer = CFRunLoopObserverCreateWithHandler(NULL, kCFRunLoopAfterWaiting | kCFRunLoopBeforeWaiting, true, 0, observerBlock);
+    // A high `order` is required to ensure our observer runs after others that may introduce an app hang.
+    // Once such culprit is -[UITableView tableView:didSelectRowAtIndexPath:] which is run in a
+    // _afterCACommitHandler, which is invoked via a CFRunLoopObserver.
+    CFIndex order = INT_MAX;
+    self.observer = CFRunLoopObserverCreateWithHandler(NULL, kCFRunLoopAfterWaiting | kCFRunLoopBeforeWaiting, true, order, observerBlock);
     
     CFRunLoopMode runLoopMode = CFRunLoopCopyCurrentMode(CFRunLoopGetCurrent());
     // The run loop mode will be NULL if called before the run loop has started; e.g. in a +load method.


### PR DESCRIPTION
## Goal

@xander-jones found that app hangs in `tableView:didSelectRowAtIndexPath:` implementations were not being detected.

This is because they are executed in the context of a CFRunLoopObserver that executes after the BSGAppHangDetector's, and therefore our detector thinks the run loop has already gone to sleep.

Example backtrace:

```
  * frame #0: 0x000000010878dd62 bugsnag-example`ViewController.tableView(tableView=0x00007fc434046800, indexPath=<unavailable; try printing with "vo" or "po">, self=0x00007fc432e09660) at ViewController.swift:62:17
    frame #1: 0x000000010878e797 bugsnag-example`@objc ViewController.tableView(_:didSelectRowAt:) at <compiler-generated>:0
    frame #2: 0x00007fff248b1a43 UIKitCore`-[UITableView _selectRowAtIndexPath:animated:scrollPosition:notifyDelegate:isCellMultiSelect:] + 1078
    frame #3: 0x00007fff248b15f6 UIKitCore`-[UITableView _selectRowAtIndexPath:animated:scrollPosition:notifyDelegate:] + 97
    frame #4: 0x00007fff248b1f42 UIKitCore`-[UITableView _userSelectRowAtPendingSelectionIndexPath:] + 334
    frame #5: 0x00007fff24b9107a UIKitCore`-[_UIAfterCACommitBlock run] + 54
    frame #6: 0x00007fff246a5954 UIKitCore`_runAfterCACommitDeferredBlocks + 333
    frame #7: 0x00007fff246959fc UIKitCore`_cleanUpAfterCAFlushAndRunDeferredBlocks + 221
    frame #8: 0x00007fff246c72ac UIKitCore`_afterCACommitHandler + 85
    frame #9: 0x00007fff2038f1f8 CoreFoundation`__CFRUNLOOP_IS_CALLING_OUT_TO_AN_OBSERVER_CALLBACK_FUNCTION__ + 23
    frame #10: 0x00007fff20389a77 CoreFoundation`__CFRunLoopDoObservers + 547
    frame #11: 0x00007fff2038a01a CoreFoundation`__CFRunLoopRun + 1113
    frame #12: 0x00007fff203896d6 CoreFoundation`CFRunLoopRunSpecific + 567
    frame #13: 0x00007fff2c257db3 GraphicsServices`GSEventRunModal + 139
    frame #14: 0x00007fff24696cf7 UIKitCore`-[UIApplication _run] + 912
    frame #15: 0x00007fff2469bba8 UIKitCore`UIApplicationMain + 101
    frame #16: 0x000000010879090b bugsnag-example`main at AppDelegate.swift:25:7
    frame #17: 0x00007fff2025a3e9 libdyld.dylib`start + 1
    frame #18: 0x00007fff2025a3e9 libdyld.dylib`start + 1
```

## Changeset

The `order` parameter controls the order in which observers are run.

This PR sets the order to `INT_MAX` to try and ensure our observer is the last to run.

## Testing

Manually verified that this fixes the detection of app hangs.

Have not found a way to verify this within our existing E2E fixture app, since it does not use a table view.