### PR TITLE
Improve reliability of OOM scenario

### DIFF
--- a/examples/objective-c-ios/Bugsnag Test App/OutOfMemoryController.m
+++ b/examples/objective-c-ios/Bugsnag Test App/OutOfMemoryController.m
@@ -1,18 +1,16 @@
 #import "OutOfMemoryController.h"
 
-#define PRINT_STATS 0
+#include <mach/mach_init.h>
+#include <mach/task_info.h>
+#include <mach/task.h>
+#include <os/proc.h>
+#include <sys/utsname.h>
 
-#if PRINT_STATS
-#import <mach/mach_init.h>
-#import <mach/task_info.h>
-#import <mach/task.h>
-#endif
+#define PRINT_STATS 1
 
 #define MEGABYTE 0x100000
 
-@implementation OutOfMemoryController {
-    NSUInteger _blockSize;
-}
+@implementation OutOfMemoryController
 
 - (void)viewDidLoad {
     [super viewDidLoad];
@@ -27,41 +25,76 @@
 - (void)viewDidAppear:(BOOL)animated {
     [super viewDidAppear:animated];
     
+    struct utsname system = {0};
+    uname(&system);
+    NSLog(@"*** Device = %s", system.machine);
+    
     NSUInteger physicalMemory = (NSUInteger)NSProcessInfo.processInfo.physicalMemory;
     NSUInteger megabytes = physicalMemory / MEGABYTE;
     NSLog(@"*** Physical memory = %lu MB", (unsigned long)megabytes);
     
-    // The ActiveHard limit varies between devices
     //
-    // Device       iOS     Total   Limit
-    // ========================================
-    // iPad3,19      9       987     700  (70%)
-    // iPhone12,1   14      3859    2098  (54%)
-    // iPhone12,8   14      2965    2095  (70%)
-    // iPhone13,1   14      3718    2098  (57%)
+    // The ActiveHard limit and point at which a memory warning is sent varies by device
+    // Some data from http://www.chenxiyao.com/article/10/read
     //
-    NSUInteger limit = MIN(2098, megabytes * 70 / 100);
+    // Device                       Total   Warn    Limit
+    // =======================================================
+    // iPad3,1      iPad 3rd gen     987     560     700  (70%)
+    // iPhone5,1    iPhone 5                         650
+    // iPhone6,2    iPhone 5s       1000     600     650  (65%)
+    // iPhone7,1    iPhone 6 Plus                    650
+    // iPhone7,2    iPhone 6                         650
+    // iPhone8,1    iPhone 6s                       1380
+    // iPhone8,2    iPhone 6s Plus                  1380
+    // iPhone8,4    iPhone SE                       1380
+    // iPhone9,1    iPhone 7                        1380
+    // iPhone9,2    iPhone 7 Plus                   2050
+    // iPhone10,1   iPhone 8                        1380
+    // iPhone10,2   iPhone 8 Plus                   2050
+    // iPhone10,3   iPhone X                        1400
+    // iPhone11,2   iPhone XS                       2050
+    // iPhone11,4   iPhone XS Max                   2050
+    // iPhone11,8   iPhone XR                       1400
+    // iPhone12,1   iPhone 11       3859            2098  (54%)
+    // iPhone12,8   iPhone SE (2)   2965    1994    2098  (70%)
+    // iPhone13,1   iPhone 12 mini  3718    1546    2098  (57%)
+    //
+    NSUInteger limit = 0;
+    task_vm_info_data_t vm_info = {0};
+    mach_msg_type_number_t count = TASK_VM_INFO_COUNT;
+    kern_return_t result = task_info(mach_task_self(), TASK_VM_INFO, (task_info_t)&vm_info, &count);
+    if (result == KERN_SUCCESS && count >= TASK_VM_INFO_REV4_COUNT) {
+        limit = (NSUInteger)(vm_info.phys_footprint + vm_info.limit_bytes_remaining) / MEGABYTE;
+        NSLog(@"*** Memory limit = %lu MB", (unsigned long)limit);
+    } else if (!strcmp(system.machine, "iPhone6,2")) {
+        limit = 650;
+        NSLog(@"*** Memory limit = %lu MB", (unsigned long)limit);
+    } else {
+        limit = MIN(2098, megabytes * 70 / 100);
+        NSLog(@"*** Memory limit = %lu MB (estimated)", (unsigned long)limit);
+    }
     
-    NSUInteger initial = limit * 95 / 100;
+    // The size of the initial block needs to be under the memory warning limit in order for one to be reliably sent.
+    NSUInteger initial = limit * 70 / 100;
     NSLog(@"*** Dirtying an initial block of %lu MB", (unsigned long)initial);
     [self consumeMegabytes:initial];
     
-    _blockSize = limit <= 1024 ? 1 : 2;
-    NSLog(@"*** Dirtying remaining memory in %lu MB blocks", (unsigned long)_blockSize);
-    // This should take around 2 seconds to trigger an OOM kill
-    [NSTimer scheduledTimerWithTimeInterval:0.03 target:self selector:@selector(timerFired) userInfo:nil repeats:YES];
+    NSLog(@"*** Dirtying remaining memory in ~2 seconds");
+    NSTimeInterval timeInterval = 2.0 / (limit - initial);
+    [NSTimer scheduledTimerWithTimeInterval:timeInterval target:self selector:@selector(timerFired) userInfo:nil repeats:YES];
 }
 
 - (void)timerFired {
-    [self consumeMegabytes:_blockSize];
+    [self consumeMegabytes:1];
 }
 
 - (void)consumeMegabytes:(NSUInteger)megabytes {
     for (NSUInteger i = 0; i < megabytes; i++) {
-        const NSUInteger pagesize = NSPageSize();
-        const NSUInteger npages = MEGABYTE / pagesize;
         volatile char *ptr = malloc(MEGABYTE);
-        for (NSUInteger page = 0; page < npages; page++) {
+        // Originally used NSPageSize() but on iPhone 5s iOS 12 that didn't result in dirtying all the memory allocated.
+        const int pagesize = 4096;
+        const int npages = MEGABYTE / pagesize;
+        for (int page = 0; page < npages; page++) {
             ptr[page * pagesize] = 42; // Dirty each page
         }
     }

--- a/examples/swift-ios/bugsnag-example/OutOfMemoryController.m
+++ b/examples/swift-ios/bugsnag-example/OutOfMemoryController.m
@@ -18,24 +18,24 @@
 // OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
 // THE SOFTWARE.
 
-#import <WebKit/WebKit.h>
-#import <signal.h>
 #import "OutOfMemoryController.h"
-#import <Bugsnag/Bugsnag.h>
 
-@interface OutOfMemoryController ()
-@property (nonatomic, strong) UIWebView *webView;
-@end
+#include <mach/mach_init.h>
+#include <mach/task_info.h>
+#include <mach/task.h>
+#include <os/proc.h>
+#include <sys/utsname.h>
+
+#define PRINT_STATS 1
+
+#define MEGABYTE 0x100000
 
 @implementation OutOfMemoryController
 
 - (void)viewDidLoad {
     [super viewDidLoad];
-    self.webView = [[UIWebView alloc] initWithFrame:self.view.bounds];
-    [self.webView loadHTMLString:@"<h2>Loading a lot of JavaScript. Please wait.</h2>"
-                                  "<p>You can follow along in Console.app</p>"
-                         baseURL:nil];
-    [self.view addSubview:self.webView];
+    
+    self.view.backgroundColor = UIColor.groupTableViewBackgroundColor;
 }
 
 - (void)didReceiveMemoryWarning {
@@ -44,15 +44,88 @@
 
 - (void)viewDidAppear:(BOOL)animated {
     [super viewDidAppear:animated];
-    NSString *format = @"var b = document.createElement('div'); div.innerHTML = 'Hello item %d'; document.documentElement.appendChild(div);";
-    for (int i = 0; i < 3000 * 1024; i++) {
-        NSString *item = [NSString stringWithFormat:format, i];
-        [self.webView stringByEvaluatingJavaScriptFromString:item];
+    
+    struct utsname system = {0};
+    uname(&system);
+    NSLog(@"*** Device = %s", system.machine);
+    
+    NSUInteger physicalMemory = (NSUInteger)NSProcessInfo.processInfo.physicalMemory;
+    NSUInteger megabytes = physicalMemory / MEGABYTE;
+    NSLog(@"*** Physical memory = %lu MB", (unsigned long)megabytes);
+    
+    //
+    // The ActiveHard limit and point at which a memory warning is sent varies by device
+    // Some data from http://www.chenxiyao.com/article/10/read
+    //
+    // Device                       Total   Warn    Limit
+    // =======================================================
+    // iPad3,1      iPad 3rd gen     987     560     700  (70%)
+    // iPhone5,1    iPhone 5                         650
+    // iPhone6,2    iPhone 5s       1000     600     650  (65%)
+    // iPhone7,1    iPhone 6 Plus                    650
+    // iPhone7,2    iPhone 6                         650
+    // iPhone8,1    iPhone 6s                       1380
+    // iPhone8,2    iPhone 6s Plus                  1380
+    // iPhone8,4    iPhone SE                       1380
+    // iPhone9,1    iPhone 7                        1380
+    // iPhone9,2    iPhone 7 Plus                   2050
+    // iPhone10,1   iPhone 8                        1380
+    // iPhone10,2   iPhone 8 Plus                   2050
+    // iPhone10,3   iPhone X                        1400
+    // iPhone11,2   iPhone XS                       2050
+    // iPhone11,4   iPhone XS Max                   2050
+    // iPhone11,8   iPhone XR                       1400
+    // iPhone12,1   iPhone 11       3859            2098  (54%)
+    // iPhone12,8   iPhone SE (2)   2965    1994    2098  (70%)
+    // iPhone13,1   iPhone 12 mini  3718    1546    2098  (57%)
+    //
+    NSUInteger limit = 0;
+    task_vm_info_data_t vm_info = {0};
+    mach_msg_type_number_t count = TASK_VM_INFO_COUNT;
+    kern_return_t result = task_info(mach_task_self(), TASK_VM_INFO, (task_info_t)&vm_info, &count);
+    if (result == KERN_SUCCESS && count >= TASK_VM_INFO_REV4_COUNT) {
+        limit = (NSUInteger)(vm_info.phys_footprint + vm_info.limit_bytes_remaining) / MEGABYTE;
+        NSLog(@"*** Memory limit = %lu MB", (unsigned long)limit);
+    } else if (!strcmp(system.machine, "iPhone6,2")) {
+        limit = 650;
+        NSLog(@"*** Memory limit = %lu MB", (unsigned long)limit);
+    } else {
+        limit = MIN(2098, megabytes * 70 / 100);
+        NSLog(@"*** Memory limit = %lu MB (estimated)", (unsigned long)limit);
+    }
+    
+    // The size of the initial block needs to be under the memory warning limit in order for one to be reliably sent.
+    NSUInteger initial = limit * 70 / 100;
+    NSLog(@"*** Dirtying an initial block of %lu MB", (unsigned long)initial);
+    [self consumeMegabytes:initial];
+    
+    NSLog(@"*** Dirtying remaining memory in ~2 seconds");
+    NSTimeInterval timeInterval = 2.0 / (limit - initial);
+    [NSTimer scheduledTimerWithTimeInterval:timeInterval target:self selector:@selector(timerFired) userInfo:nil repeats:YES];
+}
 
-        if (i % 1000 == 0) {
-            NSLog(@"Loaded %d items", i);
+- (void)timerFired {
+    [self consumeMegabytes:1];
+}
+
+- (void)consumeMegabytes:(NSUInteger)megabytes {
+    for (NSUInteger i = 0; i < megabytes; i++) {
+        volatile char *ptr = malloc(MEGABYTE);
+        // Originally used NSPageSize() but on iPhone 5s iOS 12 that didn't result in dirtying all the memory allocated.
+        const int pagesize = 4096;
+        const int npages = MEGABYTE / pagesize;
+        for (int page = 0; page < npages; page++) {
+            ptr[page * pagesize] = 42; // Dirty each page
         }
     }
+#if PRINT_STATS
+    task_vm_info_data_t info;
+    mach_msg_type_number_t count = TASK_VM_INFO_COUNT;
+    kern_return_t result = task_info(mach_task_self(), TASK_VM_INFO, (task_info_t) &info, &count);
+    assert(result == KERN_SUCCESS);
+    unsigned long long physicalMemory = NSProcessInfo.processInfo.physicalMemory;
+    NSLog(@"%4llu / %4llu MB (%llu%%)", info.phys_footprint / MEGABYTE, physicalMemory / MEGABYTE, info.phys_footprint * 100 / physicalMemory);
+#endif
 }
 
 @end

--- a/features/fixtures/shared/scenarios/OOMScenario.m
+++ b/features/fixtures/shared/scenarios/OOMScenario.m
@@ -10,11 +10,15 @@
 
 #import <UIKit/UIKit.h>
 
+#include <mach/mach_init.h>
+#include <mach/task_info.h>
+#include <mach/task.h>
+#include <os/proc.h>
+#include <sys/utsname.h>
+
 #define MEGABYTE 0x100000
 
-@implementation OOMScenario {
-    NSUInteger _blockSize;
-}
+@implementation OOMScenario
 
 - (void)startBugsnag {
     self.config.autoTrackSessions = YES;
@@ -45,41 +49,76 @@
 }
 
 - (void)consumeAllMemory {
+    struct utsname system = {0};
+    uname(&system);
+    NSLog(@"*** Device = %s", system.machine);
+    
     NSUInteger physicalMemory = (NSUInteger)NSProcessInfo.processInfo.physicalMemory;
     NSUInteger megabytes = physicalMemory / MEGABYTE;
     NSLog(@"*** Physical memory = %lu MB", (unsigned long)megabytes);
     
-    // The ActiveHard limit varies between devices
     //
-    // Device       iOS     Total   Limit
-    // ========================================
-    // iPad3,19      9       987     700  (70%)
-    // iPhone12,1   14      3859    2098  (54%)
-    // iPhone12,8   14      2965    2095  (70%)
-    // iPhone13,1   14      3718    2098  (57%)
+    // The ActiveHard limit and point at which a memory warning is sent varies by device
+    // Some data from http://www.chenxiyao.com/article/10/read
     //
-    NSUInteger limit = MIN(2098, megabytes * 70 / 100);
+    // Device                       Total   Warn    Limit
+    // =======================================================
+    // iPad3,1      iPad 3rd gen     987     560     700  (70%)
+    // iPhone5,1    iPhone 5                         650
+    // iPhone6,2    iPhone 5s       1000     600     650  (65%)
+    // iPhone7,1    iPhone 6 Plus                    650
+    // iPhone7,2    iPhone 6                         650
+    // iPhone8,1    iPhone 6s                       1380
+    // iPhone8,2    iPhone 6s Plus                  1380
+    // iPhone8,4    iPhone SE                       1380
+    // iPhone9,1    iPhone 7                        1380
+    // iPhone9,2    iPhone 7 Plus                   2050
+    // iPhone10,1   iPhone 8                        1380
+    // iPhone10,2   iPhone 8 Plus                   2050
+    // iPhone10,3   iPhone X                        1400
+    // iPhone11,2   iPhone XS                       2050
+    // iPhone11,4   iPhone XS Max                   2050
+    // iPhone11,8   iPhone XR                       1400
+    // iPhone12,1   iPhone 11       3859            2098  (54%)
+    // iPhone12,8   iPhone SE (2)   2965    1994    2098  (70%)
+    // iPhone13,1   iPhone 12 mini  3718    1546    2098  (57%)
+    //
+    NSUInteger limit = 0;
+    task_vm_info_data_t vm_info = {0};
+    mach_msg_type_number_t count = TASK_VM_INFO_COUNT;
+    kern_return_t result = task_info(mach_task_self(), TASK_VM_INFO, (task_info_t)&vm_info, &count);
+    if (result == KERN_SUCCESS && count >= TASK_VM_INFO_REV4_COUNT) {
+        limit = (NSUInteger)(vm_info.phys_footprint + vm_info.limit_bytes_remaining) / MEGABYTE;
+        NSLog(@"*** Memory limit = %lu MB", (unsigned long)limit);
+    } else if (!strcmp(system.machine, "iPhone6,2")) {
+        limit = 650;
+        NSLog(@"*** Memory limit = %lu MB", (unsigned long)limit);
+    } else {
+        limit = MIN(2098, megabytes * 70 / 100);
+        NSLog(@"*** Memory limit = %lu MB (estimated)", (unsigned long)limit);
+    }
     
-    NSUInteger initial = limit * 95 / 100;
+    // The size of the initial block needs to be under the memory warning limit in order for one to be reliably sent.
+    NSUInteger initial = limit * 70 / 100;
     NSLog(@"*** Dirtying an initial block of %lu MB", (unsigned long)initial);
     [self consumeMegabytes:initial];
     
-    _blockSize = limit <= 1024 ? 1 : 2;
-    NSLog(@"*** Dirtying remaining memory in %lu MB blocks", (unsigned long)_blockSize);
-    // This should take around 2 seconds to trigger an OOM kill
-    [NSTimer scheduledTimerWithTimeInterval:0.03 target:self selector:@selector(timerFired) userInfo:nil repeats:YES];
+    NSLog(@"*** Dirtying remaining memory in ~2 seconds");
+    NSTimeInterval timeInterval = 2.0 / (limit - initial);
+    [NSTimer scheduledTimerWithTimeInterval:timeInterval target:self selector:@selector(timerFired) userInfo:nil repeats:YES];
 }
 
 - (void)timerFired {
-    [self consumeMegabytes:_blockSize];
+    [self consumeMegabytes:1];
 }
 
 - (void)consumeMegabytes:(NSUInteger)megabytes {
     for (NSUInteger i = 0; i < megabytes; i++) {
-        const NSUInteger pagesize = NSPageSize();
-        const NSUInteger npages = MEGABYTE / pagesize;
         volatile char *ptr = malloc(MEGABYTE);
-        for (NSUInteger page = 0; page < npages; page++) {
+        // Originally used NSPageSize() but on iPhone 5s iOS 12 that didn't result in dirtying all the memory allocated.
+        const int pagesize = 4096;
+        const int npages = MEGABYTE / pagesize;
+        for (int page = 0; page < npages; page++) {
             ptr[page * pagesize] = 42; // Dirty each page
         }
     }


### PR DESCRIPTION
## Goal

Improve the OOM scenario in the Objective-C iOS sample app so that it works on iPhone 5s.

## Changeset

Fixed iPhone 5s case by ignoring the size reported by `NSPageSize()` and instead dirty each 4096th byte.

The iPhone 5s also has a quirk where its memory limit is a lower percentage (65%) than other devices with similar amount of memory (70%) which has been addressed.

Improved the reliability of receiving a low memory warning after determining that it's important to _cross_ the memory limit boundary in a gradual way to trigger it.

Also updates the Swift iOS sample app to use the same method of provoking an OOM.

## Testing

Tested locally on iPhone 5s, iPhone 8, iPhone 12 mini and iPad 3rd generation.