### PR TITLE
Fix flake in BareboneTestHandledScenario

### DIFF
--- a/features/fixtures/shared/scenarios/BareboneTestScenarios.swift
+++ b/features/fixtures/shared/scenarios/BareboneTestScenarios.swift
@@ -61,13 +61,13 @@ class BareboneTestHandledScenario: Scenario {
         
         Bugsnag.leaveBreadcrumb(withMessage: "This is super secret")
         
+        self.afterSendErrorBlock = self.afterSendError
+        
         Bugsnag.notify(NSException(name: .rangeException, reason: "-[__NSSingleObjectArrayI objectAtIndex:]: index 1 beyond bounds [0 .. 0]")) {
             $0.addMetadata(["info": "Some error specific information"], section: "Exception")
             $0.unhandled = true
             return true
         }
-        
-        self.afterSendErrorBlock = self.afterSendError
     }
     
     func afterSendError() {


### PR DESCRIPTION
## Goal

Observed a flake in this test during a [recent run](https://buildkite.com/bugsnag/bugsnag-cocoa/builds/2217#b2221070-115b-4a78-a5ba-9e250a03155e).

## Changeset

There used to be a 1 second delay between `notify()` and the event being sent (and `OnSendError()` called.)

Now that the delay has been removed, it's possible for `OnSendError()` to be called before the scenario sets `afterSendErrorBlock`.

`afterSendErrorBlock` is now assigned before calling `notify()` to fix the flake.

## Testing

On CI