### PR TITLE
Move pipeline steps to macOS 11

### DIFF
--- a/.buildkite/pipeline.quick.yml
+++ b/.buildkite/pipeline.quick.yml
@@ -165,7 +165,7 @@ steps:
       - cocoa_fixture
     timeout_in_minutes: 60
     agents:
-      queue: opensource-mac-cocoa
+      queue: opensource-mac-cocoa-10.15
     plugins:
       artifacts#v1.3.0:
         download: ["features/fixtures/macos/output/macOSTestApp.zip"]

--- a/.buildkite/pipeline.quick.yml
+++ b/.buildkite/pipeline.quick.yml
@@ -30,7 +30,7 @@ steps:
   - label: iOS 13 unit tests
     timeout_in_minutes: 10
     agents:
-      queue: opensource-mac-cocoa
+      queue: opensource-mac-cocoa-11
     env:
       LANG: "en_GB.UTF-8"
       TEST_CONFIGURATION: "Debug"
@@ -47,7 +47,7 @@ steps:
   - label: iOS 12 unit tests
     timeout_in_minutes: 10
     agents:
-      queue: opensource-mac-cocoa
+      queue: opensource-mac-cocoa-11
     env:
       LANG: "en_GB.UTF-8"
       TEST_CONFIGURATION: "Debug"
@@ -64,7 +64,7 @@ steps:
   - label: iOS 11 unit tests
     timeout_in_minutes: 10
     agents:
-      queue: opensource-mac-cocoa
+      queue: opensource-mac-cocoa-11
     env:
       LANG: "en_GB.UTF-8"
       TEST_CONFIGURATION: "Debug"
@@ -81,7 +81,7 @@ steps:
   - label: iOS 10 unit tests
     timeout_in_minutes: 10
     agents:
-      queue: opensource-mac-cocoa-10.14
+      queue: opensource-mac-cocoa-11
     env:
       LANG: "en_GB.UTF-8"
       TEST_CONFIGURATION: "Debug"
@@ -97,7 +97,7 @@ steps:
   - label: tvOS 13 unit tests
     timeout_in_minutes: 10
     agents:
-      queue: opensource-mac-cocoa
+      queue: opensource-mac-cocoa-11
     env:
       LANG: "en_GB.UTF-8"
       TEST_CONFIGURATION: "Debug"
@@ -114,7 +114,7 @@ steps:
   - label: tvOS 12 unit tests
     timeout_in_minutes: 10
     agents:
-      queue: opensource-mac-cocoa
+      queue: opensource-mac-cocoa-11
     env:
       LANG: "en_GB.UTF-8"
       TEST_CONFIGURATION: "Debug"
@@ -131,7 +131,7 @@ steps:
   - label: tvOS 11 unit tests
     timeout_in_minutes: 10
     agents:
-      queue: opensource-mac-cocoa
+      queue: opensource-mac-cocoa-11
     env:
       LANG: "en_GB.UTF-8"
       TEST_CONFIGURATION: "Debug"
@@ -148,7 +148,7 @@ steps:
   - label: tvOS 10 unit tests
     timeout_in_minutes: 10
     agents:
-      queue: opensource-mac-cocoa-10.14
+      queue: opensource-mac-cocoa-11
     env:
       LANG: "en_GB.UTF-8"
       TEST_CONFIGURATION: "Debug"

--- a/.buildkite/pipeline.yml
+++ b/.buildkite/pipeline.yml
@@ -14,7 +14,7 @@ steps:
   - label: Static framework and Swift Package Manager builds
     timeout_in_minutes: 10
     agents:
-      queue: opensource-mac-cocoa
+      queue: opensource-mac-cocoa-10.15
     concurrency: 3
     concurrency_group: cocoa-unit-tests
     env:
@@ -27,7 +27,7 @@ steps:
   - label: Static Carthage build
     timeout_in_minutes: 10
     agents:
-      queue: opensource-mac-cocoa
+      queue: opensource-mac-cocoa-10.15
     concurrency: 3
     concurrency_group: cocoa-unit-tests
     env:
@@ -40,7 +40,7 @@ steps:
   - label: macOS 10.15 unit tests
     timeout_in_minutes: 10
     agents:
-      queue: opensource-mac-cocoa
+      queue: opensource-mac-cocoa-10.15
     concurrency: 3
     concurrency_group: cocoa-unit-tests
     env:
@@ -182,7 +182,7 @@ steps:
       - cocoa_fixture
     timeout_in_minutes: 60
     agents:
-      queue: opensource-mac-cocoa
+      queue: opensource-mac-cocoa-10.15
     plugins:
       artifacts#v1.3.0:
         download: ["features/fixtures/macos/output/macOSTestApp.zip"]

--- a/.buildkite/pipeline.yml
+++ b/.buildkite/pipeline.yml
@@ -73,7 +73,7 @@ steps:
       LANG: "en_GB.UTF-8"
       TEST_CONFIGURATION: "Debug"
       PLATFORM: "iOS"
-      OS: "14.2"
+      OS: "14.3"
     commands:
       - make bootstrap
       - make test
@@ -104,7 +104,7 @@ steps:
       LANG: "en_GB.UTF-8"
       TEST_CONFIGURATION: "Debug"
       PLATFORM: "tvOS"
-      OS: "14.0"
+      OS: "14.3"
     commands:
       - make bootstrap
       - make test

--- a/.buildkite/pipeline.yml
+++ b/.buildkite/pipeline.yml
@@ -3,7 +3,7 @@ steps:
     key: cocoa_fixture
     timeout_in_minutes: 20
     agents:
-      queue: opensource-mac-cocoa
+      queue: opensource-mac-cocoa-11
     artifact_paths:
       - features/fixtures/ios-swift-cocoapods/output/iOSTestApp.ipa
       - features/fixtures/macos/output/macOSTestApp.zip


### PR DESCRIPTION
## Goal

Refresh test coverage to use macOS 11 by default.  

## Design

The change in this PR are supported by a refresh of our build servers:
- Number of macOS 11 servers increased
- On macOS 11 servers, XCode moved to the latest currently available (12.4)

## Changeset

Add/move build/test steps on to use XCode 12 on macOS 11 whilst maintaining end-to-end test coverage on macOS 10.14 and 10.15.
tvOS/iOS unit tests moved on to the latest currently available simulator versions.

## Testing

Covered by CI.