### PR TITLE
Replace sprintf in JSON encoder

### DIFF
--- a/Bugsnag/KSCrash/Source/KSCrash/Recording/Tools/BSG_KSJSONCodec.c
+++ b/Bugsnag/KSCrash/Source/KSCrash/Recording/Tools/BSG_KSJSONCodec.c
@@ -26,8 +26,9 @@
 
 #include "BSG_KSJSONCodec.h"
 
-#include <ctype.h>
-#include <stdlib.h>
+#include <math.h>
+#include <stdbool.h>
+#include <stdint.h>
 #include <string.h>
 
 // ============================================================================
@@ -52,6 +53,12 @@
 #ifndef BSG_KSJSONCODEC_WorkBufferSize
 #define BSG_KSJSONCODEC_WorkBufferSize 512
 #endif
+
+/**
+ * The maximum number of significant digits when printing floats.
+ * 7 (6 + 1 whole digit in exp form) is the default used by the old sprintf code.
+ */
+#define MAX_SIGNIFICANT_DIGITS 7
 
 // ============================================================================
 #pragma mark - Helpers -
@@ -78,6 +85,171 @@ const char *bsg_ksjsonstringForError(const int error) {
     default:
         return "(unknown error)";
     }
+}
+
+// Max uint64 is 18446744073709551615
+#define MAX_UINT64_DIGITS 20
+
+/**
+ * Convert an unsigned integer to a string.
+ * This will write a maximum of 21 characters (including the NUL) to dst.
+ *
+ * Returns the length of the string written to dst (not including the NUL).
+ */
+static size_t uint64_to_string(uint64_t value, char* dst) {
+    if(value == 0) {
+        dst[0] = '0';
+        dst[1] = 0;
+        return 1;
+    }
+
+    char buff[MAX_UINT64_DIGITS+1];
+    buff[sizeof(buff)-1] = 0;
+    int index = sizeof(buff) - 2;
+    for(;;) {
+        buff[index] = (value%10) + '0';
+        value /= 10;
+        if (value == 0) {
+            break;
+        }
+        index--;
+    }
+
+    size_t length = sizeof(buff) - index;
+    memcpy(dst, buff+index, length);
+    return length - 1;
+}
+
+/**
+ * Convert an integer to a string.
+ * This will write a maximum of 22 characters (including the null terminator) to dst.
+ *
+ * Returns the length of the string written to dst (not including the null termination byte).
+ */
+static size_t int64_to_string(int64_t value, char* dst) {
+    if (value < 0) {
+        dst[0] = '-';
+        return uint64_to_string(-value, dst+1) + 1;
+    }
+    return uint64_to_string(value, dst);
+}
+
+/**
+ * Convert a positive double to a string, allowing up to max_sig_digits.
+ * To reduce the complexity of this algorithm, values with an exponent
+ * other than 0 are always printed in exponential form.
+ *
+ * Values are rounded half-up.
+ *
+ * This function makes use of compiler intrinsic functions which, though not
+ * officially async-safe, are actually async-safe (no allocations, locks, etc).
+ *
+ * This function will write a maximum of 21 characters (including the NUL) to dst.
+ *
+ * Returns the length of the string written to dst (not including the NUL).
+ */
+static size_t positive_double_to_string(const double value, char* dst, const int max_sig_digits) {
+    const char* const orig_dst = dst;
+
+    if(value == 0) {
+        dst[0] = '0';
+        dst[1] = 0;
+        return 1;
+    }
+
+    // isnan() is basically ((x) != (x))
+    if(isnan(value)) {
+        strcpy(dst, "nan");
+        return 3;
+    }
+
+    // isinf() is a compiler intrinsic.
+    if(isinf(value)) {
+        strcpy(dst, "inf");
+        return 3;
+    }
+
+    // log10() is a compiler intrinsic.
+    int exponent = log10(value);
+    // Values < 1.0 must subtract 1 from exponent to handle zero wraparound.
+    if (value < 1.0) {
+        exponent--;
+    }
+
+    // pow() is a compiler intrinsic.
+    double normalized = value / pow(10, exponent);
+    // Special case for 0.1, 0.01, 0.001, etc giving a normalized value of 10.xyz.
+    // We use 9.999... because 10.0 converts to a value > 10 in ieee754 binary floats.
+    if (normalized > 9.99999999999999822364316059975) {
+        exponent++;
+        normalized = value / pow(10, exponent);
+    }
+
+    // Put all of the digits we'll use into an integer.
+    double digits_and_remainder = normalized * pow(10, max_sig_digits-1);
+    uint64_t digits = digits_and_remainder;
+    // Also round up if necessary (note: 0.5 is exact in both binary and decimal).
+    if (digits_and_remainder - digits >= 0.5) {
+        digits++;
+        // Special case: Adding one bumps us to next magnitude.
+        if (digits >= (uint64_t)pow(10, max_sig_digits)) {
+            exponent++;
+            digits /= 10;
+        }
+    }
+
+    // Extract the fractional digits.
+    for (int i = max_sig_digits; i > 1; i--) {
+        dst[i] = digits % 10 + '0';
+        digits /= 10;
+    }
+    // Extract the single-digit whole part.
+    dst[0] = digits + '0';
+    dst[1] = '.';
+
+    // Strip off trailing zeroes, and also the '.' if there is no fractional part.
+    int e_offset = max_sig_digits;
+    for (int i = max_sig_digits; i > 0; i--) {
+        if (dst[i] != '0') {
+            if (dst[i] == '.') {
+                e_offset = i;
+            } else {
+                e_offset = i + 1;
+            }
+            break;
+        }
+    }
+    dst += e_offset;
+
+    // Add the exponent if it's not 0.
+    if (exponent != 0) {
+        *dst++ = 'e';
+        if (exponent >= 0) {
+            *dst++ = '+';
+        }
+        dst += int64_to_string(exponent, dst);
+    } else {
+        *dst = 0;
+    }
+
+    return dst - orig_dst;
+}
+
+/**
+ * Convert a positive double to a string, allowing up to max_sig_digits. See
+ * positive_double_to_string() for important information about how this
+ * algorithm differs from sprintf.
+ *
+ * This function will write a maximum of 22 characters (including the NUL) to dst.
+ *
+ * Returns the length of the string written to dst (not including the NUL).
+ */
+static size_t double_to_string(double value, char* dst, int max_sig_digits) {
+    if (value < 0) {
+        dst[0] = '-';
+        return positive_double_to_string(-value, dst+1, max_sig_digits) + 1;
+    }
+    return positive_double_to_string(value, dst, max_sig_digits);
 }
 
 // ============================================================================
@@ -320,7 +492,7 @@ int bsg_ksjsonaddFloatingPointElement(BSG_KSJSONEncodeContext *const context,
     int result = bsg_ksjsonbeginElement(context, name);
     unlikely_if(result != BSG_KSJSON_OK) { return result; }
     char buff[30];
-    sprintf(buff, "%lg", value);
+    double_to_string(value, buff, MAX_SIGNIFICANT_DIGITS);
     return addJSONData(context, buff, strlen(buff));
 }
 
@@ -329,7 +501,7 @@ int bsg_ksjsonaddIntegerElement(BSG_KSJSONEncodeContext *const context,
     int result = bsg_ksjsonbeginElement(context, name);
     unlikely_if(result != BSG_KSJSON_OK) { return result; }
     char buff[30];
-    sprintf(buff, "%lld", value);
+    int64_to_string(value, buff);
     return addJSONData(context, buff, strlen(buff));
 }
 
@@ -339,7 +511,7 @@ int bsg_ksjsonaddUIntegerElement(BSG_KSJSONEncodeContext *const context,
     int result = bsg_ksjsonbeginElement(context, name);
     unlikely_if(result != BSG_KSJSON_OK) { return result; }
     char buff[30];
-    sprintf(buff, "%llu", value);
+    uint64_to_string(value, buff);
     return addJSONData(context, buff, (int)strlen(buff));
 }
 

--- a/Bugsnag/KSCrash/Source/KSCrash/Recording/Tools/BSG_KSJSONCodec.h
+++ b/Bugsnag/KSCrash/Source/KSCrash/Recording/Tools/BSG_KSJSONCodec.h
@@ -35,7 +35,6 @@ extern "C" {
 #endif
 
 #include <stdbool.h>
-#include <stdio.h>
 #include <sys/types.h>
 
 /* Tells the encoder to automatically determine the length of a field value.


### PR DESCRIPTION
## Goal

sprintf can call malloc, which can cause lockups in a crash scenario. Replace the sprintf calls in the JSON encoder with async-safe code. The new code is a simplified algorithm that always outputs in exponential form when the exponent is not 0. The result is the same effective value as before when ingested by a machine, but it may look a little strange to a human.

## Testing

* Added more unit tests specifically targeting the integer and float encoding in the JSON encoder.
* Re-ran unit and e2e tests.
