### PR TITLE
Fix test flakes

### DIFF
--- a/.buildkite/pipeline.quick.yml
+++ b/.buildkite/pipeline.quick.yml
@@ -81,7 +81,7 @@ steps:
   - label: iOS 10 unit tests
     timeout_in_minutes: 10
     agents:
-      queue: opensource-mac-cocoa-11
+      queue: opensource-mac-cocoa-10.14
     env:
       LANG: "en_GB.UTF-8"
       TEST_CONFIGURATION: "Debug"
@@ -148,7 +148,7 @@ steps:
   - label: tvOS 10 unit tests
     timeout_in_minutes: 10
     agents:
-      queue: opensource-mac-cocoa-11
+      queue: opensource-mac-cocoa-10.14
     env:
       LANG: "en_GB.UTF-8"
       TEST_CONFIGURATION: "Debug"

--- a/features/enabled_error_types.feature
+++ b/features/enabled_error_types.feature
@@ -28,8 +28,7 @@ Feature: Enabled error types
     And the event "unhandled" is false
 
   Scenario: Mach Crash Reporting is disabled
-    When I run "DisableMachExceptionScenario"
-    And I relaunch the app
+    When I run "DisableMachExceptionScenario" and relaunch the app
     And I configure Bugsnag for "DisableMachExceptionScenario"
     And I wait to receive an error
     Then the error is valid for the error reporting API

--- a/features/fixtures/macos/macOSTestApp/MainWindowController.m
+++ b/features/fixtures/macos/macOSTestApp/MainWindowController.m
@@ -59,11 +59,12 @@
         [self.scenario startBugsnag];
     }
 
-    NSLog(@"Running scenario: %@", self.scenario);
+    NSLog(@"Will run scenario: %@", self.scenario);
     // Using dispatch_async to prevent AppleEvents swallowing exceptions.
     // For more info see https://www.chimehq.com/blog/sad-state-of-exceptions
     // 0.1s delay allows accessibility APIs to finish handling the mouse click and returns control to the tests framework.
     dispatch_after(dispatch_time(DISPATCH_TIME_NOW, (int64_t)(0.1 * NSEC_PER_SEC)), dispatch_get_main_queue(), ^{
+        NSLog(@"Running scenario: %@", self.scenario);
         [self.scenario run];
     });
 }

--- a/features/fixtures/macos/macOSTestApp/main.m
+++ b/features/fixtures/macos/macOSTestApp/main.m
@@ -8,6 +8,11 @@
 
 #import <Cocoa/Cocoa.h>
 
+void sigterm(int signum) {
+    NSLog(@"Received SIGTERM");
+    exit(0);
+}
+
 int main(int argc, const char * argv[]) {
     [[NSUserDefaults standardUserDefaults] registerDefaults:@{
         // Disable state restoration to prevent the following dialog being shown after crashes
@@ -18,6 +23,8 @@ int main(int argc, const char * argv[]) {
         // Stop NSApplication swallowing NSExceptions thrown on the main thread.
         @"NSApplicationCrashOnExceptions": @YES,
     }];
+    
+    sigaction(SIGTERM, &(struct sigaction){ .sa_handler = &sigterm }, NULL);
     
     return NSApplicationMain(argc, argv);
 }

--- a/features/last_run_info.feature
+++ b/features/last_run_info.feature
@@ -4,8 +4,7 @@ Feature: Launch detection
     Given I clear all persistent data
 
   Scenario: LastRunInfo consecutiveLaunchCrashes increments when isLaunching is true
-    When I run "LastRunInfoConsecutiveLaunchCrashesScenario"
-    And I relaunch the app
+    When I run "LastRunInfoConsecutiveLaunchCrashesScenario" and relaunch the app
     And I configure Bugsnag for "LastRunInfoConsecutiveLaunchCrashesScenario"
     And I wait to receive an error
     And the event "metaData.lastRunInfo.consecutiveLaunchCrashes" equals 1

--- a/features/scripts/export_mac_app.sh
+++ b/features/scripts/export_mac_app.sh
@@ -11,7 +11,8 @@ xcrun xcodebuild \
   -configuration Debug \
   -archivePath archive/macOSTestApp.xcarchive \
   -quiet \
-  archive
+  archive \
+  GCC_PREPROCESSOR_DEFINITIONS='$(inherited) BSG_LOG_LEVEL=BSG_LOGLEVEL_DEBUG'
 
 xcrun xcodebuild \
   -exportArchive \

--- a/features/user_persistence.feature
+++ b/features/user_persistence.feature
@@ -38,6 +38,7 @@ Scenario: User Info is persisted from client across app runs
 
     # Session is captured before the user can be set on the Client
     And I wait to receive a session
+    And I wait for 1 second
     And I relaunch the app
 
     Then the session is valid for the session reporting API


### PR DESCRIPTION
## Goal

Fixes some E2E test flakes that have been plaguing the `integration/app-hangs` branch.

## Changeset

* macOS test fixture will now accept class names that are not correctly capitalized - this fixes flakes caused by AppiumForMac not reliably pressing the shift key 🤦 
* Fixed flakes caused by the test fixture being terminated by the test framework before the scenario run method had executed
* Improved logging in the macOS test fixture, to aid diagnosis of these issues
* Rolled back iOS & tvOS 10 unit tests to run on macOS 10.14, because the iOS 10 simulator is not available on macOS 11

## Testing

Was able to reproduce the flakes locally, and verified fixes locally and on CI