### PR TITLE
Fix parsing of `callStackSymbols` where the image name contains spaces

### DIFF
--- a/Bugsnag/Payload/BugsnagStackframe.m
+++ b/Bugsnag/Payload/BugsnagStackframe.m
@@ -120,7 +120,7 @@ BugsnagStackframeType const BugsnagStackframeTypeCocoa = @"cocoa";
 + (NSArray<BugsnagStackframe *> *)stackframesWithCallStackSymbols:(NSArray<NSString *> *)callStackSymbols {
     NSString *pattern = (@"^(\\d+)"             // Capture the leading frame number
                          @" +"                  // Skip whitespace
-                         @"(\\S+)"              // Image name
+                         @"([\\S ]+?)"          // Image name (may contain spaces)
                          @" +"                  // Skip whitespace
                          @"(0x[0-9a-fA-F]+)"    // Capture the frame address
                          @"("                   // Start optional group

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,13 @@
 Changelog
 =========
 
+## TBD
+
+### Bug fixes
+
+* Fix parsing of `callStackSymbols` where the image name contains spaces.
+  [#1036](https://github.com/bugsnag/bugsnag-cocoa/pull/1036)
+
 ## 6.7.1 (2021-03-10)
 
 ### Bug fixes

--- a/Tests/BugsnagStackframeTest.m
+++ b/Tests/BugsnagStackframeTest.m
@@ -170,7 +170,7 @@
         @"4   CoreFoundation                      0x00007fff23e41fd1",
         @"5   CoreFoundation                      0x00007fff23e422a4",
         @"6   ReactNativeTest                     0x000000010fd76eae",
-        @"7   ReactNativeTest                     0x000000010fd79138"]];
+        @"7   ReactNative App                     0x000000010fd79138"]];
     
     AssertStackframeValues(stackframes[0], @"ReactNativeTest",  0x000000010fda7f1b, @"0x000000010fda7f1b");
     AssertStackframeValues(stackframes[1], @"ReactNativeTest",  0x000000010fd76897, @"0x000000010fd76897");
@@ -179,7 +179,7 @@
     AssertStackframeValues(stackframes[4], @"CoreFoundation",   0x00007fff23e41fd1, @"0x00007fff23e41fd1");
     AssertStackframeValues(stackframes[5], @"CoreFoundation",   0x00007fff23e422a4, @"0x00007fff23e422a4");
     AssertStackframeValues(stackframes[6], @"ReactNativeTest",  0x000000010fd76eae, @"0x000000010fd76eae");
-    AssertStackframeValues(stackframes[7], @"ReactNativeTest",  0x000000010fd79138, @"0x000000010fd79138");
+    AssertStackframeValues(stackframes[7], @"ReactNative App",  0x000000010fd79138, @"0x000000010fd79138");
 }
 
 - (void)testRealCallStackSymbols {


### PR DESCRIPTION
## Goal

Fixes an issue raised in https://github.com/bugsnag/bugsnag-cocoa/pull/812#discussion_r594929380

Image names may contain spaces, but the regular expression that parses `callStackSymbols` was not catering for this, causing some stack frames to be lost.

## Changeset

Fixed the regular expression.

## Testing

Amended the unit tests to include an example of an image name containing a space. Ran the test locally to verify the fix.