### PR TITLE
Mark non-fatal app hangs as handled

### DIFF
--- a/Bugsnag/Client/BugsnagClient+AppHangs.m
+++ b/Bugsnag/Client/BugsnagClient+AppHangs.m
@@ -45,7 +45,7 @@
     BugsnagHandledState *handledState =
     [[BugsnagHandledState alloc] initWithSeverityReason:AppHang
                                                severity:BSGSeverityWarning
-                                              unhandled:YES
+                                              unhandled:NO
                                     unhandledOverridden:NO
                                               attrValue:nil];
     

--- a/features/app_hangs.feature
+++ b/features/app_hangs.feature
@@ -15,14 +15,14 @@ Feature: App hangs
     And the event "severity" equals "warning"
     And the event "severityReason.type" equals "appHang"
     And the event "threads.0.errorReportingThread" is true
-    And the event "unhandled" is true
+    And the event "unhandled" is false
 
     And the exception "errorClass" equals "App Hang"
     And the exception "message" equals "The app's main thread failed to respond to an event within 2000 milliseconds"
     And the exception "type" equals "cocoa"
 
-    And the event "session.events.handled" equals 0
-    And the event "session.events.unhandled" equals 1
+    And the event "session.events.handled" equals 1
+    And the event "session.events.unhandled" equals 0
 
     #
     # Checks copied from app_and_device_attributes.feature


### PR DESCRIPTION
## Goal

Mark non-fatal app hangs as "handled" to avoid affecting the stability score.

## Testing

Tested locally using `features/app_hangs.feature` and in an example app.