### PR TITLE
Test for malloc calls in more low-level crashes

### DIFF
--- a/features/fixtures/shared/scenarios/AsyncSafeMallocScenario.m
+++ b/features/fixtures/shared/scenarios/AsyncSafeMallocScenario.m
@@ -7,25 +7,7 @@
 //
 
 #import "Scenario.h"
-
-#include <libkern/OSSpinLockDeprecated.h>
-#include <mach/mach_init.h>
-#include <mach/vm_map.h>
-#include <malloc/malloc.h>
-
-static void * customMalloc(struct _malloc_zone_t *zone, size_t size) {
-    static OSSpinLock spinLock = OS_SPINLOCK_INIT;
-    OSSpinLockLock(&spinLock);
-    OSSpinLockLock(&spinLock);
-    return NULL;
-}
-
-static void installCustomMalloc() {
-    malloc_zone_t *zone = malloc_default_zone();
-    vm_protect(mach_task_self(), (uintptr_t)zone, sizeof(malloc_zone_t), 0, VM_PROT_READ | VM_PROT_WRITE);
-    zone->malloc = customMalloc;
-    vm_protect(mach_task_self(), (uintptr_t)zone, sizeof(malloc_zone_t), 0, VM_PROT_READ);
-}
+#include "spin_malloc.h"
 
 @interface AsyncSafeMallocScenario : Scenario
 
@@ -35,7 +17,7 @@ static void installCustomMalloc() {
 
 - (void)run {
     // Override malloc() with an implementation that will cause a deadlock for any thread that calls malloc()
-    installCustomMalloc();
+    install_spin_malloc();
     
     // If the signal handler calls malloc(), the app will hang instead of terminating immediately.
     abort();

--- a/features/fixtures/shared/scenarios/BuiltinTrapScenario.m
+++ b/features/fixtures/shared/scenarios/BuiltinTrapScenario.m
@@ -4,6 +4,7 @@
 //
 
 #import "BuiltinTrapScenario.h"
+#include "spin_malloc.h"
 
 /**
  * Calls __builtin_trap
@@ -17,6 +18,7 @@
 
 
 - (void)run {
+    install_spin_malloc();
     __builtin_trap();
 }
 

--- a/features/fixtures/shared/scenarios/NullPointerScenario.m
+++ b/features/fixtures/shared/scenarios/NullPointerScenario.m
@@ -24,6 +24,7 @@
  * OTHER DEALINGS IN THE SOFTWARE.
  */
 #import "NullPointerScenario.h"
+#include "spin_malloc.h"
 
 /**
  * Attempts to read from 0x0, which causes a segmentation violation.
@@ -36,6 +37,7 @@
 }
 
 - (void)run {
+    install_spin_malloc();
     volatile char *ptr = NULL;
     (void) *ptr;
 }

--- a/features/fixtures/shared/scenarios/OverwriteLinkRegisterScenario.m
+++ b/features/fixtures/shared/scenarios/OverwriteLinkRegisterScenario.m
@@ -25,6 +25,7 @@
  */
 
 #import "OverwriteLinkRegisterScenario.h"
+#include "spin_malloc.h"
 
 /**
  * Trigger a crash after first overwriting the link register. Crash reporters that insert a stack frame
@@ -46,6 +47,8 @@
     /* Call a method to trigger modification of LR. We use the result below to
      * convince the compiler to order this function the way we want it. */
     uintptr_t ptr = (uintptr_t) [NSObject class];
+
+    install_spin_malloc();
 
     /* Make-work code that simply advances the PC to better demonstrate the discrepency. We use the
      * 'ptr' value here to make sure the compiler doesn't optimize-away this code, or re-order it below

--- a/features/fixtures/shared/scenarios/PrivilegedInstructionScenario.m
+++ b/features/fixtures/shared/scenarios/PrivilegedInstructionScenario.m
@@ -25,6 +25,7 @@
  */
 
 #import "PrivilegedInstructionScenario.h"
+#include "spin_malloc.h"
 
 /**
  * Attempt to execute an instruction that can only be executed in supervisor mode.
@@ -37,6 +38,7 @@
 }
 
 - (void)run {
+    install_spin_malloc();
 #if __i386__
     asm volatile ( "hlt" : : : );
 #elif __x86_64__

--- a/features/fixtures/shared/scenarios/ReadGarbagePointerScenario.m
+++ b/features/fixtures/shared/scenarios/ReadGarbagePointerScenario.m
@@ -26,6 +26,7 @@
 
 #import "ReadGarbagePointerScenario.h"
 #import <sys/mman.h>
+#include "spin_malloc.h"
 
 /**
  * Attempts to read from a garbage pointer that's not mapped but also isn't NULL.
@@ -43,6 +44,7 @@
     if (ptr != MAP_FAILED)
         munmap(ptr, (size_t) getpagesize());
 
+    install_spin_malloc();
 #if __i386__
     asm volatile ( "mov %0, %%eax\n\tmov (%%eax), %%eax" : : "X" (ptr) : "memory", "eax" );
 #elif __x86_64__

--- a/features/fixtures/shared/scenarios/ReadOnlyPageScenario.m
+++ b/features/fixtures/shared/scenarios/ReadOnlyPageScenario.m
@@ -25,6 +25,7 @@
  */
 
 #import "ReadOnlyPageScenario.h"
+#include "spin_malloc.h"
 
 /**
  * Attempt to write to a page into which the app's code is mapped.
@@ -40,6 +41,7 @@ static void __attribute__((used)) dummyfunc(void) {
 }
 
 - (void)run {
+    install_spin_malloc();
     volatile char *ptr = (char *) dummyfunc;
     *ptr = 0;
 }

--- a/features/fixtures/shared/scenarios/UndefinedInstructionScenario.m
+++ b/features/fixtures/shared/scenarios/UndefinedInstructionScenario.m
@@ -25,6 +25,7 @@
  */
 
 #import "UndefinedInstructionScenario.h"
+#include "spin_malloc.h"
 
 /**
  * Attempt to execute an instruction not to be defined on the current architecture.
@@ -37,6 +38,7 @@
 }
 
 - (void)run {
+    install_spin_malloc();
 #if __i386__
     asm volatile ( "ud2" : : : );
 #elif __x86_64__

--- a/features/fixtures/shared/scenarios/spin_malloc.h
+++ b/features/fixtures/shared/scenarios/spin_malloc.h
@@ -1,0 +1,35 @@
+#ifndef spin_malloc_h
+#define spin_malloc_h
+
+#ifdef __cplusplus
+extern "C" {
+#endif
+
+#include <libkern/OSSpinLockDeprecated.h>
+#include <mach/mach_init.h>
+#include <mach/vm_map.h>
+#include <malloc/malloc.h>
+
+
+// Custom malloc implementation that deadlocks the current thread.
+static void * spin_malloc(struct _malloc_zone_t *zone, size_t size) {
+    static OSSpinLock spinLock = OS_SPINLOCK_INIT;
+    OSSpinLockLock(&spinLock);
+    OSSpinLockLock(&spinLock);
+    return NULL;
+}
+
+// Override malloc() with a version that deadlocks the current thread.
+static inline void install_spin_malloc() {
+    malloc_zone_t *zone = malloc_default_zone();
+    vm_protect(mach_task_self(), (uintptr_t)zone, sizeof(malloc_zone_t), 0, VM_PROT_READ | VM_PROT_WRITE);
+    zone->malloc = spin_malloc;
+    vm_protect(mach_task_self(), (uintptr_t)zone, sizeof(malloc_zone_t), 0, VM_PROT_READ);
+}
+
+
+#ifdef __cplusplus
+}
+#endif
+
+#endif /* spin_malloc_h */


### PR DESCRIPTION
## Goal

Per PLAT-6097, hidden malloc calls can cause lockups in the reporter. This PR deliberately poisons malloc in certain low-level e2e tests such that it locks up the app if called from inside of the crash handler's async-safe code.

## Testing

Re-ran e2e tests.