### PR TITLE
Use maze-runner to trigger stress test

### DIFF
--- a/.buildkite/pipeline.yml
+++ b/.buildkite/pipeline.yml
@@ -205,8 +205,12 @@ steps:
     timeout_in_minutes: 3
     agents:
       queue: opensource-mac-cocoa
+    env:
+      STRESS_TEST: "true"
     commands:
-      - cd features/fixtures/macos-stress-test && make build run
+      - bundle install
+      - bundle exec maze-runner
+        features/stress_test.feature
     artifact_paths:
       - features/fixtures/macos-stress-test/BugsnagStressTest.stdout.log
       - features/fixtures/macos-stress-test/BugsnagStressTest.stderr.log

--- a/.buildkite/pipeline.yml
+++ b/.buildkite/pipeline.yml
@@ -211,6 +211,7 @@ steps:
       - bundle install
       - bundle exec maze-runner
         features/stress_test.feature
+        --no-log-requests
     artifact_paths:
       - features/fixtures/macos-stress-test/BugsnagStressTest.stdout.log
       - features/fixtures/macos-stress-test/BugsnagStressTest.stderr.log

--- a/Gemfile
+++ b/Gemfile
@@ -7,7 +7,7 @@ gem 'xcpretty'
 
 # A reference to Maze Runner is only needed for running tests locally and if committed it must be
 # portable for CI, e.g. a specific release.  However, leaving it commented out would mean quicker CI.
-gem 'bugsnag-maze-runner', git: 'https://github.com/bugsnag/maze-runner', tag: 'v4.11.1'
+gem 'bugsnag-maze-runner', git: 'https://github.com/bugsnag/maze-runner', tag: 'v4.13.0'
 
 # Locally, you can run against Maze Runner branches and uncommitted changes:
 # gem 'bugsnag-maze-runner', path: '../maze-runner'

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -1,9 +1,9 @@
 GIT
   remote: https://github.com/bugsnag/maze-runner
-  revision: b5925737b0c3db49ac38a5a68e6bfe38026ef508
-  tag: v4.11.1
+  revision: 3161e2a7115a2642a1929aa5c037ead65d4ebfba
+  tag: v4.13.0
   specs:
-    bugsnag-maze-runner (4.11.1)
+    bugsnag-maze-runner (4.13.0)
       appium_lib (~> 11.2.0)
       boring (~> 0.1.0)
       cucumber (~> 3.1.2)
@@ -35,7 +35,7 @@ GEM
       appium_lib_core (~> 4.1)
       nokogiri (~> 1.8, >= 1.8.1)
       tomlrb (~> 1.1)
-    appium_lib_core (4.4.1)
+    appium_lib_core (4.5.0)
       faye-websocket (~> 0.11.0)
       selenium-webdriver (~> 3.14, >= 3.14.1)
     atomos (0.1.3)
@@ -170,7 +170,7 @@ GEM
     nap (1.1.0)
     netrc (0.11.0)
     no_proxy_fix (0.1.2)
-    nokogiri (1.11.1)
+    nokogiri (1.11.2)
       mini_portile2 (~> 2.5.0)
       racc (~> 1.4)
     octokit (4.20.0)

--- a/features/fixtures/macos-stress-test/BugsnagStressTest/main.m
+++ b/features/fixtures/macos-stress-test/BugsnagStressTest/main.m
@@ -11,7 +11,7 @@
 #import <mach/task.h>
 #import <mach/task_info.h>
 
-static NSString * const kNotifyEndpoint = @"http://bs-local.com:9339/notify";
+static NSString * const kNotifyEndpoint = @"http://localhost:9339/notify";
 
 static const int kNumberOfIterations = 5000;
 

--- a/features/fixtures/macos-stress-test/Makefile
+++ b/features/fixtures/macos-stress-test/Makefile
@@ -19,4 +19,4 @@ run:
 	rm -rf $(HOME)/Library/Application\ Support/com.bugsnag.Bugsnag
 	QUIET=true /usr/bin/time -l ./build/usr/local/bin/BugsnagStressTest
 	rm -rf $(HOME)/Library/Application\ Support/com.bugsnag.Bugsnag
-	echo "MacOS stress-test complete"
+	echo "macOS stress-test complete"

--- a/features/fixtures/macos-stress-test/Makefile
+++ b/features/fixtures/macos-stress-test/Makefile
@@ -19,3 +19,4 @@ run:
 	rm -rf $(HOME)/Library/Application\ Support/com.bugsnag.Bugsnag
 	QUIET=true /usr/bin/time -l ./build/usr/local/bin/BugsnagStressTest
 	rm -rf $(HOME)/Library/Application\ Support/com.bugsnag.Bugsnag
+	echo "MacOS stress-test complete"

--- a/features/steps/ios_steps.rb
+++ b/features/steps/ios_steps.rb
@@ -328,11 +328,6 @@ Then('the error is an OOM event') do
   )
 end
 
-Then('I have received at least {int} {word} requests') do |min_received, request_type|
-  list = Maze::Server.list_for(request_type)
-  assert(list.size >= min_received, "Actually received #{list.size} requests")
-end
-
 def wait_for_true
   max_attempts = 300
   attempts = 0

--- a/features/steps/ios_steps.rb
+++ b/features/steps/ios_steps.rb
@@ -328,6 +328,11 @@ Then('the error is an OOM event') do
   )
 end
 
+Then('I have received at least {int} {word} requests') do |min_received, request_type|
+  list = Maze::Server.list_for(request_type)
+  assert(list.size >= min_received, "Actually received #{list.size} requests")
+end
+
 def wait_for_true
   max_attempts = 300
   attempts = 0

--- a/features/stress_test.feature
+++ b/features/stress_test.feature
@@ -9,4 +9,4 @@ Feature: Stress test
     Then the last interactive command exited successfully
 
     # This is low, but due to network congestion all we can guarantee in the course of a normal test
-    And I have received at least 1 error requests
+    And I have received at least 1 error

--- a/features/stress_test.feature
+++ b/features/stress_test.feature
@@ -1,0 +1,11 @@
+@stress_test
+Feature: Stress test
+
+  Scenario: Triggering error notifications continuously
+    When I start a new shell
+    And I input "cd features/fixtures/macos-stress-test" interactively
+    And I input "make build run" interactively
+    And I wait for 180 seconds
+    And I wait for the shell to output "MacOS stress-test complete" to stdout
+    Then the last interactive command exited successfully
+    And I have received at least 1000 error requests

--- a/features/stress_test.feature
+++ b/features/stress_test.feature
@@ -5,7 +5,6 @@ Feature: Stress test
     When I start a new shell
     And I input "cd features/fixtures/macos-stress-test" interactively
     And I input "make build run" interactively
-    And I wait for 180 seconds
     And I wait for the shell to output "MacOS stress-test complete" to stdout
     Then the last interactive command exited successfully
     And I have received at least 1000 error requests

--- a/features/stress_test.feature
+++ b/features/stress_test.feature
@@ -5,7 +5,7 @@ Feature: Stress test
     When I start a new shell
     And I input "cd features/fixtures/macos-stress-test" interactively
     And I input "make build run" interactively
-    And I wait for the shell to output "MacOS stress-test complete" to stdout
+    And I wait for the shell to output "macOS stress-test complete" to stdout
     Then the last interactive command exited successfully
 
     # This is low, but due to network congestion all we can guarantee in the course of a normal test

--- a/features/stress_test.feature
+++ b/features/stress_test.feature
@@ -9,4 +9,4 @@ Feature: Stress test
     Then the last interactive command exited successfully
 
     # This is low, but due to network congestion all we can guarantee in the course of a normal test
-    And I have received at least 2 error requests
+    And I have received at least 1 error requests

--- a/features/stress_test.feature
+++ b/features/stress_test.feature
@@ -7,4 +7,6 @@ Feature: Stress test
     And I input "make build run" interactively
     And I wait for the shell to output "MacOS stress-test complete" to stdout
     Then the last interactive command exited successfully
-    And I have received at least 1000 error requests
+
+    # This is low, but due to network congestion all we can guarantee in the course of a normal test
+    And I have received at least 2 error requests

--- a/features/support/env.rb
+++ b/features/support/env.rb
@@ -5,6 +5,14 @@ $api_key = "12312312312312312312312312312312"
 
 AfterConfiguration do |_config|
   Maze.config.receive_no_requests_wait = 15
+
+  # Setup a 3 minute timeout for receiving requests is STRESS_TEST env var is set
+  Maze.config.receive_requests_wait = 90 unless ENV['STRESS_TEST'].nil?
+end
+
+# Skip stress tests unless STRESS_TEST env var is set
+Before('@stress_test') do |_scenario|
+  skip_this_scenario('Skipping: Run is not configured for stress tests') if ENV['STRESS_TEST'].nil?
 end
 
 # Additional require MacOS configuration

--- a/features/support/env.rb
+++ b/features/support/env.rb
@@ -7,7 +7,7 @@ AfterConfiguration do |_config|
   Maze.config.receive_no_requests_wait = 15
 
   # Setup a 3 minute timeout for receiving requests is STRESS_TEST env var is set
-  Maze.config.receive_requests_wait = 90 unless ENV['STRESS_TEST'].nil?
+  Maze.config.receive_requests_wait = 180 unless ENV['STRESS_TEST'].nil?
 end
 
 # Skip stress tests unless STRESS_TEST env var is set


### PR DESCRIPTION
## Goal

Changes buildkite pipeline to use Maze-runner to make assertions on the outcome of the current stress test.

This will also allow more flexibility if we wish to add more of these style of tests in the future.