### PR TITLE
Use macOS 10.15 where possible

### DIFF
--- a/.buildkite/pipeline.quick.yml
+++ b/.buildkite/pipeline.quick.yml
@@ -81,7 +81,7 @@ steps:
   - label: iOS 10 unit tests
     timeout_in_minutes: 10
     agents:
-      queue: opensource-mac-cocoa-11
+      queue: opensource-mac-cocoa-10.15
     env:
       LANG: "en_GB.UTF-8"
       TEST_CONFIGURATION: "Debug"
@@ -148,7 +148,7 @@ steps:
   - label: tvOS 10 unit tests
     timeout_in_minutes: 10
     agents:
-      queue: opensource-mac-cocoa-11
+      queue: opensource-mac-cocoa-10.15
     env:
       LANG: "en_GB.UTF-8"
       TEST_CONFIGURATION: "Debug"


### PR DESCRIPTION
## Goal

Run iOS/tvOS 10 unit tests on macOS 10.15 (with XCode 11).  Simulators are not supported on Xcode 12 (which our macOS 11 machines use).

## Testing

Covered by "Quick" CI, which was triggered by commit message.