### PR TITLE
Default appHangThresholdMillis to fatal only

### DIFF
--- a/Bugsnag.xcodeproj/project.pbxproj
+++ b/Bugsnag.xcodeproj/project.pbxproj
@@ -1332,6 +1332,8 @@
 		01BDB1CE25DEBF4600A91FAF /* BSGEventUploadKSCrashReportOperationTests.m */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.objc; path = BSGEventUploadKSCrashReportOperationTests.m; sourceTree = "<group>"; };
 		01BDB21425DEC02900A91FAF /* Data */ = {isa = PBXFileReference; lastKnownFileType = folder; path = Data; sourceTree = "<group>"; };
 		01C17AE62542ED7F00C102C9 /* KSCrashReportWriterTests.m */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.objc; path = KSCrashReportWriterTests.m; sourceTree = "<group>"; };
+		01C2769B2601F44D006901EA /* CHANGELOG.md */ = {isa = PBXFileReference; lastKnownFileType = net.daringfireball.markdown; path = CHANGELOG.md; sourceTree = "<group>"; };
+		01C2769C2601F455006901EA /* CONTRIBUTING.md */ = {isa = PBXFileReference; lastKnownFileType = net.daringfireball.markdown; path = CONTRIBUTING.md; sourceTree = "<group>"; };
 		01CCAEE825D414D60057268D /* BugsnagLastRunInfo.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; path = BugsnagLastRunInfo.h; sourceTree = "<group>"; };
 		01CCAEE925D414D60057268D /* BugsnagLastRunInfo.m */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.objc; path = BugsnagLastRunInfo.m; sourceTree = "<group>"; };
 		01CCAEFF25D4151C0057268D /* BugsnagLastRunInfo+Private.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; path = "BugsnagLastRunInfo+Private.h"; sourceTree = "<group>"; };
@@ -1644,6 +1646,8 @@
 		00AD1C6824869B0E00A27979 = {
 			isa = PBXGroup;
 			children = (
+				01C2769B2601F44D006901EA /* CHANGELOG.md */,
+				01C2769C2601F455006901EA /* CONTRIBUTING.md */,
 				00E636B2248702A1006CBF1A /* README.md */,
 				00E636B3248702A1006CBF1A /* LICENSE.txt */,
 				00AD1C7424869B0E00A27979 /* Bugsnag */,

--- a/Bugsnag/Configuration/BugsnagConfiguration.m
+++ b/Bugsnag/Configuration/BugsnagConfiguration.m
@@ -171,7 +171,7 @@ static NSUserDefaults *userDefaults;
     _endpoints = [BugsnagEndpointConfiguration new];
     _sessionURL = [NSURL URLWithString:@"https://sessions.bugsnag.com"];
     _autoDetectErrors = YES;
-    _appHangThresholdMillis = 2000;
+    _appHangThresholdMillis = BugsnagAppHangThresholdFatalOnly;
     _notifyURL = [NSURL URLWithString:BSGDefaultNotifyUrl];
     _onSendBlocks = [NSMutableArray new];
     _onSessionBlocks = [NSMutableArray new];

--- a/Bugsnag/include/Bugsnag/BugsnagConfiguration.h
+++ b/Bugsnag/include/Bugsnag/BugsnagConfiguration.h
@@ -212,10 +212,11 @@ typedef BOOL (^BugsnagOnSessionBlock)(BugsnagSession *_Nonnull session);
  * The minimum number of milliseconds of main thread unresponsiveness that will trigger the
  * detection and reporting of an app hang.
  *
- * By default this is 2000 milliseconds, and can be configured down to 250 milliseconds.
- * 
  * Set to `BugsnagAppHangThresholdFatalOnly` to disable reporting of app hangs that did not
  * end with the app being force quit by the user or terminated by the system watchdog.
+ *
+ * By default this is `BugsnagAppHangThresholdFatalOnly`, and can be set to a minimum of 250
+ * milliseconds.
  */
 @property (nonatomic) NSUInteger appHangThresholdMillis;
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,8 @@ Changelog
 ### Enhancements
 
 * Bugsnag now detects app hangs (when the main thread is unresponsive for a period of time), alerting you of issues with your app’s responsiveness.
+  By default, only fatal app hangs (those that end with termination by the system watchdog or being force-quit by the user) will be reported.
+  This behaviour can be configured using the new  `appHangThresholdMillis` configuration option.
   For more information see [the documentation](https://docs.bugsnag.com/platforms/ios/reporting-app-hangs/).
   [#1039](https://github.com/bugsnag/bugsnag-cocoa/pull/1039)
 

--- a/features/app_hangs.feature
+++ b/features/app_hangs.feature
@@ -3,6 +3,10 @@ Feature: App hangs
   Background:
     Given I clear all persistent data
 
+  Scenario: Non-fatal app hangs should not be reported by default
+    When I run "AppHangDefaultConfigScenario"
+    Then I should receive no errors
+
   Scenario: App hangs above the threshold should be reported
     When I set the app to "2.1" mode
     And I run "AppHangScenario"

--- a/features/fixtures/shared/scenarios/AppHangScenario.swift
+++ b/features/fixtures/shared/scenarios/AppHangScenario.swift
@@ -8,8 +8,23 @@
 
 class AppHangScenario: Scenario {
     
+    override func startBugsnag() {
+        config.appHangThresholdMillis = 2_000
+        super.startBugsnag()
+    }
+    
     override func run() {
         let timeInterval = TimeInterval(eventMode!)!
+        NSLog("Simulating an app hang of \(timeInterval) seconds...")
+        Thread.sleep(forTimeInterval: timeInterval)
+        NSLog("Finished sleeping")
+    }
+}
+
+class AppHangDefaultConfigScenario: Scenario {
+    
+    override func run() {
+        let timeInterval: TimeInterval = 5
         NSLog("Simulating an app hang of \(timeInterval) seconds...")
         Thread.sleep(forTimeInterval: timeInterval)
         NSLog("Finished sleeping")


### PR DESCRIPTION
## Goal

Following some internal discussions, the decision was made to only report fatal app hangs by default in the initial release.

## Testing

Amended E2E tests to verify the change.