### PR TITLE
6211 fix jailbreak heap overhang

### DIFF
--- a/.buildkite/pipeline.quick.yml
+++ b/.buildkite/pipeline.quick.yml
@@ -30,7 +30,7 @@ steps:
   - label: iOS 13 unit tests
     timeout_in_minutes: 10
     agents:
-      queue: opensource-mac-cocoa
+      queue: opensource-mac-cocoa-11
     env:
       LANG: "en_GB.UTF-8"
       TEST_CONFIGURATION: "Debug"
@@ -47,7 +47,7 @@ steps:
   - label: iOS 12 unit tests
     timeout_in_minutes: 10
     agents:
-      queue: opensource-mac-cocoa
+      queue: opensource-mac-cocoa-11
     env:
       LANG: "en_GB.UTF-8"
       TEST_CONFIGURATION: "Debug"
@@ -64,7 +64,7 @@ steps:
   - label: iOS 11 unit tests
     timeout_in_minutes: 10
     agents:
-      queue: opensource-mac-cocoa
+      queue: opensource-mac-cocoa-11
     env:
       LANG: "en_GB.UTF-8"
       TEST_CONFIGURATION: "Debug"
@@ -81,7 +81,7 @@ steps:
   - label: iOS 10 unit tests
     timeout_in_minutes: 10
     agents:
-      queue: opensource-mac-cocoa-10.14
+      queue: opensource-mac-cocoa-11
     env:
       LANG: "en_GB.UTF-8"
       TEST_CONFIGURATION: "Debug"
@@ -97,7 +97,7 @@ steps:
   - label: tvOS 13 unit tests
     timeout_in_minutes: 10
     agents:
-      queue: opensource-mac-cocoa
+      queue: opensource-mac-cocoa-11
     env:
       LANG: "en_GB.UTF-8"
       TEST_CONFIGURATION: "Debug"
@@ -114,7 +114,7 @@ steps:
   - label: tvOS 12 unit tests
     timeout_in_minutes: 10
     agents:
-      queue: opensource-mac-cocoa
+      queue: opensource-mac-cocoa-11
     env:
       LANG: "en_GB.UTF-8"
       TEST_CONFIGURATION: "Debug"
@@ -131,7 +131,7 @@ steps:
   - label: tvOS 11 unit tests
     timeout_in_minutes: 10
     agents:
-      queue: opensource-mac-cocoa
+      queue: opensource-mac-cocoa-11
     env:
       LANG: "en_GB.UTF-8"
       TEST_CONFIGURATION: "Debug"
@@ -148,7 +148,7 @@ steps:
   - label: tvOS 10 unit tests
     timeout_in_minutes: 10
     agents:
-      queue: opensource-mac-cocoa-10.14
+      queue: opensource-mac-cocoa-11
     env:
       LANG: "en_GB.UTF-8"
       TEST_CONFIGURATION: "Debug"
@@ -165,7 +165,7 @@ steps:
       - cocoa_fixture
     timeout_in_minutes: 60
     agents:
-      queue: opensource-mac-cocoa
+      queue: opensource-mac-cocoa-10.15
     plugins:
       artifacts#v1.3.0:
         download: ["features/fixtures/macos/output/macOSTestApp.zip"]

--- a/.buildkite/pipeline.quick.yml
+++ b/.buildkite/pipeline.quick.yml
@@ -81,7 +81,7 @@ steps:
   - label: iOS 10 unit tests
     timeout_in_minutes: 10
     agents:
-      queue: opensource-mac-cocoa-11
+      queue: opensource-mac-cocoa-10.15
     env:
       LANG: "en_GB.UTF-8"
       TEST_CONFIGURATION: "Debug"
@@ -148,7 +148,7 @@ steps:
   - label: tvOS 10 unit tests
     timeout_in_minutes: 10
     agents:
-      queue: opensource-mac-cocoa-11
+      queue: opensource-mac-cocoa-10.15
     env:
       LANG: "en_GB.UTF-8"
       TEST_CONFIGURATION: "Debug"

--- a/.buildkite/pipeline.yml
+++ b/.buildkite/pipeline.yml
@@ -3,7 +3,7 @@ steps:
     key: cocoa_fixture
     timeout_in_minutes: 20
     agents:
-      queue: opensource-mac-cocoa
+      queue: opensource-mac-cocoa-11
     artifact_paths:
       - features/fixtures/ios-swift-cocoapods/output/iOSTestApp.ipa
       - features/fixtures/macos/output/macOSTestApp.zip
@@ -14,7 +14,7 @@ steps:
   - label: Static framework and Swift Package Manager builds
     timeout_in_minutes: 10
     agents:
-      queue: opensource-mac-cocoa
+      queue: opensource-mac-cocoa-10.15
     concurrency: 3
     concurrency_group: cocoa-unit-tests
     env:
@@ -27,7 +27,7 @@ steps:
   - label: Static Carthage build
     timeout_in_minutes: 10
     agents:
-      queue: opensource-mac-cocoa
+      queue: opensource-mac-cocoa-10.15
     concurrency: 3
     concurrency_group: cocoa-unit-tests
     env:
@@ -40,7 +40,7 @@ steps:
   - label: macOS 10.15 unit tests
     timeout_in_minutes: 10
     agents:
-      queue: opensource-mac-cocoa
+      queue: opensource-mac-cocoa-10.15
     concurrency: 3
     concurrency_group: cocoa-unit-tests
     env:
@@ -73,7 +73,7 @@ steps:
       LANG: "en_GB.UTF-8"
       TEST_CONFIGURATION: "Debug"
       PLATFORM: "iOS"
-      OS: "14.2"
+      OS: "14.3"
     commands:
       - make bootstrap
       - make test
@@ -104,7 +104,7 @@ steps:
       LANG: "en_GB.UTF-8"
       TEST_CONFIGURATION: "Debug"
       PLATFORM: "tvOS"
-      OS: "14.0"
+      OS: "14.3"
     commands:
       - make bootstrap
       - make test
@@ -182,7 +182,7 @@ steps:
       - cocoa_fixture
     timeout_in_minutes: 60
     agents:
-      queue: opensource-mac-cocoa
+      queue: opensource-mac-cocoa-10.15
     plugins:
       artifacts#v1.3.0:
         download: ["features/fixtures/macos/output/macOSTestApp.zip"]

--- a/.github/workflows/unit_tests.yml
+++ b/.github/workflows/unit_tests.yml
@@ -1,0 +1,25 @@
+name: "Unit Tests"
+on: [push]
+
+# The purpose of this workflow is to run unit tests on beta versions of
+# Xcode and iOS that have not yet been added to Bugsnag's Buildkite.
+
+jobs:
+  build:
+    runs-on: macos-11.0
+    env:
+      DEVELOPER_DIR: /Applications/Xcode_12.5.app
+      PLATFORM: iOS
+      OS: 14.5
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v2
+
+      - name: Unit Tests
+        run: make test
+
+      - name: Archive xcodebuild output
+        uses: actions/upload-artifact@v2
+        with:
+          name: xcodebuild-${{ env.PLATFORM }}-${{ env.OS }}-${{ github.run_id }}
+          path: xcodebuild.log

--- a/Bugsnag/KSCrash/Source/KSCrash/Recording/BSG_Jailbreak.h
+++ b/Bugsnag/KSCrash/Source/KSCrash/Recording/BSG_Jailbreak.h
@@ -49,10 +49,17 @@
 extern char **environ;
 
 static inline bool bsg_local_is_insert_libraries_env_var(const char* str) {
+    if (str == NULL) {
+        return false;
+    }
+
     // DYLD_INSERT_LIBRARIES lets you override functions by loading other libraries first.
     // This is a common technique used for defeating detection.
     // See: https://opensource.apple.com/source/dyld/dyld-832.7.3/doc/man/man1/dyld.1
     const char insert[] = "DYLD_INSERT_LIBRARIES";
+    if (strlen(str) < sizeof(insert)) {
+        return false;
+    }
     return __builtin_memcmp(str, insert, sizeof(insert)) == 0;
 }
 

--- a/Bugsnag/KSCrash/Source/KSCrash/Recording/Tools/BSG_KSJSONCodec.c
+++ b/Bugsnag/KSCrash/Source/KSCrash/Recording/Tools/BSG_KSJSONCodec.c
@@ -26,8 +26,9 @@
 
 #include "BSG_KSJSONCodec.h"
 
-#include <ctype.h>
-#include <stdlib.h>
+#include <math.h>
+#include <stdbool.h>
+#include <stdint.h>
 #include <string.h>
 
 // ============================================================================
@@ -52,6 +53,12 @@
 #ifndef BSG_KSJSONCODEC_WorkBufferSize
 #define BSG_KSJSONCODEC_WorkBufferSize 512
 #endif
+
+/**
+ * The maximum number of significant digits when printing floats.
+ * 7 (6 + 1 whole digit in exp form) is the default used by the old sprintf code.
+ */
+#define MAX_SIGNIFICANT_DIGITS 7
 
 // ============================================================================
 #pragma mark - Helpers -
@@ -78,6 +85,171 @@ const char *bsg_ksjsonstringForError(const int error) {
     default:
         return "(unknown error)";
     }
+}
+
+// Max uint64 is 18446744073709551615
+#define MAX_UINT64_DIGITS 20
+
+/**
+ * Convert an unsigned integer to a string.
+ * This will write a maximum of 21 characters (including the NUL) to dst.
+ *
+ * Returns the length of the string written to dst (not including the NUL).
+ */
+static size_t uint64_to_string(uint64_t value, char* dst) {
+    if(value == 0) {
+        dst[0] = '0';
+        dst[1] = 0;
+        return 1;
+    }
+
+    char buff[MAX_UINT64_DIGITS+1];
+    buff[sizeof(buff)-1] = 0;
+    int index = sizeof(buff) - 2;
+    for(;;) {
+        buff[index] = (value%10) + '0';
+        value /= 10;
+        if (value == 0) {
+            break;
+        }
+        index--;
+    }
+
+    size_t length = sizeof(buff) - index;
+    memcpy(dst, buff+index, length);
+    return length - 1;
+}
+
+/**
+ * Convert an integer to a string.
+ * This will write a maximum of 22 characters (including the null terminator) to dst.
+ *
+ * Returns the length of the string written to dst (not including the null termination byte).
+ */
+static size_t int64_to_string(int64_t value, char* dst) {
+    if (value < 0) {
+        dst[0] = '-';
+        return uint64_to_string(-value, dst+1) + 1;
+    }
+    return uint64_to_string(value, dst);
+}
+
+/**
+ * Convert a positive double to a string, allowing up to max_sig_digits.
+ * To reduce the complexity of this algorithm, values with an exponent
+ * other than 0 are always printed in exponential form.
+ *
+ * Values are rounded half-up.
+ *
+ * This function makes use of compiler intrinsic functions which, though not
+ * officially async-safe, are actually async-safe (no allocations, locks, etc).
+ *
+ * This function will write a maximum of 21 characters (including the NUL) to dst.
+ *
+ * Returns the length of the string written to dst (not including the NUL).
+ */
+static size_t positive_double_to_string(const double value, char* dst, const int max_sig_digits) {
+    const char* const orig_dst = dst;
+
+    if(value == 0) {
+        dst[0] = '0';
+        dst[1] = 0;
+        return 1;
+    }
+
+    // isnan() is basically ((x) != (x))
+    if(isnan(value)) {
+        strcpy(dst, "nan");
+        return 3;
+    }
+
+    // isinf() is a compiler intrinsic.
+    if(isinf(value)) {
+        strcpy(dst, "inf");
+        return 3;
+    }
+
+    // log10() is a compiler intrinsic.
+    int exponent = log10(value);
+    // Values < 1.0 must subtract 1 from exponent to handle zero wraparound.
+    if (value < 1.0) {
+        exponent--;
+    }
+
+    // pow() is a compiler intrinsic.
+    double normalized = value / pow(10, exponent);
+    // Special case for 0.1, 0.01, 0.001, etc giving a normalized value of 10.xyz.
+    // We use 9.999... because 10.0 converts to a value > 10 in ieee754 binary floats.
+    if (normalized > 9.99999999999999822364316059975) {
+        exponent++;
+        normalized = value / pow(10, exponent);
+    }
+
+    // Put all of the digits we'll use into an integer.
+    double digits_and_remainder = normalized * pow(10, max_sig_digits-1);
+    uint64_t digits = digits_and_remainder;
+    // Also round up if necessary (note: 0.5 is exact in both binary and decimal).
+    if (digits_and_remainder - digits >= 0.5) {
+        digits++;
+        // Special case: Adding one bumps us to next magnitude.
+        if (digits >= (uint64_t)pow(10, max_sig_digits)) {
+            exponent++;
+            digits /= 10;
+        }
+    }
+
+    // Extract the fractional digits.
+    for (int i = max_sig_digits; i > 1; i--) {
+        dst[i] = digits % 10 + '0';
+        digits /= 10;
+    }
+    // Extract the single-digit whole part.
+    dst[0] = digits + '0';
+    dst[1] = '.';
+
+    // Strip off trailing zeroes, and also the '.' if there is no fractional part.
+    int e_offset = max_sig_digits;
+    for (int i = max_sig_digits; i > 0; i--) {
+        if (dst[i] != '0') {
+            if (dst[i] == '.') {
+                e_offset = i;
+            } else {
+                e_offset = i + 1;
+            }
+            break;
+        }
+    }
+    dst += e_offset;
+
+    // Add the exponent if it's not 0.
+    if (exponent != 0) {
+        *dst++ = 'e';
+        if (exponent >= 0) {
+            *dst++ = '+';
+        }
+        dst += int64_to_string(exponent, dst);
+    } else {
+        *dst = 0;
+    }
+
+    return dst - orig_dst;
+}
+
+/**
+ * Convert a positive double to a string, allowing up to max_sig_digits. See
+ * positive_double_to_string() for important information about how this
+ * algorithm differs from sprintf.
+ *
+ * This function will write a maximum of 22 characters (including the NUL) to dst.
+ *
+ * Returns the length of the string written to dst (not including the NUL).
+ */
+static size_t double_to_string(double value, char* dst, int max_sig_digits) {
+    if (value < 0) {
+        dst[0] = '-';
+        return positive_double_to_string(-value, dst+1, max_sig_digits) + 1;
+    }
+    return positive_double_to_string(value, dst, max_sig_digits);
 }
 
 // ============================================================================
@@ -320,7 +492,7 @@ int bsg_ksjsonaddFloatingPointElement(BSG_KSJSONEncodeContext *const context,
     int result = bsg_ksjsonbeginElement(context, name);
     unlikely_if(result != BSG_KSJSON_OK) { return result; }
     char buff[30];
-    sprintf(buff, "%lg", value);
+    double_to_string(value, buff, MAX_SIGNIFICANT_DIGITS);
     return addJSONData(context, buff, strlen(buff));
 }
 
@@ -329,7 +501,7 @@ int bsg_ksjsonaddIntegerElement(BSG_KSJSONEncodeContext *const context,
     int result = bsg_ksjsonbeginElement(context, name);
     unlikely_if(result != BSG_KSJSON_OK) { return result; }
     char buff[30];
-    sprintf(buff, "%lld", value);
+    int64_to_string(value, buff);
     return addJSONData(context, buff, strlen(buff));
 }
 
@@ -339,7 +511,7 @@ int bsg_ksjsonaddUIntegerElement(BSG_KSJSONEncodeContext *const context,
     int result = bsg_ksjsonbeginElement(context, name);
     unlikely_if(result != BSG_KSJSON_OK) { return result; }
     char buff[30];
-    sprintf(buff, "%llu", value);
+    uint64_to_string(value, buff);
     return addJSONData(context, buff, (int)strlen(buff));
 }
 

--- a/Bugsnag/KSCrash/Source/KSCrash/Recording/Tools/BSG_KSJSONCodec.h
+++ b/Bugsnag/KSCrash/Source/KSCrash/Recording/Tools/BSG_KSJSONCodec.h
@@ -35,7 +35,6 @@ extern "C" {
 #endif
 
 #include <stdbool.h>
-#include <stdio.h>
 #include <sys/types.h>
 
 /* Tells the encoder to automatically determine the length of a field value.

--- a/Bugsnag/Payload/BugsnagStackframe.m
+++ b/Bugsnag/Payload/BugsnagStackframe.m
@@ -120,7 +120,7 @@ BugsnagStackframeType const BugsnagStackframeTypeCocoa = @"cocoa";
 + (NSArray<BugsnagStackframe *> *)stackframesWithCallStackSymbols:(NSArray<NSString *> *)callStackSymbols {
     NSString *pattern = (@"^(\\d+)"             // Capture the leading frame number
                          @" +"                  // Skip whitespace
-                         @"(\\S+)"              // Image name
+                         @"([\\S ]+?)"          // Image name (may contain spaces)
                          @" +"                  // Skip whitespace
                          @"(0x[0-9a-fA-F]+)"    // Capture the frame address
                          @"("                   // Start optional group

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,13 @@
 Changelog
 =========
 
+## TBD
+
+### Bug fixes
+
+* Fix parsing of `callStackSymbols` where the image name contains spaces.
+  [#1036](https://github.com/bugsnag/bugsnag-cocoa/pull/1036)
+
 ## 6.7.1 (2021-03-10)
 
 ### Bug fixes

--- a/Tests/BugsnagStackframeTest.m
+++ b/Tests/BugsnagStackframeTest.m
@@ -170,7 +170,7 @@
         @"4   CoreFoundation                      0x00007fff23e41fd1",
         @"5   CoreFoundation                      0x00007fff23e422a4",
         @"6   ReactNativeTest                     0x000000010fd76eae",
-        @"7   ReactNativeTest                     0x000000010fd79138"]];
+        @"7   ReactNative App                     0x000000010fd79138"]];
     
     AssertStackframeValues(stackframes[0], @"ReactNativeTest",  0x000000010fda7f1b, @"0x000000010fda7f1b");
     AssertStackframeValues(stackframes[1], @"ReactNativeTest",  0x000000010fd76897, @"0x000000010fd76897");
@@ -179,7 +179,7 @@
     AssertStackframeValues(stackframes[4], @"CoreFoundation",   0x00007fff23e41fd1, @"0x00007fff23e41fd1");
     AssertStackframeValues(stackframes[5], @"CoreFoundation",   0x00007fff23e422a4, @"0x00007fff23e422a4");
     AssertStackframeValues(stackframes[6], @"ReactNativeTest",  0x000000010fd76eae, @"0x000000010fd76eae");
-    AssertStackframeValues(stackframes[7], @"ReactNativeTest",  0x000000010fd79138, @"0x000000010fd79138");
+    AssertStackframeValues(stackframes[7], @"ReactNative App",  0x000000010fd79138, @"0x000000010fd79138");
 }
 
 - (void)testRealCallStackSymbols {

--- a/examples/objective-c-ios/Bugsnag Test App/OutOfMemoryController.m
+++ b/examples/objective-c-ios/Bugsnag Test App/OutOfMemoryController.m
@@ -1,18 +1,16 @@
 #import "OutOfMemoryController.h"
 
-#define PRINT_STATS 0
+#include <mach/mach_init.h>
+#include <mach/task_info.h>
+#include <mach/task.h>
+#include <os/proc.h>
+#include <sys/utsname.h>
 
-#if PRINT_STATS
-#import <mach/mach_init.h>
-#import <mach/task_info.h>
-#import <mach/task.h>
-#endif
+#define PRINT_STATS 1
 
 #define MEGABYTE 0x100000
 
-@implementation OutOfMemoryController {
-    NSUInteger _blockSize;
-}
+@implementation OutOfMemoryController
 
 - (void)viewDidLoad {
     [super viewDidLoad];
@@ -27,41 +25,76 @@
 - (void)viewDidAppear:(BOOL)animated {
     [super viewDidAppear:animated];
     
+    struct utsname system = {0};
+    uname(&system);
+    NSLog(@"*** Device = %s", system.machine);
+    
     NSUInteger physicalMemory = (NSUInteger)NSProcessInfo.processInfo.physicalMemory;
     NSUInteger megabytes = physicalMemory / MEGABYTE;
     NSLog(@"*** Physical memory = %lu MB", (unsigned long)megabytes);
     
-    // The ActiveHard limit varies between devices
     //
-    // Device       iOS     Total   Limit
-    // ========================================
-    // iPad3,19      9       987     700  (70%)
-    // iPhone12,1   14      3859    2098  (54%)
-    // iPhone12,8   14      2965    2095  (70%)
-    // iPhone13,1   14      3718    2098  (57%)
+    // The ActiveHard limit and point at which a memory warning is sent varies by device
+    // Some data from http://www.chenxiyao.com/article/10/read
     //
-    NSUInteger limit = MIN(2098, megabytes * 70 / 100);
+    // Device                       Total   Warn    Limit
+    // =======================================================
+    // iPad3,1      iPad 3rd gen     987     560     700  (70%)
+    // iPhone5,1    iPhone 5                         650
+    // iPhone6,2    iPhone 5s       1000     600     650  (65%)
+    // iPhone7,1    iPhone 6 Plus                    650
+    // iPhone7,2    iPhone 6                         650
+    // iPhone8,1    iPhone 6s                       1380
+    // iPhone8,2    iPhone 6s Plus                  1380
+    // iPhone8,4    iPhone SE                       1380
+    // iPhone9,1    iPhone 7                        1380
+    // iPhone9,2    iPhone 7 Plus                   2050
+    // iPhone10,1   iPhone 8                        1380
+    // iPhone10,2   iPhone 8 Plus                   2050
+    // iPhone10,3   iPhone X                        1400
+    // iPhone11,2   iPhone XS                       2050
+    // iPhone11,4   iPhone XS Max                   2050
+    // iPhone11,8   iPhone XR                       1400
+    // iPhone12,1   iPhone 11       3859            2098  (54%)
+    // iPhone12,8   iPhone SE (2)   2965    1994    2098  (70%)
+    // iPhone13,1   iPhone 12 mini  3718    1546    2098  (57%)
+    //
+    NSUInteger limit = 0;
+    task_vm_info_data_t vm_info = {0};
+    mach_msg_type_number_t count = TASK_VM_INFO_COUNT;
+    kern_return_t result = task_info(mach_task_self(), TASK_VM_INFO, (task_info_t)&vm_info, &count);
+    if (result == KERN_SUCCESS && count >= TASK_VM_INFO_REV4_COUNT) {
+        limit = (NSUInteger)(vm_info.phys_footprint + vm_info.limit_bytes_remaining) / MEGABYTE;
+        NSLog(@"*** Memory limit = %lu MB", (unsigned long)limit);
+    } else if (!strcmp(system.machine, "iPhone6,2")) {
+        limit = 650;
+        NSLog(@"*** Memory limit = %lu MB", (unsigned long)limit);
+    } else {
+        limit = MIN(2098, megabytes * 70 / 100);
+        NSLog(@"*** Memory limit = %lu MB (estimated)", (unsigned long)limit);
+    }
     
-    NSUInteger initial = limit * 95 / 100;
+    // The size of the initial block needs to be under the memory warning limit in order for one to be reliably sent.
+    NSUInteger initial = limit * 70 / 100;
     NSLog(@"*** Dirtying an initial block of %lu MB", (unsigned long)initial);
     [self consumeMegabytes:initial];
     
-    _blockSize = limit <= 1024 ? 1 : 2;
-    NSLog(@"*** Dirtying remaining memory in %lu MB blocks", (unsigned long)_blockSize);
-    // This should take around 2 seconds to trigger an OOM kill
-    [NSTimer scheduledTimerWithTimeInterval:0.03 target:self selector:@selector(timerFired) userInfo:nil repeats:YES];
+    NSLog(@"*** Dirtying remaining memory in ~2 seconds");
+    NSTimeInterval timeInterval = 2.0 / (limit - initial);
+    [NSTimer scheduledTimerWithTimeInterval:timeInterval target:self selector:@selector(timerFired) userInfo:nil repeats:YES];
 }
 
 - (void)timerFired {
-    [self consumeMegabytes:_blockSize];
+    [self consumeMegabytes:1];
 }
 
 - (void)consumeMegabytes:(NSUInteger)megabytes {
     for (NSUInteger i = 0; i < megabytes; i++) {
-        const NSUInteger pagesize = NSPageSize();
-        const NSUInteger npages = MEGABYTE / pagesize;
         volatile char *ptr = malloc(MEGABYTE);
-        for (NSUInteger page = 0; page < npages; page++) {
+        // Originally used NSPageSize() but on iPhone 5s iOS 12 that didn't result in dirtying all the memory allocated.
+        const int pagesize = 4096;
+        const int npages = MEGABYTE / pagesize;
+        for (int page = 0; page < npages; page++) {
             ptr[page * pagesize] = 42; // Dirty each page
         }
     }

--- a/examples/swift-ios/bugsnag-example/OutOfMemoryController.m
+++ b/examples/swift-ios/bugsnag-example/OutOfMemoryController.m
@@ -18,24 +18,24 @@
 // OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
 // THE SOFTWARE.
 
-#import <WebKit/WebKit.h>
-#import <signal.h>
 #import "OutOfMemoryController.h"
-#import <Bugsnag/Bugsnag.h>
 
-@interface OutOfMemoryController ()
-@property (nonatomic, strong) UIWebView *webView;
-@end
+#include <mach/mach_init.h>
+#include <mach/task_info.h>
+#include <mach/task.h>
+#include <os/proc.h>
+#include <sys/utsname.h>
+
+#define PRINT_STATS 1
+
+#define MEGABYTE 0x100000
 
 @implementation OutOfMemoryController
 
 - (void)viewDidLoad {
     [super viewDidLoad];
-    self.webView = [[UIWebView alloc] initWithFrame:self.view.bounds];
-    [self.webView loadHTMLString:@"<h2>Loading a lot of JavaScript. Please wait.</h2>"
-                                  "<p>You can follow along in Console.app</p>"
-                         baseURL:nil];
-    [self.view addSubview:self.webView];
+    
+    self.view.backgroundColor = UIColor.groupTableViewBackgroundColor;
 }
 
 - (void)didReceiveMemoryWarning {
@@ -44,15 +44,88 @@
 
 - (void)viewDidAppear:(BOOL)animated {
     [super viewDidAppear:animated];
-    NSString *format = @"var b = document.createElement('div'); div.innerHTML = 'Hello item %d'; document.documentElement.appendChild(div);";
-    for (int i = 0; i < 3000 * 1024; i++) {
-        NSString *item = [NSString stringWithFormat:format, i];
-        [self.webView stringByEvaluatingJavaScriptFromString:item];
+    
+    struct utsname system = {0};
+    uname(&system);
+    NSLog(@"*** Device = %s", system.machine);
+    
+    NSUInteger physicalMemory = (NSUInteger)NSProcessInfo.processInfo.physicalMemory;
+    NSUInteger megabytes = physicalMemory / MEGABYTE;
+    NSLog(@"*** Physical memory = %lu MB", (unsigned long)megabytes);
+    
+    //
+    // The ActiveHard limit and point at which a memory warning is sent varies by device
+    // Some data from http://www.chenxiyao.com/article/10/read
+    //
+    // Device                       Total   Warn    Limit
+    // =======================================================
+    // iPad3,1      iPad 3rd gen     987     560     700  (70%)
+    // iPhone5,1    iPhone 5                         650
+    // iPhone6,2    iPhone 5s       1000     600     650  (65%)
+    // iPhone7,1    iPhone 6 Plus                    650
+    // iPhone7,2    iPhone 6                         650
+    // iPhone8,1    iPhone 6s                       1380
+    // iPhone8,2    iPhone 6s Plus                  1380
+    // iPhone8,4    iPhone SE                       1380
+    // iPhone9,1    iPhone 7                        1380
+    // iPhone9,2    iPhone 7 Plus                   2050
+    // iPhone10,1   iPhone 8                        1380
+    // iPhone10,2   iPhone 8 Plus                   2050
+    // iPhone10,3   iPhone X                        1400
+    // iPhone11,2   iPhone XS                       2050
+    // iPhone11,4   iPhone XS Max                   2050
+    // iPhone11,8   iPhone XR                       1400
+    // iPhone12,1   iPhone 11       3859            2098  (54%)
+    // iPhone12,8   iPhone SE (2)   2965    1994    2098  (70%)
+    // iPhone13,1   iPhone 12 mini  3718    1546    2098  (57%)
+    //
+    NSUInteger limit = 0;
+    task_vm_info_data_t vm_info = {0};
+    mach_msg_type_number_t count = TASK_VM_INFO_COUNT;
+    kern_return_t result = task_info(mach_task_self(), TASK_VM_INFO, (task_info_t)&vm_info, &count);
+    if (result == KERN_SUCCESS && count >= TASK_VM_INFO_REV4_COUNT) {
+        limit = (NSUInteger)(vm_info.phys_footprint + vm_info.limit_bytes_remaining) / MEGABYTE;
+        NSLog(@"*** Memory limit = %lu MB", (unsigned long)limit);
+    } else if (!strcmp(system.machine, "iPhone6,2")) {
+        limit = 650;
+        NSLog(@"*** Memory limit = %lu MB", (unsigned long)limit);
+    } else {
+        limit = MIN(2098, megabytes * 70 / 100);
+        NSLog(@"*** Memory limit = %lu MB (estimated)", (unsigned long)limit);
+    }
+    
+    // The size of the initial block needs to be under the memory warning limit in order for one to be reliably sent.
+    NSUInteger initial = limit * 70 / 100;
+    NSLog(@"*** Dirtying an initial block of %lu MB", (unsigned long)initial);
+    [self consumeMegabytes:initial];
+    
+    NSLog(@"*** Dirtying remaining memory in ~2 seconds");
+    NSTimeInterval timeInterval = 2.0 / (limit - initial);
+    [NSTimer scheduledTimerWithTimeInterval:timeInterval target:self selector:@selector(timerFired) userInfo:nil repeats:YES];
+}
 
-        if (i % 1000 == 0) {
-            NSLog(@"Loaded %d items", i);
+- (void)timerFired {
+    [self consumeMegabytes:1];
+}
+
+- (void)consumeMegabytes:(NSUInteger)megabytes {
+    for (NSUInteger i = 0; i < megabytes; i++) {
+        volatile char *ptr = malloc(MEGABYTE);
+        // Originally used NSPageSize() but on iPhone 5s iOS 12 that didn't result in dirtying all the memory allocated.
+        const int pagesize = 4096;
+        const int npages = MEGABYTE / pagesize;
+        for (int page = 0; page < npages; page++) {
+            ptr[page * pagesize] = 42; // Dirty each page
         }
     }
+#if PRINT_STATS
+    task_vm_info_data_t info;
+    mach_msg_type_number_t count = TASK_VM_INFO_COUNT;
+    kern_return_t result = task_info(mach_task_self(), TASK_VM_INFO, (task_info_t) &info, &count);
+    assert(result == KERN_SUCCESS);
+    unsigned long long physicalMemory = NSProcessInfo.processInfo.physicalMemory;
+    NSLog(@"%4llu / %4llu MB (%llu%%)", info.phys_footprint / MEGABYTE, physicalMemory / MEGABYTE, info.phys_footprint * 100 / physicalMemory);
+#endif
 }
 
 @end

--- a/features/fixtures/shared/scenarios/OOMScenario.m
+++ b/features/fixtures/shared/scenarios/OOMScenario.m
@@ -10,11 +10,15 @@
 
 #import <UIKit/UIKit.h>
 
+#include <mach/mach_init.h>
+#include <mach/task_info.h>
+#include <mach/task.h>
+#include <os/proc.h>
+#include <sys/utsname.h>
+
 #define MEGABYTE 0x100000
 
-@implementation OOMScenario {
-    NSUInteger _blockSize;
-}
+@implementation OOMScenario
 
 - (void)startBugsnag {
     self.config.autoTrackSessions = YES;
@@ -45,41 +49,76 @@
 }
 
 - (void)consumeAllMemory {
+    struct utsname system = {0};
+    uname(&system);
+    NSLog(@"*** Device = %s", system.machine);
+    
     NSUInteger physicalMemory = (NSUInteger)NSProcessInfo.processInfo.physicalMemory;
     NSUInteger megabytes = physicalMemory / MEGABYTE;
     NSLog(@"*** Physical memory = %lu MB", (unsigned long)megabytes);
     
-    // The ActiveHard limit varies between devices
     //
-    // Device       iOS     Total   Limit
-    // ========================================
-    // iPad3,19      9       987     700  (70%)
-    // iPhone12,1   14      3859    2098  (54%)
-    // iPhone12,8   14      2965    2095  (70%)
-    // iPhone13,1   14      3718    2098  (57%)
+    // The ActiveHard limit and point at which a memory warning is sent varies by device
+    // Some data from http://www.chenxiyao.com/article/10/read
     //
-    NSUInteger limit = MIN(2098, megabytes * 70 / 100);
+    // Device                       Total   Warn    Limit
+    // =======================================================
+    // iPad3,1      iPad 3rd gen     987     560     700  (70%)
+    // iPhone5,1    iPhone 5                         650
+    // iPhone6,2    iPhone 5s       1000     600     650  (65%)
+    // iPhone7,1    iPhone 6 Plus                    650
+    // iPhone7,2    iPhone 6                         650
+    // iPhone8,1    iPhone 6s                       1380
+    // iPhone8,2    iPhone 6s Plus                  1380
+    // iPhone8,4    iPhone SE                       1380
+    // iPhone9,1    iPhone 7                        1380
+    // iPhone9,2    iPhone 7 Plus                   2050
+    // iPhone10,1   iPhone 8                        1380
+    // iPhone10,2   iPhone 8 Plus                   2050
+    // iPhone10,3   iPhone X                        1400
+    // iPhone11,2   iPhone XS                       2050
+    // iPhone11,4   iPhone XS Max                   2050
+    // iPhone11,8   iPhone XR                       1400
+    // iPhone12,1   iPhone 11       3859            2098  (54%)
+    // iPhone12,8   iPhone SE (2)   2965    1994    2098  (70%)
+    // iPhone13,1   iPhone 12 mini  3718    1546    2098  (57%)
+    //
+    NSUInteger limit = 0;
+    task_vm_info_data_t vm_info = {0};
+    mach_msg_type_number_t count = TASK_VM_INFO_COUNT;
+    kern_return_t result = task_info(mach_task_self(), TASK_VM_INFO, (task_info_t)&vm_info, &count);
+    if (result == KERN_SUCCESS && count >= TASK_VM_INFO_REV4_COUNT) {
+        limit = (NSUInteger)(vm_info.phys_footprint + vm_info.limit_bytes_remaining) / MEGABYTE;
+        NSLog(@"*** Memory limit = %lu MB", (unsigned long)limit);
+    } else if (!strcmp(system.machine, "iPhone6,2")) {
+        limit = 650;
+        NSLog(@"*** Memory limit = %lu MB", (unsigned long)limit);
+    } else {
+        limit = MIN(2098, megabytes * 70 / 100);
+        NSLog(@"*** Memory limit = %lu MB (estimated)", (unsigned long)limit);
+    }
     
-    NSUInteger initial = limit * 95 / 100;
+    // The size of the initial block needs to be under the memory warning limit in order for one to be reliably sent.
+    NSUInteger initial = limit * 70 / 100;
     NSLog(@"*** Dirtying an initial block of %lu MB", (unsigned long)initial);
     [self consumeMegabytes:initial];
     
-    _blockSize = limit <= 1024 ? 1 : 2;
-    NSLog(@"*** Dirtying remaining memory in %lu MB blocks", (unsigned long)_blockSize);
-    // This should take around 2 seconds to trigger an OOM kill
-    [NSTimer scheduledTimerWithTimeInterval:0.03 target:self selector:@selector(timerFired) userInfo:nil repeats:YES];
+    NSLog(@"*** Dirtying remaining memory in ~2 seconds");
+    NSTimeInterval timeInterval = 2.0 / (limit - initial);
+    [NSTimer scheduledTimerWithTimeInterval:timeInterval target:self selector:@selector(timerFired) userInfo:nil repeats:YES];
 }
 
 - (void)timerFired {
-    [self consumeMegabytes:_blockSize];
+    [self consumeMegabytes:1];
 }
 
 - (void)consumeMegabytes:(NSUInteger)megabytes {
     for (NSUInteger i = 0; i < megabytes; i++) {
-        const NSUInteger pagesize = NSPageSize();
-        const NSUInteger npages = MEGABYTE / pagesize;
         volatile char *ptr = malloc(MEGABYTE);
-        for (NSUInteger page = 0; page < npages; page++) {
+        // Originally used NSPageSize() but on iPhone 5s iOS 12 that didn't result in dirtying all the memory allocated.
+        const int pagesize = 4096;
+        const int npages = MEGABYTE / pagesize;
+        for (int page = 0; page < npages; page++) {
             ptr[page * pagesize] = 42; // Dirty each page
         }
     }


### PR DESCRIPTION
## Goal

Blindly using memcmp to compare env variables to `DYLD_INSERT_LIBRARIES` was breaking when the address sanitizer was on because technically the comparison would run off the end of the array. This is *technically* not a problem since the ENV vars are all contiguous in memory and the small overhang can't cause real problems, but the address sanitizer IS correctly detecting the undefined behaviour.

## Changeset

Check if the env var is smaller than `DYLD_INSERT_LIBRARIES` and short-circuit if so.

## Testing

Manually ran the example app before to verify the problem, and afterwards to verify the fix.
