### PR TITLE
[PLAT-6223] Fix unreliable ordering of breadcrumbs

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,13 @@
 Changelog
 =========
 
+## TBD
+
+### Bug fixes
+
+* Fix unreliable ordering of breadcrumbs.
+  [#1049](https://github.com/bugsnag/bugsnag-cocoa/pull/1049)
+
 ## 6.8.0 (2021-03-18)
 
 ### Enhancements


### PR DESCRIPTION
## Goal

Fixes a customer reported issue where breadcrumbs sometimes appeared in the wrong order.

## Changeset

The bug was caused by sorting the breadcrumb filenames using `-[NSString compare:]` - which causes e.g. "20" to appear before "3".

`-[BugsnagBreadcrumbs loadBreadcrumbsAsDictionaries:]` now sorts filenames using a custom comparator. 

There is remaining issue - when leaving breadcrumbs simultaneously from multiple threads, the order of file writes does not always match the timestamps (a thread may stop executing between recording the timestamp and writing the file) so the timestamps sometimes are out of order.

Attempted sorting breadcrumbs by their timestamp, but that is problematic due to the limited accuracy used in the JSON representation - causing unit tests to fail due to unreliable ordering of breadcrumbs.

## Testing

Reproduced the issue by amending the BugsnagStressTest fixture to check breadcrumbs ordering. I have not committed this check since it fails due to the concurrency issue.

Reproducing via E2E tests was not successful as they do not log a sufficient volume of breadcrumbs to trigger the bug.