### PR TITLE
[PLAT-5991] Improve performance of deserializing breadcrumbs

### DIFF
--- a/Bugsnag/Helpers/BSG_RFC3339DateTool.h
+++ b/Bugsnag/Helpers/BSG_RFC3339DateTool.h
@@ -53,4 +53,11 @@
  */
 + (NSString *)stringFromUNIXTimestamp:(unsigned long long)timestamp;
 
+/**
+ * Determines whether a string might contain an RFC3339 formatted date.
+ *
+ * Useful if the overhead of -dateFromString: needs to be avoided.
+ */
++ (BOOL)isLikelyDateString:(NSString *)string;
+
 @end

--- a/Bugsnag/Helpers/BSG_RFC3339DateTool.m
+++ b/Bugsnag/Helpers/BSG_RFC3339DateTool.m
@@ -86,4 +86,28 @@ static NSDateFormatter *g_timezoneAllowedDateFormatter;
         [self stringFromDate:[NSDate dateWithTimeIntervalSince1970:timestamp]];
 }
 
++ (BOOL)isLikelyDateString:(NSString *)string {
+    const char *ptr = string.UTF8String;
+    return (string.length >= 19 &&
+            isdigit(ptr[0]) &&
+            isdigit(ptr[1]) &&
+            isdigit(ptr[2]) &&
+            isdigit(ptr[3]) &&
+            '-' == (ptr[4]) &&
+            isdigit(ptr[5]) &&
+            isdigit(ptr[6]) &&
+            '-' == (ptr[7]) &&
+            isdigit(ptr[8]) &&
+            isdigit(ptr[9]) &&
+            'T' ==  ptr[10] &&
+            isdigit(ptr[11]) &&
+            isdigit(ptr[12]) &&
+            ':' == (ptr[13]) &&
+            isdigit(ptr[14]) &&
+            isdigit(ptr[15]) &&
+            ':' == (ptr[16]) &&
+            isdigit(ptr[17]) &&
+            isdigit(ptr[18]));
+}
+
 @end

--- a/Bugsnag/Payload/BugsnagBreadcrumb.m
+++ b/Bugsnag/Payload/BugsnagBreadcrumb.m
@@ -138,7 +138,7 @@ BSGBreadcrumbType BSGBreadcrumbTypeFromString(NSString *value) {
 - (void)setTimestampString:(NSString *)timestampString {
     @synchronized (self) {
         _timestampString = [timestampString copy];
-        _timestamp = nil;
+        _timestamp = nil; //!OCLint
     }
 }
 

--- a/Bugsnag/Payload/BugsnagBreadcrumb.m
+++ b/Bugsnag/Payload/BugsnagBreadcrumb.m
@@ -74,6 +74,15 @@ BSGBreadcrumbType BSGBreadcrumbTypeFromString(NSString *value) {
     }
 }
 
+
+@interface BugsnagBreadcrumb ()
+
+/// String representation of `timestamp` used to avoid unnecessary date <--> string conversions
+@property (copy, nonatomic) NSString *timestampString;
+
+@end
+
+
 @implementation BugsnagBreadcrumb
 
 - (instancetype)init {
@@ -86,12 +95,12 @@ BSGBreadcrumbType BSGBreadcrumbTypeFromString(NSString *value) {
 }
 
 - (BOOL)isValid {
-    return self.message.length > 0 && self.timestamp != nil;
+    return self.message.length > 0 && (self.timestampString || self.timestamp);
 }
 
 - (NSDictionary *)objectValue {
     @synchronized (self) {
-        NSString *timestamp = [BSG_RFC3339DateTool stringFromDate:_timestamp];
+        NSString *timestamp = self.timestampString ?: [BSG_RFC3339DateTool stringFromDate:self.timestamp];
         if (timestamp && _message.length > 0) {
             NSMutableDictionary *metadata = [NSMutableDictionary new];
             for (NSString *key in _metadata) {
@@ -112,17 +121,24 @@ BSGBreadcrumbType BSGBreadcrumbTypeFromString(NSString *value) {
 
 @synthesize timestamp = _timestamp;
 
+// The timestamp is lazily computed from the timestampString to avoid unnecessary
+// calls to -dateFromString: (which is expensive) when loading breadcrumbs from disk.
+
 - (NSDate *)timestamp {
     @synchronized (self) {
+        if (!_timestamp) {
+            _timestamp = [BSG_RFC3339DateTool dateFromString:self.timestampString];
+        }
         return _timestamp;
     }
 }
 
-- (void)setTimestamp:(NSDate * _Nullable)timestamp {
+@synthesize timestampString = _timestampString;
+
+- (void)setTimestampString:(NSString *)timestampString {
     @synchronized (self) {
-        [self willChangeValueForKey:NSStringFromSelector(@selector(timestamp))];
-        _timestamp = timestamp;
-        [self didChangeValueForKey:NSStringFromSelector(@selector(timestamp))];
+        _timestampString = [timestampString copy];
+        _timestamp = nil;
     }
 }
 
@@ -200,6 +216,7 @@ BSGBreadcrumbType BSGBreadcrumbTypeFromString(NSString *value) {
 + (instancetype)breadcrumbFromDict:(NSDictionary *)dict {
     BOOL isValidCrumb = [dict[BSGKeyType] isKindOfClass:[NSString class]]
         && [dict[BSGKeyTimestamp] isKindOfClass:[NSString class]]
+        && [BSG_RFC3339DateTool isLikelyDateString:dict[BSGKeyTimestamp]]
         && (
             [dict[BSGKeyMetadata] isKindOfClass:[NSDictionary class]]
             || [dict[@"metadata"] isKindOfClass:[NSDictionary class]] // react-native uses lowercase key
@@ -211,7 +228,7 @@ BSGBreadcrumbType BSGBreadcrumbTypeFromString(NSString *value) {
         return [self breadcrumbWithBlock:^(BugsnagBreadcrumb *crumb) {
             crumb.message = dict[BSGKeyMessage] ?: dict[BSGKeyName];
             crumb.metadata = dict[BSGKeyMetadata] ?: dict[@"metadata"];
-            crumb.timestamp = [BSG_RFC3339DateTool dateFromString:dict[BSGKeyTimestamp]];
+            crumb.timestampString = dict[BSGKeyTimestamp];
             crumb.type = BSGBreadcrumbTypeFromString(dict[BSGKeyType]);
         }];
     }


### PR DESCRIPTION
## Goal

Improve the performance of deserializing breadcrumbs, because they are deserialized every time `notify()` is called.

`-[NSDateFormatter dateFromString:]` in `+[BugsnagBreadcrumb breadcrumbFromDict:]` was taking up a sizeable portion of CPU time when running performance tests on `notify()`.

## Changeset

The timestamp string in the JSON payload is now stored directly in a new `timestampString` property, and also used when formatting JSON output, thus avoiding any `NSDateFormatter` conversions.

The `timestamp` property, if needed, is now lazily computed from the `timestampString`.

Since `timestamp` is a read-only property, the implementation of `-setTimestamp:` has been removed.

`isValid` now checks the timestamp string to see if it looks like it contains a date - this is to preserve the existing behaviour of returning `nil` from `+breadcrumbWithBlock:` when given bad input, as verified by the unit tests.

## Testing

Unit tests & barebone E2E tests passed ✅ 

The time taken for a single `notify()` call in the performance test has decreased from `4.9` ms to `3.9` ms