### PR TITLE
[PLAT-6279] Fix flake in AutoSessionMixedEventsScenario due to race condition

### DIFF
--- a/features/fixtures/shared/scenarios/Scenario.m
+++ b/features/fixtures/shared/scenarios/Scenario.m
@@ -113,9 +113,10 @@ static Scenario *theScenario;
 }
 
 - (void)requestDidComplete:(NSURLRequest *)request {
-    if (_onEventDelivery && [request.URL.absoluteString isEqual:self.config.endpoints.notify]) {
-        _onEventDelivery();
+    dispatch_block_t block = _onEventDelivery;
+    if (block && [request.URL.absoluteString isEqual:self.config.endpoints.notify]) {
         _onEventDelivery = nil;
+        block();
     }
 }
 


### PR DESCRIPTION
## Goal

`features/session_tracking.feature:127` / `AutoSessionMixedEventsScenario` was occasionally flaking with a fatal app hang instead of the expected C++ exception.

## Analysis

Added additional logging and identified that this was happening due to `-performBlockAndWaitForEventDelivery:` blocking indefinitely when `_onEventDelivery` was unexpectedly nil.

The cause was the next call to `-performBlockAndWaitForEventDelivery:` occurring before `_onEventDelivery` had been set to nil by `requestDidComplete:` - thus the new `_onEventDelivery` block was being replaced.

## Changeset

`_onEventDelivery` is now set to nil before being invoked to remove the race condition.

## Testing

Tested on BrowserStack with additional logging to identify the cause, and then to verify that no flakes occurred after 16 successful consecutive runs with the fix.