### PR TITLE
[PLAT-6291] Ignore app hangs when a debugger is attached

### DIFF
--- a/Bugsnag/Helpers/BSGAppHangDetector.m
+++ b/Bugsnag/Helpers/BSGAppHangDetector.m
@@ -11,6 +11,7 @@
 #import <Bugsnag/BugsnagConfiguration.h>
 #import <Bugsnag/BugsnagErrorTypes.h>
 
+#import "BSG_KSMach.h"
 #import "BugsnagLogger.h"
 #import "BugsnagThread+Recording.h"
 #import "BugsnagThread+Private.h"
@@ -74,6 +75,12 @@
             dispatch_time_t timeout = dispatch_time(now, (int64_t)(threshold * NSEC_PER_SEC));
             dispatch_after(after, backgroundQueue, ^{
                 if (dispatch_semaphore_wait(semaphore, timeout) != 0) {
+                    if (bsg_ksmachisBeingTraced()) {
+                        bsg_log_debug("Ignoring app hang because debugger is attached");
+                        dispatch_semaphore_wait(semaphore, DISPATCH_TIME_FOREVER);
+                        return;
+                    }
+                    
                     bsg_log_info("App hang detected");
                     
                     NSArray<BugsnagThread *> *threads = nil;

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,13 @@
 Changelog
 =========
 
+## TBD
+
+### Bug fixes
+
+* Prevent app hangs being reported if a debugger is attached.
+  [#1058](https://github.com/bugsnag/bugsnag-cocoa/pull/1058)
+
 ## 6.8.2 (2021-03-31)
 
 ### Bug fixes


### PR DESCRIPTION
## Goal

App hangs were being reported if a breakpoint was hit on an app's main thread.

## Changeset

The app hang detector now checks if a debugger is attached, and avoids reporting if so.

## Testing

Tested manually using example app.