### PR TITLE
Fix react native E2E test failure

### DIFF
--- a/Bugsnag/Client/BugsnagClient.m
+++ b/Bugsnag/Client/BugsnagClient.m
@@ -953,7 +953,7 @@ NSString *_lastOrientation = nil;
         [self.eventUploader storeEvent:event];
         // Replicate previous delivery mechanism's behaviour of waiting 1 second before delivering the event.
         // This should prevent potential duplicate uploads of unhandled errors where the app subsequently terminates.
-        [self.eventUploader performSelector:@selector(uploadStoredEvents) withObject:nil afterDelay:1];
+        [self.eventUploader uploadStoredEventsAfterDelay:1];
     } else {
         [self.eventUploader uploadEvent:event completionHandler:nil];
     }

--- a/Bugsnag/Delivery/BSGEventUploader.h
+++ b/Bugsnag/Delivery/BSGEventUploader.h
@@ -25,6 +25,8 @@ NS_ASSUME_NONNULL_BEGIN
 
 - (void)uploadStoredEvents;
 
+- (void)uploadStoredEventsAfterDelay:(NSTimeInterval)delay;
+
 - (void)uploadLatestStoredEvent:(void (^)(void))completionHandler;
 
 @end

--- a/Bugsnag/Delivery/BSGEventUploader.m
+++ b/Bugsnag/Delivery/BSGEventUploader.m
@@ -92,6 +92,13 @@
     }];
 }
 
+- (void)uploadStoredEventsAfterDelay:(NSTimeInterval)delay {
+    dispatch_queue_t queue = dispatch_get_global_queue(QOS_CLASS_UTILITY, 0);
+    dispatch_after(dispatch_time(DISPATCH_TIME_NOW, (int64_t)(delay * NSEC_PER_SEC)), queue, ^{
+        [self uploadStoredEvents];
+    });
+}
+
 - (void)uploadLatestStoredEvent:(void (^)(void))completionHandler {
     NSString *latestFile = [self sortedEventFiles].lastObject;
     BSGEventUploadFileOperation *operation = latestFile ? [self uploadOperationsWithFiles:@[latestFile]].lastObject : nil;


### PR DESCRIPTION
## Goal

Fix a React Native E2E test failure when reporting unhandled native promise rejections.

## Changeset

The symptom was the unhandled event not being sent.

The root cause was the use of [`performSelector:withObject:afterDelay:`](https://developer.apple.com/documentation/objectivec/nsobject/1416176-performselector) to upload the stored event(s). This API sets up a timer to perform the selector on the **current** thread. This is not guaranteed to fire since the user thread may terminate or not be running a runloop.

Fixed by using a global dispatch queue to perform the delayed upload.

## Testing

Verified fix on a testing branch - https://buildkite.com/bugsnag/bugsnag-js-react-native/builds/2039

Test failures for reference - https://buildkite.com/bugsnag/bugsnag-js-react-native/builds/2031