### PR TITLE
Add 10.13 e2e tests

### DIFF
--- a/.buildkite/pipeline.full.yml
+++ b/.buildkite/pipeline.full.yml
@@ -95,6 +95,26 @@ steps:
         --tags='not @skip_macos'
         --fail-fast
 
+  - label: ':apple: macOS 10.13 full end-to-end tests'
+    depends_on:
+      - cocoa_fixture
+    timeout_in_minutes: 60
+    agents:
+      queue: opensource-mac-cocoa-10.13
+    plugins:
+      artifacts#v1.3.0:
+        download: ["features/fixtures/macos/output/macOSTestApp.zip"]
+        upload: ["macOSTestApp.log"]
+    commands:
+      - bundle install
+      - bundle exec maze-runner
+        --farm=local
+        --os=macos
+        --os-version=10.13
+        --app=macOSTestApp
+        --tags='not @skip_macos'
+        --fail-fast
+
   - label: ':apple: macOS 10.14 full end-to-end tests'
     depends_on:
       - cocoa_fixture


### PR DESCRIPTION
## Goal

Add macOS 10.13 end-to-end tests to a full CI run.

## Testing

Covered by CI.