### PR TITLE
[PLAT-6298] Improve accuracy of KSCrashReport timestamp

### DIFF
--- a/Bugsnag/Delivery/BSGEventUploadKSCrashReportOperation.m
+++ b/Bugsnag/Delivery/BSGEventUploadKSCrashReportOperation.m
@@ -56,7 +56,14 @@
     mutableReport[@BSG_KSCrashField_Report] = mutableInfo;
 
     // Timestamp gets stored as a unix timestamp. Convert it to rfc3339.
-    [self convertTimestamp:@BSG_KSCrashField_Timestamp inReport:mutableInfo];
+    NSNumber *timestampMillis = mutableInfo[@(BSG_KSCrashField_Timestamp_Millis)];
+    if ([timestampMillis isKindOfClass:[NSNumber class]]) {
+        NSTimeInterval timeInterval = timestampMillis.unsignedLongLongValue / 1000.0;
+        NSDate *date = [NSDate dateWithTimeIntervalSince1970:timeInterval];
+        mutableInfo[@(BSG_KSCrashField_Timestamp)] = [BSG_RFC3339DateTool stringFromDate:date];
+    } else {
+        [self convertTimestamp:@BSG_KSCrashField_Timestamp inReport:mutableInfo];
+    }
 
     [self mergeDictWithKey:@BSG_KSCrashField_SystemAtCrash
            intoDictWithKey:@BSG_KSCrashField_System

--- a/Bugsnag/KSCrash/Source/KSCrash/Recording/BSG_KSCrashReportFields.h
+++ b/Bugsnag/KSCrash/Source/KSCrash/Recording/BSG_KSCrashReportFields.h
@@ -161,6 +161,7 @@
 #define BSG_KSCrashField_ProcessName "process_name"
 #define BSG_KSCrashField_Report "report"
 #define BSG_KSCrashField_Timestamp "timestamp"
+#define BSG_KSCrashField_Timestamp_Millis "timestamp_millis"
 #define BSG_KSCrashField_Version "version"
 
 #pragma mark Minimal

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,13 @@
 Changelog
 =========
 
+## TBD
+
+### Bug fixes
+
+* Improve timestamp accuracy to fix breadcrumbs that are reported to occur after the error.
+  [#1062](https://github.com/bugsnag/bugsnag-cocoa/pull/1062)
+
 ## 6.8.3 (2021-04-07)
 
 ### Bug fixes

--- a/features/steps/ios_steps.rb
+++ b/features/steps/ios_steps.rb
@@ -243,6 +243,15 @@ Then('the session payload field {string} matches the test device model') do |fie
   check_device_model field, Maze::Server.sessions
 end
 
+Then('the breadcrumbs are valid for the event') do
+  device = Maze::Helper.read_key_path(Maze::Server.errors.current[:body], 'events.0.device')
+  breadcrumbs = Maze::Helper.read_key_path(Maze::Server.errors.current[:body], 'events.0.breadcrumbs')
+  breadcrumbs.each do |breadcrumb|
+    assert(breadcrumb['timestamp'] <= device['time'],
+      "Expected breadcrumb timestamp (#{breadcrumb['timestamp']}) <= event timestamp (#{device['time']})")
+  end
+end
+
 Then('the thread information is valid for the event') do
   # verify that thread/stacktrace information was captured at all
   thread_traces = Maze::Helper.read_key_path(Maze::Server.errors.current[:body], 'events.0.threads')
@@ -286,10 +295,12 @@ Then('the error is valid for the error reporting API') do
   when 'iOS'
     steps %(
       Then the error is valid for the error reporting API version "4.0" for the "iOS Bugsnag Notifier" notifier
+      Then the breadcrumbs are valid for the event
     )
   when 'Mac'
     steps %(
       Then the error is valid for the error reporting API version "4.0" for the "OSX Bugsnag Notifier" notifier
+      Then the breadcrumbs are valid for the event
     )
   else
     raise 'Unknown platformName'


### PR DESCRIPTION
## Goal

KSCrashReport timestamps were accurate only to the nearest second.

This mean that some breadcrumbs could appear to occur after the error, e.g.

![breadcrumbs](https://user-images.githubusercontent.com/61777/113700232-7e389980-96ce-11eb-96dd-cf8f30512b0d.png)

## Changeset

Add a new `BSG_KSCrashField_Timestamp_Millis` field to KSCrashReports containing a millisecond-accurate timestamp.

Based on the `gettimeofday()` API which although not documented to be async-signal safe, is [used by `times()`](https://opensource.apple.com/source/Libc/Libc-320.1.3/gen/FreeBSD/times.c.auto.html) which is...

## Testing

Was able to reliably detect the issue in E2E tests. Verified that they now pass.