### PR TITLE
Prevent uploads from crashing with bad JSON

### DIFF
--- a/Bugsnag/Delivery/BSGEventUploadOperation.m
+++ b/Bugsnag/Delivery/BSGEventUploadOperation.m
@@ -87,8 +87,16 @@ typedef NS_ENUM(NSUInteger, BSGEventUploadOperationState) {
         }
     }
     
-    NSDictionary *eventPayload = [event toJsonWithRedactedKeys:configuration.redactedKeys];
-
+    NSDictionary *eventPayload;
+    @try {
+        eventPayload = [event toJsonWithRedactedKeys:configuration.redactedKeys];
+    } @catch (NSException *exception) {
+        bsg_log_err(@"Discarding event %@ because an exception was thrown by -toJsonWithRedactedKeys: %@", self.name, exception);
+        [self deleteEvent];
+        completionHandler();
+        return;
+    }
+    
     NSString *apiKey = event.apiKey ?: configuration.apiKey;
     
     NSMutableDictionary *requestPayload = [NSMutableDictionary dictionary];

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,9 @@ Changelog
 
 ### Bug fixes
 
+* Catch exceptions thrown while preparing JSON for upload rather than crashing.
+  [#1063](https://github.com/bugsnag/bugsnag-cocoa/pull/1063)
+
 * Prevent app hangs being reported if a debugger is attached.
   [#1058](https://github.com/bugsnag/bugsnag-cocoa/pull/1058)
 


### PR DESCRIPTION
## Goal

If the metadata JSON contains non-object values at the top level, an exception will be thrown from `-[BugsnagEvent sanitiseMetadata:redactedKeys:]`

## Changeset

`-[BugsnagEvent sanitiseMetadata:redactedKeys:]` now rejects top-level values that are are not dictionaries, and leaves a diagnostic showing the unexpected data.

`@try` / `@catch` blocks have also been added to prevent any other exceptions from causing a crash while preparing the payload for upload.

## Testing

Tested locally by adding bad data to `NSMutableDictionary *metadata` before calling `-[BugsnagEvent sanitiseMetadata:redactedKeys:]`