### PR TITLE
[PLAT-6316] Fix SIGSEGV in bsg_ksmachgetThreadQueueName

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,13 @@
 Changelog
 =========
 
+## TBD
+
+### Bug fixes
+
+* Fix a crash in `bsg_ksmachgetThreadQueueName`.
+  [#1065](https://github.com/bugsnag/bugsnag-cocoa/pull/1065)
+
 ## 6.8.3 (2021-04-07)
 
 ### Bug fixes


### PR DESCRIPTION
## Goal

Fixes a crash that can occur in `bsg_ksmachgetThreadQueueName`

## Changeset

The `thread_identifier_info.dispatch_qaddr` can sometimes contain an invalid address, which will cause a crash if dereferenced. This is something that has been noted [in the Crashlytics source code](https://github.com/firebase/firebase-ios-sdk/blob/Crashlytics-4.6.2/Crashlytics/Crashlytics/Components/FIRCLSProcess.c#L261-L270).

`bsg_ksmachcopyMem()` is now used to read the contents of the memory without causing a crash if invalid.

## Testing

I was not able to reproduce the crash, but manual testing and the E2E tests confirm that the function continues to return the expected queue name.