### PR TITLE
[PLAT-6307] Add macCatalystiOSVersion

### DIFF
--- a/Bugsnag/KSCrash/Source/KSCrash/Recording/BSG_KSSystemInfo.h
+++ b/Bugsnag/KSCrash/Source/KSCrash/Recording/BSG_KSSystemInfo.h
@@ -55,6 +55,7 @@
 #define BSG_KSSystemField_ClangVersion "clang_version"
 #define BSG_KSSystemField_TimeZone "time_zone"
 #define BSG_KSSystemField_BuildType "build_type"
+#define BSG_KSSystemField_iOSSupportVersion "iOSSupportVersion"
 
 #import <Foundation/Foundation.h>
 #import "BugsnagPlatformConditional.h"

--- a/Bugsnag/KSCrash/Source/KSCrash/Recording/BSG_KSSystemInfo.m
+++ b/Bugsnag/KSCrash/Source/KSCrash/Recording/BSG_KSSystemInfo.m
@@ -466,6 +466,10 @@ static NSDictionary * bsg_systemversion() {
     sysInfo[@(BSG_KSSystemField_SystemName)] = systemName;
     sysInfo[@(BSG_KSSystemField_SystemVersion)] = sysVersion[@"ProductVersion"];
 
+#if TARGET_OS_IOS
+    sysInfo[@(BSG_KSSystemField_iOSSupportVersion)] = sysVersion[@"iOSSupportVersion"];
+#endif
+
     // Bugsnag payload mapping:
     //
     // BSG_KSSystemField_Machine => device.model

--- a/Bugsnag/Payload/BugsnagDeviceWithState.m
+++ b/Bugsnag/Payload/BugsnagDeviceWithState.m
@@ -21,6 +21,7 @@ NSMutableDictionary *BSGParseDeviceMetadata(NSDictionary *event) {
     NSDictionary *state = [event valueForKeyPath:@"user.state.deviceState"];
     [device addEntriesFromDictionary:state];
     device[@"timezone"] = [event valueForKeyPath:@"system.time_zone"];
+    device[@"macCatalystiOSVersion"] = [event valueForKeyPath:@"system.iOSSupportVersion"];
 
 #if BSG_PLATFORM_SIMULATOR
     device[@"simulator"] = @YES;

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,11 @@ Changelog
 
 ## TBD
 
+### Enhancements
+
+* `macCatalystiOSVersion` is now reported for apps built with Mac Catalyst and iOS app running on Apple silicon.
+  [#1066](https://github.com/bugsnag/bugsnag-cocoa/pull/1066)
+
 ### Bug fixes
 
 * Fix a crash in `bsg_ksmachgetThreadQueueName`.


### PR DESCRIPTION
## Goal

Include information about the "simulated" iOS version when running Mac Catalyst apps or iOS apps running on Macs with Apple silicon.

## Changeset

The `iOSSupportVersion` value from SystemVersion.plist is now sent as `metaData.device.macCatalystiOSVersion`

This appears in the device tab on the dashboard.

<img width="439" alt="Screenshot 2021-04-07 at 16 02 19" src="https://user-images.githubusercontent.com/61777/114164630-6ad23c00-9923-11eb-82d1-2083f9f09d60.png">

## Testing

Tested manually. We don't currently have tests or CI for Mac Catalyst or iOS apps on Macs with Apple silicon.