### PR TITLE
Fix crashes in bsg_recordException()

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,9 @@ Changelog
 
 ### Bug fixes
 
+* Fix crashes that could occur in `bsg_recordException` in low memory conditions.
+  [#1068](https://github.com/bugsnag/bugsnag-cocoa/pull/1068)
+
 * Fix a crash in `bsg_ksmachgetThreadQueueName`.
   [#1065](https://github.com/bugsnag/bugsnag-cocoa/pull/1065)
 


### PR DESCRIPTION
## Goal

Fixes some crashes that were observed in `bsg_recordException()` in the event of malloc failures.

## Changeset

The result of malloc is now checked before dereferencing.

`strdup()` is no longer passed NULL values if `-UTF8String` returns NULL.

## Testing

Manually verified that uncaught Objective-C exceptions are still reported with stacktrace, name and reason.

Was not able to reproduce the crash.