### PR TITLE
Fix flakes in ManyConcurrentNotifyScenario

### DIFF
--- a/features/handled_errors.feature
+++ b/features/handled_errors.feature
@@ -77,18 +77,18 @@ Feature: Handled Errors and Exceptions
         | FooError                | Err 1   |
         | FooError                | Err 2   |
         | FooError                | Err 3   |
-    Then the error is valid for the error reporting API
+    Then the error is valid for the error reporting API ignoring breadcrumb timestamps
     And I discard the oldest error
-    Then the error is valid for the error reporting API
+    Then the error is valid for the error reporting API ignoring breadcrumb timestamps
     And I discard the oldest error
-    Then the error is valid for the error reporting API
+    Then the error is valid for the error reporting API ignoring breadcrumb timestamps
     And I discard the oldest error
-    Then the error is valid for the error reporting API
+    Then the error is valid for the error reporting API ignoring breadcrumb timestamps
     And I discard the oldest error
-    Then the error is valid for the error reporting API
+    Then the error is valid for the error reporting API ignoring breadcrumb timestamps
     And I discard the oldest error
-    Then the error is valid for the error reporting API
+    Then the error is valid for the error reporting API ignoring breadcrumb timestamps
     And I discard the oldest error
-    Then the error is valid for the error reporting API
+    Then the error is valid for the error reporting API ignoring breadcrumb timestamps
     And I discard the oldest error
-    Then the error is valid for the error reporting API
+    Then the error is valid for the error reporting API ignoring breadcrumb timestamps

--- a/features/steps/ios_steps.rb
+++ b/features/steps/ios_steps.rb
@@ -243,7 +243,7 @@ Then('the session payload field {string} matches the test device model') do |fie
   check_device_model field, Maze::Server.sessions
 end
 
-Then('the breadcrumbs are valid for the event') do
+Then('the breadcrumb timestamps are valid for the event') do
   device = Maze::Helper.read_key_path(Maze::Server.errors.current[:body], 'events.0.device')
   breadcrumbs = Maze::Helper.read_key_path(Maze::Server.errors.current[:body], 'events.0.breadcrumbs')
   breadcrumbs.each do |breadcrumb|
@@ -295,12 +295,27 @@ Then('the error is valid for the error reporting API') do
   when 'iOS'
     steps %(
       Then the error is valid for the error reporting API version "4.0" for the "iOS Bugsnag Notifier" notifier
-      Then the breadcrumbs are valid for the event
+      Then the breadcrumb timestamps are valid for the event
     )
   when 'Mac'
     steps %(
       Then the error is valid for the error reporting API version "4.0" for the "OSX Bugsnag Notifier" notifier
-      Then the breadcrumbs are valid for the event
+      Then the breadcrumb timestamps are valid for the event
+    )
+  else
+    raise 'Unknown platformName'
+  end
+end
+
+Then('the error is valid for the error reporting API ignoring breadcrumb timestamps') do
+  case Maze.driver.capabilities['platformName']
+  when 'iOS'
+    steps %(
+      Then the error is valid for the error reporting API version "4.0" for the "iOS Bugsnag Notifier" notifier
+    )
+  when 'Mac'
+    steps %(
+      Then the error is valid for the error reporting API version "4.0" for the "OSX Bugsnag Notifier" notifier
     )
   else
     raise 'Unknown platformName'


### PR DESCRIPTION
## Goal

A few flakes have been observed when running the "ManyConcurrentNotifyScenario" E2E test.

e.g. https://buildkite.com/bugsnag/bugsnag-cocoa/builds/2486#8efb62ed-4c68-4f5c-85a0-0350f57f6933/1391-1413

Breadcrumbs left by other threads after a thread has started executing `Bugsnag.notify()` can end up in the error, causing the `breadcrumb.timestamp <= event.timestamp` assertion to fail.

## Changeset

Bypasses breadcrumb timestamp assertions for this scenario, by introducing a new variant of the "the error is valid ..." clause.

## Testing

Tested manually using maze runner and BrowserStack.