### PR TITLE
Omit all but instruction_addr field when symbol address not found

### DIFF
--- a/Bugsnag/KSCrash/Source/KSCrash/Recording/BSG_KSCrashReport.c
+++ b/Bugsnag/KSCrash/Source/KSCrash/Recording/BSG_KSCrashReport.c
@@ -735,19 +735,21 @@ void bsg_kscrw_i_writeBacktraceEntry(
     const uintptr_t address, const Dl_info *const info) {
     writer->beginObject(writer, key);
     {
-        if (info->dli_fname != NULL) {
-            writer->addStringElement(writer, BSG_KSCrashField_ObjectName,
-                                     bsg_ksfulastPathEntry(info->dli_fname));
+        if (info->dli_saddr != NULL) {
+            if (info->dli_fname != NULL) {
+                writer->addStringElement(writer, BSG_KSCrashField_ObjectName,
+                                         bsg_ksfulastPathEntry(info->dli_fname));
+            }
+            writer->addUIntegerElement(writer, BSG_KSCrashField_ObjectAddr,
+                                       (uintptr_t)info->dli_fbase);
+            if (info->dli_sname != NULL) {
+                const char *sname = info->dli_sname;
+                writer->addStringElement(writer, BSG_KSCrashField_SymbolName,
+                                         sname);
+            }
+            writer->addUIntegerElement(writer, BSG_KSCrashField_SymbolAddr,
+                                       (uintptr_t)info->dli_saddr);
         }
-        writer->addUIntegerElement(writer, BSG_KSCrashField_ObjectAddr,
-                                   (uintptr_t)info->dli_fbase);
-        if (info->dli_sname != NULL) {
-            const char *sname = info->dli_sname;
-            writer->addStringElement(writer, BSG_KSCrashField_SymbolName,
-                                     sname);
-        }
-        writer->addUIntegerElement(writer, BSG_KSCrashField_SymbolAddr,
-                                   (uintptr_t)info->dli_saddr);
         writer->addUIntegerElement(writer, BSG_KSCrashField_InstructionAddr,
                                    address);
     }


### PR DESCRIPTION
## Goal

Stack trace entries whose symbol address cannot be determined will now only have an `instruction_addr` field.

Previously, it would send 0 values for missing fields, which would confuse the backend.

```
        "threads": [
            {
                "backtrace": {
                    "contents": [
                        {
                            "instruction_addr": 6230833072
                            "object_addr": 4367945728,
                            "symbol_addr": 0,
                        },
...
```

## Testing

Manually tested using:

```c
#if TARGET_CPU_X86 || TARGET_CPU_X86_64
    asm("jmp 0x70000000");
#elif TARGET_CPU_ARM || TARGET_CPU_ARM64
	asm volatile("bx %0" : : "r" (0x70000000));
#else
    #error(Unhandled CPU architecture)
#endif
```

Manually checked that the correct report is generated:

```
        "threads": [
            {
                "backtrace": {
                    "contents": [
                        {
                            "instruction_addr": 6230833072
                        },
                        {
                            "instruction_addr": 4368117122,
                            "object_addr": 4367945728,
                            "object_name": "UIKit",
                            "symbol_addr": 4368117039,
                            "symbol_name": "-[UIApplication sendAction:to:from:forEvent:]"
                        },
...
```

Manually checked backend display.
