### PR TITLE
[PLAT-6339] Add binaryArch and runningOnRosetta to app metadata

### DIFF
--- a/.oclint
+++ b/.oclint
@@ -1,5 +1,6 @@
 # vim: set ft=yaml
 
+# https://oclint-docs.readthedocs.io/en/stable/rules/index.html
 disable-rules:
   - BitwiseOperatorInConditional    # Used quite a bit in KSCrash
   - CollapsibleIfStatements         # Fixing violations would churn a lot of code
@@ -14,6 +15,7 @@ disable-rules:
   - ParameterReassignment
   - PreferEarlyExit                 # Fixing violations would churn a lot of code
   - ShortVariableName
+  - TooFewBranchesInSwitchStatement
   - UnnecessaryElseStatement        # Fixing violations would churn a lot of code
   - UnusedMethodParameter           # Quite common for notification handlers
   - UselessParentheses              # False positive for e.g. ULONG_MAX

--- a/Bugsnag/KSCrash/Source/KSCrash/Recording/BSG_KSSystemInfo.h
+++ b/Bugsnag/KSCrash/Source/KSCrash/Recording/BSG_KSSystemInfo.h
@@ -26,6 +26,7 @@
 
 #define BSG_KSSystemField_AppStartTime "app_start_time"
 #define BSG_KSSystemField_AppUUID "app_uuid"
+#define BSG_KSSystemField_BinaryArch "binary_arch"
 #define BSG_KSSystemField_BootTime "boot_time"
 #define BSG_KSSystemField_BundleID "CFBundleIdentifier"
 #define BSG_KSSystemField_BundleName "CFBundleName"
@@ -35,8 +36,6 @@
 #define BSG_KSSystemField_CPUArch "cpu_arch"
 #define BSG_KSSystemField_CPUType "cpu_type"
 #define BSG_KSSystemField_CPUSubType "cpu_subtype"
-#define BSG_KSSystemField_BinaryCPUType "binary_cpu_type"
-#define BSG_KSSystemField_BinaryCPUSubType "binary_cpu_subtype"
 #define BSG_KSSystemField_DeviceAppHash "device_app_hash"
 #define BSG_KSSystemField_Executable "CFBundleExecutable"
 #define BSG_KSSystemField_ExecutablePath "CFBundleExecutablePath"
@@ -54,6 +53,7 @@
 #define BSG_KSSystemField_SystemVersion "system_version"
 #define BSG_KSSystemField_ClangVersion "clang_version"
 #define BSG_KSSystemField_TimeZone "time_zone"
+#define BSG_KSSystemField_Translated "proc_translated"
 #define BSG_KSSystemField_BuildType "build_type"
 #define BSG_KSSystemField_iOSSupportVersion "iOSSupportVersion"
 

--- a/Bugsnag/Payload/BugsnagApp.m
+++ b/Bugsnag/Payload/BugsnagApp.m
@@ -7,6 +7,8 @@
 //
 
 #import "BugsnagApp.h"
+
+#import "BSG_KSSystemInfo.h"
 #import "BugsnagKeys.h"
 #import "BugsnagConfiguration.h"
 #import "BugsnagCollections.h"
@@ -18,7 +20,9 @@
  */
 NSDictionary *BSGParseAppMetadata(NSDictionary *event) {
     NSMutableDictionary *app = [NSMutableDictionary new];
-    app[@"name"] = [event valueForKeyPath:@"system.CFBundleExecutable"];
+    app[@"name"] = [event valueForKeyPath:@"system." BSG_KSSystemField_BundleExecutable];
+    app[@"binaryArch"] = [event valueForKeyPath:@"system." BSG_KSSystemField_BinaryArch];
+    app[@"runningOnRosetta"] = [event valueForKeyPath:@"system." BSG_KSSystemField_Translated];
     return app;
 }
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,9 @@ Changelog
 
 ### Enhancements
 
+* Add `binaryArch` and `runningOnRosetta` to the `app` metadata tab.
+  [#1073](https://github.com/bugsnag/bugsnag-cocoa/pull/1073)
+
 * Bugsnag can now be used without AppKit, allowing use in daemons and other processes running in non-UI sessions.
   [#1072](https://github.com/bugsnag/bugsnag-cocoa/pull/1072)
 

--- a/Tests/BugsnagEventTests.m
+++ b/Tests/BugsnagEventTests.m
@@ -359,6 +359,7 @@
     [client start];
 
     [client notify:ex block:^BOOL(BugsnagEvent * _Nonnull event) {
+        [event clearMetadataFromSection:@"app"];
         [event clearMetadataFromSection:@"user"];
         [event clearMetadataFromSection:@"device"];
         NSDictionary *invalidDict = @{};
@@ -378,6 +379,7 @@
     [client start];
 
     [client notify:ex block:^BOOL(BugsnagEvent * _Nonnull event) {
+        [event clearMetadataFromSection:@"app"];
         [event clearMetadataFromSection:@"user"];
         [event clearMetadataFromSection:@"device"];
         [event addMetadata:[NSNull null] withKey:@"myKey" toSection:@"mySection"];

--- a/features/app_and_device_attributes.feature
+++ b/features/app_and_device_attributes.feature
@@ -58,6 +58,13 @@ Feature: App and Device attributes present
     And the error payload field "events.0.app.durationInForeground" is a number
     And the error payload field "events.0.app.inForeground" is not null
 
+    # App metadata
+
+    And the event "metaData.app.binaryArch" is not null
+    And the event "metaData.app.name" equals the platform-dependent string:
+      | ios   | iOSTestApp   |
+      | macos | macOSTestApp |
+
     And I discard the oldest error
     And the event "app.isLaunching" is false
 


### PR DESCRIPTION
## Goal

Allows Mac developers to identify which code slice from a Universal binary was running when an error occurred, and identify errors that may be specific to Rosetta.

## Changeset

Adds `binaryArch` and `runningOnRosetta` to the `app` metadata.

Removes `BSG_KSSystemField_BinaryCPUType` and `BSG_KSSystemField_BinaryCPUSubType` since they are unused.

## Testing

Manually tested using example apps and verified new fields appear on dashboard.

Amended E2E test scenario to verify presence of `binaryArch`