### PR TITLE
[PLAT-4706] Fix thread sending behaviour

### DIFF
--- a/Bugsnag/Payload/BugsnagError+Private.h
+++ b/Bugsnag/Payload/BugsnagError+Private.h
@@ -14,7 +14,7 @@ NS_ASSUME_NONNULL_BEGIN
 
 @interface BugsnagError ()
 
-- (instancetype)initWithEvent:(NSDictionary *)event errorReportingThread:(nullable BugsnagThread *)thread;
+- (instancetype)initWithKSCrashReport:(NSDictionary *)event stacktrace:(NSArray<BugsnagStackframe *> *)stacktrace;
 
 - (instancetype)initWithErrorClass:(NSString *)errorClass
                       errorMessage:(NSString *)errorMessage

--- a/Bugsnag/Payload/BugsnagError.m
+++ b/Bugsnag/Payload/BugsnagError.m
@@ -83,11 +83,7 @@ NSString *BSGParseErrorMessage(NSDictionary *report, NSDictionary *error, NSStri
 
 @dynamic type;
 
-- (instancetype)initWithErrorReportingThread:(BugsnagThread *)thread {
-    return [self initWithEvent:@{} errorReportingThread:thread];
-}
-
-- (instancetype)initWithEvent:(NSDictionary *)event errorReportingThread:(BugsnagThread *)thread {
+- (instancetype)initWithKSCrashReport:(NSDictionary *)event stacktrace:(NSArray<BugsnagStackframe *> *)stacktrace {
     if (self = [super init]) {
         NSDictionary *error = [event valueForKeyPath:@"crash.error"];
         NSString *errorType = error[BSGKeyType];
@@ -96,7 +92,7 @@ NSString *BSGParseErrorMessage(NSDictionary *report, NSDictionary *error, NSStri
         _typeString = BSGSerializeErrorType(BSGErrorTypeCocoa);
 
         if (![[event valueForKeyPath:@"user.state.didOOM"] boolValue]) {
-            _stacktrace = thread.stacktrace;
+            _stacktrace = stacktrace;
         }
     }
     return self;

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,13 @@
 Changelog
 =========
 
+## TBD
+
+### Bug fixes
+
+* `event.threads` will now be empty, rather than containing a single thread, if `sendThreads` dictates that threads should not be sent.
+  [#1077](https://github.com/bugsnag/bugsnag-cocoa/pull/1077)
+
 ## 6.9.0 (2021-04-21)
 
 ### Enhancements

--- a/Tests/BugsnagErrorTest.m
+++ b/Tests/BugsnagErrorTest.m
@@ -65,7 +65,7 @@ NSString *BSGParseErrorMessage(NSDictionary *report, NSDictionary *error, NSStri
 
 - (void)testErrorLoad {
     BugsnagThread *thread = [self findErrorReportingThread:self.event];
-    BugsnagError *error = [[BugsnagError alloc] initWithEvent:self.event errorReportingThread:thread];
+    BugsnagError *error = [[BugsnagError alloc] initWithKSCrashReport:self.event stacktrace:thread.stacktrace];
     XCTAssertEqualObjects(@"Foo Exception", error.errorClass);
     XCTAssertEqualObjects(@"Foo overload", error.errorMessage);
     XCTAssertEqual(BSGErrorTypeCocoa, error.type);
@@ -79,7 +79,7 @@ NSString *BSGParseErrorMessage(NSDictionary *report, NSDictionary *error, NSStri
 
 - (void)testToDictionary {
     BugsnagThread *thread = [self findErrorReportingThread:self.event];
-    BugsnagError *error = [[BugsnagError alloc] initWithEvent:self.event errorReportingThread:thread];
+    BugsnagError *error = [[BugsnagError alloc] initWithKSCrashReport:self.event stacktrace:thread.stacktrace];
     NSDictionary *dict = [error toDictionary];
     XCTAssertEqualObjects(@"Foo Exception", dict[@"errorClass"]);
     XCTAssertEqualObjects(@"Foo overload", dict[@"message"]);
@@ -141,7 +141,7 @@ NSString *BSGParseErrorMessage(NSDictionary *report, NSDictionary *error, NSStri
 
 - (void)testStacktraceOverride {
     BugsnagThread *thread = [self findErrorReportingThread:self.event];
-    BugsnagError *error = [[BugsnagError alloc] initWithEvent:self.event errorReportingThread:thread];
+    BugsnagError *error = [[BugsnagError alloc] initWithKSCrashReport:self.event stacktrace:thread.stacktrace];
     XCTAssertNotNil(error.stacktrace);
     XCTAssertEqual(1, error.stacktrace.count);
     error.stacktrace = @[];

--- a/features/barebone_tests.feature
+++ b/features/barebone_tests.feature
@@ -61,10 +61,6 @@ Feature: Barebone tests
     And the event "severity" equals "warning"
     And the event "severityReason.type" equals "handledException"
     And the event "severityReason.unhandledOverridden" is true
-    And the event "threads.0.errorReportingThread" is true
-    And the event "threads.0.id" equals "0"
-    And the event "threads.0.name" equals "com.apple.main-thread"
-    And the event "threads.0.stacktrace.0.method" matches "BareboneTestHandledScenario"
     And the event "unhandled" is true
     And the event "user.email" equals "foobar@example.com"
     And the event "user.id" equals "foobar"
@@ -79,7 +75,7 @@ Feature: Barebone tests
     And the error payload field "events.0.device.freeMemory" is an integer
     And the error payload field "events.0.device.model" matches the test device model
     And the error payload field "events.0.device.totalMemory" is an integer
-    And the error payload field "events.0.threads" is an array with 1 elements
+    And the error payload field "events.0.threads" is an array with 0 elements
     And the "method" of stack frame 0 matches "BareboneTestHandledScenario"
 
     And I discard the oldest error
@@ -158,6 +154,8 @@ Feature: Barebone tests
     And the error payload field "events.0.device.freeMemory" is an integer
     And the error payload field "events.0.device.model" matches the test device model
     And the error payload field "events.0.device.totalMemory" is an integer
+    And the error payload field "events.0.threads" is a non-empty array
+    And the error payload field "events.0.threads.1" is not null
     And the "method" of stack frame 0 matches "(assertionFailure|<redacted>)"
 
   @skip_macos
@@ -246,3 +244,4 @@ Feature: Barebone tests
     And the error payload field "events.0.device.freeMemory" is null
     And the error payload field "events.0.device.model" matches the test device model
     And the error payload field "events.0.device.totalMemory" is an integer
+    And the error payload field "events.0.threads" is an array with 0 elements

--- a/features/threads.feature
+++ b/features/threads.feature
@@ -1,4 +1,4 @@
-Feature: Handled Errors and Exceptions
+Feature: Threads
 
   Background:
     Given I clear all persistent data
@@ -10,6 +10,8 @@ Feature: Handled Errors and Exceptions
     And the event "unhandled" is false
     And the error payload field "events" is an array with 1 elements
     And the exception "message" equals "HandledErrorThreadSendAlwaysScenario"
+    And the error payload field "events.0.threads" is a non-empty array
+    And the error payload field "events.0.threads.1" is not null
     And the thread information is valid for the event
 
   Scenario: Threads are captured for unhandled errors by default
@@ -20,6 +22,8 @@ Feature: Handled Errors and Exceptions
     And the event "unhandled" is true
     And the error payload field "events" is an array with 1 elements
     And the exception "message" equals "UnhandledErrorThreadSendAlwaysScenario"
+    And the error payload field "events.0.threads" is a non-empty array
+    And the error payload field "events.0.threads.1" is not null
     And the thread information is valid for the event
 
   Scenario: Threads are not captured for handled errors when sendThreads is set to unhandled_only
@@ -29,12 +33,7 @@ Feature: Handled Errors and Exceptions
     And the event "unhandled" is false
     And the error payload field "events" is an array with 1 elements
     And the exception "errorClass" equals "HandledErrorThreadSendUnhandledOnlyScenario"
-    And the error payload field "events.0.threads" is an array with 1 elements
-    And the error payload field "events.0.threads.0.errorReportingThread" is true
-    And the error payload field "events.0.threads.0.id" is not null
-    And the error payload field "events.0.threads.0.name" equals "com.apple.main-thread"
-    And the error payload field "events.0.threads.0.type" equals "cocoa"
-    And the thread information is valid for the event
+    And the error payload field "events.0.threads" is an array with 0 elements
 
   Scenario: Threads are not captured for unhandled errors when sendThreads is set to never
     When I run "UnhandledErrorThreadSendNeverScenario" and relaunch the app
@@ -44,9 +43,4 @@ Feature: Handled Errors and Exceptions
     And the event "unhandled" is true
     And the error payload field "events" is an array with 1 elements
     And the exception "message" equals "UnhandledErrorThreadSendNeverScenario"
-    And the error payload field "events.0.threads" is an array with 1 elements
-    And the error payload field "events.0.threads.0.errorReportingThread" is true
-    And the error payload field "events.0.threads.0.id" is not null
-    And the error payload field "events.0.threads.0.name" is null
-    And the error payload field "events.0.threads.0.type" equals "cocoa"
-    And the thread information is valid for the event
+    And the error payload field "events.0.threads" is an array with 0 elements


### PR DESCRIPTION
## Goal

To stop `threads` being sent if the notifier has been configured not to via the `sendThreads` property.

Prior to this change, `threads` would contain a single object.

## Changeset

`-[BugsnagClient notify:]` has been amended to send an empty `threads` array if threads should not be sent.

`-[BugnagEvent initWithKSCrashData:]` has been amended to send an empty `threads` array if a single thread was captured - this is what KSCrash does when if thread sending is disabled (so that the offending stacktrace is captured.)

## Testing

Verified through E2E tests, and manually tested using example app.