### PR TITLE
[PLAT-6391] Fix OOM app info

### DIFF
--- a/.buildkite/pipeline.yml
+++ b/.buildkite/pipeline.yml
@@ -138,7 +138,6 @@ steps:
       docker-compose#v3.3.0:
         run: cocoa-maze-runner
         command:
-          - "features/app_hangs.feature"
           - "features/barebone_tests.feature"
           - "--app=/app/build/iOSTestApp.ipa"
           - "--farm=bs"
@@ -165,7 +164,6 @@ steps:
       docker-compose#v3.3.0:
         run: cocoa-maze-runner
         command:
-          - "features/app_hangs.feature"
           - "features/barebone_tests.feature"
           - "--app=/app/build/iOSTestApp.ipa"
           - "--farm=bs"
@@ -192,7 +190,6 @@ steps:
     commands:
       - bundle install
       - bundle exec maze-runner
-        features/app_hangs.feature
         features/barebone_tests.feature
         --farm=local
         --os=macos

--- a/Bugsnag/Client/BugsnagClient+OutOfMemory.m
+++ b/Bugsnag/Client/BugsnagClient+OutOfMemory.m
@@ -11,6 +11,7 @@
 #import "BugsnagAppWithState+Private.h"
 #import "BugsnagBreadcrumbs.h"
 #import "BugsnagClient+Private.h"
+#import "BugsnagConfiguration+Private.h"
 #import "BugsnagDeviceWithState+Private.h"
 #import "BugsnagError+Private.h"
 #import "BugsnagEvent+Private.h"
@@ -26,6 +27,12 @@
     BugsnagAppWithState *app = [BugsnagAppWithState appFromJson:appDict];
     app.dsymUuid = appDict[BSGKeyMachoUUID];
     app.isLaunching = [self.stateMetadataFromLastLaunch[BSGKeyApp][BSGKeyIsLaunching] boolValue];
+    
+    if (self.configMetadataFromLastLaunch) {
+        [app setValuesFromConfiguration:
+         [[BugsnagConfiguration alloc] initWithDictionaryRepresentation:
+          (NSDictionary * _Nonnull)self.configMetadataFromLastLaunch]];
+    }
     
     NSDictionary *deviceDict = self.systemState.lastLaunchState[SYSTEMSTATE_KEY_DEVICE];
     BugsnagDeviceWithState *device = [BugsnagDeviceWithState deviceFromJson:deviceDict];

--- a/Bugsnag/Payload/BugsnagApp+Private.h
+++ b/Bugsnag/Payload/BugsnagApp+Private.h
@@ -20,6 +20,8 @@ NS_ASSUME_NONNULL_BEGIN
 
 + (void)populateFields:(BugsnagApp *)app dictionary:(NSDictionary *)event config:(BugsnagConfiguration *)config codeBundleId:(NSString *)codeBundleId;
 
+- (void)setValuesFromConfiguration:(BugsnagConfiguration *)configuration;
+
 - (NSDictionary *)toDict;
 
 @end

--- a/Bugsnag/Payload/BugsnagApp.m
+++ b/Bugsnag/Payload/BugsnagApp.m
@@ -61,12 +61,27 @@ NSDictionary *BSGParseAppMetadata(NSDictionary *event) {
 {
     NSDictionary *system = event[BSGKeySystem];
     app.id = system[@"CFBundleIdentifier"];
-    app.bundleVersion = config.bundleVersion ?: system[@"CFBundleVersion"];
+    app.bundleVersion = system[@"CFBundleVersion"];
     app.dsymUuid = system[@"app_uuid"];
-    app.version = config.appVersion ?: system[@"CFBundleShortVersionString"];
-    app.releaseStage = config.releaseStage;
+    app.version = system[@"CFBundleShortVersionString"];
     app.codeBundleId = [event valueForKeyPath:@"user.state.app.codeBundleId"] ?: codeBundleId;
-    app.type = config.appType;
+    [app setValuesFromConfiguration:config];
+}
+
+- (void)setValuesFromConfiguration:(BugsnagConfiguration *)configuration
+{
+    if (configuration.appType) {
+        self.type = configuration.appType;
+    }
+    if (configuration.appVersion) {
+        self.version = configuration.appVersion;
+    }
+    if (configuration.bundleVersion) {
+        self.bundleVersion = configuration.bundleVersion;
+    }
+    if (configuration.releaseStage) {
+        self.releaseStage = configuration.releaseStage;
+    }
 }
 
 - (NSDictionary *)toDict

--- a/Bugsnag/Payload/BugsnagAppWithState+Private.h
+++ b/Bugsnag/Payload/BugsnagAppWithState+Private.h
@@ -7,6 +7,7 @@
 //
 
 #import "BugsnagAppWithState.h"
+#import "BugsnagApp+Private.h"
 
 @class BugsnagConfiguration;
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,9 @@ Changelog
 
 ### Bug fixes
 
+* Fix `app` properties in OOMs for apps that override `appType`, `appVersion`, `bundleVersion` or `releaseStage` in their config.
+  [#1078](https://github.com/bugsnag/bugsnag-cocoa/pull/1078)
+
 * `event.threads` will now be empty, rather than containing a single thread, if `sendThreads` dictates that threads should not be sent.
   [#1077](https://github.com/bugsnag/bugsnag-cocoa/pull/1077)
 

--- a/features/barebone_tests.feature
+++ b/features/barebone_tests.feature
@@ -178,17 +178,16 @@ Feature: Barebone tests
 
     And I wait to receive an error
     Then the error is an OOM event
-    And the event "app.bundleVersion" is not null
+    And the event "app.bundleVersion" equals "321.123"
     And the event "app.dsymUUIDs" is not null
     And the event "app.id" equals the platform-dependent string:
       | ios   | com.bugsnag.iOSTestApp   |
       | macos | com.bugsnag.macOSTestApp |
     And the event "app.inForeground" is true
     And the event "app.isLaunching" is true
-    And the event "app.type" equals the platform-dependent string:
-      | ios   | iOS   |
-      | macos | macOS |
-    And the event "app.version" is not null
+    And the event "app.releaseStage" equals "staging"
+    And the event "app.type" equals "vanilla"
+    And the event "app.version" equals "3.2.1"
     And the event "breadcrumbs.0.name" equals "Bugsnag loaded"
     And the event "breadcrumbs.1.name" equals "Memory Warning"
     And the event "device.id" is not null

--- a/features/fixtures/shared/scenarios/OOMScenario.m
+++ b/features/fixtures/shared/scenarios/OOMScenario.m
@@ -24,6 +24,10 @@
     self.config.autoTrackSessions = YES;
     self.config.enabledErrorTypes.ooms = YES;
     self.config.launchDurationMillis = 0; // Ensure isLaunching will be true for the OOM, no matter how long it takes to occur.
+    self.config.appType = @"vanilla";
+    self.config.appVersion = @"3.2.1";
+    self.config.bundleVersion = @"321.123";
+    self.config.releaseStage = @"staging";
     [self.config addMetadata:@{@"bar": @"foo"} toSection:@"custom"];
     [self.config setUser:@"foobar" withEmail:@"foobar@example.com" andName:@"Foo Bar"];
     [self.config addOnSendErrorBlock:^BOOL(BugsnagEvent *event) {


### PR DESCRIPTION
## Goal

Honor the configuration's `appType`, `appVersion`, `bundleVersion` and `releaseStage` properties in OOM payloads.

## Changeset

`-[BugsnagClient generateOutOfMemoryEvent]` now updates the app info with values from the last run's configuration.

## Testing

Updated E2E test scenario to check for the values specified in the configuration.