### PR TITLE
Fix missing context for crash, OOM, and app hang errors

### DIFF
--- a/Bugsnag/Client/BugsnagClient+AppHangs.m
+++ b/Bugsnag/Client/BugsnagClient+AppHangs.m
@@ -60,6 +60,8 @@
                               threads:threads
                               session:self.sessionTracker.runningSession];
     
+    self.appHangEvent.context = self.context;
+    
     NSError *writeError = nil;
     NSDictionary *json = [self.appHangEvent toJsonWithRedactedKeys:self.configuration.redactedKeys];
     if (![BSGJSONSerialization writeJSONObject:json toFile:BSGFileLocations.current.appHangEvent options:0 error:&writeError]) {

--- a/Bugsnag/Client/BugsnagClient+OutOfMemory.m
+++ b/Bugsnag/Client/BugsnagClient+OutOfMemory.m
@@ -66,6 +66,8 @@
                               threads:@[]
                               session:session];
     
+    event.context = self.stateMetadataFromLastLaunch[BSGKeyClient][BSGKeyContext];
+    
     return event;
 }
 

--- a/Bugsnag/Client/BugsnagClient+Private.h
+++ b/Bugsnag/Client/BugsnagClient+Private.h
@@ -72,6 +72,32 @@ NS_ASSUME_NONNULL_BEGIN
 
 @property (readonly, nonatomic) BOOL started;
 
+/// State related metadata
+///
+/// Upon change this is automatically persisted to disk, making it available when contructing OOM payloads.
+/// Is it also added to KSCrashReports under `user.state` by `BSSerializeDataCrashHandler()`.
+///
+/// Example contents:
+///
+/// {
+///     "app": {
+///         "codeBundleId": "com.example.app",
+///         "isLaunching": true
+///     },
+///     "client": {
+///         "context": "MyViewController",
+///     },
+///     "deviceState": {
+///         "batteryLevel": 0.5,
+///         "charging": false,
+///         "lowMemoryWarning": "2021-01-01T15:29:02.170Z",
+///         "orientation": "portrait"
+///     },
+///     "user": {
+///         "id": "abc123",
+///         "name": "bob"
+///     }
+/// }
 @property (strong, nonatomic) BugsnagMetadata *state;
 
 @property (strong, nonatomic) NSMutableArray *stateEventBlocks;

--- a/Bugsnag/Helpers/BugsnagCollections.h
+++ b/Bugsnag/Helpers/BugsnagCollections.h
@@ -39,6 +39,9 @@ NSArray * BSGArraySubarrayFromIndex(NSArray *array, NSUInteger index);
 
 // MARK: - NSDictionary
 
+/// Returns a dictionary containing the key and object, or an empty dictionary if the object is nil.
+NSDictionary * BSGDictionaryWithKeyAndObject(NSString *key, id _Nullable object);
+
 /**
  *  Merge values from source dictionary with destination
  *

--- a/Bugsnag/Helpers/BugsnagCollections.m
+++ b/Bugsnag/Helpers/BugsnagCollections.m
@@ -56,6 +56,10 @@ NSArray * BSGArraySubarrayFromIndex(NSArray *array, NSUInteger index) {
 
 // MARK: - NSDictionary
 
+NSDictionary * BSGDictionaryWithKeyAndObject(NSString *key, id _Nullable object) {
+    return object ? @{key: (id _Nonnull)object} : @{};
+}
+
 NSDictionary *BSGDictMerge(NSDictionary *source, NSDictionary *destination) {
     if ([destination count] == 0) {
         return source;

--- a/Bugsnag/Helpers/BugsnagKeys.h
+++ b/Bugsnag/Helpers/BugsnagKeys.h
@@ -24,6 +24,7 @@ extern NSString *const BSGKeyBatteryLevel;
 extern NSString *const BSGKeyBreadcrumbs;
 extern NSString *const BSGKeyBundleVersion;
 extern NSString *const BSGKeyCharging;
+extern NSString *const BSGKeyClient;
 extern NSString *const BSGKeyCodeBundleId;
 extern NSString *const BSGKeyConfig;
 extern NSString *const BSGKeyContext;

--- a/Bugsnag/Helpers/BugsnagKeys.m
+++ b/Bugsnag/Helpers/BugsnagKeys.m
@@ -20,6 +20,7 @@ NSString *const BSGKeyBatteryLevel = @"batteryLevel";
 NSString *const BSGKeyBreadcrumbs = @"breadcrumbs";
 NSString *const BSGKeyBundleVersion = @"bundleVersion";
 NSString *const BSGKeyCharging = @"charging";
+NSString *const BSGKeyClient = @"client";
 NSString *const BSGKeyCodeBundleId = @"codeBundleId";
 NSString *const BSGKeyConfig = @"config";
 NSString *const BSGKeyContext = @"context";

--- a/Bugsnag/Payload/BugsnagEvent.m
+++ b/Bugsnag/Payload/BugsnagEvent.m
@@ -246,7 +246,7 @@ NSDictionary *BSGParseCustomException(NSDictionary *report,
     } else if ([event valueForKeyPath:@"user.event"] != nil) {
         return [self initWithUserData:event];
     } else {
-        return [self initWithKSCrashData:event];
+        return [self initWithKSCrashReport:event];
     }
 }
 
@@ -259,7 +259,7 @@ NSDictionary *BSGParseCustomException(NSDictionary *report,
  *
  * @return a BugsnagEvent containing the parsed information
  */
-- (instancetype)initWithKSCrashData:(NSDictionary *)event {
+- (instancetype)initWithKSCrashReport:(NSDictionary *)event {
     NSMutableDictionary *error = [[event valueForKeyPath:@"crash.error"] mutableCopy];
     NSString *errorType = error[BSGKeyType];
 
@@ -377,6 +377,7 @@ NSDictionary *BSGParseCustomException(NSDictionary *report,
     obj.enabledReleaseStages = BSGLoadConfigValue(event, BSGKeyEnabledReleaseStages);
     obj.releaseStage = BSGParseReleaseStage(event);
     obj.deviceAppHash = deviceAppHash;
+    obj.context = [event valueForKeyPath:@"user.state.client.context"];
     obj.customException = BSGParseCustomException(event, [errors[0].errorClass copy], [errors[0].errorMessage copy]);
     obj.error = error;
     obj.depth = depth;

--- a/Bugsnag/include/Bugsnag/BugsnagConfiguration.h
+++ b/Bugsnag/include/Bugsnag/BugsnagConfiguration.h
@@ -175,7 +175,7 @@ typedef BOOL (^BugsnagOnSessionBlock)(BugsnagSession *_Nonnull session);
 /**
  *  A general summary of what was occuring in the application
  */
-@property (copy, nullable, nonatomic) NSString *context;
+@property (copy, nullable, atomic) NSString *context;
 
 /**
  *  The version of the application

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,9 @@ Changelog
 
 ### Bug fixes
 
+* Fix missing `context` for crash, OOM, and app hang errors.
+  [#1079](https://github.com/bugsnag/bugsnag-cocoa/pull/1079)
+
 * Fix `app` properties in OOMs for apps that override `appType`, `appVersion`, `bundleVersion` or `releaseStage` in their config.
   [#1078](https://github.com/bugsnag/bugsnag-cocoa/pull/1078)
 

--- a/features/app_hangs.feature
+++ b/features/app_hangs.feature
@@ -28,6 +28,8 @@ Feature: App hangs
     And the event "session.events.handled" equals 1
     And the event "session.events.unhandled" equals 0
 
+    And the event "context" equals "App Hang Scenario"
+
     #
     # Checks copied from app_and_device_attributes.feature
     #

--- a/features/barebone_tests.feature
+++ b/features/barebone_tests.feature
@@ -116,6 +116,7 @@ Feature: Barebone tests
     And the event "app.version" equals "12.3"
     And the event "breadcrumbs.0.name" equals "Bugsnag loaded"
     And the event "breadcrumbs.1.name" is null
+    And the event "context" equals "Something"
     And the event "device.freeMemory" is less than the event "device.totalMemory"
     And the event "device.id" is not null
     And the event "device.jailbroken" is false
@@ -190,6 +191,7 @@ Feature: Barebone tests
     And the event "app.version" equals "3.2.1"
     And the event "breadcrumbs.0.name" equals "Bugsnag loaded"
     And the event "breadcrumbs.1.name" equals "Memory Warning"
+    And the event "context" equals "OOM Scenario"
     And the event "device.id" is not null
     And the event "device.jailbroken" is false
     And the event "device.locale" is not null

--- a/features/fixtures/shared/scenarios/AppHangScenarios.swift
+++ b/features/fixtures/shared/scenarios/AppHangScenarios.swift
@@ -14,6 +14,7 @@ class AppHangScenario: Scenario {
     }
     
     override func run() {
+        Bugsnag.setContext("App Hang Scenario")
         let timeInterval = TimeInterval(eventMode!)!
         NSLog("Simulating an app hang of \(timeInterval) seconds...")
         Thread.sleep(forTimeInterval: timeInterval)

--- a/features/fixtures/shared/scenarios/BareboneTestScenarios.swift
+++ b/features/fixtures/shared/scenarios/BareboneTestScenarios.swift
@@ -116,6 +116,7 @@ class BareboneTestUnhandledErrorScenario: Scenario {
     }
     
     override func run() {
+        Bugsnag.setContext("Something")
         Bugsnag.setUser("barfoo", withEmail: "barfoo@example.com", andName: "Bar Foo")
         
         // Triggers "Fatal error: Unexpectedly found nil while implicitly unwrapping an Optional value: ..."

--- a/features/fixtures/shared/scenarios/OOMScenario.m
+++ b/features/fixtures/shared/scenarios/OOMScenario.m
@@ -44,6 +44,7 @@
 }
 
 - (void)run {
+    [Bugsnag setContext:@"OOM Scenario"];
     [NSNotificationCenter.defaultCenter addObserverForName:UIApplicationDidReceiveMemoryWarningNotification object:nil
                                                      queue:nil usingBlock:^(NSNotification *note) {
         NSLog(@"*** Received memory warning");


### PR DESCRIPTION
## Goal

Include the `context` value in crash, OOM, and app hang errors.

## Changeset

`context` is now stored in the `state` metadata (which is added to KSCrashReports and persisted to be available at next launch.)

App hang events now have the `context` applied.

OOM events now take the context from the previously persisted state metadata.

Crashes now take the `context` from the state metadata included in the KSCrashReport.

Made `config.context` `atomic` because it could be written to and read from arbitrary threads.

## Testing

Amended E2E scenarios to verify presence of `context` and ran them locally.