### PR TITLE
[PLAT-6443] Fix -Wstrict-selector-match

### DIFF
--- a/Bugsnag/Storage/BSGStorageMigratorV0V1.m
+++ b/Bugsnag/Storage/BSGStorageMigratorV0V1.m
@@ -11,26 +11,12 @@
 #import "BSGFileLocations.h"
 #import "BugsnagLogger.h"
 
-static NSString *getCachesDir() {
-    NSArray *dirs = NSSearchPathForDirectoriesInDomains(NSCachesDirectory, NSUserDomainMask, YES);
-    if ([dirs count] == 0) {
-        bsg_log_err(@"Could not locate cache directory path.");
-        return nil;
-    }
-
-    if ([dirs[0] length] == 0) {
-        bsg_log_err(@"Cache directory path is empty!");
-        return nil;
-    }
-    return dirs[0];
-}
-
 @implementation BSGStorageMigratorV0V1
 
 + (BOOL) migrate {
     NSString *bundleName = [[NSBundle mainBundle] infoDictionary][@"CFBundleName"];
-    NSString *cachesDir = getCachesDir();
-    if(cachesDir == nil) {
+    NSString *cachesDir = NSSearchPathForDirectoriesInDomains(NSCachesDirectory, NSUserDomainMask, YES).firstObject;
+    if (!cachesDir.length) {
         bsg_log_err(@"Could not migrate v0 data to v1.");
         return false;
     }


### PR DESCRIPTION
## Goal

Fixes a compiler warning encountered by some users.

```
Pods/Bugsnag/Bugsnag/Storage/BSGStorageMigratorV0V1.m:21:9: error: multiple methods named 'length' found [-Werror,-Wstrict-selector-match]
    if ([dirs[0] length] == 0) {
        ^~~~~~~~~~~~~~~~
```

## Changeset

The cause of the warning was the use of an NSArray without lightweight generics.

Have simplified the logic at the same time as addressing the issue.

## Testing

I was not able to reproduce the compiler warning locally or on CI, so unable to test or verify.