### PR TITLE
[PLAT-6346] Fix deadlock in bsg_recordException()

### DIFF
--- a/Bugsnag/KSCrash/Source/KSCrash/Recording/Sentry/BSG_KSCrashSentry_NSException.m
+++ b/Bugsnag/KSCrash/Source/KSCrash/Recording/Sentry/BSG_KSCrashSentry_NSException.m
@@ -116,9 +116,6 @@ void bsg_recordException(NSException *exception) {
         bsg_lastHandledException = exception;
         BSG_KSLOG_DEBUG(@"Writing exception info into a new report");
 
-        BSG_KSLOG_DEBUG(@"Suspending all threads.");
-        bsg_kscrashsentry_suspendThreads();
-
         BSG_KSLOG_DEBUG(@"Filling out context.");
         NSArray *addresses = [exception callStackReturnAddresses];
         NSUInteger numFrames = [addresses count];
@@ -136,6 +133,9 @@ void bsg_recordException(NSException *exception) {
         bsg_g_context->crashReason = CopyUTF8String([exception reason]);
         bsg_g_context->stackTrace = callstack;
         bsg_g_context->stackTraceLength = callstack ? (int)numFrames : 0;
+
+        BSG_KSLOG_DEBUG(@"Suspending all threads.");
+        bsg_kscrashsentry_suspendThreads();
 
         BSG_KSLOG_DEBUG(@"Calling main crash handler.");
         bsg_g_context->onCrash(crashContext());

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,9 @@ Changelog
 
 ### Bug fixes
 
+* Fix a possible deadlock when writing crash reports for uncaught Objective-C exceptions.
+  [#1082](https://github.com/bugsnag/bugsnag-cocoa/pull/1082)
+
 * Fix missing `context` for crash, OOM, and app hang errors.
   [#1079](https://github.com/bugsnag/bugsnag-cocoa/pull/1079)
 


### PR DESCRIPTION
## Goal

Some flakiness in E2E tests was being caused by a deadlock in the NSException crash handler.

When the test(s) failed, `Filling out context.` was the last log output from the test fixture.

## Design

The deadlock occurred because `malloc` and the objc runtime were being called while other threads were suspended and may be holding a lock.

## Changeset

`bsg_kscrashsentry_suspendThreads()` is now called immediately before calling the main crash handler.

## Testing

Was not able to reproduce the deadlock manually, however the E2E tests pass with this fix.