### PR TITLE
Trigger RN tests for all builds of next

### DIFF
--- a/.buildkite/pipeline.yml
+++ b/.buildkite/pipeline.yml
@@ -1,4 +1,14 @@
 steps:
+  - label: 'Trigger RN tests for all builds of our next branch'
+    if: build.branch == "next"
+    trigger: 'bugsnag-js'
+    build:
+      branch: 'next'
+      message: 'Run RN tests with latest Cocoa next branch'
+      env:
+        BUILD_RN_WITH_LATEST_NATIVES: "true"
+    async: true
+
   - label: Build cocoa IPA
     key: cocoa_fixture
     timeout_in_minutes: 20


### PR DESCRIPTION
## Goal

Trigger the bugsnag-js pipeline when building the Cocoa `next` branch, passing the `BUILD_RN_WITH_LATEST_NATIVES` variable set to "true". This will cause the React Native e2e tests to be run with the latest version of the Cocoa (and Android) notifier from `next`.

The onus will be on the native notifier maintainers to check the RN test run before making a release.
