### PR TITLE
PLAT-6370 unity support

### DIFF
--- a/Bugsnag/Payload/BugsnagBreadcrumb+Private.h
+++ b/Bugsnag/Payload/BugsnagBreadcrumb+Private.h
@@ -20,4 +20,7 @@ NS_ASSUME_NONNULL_BEGIN
 
 @end
 
+FOUNDATION_EXPORT NSString *BSGBreadcrumbTypeValue(BSGBreadcrumbType type);
+FOUNDATION_EXPORT BSGBreadcrumbType BSGBreadcrumbTypeFromString( NSString * _Nullable value);
+
 NS_ASSUME_NONNULL_END


### PR DESCRIPTION
## Goal

Expose `BSGBreadcrumbTypeValue` and `BSGBreadcrumbTypeFromString` via BugsnagBreadcrumb+Private.h

This is needed to support https://github.com/bugsnag/bugsnag-unity/pull/234

## Testing

Re-run unit and e2e tests
