### PR TITLE
Attach appium server logs to MacOS test runs

### DIFF
--- a/.buildkite/pipeline.full.yml
+++ b/.buildkite/pipeline.full.yml
@@ -87,7 +87,7 @@ steps:
     plugins:
       artifacts#v1.3.0:
         download: ["features/fixtures/macos/output/macOSTestApp.zip"]
-        upload: ["macOSTestApp.log", "appium-server.log"]
+        upload: ["macOSTestApp.log", "appium_server.log"]
     commands:
       - bundle install
       - bundle exec maze-runner
@@ -107,7 +107,7 @@ steps:
     plugins:
       artifacts#v1.3.0:
         download: ["features/fixtures/macos/output/macOSTestApp.zip"]
-        upload: ["macOSTestApp.log", "appium-server.log"]
+        upload: ["macOSTestApp.log", "appium_server.log"]
     commands:
       - bundle install
       - bundle exec maze-runner
@@ -127,7 +127,7 @@ steps:
     plugins:
       artifacts#v1.3.0:
         download: ["features/fixtures/macos/output/macOSTestApp.zip"]
-        upload: ["macOSTestApp.log", "appium-server.log"]
+        upload: ["macOSTestApp.log", "appium_server.log"]
     commands:
       - bundle install
       - bundle exec maze-runner

--- a/.buildkite/pipeline.full.yml
+++ b/.buildkite/pipeline.full.yml
@@ -87,7 +87,7 @@ steps:
     plugins:
       artifacts#v1.3.0:
         download: ["features/fixtures/macos/output/macOSTestApp.zip"]
-        upload: ["macOSTestApp.log"]
+        upload: ["macOSTestApp.log", "appium-server.log"]
     commands:
       - bundle install
       - bundle exec maze-runner
@@ -107,7 +107,7 @@ steps:
     plugins:
       artifacts#v1.3.0:
         download: ["features/fixtures/macos/output/macOSTestApp.zip"]
-        upload: ["macOSTestApp.log"]
+        upload: ["macOSTestApp.log", "appium-server.log"]
     commands:
       - bundle install
       - bundle exec maze-runner
@@ -127,7 +127,7 @@ steps:
     plugins:
       artifacts#v1.3.0:
         download: ["features/fixtures/macos/output/macOSTestApp.zip"]
-        upload: ["macOSTestApp.log"]
+        upload: ["macOSTestApp.log", "appium-server.log"]
     commands:
       - bundle install
       - bundle exec maze-runner

--- a/.buildkite/pipeline.quick.yml
+++ b/.buildkite/pipeline.quick.yml
@@ -169,7 +169,7 @@ steps:
     plugins:
       artifacts#v1.3.0:
         download: ["features/fixtures/macos/output/macOSTestApp.zip"]
-        upload: ["macOSTestApp.log"]
+        upload: ["macOSTestApp.log", "appium-server.log"]
     commands:
       - bundle install
       - bundle exec maze-runner

--- a/.buildkite/pipeline.quick.yml
+++ b/.buildkite/pipeline.quick.yml
@@ -169,7 +169,7 @@ steps:
     plugins:
       artifacts#v1.3.0:
         download: ["features/fixtures/macos/output/macOSTestApp.zip"]
-        upload: ["macOSTestApp.log", "appium-server.log"]
+        upload: ["macOSTestApp.log", "appium_server.log"]
     commands:
       - bundle install
       - bundle exec maze-runner

--- a/.buildkite/pipeline.yml
+++ b/.buildkite/pipeline.yml
@@ -196,7 +196,7 @@ steps:
     plugins:
       artifacts#v1.3.0:
         download: ["features/fixtures/macos/output/macOSTestApp.zip"]
-        upload: ["macOSTestApp.log"]
+        upload: ["macOSTestApp.log", "appium-server.log"]
     commands:
       - bundle install
       - bundle exec maze-runner

--- a/.buildkite/pipeline.yml
+++ b/.buildkite/pipeline.yml
@@ -196,7 +196,7 @@ steps:
     plugins:
       artifacts#v1.3.0:
         download: ["features/fixtures/macos/output/macOSTestApp.zip"]
-        upload: ["macOSTestApp.log", "appium-server.log"]
+        upload: ["macOSTestApp.log", "appium_server.log"]
     commands:
       - bundle install
       - bundle exec maze-runner

--- a/Gemfile
+++ b/Gemfile
@@ -7,7 +7,7 @@ gem 'xcpretty'
 
 # A reference to Maze Runner is only needed for running tests locally and if committed it must be
 # portable for CI, e.g. a specific release.  However, leaving it commented out would mean quicker CI.
-gem 'bugsnag-maze-runner', git: 'https://github.com/bugsnag/maze-runner', tag: 'v4.13.0'
+gem 'bugsnag-maze-runner', git: 'https://github.com/bugsnag/maze-runner', branch: 'local-appium-server-logs'
 
 # Locally, you can run against Maze Runner branches and uncommitted changes:
 # gem 'bugsnag-maze-runner', path: '../maze-runner'

--- a/Gemfile
+++ b/Gemfile
@@ -7,7 +7,7 @@ gem 'xcpretty'
 
 # A reference to Maze Runner is only needed for running tests locally and if committed it must be
 # portable for CI, e.g. a specific release.  However, leaving it commented out would mean quicker CI.
-gem 'bugsnag-maze-runner', git: 'https://github.com/bugsnag/maze-runner', branch: 'local-appium-server-logs'
+gem 'bugsnag-maze-runner', git: 'https://github.com/bugsnag/maze-runner', tag: 'v5.0.1'
 
 # Locally, you can run against Maze Runner branches and uncommitted changes:
 # gem 'bugsnag-maze-runner', path: '../maze-runner'

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -1,11 +1,10 @@
 GIT
   remote: https://github.com/bugsnag/maze-runner
-  revision: 3161e2a7115a2642a1929aa5c037ead65d4ebfba
-  tag: v4.13.0
+  revision: 5e6c9624177f6087a75f5099130e24fb51036bb2
+  branch: local-appium-server-logs
   specs:
-    bugsnag-maze-runner (4.13.0)
+    bugsnag-maze-runner (5.0.2)
       appium_lib (~> 11.2.0)
-      boring (~> 0.1.0)
       cucumber (~> 3.1.2)
       cucumber-expressions (~> 6.0.0)
       curb (~> 0.9.6)
@@ -39,8 +38,7 @@ GEM
       faye-websocket (~> 0.11.0)
       selenium-webdriver (~> 3.14, >= 3.14.1)
     atomos (0.1.3)
-    backports (3.20.2)
-    boring (0.1.0)
+    backports (3.21.0)
     builder (3.2.4)
     childprocess (3.0.0)
     claide (1.0.3)
@@ -170,7 +168,7 @@ GEM
     nap (1.1.0)
     netrc (0.11.0)
     no_proxy_fix (0.1.2)
-    nokogiri (1.11.2)
+    nokogiri (1.11.3)
       mini_portile2 (~> 2.5.0)
       racc (~> 1.4)
     octokit (4.20.0)


### PR DESCRIPTION
## Goal

To enable easier debugging, use the newest version of maze-runner to log the appium output to a file and attach it to the buildkite step.

Note: There appears to be an error/potential flake at the moment, and this PR will be updated once resolved.