### PR TITLE
fix: remove failure msg when disabling crash handling

### DIFF
--- a/.buildkite/pipeline.yml
+++ b/.buildkite/pipeline.yml
@@ -1,3 +1,6 @@
+env:
+  LANG: "en_GB.UTF-8"
+
 steps:
   - label: 'Trigger RN tests for all builds of our next branch'
     if: build.branch == "next"
@@ -215,13 +218,17 @@ steps:
     env:
       STRESS_TEST: "true"
     commands:
+      - echo "--- Bundle install"
       - bundle install
+      - echo "--- Build"
+      - make -C features/fixtures/macos-stress-test
+      - echo "--- Test"
       - bundle exec maze-runner
         features/stress_test.feature
         --no-log-requests
     artifact_paths:
-      - features/fixtures/macos-stress-test/BugsnagStressTest.stdout.log
-      - features/fixtures/macos-stress-test/BugsnagStressTest.stderr.log
+      - features/fixtures/macos-stress-test/*.log
+      - features/fixtures/macos-stress-test/*.crash
 
   - label: 'Conditionally trigger full set of tests'
     command: sh -c .buildkite/pipeline_trigger.sh

--- a/Bugsnag/BugsnagCrashSentry.h
+++ b/Bugsnag/BugsnagCrashSentry.h
@@ -10,7 +10,9 @@
 
 #import "BSG_KSCrashReportWriter.h"
 #import "BSG_KSCrashType.h"
-#import "BugsnagConfiguration.h"
+
+@class BugsnagConfiguration;
+@class BugsnagErrorTypes;
 
 @interface BugsnagCrashSentry : NSObject
 

--- a/Bugsnag/BugsnagCrashSentry.m
+++ b/Bugsnag/BugsnagCrashSentry.m
@@ -21,6 +21,9 @@
 
 - (void)install:(BugsnagConfiguration *)config onCrash:(BSGReportCallback)onCrash
 {
+    if (!config.autoDetectErrors) {
+      return;
+    }
     BSG_KSCrash *ksCrash = [BSG_KSCrash sharedInstance];
     ksCrash.introspectMemory = NO;
     ksCrash.onCrash = onCrash;
@@ -30,18 +33,8 @@
     // applies to unhandled errors
     ksCrash.threadTracingEnabled = config.sendThreads != BSGThreadSendPolicyNever;
 
-    // User reported events do not go through KSCrash
-    BSG_KSCrashType crashTypes = 0;
-    
-    // If Bugsnag is autodetecting errors then the types of event detected is configurable
-    // (otherwise it's just the user reported events)
-    if (config.autoDetectErrors) {
-        // Translate the relevant BSGErrorTypes bitfield into the equivalent BSG_KSCrashType one
-        crashTypes = crashTypes | [self mapKSToBSGCrashTypes:config.enabledErrorTypes];
-    }
-    
-    bsg_kscrash_setHandlingCrashTypes(crashTypes);
-    
+    bsg_kscrash_setHandlingCrashTypes([self mapKSToBSGCrashTypes:config.enabledErrorTypes]);
+
     if ((![ksCrash install:[BSGFileLocations current].kscrashReports])) {
         bsg_log_err(@"Failed to install crash handler. No exceptions will be reported!");
     }

--- a/Bugsnag/BugsnagCrashSentry.m
+++ b/Bugsnag/BugsnagCrashSentry.m
@@ -22,7 +22,7 @@
 - (void)install:(BugsnagConfiguration *)config onCrash:(BSGReportCallback)onCrash
 {
     if (!config.autoDetectErrors) {
-      return;
+        return;
     }
     BSG_KSCrash *ksCrash = [BSG_KSCrash sharedInstance];
     ksCrash.introspectMemory = NO;

--- a/Bugsnag/KSCrash/Source/KSCrash/Recording/BSG_KSCrash.h
+++ b/Bugsnag/KSCrash/Source/KSCrash/Recording/BSG_KSCrash.h
@@ -44,12 +44,6 @@
  */
 @property(nonatomic, readwrite, retain) NSDictionary *userInfo;
 
-/** The crash types that are being handled.
- * Note: This value may change once BSG_KSCrash is installed if some handlers
- *       fail to install.
- */
-@property(nonatomic, readwrite, assign) BSG_KSCrashType handlingCrashTypes;
-
 /** If YES, introspect memory contents during a crash.
  * Any Objective-C objects or C strings near the stack pointer or referenced by
  * cpu registers or exceptions will be recorded in the crash report, along with
@@ -63,13 +57,13 @@
  */
 + (BSG_KSCrash *)sharedInstance;
 
-/** Install the crash reporter.
- * The reporter will record crashes, but will not send any crash reports unless
- * sink is set.
+/**
+ * Install the crash reporter.
  *
- * @return YES if the reporter successfully installed.
+ * @return The crash types that are now behing handled, representing the crash
+ *         sentries that were successfully installed.
  */
-- (BOOL)install:(NSString *)directory;
+- (BSG_KSCrashType)install:(BSG_KSCrashType)crashTypes directory:(NSString *)directory;
 
 /**
  * Collects information about the application's foreground state (duration in foreground/background)

--- a/Bugsnag/KSCrash/Source/KSCrash/Recording/BSG_KSCrash.m
+++ b/Bugsnag/KSCrash/Source/KSCrash/Recording/BSG_KSCrash.m
@@ -89,7 +89,6 @@
 // ============================================================================
 
 @synthesize userInfo = _userInfo;
-@synthesize handlingCrashTypes = _handlingCrashTypes;
 @synthesize printTraceToStdout = _printTraceToStdout;
 @synthesize onCrash = _onCrash;
 @synthesize bundleName = _bundleName;
@@ -146,10 +145,6 @@
     bsg_kscrash_setUserInfoJSON([userInfoJSON bytes]);
 }
 
-- (void)setHandlingCrashTypes:(BSG_KSCrashType)handlingCrashTypes {
-    _handlingCrashTypes = bsg_kscrash_setHandlingCrashTypes(handlingCrashTypes);
-}
-
 - (void)setPrintTraceToStdout:(bool)printTraceToStdout {
     _printTraceToStdout = printTraceToStdout;
     bsg_kscrash_setPrintTraceToStdout(printTraceToStdout);
@@ -175,22 +170,24 @@
     bsg_kscrash_setThreadTracingEnabled(threadTracingEnabled);
 }
 
-- (BOOL)install:(NSString *)directory {
+- (BSG_KSCrashType)install:(BSG_KSCrashType)crashTypes directory:(NSString *)directory {
     bsg_kscrash_generate_report_initialize(directory.fileSystemRepresentation, self.bundleName.UTF8String);
     char *crashReportPath = (char *)bsg_kscrash_generate_report_path(self.nextCrashID.UTF8String, false);
     char *recrashReportPath = (char *)bsg_kscrash_generate_report_path(self.nextCrashID.UTF8String, true);
     NSString *stateFilePath = [directory stringByAppendingPathComponent:
                                [self.bundleName stringByAppendingString:@BSG_kCrashStateFilenameSuffix]];
     
-    self.handlingCrashTypes = bsg_kscrash_install(
+    bsg_kscrash_setHandlingCrashTypes(crashTypes);
+    
+    BSG_KSCrashType installedCrashTypes = bsg_kscrash_install(
         crashReportPath, recrashReportPath,
         [stateFilePath UTF8String], [self.nextCrashID UTF8String]);
     
     free(crashReportPath);
     free(recrashReportPath);
     
-    if (self.handlingCrashTypes == 0) {
-        return false;
+    if (!installedCrashTypes) {
+        return 0;
     }
     
     NSNotificationCenter *nCenter = [NSNotificationCenter defaultCenter];
@@ -231,7 +228,7 @@
                   object:nil];
 #endif
 
-    return true;
+    return installedCrashTypes;
 }
 
 - (NSDictionary *)captureAppStats {

--- a/features/fixtures/macos-stress-test/BugsnagStressTest.xcodeproj/project.pbxproj
+++ b/features/fixtures/macos-stress-test/BugsnagStressTest.xcodeproj/project.pbxproj
@@ -231,6 +231,7 @@
 				MTL_FAST_MATH = YES;
 				ONLY_ACTIVE_ARCH = YES;
 				SDKROOT = macosx;
+				STRIP_INSTALLED_PRODUCT = NO;
 			};
 			name = Debug;
 		};
@@ -283,6 +284,7 @@
 				MTL_ENABLE_DEBUG_INFO = NO;
 				MTL_FAST_MATH = YES;
 				SDKROOT = macosx;
+				STRIP_INSTALLED_PRODUCT = NO;
 			};
 			name = Release;
 		};

--- a/features/fixtures/macos-stress-test/Makefile
+++ b/features/fixtures/macos-stress-test/Makefile
@@ -1,4 +1,4 @@
-.PHONY: all build clean run
+.PHONY: all build clean
 
 all: build
 
@@ -14,8 +14,3 @@ build:
 
 clean:
 	rm -rf build Pods *.log
-
-run:
-	QUIET=true /usr/bin/time -l ./build/usr/local/bin/BugsnagStressTest
-	rm -rf $(HOME)/Library/Application\ Support/com.bugsnag.Bugsnag
-	@echo "macOS stress-test complete"

--- a/features/fixtures/macos-stress-test/run.sh
+++ b/features/fixtures/macos-stress-test/run.sh
@@ -1,0 +1,22 @@
+#!/bin/bash
+
+cd "$(dirname "$0")"
+
+QUIET=true ./build/usr/local/bin/BugsnagStressTest
+RESULT=$?
+
+rm -rf ~/Library/Application\ Support/com.bugsnag.Bugsnag
+
+if [ "$RESULT" -ne "0" ]; then
+	# Wait for the crash reporter to write a crash report
+	sleep 5
+
+	find ~/Library/Logs/DiagnosticReports \
+		-name 'BugsnagStressTest_*.crash' \
+		-newer build/usr/local/bin/BugsnagStressTest \
+		-exec mv {} . \;
+fi
+
+echo "BugsnagStressTest exited with $RESULT"
+
+exit $RESULT

--- a/features/fixtures/shared/scenarios/BareboneTestScenarios.swift
+++ b/features/fixtures/shared/scenarios/BareboneTestScenarios.swift
@@ -38,6 +38,7 @@ class BareboneTestHandledScenario: Scenario {
             return true
         }
         config.enabledBreadcrumbTypes = [.error]
+        config.autoDetectErrors = false
         config.addMetadata(["Testing": true], section: "Flags")
         config.addMetadata(["password": "123456"], section: "Other")
         config.launchDurationMillis = 0

--- a/features/stress_test.feature
+++ b/features/stress_test.feature
@@ -3,10 +3,9 @@ Feature: Stress test
 
   Scenario: Triggering error notifications continuously
     When I start a new shell
-    And I input "cd features/fixtures/macos-stress-test" interactively
-    And I input "make build run" interactively
-    And I wait for the shell to output "macOS stress-test complete" to stdout
-    Then the last interactive command exited successfully
+    And I input "./features/fixtures/macos-stress-test/run.sh" interactively
+    And I wait for the shell to output a match for the regex "BugsnagStressTest exited with " to stdout
+    And the shell has output "BugsnagStressTest exited with 0" to stdout
 
     # This is low, but due to network congestion all we can guarantee in the course of a normal test
     And I have received at least 1 error


### PR DESCRIPTION
## Goal

Remove a potentially concerning message indicating crash handling "failed" to be installed when its actually configured not to install anything.
