### PR TITLE
Add autoNotify API for internal use by bugsnag-unity

### DIFF
--- a/Bugsnag/Client/BugsnagClient+Private.h
+++ b/Bugsnag/Client/BugsnagClient+Private.h
@@ -35,6 +35,10 @@ NS_ASSUME_NONNULL_BEGIN
 
 @property (nullable, nonatomic) BugsnagEvent *appHangEvent;
 
+/// Alters whether error detection should be enabled or not after Bugsnag has been initialized.
+/// Intended for internal use only by Unity.
+@property (nonatomic) BOOL autoNotify;
+
 @property (nullable, retain, nonatomic) BugsnagBreadcrumbs *breadcrumbs;
 
 @property (nullable, nonatomic) NSString *codeBundleId;

--- a/Tests/BugsnagClientMirrorTest.m
+++ b/Tests/BugsnagClientMirrorTest.m
@@ -153,6 +153,10 @@
             @"startAppHangDetector v16@0:8",
             @"stateMetadataFile @16@0:8",
             @"stateMetadataFromLastLaunch @16@0:8",
+            @"autoNotify B16@0:8",
+            @"autoNotify c16@0:8",
+            @"setAutoNotify: v20@0:8B16",
+            @"setAutoNotify: v20@0:8c16"
     ]];
 
     // the following methods are implemented on Bugsnag but do not need to

--- a/features/auto_notify.feature
+++ b/features/auto_notify.feature
@@ -1,0 +1,43 @@
+Feature: autoNotify flag allows disabling error detection after Bugsnag is initialized
+
+    Background:
+        Given I clear all persistent data
+
+    Scenario: Uncaught NSException not reported when autoNotify is false
+        When I run "AutoNotifyFalseHandledScenario"
+        And I wait to receive an error
+        Then the error is valid for the error reporting API
+        And the error payload field "events" is an array with 1 elements
+        And the event "unhandled" is false
+        And I discard the oldest error
+        And I relaunch the app
+        When I run "AutoNotifyFalseNSExceptionScenario" and relaunch the app
+        And I configure Bugsnag for "AutoNotifyFalseHandledScenario"
+        Then I should receive no requests
+
+    Scenario: Signal not reported when autoNotify is false
+        When I run "AutoNotifyFalseHandledScenario"
+        And I wait to receive an error
+        Then the error is valid for the error reporting API
+        And the error payload field "events" is an array with 1 elements
+        And the event "unhandled" is false
+        And I discard the oldest error
+        And I relaunch the app
+        When I run "AutoNotifyFalseAbortScenario" and relaunch the app
+        And I configure Bugsnag for "AutoNotifyFalseHandledScenario"
+        Then I should receive no requests
+
+    Scenario: Uncaught NSException reported when autoDetectErrors set to false then true
+        When I run "AutoDetectFalseHandledScenario"
+        And I wait to receive an error
+        Then the error is valid for the error reporting API
+        And the error payload field "events" is an array with 1 elements
+        And the event "unhandled" is false
+        And I discard the oldest error
+        And I relaunch the app
+        When I run "AutoNotifyReenabledScenario" and relaunch the app
+        And I configure Bugsnag for "AutoNotifyReenabledScenario"
+        And I wait to receive an error
+        Then the error is valid for the error reporting API
+        And the error payload field "events" is an array with 1 elements
+        And the event "unhandled" is true

--- a/features/fixtures/ios-swift-cocoapods/iOSTestApp.xcodeproj/project.pbxproj
+++ b/features/fixtures/ios-swift-cocoapods/iOSTestApp.xcodeproj/project.pbxproj
@@ -111,6 +111,10 @@
 		E7B79CD8247FD7810039FB88 /* AutoContextNSExceptionScenario.swift in Sources */ = {isa = PBXBuildFile; fileRef = E7B79CD7247FD7810039FB88 /* AutoContextNSExceptionScenario.swift */; };
 		E7B79CDA24800A5D0039FB88 /* MetadataMergeScenario.swift in Sources */ = {isa = PBXBuildFile; fileRef = E7B79CD924800A5D0039FB88 /* MetadataMergeScenario.swift */; };
 		E7DD40452473D980000EDC14 /* UserDefaultInfoScenario.swift in Sources */ = {isa = PBXBuildFile; fileRef = E7DD40442473D980000EDC14 /* UserDefaultInfoScenario.swift */; };
+		E7FDB6C2264D5AB900BCF881 /* AutoNotifyFalseHandledScenario.swift in Sources */ = {isa = PBXBuildFile; fileRef = E7FDB6C1264D5AB900BCF881 /* AutoNotifyFalseHandledScenario.swift */; };
+		E7FDB6C4264D5ACA00BCF881 /* AutoNotifyFalseNSExceptionScenario.swift in Sources */ = {isa = PBXBuildFile; fileRef = E7FDB6C3264D5ACA00BCF881 /* AutoNotifyFalseNSExceptionScenario.swift */; };
+		E7FDB6C6264D5AD800BCF881 /* AutoNotifyFalseAbortScenario.swift in Sources */ = {isa = PBXBuildFile; fileRef = E7FDB6C5264D5AD800BCF881 /* AutoNotifyFalseAbortScenario.swift */; };
+		E7FDB6C8264D607F00BCF881 /* AutoNotifyReenabledScenario.swift in Sources */ = {isa = PBXBuildFile; fileRef = E7FDB6C7264D607F00BCF881 /* AutoNotifyReenabledScenario.swift */; };
 		F429502603396F8671B333B3 /* HandledExceptionScenario.swift in Sources */ = {isa = PBXBuildFile; fileRef = F429526319377A8848136413 /* HandledExceptionScenario.swift */; };
 		F4295109FCAB93708FDAFE12 /* DisabledSessionTrackingScenario.m in Sources */ = {isa = PBXBuildFile; fileRef = F429563584D9BC3A5B86BECF /* DisabledSessionTrackingScenario.m */; };
 		F42951A9FD696D9047149DA8 /* UndefinedInstructionScenario.m in Sources */ = {isa = PBXBuildFile; fileRef = F429538D19421F28D8EB0446 /* UndefinedInstructionScenario.m */; };
@@ -296,6 +300,10 @@
 		E7B79CD924800A5D0039FB88 /* MetadataMergeScenario.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = MetadataMergeScenario.swift; sourceTree = "<group>"; };
 		E7DD40442473D980000EDC14 /* UserDefaultInfoScenario.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = UserDefaultInfoScenario.swift; sourceTree = "<group>"; };
 		E7F6087B244F0A3A00F1532A /* BugsnagHooks.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; path = BugsnagHooks.h; sourceTree = "<group>"; };
+		E7FDB6C1264D5AB900BCF881 /* AutoNotifyFalseHandledScenario.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AutoNotifyFalseHandledScenario.swift; sourceTree = "<group>"; };
+		E7FDB6C3264D5ACA00BCF881 /* AutoNotifyFalseNSExceptionScenario.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AutoNotifyFalseNSExceptionScenario.swift; sourceTree = "<group>"; };
+		E7FDB6C5264D5AD800BCF881 /* AutoNotifyFalseAbortScenario.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AutoNotifyFalseAbortScenario.swift; sourceTree = "<group>"; };
+		E7FDB6C7264D607F00BCF881 /* AutoNotifyReenabledScenario.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AutoNotifyReenabledScenario.swift; sourceTree = "<group>"; };
 		EE18B3777C62D7BCA8DDBE30 /* Pods-iOSTestApp.debug.xcconfig */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.xcconfig; name = "Pods-iOSTestApp.debug.xcconfig"; path = "Pods/Target Support Files/Pods-iOSTestApp/Pods-iOSTestApp.debug.xcconfig"; sourceTree = "<group>"; };
 		F42950588CE34967588DF438 /* ObjCExceptionScenario.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = ObjCExceptionScenario.h; sourceTree = "<group>"; };
 		F42950D49A5F24FF7155EEE1 /* NonExistentMethodScenario.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = NonExistentMethodScenario.h; sourceTree = "<group>"; };
@@ -555,6 +563,17 @@
 			name = Context;
 			sourceTree = "<group>";
 		};
+		E7FDB6C0264D5A8800BCF881 /* AutoNotify */ = {
+			isa = PBXGroup;
+			children = (
+				E7FDB6C1264D5AB900BCF881 /* AutoNotifyFalseHandledScenario.swift */,
+				E7FDB6C3264D5ACA00BCF881 /* AutoNotifyFalseNSExceptionScenario.swift */,
+				E7FDB6C5264D5AD800BCF881 /* AutoNotifyFalseAbortScenario.swift */,
+				E7FDB6C7264D607F00BCF881 /* AutoNotifyReenabledScenario.swift */,
+			);
+			name = AutoNotify;
+			sourceTree = "<group>";
+		};
 		F42953DE2BB41023C0B07F41 /* scenarios */ = {
 			isa = PBXGroup;
 			children = (
@@ -562,6 +581,7 @@
 				E7A324E4247E9C96008B0052 /* Breadcrumb Callbacks */,
 				E75040AC2478213D005D33BD /* Metadata Redaction */,
 				E750409C24780158005D33BD /* AutoDetectErrors */,
+				E7FDB6C0264D5A8800BCF881 /* AutoNotify */,
 				E7B79CCE247FD6520039FB88 /* Context */,
 				F49695A9244545EC00105DA9 /* Crashprobe */,
 				F49695B0244547CB00105DA9 /* Cross notifier notify */,
@@ -926,6 +946,7 @@
 				F429565A951303E2C3136D0D /* UserIdScenario.swift in Sources */,
 				8A38C5D124094D7B00BC4463 /* DiscardedBreadcrumbTypeScenario.swift in Sources */,
 				8AEEBBD020FC9E1D00C60763 /* AutoSessionMixedEventsScenario.m in Sources */,
+				E7FDB6C8264D607F00BCF881 /* AutoNotifyReenabledScenario.swift in Sources */,
 				E753F24624927409001FB671 /* NotifyCallbackCrashScenario.swift in Sources */,
 				8AF8FCAC22BD1E5400A967CA /* UnhandledInternalNotifyScenario.swift in Sources */,
 				6526A0D4248A83350002E2C9 /* LoadConfigFromFileAutoScenario.swift in Sources */,
@@ -942,6 +963,7 @@
 				CBE1C9242574F532004B8B5B /* OnErrorOverwriteUnhandledFalseScenario.swift in Sources */,
 				A1117E5B2536036400014FDA /* OOMSessionScenario.swift in Sources */,
 				8AF8FCAE22BD23BA00A967CA /* HandledInternalNotifyScenario.swift in Sources */,
+				E7FDB6C4264D5ACA00BCF881 /* AutoNotifyFalseNSExceptionScenario.swift in Sources */,
 				CBE1C9252574F532004B8B5B /* OnErrorOverwriteUnhandledTrueScenario.swift in Sources */,
 				8A42FD35225DEE04007AE561 /* SessionOOMScenario.m in Sources */,
 				E7A324EF247E9DBC008B0052 /* BreadcrumbCallbackCrashScenario.swift in Sources */,
@@ -951,6 +973,7 @@
 				01E5EAD225B713990066EA8A /* OOMScenario.m in Sources */,
 				8A530CCC22FDDBF000F0C108 /* ManyConcurrentNotifyScenario.m in Sources */,
 				F42958881D3F34A76CADE4EC /* SwiftCrash.swift in Sources */,
+				E7FDB6C6264D5AD800BCF881 /* AutoNotifyFalseAbortScenario.swift in Sources */,
 				E7A324EA247E9DA5008B0052 /* BreadcrumbCallbackOverrideScenario.swift in Sources */,
 				F42955DB6D08642528917FAB /* CxxExceptionScenario.mm in Sources */,
 				8A3B5F2B240807EE00CE4A3A /* ModifyBreadcrumbInNotify.swift in Sources */,
@@ -1010,6 +1033,7 @@
 				E700EE6F247D79F6008CFFB6 /* SIGTRAPScenario.m in Sources */,
 				F4295A0B0DA0AF3B5502D29C /* PrivilegedInstructionScenario.m in Sources */,
 				F42958BE5DDACDBF653CA926 /* ManualSessionScenario.m in Sources */,
+				E7FDB6C2264D5AB900BCF881 /* AutoNotifyFalseHandledScenario.swift in Sources */,
 				E7A324E8247E9D9A008B0052 /* BreadcrumbCallbackOrderScenario.swift in Sources */,
 				F42951BF19D7F35A03273CFB /* AutoSessionScenario.m in Sources */,
 				E700EE4A247D1164008CFFB6 /* UserSessionOverrideScenario.swift in Sources */,

--- a/features/fixtures/macos/macOSTestApp.xcodeproj/project.pbxproj
+++ b/features/fixtures/macos/macOSTestApp.xcodeproj/project.pbxproj
@@ -138,6 +138,10 @@
 		01F47D31254B1B3100B184AD /* OverwriteLinkRegisterScenario.m in Sources */ = {isa = PBXBuildFile; fileRef = 01F47CC0254B1B3000B184AD /* OverwriteLinkRegisterScenario.m */; };
 		01F47D32254B1B3100B184AD /* ResumeSessionOOMScenario.m in Sources */ = {isa = PBXBuildFile; fileRef = 01F47CC1254B1B3000B184AD /* ResumeSessionOOMScenario.m */; };
 		CBB7878E2578FB3F0071BDE4 /* MarkUnhandledHandledScenario.m in Sources */ = {isa = PBXBuildFile; fileRef = CBB7878C2578FB3F0071BDE4 /* MarkUnhandledHandledScenario.m */; };
+		E780377D264D703500430C11 /* AutoNotifyReenabledScenario.swift in Sources */ = {isa = PBXBuildFile; fileRef = E7803779264D703500430C11 /* AutoNotifyReenabledScenario.swift */; };
+		E780377E264D703500430C11 /* AutoNotifyFalseHandledScenario.swift in Sources */ = {isa = PBXBuildFile; fileRef = E780377A264D703500430C11 /* AutoNotifyFalseHandledScenario.swift */; };
+		E780377F264D703500430C11 /* AutoNotifyFalseNSExceptionScenario.swift in Sources */ = {isa = PBXBuildFile; fileRef = E780377B264D703500430C11 /* AutoNotifyFalseNSExceptionScenario.swift */; };
+		E7803780264D703500430C11 /* AutoNotifyFalseAbortScenario.swift in Sources */ = {isa = PBXBuildFile; fileRef = E780377C264D703500430C11 /* AutoNotifyFalseAbortScenario.swift */; };
 /* End PBXBuildFile section */
 
 /* Begin PBXCopyFilesBuildPhase section */
@@ -343,6 +347,10 @@
 		01F47CC3254B1B3100B184AD /* SIGFPEScenario.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = SIGFPEScenario.h; sourceTree = "<group>"; };
 		CBB7878C2578FB3F0071BDE4 /* MarkUnhandledHandledScenario.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; path = MarkUnhandledHandledScenario.m; sourceTree = "<group>"; };
 		CBB7878D2578FB3F0071BDE4 /* MarkUnhandledHandledScenario.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = MarkUnhandledHandledScenario.h; sourceTree = "<group>"; };
+		E7803779264D703500430C11 /* AutoNotifyReenabledScenario.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = AutoNotifyReenabledScenario.swift; sourceTree = "<group>"; };
+		E780377A264D703500430C11 /* AutoNotifyFalseHandledScenario.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = AutoNotifyFalseHandledScenario.swift; sourceTree = "<group>"; };
+		E780377B264D703500430C11 /* AutoNotifyFalseNSExceptionScenario.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = AutoNotifyFalseNSExceptionScenario.swift; sourceTree = "<group>"; };
+		E780377C264D703500430C11 /* AutoNotifyFalseAbortScenario.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = AutoNotifyFalseAbortScenario.swift; sourceTree = "<group>"; };
 /* End PBXFileReference section */
 
 /* Begin PBXFrameworksBuildPhase section */
@@ -378,6 +386,10 @@
 				01F47C68254B1B2E00B184AD /* AutoDetectFalseAbortScenario.swift */,
 				01F47C44254B1B2D00B184AD /* AutoDetectFalseHandledScenario.swift */,
 				01F47C59254B1B2E00B184AD /* AutoDetectFalseNSExceptionScenario.swift */,
+				E780377C264D703500430C11 /* AutoNotifyFalseAbortScenario.swift */,
+				E780377A264D703500430C11 /* AutoNotifyFalseHandledScenario.swift */,
+				E780377B264D703500430C11 /* AutoNotifyFalseNSExceptionScenario.swift */,
+				E7803779264D703500430C11 /* AutoNotifyReenabledScenario.swift */,
 				01F47CBC254B1B3000B184AD /* AutoSessionCustomVersionScenario.h */,
 				01F47C8B254B1B2F00B184AD /* AutoSessionCustomVersionScenario.m */,
 				01F47C9A254B1B2F00B184AD /* AutoSessionHandledEventsScenario.h */,
@@ -674,6 +686,7 @@
 				01F47D1E254B1B3100B184AD /* SIGPIPEScenario.m in Sources */,
 				01F47CCF254B1B3100B184AD /* ObjCExceptionScenario.m in Sources */,
 				01ECBCF425A7522000FC0678 /* OnErrorOverwriteUnhandledFalseScenario.swift in Sources */,
+				E780377F264D703500430C11 /* AutoNotifyFalseNSExceptionScenario.swift in Sources */,
 				01AF6A50258A00DE00FFC803 /* BareboneTestScenarios.swift in Sources */,
 				01F47CED254B1B3100B184AD /* ResumedSessionScenario.swift in Sources */,
 				01F47CE8254B1B3100B184AD /* AppAndDeviceAttributesScenario.swift in Sources */,
@@ -752,8 +765,10 @@
 				01F47CDB254B1B3100B184AD /* UnhandledMachExceptionScenario.m in Sources */,
 				01F47D12254B1B3100B184AD /* OnSendCallbackRemovalScenario.m in Sources */,
 				01F47D24254B1B3100B184AD /* UserSessionOverrideScenario.swift in Sources */,
+				E780377E264D703500430C11 /* AutoNotifyFalseHandledScenario.swift in Sources */,
 				01F47CD8254B1B3100B184AD /* ManualContextConfigurationScenario.swift in Sources */,
 				01F47CFA254B1B3100B184AD /* BreadcrumbCallbackOrderScenario.swift in Sources */,
+				E780377D264D703500430C11 /* AutoNotifyReenabledScenario.swift in Sources */,
 				01F47CF3254B1B3100B184AD /* AutoCaptureRunScenario.m in Sources */,
 				01F47CF8254B1B3100B184AD /* ModifyBreadcrumbInNotify.swift in Sources */,
 				01F47D14254B1B3100B184AD /* OOMEnabledErrorTypesScenario.swift in Sources */,
@@ -769,6 +784,7 @@
 				01F47D20254B1B3100B184AD /* ObjCMsgSendScenario.m in Sources */,
 				01F47CD4254B1B3100B184AD /* AsyncSafeThreadScenario.m in Sources */,
 				01ECBCF525A7522000FC0678 /* OnErrorOverwriteUnhandledTrueScenario.swift in Sources */,
+				E7803780264D703500430C11 /* AutoNotifyFalseAbortScenario.swift in Sources */,
 				01F47CDE254B1B3100B184AD /* ReleasedObjectScenario.m in Sources */,
 				01F47CF1254B1B3100B184AD /* UserEnabledScenario.swift in Sources */,
 				01F47D16254B1B3100B184AD /* NewSessionScenario.swift in Sources */,

--- a/features/fixtures/shared/scenarios/AutoNotifyFalseAbortScenario.swift
+++ b/features/fixtures/shared/scenarios/AutoNotifyFalseAbortScenario.swift
@@ -1,0 +1,26 @@
+//
+//  AutoNotifyFalseAbortScenario.swift
+//  iOSTestApp
+//
+//  Created by Jamie Lynch on 13/05/2021.
+//  Copyright © 2021 Bugsnag. All rights reserved.
+//
+
+import Foundation
+import Bugsnag
+
+/**
+* Raises a SIGABRT with autoNotify set to false, which should be ignored by Bugsnag
+*/
+internal class AutoNotifyFalseAbortScenario: Scenario {
+
+    override func startBugsnag() {
+      self.config.autoTrackSessions = false
+      super.startBugsnag()
+    }
+
+    override func run() {
+        Bugsnag.client.autoNotify = false
+        abort()
+    }
+}

--- a/features/fixtures/shared/scenarios/AutoNotifyFalseHandledScenario.swift
+++ b/features/fixtures/shared/scenarios/AutoNotifyFalseHandledScenario.swift
@@ -1,0 +1,27 @@
+//
+//  AutoNotifyFalseHandledScenario.swift
+//  iOSTestApp
+//
+//  Created by Jamie Lynch on 13/05/2021.
+//  Copyright © 2021 Bugsnag. All rights reserved.
+//
+
+import Foundation
+import Bugsnag
+
+/**
+ * Sends a handled error to Bugsnag with autoNotify set to false
+ */
+internal class AutoNotifyFalseHandledScenario: Scenario {
+
+    override func startBugsnag() {
+      self.config.autoTrackSessions = false
+      super.startBugsnag()
+    }
+
+    override func run() {
+        Bugsnag.client.autoNotify = false
+        let error = NSError(domain: "UserDefaultInfoScenario", code: 100, userInfo: nil)
+        Bugsnag.notifyError(error)
+    }
+}

--- a/features/fixtures/shared/scenarios/AutoNotifyFalseNSExceptionScenario.swift
+++ b/features/fixtures/shared/scenarios/AutoNotifyFalseNSExceptionScenario.swift
@@ -1,0 +1,26 @@
+//
+//  AutoNotifyFalseNSExceptionScenario.swift
+//  iOSTestApp
+//
+//  Created by Jamie Lynch on 13/05/2021.
+//  Copyright © 2021 Bugsnag. All rights reserved.
+//
+
+import Foundation
+import Bugsnag
+
+/**
+ * Raises an unhandled NSException with autoNotify set to false, which should be ignored by Bugsnag
+ */
+internal class AutoNotifyFalseNSExceptionScenario: Scenario {
+
+    override func startBugsnag() {
+      self.config.autoTrackSessions = false
+      super.startBugsnag()
+    }
+
+    override func run() {
+        Bugsnag.client.autoNotify = false
+        NSException.init(name: NSExceptionName("SomeError"), reason: "Something went wrnog", userInfo: nil).raise()
+    }
+}

--- a/features/fixtures/shared/scenarios/AutoNotifyReenabledScenario.swift
+++ b/features/fixtures/shared/scenarios/AutoNotifyReenabledScenario.swift
@@ -1,0 +1,28 @@
+//
+//  AutoNotifyReenabledScenario.swift
+//  iOSTestApp
+//
+//  Created by Jamie Lynch on 13/05/2021.
+//  Copyright © 2021 Bugsnag. All rights reserved.
+//
+
+import Foundation
+import Bugsnag
+
+/**
+ * Raises an unhandled NSException with autoNotify set to false then true,
+ * which should be reported by Bugsnag
+ */
+internal class AutoNotifyReenabledScenario: Scenario {
+
+    override func startBugsnag() {
+      self.config.autoTrackSessions = false
+      super.startBugsnag()
+    }
+
+    override func run() {
+        Bugsnag.client.autoNotify = false
+        Bugsnag.client.autoNotify = true
+        NSException.init(name: NSExceptionName("SomeError"), reason: "Something went wrnog", userInfo: nil).raise()
+    }
+}

--- a/features/fixtures/shared/scenarios/BugsnagHooks.h
+++ b/features/fixtures/shared/scenarios/BugsnagHooks.h
@@ -12,4 +12,10 @@
 @interface Bugsnag ()
 + (void)notifyInternal:(BugsnagEvent *_Nonnull)event
                  block:(BugsnagOnErrorBlock _Nonnull)block;
+
+@property (class, readonly) BugsnagClient *client;
+@end
+
+@interface BugsnagClient()
+@property (nonatomic) BOOL autoNotify;
 @end


### PR DESCRIPTION
## Goal

Alters bugsnag-cocoa so that it is capable of supporting [Unity's AutoNotify](https://docs.bugsnag.com/platforms/unity/configuration-options/#autonotify) API, which allows automatic error detection to be enabled/disabled after Bugsnag has initialized. This is not exposed as part of the Cocoa interface and is intended for internal use by Unity only.

## Changeset

- Added `autoNotify` as a private property of `BugsnagClient`
- When `autoNotify` is updated `bsg_kscrash_setHandlingCrashTypes` is invoked with the appropriate error types to capture automatically

## Testing

Added E2E tests to verify that `autoNotify` is respected for NSException/Signals, and that error capture behaviour is unaltered if the flag is toggled off then on.