### PR TITLE
[PLAT-6536] Disable Cocoapods prefix header and enable additional warnings

### DIFF
--- a/Bugsnag.podspec.json
+++ b/Bugsnag.podspec.json
@@ -28,6 +28,7 @@
     "Bugsnag/{**/,}*.{m,h,mm,c}"
   ],
   "requires_arc": true,
+  "prefix_header_file": false,
   "public_header_files": [
     "Bugsnag/include/Bugsnag/*.h"
   ]

--- a/Bugsnag/Delivery/BugsnagApiClient.m
+++ b/Bugsnag/Delivery/BugsnagApiClient.m
@@ -120,7 +120,7 @@ typedef NS_ENUM(NSInteger, HTTPStatusCode) {
             NSURLErrorFailingURLErrorKey: url }];
         
         bsg_log_debug(@"Response headers: %@", ((NSHTTPURLResponse *)response).allHeaderFields);
-        bsg_log_debug(@"Response body: %.*s", (int)data.length, data.bytes);
+        bsg_log_debug(@"Response body: %.*s", (int)data.length, (const char *)data.bytes);
         
         if (statusCode / 100 == 4 &&
             statusCode != HTTPStatusCodePaymentRequired &&

--- a/features/fixtures/ios-swift-cocoapods/Podfile
+++ b/features/fixtures/ios-swift-cocoapods/Podfile
@@ -18,6 +18,12 @@ post_install do |installer|
       target.build_configurations.each do |config|
         config.build_settings['GCC_PREPROCESSOR_DEFINITIONS'] ||= ['$(inherited)', 'BSG_LOG_LEVEL=BSG_LOGLEVEL_DEBUG']
         config.build_settings['GCC_TREAT_WARNINGS_AS_ERRORS'] = 'YES'
+
+        # Include all our build warning settings without needing to duplicate them here
+        xcconfig = "Pods/Target Support Files/#{target.name}/#{target.name}.#{config.name.downcase}.xcconfig"
+        File.open(xcconfig, 'a') do |file|
+          file << '#include "../../../../../../Bugsnag.xcconfig"'
+        end
       end
     end
   end


### PR DESCRIPTION
## Goal

Disable the prefix header created by Cocoapods. Sometimes different warnings would appear in Cocoapods builds because of the prefix header force-including UIKit on iOS, so removing it makes the builds more consistent.

Enable additional warnings when building the iOS fixture app (which uses Cocoapods to integrate Bugsnag) so that we are alerted of any build warnings that only appear there.

## Changeset

The main `Bugsnag.xcconfig` is included by the test fixture when building Bugsnag so that the same warnings settings are applied.

A build warning was fixed that was only appearing when `BSG_LOG_LEVEL` was set to `BSG_LOGLEVEL_DEBUG`

## Testing

Tested via unit and E2E tests.