### PR TITLE
Split E2E runs into batches and randomize order

### DIFF
--- a/.buildkite/pipeline.full.yml
+++ b/.buildkite/pipeline.full.yml
@@ -4,7 +4,7 @@ env:
 steps:
   ##############################################################################
   #
-  # Barebones E2E tests
+  # E2E tests
   #
 
   - label: 'iOS 13 E2E tests batch 1'

--- a/.buildkite/pipeline.full.yml
+++ b/.buildkite/pipeline.full.yml
@@ -2,10 +2,15 @@ env:
   LANG: "en_GB.UTF-8"
 
 steps:
-  - label: ':ios: iOS 13 full end-to-end tests'
+  ##############################################################################
+  #
+  # Barebones E2E tests
+  #
+
+  - label: 'iOS 13 E2E tests batch 1'
     depends_on:
       - cocoa_fixture
-    timeout_in_minutes: 120
+    timeout_in_minutes: 45
     agents:
       queue: opensource
     plugins:
@@ -20,6 +25,8 @@ steps:
           - "--resilient"
           - "--appium-version=1.17.0"
           - "--fail-fast"
+          - "--exclude=features/[h-z].*.feature"
+          - "--order=random"
     concurrency: 9
     concurrency_group: browserstack-app
     retry:
@@ -27,10 +34,37 @@ steps:
         - exit_status: -1  # Agent was lost
           limit: 2
 
-  - label: ':ios: iOS 12 full end-to-end tests'
+  - label: 'iOS 13 E2E tests batch 2'
     depends_on:
       - cocoa_fixture
-    timeout_in_minutes: 120
+    timeout_in_minutes: 45
+    agents:
+      queue: opensource
+    plugins:
+      artifacts#v1.3.0:
+        download: ["features/fixtures/ios-swift-cocoapods/output/iOSTestApp.ipa"]
+      docker-compose#v3.3.0:
+        run: cocoa-maze-runner
+        command:
+          - "--app=/app/build/iOSTestApp.ipa"
+          - "--farm=bs"
+          - "--device=IOS_13"
+          - "--resilient"
+          - "--appium-version=1.17.0"
+          - "--fail-fast"
+          - "--exclude=features/[a-g].*.feature"
+          - "--order=random"
+    concurrency: 9
+    concurrency_group: browserstack-app
+    retry:
+      automatic:
+        - exit_status: -1  # Agent was lost
+          limit: 2
+
+  - label: 'iOS 12 E2E tests batch 1'
+    depends_on:
+      - cocoa_fixture
+    timeout_in_minutes: 45
     agents:
       queue: opensource
     plugins:
@@ -45,6 +79,8 @@ steps:
           - "--resilient"
           - "--appium-version=1.17.0"
           - "--fail-fast"
+          - "--exclude=features/[h-z].*.feature"
+          - "--order=random"
     concurrency: 9
     concurrency_group: browserstack-app
     retry:
@@ -52,12 +88,39 @@ steps:
         - exit_status: -1  # Agent was lost
           limit: 2
 
-  - label: ':ios: iOS 11 full end-to-end tests'
+  - label: 'iOS 12 E2E tests batch 2'
+    depends_on:
+      - cocoa_fixture
+    timeout_in_minutes: 45
+    agents:
+      queue: opensource
+    plugins:
+      artifacts#v1.3.0:
+        download: ["features/fixtures/ios-swift-cocoapods/output/iOSTestApp.ipa"]
+      docker-compose#v3.3.0:
+        run: cocoa-maze-runner
+        command:
+          - "--app=/app/build/iOSTestApp.ipa"
+          - "--farm=bs"
+          - "--device=IOS_12"
+          - "--resilient"
+          - "--appium-version=1.17.0"
+          - "--fail-fast"
+          - "--exclude=features/[a-g].*.feature"
+          - "--order=random"
+    concurrency: 9
+    concurrency_group: browserstack-app
+    retry:
+      automatic:
+        - exit_status: -1  # Agent was lost
+          limit: 2
+
+  - label: 'iOS 11 E2E tests batch 1'
     depends_on:
       - cocoa_fixture
     # More time than other steps as the BrowserStack iOS 11 devices seem particularly unstable and
     # sessions need resetting frequently, taking a minute or more each time.
-    timeout_in_minutes: 120
+    timeout_in_minutes: 50
     agents:
       queue: opensource
     plugins:
@@ -71,6 +134,8 @@ steps:
           - "--device=IOS_11_0_IPHONE_8_PLUS"
           - "--appium-version=1.8.0"
           - "--fail-fast"
+          - "--exclude=features/[h-z].*.feature"
+          - "--order=random"
     concurrency: 9
     concurrency_group: browserstack-app
     retry:
@@ -78,7 +143,35 @@ steps:
         - exit_status: -1  # Agent was lost
           limit: 2
 
-  - label: ':apple: macOS 11.0 full end-to-end tests'
+  - label: 'iOS 11 E2E tests batch 2'
+    depends_on:
+      - cocoa_fixture
+    # More time than other steps as the BrowserStack iOS 11 devices seem particularly unstable and
+    # sessions need resetting frequently, taking a minute or more each time.
+    timeout_in_minutes: 50
+    agents:
+      queue: opensource
+    plugins:
+      artifacts#v1.3.0:
+        download: ["features/fixtures/ios-swift-cocoapods/output/iOSTestApp.ipa"]
+      docker-compose#v3.3.0:
+        run: cocoa-maze-runner
+        command:
+          - "--app=/app/build/iOSTestApp.ipa"
+          - "--farm=bs"
+          - "--device=IOS_11_0_IPHONE_8_PLUS"
+          - "--appium-version=1.8.0"
+          - "--fail-fast"
+          - "--exclude=features/[a-g].*.feature"
+          - "--order=random"
+    concurrency: 9
+    concurrency_group: browserstack-app
+    retry:
+      automatic:
+        - exit_status: -1  # Agent was lost
+          limit: 2
+
+  - label: 'macOS 11.0 E2E tests'
     depends_on:
       - cocoa_fixture
     timeout_in_minutes: 60
@@ -97,8 +190,9 @@ steps:
         --app=macOSTestApp
         --tags='not @skip_macos'
         --fail-fast
+        --order=random
 
-  - label: ':apple: macOS 10.13 full end-to-end tests'
+  - label: 'macOS 10.13 E2E tests'
     depends_on:
       - cocoa_fixture
     timeout_in_minutes: 60
@@ -117,8 +211,9 @@ steps:
         --app=macOSTestApp
         --tags='not @skip_macos'
         --fail-fast
+        --order=random
 
-  - label: ':apple: macOS 10.14 full end-to-end tests'
+  - label: 'macOS 10.14 E2E tests'
     depends_on:
       - cocoa_fixture
     timeout_in_minutes: 60
@@ -137,6 +232,12 @@ steps:
         --app=macOSTestApp
         --tags='not @skip_macos'
         --fail-fast
+        --order=random
+
+  ##############################################################################
+  #
+  # Build example apps
+  #
 
   - label: 'examples/objective-c-ios'
     agents:

--- a/.buildkite/pipeline.quick.yml
+++ b/.buildkite/pipeline.quick.yml
@@ -2,6 +2,11 @@ env:
   LANG: "en_GB.UTF-8"
 
 steps:
+  ##############################################################################
+  #
+  # Unit tests
+  #
+
   - label: macOS 11 unit tests
     timeout_in_minutes: 10
     agents:
@@ -104,7 +109,12 @@ steps:
     artifact_paths:
       - logs/*
 
-  - label: ':apple: macOS 10.15 full end-to-end tests'
+  ##############################################################################
+  #
+  # E2E tests
+  #
+
+  - label: 'macOS 10.15 E2E tests'
     depends_on:
       - cocoa_fixture
     timeout_in_minutes: 60
@@ -123,11 +133,12 @@ steps:
         --app=macOSTestApp
         --tags='not @skip_macos'
         --fail-fast
+        --order=random
 
-  - label: ':ios: iOS 14 full end-to-end tests'
+  - label: 'iOS 14 E2E tests batch 1'
     depends_on:
       - cocoa_fixture
-    timeout_in_minutes: 120
+    timeout_in_minutes: 45
     agents:
       queue: opensource
     plugins:
@@ -142,6 +153,8 @@ steps:
           - "--resilient"
           - "--appium-version=1.17.0"
           - "--fail-fast"
+          - "--exclude=features/[h-z].*.feature"
+          - "--order=random"
     concurrency: 9
     concurrency_group: browserstack-app
     retry:
@@ -149,10 +162,37 @@ steps:
         - exit_status: -1  # Agent was lost
           limit: 2
 
-  - label: ':ios: iOS 10 full end-to-end tests - batch 1'
+  - label: 'iOS 14 E2E tests batch 2'
     depends_on:
       - cocoa_fixture
-    timeout_in_minutes: 60
+    timeout_in_minutes: 45
+    agents:
+      queue: opensource
+    plugins:
+      artifacts#v1.3.0:
+        download: ["features/fixtures/ios-swift-cocoapods/output/iOSTestApp.ipa"]
+      docker-compose#v3.3.0:
+        run: cocoa-maze-runner
+        command:
+          - "--app=/app/build/iOSTestApp.ipa"
+          - "--farm=bs"
+          - "--device=IOS_14"
+          - "--resilient"
+          - "--appium-version=1.17.0"
+          - "--fail-fast"
+          - "--exclude=features/[a-g].*.feature"
+          - "--order=random"
+    concurrency: 9
+    concurrency_group: browserstack-app
+    retry:
+      automatic:
+        - exit_status: -1  # Agent was lost
+          limit: 2
+
+  - label: 'iOS 10 E2E tests batch 1'
+    depends_on:
+      - cocoa_fixture
+    timeout_in_minutes: 45
     agents:
       queue: opensource
     plugins:
@@ -166,8 +206,8 @@ steps:
           - "--device=IOS_10"
           - "--appium-version=1.8.0"
           - "--fail-fast"
-          - "-e"
-          - "features/[o-z].*.feature"
+          - "--exclude=features/[h-z].*.feature"
+          - "--order=random"
     concurrency: 9
     concurrency_group: browserstack-app
     retry:
@@ -175,10 +215,10 @@ steps:
         - exit_status: -1  # Agent was lost
           limit: 2
 
-  - label: ':ios: iOS 10 full end-to-end tests - batch 2'
+  - label: 'iOS 10 E2E tests batch 2'
     depends_on:
       - cocoa_fixture
-    timeout_in_minutes: 60
+    timeout_in_minutes: 45
     agents:
       queue: opensource
     plugins:
@@ -192,8 +232,8 @@ steps:
           - "--device=IOS_10"
           - "--appium-version=1.8.0"
           - "--fail-fast"
-          - "-e"
-          - "features/[a-n].*.feature"
+          - "--exclude=features/[a-g].*.feature"
+          - "--order=random"
     concurrency: 9
     concurrency_group: browserstack-app
     retry:

--- a/.buildkite/pipeline.yml
+++ b/.buildkite/pipeline.yml
@@ -12,6 +12,11 @@ steps:
         BUILD_RN_WITH_LATEST_NATIVES: "true"
     async: true
 
+  ##############################################################################
+  #
+  # Build
+  #
+
   - label: Build cocoa IPA
     key: cocoa_fixture
     timeout_in_minutes: 20
@@ -42,11 +47,15 @@ steps:
     concurrency: 3
     concurrency_group: cocoa-unit-tests
     env:
-      LANG: "en_GB.UTF-8"
       DEVELOPER_DIR: "/Applications/Xcode11.app/Contents/Developer"
     commands:
       - mkdir -p features/fixtures/carthage-proj
       - make build_swift
+
+  ##############################################################################
+  #
+  # Unit tests
+  #
 
   - label: macOS 10.15 unit tests
     timeout_in_minutes: 10
@@ -104,7 +113,12 @@ steps:
     artifact_paths:
       - logs/*
 
-  - label: ':ios: iOS 14 barebones end-to-end tests'
+  ##############################################################################
+  #
+  # Barebones E2E tests
+  #
+
+  - label: 'iOS 14 barebones E2E tests'
     depends_on:
       - cocoa_fixture
     timeout_in_minutes: 10
@@ -123,6 +137,7 @@ steps:
           - "--resilient"
           - "--appium-version=1.17.0"
           - "--fail-fast"
+          - "--order=random"
     concurrency: 9
     concurrency_group: browserstack-app
     retry:
@@ -130,7 +145,7 @@ steps:
         - exit_status: -1  # Agent was lost
           limit: 2
 
-  - label: ':ios: iOS 10 barebones end-to-end tests'
+  - label: 'iOS 10 barebones E2E tests'
     depends_on:
       - cocoa_fixture
     timeout_in_minutes: 10
@@ -148,6 +163,7 @@ steps:
           - "--device=IOS_10"
           - "--appium-version=1.8.0"
           - "--fail-fast"
+          - "--order=random"
     concurrency: 9
     concurrency_group: browserstack-app
     retry:
@@ -155,10 +171,10 @@ steps:
         - exit_status: -1  # Agent was lost
           limit: 2
 
-  - label: ':apple: macOS 10.15 barebones end-to-end tests'
+  - label: 'macOS 10.15 barebones E2E tests'
     depends_on:
       - cocoa_fixture
-    timeout_in_minutes: 60
+    timeout_in_minutes: 10
     agents:
       queue: opensource-mac-cocoa-10.15
     plugins:
@@ -175,6 +191,7 @@ steps:
         --app=macOSTestApp
         --tags='not @skip_macos'
         --fail-fast
+        --order=random
 
   - label: 'macOS 10.15 stress test'
     timeout_in_minutes: 3
@@ -194,6 +211,11 @@ steps:
     artifact_paths:
       - features/fixtures/macos-stress-test/*.log
       - features/fixtures/macos-stress-test/*.crash
+
+  ##############################################################################
+  #
+  # Trigger more tests
+  #
 
   - label: 'Conditionally trigger full set of tests'
     command: sh -c .buildkite/pipeline_trigger.sh

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -1,9 +1,9 @@
 GIT
   remote: https://github.com/bugsnag/maze-runner
-  revision: 5e6c9624177f6087a75f5099130e24fb51036bb2
-  branch: local-appium-server-logs
+  revision: f7536f3128462c5e56963b6c75372b3e96243823
+  tag: v5.1.0
   specs:
-    bugsnag-maze-runner (5.0.2)
+    bugsnag-maze-runner (5.1.0)
       appium_lib (~> 11.2.0)
       cucumber (~> 3.1.2)
       cucumber-expressions (~> 6.0.0)
@@ -129,7 +129,7 @@ GEM
     faraday-http-cache (2.2.0)
       faraday (>= 0.8)
     faraday-net_http (1.0.1)
-    faye-websocket (0.11.0)
+    faye-websocket (0.11.1)
       eventmachine (>= 0.12.0)
       websocket-driver (>= 0.5.1)
     ffi (1.14.2)
@@ -157,7 +157,7 @@ GEM
     kramdown-parser-gfm (1.1.0)
       kramdown (~> 2.0)
     liferaft (0.0.6)
-    mini_portile2 (2.5.0)
+    mini_portile2 (2.5.1)
     minitest (5.14.4)
     molinillo (0.6.6)
     multi_json (1.15.0)
@@ -168,7 +168,7 @@ GEM
     nap (1.1.0)
     netrc (0.11.0)
     no_proxy_fix (0.1.2)
-    nokogiri (1.11.3)
+    nokogiri (1.11.6)
       mini_portile2 (~> 2.5.0)
       racc (~> 1.4)
     octokit (4.20.0)
@@ -208,7 +208,7 @@ GEM
     tzinfo (1.2.9)
       thread_safe (~> 0.1)
     unicode-display_width (1.7.0)
-    websocket-driver (0.7.3)
+    websocket-driver (0.7.4)
       websocket-extensions (>= 0.1.0)
     websocket-extensions (0.1.5)
     xcinvoke (0.3.0)


### PR DESCRIPTION
## Goal

We have observed test flakes that appear to be Appium related occur around the 1hr mark during an E2E test run.

## Changeset

Split all E2E runs into batches to reduce the duration of each Appium / BS session. Note that batch 1 takes longer than batch 2 because there are a large number of scenarios in files beginning with `e` that prevent an even split.

Enabled `--order=random` to make it easier to differentiate between flakey scenarios and time-related issues.

Made the step naming more consistent and concise.

## Testing

For a sample full run see https://buildkite.com/bugsnag/bugsnag-cocoa/builds/2709