### PR TITLE
[PLAT-6626] Perform symbolication on background thread

### DIFF
--- a/Bugsnag/Delivery/BSGEventUploadObjectOperation.m
+++ b/Bugsnag/Delivery/BSGEventUploadObjectOperation.m
@@ -8,7 +8,7 @@
 
 #import "BSGEventUploadObjectOperation.h"
 
-#import "BugsnagEvent.h"
+#import "BugsnagEvent+Private.h"
 #import "BugsnagLogger.h"
 
 @implementation BSGEventUploadObjectOperation
@@ -21,6 +21,7 @@
 }
 
 - (BugsnagEvent *)loadEventAndReturnError:(__attribute__((unused)) NSError * __autoreleasing *)errorPtr {
+    [self.event symbolicateIfNeeded];
     return self.event;
 }
 

--- a/Bugsnag/Delivery/BSGEventUploader.m
+++ b/Bugsnag/Delivery/BSGEventUploader.m
@@ -63,6 +63,7 @@
 // MARK: - Public API
 
 - (void)storeEvent:(BugsnagEvent *)event {
+    [event symbolicateIfNeeded];
     [self storeEventPayload:[event toJsonWithRedactedKeys:self.configuration.redactedKeys]];
 }
 

--- a/Bugsnag/KSCrash/Source/KSCrash/Recording/Tools/BSG_KSMachHeaders.c
+++ b/Bugsnag/KSCrash/Source/KSCrash/Recording/Tools/BSG_KSMachHeaders.c
@@ -9,6 +9,7 @@
 #include "BSG_KSMachHeaders.h"
 
 #include "BSG_KSDynamicLinker.h"
+#include "BSG_KSLogger.h"
 #include "BSG_KSMach.h"
 
 #include <dispatch/dispatch.h>
@@ -143,7 +144,14 @@ bool bsg_mach_headers_populate_info(const struct mach_header *header, intptr_t s
         cmdPtr += loadCmd->cmdsize;
     }
     
-    // Save these values
+    // Sanity checks that should never fail
+    if (((uintptr_t)imageVmAddr + (uintptr_t)slide) != (uintptr_t)header) {
+        BSG_KSLOG_ERROR("Mach header != (vmaddr + slide) for %s; symbolication will be compromised.", imageName);
+    }
+    if ((uintptr_t)DlInfo.dli_fbase != (uintptr_t)header) {
+        BSG_KSLOG_ERROR("Mach header != dli_fbase for %s", imageName);
+    }
+    
     info->header = header;
     info->imageSize = imageSize;
     info->imageVmAddr = imageVmAddr;

--- a/Bugsnag/KSCrash/Source/KSCrash/Recording/Tools/BSG_KSMachHeaders.h
+++ b/Bugsnag/KSCrash/Source/KSCrash/Recording/Tools/BSG_KSMachHeaders.h
@@ -9,9 +9,8 @@
 #ifndef BSG_KSMachHeaders_h
 #define BSG_KSMachHeaders_h
 
-#include <mach/machine.h>
-#include <os/lock.h>
-#include <libkern/OSAtomic.h>
+#include <stdbool.h>
+#include <stdint.h>
 
 /* Maintaining our own list of framework Mach headers means that we avoid potential
  * deadlock situations where we try and suspend lock-holding threads prior to
@@ -21,18 +20,38 @@
 /**
  * An encapsulation of the Mach header data as a linked list - either 64 or 32 bit, along with some additiona
  * information required for detailing a crash report's binary images.
- * 
- * The removed field indicates that the library has since been unloaded by dyld and can be ignored.
  */
 typedef struct bsg_mach_image {
-    const struct mach_header *header; /* The mach_header - 32 or 64 bit */
+
+    /// The mach_header or mach_header_64
+    ///
+    /// This is also the memory address where the image has been loaded by dyld, including slide.
+    const struct mach_header *header;
+
+    /// The vmaddr specified for the __TEXT segment
+    ///
+    /// This is the load address specified at build time, and does not account for slide applied by dyld.
     uint64_t imageVmAddr;
+
+    /// The vmsize of the __TEXT segment
     uint64_t imageSize;
-    uint8_t *uuid;
+
+    /// A UUID that uniquely identifies this image, used to identify its associated dSYM
+    const uint8_t *uuid;
+
+    /// The pathname of the shared object (Dl_info.dli_fname)
     const char* name;
+
+    /// The virtural memory address slide of the image
     intptr_t slide;
+
+    /// True if the image has been unloaded and should be ignored
     bool unloaded;
+
+    /// True if this image is a program with an entry point; i.e. LC_MAIN or LC_UNIXTHREAD
     bool isMain;
+
+    /// The next image in the linked list
     struct bsg_mach_image *next;
 } BSG_Mach_Header_Info;
 

--- a/Bugsnag/Payload/BugsnagEvent+Private.h
+++ b/Bugsnag/Payload/BugsnagEvent+Private.h
@@ -65,6 +65,8 @@ NS_ASSUME_NONNULL_BEGIN
 /// Whether this report should be sent, based on release stage information cached at crash time and within the application currently.
 - (BOOL)shouldBeSent;
 
+- (void)symbolicateIfNeeded;
+
 - (NSDictionary *)toJsonWithRedactedKeys:(nullable NSSet *)redactedKeys;
 
 - (void)notifyUnhandledOverridden;

--- a/Bugsnag/Payload/BugsnagEvent.m
+++ b/Bugsnag/Payload/BugsnagEvent.m
@@ -34,6 +34,7 @@
 #import "BugsnagMetadata+Private.h"
 #import "BugsnagLogger.h"
 #import "BugsnagSession+Private.h"
+#import "BugsnagStackframe+Private.h"
 #import "BugsnagStacktrace.h"
 #import "BugsnagThread+Private.h"
 #import "BugsnagUser+Private.h"
@@ -524,8 +525,6 @@ NSDictionary *BSGParseCustomException(NSDictionary *report,
     return [[BugsnagUser alloc] initWithDictionary:user];
 }
 
-// MARK: - Callback overrides
-
 - (void)notifyUnhandledOverridden {
     self.handledState.unhandledOverridden = YES;
 }
@@ -657,6 +656,19 @@ NSDictionary *BSGParseCustomException(NSDictionary *report,
         }
     }
     return false;
+}
+
+- (void)symbolicateIfNeeded {
+    for (BugsnagError *error in self.errors) {
+        for (BugsnagStackframe *stackframe in error.stacktrace) {
+            [stackframe symbolicateIfNeeded];
+        }
+    }
+    for (BugsnagThread *thread in self.threads) {
+        for (BugsnagStackframe *stackframe in thread.stacktrace) {
+            [stackframe symbolicateIfNeeded];
+        }
+    }
 }
 
 - (BOOL)unhandled {

--- a/Bugsnag/Payload/BugsnagStackframe+Private.h
+++ b/Bugsnag/Payload/BugsnagStackframe+Private.h
@@ -22,8 +22,14 @@ NS_ASSUME_NONNULL_BEGIN
 /// Constructs a stackframe object from a JSON object (typically loaded from disk.)
 + (instancetype)frameFromJson:(NSDictionary<NSString *, id> *)json;
 
+/// Populates the method and symbolAddress via `dladdr()` if this object was created from a backtrace or callstack.
+/// This can be a slow operation, so should be performed on a background thread.
+- (void)symbolicateIfNeeded;
+
 /// Returns a JSON compatible representation of the stackframe.
 - (NSDictionary *)toDictionary;
+
+@property (nonatomic) BOOL needsSymbolication;
 
 @end
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,9 @@ Changelog
 
 ### Bug fixes
 
+* Improve performance of `notify()`.
+  [#1102](https://github.com/bugsnag/bugsnag-cocoa/pull/1102)
+
 * Fix a crash in `-[BugsnagApp deserializeFromJson:]` if main Mach-O image could not be identified, and improve reliability of identification.
   [#1097](https://github.com/bugsnag/bugsnag-cocoa/issues/1097)
   [#1101](https://github.com/bugsnag/bugsnag-cocoa/pull/1101)

--- a/Tests/BugsnagStackframeTest.m
+++ b/Tests/BugsnagStackframeTest.m
@@ -202,6 +202,7 @@
         XCTAssertNotNil(stackframe.machoUuid);
         XCTAssertNotNil(stackframe.machoVmAddress);
         XCTAssertNotNil(stackframe.machoLoadAddress);
+        [stackframe symbolicateIfNeeded];
         XCTAssertNotNil(stackframe.symbolAddress);
         XCTAssertNil(stackframe.type);
         XCTAssertTrue([callStackSymbols[idx] containsString:stackframe.method]);

--- a/Tests/BugsnagThreadTests.m
+++ b/Tests/BugsnagThreadTests.m
@@ -9,7 +9,7 @@
 #import <XCTest/XCTest.h>
 
 #import "BSG_KSMachHeaders.h"
-#import "BugsnagStackframe.h"
+#import "BugsnagStackframe+Private.h"
 #import "BugsnagThread+Private.h"
 #import "BugsnagThread+Recording.h"
 
@@ -216,6 +216,7 @@
 
 - (void)testAllThreads {
     NSArray<BugsnagThread *> *threads = [BugsnagThread allThreads:YES callStackReturnAddresses:NSThread.callStackReturnAddresses];
+    [threads[0].stacktrace makeObjectsPerformSelector:@selector(symbolicateIfNeeded)];
     XCTAssertTrue(threads[0].errorReportingThread);
     XCTAssertEqualObjects(threads[0].name, @"com.apple.main-thread");
     XCTAssertEqualObjects(threads[0].stacktrace.firstObject.method, @(__PRETTY_FUNCTION__));
@@ -224,6 +225,7 @@
 
 - (void)testCurrentThread {
     NSArray<BugsnagThread *> *threads = [BugsnagThread allThreads:NO callStackReturnAddresses:NSThread.callStackReturnAddresses];
+    [threads[0].stacktrace makeObjectsPerformSelector:@selector(symbolicateIfNeeded)];
     XCTAssertEqual(threads.count, 1);
     XCTAssertTrue(threads[0].errorReportingThread);
     XCTAssertEqualObjects(threads[0].id, @"0");
@@ -236,6 +238,7 @@
     XCTestExpectation *expectation = [self expectationWithDescription:@"Thread recorded in background"];
     dispatch_async(dispatch_get_global_queue(QOS_CLASS_USER_INITIATED, 0), ^{
         thread = [BugsnagThread allThreads:NO callStackReturnAddresses:NSThread.callStackReturnAddresses][0];
+        [thread.stacktrace makeObjectsPerformSelector:@selector(symbolicateIfNeeded)];
         [expectation fulfill];
     });
     [self waitForExpectationsWithTimeout:2 handler:nil];
@@ -260,6 +263,7 @@
             // Wait for main thread to be back in -testMainThreadFromBackground
         }
         thread = [BugsnagThread mainThread];
+        [thread.stacktrace makeObjectsPerformSelector:@selector(symbolicateIfNeeded)];
         atomic_store(&state, 2);
     });
     atomic_store(&state, 1);

--- a/features/barebone_tests.feature
+++ b/features/barebone_tests.feature
@@ -77,6 +77,7 @@ Feature: Barebone tests
     And the error payload field "events.0.device.totalMemory" is an integer
     And the error payload field "events.0.threads" is an array with 0 elements
     And the "method" of stack frame 0 matches "BareboneTestHandledScenario"
+    And the stacktrace is valid for the event
 
     And I discard the oldest error
 
@@ -98,6 +99,8 @@ Feature: Barebone tests
     And the exception "errorClass" equals "__SwiftNativeNSError"
     And the exception "message" equals "The data couldn’t be read because it isn’t in the correct format."
     And the exception "type" equals "cocoa"
+    And the "method" of stack frame 0 matches "BareboneTestHandledScenario"
+    And the stacktrace is valid for the event
 
   Scenario: Barebone test: unhandled error
     When I run "BareboneTestUnhandledErrorScenario" and relaunch the app
@@ -158,6 +161,7 @@ Feature: Barebone tests
     And the error payload field "events.0.threads" is a non-empty array
     And the error payload field "events.0.threads.1" is not null
     And the "method" of stack frame 0 matches "(assertionFailure|<redacted>)"
+    And the stacktrace is valid for the event
 
   @skip_macos
   Scenario: Barebone test: Out Of Memory

--- a/features/steps/ios_steps.rb
+++ b/features/steps/ios_steps.rb
@@ -256,6 +256,17 @@ Then('the breadcrumb timestamps are valid for the event') do
   end
 end
 
+Then('the stacktrace is valid for the event') do
+  stacktrace = Maze::Helper.read_key_path(Maze::Server.errors.current[:body], 'events.0.exceptions.0.stacktrace')
+  # values that are required for symbolication to work
+  keys = ['frameAddress', 'machoFile', 'machoLoadAddress', 'machoUUID', 'machoVMAddress']
+  stacktrace.each_with_index do |frame, i|
+    keys.each do |key|
+      assert_not_nil(frame[key], "Stack frame #{i} is missing #{key}")
+    end
+  end
+end
+
 Then('the thread information is valid for the event') do
   # verify that thread/stacktrace information was captured at all
   thread_traces = Maze::Helper.read_key_path(Maze::Server.errors.current[:body], 'events.0.threads')


### PR DESCRIPTION
## Goal

Reduce overhead of calling `Bugsnag.notify()`

## Changeset

Symbolication of function names via `dladdr()` is now performed on a background thread to reduce the impact on the calling thread.

## Testing

Tested manually using example app and amended barebones tests to validate that stack frames contain the necessary macho properties for symbolication.

In a simple test app, performance per call to `notify()` has been reduced from 6ms to 3ms 🎉 