### PR TITLE
[PLAT-6632] Fix KSCrash state storage for apps with no CFBundleName

### DIFF
--- a/Bugsnag/KSCrash/Source/KSCrash/Recording/BSG_KSCrash.m
+++ b/Bugsnag/KSCrash/Source/KSCrash/Recording/BSG_KSCrash.m
@@ -62,7 +62,6 @@
 
 @interface BSG_KSCrash ()
 
-@property(nonatomic, readwrite, retain) NSString *bundleName;
 @property(nonatomic, readwrite, retain) NSString *nextCrashID;
 
 // Mirrored from BSG_KSCrashAdvanced.h to provide ivars
@@ -82,7 +81,6 @@
 @synthesize userInfo = _userInfo;
 @synthesize printTraceToStdout = _printTraceToStdout;
 @synthesize onCrash = _onCrash;
-@synthesize bundleName = _bundleName;
 @synthesize logFilePath = _logFilePath;
 @synthesize nextCrashID = _nextCrashID;
 @synthesize introspectMemory = _introspectMemory;
@@ -105,7 +103,6 @@
 
 - (instancetype)init {
     if ((self = [super init])) {
-        self.bundleName = [[NSBundle mainBundle] infoDictionary][@"CFBundleName"];
         self.nextCrashID = [NSUUID UUID].UUIDString;
         self.introspectMemory = YES;
         self.maxStoredReports = 5;
@@ -162,11 +159,13 @@
 }
 
 - (BSG_KSCrashType)install:(BSG_KSCrashType)crashTypes directory:(NSString *)directory {
-    bsg_kscrash_generate_report_initialize(directory.fileSystemRepresentation, self.bundleName.UTF8String);
+    bsg_kscrash_generate_report_initialize(directory.fileSystemRepresentation);
     char *crashReportPath = bsg_kscrash_generate_report_path(self.nextCrashID.UTF8String, false);
     char *recrashReportPath = bsg_kscrash_generate_report_path(self.nextCrashID.UTF8String, true);
+    NSString *stateFilePrefix = [[NSBundle mainBundle] infoDictionary][@"CFBundleName"]
+    /* Not all processes have an Info.plist */ ?: NSProcessInfo.processInfo.processName;
     NSString *stateFilePath = [directory stringByAppendingPathComponent:
-                               [self.bundleName stringByAppendingString:@BSG_kCrashStateFilenameSuffix]];
+                               [stateFilePrefix stringByAppendingString:@BSG_kCrashStateFilenameSuffix]];
     
     bsg_kscrash_setHandlingCrashTypes(crashTypes);
     

--- a/Bugsnag/KSCrash/Source/KSCrash/Recording/BSG_KSCrashIdentifier.h
+++ b/Bugsnag/KSCrash/Source/KSCrash/Recording/BSG_KSCrashIdentifier.h
@@ -6,7 +6,7 @@
 extern "C" {
 #endif
 
-void bsg_kscrash_generate_report_initialize(const char *directory, const char *bundleName);
+void bsg_kscrash_generate_report_initialize(const char *directory);
 
 /**
  * Generates a new UUID. Not async signal safe. Caller responsible for

--- a/Bugsnag/KSCrash/Source/KSCrash/Recording/BSG_KSCrashIdentifier.m
+++ b/Bugsnag/KSCrash/Source/KSCrash/Recording/BSG_KSCrashIdentifier.m
@@ -8,11 +8,9 @@
 #include <string.h>
 
 static char *report_directory;
-static char *bundle_name;
 
-void bsg_kscrash_generate_report_initialize(const char *directory, const char *bundleName) {
+void bsg_kscrash_generate_report_initialize(const char *directory) {
     report_directory = directory ? strdup(directory) : NULL;
-    bundle_name = bundleName ? strdup(bundleName) : NULL;
 }
 
 char *bsg_kscrash_generate_report_identifier(void) {
@@ -25,6 +23,6 @@ char *bsg_kscrash_generate_report_path(const char *identifier, bool is_recrash_r
     }
     char *type = is_recrash_report ? "RecrashReport" : "CrashReport";
     char *path = NULL;
-    asprintf(&path, "%s/%s-%s-%s.json", report_directory, bundle_name, type, identifier);
+    asprintf(&path, "%s/%s-%s.json", report_directory, type, identifier);
     return path;
 }

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,9 @@ Changelog
   [#1097](https://github.com/bugsnag/bugsnag-cocoa/issues/1097)
   [#1101](https://github.com/bugsnag/bugsnag-cocoa/pull/1101)
 
+* Fix KSCrash state storage for apps with no CFBundleName.
+  [#1103](https://github.com/bugsnag/bugsnag-cocoa/pull/1103)
+
 ## 6.9.3 (2021-05-26)
 
 ### Bug fixes


### PR DESCRIPTION
## Goal

Some apps (e.g. macOS command line tools and background daemons) may not have an Info.plist or CFBundleName, and this was causing the KSCrash state persistence to fail, resulting in failing to detect that the last run ended with a crash.

## Changeset

When constructing the stateFilePath, the notifier now falls back to the process's name if it the app has no bundle name.

The bundle name is also no longer included in the KSCrashReport file names.

## Testing

Reproduced the reported issue using the macOS stress test app and verified the fix.

E2E tests ensure that crash reporting continues to work as expected.