### PR TITLE
[PLAT-6627] Improve performance of bsg_mach_headers_image_at_address

### DIFF
--- a/Bugsnag.xcodeproj/project.pbxproj
+++ b/Bugsnag.xcodeproj/project.pbxproj
@@ -129,9 +129,9 @@
 		008967752486D43700DC48C2 /* XCTestCase+KSCrash.m in Sources */ = {isa = PBXBuildFile; fileRef = 008966D72486D43700DC48C2 /* XCTestCase+KSCrash.m */; };
 		008967762486D43700DC48C2 /* XCTestCase+KSCrash.m in Sources */ = {isa = PBXBuildFile; fileRef = 008966D72486D43700DC48C2 /* XCTestCase+KSCrash.m */; };
 		008967772486D43700DC48C2 /* XCTestCase+KSCrash.m in Sources */ = {isa = PBXBuildFile; fileRef = 008966D72486D43700DC48C2 /* XCTestCase+KSCrash.m */; };
-		008967782486D43700DC48C2 /* KSMachHeader_Tests.m in Sources */ = {isa = PBXBuildFile; fileRef = 008966D82486D43700DC48C2 /* KSMachHeader_Tests.m */; };
-		008967792486D43700DC48C2 /* KSMachHeader_Tests.m in Sources */ = {isa = PBXBuildFile; fileRef = 008966D82486D43700DC48C2 /* KSMachHeader_Tests.m */; };
-		0089677A2486D43700DC48C2 /* KSMachHeader_Tests.m in Sources */ = {isa = PBXBuildFile; fileRef = 008966D82486D43700DC48C2 /* KSMachHeader_Tests.m */; };
+		008967782486D43700DC48C2 /* BSG_KSMachHeadersTests.m in Sources */ = {isa = PBXBuildFile; fileRef = 008966D82486D43700DC48C2 /* BSG_KSMachHeadersTests.m */; };
+		008967792486D43700DC48C2 /* BSG_KSMachHeadersTests.m in Sources */ = {isa = PBXBuildFile; fileRef = 008966D82486D43700DC48C2 /* BSG_KSMachHeadersTests.m */; };
+		0089677A2486D43700DC48C2 /* BSG_KSMachHeadersTests.m in Sources */ = {isa = PBXBuildFile; fileRef = 008966D82486D43700DC48C2 /* BSG_KSMachHeadersTests.m */; };
 		0089677B2486D43700DC48C2 /* RFC3339DateTool_Tests.m in Sources */ = {isa = PBXBuildFile; fileRef = 008966D92486D43700DC48C2 /* RFC3339DateTool_Tests.m */; };
 		0089677C2486D43700DC48C2 /* RFC3339DateTool_Tests.m in Sources */ = {isa = PBXBuildFile; fileRef = 008966D92486D43700DC48C2 /* RFC3339DateTool_Tests.m */; };
 		0089677D2486D43700DC48C2 /* RFC3339DateTool_Tests.m in Sources */ = {isa = PBXBuildFile; fileRef = 008966D92486D43700DC48C2 /* RFC3339DateTool_Tests.m */; };
@@ -1116,7 +1116,7 @@
 		008966D52486D43700DC48C2 /* KSSysCtl_Tests.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; path = KSSysCtl_Tests.m; sourceTree = "<group>"; };
 		008966D62486D43700DC48C2 /* FileBasedTestCase.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = FileBasedTestCase.h; sourceTree = "<group>"; };
 		008966D72486D43700DC48C2 /* XCTestCase+KSCrash.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; path = "XCTestCase+KSCrash.m"; sourceTree = "<group>"; };
-		008966D82486D43700DC48C2 /* KSMachHeader_Tests.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; path = KSMachHeader_Tests.m; sourceTree = "<group>"; };
+		008966D82486D43700DC48C2 /* BSG_KSMachHeadersTests.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; path = BSG_KSMachHeadersTests.m; sourceTree = "<group>"; };
 		008966D92486D43700DC48C2 /* RFC3339DateTool_Tests.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; path = RFC3339DateTool_Tests.m; sourceTree = "<group>"; };
 		008966DA2486D43700DC48C2 /* KSLogger_Tests.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; path = KSLogger_Tests.m; sourceTree = "<group>"; };
 		008966DB2486D43700DC48C2 /* KSSystemInfo_Tests.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; path = KSSystemInfo_Tests.m; sourceTree = "<group>"; };
@@ -1490,7 +1490,7 @@
 				008966E02486D43700DC48C2 /* KSJSONCodec_Tests.m */,
 				008966DA2486D43700DC48C2 /* KSLogger_Tests.m */,
 				008966EA2486D43700DC48C2 /* KSMach_Tests.m */,
-				008966D82486D43700DC48C2 /* KSMachHeader_Tests.m */,
+				008966D82486D43700DC48C2 /* BSG_KSMachHeadersTests.m */,
 				008966E12486D43700DC48C2 /* KSSignalInfo_Tests.m */,
 				008966E82486D43700DC48C2 /* KSString_Tests.m */,
 				008966D52486D43700DC48C2 /* KSSysCtl_Tests.m */,
@@ -2695,7 +2695,7 @@
 				0089679C2486D43700DC48C2 /* KSFileUtils_Tests.m in Sources */,
 				008966EE2486D43700DC48C2 /* BugsnagClientPayloadInfoTest.m in Sources */,
 				01BDB1F525DEBFB200A91FAF /* BSGEventUploadKSCrashReportOperationTests.m in Sources */,
-				008967782486D43700DC48C2 /* KSMachHeader_Tests.m in Sources */,
+				008967782486D43700DC48C2 /* BSG_KSMachHeadersTests.m in Sources */,
 				0089673F2486D43700DC48C2 /* BugsnagAppTest.m in Sources */,
 				0089675A2486D43700DC48C2 /* BugsnagEnabledBreadcrumbTest.m in Sources */,
 				008967422486D43700DC48C2 /* BugsnagSessionTrackerStopTest.m in Sources */,
@@ -2847,7 +2847,7 @@
 				008967162486D43700DC48C2 /* BugsnagCollectionsTests.m in Sources */,
 				008967582486D43700DC48C2 /* BugsnagClientMirrorTest.m in Sources */,
 				0089676A2486D43700DC48C2 /* BugsnagSessionTrackerTest.m in Sources */,
-				008967792486D43700DC48C2 /* KSMachHeader_Tests.m in Sources */,
+				008967792486D43700DC48C2 /* BSG_KSMachHeadersTests.m in Sources */,
 				0089675E2486D43700DC48C2 /* BugsnagSessionTrackingPayloadTest.m in Sources */,
 				008967A92486D43700DC48C2 /* KSCrashIdentifierTests.m in Sources */,
 				01847DAD26441A5E00ADA4C7 /* BSGInternalErrorReporterTests.m in Sources */,
@@ -3012,7 +3012,7 @@
 				0089676B2486D43700DC48C2 /* BugsnagSessionTrackerTest.m in Sources */,
 				E701FAA12490EF4A008D842F /* BugsnagApiValidationTest.m in Sources */,
 				01B6BB7E25D5777F00FC4DE6 /* BugsnagSwiftPublicAPITests.swift in Sources */,
-				0089677A2486D43700DC48C2 /* KSMachHeader_Tests.m in Sources */,
+				0089677A2486D43700DC48C2 /* BSG_KSMachHeadersTests.m in Sources */,
 				0089675F2486D43700DC48C2 /* BugsnagSessionTrackingPayloadTest.m in Sources */,
 				008967AA2486D43700DC48C2 /* KSCrashIdentifierTests.m in Sources */,
 				0089672C2486D43700DC48C2 /* BugsnagStacktraceTest.m in Sources */,

--- a/Bugsnag/KSCrash/Source/KSCrash/Recording/Tools/BSG_KSMachHeaders.c
+++ b/Bugsnag/KSCrash/Source/KSCrash/Recording/Tools/BSG_KSMachHeaders.c
@@ -222,42 +222,16 @@ BSG_Mach_Header_Info *bsg_mach_headers_image_named(const char *const imageName, 
 }
 
 BSG_Mach_Header_Info *bsg_mach_headers_image_at_address(const uintptr_t address) {
-        
-    for (BSG_Mach_Header_Info *img = bsg_g_mach_headers_images_head; img != NULL; img = img->next) {
+    for (BSG_Mach_Header_Info *img = bsg_mach_headers_get_images(); img; img = img->next) {
         if (img->unloaded == true) {
             continue;
         }
-        // Look for a segment command with this address within its range.
-        uintptr_t cmdPtr = bsg_mach_headers_first_cmd_after_header(img->header);
-        if (cmdPtr == 0) {
-            continue;
-        }
-        if (address < (uintptr_t)img->slide) {
-            continue;
-        }
-        uintptr_t addressWSlide = address - (uintptr_t)img->slide;
-        for (uint32_t iCmd = 0; iCmd < img->header->ncmds; iCmd++) {
-            const struct load_command *loadCmd =
-                (struct load_command *)cmdPtr;
-            if (loadCmd->cmd == LC_SEGMENT) {
-                const struct segment_command *segCmd =
-                    (struct segment_command *)cmdPtr;
-                if (addressWSlide >= segCmd->vmaddr &&
-                    addressWSlide < segCmd->vmaddr + segCmd->vmsize) {
-                    return img;
-                }
-            } else if (loadCmd->cmd == LC_SEGMENT_64) {
-                const struct segment_command_64 *segCmd =
-                    (struct segment_command_64 *)cmdPtr;
-                if (addressWSlide >= segCmd->vmaddr &&
-                    addressWSlide < segCmd->vmaddr + segCmd->vmsize) {
-                    return img;
-                }
-            }
-            cmdPtr += loadCmd->cmdsize;
+        uintptr_t imageAddress = (uintptr_t)img->header;
+        if (address >= imageAddress &&
+            address < (imageAddress + img->imageSize)) {
+            return img;
         }
     }
-    
     return NULL;
 }
 

--- a/Bugsnag/KSCrash/Source/KSCrash/Recording/Tools/BSG_KSMachHeaders.h
+++ b/Bugsnag/KSCrash/Source/KSCrash/Recording/Tools/BSG_KSMachHeaders.h
@@ -87,10 +87,8 @@ void bsg_mach_headers_add_image(const struct mach_header *mh, intptr_t slide);
  */
 void bsg_mach_headers_remove_image(const struct mach_header *mh, intptr_t slide);
 
-/** Get the image index that the specified address is part of.
-*
-* @param address The address to examine.
-* @return The index of the image it is part of, or UINT_MAX if none was found.
+/**
+ * Find the loaded binary image that contains the specified instruction address.
 */
 BSG_Mach_Header_Info *bsg_mach_headers_image_at_address(const uintptr_t address);
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,7 @@ Changelog
 * Improve performance of `notify()`.
   [#1102](https://github.com/bugsnag/bugsnag-cocoa/pull/1102)
   [#1104](https://github.com/bugsnag/bugsnag-cocoa/pull/1104)
+  [#1105](https://github.com/bugsnag/bugsnag-cocoa/pull/1105)
 
 * Fix a crash in `-[BugsnagApp deserializeFromJson:]` if main Mach-O image could not be identified, and improve reliability of identification.
   [#1097](https://github.com/bugsnag/bugsnag-cocoa/issues/1097)

--- a/Tests/KSCrash/BSG_KSMachHeadersTests.m
+++ b/Tests/KSCrash/BSG_KSMachHeadersTests.m
@@ -1,5 +1,5 @@
 //
-//  KSMachHeader_Tests.m
+//  BSG_KSMachHeadersTests.m
 //  Tests
 //
 //  Created by Robin Macharg on 04/05/2020.
@@ -8,6 +8,7 @@
 
 #import <XCTest/XCTest.h>
 #import "BSG_KSMachHeaders.h"
+#import <dlfcn.h>
 #import <mach-o/dyld.h>
 
 void bsg_mach_headers_add_image(const struct mach_header *mh, intptr_t slide);
@@ -38,10 +39,10 @@ const struct segment_command command2 = {
     LC_SEGMENT,0,SEG_TEXT,222,10,0,0,0,0,0,0
 };
 
-@interface KSMachHeader_Tests : XCTestCase
+@interface BSG_KSMachHeadersTests : XCTestCase
 @end
 
-@implementation KSMachHeader_Tests
+@implementation BSG_KSMachHeadersTests
 
 - (void)testAddRemoveHeaders {
     
@@ -88,10 +89,10 @@ const struct segment_command command2 = {
     bsg_mach_headers_add_image(&header2, 0);
     
     BSG_Mach_Header_Info *item;
-    item = bsg_mach_headers_image_at_address(111);
+    item = bsg_mach_headers_image_at_address(&header1);
     XCTAssertEqual(item->imageVmAddr, 111);
     
-    item = bsg_mach_headers_image_at_address(222);
+    item = bsg_mach_headers_image_at_address(&header2);
     XCTAssertEqual(item->imageVmAddr, 222);
 }
 
@@ -105,6 +106,29 @@ const struct segment_command command2 = {
     bsg_mach_headers_initialize();
 
     XCTAssert(bsg_mach_headers_get_main_image() != NULL);
+}
+
+- (void)testImageAtAddress {
+    bsg_mach_headers_initialize();
+    
+    for (NSNumber *number in NSThread.callStackReturnAddresses) {
+        uintptr_t address = number.unsignedIntegerValue;
+        BSG_Mach_Header_Info *image = bsg_mach_headers_image_at_address(address);
+        struct dl_info dlinfo = {0}; dladdr(address, &dlinfo);
+        if (dlinfo.dli_fbase) {
+            // If dladdr was able to locate the image, so should bsg_mach_headers_image_at_address
+            XCTAssertEqual(image->header, dlinfo.dli_fbase);
+            XCTAssertEqual(image->imageVmAddr + image->slide, (uint64_t)dlinfo.dli_fbase);
+            XCTAssertEqual(image->name, dlinfo.dli_fname);
+            XCTAssertFalse(image->unloaded);
+        } else {
+            XCTAssertEqual(image, NULL);
+        }
+    }
+    
+    XCTAssertEqual(bsg_mach_headers_image_at_address(0x0000000000000000), NULL);
+    XCTAssertEqual(bsg_mach_headers_image_at_address(0x0000000000001000), NULL);
+    XCTAssertEqual(bsg_mach_headers_image_at_address(0x7FFFFFFFFFFFFFFF), NULL);
 }
 
 @end


### PR DESCRIPTION
## Goal

Reduce overhead of calling `Bugsnag.notify()`

## Changeset

`bsg_mach_headers_image_at_address` now only compares the passed in address against the `__TEXT` segment of each image (using its precomputed `imageSize` value.)

This improves performance but means only addresses of executable code will be resolved. Since we only use this function against instruction addresses, this should not present a problem.

## Testing

Tested via unit and E2E tests.

In a simple test app, performance per call to `notify()` has been reduced from 3.8 ms to 2.8 ms 🎉 