### PR TITLE
Fix test flake in features/session_stopping.feature:21

### DIFF
--- a/Bugsnag/BugsnagSessionTracker.h
+++ b/Bugsnag/BugsnagSessionTracker.h
@@ -72,17 +72,10 @@ extern NSString *const BSGSessionUpdateNotification;
 
 /**
  Handle some variation of Bugsnag.notify() being called.
- Increases the number of handled errors recorded for the current session, if
+ Increments the number of handled or unhandled errors recorded for the current session, if
  a session exists.
  */
-- (void)handleHandledErrorEvent;
-
-/**
- Handled Bugsnag.notify() being called with an event with unhandled = YES.
- Increases the number of unhandled errors recorded for the current session, if
- a session exists.
- */
-- (void)handleUnhandledErrorEvent;
+- (void)incrementEventCountUnhandled:(BOOL)unhandled;
 
 /**
  * Retrieves the running session, or nil if the session is stopped or has not yet been started/resumed.

--- a/Bugsnag/BugsnagSessionTracker.m
+++ b/Bugsnag/BugsnagSessionTracker.m
@@ -202,7 +202,7 @@ NSString *const BSGSessionUpdateNotification = @"BugsnagSessionChanged";
     self.backgroundStartTime = nil;
 }
 
-- (void)handleHandledErrorEvent {
+- (void)incrementEventCountUnhandled:(BOOL)unhandled {
     BugsnagSession *session = [self runningSession];
 
     if (session == nil) {
@@ -210,23 +210,11 @@ NSString *const BSGSessionUpdateNotification = @"BugsnagSessionChanged";
     }
 
     @synchronized (session) {
-        session.handledCount++;
-        if (self.callback) {
-            self.callback(session);
+        if (unhandled) {
+            session.unhandledCount++;
+        } else {
+            session.handledCount++;
         }
-        [self postUpdateNotice];
-    }
-}
-
-- (void)handleUnhandledErrorEvent {
-    BugsnagSession *session = [self runningSession];
-
-    if (session == nil) {
-        return;
-    }
-
-    @synchronized (session) {
-        session.unhandledCount++;
         if (self.callback) {
             self.callback(session);
         }

--- a/Bugsnag/Client/BugsnagClient.m
+++ b/Bugsnag/Client/BugsnagClient.m
@@ -925,11 +925,7 @@ __attribute__((annotate("oclint:suppress[too many methods]")))
         [event notifyUnhandledOverridden];
     }
 
-    if (event.handledState.unhandled) {
-        [self.sessionTracker handleUnhandledErrorEvent];
-    } else {
-        [self.sessionTracker handleHandledErrorEvent];
-    }
+    [self.sessionTracker incrementEventCountUnhandled:event.handledState.unhandled];
     event.session = self.sessionTracker.runningSession;
 
     if (event.unhandled) {

--- a/Bugsnag/Client/BugsnagClient.m
+++ b/Bugsnag/Client/BugsnagClient.m
@@ -883,7 +883,7 @@ __attribute__((annotate("oclint:suppress[too many methods]")))
                                                 breadcrumbs:self.breadcrumbs.breadcrumbs ?: @[]
                                                      errors:@[error]
                                                     threads:threads
-                                                    session:self.sessionTracker.runningSession];
+                                                    session:nil /* the session's event counts have not yet been incremented! */];
     event.apiKey = self.configuration.apiKey;
     event.context = self.context;
     event.originalError = exception;
@@ -930,6 +930,7 @@ __attribute__((annotate("oclint:suppress[too many methods]")))
     } else {
         [self.sessionTracker handleHandledErrorEvent];
     }
+    event.session = self.sessionTracker.runningSession;
 
     if (event.unhandled) {
         // Unhandled Javscript exceptions from React Native result in the app being terminated shortly after the

--- a/Bugsnag/Payload/BugsnagEvent+Private.h
+++ b/Bugsnag/Payload/BugsnagEvent+Private.h
@@ -37,7 +37,7 @@ NS_ASSUME_NONNULL_BEGIN
 /// The release stage of the application
 @property (readwrite, copy, nullable, nonatomic) NSString *releaseStage;
 
-@property (strong, nullable, nonatomic) BugsnagSession *session;
+@property (copy, nullable, nonatomic) BugsnagSession *session;
 
 /// An array of string representations of BSGErrorType describing the types of stackframe / stacktrace in this error.
 @property (readonly, nonatomic) NSArray<NSString *> *stacktraceTypes;

--- a/Bugsnag/Payload/BugsnagEvent.m
+++ b/Bugsnag/Payload/BugsnagEvent.m
@@ -176,7 +176,7 @@ NSDictionary *BSGParseCustomException(NSDictionary *report,
         _breadcrumbs = breadcrumbs;
         _errors = errors;
         _threads = threads;
-        _session = session;
+        _session = [session copy];
     }
     return self;
 }

--- a/Bugsnag/Payload/BugsnagSession.m
+++ b/Bugsnag/Payload/BugsnagSession.m
@@ -104,6 +104,16 @@ static NSString *const kBugsnagUser = @"user";
     return self;
 }
 
+- (nonnull id)copyWithZone:(nullable __attribute__((unused)) NSZone *)zone {
+    return [[BugsnagSession alloc] initWithId:self.id
+                                    startDate:self.startedAt
+                                         user:self.user
+                                 handledCount:self.handledCount
+                               unhandledCount:self.unhandledCount
+                                          app:self.app
+                                       device:self.device];
+}
+
 - (NSDictionary *)toJson {
     NSMutableDictionary *dict = [NSMutableDictionary new];
     dict[kBugsnagSessionId] = self.id;

--- a/Bugsnag/include/Bugsnag/BugsnagSession.h
+++ b/Bugsnag/include/Bugsnag/BugsnagSession.h
@@ -17,7 +17,7 @@ NS_ASSUME_NONNULL_BEGIN
 /**
  * Represents a session of user interaction with your app.
  */
-@interface BugsnagSession : NSObject
+@interface BugsnagSession : NSObject <NSCopying>
 
 @property (copy, nonatomic) NSString *id;
 

--- a/Tests/BugsnagSessionTrackerTest.m
+++ b/Tests/BugsnagSessionTrackerTest.m
@@ -102,8 +102,8 @@
 - (void)testIncrementCounts {
 
     [self.sessionTracker startNewSession];
-    [self.sessionTracker handleHandledErrorEvent];
-    [self.sessionTracker handleHandledErrorEvent];
+    [self.sessionTracker incrementEventCountUnhandled:NO];
+    [self.sessionTracker incrementEventCountUnhandled:NO];
 
     BugsnagSession *session = self.sessionTracker.runningSession;
     XCTAssertNotNil(session);
@@ -116,11 +116,11 @@
     XCTAssertEqual(0, session.handledCount);
     XCTAssertEqual(0, session.unhandledCount);
 
-    [self.sessionTracker handleUnhandledErrorEvent];
+    [self.sessionTracker incrementEventCountUnhandled:YES];
     XCTAssertEqual(0, session.handledCount);
     XCTAssertEqual(1, session.unhandledCount);
 
-    [self.sessionTracker handleHandledErrorEvent];
+    [self.sessionTracker incrementEventCountUnhandled:NO];
     XCTAssertEqual(1, session.handledCount);
     XCTAssertEqual(1, session.unhandledCount);
 }


### PR DESCRIPTION
## Goal

Fix an E2E test flake in `features/session_stopping.feature:21` caused by an event's session `handledCount` being incremented by a subsequent call to `notify()`.

Recent performance improvements have made this more likely to occur before the event uploader builds the JSON payload.

## Changeset

A copy of the current session is now stored in `BugsnagEvent` so that subsequent calls to `notify()` will not alter previous events' sessions.

Removed some code duplication by consolidating handled and unhandled increments into `-incrementEventCountUnhandled:`

## Testing

Reproduced by running the scenario locally.

Verified fix with a full E2E run - https://buildkite.com/bugsnag/bugsnag-cocoa/builds/2742