### PR TITLE
[PLAT-6614] Stop session being reported if app is launched in the background

### DIFF
--- a/Bugsnag/BugsnagSessionTracker.m
+++ b/Bugsnag/BugsnagSessionTracker.m
@@ -195,8 +195,8 @@ NSString *const BSGSessionUpdateNotification = @"BugsnagSessionChanged";
 }
 
 - (void)handleAppForegroundEvent {
-    if (self.backgroundStartTime
-        && [[NSDate date] timeIntervalSinceDate:self.backgroundStartTime] >= BSGNewSessionBackgroundDuration) {
+    if (!self.currentSession ||
+        (self.backgroundStartTime && [[NSDate date] timeIntervalSinceDate:self.backgroundStartTime] >= BSGNewSessionBackgroundDuration)) {
         [self startNewSessionIfAutoCaptureEnabled];
     }
     self.backgroundStartTime = nil;

--- a/Bugsnag/Client/BugsnagClient.m
+++ b/Bugsnag/Client/BugsnagClient.m
@@ -403,13 +403,15 @@ __attribute__((annotate("oclint:suppress[too many methods]")))
 
     self.started = YES;
 
-    [self.sessionTracker startNewSessionIfAutoCaptureEnabled];
+    if (bsg_kscrashstate_currentState()->applicationIsInForeground) {
+        [self.sessionTracker startNewSessionIfAutoCaptureEnabled];
+    } else {
+        bsg_log_debug(@"Not starting session because app is not in the foreground");
+    }
 
     // Record a "Bugsnag Loaded" message
     [self addAutoBreadcrumbOfType:BSGBreadcrumbTypeState withMessage:@"Bugsnag loaded" andMetadata:nil];
 
-    // notification not received in time on initial startup, so trigger manually
-    [self willEnterForeground:self];
     [self.pluginClient loadPlugins];
     
     if (self.configuration.launchDurationMillis > 0) {

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,9 @@ Changelog
 
 ### Bug fixes
 
+* Stop session being reported if app is launched in the background.
+  [#1107](https://github.com/bugsnag/bugsnag-cocoa/pull/1107)
+
 * Fix KSCrash state storage for apps with no CFBundleName.
   [#1103](https://github.com/bugsnag/bugsnag-cocoa/pull/1103)
 


### PR DESCRIPTION
## Goal

A session should not be reported if an app was started in the background (for example to perform a background fetch.)

Only once a user opens the app (and it moves to the foreground) should a session be recorded.

## Changeset

`BugsnagClient` now checks whether the app is in the foreground before starting a session.

`BugsnagSessionTracker` now starts a session as soon as the app moves into the foreground if there was no previous session.

## Testing

Manual testing only because it's not possible to trigger a background launch via Appium.

In one of the example Xcode projects, add the background fetch capability and then in the scheme's run options enable the Background Fetch option. Note: this only works when debugging an app.

E2E tests verify that automatic sessions reporting still works when an app is launched in the foreground.