### PR TITLE
Fix test flakes in macOS stress test and BugsnagKVStoreTest

### DIFF
--- a/Bugsnag/Helpers/BugsnagKVStore.c
+++ b/Bugsnag/Helpers/BugsnagKVStore.c
@@ -53,6 +53,8 @@ void bsgkv_open(const char* path, int* err) {
 
     g_currentDirFD = dirfd(g_currentDir);
     if(g_currentDirFD < 0) {
+        closedir(g_currentDir);
+        g_currentDir = NULL;
         *err = errno;
         return;
     }
@@ -63,13 +65,12 @@ void bsgkv_open(const char* path, int* err) {
 }
 
 void bsgkv_close(void) {
-    if(g_currentDirFD != 0) {
-        close(g_currentDirFD);
-        g_currentDirFD = 0;
-    }
     if(g_currentDir != NULL) {
         closedir(g_currentDir);
         g_currentDir = NULL;
+        // Note: closedir() closes the underlying file descriptor.
+        // Attempting to close it again is a programming error.
+        g_currentDirFD = 0;
     }
 }
 


### PR DESCRIPTION
## Changeset

### macOS stress test

The macOS stress test would occasionally fail due a partial HTTP request being received by maze runner. This would happen because the test fixture could exit during an upload.

The fixture now waits for all uploads to complete before exiting.

Tested manually.

### BugsnagKVStoreTest

`BugsnagKVStoreTest` would occasionally fail with an `EXC_GUARD` crash.

After examining some crash reports and the code, the cause seems to be `bsgkv_close()` erroneously closing the `DIR`'s file descriptor, which it should not do since `closedir()` [already does this](https://opensource.apple.com/source/Libc/Libc-1439.40.11/gen/FreeBSD/closedir.c.auto.html). `dirfd()` simply [returns the existing file descriptor](https://opensource.apple.com/source/Libc/Libc-1439.40.11/gen/dirfd.c.auto.html), it does not create a new one that needs to be closed.

`bsgkv_close()` now does not `close()` the file descriptor.

Fixed a potential file descripor leak in `bsgkv_open()`'s error handling.

An additional unit test has been added to check for potential file descriptor leaks.