### PR TITLE
Fix features/unhandled_cpp_exception.feature

### DIFF
--- a/features/unhandled_cpp_exception.feature
+++ b/features/unhandled_cpp_exception.feature
@@ -10,7 +10,7 @@ Feature: Thrown C++ exceptions are captured by Bugsnag
     Then the error is valid for the error reporting API
     And the exception "errorClass" equals "P16kaboom_exception"
     And the exception "type" equals "cocoa"
-    And the error payload field "events.0.exceptions.0.stacktrace" is an array with 0 elements
+    And the stacktrace is valid for the event
     And the event "severity" equals "error"
     And the event "unhandled" is true
     And the event "severityReason.type" equals "unhandledException"
@@ -22,7 +22,7 @@ Feature: Thrown C++ exceptions are captured by Bugsnag
     Then the error is valid for the error reporting API
     And the exception "errorClass" equals "P16kaboom_exception"
     And the exception "type" equals "cocoa"
-    And the error payload field "events.0.exceptions.0.stacktrace" is an array with 0 elements
+    And the stacktrace is valid for the event
     And the event "severity" equals "error"
     And the event "unhandled" is false
     And the event "severityReason.unhandledOverridden" is true


### PR DESCRIPTION
## Goal

Fix a test failure in `features/unhandled_cpp_exception.feature`.

Linking Bugsnag statically #1110 inadvertently fixed C++ exception stacktrace recording on iOS 10, 11 and 12. Since the test was coded to expect an empty stacktrace, it started failing.

## Changeset

Use `the stacktrace is valid for the event` instead to verify the correctness of any stack frames.

## Testing

Tested by [running the test scenarios on BrowserStack](https://app-automate.browserstack.com/dashboard/v2/builds/d386c5ef3037a12860a567208aec3efca66778d7/sessions/be2b4c725607767bd12ee5b22226e6c70a080ce1?buildUserIds=4435777).