### PR TITLE
[PLAT-6708] Stop app hangs being reported if app is launched in the background

### DIFF
--- a/Bugsnag/KSCrash/Source/KSCrash/Recording/BSG_KSCrash.m
+++ b/Bugsnag/KSCrash/Source/KSCrash/Recording/BSG_KSCrash.m
@@ -176,10 +176,6 @@
     free(crashReportPath);
     free(recrashReportPath);
     
-    if (!installedCrashTypes) {
-        return 0;
-    }
-    
     NSNotificationCenter *nCenter = [NSNotificationCenter defaultCenter];
 #if BSG_HAS_UIKIT
     [nCenter addObserver:self

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,9 @@ Changelog
 
 ### Bug fixes
 
+* Stop app hangs being reported if app is launched in the background.
+  [#1112](https://github.com/bugsnag/bugsnag-cocoa/pull/1112)
+
 * Stop session being reported if app is launched in the background.
   [#1107](https://github.com/bugsnag/bugsnag-cocoa/pull/1107)
 


### PR DESCRIPTION
## Goal

The intention behind #1075 was to ignore all app hangs that occur while an app in is the background. The initial state of the app was not being taken into account, though, resulting in app hags being reported if an app is launched for a background fetch or other background activity.

## Changeset

The app hang detector now uses `applicationIsInForeground` from `BSG_KSCrash_State` which is correctly initialised at start-up.

Updated `BSG_KSCrash.m` to ensure the `applicationIsInForeground` value is updated even is none of KSCrash's sentries are installed.

## Testing

Tested manually. Not tested via E2E because it's not possible to trigger a background launch via Appium.