### PR TITLE
Xcode 13 beta fixes

### DIFF
--- a/Bugsnag/KSCrash/Source/KSCrash/Recording/Tools/BSG_KSJSONCodec.c
+++ b/Bugsnag/KSCrash/Source/KSCrash/Recording/Tools/BSG_KSJSONCodec.c
@@ -345,7 +345,7 @@ int bsg_ksjsoncodec_i_appendEscapedString(
             // see https://www.ietf.org/rfc/rfc4627.txt
 
             if ((unsigned char)*src < ' ') {
-                unsigned int last = *src % 16;
+                unsigned int last = (unsigned int)*src % 16;
                 unsigned int first = ((unsigned int)*src - last) / 16;
 
                 *dst++ = '\\';

--- a/Tests/BSGConfigurationBuilderTests.m
+++ b/Tests/BSGConfigurationBuilderTests.m
@@ -52,7 +52,7 @@
     XCTAssertNotNil(config);
     XCTAssertEqualObjects(DUMMY_APIKEY_32CHAR_1, config.apiKey);
     XCTAssertNotNil(config.appType);
-    XCTAssertNil(config.appVersion);
+    XCTAssertEqualObjects(config.appVersion, NSBundle.mainBundle.infoDictionary[@"CFBundleShortVersionString"]);
     XCTAssertTrue(config.autoDetectErrors);
     XCTAssertTrue(config.autoTrackSessions);
     XCTAssertEqual(config.maxPersistedEvents, 32);

--- a/Tests/BugsnagConfigurationTests.m
+++ b/Tests/BugsnagConfigurationTests.m
@@ -615,7 +615,7 @@ NSString * const kBugsnagUserUserId = @"BugsnagUserUserId";
     XCTAssertEqualObjects(@"macOS", config.appType);
 #endif
 
-    XCTAssertNil(config.appVersion);
+    XCTAssertEqualObjects(config.appVersion, NSBundle.mainBundle.infoDictionary[@"CFBundleShortVersionString"]);
     XCTAssertTrue(config.autoDetectErrors);
     XCTAssertTrue(config.autoTrackSessions);
     XCTAssertEqualObjects(NSBundle.mainBundle.infoDictionary[@"CFBundleVersion"], config.bundleVersion);

--- a/Tests/BugsnagStackframeTest.m
+++ b/Tests/BugsnagStackframeTest.m
@@ -183,6 +183,7 @@
 }
 
 - (void)testRealCallStackSymbols {
+    bsg_mach_headers_initialize();
     bsg_mach_headers_register_for_changes(); // Ensure call stack can be symbolicated
     
     NSArray<NSString *> *callStackSymbols = [NSThread callStackSymbols];
@@ -197,6 +198,19 @@
             (stackframe.machoLoadAddress == nil || stackframe.symbolAddress == nil)) {
             // The last callStackSymbol is often not in any Mach-O image, e.g.
             // "41  ???                                 0x0000000000000005 0x0 + 5"
+            return;
+        }
+        if (!stackframe.machoUuid && [stackframe.method isEqualToString:@"start_sim"]) {
+            // With Xcode 13 beta's iOS 15 Simulator, the stack trace ends with e.g.
+            //   xctest                              0x00000001030b03ae main + 256,
+            //   dyld                                0x00000001030bfe1e start_sim + 10,
+            //   ???                                 0x0000000000000001 0x0 + 1,
+            //   ???                                 0x0000000000000001 0x0 + 1
+            //
+            // `start_sim` is actually located in dyld_sim according to lldb's `image lookup --address` command
+            // but this image does not show up in the headers returned by `_dyld_get_image_header()`. `dladdr()`
+            // reports this symbol as being in /usr/lib/dyld
+            *stop = YES;
             return;
         }
         XCTAssertNotNil(stackframe.machoUuid);

--- a/Tests/KSCrash/BSG_KSMachHeadersTests.m
+++ b/Tests/KSCrash/BSG_KSMachHeadersTests.m
@@ -114,8 +114,8 @@ const struct segment_command command2 = {
     for (NSNumber *number in NSThread.callStackReturnAddresses) {
         uintptr_t address = number.unsignedIntegerValue;
         BSG_Mach_Header_Info *image = bsg_mach_headers_image_at_address(address);
-        struct dl_info dlinfo = {0}; dladdr(address, &dlinfo);
-        if (dlinfo.dli_fbase) {
+        struct dl_info dlinfo = {0};
+        if (dladdr(address, &dlinfo) != 0) {
             // If dladdr was able to locate the image, so should bsg_mach_headers_image_at_address
             XCTAssertEqual(image->header, dlinfo.dli_fbase);
             XCTAssertEqual(image->imageVmAddr + image->slide, (uint64_t)dlinfo.dli_fbase);


### PR DESCRIPTION
## Goal

Fixes build & unit testing with Xcode 13 beta

## Changeset

Fixes a small compiler warning in `BSG_KSJSONCodec.c`

Fixes test failures due to the `xctest` binary in Xcode 13 having a `CFBundleShortVersionString`.

Works around an issue where the notifier finds to locate the image for the `start_sim` symbol. There are some comments in the code to explain this, and it may warrant further investigation, but it appears to be a quirk in how dyld is implemented in the new iOS Simulator.

Fixes a crash in `-[BSG_KSMachHeadersTests testImageAtAddress]` - it appears that `dladdr()` will set some value in the struct even if it cannot find the image containing the address.

## Testing

Tested manually using Xcode 13 beta.

GitHub actions will soon have Xcode 13 beta available for CI but at the time of writing it has not finished rolling out.