### PR TITLE
Minor improvements

### DIFF
--- a/.github/workflows/unit_tests.yml
+++ b/.github/workflows/unit_tests.yml
@@ -6,11 +6,11 @@ on: [push]
 
 jobs:
   build:
-    runs-on: macos-11.0
+    runs-on: macos-11
     env:
-      DEVELOPER_DIR: /Applications/Xcode_12.5.app
+      DEVELOPER_DIR: /Applications/Xcode_13.0.app
       PLATFORM: iOS
-      OS: 14.5
+      OS: "15.0"
     steps:
       - name: Checkout
         uses: actions/checkout@v2

--- a/Bugsnag.xcconfig
+++ b/Bugsnag.xcconfig
@@ -11,6 +11,7 @@ CLANG_WARN_ASSIGN_ENUM                                 = YES // -Wassign-enum
 CLANG_WARN_BLOCK_CAPTURE_AUTORELEASING                 = YES // -Wblock-capture-autoreleasing
 CLANG_WARN_BOOL_CONVERSION                             = YES // -Wbool-conversion
 CLANG_WARN_COMMA                                       = YES // -Wcomma
+CLANG_WARN_COMPLETION_HANDLER_MISUSE                   = YES // -Wcompletion-handler
 CLANG_WARN_CONSTANT_CONVERSION                         = YES // -Wconstant-conversion
 CLANG_WARN_DOCUMENTATION_COMMENTS                      = YES // -Wdocumentation
 CLANG_WARN_EMPTY_BODY                                  = YES // -Wempty-body

--- a/Bugsnag/Delivery/BSGEventUploader.m
+++ b/Bugsnag/Delivery/BSGEventUploader.m
@@ -71,6 +71,9 @@
     NSUInteger operationCount = self.uploadQueue.operationCount;
     if (operationCount >= self.configuration.maxPersistedEvents) {
         bsg_log_warn(@"Dropping notification, %lu outstanding requests", (unsigned long)operationCount);
+        if (completionHandler) {
+            completionHandler();
+        }
         return;
     }
     BSGEventUploadObjectOperation *operation = [[BSGEventUploadObjectOperation alloc] initWithEvent:event delegate:self];

--- a/Bugsnag/Payload/BugsnagBreadcrumb+Private.h
+++ b/Bugsnag/Payload/BugsnagBreadcrumb+Private.h
@@ -18,6 +18,9 @@ NS_ASSUME_NONNULL_BEGIN
 
 - (nullable NSDictionary *)objectValue;
 
+/// String representation of `timestamp` used to avoid unnecessary date <--> string conversions
+@property (copy, nullable, nonatomic) NSString *timestampString;
+
 @end
 
 FOUNDATION_EXPORT NSString *BSGBreadcrumbTypeValue(BSGBreadcrumbType type);

--- a/Bugsnag/Payload/BugsnagBreadcrumb.m
+++ b/Bugsnag/Payload/BugsnagBreadcrumb.m
@@ -79,9 +79,6 @@ BSGBreadcrumbType BSGBreadcrumbTypeFromString(NSString *value) {
 
 @property (readwrite, nullable, nonatomic) NSDate *timestamp;
 
-/// String representation of `timestamp` used to avoid unnecessary date <--> string conversions
-@property (copy, nonatomic) NSString *timestampString;
-
 @end
 
 

--- a/Tests/KSCrash/BSG_KSMachHeadersTests.m
+++ b/Tests/KSCrash/BSG_KSMachHeadersTests.m
@@ -105,7 +105,9 @@ const struct segment_command command2 = {
 - (void)testMainImage {
     bsg_mach_headers_initialize();
 
-    XCTAssert(bsg_mach_headers_get_main_image() != NULL);
+    BSG_Mach_Header_Info *image = bsg_mach_headers_get_main_image();
+    XCTAssert(image != NULL);
+    XCTAssertEqualObjects(@(image ? image->name : ""), NSBundle.mainBundle.executablePath);
 }
 
 - (void)testImageAtAddress {


### PR DESCRIPTION
Fixes a flake in `-[BugsnagBreadcrumbsTest testBreadcrumbsBeforeDate]` caused by limited breadcrumb timestamp precision.

Improves the thoroughness of `-[BSG_KSMachHeadersTests testMainImage]` by checking that `bsg_mach_headers_get_main_image()` agrees with `NSBundle.mainBundle`.

Updates our GitHub action to run unit tests with Xcode 13 / iOS 15 beta.

Enables Xcode 13's new `CLANG_WARN_COMPLETION_HANDLER_MISUSE` (`-Wcompletion-handler`) warning and fixes an issue identified by it.