### PR TITLE
Fix unit test flake in -[BSG_KSMachHeadersTests testMainImage]

### DIFF
--- a/Bugsnag/KSCrash/Source/KSCrash/Recording/Tools/BSG_KSMachHeaders.c
+++ b/Bugsnag/KSCrash/Source/KSCrash/Recording/Tools/BSG_KSMachHeaders.c
@@ -165,7 +165,7 @@ bool bsg_mach_headers_populate_info(const struct mach_header *header, intptr_t s
 }
 
 void bsg_mach_headers_add_image(const struct mach_header *header, intptr_t slide) {
-    BSG_Mach_Header_Info *newImage = malloc(sizeof(BSG_Mach_Header_Info));
+    BSG_Mach_Header_Info *newImage = calloc(1, sizeof(BSG_Mach_Header_Info));
     if (newImage != NULL) {
         if (bsg_mach_headers_populate_info(header, slide, newImage)) {
             dispatch_sync(bsg_g_serial_queue, ^{


### PR DESCRIPTION
## Goal

Fixes a unit test failure that occurs on iOS 15 Simulator / Xcode 13 beta

`bsg_mach_headers_get_main_image()` was sometimes returning `libMainThreadChecker.dylib` instead of `xctest`.

## Changeset

The root cause was `BSG_Mach_Header_Info.isMain` being left uninitialised for non-main images.

The `BSG_Mach_Header_Info` struct is now initialised to 0 by using `calloc` to fix this issue and prevent similar ones in the future.

## Testing

Was able to reproduce with Xcode 13's new "Run Repeatedly..." function and verify the fix.

GitHub Unit Tests action now passing ✅ 