### PR TITLE
[PLAT-6798] Improve breadcrumbs performance with async file I/O

### DIFF
--- a/Bugsnag.xcodeproj/project.pbxproj
+++ b/Bugsnag.xcodeproj/project.pbxproj
@@ -675,6 +675,13 @@
 		01B14C57251CE55F00118748 /* report-react-native-promise-rejection.json in Resources */ = {isa = PBXBuildFile; fileRef = 01B14C55251CE55F00118748 /* report-react-native-promise-rejection.json */; };
 		01B14C58251CE55F00118748 /* report-react-native-promise-rejection.json in Resources */ = {isa = PBXBuildFile; fileRef = 01B14C55251CE55F00118748 /* report-react-native-promise-rejection.json */; };
 		01B6BB7E25D5777F00FC4DE6 /* BugsnagSwiftPublicAPITests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 008966B02486D43500DC48C2 /* BugsnagSwiftPublicAPITests.swift */; };
+		01B79DA9267CC4A000C8CC5E /* BSGGlobals.h in Headers */ = {isa = PBXBuildFile; fileRef = 01B79DA7267CC4A000C8CC5E /* BSGGlobals.h */; };
+		01B79DAA267CC4A000C8CC5E /* BSGGlobals.h in Headers */ = {isa = PBXBuildFile; fileRef = 01B79DA7267CC4A000C8CC5E /* BSGGlobals.h */; };
+		01B79DAB267CC4A000C8CC5E /* BSGGlobals.h in Headers */ = {isa = PBXBuildFile; fileRef = 01B79DA7267CC4A000C8CC5E /* BSGGlobals.h */; };
+		01B79DAC267CC4A000C8CC5E /* BSGGlobals.m in Sources */ = {isa = PBXBuildFile; fileRef = 01B79DA8267CC4A000C8CC5E /* BSGGlobals.m */; };
+		01B79DAD267CC4A000C8CC5E /* BSGGlobals.m in Sources */ = {isa = PBXBuildFile; fileRef = 01B79DA8267CC4A000C8CC5E /* BSGGlobals.m */; };
+		01B79DAE267CC4A000C8CC5E /* BSGGlobals.m in Sources */ = {isa = PBXBuildFile; fileRef = 01B79DA8267CC4A000C8CC5E /* BSGGlobals.m */; };
+		01B79DAF267CC4A000C8CC5E /* BSGGlobals.m in Sources */ = {isa = PBXBuildFile; fileRef = 01B79DA8267CC4A000C8CC5E /* BSGGlobals.m */; };
 		01BDB1F525DEBFB200A91FAF /* BSGEventUploadKSCrashReportOperationTests.m in Sources */ = {isa = PBXBuildFile; fileRef = 01BDB1CE25DEBF4600A91FAF /* BSGEventUploadKSCrashReportOperationTests.m */; };
 		01BDB1FD25DEBFB300A91FAF /* BSGEventUploadKSCrashReportOperationTests.m in Sources */ = {isa = PBXBuildFile; fileRef = 01BDB1CE25DEBF4600A91FAF /* BSGEventUploadKSCrashReportOperationTests.m */; };
 		01BDB20525DEBFB300A91FAF /* BSGEventUploadKSCrashReportOperationTests.m in Sources */ = {isa = PBXBuildFile; fileRef = 01BDB1CE25DEBF4600A91FAF /* BSGEventUploadKSCrashReportOperationTests.m */; };
@@ -1316,6 +1323,8 @@
 		0195FC3B256BC81400DE6646 /* BugsnagEvent+Private.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; path = "BugsnagEvent+Private.h"; sourceTree = "<group>"; };
 		0198762E2567D5AB000A7AF3 /* BugsnagStackframe+Private.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; path = "BugsnagStackframe+Private.h"; sourceTree = "<group>"; };
 		01B14C55251CE55F00118748 /* report-react-native-promise-rejection.json */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = text.json; path = "report-react-native-promise-rejection.json"; sourceTree = "<group>"; };
+		01B79DA7267CC4A000C8CC5E /* BSGGlobals.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; path = BSGGlobals.h; sourceTree = "<group>"; };
+		01B79DA8267CC4A000C8CC5E /* BSGGlobals.m */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.objc; path = BSGGlobals.m; sourceTree = "<group>"; };
 		01BDB1CE25DEBF4600A91FAF /* BSGEventUploadKSCrashReportOperationTests.m */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.objc; path = BSGEventUploadKSCrashReportOperationTests.m; sourceTree = "<group>"; };
 		01BDB21425DEC02900A91FAF /* Data */ = {isa = PBXFileReference; lastKnownFileType = folder; path = Data; sourceTree = "<group>"; };
 		01C17AE62542ED7F00C102C9 /* KSCrashReportWriterTests.m */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.objc; path = KSCrashReportWriterTests.m; sourceTree = "<group>"; };
@@ -1820,6 +1829,8 @@
 				010FF28225ED2A8D00E4F2B0 /* BSGAppHangDetector.h */,
 				010FF28325ED2A8D00E4F2B0 /* BSGAppHangDetector.m */,
 				019480C42625EE9800E833ED /* BSGAppKit.h */,
+				01B79DA7267CC4A000C8CC5E /* BSGGlobals.h */,
+				01B79DA8267CC4A000C8CC5E /* BSGGlobals.m */,
 				01847D942644140F00ADA4C7 /* BSGInternalErrorReporter.h */,
 				01847D952644140F00ADA4C7 /* BSGInternalErrorReporter.m */,
 				CBCF77A125010648004AF22A /* BSGJSONSerialization.h */,
@@ -2031,6 +2042,7 @@
 				008969F02486DAD100DC48C2 /* BSG_KSCrashReportFields.h in Headers */,
 				00896A2F2486DAD100DC48C2 /* BSG_KSCrashIdentifier.h in Headers */,
 				008969FC2486DAD100DC48C2 /* BSG_KSCrashAdvanced.h in Headers */,
+				01B79DA9267CC4A000C8CC5E /* BSGGlobals.h in Headers */,
 				008967B82486D9D800DC48C2 /* BugsnagBreadcrumbs.h in Headers */,
 				008969DE2486DAD100DC48C2 /* BSG_KSCrashC.h in Headers */,
 				0089699F2486DAD100DC48C2 /* BSG_KSJSONCodecObjC.h in Headers */,
@@ -2133,6 +2145,7 @@
 				008969F12486DAD100DC48C2 /* BSG_KSCrashReportFields.h in Headers */,
 				00896A302486DAD100DC48C2 /* BSG_KSCrashIdentifier.h in Headers */,
 				008969FD2486DAD100DC48C2 /* BSG_KSCrashAdvanced.h in Headers */,
+				01B79DAA267CC4A000C8CC5E /* BSGGlobals.h in Headers */,
 				008967B92486D9D800DC48C2 /* BugsnagBreadcrumbs.h in Headers */,
 				008969DF2486DAD100DC48C2 /* BSG_KSCrashC.h in Headers */,
 				008969A02486DAD100DC48C2 /* BSG_KSJSONCodecObjC.h in Headers */,
@@ -2235,6 +2248,7 @@
 				008969F22486DAD100DC48C2 /* BSG_KSCrashReportFields.h in Headers */,
 				00896A312486DAD100DC48C2 /* BSG_KSCrashIdentifier.h in Headers */,
 				008969FE2486DAD100DC48C2 /* BSG_KSCrashAdvanced.h in Headers */,
+				01B79DAB267CC4A000C8CC5E /* BSGGlobals.h in Headers */,
 				008967BA2486D9D800DC48C2 /* BugsnagBreadcrumbs.h in Headers */,
 				008969E02486DAD100DC48C2 /* BSG_KSCrashC.h in Headers */,
 				008969A12486DAD100DC48C2 /* BSG_KSJSONCodecObjC.h in Headers */,
@@ -2622,6 +2636,7 @@
 				CBE9062D25A34DAB0045B965 /* BSGStorageMigratorV0V1.m in Sources */,
 				010FF28725ED2A8D00E4F2B0 /* BSGAppHangDetector.m in Sources */,
 				00896A352486DAD100DC48C2 /* BSG_KSSystemInfo.m in Sources */,
+				01B79DAC267CC4A000C8CC5E /* BSGGlobals.m in Sources */,
 				008969E42486DAD100DC48C2 /* BSG_KSCrashIdentifier.m in Sources */,
 				008967DA2486DA2D00DC48C2 /* BugsnagConfiguration.m in Sources */,
 				008969A52486DAD100DC48C2 /* BSG_KSBacktrace.c in Sources */,
@@ -2790,6 +2805,7 @@
 				CBE9062E25A34DAB0045B965 /* BSGStorageMigratorV0V1.m in Sources */,
 				010FF28825ED2A8D00E4F2B0 /* BSGAppHangDetector.m in Sources */,
 				00896A362486DAD100DC48C2 /* BSG_KSSystemInfo.m in Sources */,
+				01B79DAD267CC4A000C8CC5E /* BSGGlobals.m in Sources */,
 				008969E52486DAD100DC48C2 /* BSG_KSCrashIdentifier.m in Sources */,
 				008967DB2486DA2D00DC48C2 /* BugsnagConfiguration.m in Sources */,
 				008969A62486DAD100DC48C2 /* BSG_KSBacktrace.c in Sources */,
@@ -2957,6 +2973,7 @@
 				CBE9062F25A34DAB0045B965 /* BSGStorageMigratorV0V1.m in Sources */,
 				010FF28925ED2A8D00E4F2B0 /* BSGAppHangDetector.m in Sources */,
 				00896A372486DAD100DC48C2 /* BSG_KSSystemInfo.m in Sources */,
+				01B79DAE267CC4A000C8CC5E /* BSGGlobals.m in Sources */,
 				008969E62486DAD100DC48C2 /* BSG_KSCrashIdentifier.m in Sources */,
 				008967DC2486DA2D00DC48C2 /* BugsnagConfiguration.m in Sources */,
 				008969A72486DAD100DC48C2 /* BSG_KSBacktrace.c in Sources */,
@@ -3123,6 +3140,7 @@
 				00AD1F262486A17900A27979 /* Bugsnag.m in Sources */,
 				008968CE2486DA9600DC48C2 /* BugsnagThread.m in Sources */,
 				00AD1F312486A17900A27979 /* BugsnagSessionTracker.m in Sources */,
+				01B79DAF267CC4A000C8CC5E /* BSGGlobals.m in Sources */,
 				008968C62486DA9600DC48C2 /* BugsnagUser.m in Sources */,
 				CBB0928F2519F891007698BC /* BugsnagSystemState.m in Sources */,
 				008968AE2486DA9600DC48C2 /* BugsnagStateEvent.m in Sources */,

--- a/Bugsnag.xcodeproj/xcshareddata/xcbaselines/00AD1CB424869C1200A27979.xcbaseline/7E1A1286-DD8C-4E45-9E88-4335CD976176.plist
+++ b/Bugsnag.xcodeproj/xcshareddata/xcbaselines/00AD1CB424869C1200A27979.xcbaseline/7E1A1286-DD8C-4E45-9E88-4335CD976176.plist
@@ -1,0 +1,22 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
+<plist version="1.0">
+<dict>
+	<key>classNames</key>
+	<dict>
+		<key>BugsnagBreadcrumbsTest</key>
+		<dict>
+			<key>testPerformance</key>
+			<dict>
+				<key>com.apple.XCTPerformanceMetric_WallClockTime</key>
+				<dict>
+					<key>baselineAverage</key>
+					<real>0.00675</real>
+					<key>baselineIntegrationDisplayName</key>
+					<string>Local Baseline</string>
+				</dict>
+			</dict>
+		</dict>
+	</dict>
+</dict>
+</plist>

--- a/Bugsnag.xcodeproj/xcshareddata/xcbaselines/00AD1CB424869C1200A27979.xcbaseline/Info.plist
+++ b/Bugsnag.xcodeproj/xcshareddata/xcbaselines/00AD1CB424869C1200A27979.xcbaseline/Info.plist
@@ -1,0 +1,33 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
+<plist version="1.0">
+<dict>
+	<key>runDestinationsByUUID</key>
+	<dict>
+		<key>7E1A1286-DD8C-4E45-9E88-4335CD976176</key>
+		<dict>
+			<key>localComputer</key>
+			<dict>
+				<key>busSpeedInMHz</key>
+				<integer>400</integer>
+				<key>cpuCount</key>
+				<integer>1</integer>
+				<key>cpuKind</key>
+				<string>8-Core Intel Core i9</string>
+				<key>cpuSpeedInMHz</key>
+				<integer>2300</integer>
+				<key>logicalCPUCoresPerPackage</key>
+				<integer>16</integer>
+				<key>modelCode</key>
+				<string>MacBookPro16,1</string>
+				<key>physicalCPUCoresPerPackage</key>
+				<integer>8</integer>
+				<key>platformIdentifier</key>
+				<string>com.apple.platform.macosx</string>
+			</dict>
+			<key>targetArchitecture</key>
+			<string>x86_64</string>
+		</dict>
+	</dict>
+</dict>
+</plist>

--- a/Bugsnag/Breadcrumbs/BugsnagBreadcrumbs.h
+++ b/Bugsnag/Breadcrumbs/BugsnagBreadcrumbs.h
@@ -39,6 +39,13 @@ NS_ASSUME_NONNULL_BEGIN
  */
 - (void)addBreadcrumbWithBlock:(BSGBreadcrumbConfiguration)block;
 
+/**
+ * Store a new serialized breadcrumb.
+ *
+ * This method is not intended to be used from other classes, it is exposed to facilitate unit testing.
+ */
+- (void)addBreadcrumbWithData:(NSData *)data writeToDisk:(BOOL)writeToDisk;
+
 - (NSArray<BugsnagBreadcrumb *> *)breadcrumbsBeforeDate:(NSDate *)date;
 
 /**
@@ -65,6 +72,7 @@ NS_ASSUME_NONNULL_END
 /**
  * Inserts the current breadcrumbs into a crash report.
  *
- * This function is async-signal-safe.
+ * This function is async-signal-safe, but requires that any threads that could be adding
+ * breadcrumbs are suspended.
  */
 void BugsnagBreadcrumbsWriteCrashReport(const BSG_KSCrashReportWriter * _Nonnull writer);

--- a/Bugsnag/Breadcrumbs/BugsnagBreadcrumbs.h
+++ b/Bugsnag/Breadcrumbs/BugsnagBreadcrumbs.h
@@ -54,11 +54,6 @@ NS_ASSUME_NONNULL_BEGIN
 - (NSArray<BugsnagBreadcrumb *> *)cachedBreadcrumbs;
 
 /**
- * Used by the unit tests.
- */
-- (nullable NSArray *)loadBreadcrumbsAsDictionaries:(BOOL)asDictionaries;
-
-/**
  * Removes breadcrumbs from disk.
  */
 - (void)removeAllBreadcrumbs;

--- a/Bugsnag/Breadcrumbs/BugsnagBreadcrumbs.h
+++ b/Bugsnag/Breadcrumbs/BugsnagBreadcrumbs.h
@@ -23,7 +23,7 @@ NS_ASSUME_NONNULL_BEGIN
 - (instancetype)initWithConfiguration:(BugsnagConfiguration *)config;
 
 /**
- * The current breadcrumbs, loaded from disk.
+ * The breadcrumbs stored in memory.
  */
 @property (readonly, nonatomic) NSArray<BugsnagBreadcrumb *> *breadcrumbs;
 
@@ -42,9 +42,14 @@ NS_ASSUME_NONNULL_BEGIN
 - (NSArray<BugsnagBreadcrumb *> *)breadcrumbsBeforeDate:(NSDate *)date;
 
 /**
- * Returns the breadcrumb JSON dictionaries stored on disk.
+ * The breadcrumb stored on disk.
  */
-- (nullable NSArray<NSDictionary *> *)cachedBreadcrumbs;
+- (NSArray<BugsnagBreadcrumb *> *)cachedBreadcrumbs;
+
+/**
+ * Used by the unit tests.
+ */
+- (nullable NSArray *)loadBreadcrumbsAsDictionaries:(BOOL)asDictionaries;
 
 /**
  * Removes breadcrumbs from disk.

--- a/Bugsnag/Breadcrumbs/BugsnagBreadcrumbs.m
+++ b/Bugsnag/Breadcrumbs/BugsnagBreadcrumbs.m
@@ -114,7 +114,10 @@ static struct bsg_breadcrumb_list_item *g_breadcrumbs_head;
     if (!data) {
         return;
     }
-    
+    [self addBreadcrumbWithData:data writeToDisk:YES];
+}
+
+- (void)addBreadcrumbWithData:(NSData *)data writeToDisk:(BOOL)writeToDisk {
     struct bsg_breadcrumb_list_item *newItem = calloc(1, sizeof(struct bsg_breadcrumb_list_item) + data.length + 1);
     [data enumerateByteRangesUsingBlock:^(const void *bytes, NSRange byteRange, __unused BOOL *stop) {
         memcpy(newItem->jsonData + byteRange.location, bytes, byteRange.length);
@@ -145,6 +148,9 @@ static struct bsg_breadcrumb_list_item *g_breadcrumbs_head;
         }
     }
     
+    if (!writeToDisk) {
+        return;
+    }
     //
     // Breadcrumbs are also stored on disk so that they are accessible at next
     // launch if an OOM is detected.

--- a/Bugsnag/Breadcrumbs/BugsnagBreadcrumbs.m
+++ b/Bugsnag/Breadcrumbs/BugsnagBreadcrumbs.m
@@ -119,6 +119,9 @@ static struct bsg_breadcrumb_list_item *g_breadcrumbs_head;
 
 - (void)addBreadcrumbWithData:(NSData *)data writeToDisk:(BOOL)writeToDisk {
     struct bsg_breadcrumb_list_item *newItem = calloc(1, sizeof(struct bsg_breadcrumb_list_item) + data.length + 1);
+    if (!newItem) {
+        return;
+    }
     [data enumerateByteRangesUsingBlock:^(const void *bytes, NSRange byteRange, __unused BOOL *stop) {
         memcpy(newItem->jsonData + byteRange.location, bytes, byteRange.length);
     }];

--- a/Bugsnag/Breadcrumbs/BugsnagBreadcrumbs.m
+++ b/Bugsnag/Breadcrumbs/BugsnagBreadcrumbs.m
@@ -6,9 +6,9 @@
 //  Copyright © 2020 Bugsnag. All rights reserved.
 //
 
-
 #import "BugsnagBreadcrumbs.h"
 
+#import "BSGGlobals.h"
 #import "BSGFileLocations.h"
 #import "BSGJSONSerialization.h"
 #import "BSG_KSCrashReportWriter.h"
@@ -18,16 +18,18 @@
 #import "BugsnagConfiguration+Private.h"
 #import "BugsnagLogger.h"
 
-/**
- * Information that can be accessed in an async-safe manner from the crash handler.
- */
-typedef struct {
-    char directoryPath[PATH_MAX];
-    unsigned int firstFileNumber;
-    unsigned int nextFileNumber;
-} BugsnagBreadcrumbsContext;
 
-static BugsnagBreadcrumbsContext g_context;
+//
+// Breadcrumbs are stored as a linked list of JSON encoded C strings
+// so that they are accessible at crash time.
+//
+
+struct bsg_breadcrumb_list_item {
+    struct bsg_breadcrumb_list_item *next;
+    char jsonData[]; // MUST be null terminated
+};
+
+static struct bsg_breadcrumb_list_item *g_breadcrumbs_head;
 
 #pragma mark -
 
@@ -55,13 +57,31 @@ static BugsnagBreadcrumbsContext g_context;
     _maxBreadcrumbs = (unsigned int)config.maxBreadcrumbs;
     
     _breadcrumbsPath = [BSGFileLocations current].breadcrumbs;
-    [_breadcrumbsPath getFileSystemRepresentation:g_context.directoryPath maxLength:sizeof(g_context.directoryPath)];
     
     return self;
 }
 
 - (NSArray<BugsnagBreadcrumb *> *)breadcrumbs {
-    return [self loadBreadcrumbsAsDictionaries:NO] ?: @[];
+    NSMutableArray<BugsnagBreadcrumb *> *breadcrumbs = [NSMutableArray array];
+    @synchronized (self) {
+        for (struct bsg_breadcrumb_list_item *item = g_breadcrumbs_head; item != NULL; item = item->next) {
+            NSError *error = nil;
+            NSData *data = [NSData dataWithBytesNoCopy:item->jsonData length:strlen(item->jsonData) freeWhenDone:NO];
+            id JSONObject = [BSGJSONSerialization JSONObjectWithData:data options:0 error:&error];
+            if (!JSONObject) {
+                bsg_log_err(@"Unable to parse breadcrumb: %@", error);
+                continue;
+            }
+            BugsnagBreadcrumb *breadcrumb = nil;
+            if (![JSONObject isKindOfClass:[NSDictionary class]] ||
+                !(breadcrumb = [BugsnagBreadcrumb breadcrumbFromDict:JSONObject])) {
+                bsg_log_err(@"Unexpected breadcrumb payload in buffer");
+                continue;
+            }
+            [breadcrumbs addObject:breadcrumb];
+        }
+    }
+    return breadcrumbs;
 }
 
 - (NSArray<BugsnagBreadcrumb *> *)breadcrumbsBeforeDate:(nonnull NSDate *)date {
@@ -94,16 +114,55 @@ static BugsnagBreadcrumbsContext g_context;
     if (!data) {
         return;
     }
+    
+    struct bsg_breadcrumb_list_item *newItem = calloc(1, sizeof(struct bsg_breadcrumb_list_item) + data.length + 1);
+    [data enumerateByteRangesUsingBlock:^(const void *bytes, NSRange byteRange, __unused BOOL *stop) {
+        memcpy(newItem->jsonData + byteRange.location, bytes, byteRange.length);
+    }];
+    
     unsigned int fileNumber;
+    BOOL deleteOld;
+    
     @synchronized (self) {
         fileNumber = self.nextFileNumber;
+        deleteOld = fileNumber >= self.maxBreadcrumbs;
         self.nextFileNumber = fileNumber + 1;
-        if (fileNumber + 1 > self.maxBreadcrumbs) {
-            g_context.firstFileNumber = fileNumber + 1 - self.maxBreadcrumbs;
+        
+        if (g_breadcrumbs_head) {
+            struct bsg_breadcrumb_list_item *tail = g_breadcrumbs_head;
+            while (tail->next) {
+                tail = tail->next;
+            }
+            tail->next = newItem;
+            if (deleteOld) {
+                struct bsg_breadcrumb_list_item *head = g_breadcrumbs_head;
+                g_breadcrumbs_head = head->next;
+                head->next = NULL;
+                free(head);
+            }
+        } else {
+            g_breadcrumbs_head = newItem;
         }
-        g_context.nextFileNumber = fileNumber + 1;
     }
-    [self writeBreadcrumbData:(NSData *)data toFileNumber:fileNumber];
+    
+    //
+    // Breadcrumbs are also stored on disk so that they are accessible at next
+    // launch if an OOM is detected.
+    //
+    dispatch_async(BSGGlobalsFileSystemQueue(), ^{
+        NSError *error = nil;
+        NSString *file = [self pathForFileNumber:fileNumber];
+        if (![data writeToFile:file options:NSDataWritingAtomic error:&error]) {
+            bsg_log_err(@"Unable to write breadcrumb: %@", error);
+        }
+        
+        if (deleteOld) {
+            NSString *fileToDelete = [self pathForFileNumber:fileNumber - self.maxBreadcrumbs];
+            if (![[[NSFileManager alloc] init] removeItemAtPath:fileToDelete error:&error]) {
+                bsg_log_err(@"Unable to delete old breadcrumb: %@", error);
+            }
+        }
+    });
 }
 
 - (BOOL)shouldSendBreadcrumb:(BugsnagBreadcrumb *)crumb {
@@ -121,9 +180,14 @@ static BugsnagBreadcrumbsContext g_context;
 
 - (void)removeAllBreadcrumbs {
     @synchronized (self) {
+        struct bsg_breadcrumb_list_item *item = g_breadcrumbs_head;
+        g_breadcrumbs_head = NULL;
+        while (item) {
+            struct bsg_breadcrumb_list_item *next = item->next;
+            free(item);
+            item = next;
+        }
         self.nextFileNumber = 0;
-        g_context.firstFileNumber = 0;
-        g_context.nextFileNumber = 0;
     }
     [self deleteBreadcrumbFiles];
 }
@@ -148,25 +212,8 @@ static BugsnagBreadcrumbsContext g_context;
     return [self.breadcrumbsPath stringByAppendingPathComponent:[NSString stringWithFormat:@"%u.json", fileNumber]];
 }
 
-- (void)writeBreadcrumbData:(NSData *)data toFileNumber:(unsigned int)fileNumber {
-    NSString *path = [self pathForFileNumber:fileNumber];
-    
-    NSError *error = nil;
-    if (![data writeToFile:path options:NSDataWritingAtomic error:&error]) {
-        bsg_log_err(@"Unable to write breadcrumb: %@", error);
-        return;
-    }
-    
-    if (fileNumber >= self.maxBreadcrumbs) {
-        NSString *oldPath = [self pathForFileNumber:fileNumber - self.maxBreadcrumbs];
-        if (![[NSFileManager defaultManager] removeItemAtPath:oldPath error:&error]) {
-            bsg_log_err(@"Unable to delete old breadcrumb: %@", error);
-        }
-    }
-}
-
-- (nullable NSArray<NSDictionary *> *)cachedBreadcrumbs {
-    return [self loadBreadcrumbsAsDictionaries:YES];
+- (NSArray<BugsnagBreadcrumb *> *)cachedBreadcrumbs {
+    return [self loadBreadcrumbsAsDictionaries:NO] ?: @[];
 }
 
 - (nullable NSArray *)loadBreadcrumbsAsDictionaries:(BOOL)asDictionaries {
@@ -187,7 +234,7 @@ static BugsnagBreadcrumbsContext g_context;
         return NSOrderedSame;
     }];
     
-    NSMutableArray<NSDictionary *> *breadcrumbs = [NSMutableArray array];
+    NSMutableArray *breadcrumbs = [NSMutableArray array];
     
     for (NSString *file in filenames) {
         if ([file hasPrefix:@"."] || ![file.pathExtension isEqual:@"json"]) {
@@ -234,15 +281,11 @@ static BugsnagBreadcrumbsContext g_context;
 #pragma mark -
 
 void BugsnagBreadcrumbsWriteCrashReport(const BSG_KSCrashReportWriter *writer) {
-    char path[PATH_MAX];
     writer->beginArray(writer, "breadcrumbs");
-    for (unsigned int i = g_context.firstFileNumber; i < g_context.nextFileNumber; i++) {
-        int result = snprintf(path, sizeof(path), "%s/%u.json", g_context.directoryPath, i);
-        if (result < 0 || result >= (int)sizeof(path)) {
-            bsg_log_err(@"Breadcrumb path is too long");
-            continue;
-        }
-        writer->addJSONFileElement(writer, NULL, path);
+    
+    for (struct bsg_breadcrumb_list_item *item = g_breadcrumbs_head; item != NULL; item = item->next) {
+        writer->addJSONElement(writer, NULL, item->jsonData);
     }
+    
     writer->endContainer(writer);
 }

--- a/Bugsnag/Breadcrumbs/BugsnagBreadcrumbs.m
+++ b/Bugsnag/Breadcrumbs/BugsnagBreadcrumbs.m
@@ -164,7 +164,8 @@ static struct bsg_breadcrumb_list_item *g_breadcrumbs_head;
             
             if (!isStale) {
                 NSString *file = [self pathForFileNumber:fileNumber];
-                if (![data writeToFile:file options:NSDataWritingAtomic error:&error]) {
+                // NSDataWritingAtomic not required because we no longer read the files without checking for validity
+                if (![data writeToFile:file options:0 error:&error]) {
                     bsg_log_err(@"Unable to write breadcrumb: %@", error);
                 }
             }

--- a/Bugsnag/Breadcrumbs/BugsnagBreadcrumbs.m
+++ b/Bugsnag/Breadcrumbs/BugsnagBreadcrumbs.m
@@ -219,16 +219,12 @@ static struct bsg_breadcrumb_list_item *g_breadcrumbs_head;
 }
 
 - (NSArray<BugsnagBreadcrumb *> *)cachedBreadcrumbs {
-    return [self loadBreadcrumbsAsDictionaries:NO] ?: @[];
-}
-
-- (nullable NSArray *)loadBreadcrumbsAsDictionaries:(BOOL)asDictionaries {
     NSError *error = nil;
     
     NSArray<NSString *> *filenames = [[NSFileManager defaultManager] contentsOfDirectoryAtPath:self.breadcrumbsPath error:&error];
     if (!filenames) {
         bsg_log_err(@"Unable to read breadcrumbs: %@", error);
-        return nil;
+        return @[];
     }
     
     // We cannot use NSString's -localizedStandardCompare: because its sorting may vary by locale.
@@ -267,7 +263,7 @@ static struct bsg_breadcrumb_list_item *g_breadcrumbs_head;
             bsg_log_err(@"Unexpected breadcrumb payload in file %@", file);
             continue;
         }
-        [breadcrumbs addObject:asDictionaries ? JSONObject : breadcrumb];
+        [breadcrumbs addObject:breadcrumb];
     }
     
     return breadcrumbs;

--- a/Bugsnag/BugsnagSystemState.m
+++ b/Bugsnag/BugsnagSystemState.m
@@ -261,7 +261,7 @@ static NSDictionary *copyDictionary(NSDictionary *launchState) {
     }];
 }
 
-- (void)mutateLaunchState:(void (^)(NSMutableDictionary *state))block {
+- (void)mutateLaunchState:(nonnull void (^)(NSMutableDictionary *state))block {
     NSDictionary *state = nil;
     @synchronized (self) {
         block(self.currentLaunchStateRW);

--- a/Bugsnag/Client/BugsnagClient.m
+++ b/Bugsnag/Client/BugsnagClient.m
@@ -1347,7 +1347,7 @@ __attribute__((annotate("oclint:suppress[too many methods]")))
                          handledState:[BugsnagHandledState handledStateWithSeverityReason:LikelyOutOfMemory]
                                  user:session.user ?: [[BugsnagUser alloc] init]
                              metadata:metadata
-                          breadcrumbs:self.breadcrumbs.breadcrumbs ?: @[]
+                          breadcrumbs:[self.breadcrumbs cachedBreadcrumbs] ?: @[]
                                errors:@[error]
                               threads:@[]
                               session:session];

--- a/Bugsnag/Delivery/BSGEventUploadFileOperation.m
+++ b/Bugsnag/Delivery/BSGEventUploadFileOperation.m
@@ -9,6 +9,7 @@
 #import "BSGEventUploadFileOperation.h"
 
 #import "BSGFileLocations.h"
+#import "BSGGlobals.h"
 #import "BSGJSONSerialization.h"
 #import "BugsnagEvent+Private.h"
 #import "BugsnagLogger.h"
@@ -32,12 +33,14 @@
 }
 
 - (void)deleteEvent {
-    NSError *error = nil;
-    if ([NSFileManager.defaultManager removeItemAtPath:self.file error:&error]) {
-        bsg_log_debug(@"Deleted event %@", self.name);
-    } else {
-        bsg_log_err(@"%@", error);
-    }
+    dispatch_sync(BSGGlobalsFileSystemQueue(), ^{
+        NSError *error = nil;
+        if ([NSFileManager.defaultManager removeItemAtPath:self.file error:&error]) {
+            bsg_log_debug(@"Deleted event %@", self.name);
+        } else {
+            bsg_log_err(@"%@", error);
+        }
+    });
 }
 
 - (void)storeEventPayload:(__attribute__((unused)) NSDictionary *)eventPayload {

--- a/Bugsnag/Helpers/BSGGlobals.h
+++ b/Bugsnag/Helpers/BSGGlobals.h
@@ -1,0 +1,15 @@
+//
+//  BSGGlobals.h
+//  Bugsnag
+//
+//  Created by Nick Dowell on 18/06/2021.
+//  Copyright © 2021 Bugsnag Inc. All rights reserved.
+//
+
+#import <Foundation/Foundation.h>
+
+__BEGIN_DECLS
+
+dispatch_queue_t BSGGlobalsFileSystemQueue(void);
+
+__END_DECLS

--- a/Bugsnag/Helpers/BSGGlobals.m
+++ b/Bugsnag/Helpers/BSGGlobals.m
@@ -1,0 +1,23 @@
+//
+//  BSGGlobals.m
+//  Bugsnag
+//
+//  Created by Nick Dowell on 18/06/2021.
+//  Copyright © 2021 Bugsnag Inc. All rights reserved.
+//
+
+#import "BSGGlobals.h"
+
+static dispatch_queue_t bsg_g_fileSystemQueue;
+
+static void BSGGlobalsInit(void) {
+    static dispatch_once_t onceToken;
+    dispatch_once(&onceToken, ^{
+        bsg_g_fileSystemQueue = dispatch_queue_create("com.bugsnag.filesystem", DISPATCH_QUEUE_SERIAL);
+    });
+}
+
+dispatch_queue_t BSGGlobalsFileSystemQueue(void) {
+    BSGGlobalsInit();
+    return bsg_g_fileSystemQueue;
+}

--- a/Bugsnag/Payload/BugsnagBreadcrumb.m
+++ b/Bugsnag/Payload/BugsnagBreadcrumb.m
@@ -98,93 +98,39 @@ BSGBreadcrumbType BSGBreadcrumbTypeFromString(NSString *value) {
 }
 
 - (NSDictionary *)objectValue {
-    @synchronized (self) {
-        NSString *timestamp = self.timestampString ?: [BSG_RFC3339DateTool stringFromDate:self.timestamp];
-        if (timestamp && self.message.length > 0) {
-            NSMutableDictionary *metadata = [NSMutableDictionary new];
-            for (NSString *key in self.metadata) {
-                metadata[[key copy]] = [self.metadata[key] copy];
-            }
-            return @{
-                // Note: The Bugsnag Error Reporting API specifies that the breadcrumb "message"
-                // field should be delivered in as a "name" field.  This comment notes that variance.
-                BSGKeyName : [self.message copy],
-                BSGKeyTimestamp : timestamp,
-                BSGKeyType : BSGBreadcrumbTypeValue(self.type),
-                BSGKeyMetadata : metadata
-            };
+    NSString *timestamp = self.timestampString ?: [BSG_RFC3339DateTool stringFromDate:self.timestamp];
+    if (timestamp && self.message.length > 0) {
+        NSMutableDictionary *metadata = [NSMutableDictionary new];
+        for (NSString *key in self.metadata) {
+            metadata[[key copy]] = [self.metadata[key] copy];
         }
-        return nil;
+        return @{
+            // Note: The Bugsnag Error Reporting API specifies that the breadcrumb "message"
+            // field should be delivered in as a "name" field.  This comment notes that variance.
+            BSGKeyName : [self.message copy],
+            BSGKeyTimestamp : timestamp,
+            BSGKeyType : BSGBreadcrumbTypeValue(self.type),
+            BSGKeyMetadata : metadata
+        };
     }
+    return nil;
 }
 
 // The timestamp is lazily computed from the timestampString to avoid unnecessary
 // calls to -dateFromString: (which is expensive) when loading breadcrumbs from disk.
 
 - (NSDate *)timestamp {
-    @synchronized (self) {
-        if (!_timestamp) {
-            _timestamp = [BSG_RFC3339DateTool dateFromString:self.timestampString];
-        }
-        return _timestamp;
+    if (!_timestamp) {
+        _timestamp = [BSG_RFC3339DateTool dateFromString:self.timestampString];
     }
+    return _timestamp;
 }
 
 @synthesize timestampString = _timestampString;
 
 - (void)setTimestampString:(NSString *)timestampString {
-    @synchronized (self) {
-        _timestampString = [timestampString copy];
-        self.timestamp = nil;
-    }
-}
-
-@synthesize message = _message;
-
-- (NSString *)message {
-    @synchronized (self) {
-        return _message;
-    }
-}
-
-@synthesize type = _type;
-
-- (BSGBreadcrumbType)type {
-    @synchronized (self) {
-        return _type;
-    }
-}
-
-- (void)setType:(BSGBreadcrumbType)type {
-    @synchronized (self) {
-        [self willChangeValueForKey:NSStringFromSelector(@selector(type))];
-        _type = type;
-        [self didChangeValueForKey:NSStringFromSelector(@selector(type))];
-    }
-}
-
-- (void)setMessage:(NSString *)message {
-    @synchronized (self) {
-        [self willChangeValueForKey:NSStringFromSelector(@selector(message))];
-        _message = message;
-        [self didChangeValueForKey:NSStringFromSelector(@selector(message))];
-    }
-}
-
-@synthesize metadata = _metadata;
-
-- (NSDictionary *)metadata {
-    @synchronized (self) {
-        return _metadata;
-    }
-}
-
-- (void)setMetadata:(NSDictionary *)metadata {
-    @synchronized (self) {
-        [self willChangeValueForKey:NSStringFromSelector(@selector(metadata))];
-        _metadata = metadata;
-        [self didChangeValueForKey:NSStringFromSelector(@selector(metadata))];
-    }
+    _timestampString = [timestampString copy];
+    self.timestamp = nil;
 }
 
 + (instancetype)breadcrumbWithBlock:(BSGBreadcrumbConfiguration)block {

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,9 @@ Changelog
 
 ### Bug fixes
 
+* Improve performance of leaving breadcrumbs by using async file I/O.
+  [#1124](https://github.com/bugsnag/bugsnag-cocoa/pull/1124)
+
 * Prevent some potential false positive detection of app hangs.
   [#1122](https://github.com/bugsnag/bugsnag-cocoa/pull/1122)
 

--- a/Tests/BugsnagBreadcrumbsTest.m
+++ b/Tests/BugsnagBreadcrumbsTest.m
@@ -163,17 +163,17 @@ BSGBreadcrumbType BSGBreadcrumbTypeFromString(NSString *value);
 
 - (void)testPersistentCrumbManual {
     awaitBreadcrumbSync(self.crumbs);
-    NSArray<NSDictionary *> *value = [self.crumbs loadBreadcrumbsAsDictionaries:YES];
-    XCTAssertEqual(value.count, 3);
-    XCTAssertEqualObjects(value[0][@"type"], @"manual");
-    XCTAssertEqualObjects(value[0][@"name"], @"Launch app");
-    XCTAssertNotNil(value[0][@"timestamp"]);
-    XCTAssertEqualObjects(value[1][@"type"], @"manual");
-    XCTAssertEqualObjects(value[1][@"name"], @"Tap button");
-    XCTAssertNotNil(value[1][@"timestamp"]);
-    XCTAssertEqualObjects(value[2][@"type"], @"manual");
-    XCTAssertEqualObjects(value[2][@"name"], @"Close tutorial");
-    XCTAssertNotNil(value[2][@"timestamp"]);
+    NSArray<BugsnagBreadcrumb *> *breadcrumbs = [self.crumbs cachedBreadcrumbs];
+    XCTAssertEqual(breadcrumbs.count, 3);
+    XCTAssertEqual(breadcrumbs[0].type, BSGBreadcrumbTypeManual);
+    XCTAssertEqualObjects(breadcrumbs[0].message, @"Launch app");
+    XCTAssertNotNil(breadcrumbs[0].timestamp);
+    XCTAssertEqual(breadcrumbs[1].type, BSGBreadcrumbTypeManual);
+    XCTAssertEqualObjects(breadcrumbs[1].message, @"Tap button");
+    XCTAssertNotNil(breadcrumbs[1].timestamp);
+    XCTAssertEqual(breadcrumbs[2].type, BSGBreadcrumbTypeManual);
+    XCTAssertEqualObjects(breadcrumbs[2].message, @"Close tutorial");
+    XCTAssertNotNil(breadcrumbs[2].timestamp);
 }
 
 - (void)testPersistentCrumbCustom {
@@ -183,12 +183,12 @@ BSGBreadcrumbType BSGBreadcrumbTypeFromString(NSString *value);
         crumb.type = BSGBreadcrumbTypeState;
     }];
     awaitBreadcrumbSync(self.crumbs);
-    NSArray<NSDictionary *> *value = [self.crumbs loadBreadcrumbsAsDictionaries:YES];
-    XCTAssertEqual(value.count, 4);
-    XCTAssertEqualObjects(value[3][@"type"], @"state");
-    XCTAssertEqualObjects(value[3][@"name"], @"Initiate sequence");
-    XCTAssertEqualObjects(value[3][@"metaData"][@"captain"], @"Bob");
-    XCTAssertNotNil(value[3][@"timestamp"]);
+    NSArray<BugsnagBreadcrumb *> *breadcrumbs = [self.crumbs cachedBreadcrumbs];
+    XCTAssertEqual(breadcrumbs.count, 4);
+    XCTAssertEqual(breadcrumbs[3].type, BSGBreadcrumbTypeState);
+    XCTAssertEqualObjects(breadcrumbs[3].message, @"Initiate sequence");
+    XCTAssertEqualObjects(breadcrumbs[3].metadata[@"captain"], @"Bob");
+    XCTAssertNotNil(breadcrumbs[3].timestamp);
 }
 
 - (void)testDefaultDiscardByType {

--- a/Tests/BugsnagClientTests.m
+++ b/Tests/BugsnagClientTests.m
@@ -68,7 +68,7 @@ NSString *BSGFormatSeverity(BSGSeverity severity);
     // Check that we can change it
     [client notify:ex];
 
-    NSDictionary *breadcrumb = [client.breadcrumbs.breadcrumbs[1] objectValue];
+    NSDictionary *breadcrumb = [client.breadcrumbs.breadcrumbs.lastObject objectValue];
     NSDictionary *metadata = [breadcrumb valueForKey:@"metaData"];
 
     XCTAssertEqualObjects([breadcrumb valueForKey:@"type"], @"error");


### PR DESCRIPTION
## Goal

To reduce the overhead of leaving breadcrumbs by performing filesystem I/O on a background queue.

## Changeset

Breadcrumbs are now stored in memory as a linked list of JSON encoded C strings that are read at crash time or for calls to `notify()`.

File writing now occurs asynchronously on a dedicated serial `dispatch_queue` to free up the calling thread and avoid provoking filesystem contention.

Use of `@synchronized` and customized getters & setters in `BugsnagBreadcrumb` has been removed - breadcrumbs objects are not shared across threads so there is no need for the overhead.

## Testing

Added a unit test case to verify that interrupted updates writes to the breadcrumbs linked list do not result in invalid JSON being added to crash reports.

Run [full E2E CI](https://buildkite.com/bugsnag/bugsnag-cocoa/builds/2888)