### PR TITLE
Remove macOSTestApp SIGTERM handler

### DIFF
--- a/features/fixtures/macos/macOSTestApp/main.m
+++ b/features/fixtures/macos/macOSTestApp/main.m
@@ -8,11 +8,6 @@
 
 #import <Cocoa/Cocoa.h>
 
-void sigterm(int signum) {
-    NSLog(@"Received SIGTERM");
-    exit(0);
-}
-
 int main(int argc, const char * argv[]) {
     [[NSUserDefaults standardUserDefaults] registerDefaults:@{
         // Disable state restoration to prevent the following dialog being shown after crashes
@@ -23,8 +18,6 @@ int main(int argc, const char * argv[]) {
         // Stop NSApplication swallowing NSExceptions thrown on the main thread.
         @"NSApplicationCrashOnExceptions": @YES,
     }];
-    
-    sigaction(SIGTERM, &(struct sigaction){ .sa_handler = &sigterm }, NULL);
     
     return NSApplicationMain(argc, argv);
 }


### PR DESCRIPTION
## Goal

Fix intermittent test failures caused by test fixture calling `NSLog` from its `SIGTERM` handler.

<details>

```
_os_unfair_lock_recursive_abort
notify_check
notify_check_tz
tzsetwall_basic
localtime_r
_populateBanner
_CFLogvEx2Predicate
_CFLogvEx3
_NSLogv
NSLog
sigterm
_sigtramp
_dyld_is_memory_immutable
_notify_fork_child
_notify_fork_child
_notify_fork_child
_CFXNotificationRegisterObserver
CFNotificationCenterAddObserver
_dispatch_client_callout
_dispatch_once_callout
getServiceEntries
-[NSApplication(NSServicesMenuPrivate) _fillSpellCheckerPopupButton:]
-[NSSpellChecker _fillSpellCheckerPopupButton:]
-[NSSpellChecker init]
__36+[NSSpellChecker sharedSpellChecker]_block_invoke
_dispatch_client_callout
_dispatch_once_callout
+[NSSpellChecker sharedSpellChecker]
-[NSTextCheckingController checkTextInRange:types:options:]
-[NSTextView checkTextInRange:types:options:]
-[NSTextCheckingController _performScheduledTextChecking:]
___NSMainRunLoopPerformBlockInModes_block_invoke
__CFRUNLOOP_IS_CALLING_OUT_TO_A_BLOCK__
__CFRunLoopDoBlocks
__CFRunLoopRun
CFRunLoopRunSpecific
RunCurrentEventLoopInMode
ReceiveNextEventCommon
_BlockUntilNextEventMatchingListInModeWithFilter
_DPSNextEvent
-[NSApplication(NSEvent) _nextEventMatchingEventMask:untilDate:inMode:dequeue:]
-[NSApplication run]
NSApplicationMain
main
start
```

</details>

## Changeset

Removed SIGTERM handler.
