### PR TITLE
[PLAT-6784] Improve grouping of internal errors

### DIFF
--- a/Bugsnag/Helpers/BSGInternalErrorReporter.h
+++ b/Bugsnag/Helpers/BSGInternalErrorReporter.h
@@ -49,15 +49,18 @@ FOUNDATION_EXPORT NSString *BSGErrorDescription(NSError *error);
 /// @param message The error message associated with the error. Usually this will contain some information about this specific instance of the error
 /// and is not used to group the errors.
 /// @param diagnostics JSON compatible information to include in the `BugsnagDiagnostics` metadata section.
+/// @param groupingHash String to override Bugsnag's default event grouping. Events sharing the same grouping hash will be grouped together.
 - (void)reportErrorWithClass:(NSString *)errorClass
                      message:(nullable NSString *)message
-                 diagnostics:(nullable NSDictionary<NSString *, id> *)diagnostics;
+                 diagnostics:(nullable NSDictionary<NSString *, id> *)diagnostics
+                groupingHash:(nullable NSString *)groupingHash;
 
 // Private
 
 - (nullable BugsnagEvent *)eventWithErrorClass:(NSString *)errorClass
                                        message:(nullable NSString *)message
-                                   diagnostics:(nullable NSDictionary<NSString *, id> *)diagnostics;
+                                   diagnostics:(nullable NSDictionary<NSString *, id> *)diagnostics
+                                  groupingHash:(nullable NSString *)groupingHash;
 
 - (nullable NSURLRequest *)requestForEvent:(BugsnagEvent *)event error:(NSError * __autoreleasing *)errorPtr;
 

--- a/Bugsnag/Helpers/BSGInternalErrorReporter.m
+++ b/Bugsnag/Helpers/BSGInternalErrorReporter.m
@@ -72,9 +72,10 @@ static BSGInternalErrorReporter *sharedInstance_;
 
 - (void)reportErrorWithClass:(NSString *)errorClass
                      message:(nullable NSString *)message
-                 diagnostics:(nullable NSDictionary<NSString *, id> *)diagnostics {
+                 diagnostics:(nullable NSDictionary<NSString *, id> *)diagnostics
+                groupingHash:(nullable NSString *)groupingHash {
     @try {
-        BugsnagEvent *event = [self eventWithErrorClass:errorClass message:message diagnostics:diagnostics];
+        BugsnagEvent *event = [self eventWithErrorClass:errorClass message:message diagnostics:diagnostics groupingHash:groupingHash];
         if (event) {
             [self sendEvent:event];
         }
@@ -87,7 +88,8 @@ static BSGInternalErrorReporter *sharedInstance_;
 
 - (nullable BugsnagEvent *)eventWithErrorClass:(NSString *)errorClass
                                        message:(nullable NSString *)message
-                                   diagnostics:(nullable NSDictionary<NSString *, id> *)diagnostics {
+                                   diagnostics:(nullable NSDictionary<NSString *, id> *)diagnostics
+                                  groupingHash:(nullable NSString *)groupingHash {
     id<BSGInternalErrorReporterDataSource> dataSource = self.dataSource;
     if (!dataSource) {
         return nil;
@@ -120,6 +122,8 @@ static BSGInternalErrorReporter *sharedInstance_;
                                errors:@[error]
                               threads:@[]
                               session:nil];
+    
+    event.groupingHash = groupingHash;
     
     return event;
 }

--- a/Tests/BSGInternalErrorReporterTests.m
+++ b/Tests/BSGInternalErrorReporterTests.m
@@ -32,9 +32,10 @@
     BugsnagConfiguration *configuration = [[BugsnagConfiguration alloc] initWithApiKey:@"0192837465afbecd0192837465afbecd"];
     BSGInternalErrorReporter *reporter = [[BSGInternalErrorReporter alloc] initWithDataSource:self];
     
-    BugsnagEvent *event = [reporter eventWithErrorClass:@"Internal error" message:@"Something went wrong" diagnostics:@{}];
+    BugsnagEvent *event = [reporter eventWithErrorClass:@"Internal error" message:@"Something went wrong" diagnostics:@{} groupingHash:@"test"];
     XCTAssertEqualObjects(event.errors[0].errorClass, @"Internal error");
     XCTAssertEqualObjects(event.errors[0].errorMessage, @"Something went wrong");
+    XCTAssertEqualObjects(event.groupingHash, @"test");
     XCTAssertNil(event.apiKey);
     
     NSDictionary *diagnostics = [event.metadata getMetadataFromSection:@"BugsnagDiagnostics"];

--- a/features/fixtures/shared/scenarios/InternalErrorReportingScenarios.m
+++ b/features/fixtures/shared/scenarios/InternalErrorReportingScenarios.m
@@ -12,10 +12,8 @@
 
 @end
 
-static void InternalErrorReportingScenarios_KSCrashReport_CrashHandler() {
-    // Terminate the process without running atexit handlers. This should leave
-    // a partically written KSCrashReport which will fail to parse as JSON.
-    _exit(0);
+static void InternalErrorReportingScenarios_KSCrashReport_CrashHandler(const BSG_KSCrashReportWriter *writer) {
+    writer->addJSONElement(writer, "something", "{1: \"Not valid JSON\"}");
 }
 
 @implementation InternalErrorReportingScenarios_KSCrashReport

--- a/features/internal_error_reporting.feature
+++ b/features/internal_error_reporting.feature
@@ -11,8 +11,9 @@ Feature: Internal error reporting
     And the error "Bugsnag-Internal-Error" header equals "bugsnag-cocoa"
     And the error payload field "events.0.threads" is an array with 0 elements
     And the event "apiKey" is null
+    And the event "groupingHash" equals "BSGEventUploadKSCrashReportOperation.m: JSON parsing error: NSCocoaErrorDomain 3840: No string key for value in object"
     And the event "metaData.BugsnagDiagnostics.apiKey" equals "12312312312312312312312312312312"
     And the event "metaData.BugsnagDiagnostics.data" is not null
     And the event "unhandled" is false
     And the exception "errorClass" equals "JSON parsing error"
-    And the exception "message" equals "NSCocoaErrorDomain 3840: Unexpected end of file while parsing object."
+    And the exception "message" matches "NSCocoaErrorDomain 3840: No string key for value in object around character \d+."


### PR DESCRIPTION
## Goal

Improve error grouping for internal notifier events, to group by the specific sub-type of JSON parsing error.

## Changeset

A `groupingHash` is now computed to group similar events.

## Testing

Manually tested, along with an E2E scenario that verifies the groupingHash is set as expected.