### PR TITLE
Bump tvOS 13 simulator

### DIFF
--- a/.buildkite/pipeline.quick.yml
+++ b/.buildkite/pipeline.quick.yml
@@ -74,7 +74,7 @@ steps:
     concurrency: 3
     concurrency_group: cocoa-unit-tests
     commands:
-      - ./scripts/run-unit-tests.sh PLATFORM=tvOS OS=13.3
+      - ./scripts/run-unit-tests.sh PLATFORM=tvOS OS=13.4
     artifact_paths:
       - logs/*
 


### PR DESCRIPTION
## Goal

Bump the minor version of the tvOS 13 simulator.  All simulators are now on the latest minor versions available at this time.