### PR TITLE
[PLAT-6590] Move binaryArch from event.metaData.app to event.app

### DIFF
--- a/Bugsnag/BugsnagSystemState.m
+++ b/Bugsnag/BugsnagSystemState.m
@@ -98,6 +98,7 @@ static NSMutableDictionary* initCurrentState(BugsnagKVStore *kvstore, BugsnagCon
     app[BSGKeyVersion] = blankIfNil(systemInfo[@BSG_KSSystemField_BundleShortVersion]);
     app[BSGKeyBundleVersion] = blankIfNil(systemInfo[@BSG_KSSystemField_BundleVersion]);
     app[BSGKeyMachoUUID] = [BSG_KSSystemInfo appUUID];
+    app[@"binaryArch"] = systemInfo[@BSG_KSSystemField_BinaryArch];
     app[@"inForeground"] = @(isInForeground);
     app[@"isActive"] = @(isActive);
 #if BSG_PLATFORM_TVOS

--- a/Bugsnag/Payload/BugsnagApp.m
+++ b/Bugsnag/Payload/BugsnagApp.m
@@ -21,7 +21,6 @@
 NSDictionary *BSGParseAppMetadata(NSDictionary *event) {
     NSMutableDictionary *app = [NSMutableDictionary new];
     app[@"name"] = [event valueForKeyPath:@"system." BSG_KSSystemField_BundleExecutable];
-    app[@"binaryArch"] = [event valueForKeyPath:@"system." BSG_KSSystemField_BinaryArch];
     app[@"runningOnRosetta"] = [event valueForKeyPath:@"system." BSG_KSSystemField_Translated];
     return app;
 }
@@ -31,6 +30,7 @@ NSDictionary *BSGParseAppMetadata(NSDictionary *event) {
 + (BugsnagApp *)deserializeFromJson:(NSDictionary *)json {
     BugsnagApp *app = [BugsnagApp new];
     if (json != nil) {
+        app.binaryArch = json[@"binaryArch"];
         app.bundleVersion = json[@"bundleVersion"];
         app.codeBundleId = json[@"codeBundleId"];
         app.id = json[@"id"];
@@ -61,6 +61,7 @@ NSDictionary *BSGParseAppMetadata(NSDictionary *event) {
 {
     NSDictionary *system = event[BSGKeySystem];
     app.id = system[@BSG_KSSystemField_BundleID];
+    app.binaryArch = system[@BSG_KSSystemField_BinaryArch];
     app.bundleVersion = system[@BSG_KSSystemField_BundleVersion];
     app.dsymUuid = system[@BSG_KSSystemField_AppUUID];
     app.version = system[@BSG_KSSystemField_BundleShortVersion];
@@ -87,6 +88,7 @@ NSDictionary *BSGParseAppMetadata(NSDictionary *event) {
 - (NSDictionary *)toDict
 {
     NSMutableDictionary *dict = [NSMutableDictionary new];
+    dict[@"binaryArch"] = self.binaryArch;
     dict[@"bundleVersion"] = self.bundleVersion;
     dict[@"codeBundleId"] = self.codeBundleId;
     dict[@"dsymUUIDs"] = BSGArrayWithObject(self.dsymUuid);

--- a/Bugsnag/Payload/BugsnagAppWithState.m
+++ b/Bugsnag/Payload/BugsnagAppWithState.m
@@ -38,6 +38,7 @@
         app.dsymUuid = dsyms[0];
     }
 
+    app.binaryArch = json[@"binaryArch"];
     app.bundleVersion = json[@"bundleVersion"];
     app.codeBundleId = json[@"codeBundleId"];
     app.id = json[@"id"];

--- a/Bugsnag/include/Bugsnag/BugsnagApp.h
+++ b/Bugsnag/include/Bugsnag/BugsnagApp.h
@@ -15,6 +15,11 @@
 @interface BugsnagApp : NSObject
 
 /**
+ * The architecture of the running binary
+ */
+@property (copy, nullable, nonatomic) NSString *binaryArch;
+
+/**
  * The bundle version used by the application
  */
 @property (copy, nullable, nonatomic) NSString *bundleVersion;

--- a/Tests/BugsnagAppTest.m
+++ b/Tests/BugsnagAppTest.m
@@ -35,6 +35,7 @@
                             @"background_time_since_launch": @5,
                             @"application_in_foreground": @YES,
                     },
+                    @"binary_arch": @"arm64",
                     @"CFBundleExecutable": @"MyIosApp",
                     @"CFBundleIdentifier": @"com.example.foo.MyIosApp",
                     @"CFBundleShortVersionString": @"5.6.3",
@@ -59,6 +60,7 @@
     BugsnagApp *app = [BugsnagApp appWithDictionary:self.data config:self.config codeBundleId:self.codeBundleId];
 
     // verify stateless fields
+    XCTAssertEqualObjects(app.binaryArch, @"arm64");
     XCTAssertEqualObjects(@"1", app.bundleVersion);
     XCTAssertEqualObjects(@"bundle-123", app.codeBundleId);
     XCTAssertEqualObjects(@"dsym-uuid-123", app.dsymUuid);
@@ -77,6 +79,7 @@
     XCTAssertTrue(app.inForeground);
 
     // verify stateless fields
+    XCTAssertEqualObjects(app.binaryArch, @"arm64");
     XCTAssertEqualObjects(@"1", app.bundleVersion);
     XCTAssertEqualObjects(@"bundle-123", app.codeBundleId);
     XCTAssertEqualObjects(@"dsym-uuid-123", app.dsymUuid);
@@ -92,6 +95,7 @@
     NSDictionary *dict = [app toDict];
 
     // verify stateless fields
+    XCTAssertEqualObjects(dict[@"binaryArch"], @"arm64");
     XCTAssertEqualObjects(@"1", dict[@"bundleVersion"]);
     XCTAssertEqualObjects(@"bundle-123", dict[@"codeBundleId"]);
     XCTAssertEqualObjects(@[@"dsym-uuid-123"], dict[@"dsymUUIDs"]);
@@ -112,6 +116,7 @@
     XCTAssertTrue([dict[@"inForeground"] boolValue]);
 
     // verify stateless fields
+    XCTAssertEqualObjects(dict[@"binaryArch"], @"arm64");
     XCTAssertEqualObjects(@"1", dict[@"bundleVersion"]);
     XCTAssertEqualObjects(@"bundle-123", dict[@"codeBundleId"]);
     XCTAssertEqualObjects(@[@"dsym-uuid-123"], dict[@"dsymUUIDs"]);
@@ -123,6 +128,7 @@
 
 - (void)testAppFromJson {
     NSDictionary *json = @{
+            @"binaryArch": @"x86_64",
             @"duration": @7000,
             @"durationInForeground": @2000,
             @"inForeground": @YES,
@@ -143,6 +149,7 @@
     XCTAssertTrue(app.inForeground);
 
     // verify stateless fields
+    XCTAssertEqualObjects(app.binaryArch, @"x86_64");
     XCTAssertEqualObjects(@"1", app.bundleVersion);
     XCTAssertEqualObjects(@"bundle-123", app.codeBundleId);
     XCTAssertEqualObjects(@"dsym-uuid-123", app.dsymUuid);
@@ -178,15 +185,6 @@
 
 - (void)testBSGParseAppMetadata {
     NSDictionary *metadata = BSGParseAppMetadata(@{@"system": [BSG_KSSystemInfo systemInfo]});
-#if TARGET_CPU_ARM
-    XCTAssert([metadata[@"binaryArch"] hasPrefix:@"armv"]);
-#elif TARGET_CPU_ARM64
-    XCTAssert([metadata[@"binaryArch"] hasPrefix:@"arm64"]);
-#elif TARGET_CPU_X86
-    XCTAssert([metadata[@"binaryArch"] hasPrefix:@"x86"]);
-#elif TARGET_CPU_X86_64
-    XCTAssertEqualObjects(metadata[@"binaryArch"], @"x86_64");
-#endif
     int proc_translated = 0;
     size_t size = sizeof(proc_translated);
     if (!sysctlbyname("sysctl.proc_translated", &proc_translated, &size, NULL, 0) && proc_translated) {

--- a/features/app_and_device_attributes.feature
+++ b/features/app_and_device_attributes.feature
@@ -54,13 +54,13 @@ Feature: App and Device attributes present
 
     # AppWithState
 
+    And the error payload field "events.0.app.binaryArch" matches the regex "(arm|x86)"
     And the error payload field "events.0.app.duration" is a number
     And the error payload field "events.0.app.durationInForeground" is a number
     And the error payload field "events.0.app.inForeground" is not null
 
     # App metadata
 
-    And the event "metaData.app.binaryArch" is not null
     And the event "metaData.app.name" equals the platform-dependent string:
       | ios   | iOSTestApp   |
       | macos | macOSTestApp |

--- a/features/barebone_tests.feature
+++ b/features/barebone_tests.feature
@@ -15,6 +15,7 @@ Feature: Barebone tests
     And the session "user.name" equals "Foo Bar"
 
     Then the error is valid for the error reporting API
+    And the event "app.binaryArch" matches "(arm|x86)"
     And the event "app.bundleVersion" equals "12301"
     And the event "app.id" equals the platform-dependent string:
       | ios   | com.bugsnag.iOSTestApp   |
@@ -109,6 +110,7 @@ Feature: Barebone tests
     And I wait to receive an error
 
     Then the error is valid for the error reporting API
+    And the event "app.binaryArch" matches "(arm|x86)"
     And the event "app.bundleVersion" equals "12301"
     And the event "app.inForeground" is true
     And the event "app.isLaunching" is true
@@ -183,6 +185,7 @@ Feature: Barebone tests
 
     And I wait to receive an error
     Then the error is an OOM event
+    And the event "app.binaryArch" matches "(arm|x86)"
     And the event "app.bundleVersion" equals "321.123"
     And the event "app.dsymUUIDs" is not null
     And the event "app.id" equals the platform-dependent string:


### PR DESCRIPTION
## Goal

Bring the Cocoa notifier into line with the notifier spec by making `binaryArch` part of the `app` object.

## Changeset

`binaryArch` is now included in `event.app` instead of `event.metaData.app`

## Testing

Tested manually, and verified with unit & E2E tests.