### PR TITLE
[PLAT-6799] Improve metadata performance with async file I/O

### DIFF
--- a/Bugsnag/BugsnagSystemState.h
+++ b/Bugsnag/BugsnagSystemState.h
@@ -9,6 +9,7 @@
 #import <Foundation/Foundation.h>
 
 #import "BugsnagConfiguration.h"
+#import "BugsnagKeys.h"
 
 #define SYSTEMSTATE_KEY_APP @"app"
 #define SYSTEMSTATE_KEY_DEVICE @"device"
@@ -16,6 +17,7 @@
 #define SYSTEMSTATE_APP_WAS_TERMINATED @"wasTerminated"
 #define SYSTEMSTATE_APP_IS_ACTIVE @"isActive"
 #define SYSTEMSTATE_APP_IS_IN_FOREGROUND @"inForeground"
+#define SYSTEMSTATE_APP_IS_LAUNCHING BSGKeyIsLaunching
 #define SYSTEMSTATE_APP_VERSION @"version"
 #define SYSTEMSTATE_APP_BUNDLE_VERSION @"bundleVersion"
 #define SYSTEMSTATE_APP_DEBUGGER_IS_ACTIVE @"debuggerIsActive"
@@ -37,6 +39,8 @@ NS_ASSUME_NONNULL_BEGIN
 - (void)setCodeBundleID:(NSString*)codeBundleID;
 
 @property (nonatomic) NSUInteger consecutiveLaunchCrashes;
+
+- (void)markLaunchCompleted;
 
 /**
  * Purge all stored system state.

--- a/Bugsnag/Client/BugsnagClient.m
+++ b/Bugsnag/Client/BugsnagClient.m
@@ -32,6 +32,7 @@
 #import "BSGConnectivity.h"
 #import "BSGEventUploader.h"
 #import "BSGFileLocations.h"
+#import "BSGGlobals.h"
 #import "BSGInternalErrorReporter.h"
 #import "BSGJSONSerialization.h"
 #import "BSGNotificationBreadcrumbs.h"
@@ -92,12 +93,12 @@ static struct {
     // Contains the state of the event (handled/unhandled)
     char *handledState;
     // Contains the user-specified metadata, including the user tab from config.
-    char *metadataPath;
+    char *metadataJSON;
     // Contains the Bugsnag configuration, all under the "config" tab.
     char *configPath;
-    // Contains notifier state, under "deviceState" and crash-specific
+    // Contains notifier state under "deviceState", and crash-specific
     // information under "crash".
-    char *statePath;
+    char *stateJSON;
     // User onCrash handler
     void (*onCrash)(const BSG_KSCrashReportWriter *writer);
 } bsg_g_bugsnag_data;
@@ -128,8 +129,8 @@ void BSSerializeDataCrashHandler(const BSG_KSCrashReportWriter *writer, __attrib
     }
     if (isCrash) {
         writer->addJSONFileElement(writer, "config", bsg_g_bugsnag_data.configPath);
-        writer->addJSONFileElement(writer, "metaData", bsg_g_bugsnag_data.metadataPath);
-        writer->addJSONFileElement(writer, "state", bsg_g_bugsnag_data.statePath);
+        writer->addJSONElement(writer, "metaData", bsg_g_bugsnag_data.metadataJSON);
+        writer->addJSONElement(writer, "state", bsg_g_bugsnag_data.stateJSON);
         BugsnagBreadcrumbsWriteCrashReport(writer);
         if (watchdogSentinelPath != NULL) {
             // Delete the file to indicate a handled termination
@@ -249,11 +250,9 @@ __attribute__((annotate("oclint:suppress[too many methods]")))
         _configMetadataFromLastLaunch = [BSGJSONSerialization JSONObjectWithContentsOfFile:_configMetadataFile options:0 error:nil];
         
         _metadataFile = fileLocations.metadata;
-        bsg_g_bugsnag_data.metadataPath = strdup(_metadataFile.fileSystemRepresentation);
         _metadataFromLastLaunch = [BSGJSONSerialization JSONObjectWithContentsOfFile:_metadataFile options:0 error:nil];
         
         _stateMetadataFile = fileLocations.state;
-        bsg_g_bugsnag_data.statePath = strdup(_stateMetadataFile.fileSystemRepresentation);
         _stateMetadataFromLastLaunch = [BSGJSONSerialization JSONObjectWithContentsOfFile:_stateMetadataFile options:0 error:nil];
 
         self.stateEventBlocks = [NSMutableArray new];
@@ -284,20 +283,8 @@ __attribute__((annotate("oclint:suppress[too many methods]")))
         _lastOrientation = BSGOrientationNameFromEnum([UIDEVICE currentDevice].orientation);
         [self.state addMetadata:_lastOrientation withKey:BSGKeyOrientation toSection:BSGKeyDeviceState];
 #endif
-        // sync initial state
-        [self metadataChanged:self.metadata];
-        [self metadataChanged:self.state];
-
-        // add observers for future metadata changes
-        // weakSelf is used as the BugsnagClient will always be instantiated
-        // for the entire lifecycle of an application, and there is therefore
-        // no need to check for strong self
-        __weak __typeof__(self) weakSelf = self;
-        void (^observer)(BugsnagStateEvent *) = ^(BugsnagStateEvent *event) {
-            [weakSelf metadataChanged:event.data];
-        };
-        [self.metadata addObserverWithBlock:observer];
-        [self.state addObserverWithBlock:observer];
+        [self.metadata setStorageBuffer:&bsg_g_bugsnag_data.metadataJSON file:_metadataFile];
+        [self.state setStorageBuffer:&bsg_g_bugsnag_data.stateJSON file:_stateMetadataFile];
 
         self.pluginClient = [[BugsnagPluginClient alloc] initWithPlugins:self.configuration.plugins
                                                                   client:self];
@@ -443,6 +430,7 @@ __attribute__((annotate("oclint:suppress[too many methods]")))
     bsg_log_debug(@"App has finished launching");
     [self.appLaunchTimer invalidate];
     [self.state addMetadata:@NO withKey:BSGKeyIsLaunching toSection:BSGKeyApp];
+    [self.systemState markLaunchCompleted];
 }
 
 - (void)sendLaunchCrashSynchronously {
@@ -575,8 +563,14 @@ __attribute__((annotate("oclint:suppress[too many methods]")))
     
     self.appDidCrashLastLaunch = didCrash;
     
-    BOOL wasLaunching = [self.stateMetadataFromLastLaunch[BSGKeyApp][BSGKeyIsLaunching] boolValue];
-    BOOL didCrashDuringLaunch = didCrash && wasLaunching;
+    NSNumber *wasLaunching = ({
+        // BugsnagSystemState's KV-store is now the reliable source of the isLaunching status.
+        self.systemState.lastLaunchState[SYSTEMSTATE_KEY_APP][SYSTEMSTATE_APP_IS_LAUNCHING] ?:
+        // Earlier notifier versions stored it only in state.json - but due to async I/O this is no longer accurate.
+        self.stateMetadataFromLastLaunch[BSGKeyApp][BSGKeyIsLaunching];
+    });
+    
+    BOOL didCrashDuringLaunch = didCrash && wasLaunching.boolValue;
     if (didCrashDuringLaunch) {
         self.systemState.consecutiveLaunchCrashes++;
     } else {
@@ -962,16 +956,6 @@ __attribute__((annotate("oclint:suppress[too many methods]")))
 
 - (void)addBreadcrumbWithBlock:(void (^)(BugsnagBreadcrumb *))block {
     [self.breadcrumbs addBreadcrumbWithBlock:block];
-}
-
-- (void)metadataChanged:(BugsnagMetadata *)metadata {
-    @synchronized(metadata) {
-        if (metadata == self.metadata) {
-            [BSGJSONSerialization writeJSONObject:[metadata toDictionary] toFile:self.metadataFile options:0 error:nil];
-        } else if (metadata == self.state) {
-            [BSGJSONSerialization writeJSONObject:[metadata toDictionary] toFile:self.stateMetadataFile options:0 error:nil];
-        }
-    }
 }
 
 /**

--- a/Bugsnag/Helpers/BugsnagKVStoreObjC.h
+++ b/Bugsnag/Helpers/BugsnagKVStoreObjC.h
@@ -29,7 +29,7 @@ NS_ASSUME_NONNULL_BEGIN
 
 - (bool)booleanForKey:(NSString*)key defaultValue:(bool)defaultValue;
 
-- (NSNumber*)NSBooleanForKey:(NSString*)key defaultValue:(bool)defaultValue;
+- (nullable NSNumber*)NSBooleanForKey:(NSString*)key defaultValue:(nullable NSNumber*)defaultValue;
 
 - (void)setString:(NSString*)value forKey:(NSString*)key;
 

--- a/Bugsnag/Helpers/BugsnagKVStoreObjC.m
+++ b/Bugsnag/Helpers/BugsnagKVStoreObjC.m
@@ -63,8 +63,13 @@ static void bsgkv_init() {
     return value;
 }
 
-- (NSNumber*)NSBooleanForKey:(NSString*)key defaultValue:(bool)defaultValue {
-    return [NSNumber numberWithBool:[self booleanForKey:key defaultValue:defaultValue]];
+- (nullable NSNumber*)NSBooleanForKey:(NSString*)key defaultValue:(nullable NSNumber*)defaultValue {
+    int err = 0;
+    bool boolValue = bsgkv_getBoolean([key UTF8String], &err);
+    if (err != 0) {
+        return defaultValue;
+    }
+    return [NSNumber numberWithBool:boolValue];
 }
 
 - (void)setString:(NSString*)value forKey:(NSString*)key {

--- a/Bugsnag/include/Bugsnag/BugsnagMetadata.h
+++ b/Bugsnag/include/Bugsnag/BugsnagMetadata.h
@@ -28,7 +28,19 @@
 
 #import <Bugsnag/BugsnagMetadataStore.h>
 
+NS_ASSUME_NONNULL_BEGIN
+
 /// :nodoc:
 @interface BugsnagMetadata : NSObject <BugsnagMetadataStore>
-- (instancetype _Nonnull)initWithDictionary:(NSDictionary *_Nonnull)dict;
+
+- (instancetype)initWithDictionary:(NSDictionary *)dict;
+
+/// Configures the metadata object to serialize itself to the provided buffer and file immediately, and upon each change.
+- (void)setStorageBuffer:(char *_Nullable *_Nullable)buffer file:(nullable NSString *)file;
+
+/// Exposed to facilitate unit testing.
+- (void)writeData:(NSData *)data toBuffer:(char *_Nullable *_Nonnull)buffer;
+
 @end
+
+NS_ASSUME_NONNULL_END

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,12 +1,19 @@
 Changelog
 =========
 
-## 6.9.7 (2021-06-23)
+## TBD
 
 ### Bug fixes
 
+* Improve performance of adding metadata by using async file I/O.
+  [#1126](https://github.com/bugsnag/bugsnag-cocoa/pull/1126)
+
 * Improve performance of leaving breadcrumbs by using async file I/O.
   [#1124](https://github.com/bugsnag/bugsnag-cocoa/pull/1124)
+
+## 6.9.7 (2021-06-23)
+
+### Bug fixes
 
 * Prevent some potential false positive detection of app hangs.
   [#1122](https://github.com/bugsnag/bugsnag-cocoa/pull/1122)

--- a/Tests/BugsnagApiValidationTest.m
+++ b/Tests/BugsnagApiValidationTest.m
@@ -22,11 +22,11 @@
 @implementation BugsnagApiValidationTest
 
 - (void)setUp {
+    [TestSupport purgePersistentData];
     [Bugsnag startWithApiKey:DUMMY_APIKEY_32CHAR_1];
 }
 
 - (void)testAppDidCrashLastLaunch {
-    [TestSupport purgePersistentData];
     XCTAssertFalse(Bugsnag.lastRunInfo.crashed);
 }
 


### PR DESCRIPTION
## Goal

To reduce the overhead of adding metadata by performing filesystem I/O on a background queue.

## Changeset

Metadata is now serialized to a JSON encoded C string in memory that is read at crash time.

File writing now occurs asynchronously on a dedicated serial `dispatch_queue` to free up the calling thread and avoid provoking filesystem contention.

Storage for the `isLaunching` property now goes through the KV-store (on the main thread) so that it can be accurately read at next start-up in the event of a crash (to compute `lastRunInfo`)

## Testing

A unit test case has been added to verify that interrupted metadata updates do not result in invalid JSON being added to crash reports.

Ran [successful full E2E on CI](https://buildkite.com/bugsnag/bugsnag-cocoa/builds/2970)