### PR TITLE
Fix flake in features/crashprobe.feature:165

### DIFF
--- a/features/fixtures/shared/scenarios/ReadGarbagePointerScenario.m
+++ b/features/fixtures/shared/scenarios/ReadGarbagePointerScenario.m
@@ -39,12 +39,13 @@
 }
 
 - (void)run {
+    install_spin_malloc();
+
     void *ptr = mmap(NULL, (size_t) getpagesize(), PROT_NONE, MAP_ANON | MAP_PRIVATE, -1, 0);
 
     if (ptr != MAP_FAILED)
         munmap(ptr, (size_t) getpagesize());
 
-    install_spin_malloc();
 #if __i386__
     asm volatile ( "mov %0, %%eax\n\tmov (%%eax), %%eax" : : "X" (ptr) : "memory", "eax" );
 #elif __x86_64__


### PR DESCRIPTION
## Goal

Fix an intermittent test failure in features/crashprobe.feature:165

## Changeset

The cause of the issue appears to have been calling `install_spin_malloc()` after `munmap()`. This made it more likely for memory allocations to occur after calling `munmap()` and cause `ptr` to point to newly allocated memory, changing the behaviour of the scenario.

## Testing

Verified by repeatedly running the scenario.

Prior to this change, the failure would occur within ~20 runs of the scenario.

With the change, was able to run the scenario 100 times without failure.