### PR TITLE
Upload logs for failed scenarios

### DIFF
--- a/.buildkite/pipeline.full.yml
+++ b/.buildkite/pipeline.full.yml
@@ -180,7 +180,7 @@ steps:
     plugins:
       artifacts#v1.3.0:
         download: ["features/fixtures/macos/output/macOSTestApp.zip"]
-        upload: ["macOSTestApp.log", "appium_server.log"]
+        upload: ["macOSTestApp.log", "appium_server.log", "maze_output/failed/**/*"]
     commands:
       - bundle install
       - bundle exec maze-runner
@@ -203,7 +203,7 @@ steps:
     plugins:
       artifacts#v1.3.0:
         download: ["features/fixtures/macos/output/macOSTestApp.zip"]
-        upload: ["macOSTestApp.log", "appium_server.log"]
+        upload: ["macOSTestApp.log", "appium_server.log", "maze_output/failed/**/*"]
     commands:
       - bundle config set --local path 'vendor/bundle'
       - bundle install
@@ -225,7 +225,7 @@ steps:
     plugins:
       artifacts#v1.3.0:
         download: ["features/fixtures/macos/output/macOSTestApp.zip"]
-        upload: ["macOSTestApp.log", "appium_server.log"]
+        upload: ["macOSTestApp.log", "appium_server.log", "maze_output/failed/**/*"]
     commands:
       - bundle install
       - bundle exec maze-runner
@@ -246,7 +246,7 @@ steps:
     plugins:
       artifacts#v1.3.0:
         download: ["features/fixtures/macos/output/macOSTestApp.zip"]
-        upload: ["macOSTestApp.log", "appium_server.log"]
+        upload: ["macOSTestApp.log", "appium_server.log", "maze_output/failed/**/*"]
     commands:
       - bundle install
       - bundle exec maze-runner

--- a/.buildkite/pipeline.quick.yml
+++ b/.buildkite/pipeline.quick.yml
@@ -123,7 +123,7 @@ steps:
     plugins:
       artifacts#v1.3.0:
         download: ["features/fixtures/macos/output/macOSTestApp.zip"]
-        upload: ["macOSTestApp.log", "appium_server.log"]
+        upload: ["macOSTestApp.log", "appium_server.log", "maze_output/failed/**/*"]
     commands:
       - bundle install
       - bundle exec maze-runner
@@ -144,6 +144,7 @@ steps:
     plugins:
       artifacts#v1.3.0:
         download: ["features/fixtures/ios/output/iOSTestApp.ipa"]
+        upload: ["maze_output/failed/**/*"]
       docker-compose#v3.3.0:
         run: cocoa-maze-runner
         command:
@@ -171,6 +172,7 @@ steps:
     plugins:
       artifacts#v1.3.0:
         download: ["features/fixtures/ios/output/iOSTestApp.ipa"]
+        upload: ["maze_output/failed/**/*"]
       docker-compose#v3.3.0:
         run: cocoa-maze-runner
         command:
@@ -198,6 +200,7 @@ steps:
     plugins:
       artifacts#v1.3.0:
         download: ["features/fixtures/ios/output/iOSTestApp.ipa"]
+        upload: ["maze_output/failed/**/*"]
       docker-compose#v3.3.0:
         run: cocoa-maze-runner
         command:
@@ -224,6 +227,7 @@ steps:
     plugins:
       artifacts#v1.3.0:
         download: ["features/fixtures/ios/output/iOSTestApp.ipa"]
+        upload: ["maze_output/failed/**/*"]
       docker-compose#v3.3.0:
         run: cocoa-maze-runner
         command:

--- a/.buildkite/pipeline.yml
+++ b/.buildkite/pipeline.yml
@@ -146,7 +146,7 @@ steps:
           - "--device=IOS_14"
           - "--resilient"
           - "--appium-version=1.17.0"
-#          - "--fail-fast"
+          - "--fail-fast"
           - "--order=random"
     concurrency: 9
     concurrency_group: browserstack-app
@@ -164,6 +164,7 @@ steps:
     plugins:
       artifacts#v1.3.0:
         download: ["features/fixtures/ios/output/iOSTestApp.ipa"]
+        upload: ["maze_output/failed/**/*"]
       docker-compose#v3.3.0:
         run: cocoa-maze-runner
         command:
@@ -190,7 +191,7 @@ steps:
     plugins:
       artifacts#v1.3.0:
         download: ["features/fixtures/macos/output/macOSTestApp.zip"]
-        upload: ["macOSTestApp.log", "appium_server.log"]
+        upload: ["macOSTestApp.log", "appium_server.log", "maze_output/failed/**/*"]
     commands:
       - bundle install
       - bundle exec maze-runner
@@ -214,7 +215,7 @@ steps:
     plugins:
       artifacts#v1.3.0:
         download: ["features/fixtures/macos/output/macOSTestApp.zip"]
-        upload: ["macOSTestApp.log", "appium_server.log"]
+        upload: ["macOSTestApp.log", "appium_server.log", "maze_output/failed/**/*"]
     commands:
       - bundle config set --local path 'vendor/bundle'
       - bundle install

--- a/.buildkite/pipeline.yml
+++ b/.buildkite/pipeline.yml
@@ -136,6 +136,7 @@ steps:
     plugins:
       artifacts#v1.3.0:
         download: ["features/fixtures/ios/output/iOSTestApp.ipa"]
+        upload: ["maze_output/failed/**/*"]
       docker-compose#v3.3.0:
         run: cocoa-maze-runner
         command:
@@ -145,7 +146,7 @@ steps:
           - "--device=IOS_14"
           - "--resilient"
           - "--appium-version=1.17.0"
-          - "--fail-fast"
+#          - "--fail-fast"
           - "--order=random"
     concurrency: 9
     concurrency_group: browserstack-app

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -12,3 +12,4 @@ services:
     volumes:
       - ./features/fixtures/ios/output:/app/build
       - ./features/:/app/features/
+      - ./maze_output:/app/maze_output

--- a/features/barebone_tests.feature
+++ b/features/barebone_tests.feature
@@ -118,7 +118,7 @@ Feature: Barebone tests
     And the event "app.type" equals the platform-dependent string:
       | ios   | iOS   |
       | macos | macOS |
-    And the event "app.version" equals "12.34"
+    And the event "app.version" equals "12.3"
     And the event "breadcrumbs.0.name" equals "Bugsnag loaded"
     And the event "breadcrumbs.1.name" is null
     And the event "context" equals "Something"
@@ -243,7 +243,7 @@ Feature: Barebone tests
     And the event "severityReason.unhandledOverridden" is null
     And the event "unhandled" is true
     And the event "user.email" equals "foobar@example.com"
-    And the event "user.id" equals "foobar2"
+    And the event "user.id" equals "foobar"
     And the event "user.name" equals "Foo Bar"
     And the error payload field "events.0.app.dsymUUIDs" is a non-empty array
     And the error payload field "events.0.app.duration" is null

--- a/features/barebone_tests.feature
+++ b/features/barebone_tests.feature
@@ -118,7 +118,7 @@ Feature: Barebone tests
     And the event "app.type" equals the platform-dependent string:
       | ios   | iOS   |
       | macos | macOS |
-    And the event "app.version" equals "12.3"
+    And the event "app.version" equals "12.34"
     And the event "breadcrumbs.0.name" equals "Bugsnag loaded"
     And the event "breadcrumbs.1.name" is null
     And the event "context" equals "Something"
@@ -243,7 +243,7 @@ Feature: Barebone tests
     And the event "severityReason.unhandledOverridden" is null
     And the event "unhandled" is true
     And the event "user.email" equals "foobar@example.com"
-    And the event "user.id" equals "foobar"
+    And the event "user.id" equals "foobar2"
     And the event "user.name" equals "Foo Bar"
     And the error payload field "events.0.app.dsymUUIDs" is a non-empty array
     And the error payload field "events.0.app.duration" is null


### PR DESCRIPTION
## Goal

MazeRunner now logs all received requests for each scenario.  This change uploads them as Buildkite artifacts for any failed scenarios.

## Design

I chose not to upload logs for passed scenarios as well, because it would be overwhelming.

## Changeset

`maze_output` mapped as a Docker volume and all files beneath the `failed` folder selected for upload.

## Testing

Verified that files are uploaded as desired by forcing an artificial failure in the previous build.