### PR TITLE
Carthage improvements

### DIFF
--- a/.buildkite/pipeline.yml
+++ b/.buildkite/pipeline.yml
@@ -36,21 +36,17 @@ steps:
     concurrency: 3
     concurrency_group: cocoa-unit-tests
     commands:
-      - mkdir -p features/fixtures/carthage-proj
       - make build_swift
       - make build_ios_static
 
-  - label: Static Carthage build
+  - label: Carthage
     timeout_in_minutes: 10
     agents:
-      queue: opensource-mac-cocoa-10.15
+      queue: opensource-mac-cocoa-11
     concurrency: 3
     concurrency_group: cocoa-unit-tests
-    env:
-      DEVELOPER_DIR: "/Applications/Xcode11.app/Contents/Developer"
     commands:
-      - mkdir -p features/fixtures/carthage-proj
-      - make build_swift
+      - ./scripts/build-carthage.sh
 
   ##############################################################################
   #

--- a/Bugsnag.xcworkspace/contents.xcworkspacedata
+++ b/Bugsnag.xcworkspace/contents.xcworkspacedata
@@ -1,0 +1,7 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<Workspace
+   version = "1.0">
+   <FileRef
+      location = "group:Bugsnag.xcodeproj">
+   </FileRef>
+</Workspace>

--- a/Makefile
+++ b/Makefile
@@ -75,12 +75,7 @@ build_ios_static: ## Build the static library target
 	$(XCODEBUILD) -project Bugsnag.xcodeproj -scheme BugsnagStatic
 
 build_carthage: ## Build the latest pushed commit with Carthage
-	@mkdir -p features/fixtures/carthage-proj
-	@echo 'git "file://$(shell pwd)" "'$(shell git rev-parse HEAD)'"' > features/fixtures/carthage-proj/Cartfile
-	@cd features/fixtures/carthage-proj && \
-	 carthage update --platform ios && \
-	 carthage update --platform macos && \
-	 carthage update --platform tvos
+	@./scripts/build-carthage.sh
 
 build_swift: ## Build with Swift Package Manager
 	@swift build

--- a/scripts/build-carthage.sh
+++ b/scripts/build-carthage.sh
@@ -1,0 +1,31 @@
+#!/bin/bash
+
+set -o errexit
+set -o nounset
+
+
+echo "--- Prepare"
+
+trap "echo '^^^ +++'" ERR
+
+xcode_version_major=$(xcodebuild -version | head -n1 | cut -d ' ' -f 2 | cut -d . -f 1)
+
+dir=features/fixtures/carthage
+
+mkdir -p "$dir"
+
+echo "git \"file://$(pwd)\" \"$(git rev-parse HEAD)\"" > "$dir"/Cartfile
+
+cd "$dir"
+
+
+for platform in iOS macOS tvOS
+do
+	cmdline=("carthage" "update" "--platform" "$platform")
+	if [ "$xcode_version_major" -ge 12 ]
+	then
+		cmdline+=("--use-xcframeworks")
+	fi
+	echo "---" "${cmdline[@]}"
+	"${cmdline[@]}"
+done


### PR DESCRIPTION
## Goal

The primary goal is to stop Carthage from using sample project Xcode workspaces when building Bugnag.

For example, running make build_carthage currently outputs:

```
*** Fetching bugsnag-cocoa
*** Checking out bugsnag-cocoa at "d663819b73208f6dc0d2450dfc7717521fb1338f"
*** xcodebuild output can be found in /var/folders/kw/bbtl7jr93mv010h6tfnlh73w0000gn/T/carthage-xcodebuild.V9bg1Y.log
*** Building scheme "Bugsnag-iOS" in iOSTestApp.xcworkspace
```

Note that `iOSTestApp.xcworkspace` is being used. This is because Carthage requires an Xcode workspace, and will search for one in the repository.

## Changeset

Adds a top-level Xcode workspace for Carthage to find.

Updates the Carthage CI build step to
1. Actually run the Carthage build
2. Support Xcode 12 and later by using Carthage's `--use-xcframeworks` [option](https://github.com/Carthage/Carthage#building-platform-independent-xcframeworks-xcode-12-and-above)

## Testing

Running make `build_carthage` now outputs:

```
*** Checking out bugsnag-cocoa at "a1c36ed4dadea912b3669591cc7deeecf5921418"
*** xcodebuild output can be found in /var/folders/kw/bbtl7jr93mv010h6tfnlh73w0000gn/T/carthage-xcodebuild.m2U2Ny.log
*** Building scheme "Bugsnag-iOS" in Bugsnag.xcworkspace
```
