### PR TITLE
[PLAT-6619] Fix invalid crash reports for C++ exceptions with long descriptions

### DIFF
--- a/Bugsnag/KSCrash/Source/KSCrash/Recording/Sentry/BSG_KSCrashSentry_CPPException.mm
+++ b/Bugsnag/KSCrash/Source/KSCrash/Recording/Sentry/BSG_KSCrashSentry_CPPException.mm
@@ -129,7 +129,9 @@ static void CPPExceptionTerminate(void) {
         isNSException = true;
         bsg_recordException(exception);
     } catch (std::exception &exc) {
-        strncpy(descriptionBuff, exc.what(), sizeof(descriptionBuff));
+        strlcpy(descriptionBuff, exc.what(), sizeof(descriptionBuff));
+    } catch (std::exception *exc) {
+        strlcpy(descriptionBuff, exc->what(), sizeof(descriptionBuff));
     }
 #define CATCH_VALUE(TYPE, PRINTFTYPE)                                          \
     catch (TYPE value) {                                                       \

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,9 @@ Changelog
 
 ### Bug fixes
 
+* Fix an issue that could cause C++ exceptions with very long descriptions to not be reported.
+  [#1137](https://github.com/bugsnag/bugsnag-cocoa/pull/1137)
+
 * Improve performance of adding metadata by using async file I/O.
   [#1133](https://github.com/bugsnag/bugsnag-cocoa/pull/1133)
 

--- a/features/fixtures/shared/scenarios/CxxExceptionScenario.mm
+++ b/features/fixtures/shared/scenarios/CxxExceptionScenario.mm
@@ -32,7 +32,19 @@ class kaboom_exception : public std::exception {
 };
 
 const char *kaboom_exception::what() const throw() {
-    return "If this had been a real exception, you would be cursing now.";
+    // Long enough to exceed BSG_KSCrashSentry_CPPException's DESCRIPTION_BUFFER_LENGTH
+    return ("Lorem ipsum dolor sit amet, consectetur adipiscing elit, sed do eiusmod tempor incididunt ut labore et dolore magna aliqua. "
+            "Ut enim ad minim veniam, quis nostrud exercitation ullamco laboris nisi ut aliquip ex ea commodo consequat. "
+            "Duis aute irure dolor in reprehenderit in voluptate velit esse cillum dolore eu fugiat nulla pariatur. "
+            "Excepteur sint occaecat cupidatat non proident, sunt in culpa qui  officia deserunt mollit anim id est laborum. "
+            "Lorem ipsum dolor sit amet, consectetur adipiscing elit, sed do eiusmod tempor incididunt ut labore et dolore magna aliqua. "
+            "Ut enim ad minim veniam, quis nostrud exercitation ullamco laboris nisi ut aliquip ex ea commodo consequat. "
+            "Duis aute irure dolor in reprehenderit in voluptate velit esse cillum dolore eu fugiat nulla pariatur. "
+            "Excepteur sint occaecat cupidatat non proident, sunt in culpa qui  officia deserunt mollit anim id est laborum. "
+            "Lorem ipsum dolor sit amet, consectetur adipiscing elit, sed do eiusmod tempor incididunt ut labore et dolore magna aliqua. "
+            "Ut enim ad minim veniam, quis nostrud exercitation ullamco laboris nisi ut aliquip ex ea commodo consequat. "
+            "Duis aute irure dolor in reprehenderit in voluptate velit esse cillum dolore eu fugiat nulla pariatur. "
+            "Excepteur sint occaecat cupidatat non proident, sunt in culpa qui  officia deserunt mollit anim id est laborum. ");
 }
 
 /**


### PR DESCRIPTION
## Goal

Fix an issue where C++ exceptions with very long descriptions (> 1000 bytes) could cause an invalid crash report JSON payload to be written, and the crash to therefore not be reported.

## Changeset

`BSG_KSCrashSentry_CPPException` now uses the safer `strlcpy()` function to ensure that `descriptionBuff` is null terminated.

Adds a `catch (std::exception *exc)` clause so that the exception thrown in `CxxExceptionScenario` is caught, allowing the description copying logic to be tested.

## Testing

Amended E2E test to provide a description longer than `BSG_KSCrashSentry_CPPException`'s buffer, and verified manually that the expected truncation occurs.