### PR TITLE
Use BuildKite git repo details for Carthage build

### DIFF
--- a/scripts/build-carthage.sh
+++ b/scripts/build-carthage.sh
@@ -14,9 +14,14 @@ dir=features/fixtures/carthage
 
 mkdir -p "$dir"
 
-echo "git \"file://$(pwd)\" \"$(git rev-parse HEAD)\"" > "$dir"/Cartfile
+repo=${BUILDKITE_REPO:-file://$(pwd)}
+commit=${BUILDKITE_COMMIT:-$(git rev-parse HEAD)}
+
+echo "git \"$repo\" \"$commit\"" > "$dir"/Cartfile
 
 cd "$dir"
+
+cat Cartfile
 
 
 for platform in iOS macOS tvOS


### PR DESCRIPTION
## Goal

Fix intermittent failure of the Carthage build step on some build agents.

## Changeset

On some of our BK agents Carthage fails when given a file:// repo url.

This PR switches to using https:// urls instead which fixes the issue.

## Testing

Verified fix on one of the failing agents: https://buildkite.com/bugsnag/bugsnag-cocoa/builds?branch=carthage-debug