### PR TITLE
strictly compare for NSNull values #1138

### DIFF
--- a/Bugsnag/Payload/BugsnagError.m
+++ b/Bugsnag/Payload/BugsnagError.m
@@ -114,8 +114,9 @@ NSString *BSGParseErrorMessage(NSDictionary *report, NSDictionary *error, NSStri
 + (BugsnagError *)errorFromJson:(NSDictionary *)json {
     NSArray *trace = json[BSGKeyStacktrace];
     NSMutableArray *data = [NSMutableArray new];
+    BOOL traceIsNil = trace == nil || [trace isEqual:[NSNull null]];
 
-    if (trace != nil) {
+    if (!traceIsNil) {
         for (NSDictionary *dict in trace) {
             BugsnagStackframe *frame = [BugsnagStackframe frameFromJson:dict];
 


### PR DESCRIPTION
## Goal

When attaching a custom stack trace, the stack trace types is sometimes an `NSNull` object. This causes an unhandled error detailed in #1138 

## Design

This strictly checks for `nil` and `NSNull` values instead of exclusively `nil` values. It's a bit of a hack. 

The unhandled errors are universally reported immediately after app start, which would indicate that custom stack trace errors that are stored before the next app launch (like in the event of a simultaneous OOM) are not stored within `BSGKeyStacktrace`. I'm a little lost in this code base so please forgive me not going deeper than ensuring `NSNull` values aren't iterated. 

## Changeset

The comparison for `trace` in `BugsnagError.m` changed from `!= nil` to `!(trace == nil || trace == NSNull)`.

## Testing

This bug has been difficult to reproduce, but the change is additive and so I believe it's a low risk solution with substantial gain (the gain being the Bugsnag error collector does not produce errors itself).