### PR TITLE
[PLAT-6896] Fix NSNull handling

### DIFF
--- a/Bugsnag/Helpers/BSGInternalErrorReporter.h
+++ b/Bugsnag/Helpers/BSGInternalErrorReporter.h
@@ -55,12 +55,20 @@ FOUNDATION_EXPORT NSString *BSGErrorDescription(NSError *error);
                  diagnostics:(nullable NSDictionary<NSString *, id> *)diagnostics
                 groupingHash:(nullable NSString *)groupingHash;
 
+- (void)reportException:(NSException *)exception
+            diagnostics:(nullable NSDictionary<NSString *, id> *)diagnostics
+           groupingHash:(nullable NSString *)groupingHash;
+
 // Private
 
 - (nullable BugsnagEvent *)eventWithErrorClass:(NSString *)errorClass
                                        message:(nullable NSString *)message
                                    diagnostics:(nullable NSDictionary<NSString *, id> *)diagnostics
                                   groupingHash:(nullable NSString *)groupingHash;
+
+- (nullable BugsnagEvent *)eventWithException:(NSException *)exception
+                                  diagnostics:(nullable NSDictionary<NSString *, id> *)diagnostics
+                                 groupingHash:(nullable NSString *)groupingHash;
 
 - (nullable NSURLRequest *)requestForEvent:(BugsnagEvent *)event error:(NSError * __autoreleasing *)errorPtr;
 

--- a/Bugsnag/Helpers/BugsnagCollections.h
+++ b/Bugsnag/Helpers/BugsnagCollections.h
@@ -71,4 +71,6 @@ NSString * _Nullable BSGDeserializeString(id _Nullable rawValue);
 
 NSDate * _Nullable BSGDeserializeDate(id _Nullable rawValue);
 
+NSNumber * _Nullable BSGDeserializeNumber(id  _Nullable rawValue);
+
 NS_ASSUME_NONNULL_END

--- a/Bugsnag/Helpers/BugsnagCollections.m
+++ b/Bugsnag/Helpers/BugsnagCollections.m
@@ -151,3 +151,10 @@ NSDate * _Nullable BSGDeserializeDate(id _Nullable rawValue) {
     }
     return [BSG_RFC3339DateTool dateFromString:(NSString *)rawValue];
 }
+
+NSNumber * _Nullable BSGDeserializeNumber(id  _Nullable rawValue) {
+    if (![rawValue isKindOfClass:[NSNumber class]]) {
+        return nil;
+    }
+    return (NSNumber *)rawValue;
+}

--- a/Bugsnag/Payload/BugsnagError.m
+++ b/Bugsnag/Payload/BugsnagError.m
@@ -112,23 +112,13 @@ NSString *BSGParseErrorMessage(NSDictionary *report, NSDictionary *error, NSStri
 }
 
 + (BugsnagError *)errorFromJson:(NSDictionary *)json {
-    NSArray *trace = json[BSGKeyStacktrace];
-    NSMutableArray *data = [NSMutableArray new];
-
-    if (trace != nil) {
-        for (NSDictionary *dict in trace) {
-            BugsnagStackframe *frame = [BugsnagStackframe frameFromJson:dict];
-
-            if (frame != nil) {
-                [data addObject:frame];
-            }
-        }
-    }
     BugsnagError *error = [[BugsnagError alloc] init];
-    error.errorClass = json[BSGKeyErrorClass];
-    error.errorMessage = json[BSGKeyMessage];
-    error.stacktrace = data;
-    error.typeString = json[BSGKeyType] ?: BSGErrorTypeStringCocoa;
+    error.errorClass = BSGDeserializeString(json[BSGKeyErrorClass]);
+    error.errorMessage = BSGDeserializeString(json[BSGKeyMessage]);
+    error.stacktrace = BSGDeserializeArrayOfObjects(json[BSGKeyStacktrace], ^id _Nullable(NSDictionary * _Nonnull dict) {
+        return [BugsnagStackframe frameFromJson:dict];
+    }) ?: @[];
+    error.typeString = BSGDeserializeString(json[BSGKeyType]) ?: BSGErrorTypeStringCocoa;
     return error;
 }
 

--- a/Bugsnag/Payload/BugsnagStackframe+Private.h
+++ b/Bugsnag/Payload/BugsnagStackframe+Private.h
@@ -31,6 +31,13 @@ NS_ASSUME_NONNULL_BEGIN
 
 @property (nonatomic) BOOL needsSymbolication;
 
+// MARK: - Properties not used for Cocoa stack frames, but used by React Native and Unity.
+
+@property (strong, nullable, nonatomic) NSNumber *columnNumber;
+@property (copy, nullable, nonatomic) NSString *file;
+@property (strong, nullable, nonatomic) NSNumber *inProject;
+@property (strong, nullable, nonatomic) NSNumber *lineNumber;
+
 @end
 
 NS_ASSUME_NONNULL_END

--- a/Bugsnag/Payload/BugsnagStackframe.m
+++ b/Bugsnag/Payload/BugsnagStackframe.m
@@ -22,18 +22,6 @@ static NSString * _Nullable FormatMemoryAddress(NSNumber * _Nullable address) {
 }
 
 
-// MARK: - Properties not used for Cocoa stack frames, but used by React Native and Unity.
-
-@interface BugsnagStackframe ()
-
-@property (strong, nullable, nonatomic) NSNumber *columnNumber;
-@property (copy, nullable, nonatomic) NSString *file;
-@property (strong, nullable, nonatomic) NSNumber *inProject;
-@property (strong, nullable, nonatomic) NSNumber *lineNumber;
-
-@end
-
-
 // MARK: -
 
 @implementation BugsnagStackframe
@@ -49,26 +37,26 @@ static NSString * _Nullable FormatMemoryAddress(NSNumber * _Nullable address) {
 
 + (BugsnagStackframe *)frameFromJson:(NSDictionary *)json {
     BugsnagStackframe *frame = [BugsnagStackframe new];
-    frame.machoFile = json[BSGKeyMachoFile];
-    frame.method = json[BSGKeyMethod];
-    frame.isPc = [json[BSGKeyIsPC] boolValue];
-    frame.isLr = [json[BSGKeyIsLR] boolValue];
-    frame.machoUuid = json[BSGKeyMachoUUID];
+    frame.machoFile = BSGDeserializeString(json[BSGKeyMachoFile]);
+    frame.method = BSGDeserializeString(json[BSGKeyMethod]);
+    frame.isPc = BSGDeserializeNumber(json[BSGKeyIsPC]).boolValue;
+    frame.isLr = BSGDeserializeNumber(json[BSGKeyIsLR]).boolValue;
+    frame.machoUuid = BSGDeserializeString(json[BSGKeyMachoUUID]);
     frame.machoVmAddress = [self readInt:json key:BSGKeyMachoVMAddress];
     frame.frameAddress = [self readInt:json key:BSGKeyFrameAddress];
     frame.symbolAddress = [self readInt:json key:BSGKeySymbolAddr];
     frame.machoLoadAddress = [self readInt:json key:BSGKeyMachoLoadAddr];
-    frame.type = json[BSGKeyType];
-    frame.columnNumber = json[@"columnNumber"];
-    frame.file = json[@"file"];
-    frame.inProject = json[@"inProject"];
-    frame.lineNumber = json[@"lineNumber"];
+    frame.type = BSGDeserializeString(json[BSGKeyType]);
+    frame.columnNumber = BSGDeserializeNumber(json[@"columnNumber"]);
+    frame.file = BSGDeserializeString(json[@"file"]);
+    frame.inProject = BSGDeserializeNumber(json[@"inProject"]);
+    frame.lineNumber = BSGDeserializeNumber(json[@"lineNumber"]);
     return frame;
 }
 
 + (NSNumber *)readInt:(NSDictionary *)json key:(NSString *)key {
-    NSString *obj = json[key];
-    if (obj) {
+    id obj = json[key];
+    if ([obj isKindOfClass:[NSString class]]) {
         return @(strtoul([obj UTF8String], NULL, 16));
     }
     return nil;

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,14 @@
 Changelog
 =========
 
+## TBD
+
+### Bug fixes
+
+* Fix `NSNull` handling in `+[BugsnagError errorFromJson:]` and `+[BugsnagStackframe frameFromJson:]`.
+  [#1143](https://github.com/bugsnag/bugsnag-cocoa/pull/1143)
+  [#1138](https://github.com/bugsnag/bugsnag-cocoa/issues/1138)
+
 ## 6.10.0 (2021-06-30)
 
 ### Bug fixes

--- a/Tests/BugsnagErrorTest.m
+++ b/Tests/BugsnagErrorTest.m
@@ -77,6 +77,20 @@ NSString *BSGParseErrorMessage(NSDictionary *report, NSDictionary *error, NSStri
     XCTAssertEqualObjects(@"D0A41830-4FD2-3B02-A23B-0741AD4C7F52", frame.machoUuid);
 }
 
+- (void)testErrorFromInvalidJson {
+    BugsnagError *error;
+    
+    error = [BugsnagError errorFromJson:@{
+        @"stacktrace": [NSNull null],
+    }];
+    XCTAssertEqualObjects(error.stacktrace, @[]);
+    
+    error = [BugsnagError errorFromJson:@{
+        @"stacktrace": @{@"foo": @"bar"},
+    }];
+    XCTAssertEqualObjects(error.stacktrace, @[]);
+}
+
 - (void)testToDictionary {
     BugsnagThread *thread = [self findErrorReportingThread:self.event];
     BugsnagError *error = [[BugsnagError alloc] initWithKSCrashReport:self.event stacktrace:thread.stacktrace];

--- a/Tests/BugsnagStackframeTest.m
+++ b/Tests/BugsnagStackframeTest.m
@@ -66,9 +66,12 @@
 
 - (void)testStackframeFromJson {
     BugsnagStackframe *frame = [BugsnagStackframe frameFromJson:@{
+        @"columnNumber":        @72,
         @"frameAddress":        @"0x10b5756bf",
+        @"inProject":           @YES,
         @"isLR":                @NO,
-        @"isPC":                @NO,
+        @"isPC":                @YES,
+        @"lineNumber":          @42,
         @"machoFile":           @"/Users/foo/Bugsnag.h",
         @"machoLoadAddress":    @"0x10b54b000",
         @"machoUUID":           @"B6D80CB5-A772-3D2F-B5A1-A3A137B8B58F",
@@ -78,8 +81,11 @@
         @"type":                @"cocoa",
     }];
     XCTAssertEqual(frame.isLr, NO);
-    XCTAssertEqual(frame.isPc, NO);
+    XCTAssertEqual(frame.isPc, YES);
+    XCTAssertEqualObjects(frame.columnNumber,       @72);
     XCTAssertEqualObjects(frame.frameAddress,       @0x10b5756bf);
+    XCTAssertEqualObjects(frame.inProject,          @YES);
+    XCTAssertEqualObjects(frame.lineNumber,         @42);
     XCTAssertEqualObjects(frame.machoFile,          @"/Users/foo/Bugsnag.h");
     XCTAssertEqualObjects(frame.machoLoadAddress,   @0x10b54b000);
     XCTAssertEqualObjects(frame.machoUuid,          @"B6D80CB5-A772-3D2F-B5A1-A3A137B8B58F");
@@ -87,6 +93,37 @@
     XCTAssertEqualObjects(frame.method,             @"-[BugsnagClient notify:handledState:block:]");
     XCTAssertEqualObjects(frame.symbolAddress,      @0x10b574fa0);
     XCTAssertEqualObjects(frame.type,               BugsnagStackframeTypeCocoa);
+}
+
+- (void)testStackframeFromJsonWithNullValues {
+    BugsnagStackframe *frame = [BugsnagStackframe frameFromJson:@{
+        @"columnNumber":        [NSNull null],
+        @"frameAddress":        [NSNull null],
+        @"inProject":           [NSNull null],
+        @"isLR":                [NSNull null],
+        @"isPC":                [NSNull null],
+        @"lineNumber":          [NSNull null],
+        @"machoFile":           [NSNull null],
+        @"machoLoadAddress":    [NSNull null],
+        @"machoUUID":           [NSNull null],
+        @"machoVMAddress":      [NSNull null],
+        @"method":              [NSNull null],
+        @"symbolAddress":       [NSNull null],
+        @"type":                [NSNull null],
+    }];
+    XCTAssertEqual(frame.isLr, NO);
+    XCTAssertEqual(frame.isPc, NO);
+    XCTAssertNil(frame.columnNumber);
+    XCTAssertNil(frame.frameAddress);
+    XCTAssertNil(frame.inProject);
+    XCTAssertNil(frame.lineNumber);
+    XCTAssertNil(frame.machoFile);
+    XCTAssertNil(frame.machoLoadAddress);
+    XCTAssertNil(frame.machoUuid);
+    XCTAssertNil(frame.machoVmAddress);
+    XCTAssertNil(frame.method);
+    XCTAssertNil(frame.symbolAddress);
+    XCTAssertNil(frame.type);
 }
 
 - (void)testStackframeFromJsonWithoutType {


### PR DESCRIPTION
## Goal

Fix a crash that can occur when uploading events that contain a `null` / `NSNull` stacktrace value.

```
NSInvalidArgumentException: -[NSNull countByEnumeratingWithState:objects:count:]: unrecognized selector sent to instance 0x20a654a00

0  CoreFoundation          ___exceptionPreprocess
1  libobjc.A.dylib         _objc_exception_throw
2  CoreFoundation          -[NSObject(NSObject) doesNotRecognizeSelector:]
3  CoreFoundation          ____forwarding___
4  CoreFoundation          ___forwarding_prep_0___
5  Runner                  +[BugsnagError errorFromJson:] (BugsnagError.m:119:9)
6  Runner                  -[BugsnagEvent stacktraceTypes] (BugsnagEvent.m:729:31)
7  Runner                  -[BSGEventUploadOperation runWithDelegate:completionHandler:] (BSGEventUploadOperation.m:112:67)
8  Runner                  -[BSGEventUploadOperation start] (BSGEventUploadOperation.m:177:5)
```

See #1138 

## Changeset

`+[BugsnagError errorFromJson:]` and `+[BugsnagStackframe frameFromJson:]` now use the `BSGDeserialize...` functions to check the value types when deserializing from JSON.

`BSGEventUploadOperation` now encapsulates the main logic in a `@try ... @catch` block to prevent crashes, and reports any caught exceptions to Bugsnag using the internal error reporting mechanism.

## Testing

Unit tests have been amended to verify correct handling of `NSNull` values.