### PR TITLE
Retry launch_app to fix OOM flakes

### DIFF
--- a/features/steps/ios_steps.rb
+++ b/features/steps/ios_steps.rb
@@ -69,7 +69,12 @@ When('I relaunch the app') do
     system("killall #{app} > /dev/null && sleep 1")
     Maze.driver.get(app)
   else
-    Maze.driver.launch_app
+    begin
+      Maze.driver.launch_app
+    rescue
+      # Retry because launch_app can fail when performed immediately after an app has stopped running.
+      Maze.driver.launch_app
+    end
   end
 end
 


### PR DESCRIPTION
## Goal

To fix flakes in the OOM scenario.

## Changeset

The Appium logs revealed that the launch_app command sometimes fails when run after the fixture app has stopped running / been terminated.

This change will attempt a retry for the `I relaunch the app` step used by the OOM scenario.

## Testing

Was not able to reproduce the flake despite over 100 runs of the scenario on iOS 12.