### PR TITLE
Increase iOS E2E timeout to 60 minutes

### DIFF
--- a/.buildkite/pipeline.full.yml
+++ b/.buildkite/pipeline.full.yml
@@ -10,7 +10,7 @@ steps:
   - label: 'iOS 13 E2E tests batch 1'
     depends_on:
       - cocoa_fixture
-    timeout_in_minutes: 45
+    timeout_in_minutes: 60
     agents:
       queue: opensource
     plugins:
@@ -37,7 +37,7 @@ steps:
   - label: 'iOS 13 E2E tests batch 2'
     depends_on:
       - cocoa_fixture
-    timeout_in_minutes: 45
+    timeout_in_minutes: 60
     agents:
       queue: opensource
     plugins:
@@ -64,7 +64,7 @@ steps:
   - label: 'iOS 12 E2E tests batch 1'
     depends_on:
       - cocoa_fixture
-    timeout_in_minutes: 45
+    timeout_in_minutes: 60
     agents:
       queue: opensource
     plugins:
@@ -91,7 +91,7 @@ steps:
   - label: 'iOS 12 E2E tests batch 2'
     depends_on:
       - cocoa_fixture
-    timeout_in_minutes: 45
+    timeout_in_minutes: 60
     agents:
       queue: opensource
     plugins:

--- a/.buildkite/pipeline.quick.yml
+++ b/.buildkite/pipeline.quick.yml
@@ -138,7 +138,7 @@ steps:
   - label: 'iOS 14 E2E tests batch 1'
     depends_on:
       - cocoa_fixture
-    timeout_in_minutes: 45
+    timeout_in_minutes: 60
     agents:
       queue: opensource
     plugins:
@@ -166,7 +166,7 @@ steps:
   - label: 'iOS 14 E2E tests batch 2'
     depends_on:
       - cocoa_fixture
-    timeout_in_minutes: 45
+    timeout_in_minutes: 60
     agents:
       queue: opensource
     plugins:
@@ -194,7 +194,7 @@ steps:
   - label: 'iOS 10 E2E tests batch 1'
     depends_on:
       - cocoa_fixture
-    timeout_in_minutes: 45
+    timeout_in_minutes: 60
     agents:
       queue: opensource
     plugins:
@@ -221,7 +221,7 @@ steps:
   - label: 'iOS 10 E2E tests batch 2'
     depends_on:
       - cocoa_fixture
-    timeout_in_minutes: 45
+    timeout_in_minutes: 60
     agents:
       queue: opensource
     plugins:


### PR DESCRIPTION
Increases the timeout on the iOS E2E tests because recently we have seen failures due to reaching the 45 minute limit.