### PR TITLE
[PLAT-6948] Fix crash in bsg_ksmachgetThreadQueueName

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,9 @@ Changelog
   [#1143](https://github.com/bugsnag/bugsnag-cocoa/pull/1143)
   [#1138](https://github.com/bugsnag/bugsnag-cocoa/issues/1138)
 
+* Fix a rare crash in `bsg_ksmachgetThreadQueueName`.
+  [#1147](https://github.com/bugsnag/bugsnag-cocoa/pull/1147)
+
 ## 6.10.0 (2021-06-30)
 
 ### Bug fixes


### PR DESCRIPTION
## Goal

Fix a crash in [`dispatch_queue_get_label`](https://github.com/apple/swift-corelibs-libdispatch/blob/34f383d34450d47dd5bdfdf675fcdaa0d0ec8031/src/queue.c#L3158-L3165) which appears to be due to an invalid `dispatch_queue`.

```
Exception Type:        EXC_BAD_ACCESS (SIGSEGV)
Exception Codes:       KERN_INVALID_ADDRESS at 0x0000000100000048
Exception Note:        EXC_CORPSE_NOTIFYVM

Thread 0 Crashed:: Dispatch queue: com.apple.main-thread
0   libdispatch.dylib             0x0000000189abad00 dispatch_queue_get_label + 4
1   com.bugsnag.Bugsnag           0x0000000107e154ac bsg_ksmachgetThreadQueueName+ 324 (BSG_KSMach.c:324)
2   com.bugsnag.Bugsnag           0x0000000107e053e0 -[BugsnagThread initWithMachThread:backtraceAddresses:backtraceLength:errorReportingThread:index:] + 208 (BugsnagThread.m:326)
```

## Changeset

The `dispatch_queue` is now probed to check that it points to a valid memory address before calling `dispatch_queue_get_label`.

## Testing

Was not able to reproduce the crash.

Unit tests and E2E tests verify that `bsg_ksmachgetThreadQueueName` returns the expected name.