### PR TITLE
[PLAT-6973] Fix stack overflow in +[BugsnagThread allThreadsWithCurrentThreadBacktrace:]

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,9 @@ Changelog
 
 ### Bug fixes
 
+* Fix a potential stack overflow in `+[BugsnagThread allThreadsWithCurrentThreadBacktrace:]`.
+  [#1148](https://github.com/bugsnag/bugsnag-cocoa/pull/1148)
+
 * Fix `NSNull` handling in `+[BugsnagError errorFromJson:]` and `+[BugsnagStackframe frameFromJson:]`.
   [#1143](https://github.com/bugsnag/bugsnag-cocoa/pull/1143)
   [#1138](https://github.com/bugsnag/bugsnag-cocoa/issues/1138)


### PR DESCRIPTION
## Goal

Fix a crash due to a stack overflow when recording thread backtraces in an app that has lots (~500+) threads.

```
Exception Type:     EXC_BAD_ACCESS 
Exception Subtype:  KERN_PROTECTION_FAILURE

EXC_BAD_ACCESS: Attempted to dereference garbage pointer 0x171e083b8.

0  AppName    bsg_ksbt_backtraceThreadState (BSG_KSBacktrace.c:145:28)
1  AppName    backtrace_for_thread (BugsnagThread.m:47:38)
2  AppName    +[BugsnagThread allThreadsWithCurrentThreadBacktrace:] (BugsnagThread.m:235:13)
3  AppName    +[BugsnagThread allThreads:callStackReturnAddresses:] (BugsnagThread.m:207:16)
```

This crash is less likely to occur on the main thread because it has a larger default stack size than background threads.

## Changeset

Memory for the backtraces is now allocated from the heap rather than the stack.

## Testing

Reproduced the crash in a unit test, verified it now passes.