### PR TITLE
Increase timeout for iOS 11 E2E tests

### DIFF
--- a/.buildkite/pipeline.full.yml
+++ b/.buildkite/pipeline.full.yml
@@ -120,7 +120,7 @@ steps:
       - cocoa_fixture
     # More time than other steps as the BrowserStack iOS 11 devices seem particularly unstable and
     # sessions need resetting frequently, taking a minute or more each time.
-    timeout_in_minutes: 50
+    timeout_in_minutes: 60
     agents:
       queue: opensource
     plugins:
@@ -148,7 +148,7 @@ steps:
       - cocoa_fixture
     # More time than other steps as the BrowserStack iOS 11 devices seem particularly unstable and
     # sessions need resetting frequently, taking a minute or more each time.
-    timeout_in_minutes: 50
+    timeout_in_minutes: 60
     agents:
       queue: opensource
     plugins:


### PR DESCRIPTION
## Goal

Bring iOS E2E timeout in line with other iOS versions (my search & replace missed this in #1146)