### PR TITLE
[PLAT-6944] Remove (duplicated) user information from metaData

### DIFF
--- a/Bugsnag/Configuration/BugsnagConfiguration.m
+++ b/Bugsnag/Configuration/BugsnagConfiguration.m
@@ -194,7 +194,6 @@ static NSUserDefaults *userDefaults;
     // Only gets persisted user data if there is any, otherwise nil
     // persistUser isn't settable until post-init.
     _user = [self getPersistedUserData];
-    [self setUserMetadataFromUser:_user];
 
     if ([NSURLSession class]) {
         _session = [NSURLSession
@@ -271,24 +270,9 @@ static NSUserDefaults *userDefaults;
         andName:(NSString *_Nullable)name {
     self.user = [[BugsnagUser alloc] initWithUserId:userId name:name emailAddress:email];
 
-    // Persist the user
     if (self.persistUser) {
         [self persistUserData];
     }
-
-    // Add user info to the metadata
-    [self setUserMetadataFromUser:self.user];
-}
-
-/**
- * Add user data to the Configuration metadata
- *
- * @param user A BugsnagUser object containing data to be added to the configuration metadata.
- */
-- (void)setUserMetadataFromUser:(BugsnagUser *)user {
-    [self.metadata addMetadata:user.id withKey:BSGKeyId toSection:BSGKeyUser];
-    [self.metadata addMetadata:user.name         withKey:BSGKeyName  toSection:BSGKeyUser];
-    [self.metadata addMetadata:user.email withKey:BSGKeyEmail toSection:BSGKeyUser];
 }
 
 // =============================================================================

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,13 @@
 Changelog
 =========
 
+## TBD
+
+### Bug fixes
+
+* Remove (duplicated) `user` information from `metaData`.
+  [#1151](https://github.com/bugsnag/bugsnag-cocoa/pull/1151)
+
 ## 6.10.1 (2021-07-07)
 
 ### Bug fixes

--- a/features/barebone_tests.feature
+++ b/features/barebone_tests.feature
@@ -59,6 +59,9 @@ Feature: Barebone tests
     And the event "metaData.Exception.info" equals "Some error specific information"
     And the event "metaData.Flags.Testing" is true
     And the event "metaData.Other.password" equals "[REDACTED]"
+    And the event "metaData.user.email" is null
+    And the event "metaData.user.id" is null
+    And the event "metaData.user.name" is null
     And the event "severity" equals "warning"
     And the event "severityReason.type" equals "handledException"
     And the event "severityReason.unhandledOverridden" is true
@@ -140,6 +143,9 @@ Feature: Barebone tests
     And the event "metaData.lastRunInfo.consecutiveLaunchCrashes" equals 1
     And the event "metaData.lastRunInfo.crashed" is true
     And the event "metaData.lastRunInfo.crashedDuringLaunch" is true
+    And the event "metaData.user.email" is null
+    And the event "metaData.user.id" is null
+    And the event "metaData.user.name" is null
     And the event "severity" equals "error"
     And the event "severityReason.type" equals "unhandledException"
     And the event "severityReason.unhandledOverridden" is null
@@ -237,6 +243,9 @@ Feature: Barebone tests
     And the event "metaData.lastRunInfo.consecutiveLaunchCrashes" equals 1
     And the event "metaData.lastRunInfo.crashed" is true
     And the event "metaData.lastRunInfo.crashedDuringLaunch" is true
+    And the event "metaData.user.email" is null
+    And the event "metaData.user.id" is null
+    And the event "metaData.user.name" is null
     And the event "session.id" is not null
     And the event "session.startedAt" is not null
     And the event "session.events.handled" equals 0

--- a/features/barebone_tests.feature
+++ b/features/barebone_tests.feature
@@ -60,6 +60,7 @@ Feature: Barebone tests
     And the event "metaData.Flags.Testing" is true
     And the event "metaData.Other.password" equals "[REDACTED]"
     And the event "metaData.user.email" is null
+    And the event "metaData.user.group" equals "users"
     And the event "metaData.user.id" is null
     And the event "metaData.user.name" is null
     And the event "severity" equals "warning"
@@ -144,6 +145,7 @@ Feature: Barebone tests
     And the event "metaData.lastRunInfo.crashed" is true
     And the event "metaData.lastRunInfo.crashedDuringLaunch" is true
     And the event "metaData.user.email" is null
+    And the event "metaData.user.group" equals "users"
     And the event "metaData.user.id" is null
     And the event "metaData.user.name" is null
     And the event "severity" equals "error"
@@ -244,6 +246,7 @@ Feature: Barebone tests
     And the event "metaData.lastRunInfo.crashed" is true
     And the event "metaData.lastRunInfo.crashedDuringLaunch" is true
     And the event "metaData.user.email" is null
+    And the event "metaData.user.group" equals "users"
     And the event "metaData.user.id" is null
     And the event "metaData.user.name" is null
     And the event "session.id" is not null

--- a/features/fixtures/shared/scenarios/BareboneTestScenarios.swift
+++ b/features/fixtures/shared/scenarios/BareboneTestScenarios.swift
@@ -44,6 +44,7 @@ class BareboneTestHandledScenario: Scenario {
         config.launchDurationMillis = 0
         config.sendThreads = .unhandledOnly
         config.setUser("foobar", withEmail: "foobar@example.com", andName: "Foo Bar")
+        config.addMetadata(["group": "users"], section: "user")
         config.appVersion = "12.3"
         config.bundleVersion = "12301"
         super.startBugsnag()
@@ -119,6 +120,7 @@ class BareboneTestUnhandledErrorScenario: Scenario {
     override func run() {
         Bugsnag.setContext("Something")
         Bugsnag.setUser("barfoo", withEmail: "barfoo@example.com", andName: "Bar Foo")
+        Bugsnag.addMetadata(["group": "users"], section: "user")
         
         // Triggers "Fatal error: Unexpectedly found nil while implicitly unwrapping an Optional value: ..."
         print(payload.name)

--- a/features/fixtures/shared/scenarios/OOMScenario.m
+++ b/features/fixtures/shared/scenarios/OOMScenario.m
@@ -30,6 +30,7 @@
     self.config.releaseStage = @"staging";
     [self.config addMetadata:@{@"bar": @"foo"} toSection:@"custom"];
     [self.config setUser:@"foobar" withEmail:@"foobar@example.com" andName:@"Foo Bar"];
+    [self.config addMetadata:@{@"group": @"users"} toSection:@"user"];
     [self.config addOnSendErrorBlock:^BOOL(BugsnagEvent *event) {
         BugsnagLastRunInfo *lastRunInfo = Bugsnag.lastRunInfo;
         if (lastRunInfo) {


### PR DESCRIPTION
## Goal

An event's `metaData` would under some circumstances contain a `user` payload which could contain out of date information, breaking event filters on the dashboard.

## Changeset

User data is no longer copied into the metadata by `BugsnagConfiguration`

## Testing

Updated E2E tests to verify that `metaData.user` does not contain information copied from the `user` payload, but that setting a custom `user` payload works as expected.

Ran [full E2E test suite](https://buildkite.com/bugsnag/bugsnag-cocoa/builds/3040) to verify no failures are introduced.