### PR TITLE
Remove now duplicate Cucumber step implementation

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -7,7 +7,7 @@ gem 'xcpretty'
 
 # A reference to Maze Runner is only needed for running tests locally and if committed it must be
 # portable for CI, e.g. a specific release.  However, leaving it commented out would mean quicker CI.
-gem 'bugsnag-maze-runner', git: 'https://github.com/bugsnag/maze-runner', tag: 'v5.3.0'
+gem 'bugsnag-maze-runner', git: 'https://github.com/bugsnag/maze-runner', tag: 'v5.6.0'
 
 # Locally, you can run against Maze Runner branches and uncommitted changes:
 # gem 'bugsnag-maze-runner', path: '../maze-runner'

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -1,9 +1,9 @@
 GIT
   remote: https://github.com/bugsnag/maze-runner
-  revision: 67a22f49bc5c31a144fc72892f8cfafd0289010e
-  tag: v5.3.0
+  revision: 626bbe9d8e72e46fc8cae757a032bea88b6e3829
+  tag: v5.6.0
   specs:
-    bugsnag-maze-runner (5.3.0)
+    bugsnag-maze-runner (5.6.0)
       appium_lib (~> 11.2.0)
       cucumber (~> 3.1.2)
       cucumber-expressions (~> 6.0.0)
@@ -189,7 +189,7 @@ GEM
     rouge (2.0.7)
     ruby-macho (1.4.0)
     ruby2_keywords (0.0.4)
-    rubyzip (2.3.0)
+    rubyzip (2.3.2)
     sassc (2.4.0)
       ffi (~> 1.9)
     sawyer (0.8.2)

--- a/features/steps/header_steps.rb
+++ b/features/steps/header_steps.rb
@@ -1,8 +1,0 @@
-# frozen_string_literal: true
-
-# @!group Header steps
-
-Then('the {word} {string} header is null') do |request_type, header_name|
-  assert_nil(Maze::Server.list_for(request_type).current[:request][header_name],
-             "The #{request_type} '#{header_name}' header should be null")
-end


### PR DESCRIPTION
## Goal

Fix the e2e tests after a duplicate named step (that does the same thing) was added to Maze Runner.

## Testing

Covered by CI and having run locally successfully.