### PR TITLE
[PLAT-6990] Fix ThreadSanitizer data race warning in BSGAppHangDetector

### DIFF
--- a/Bugsnag/Helpers/BSGAppHangDetector.m
+++ b/Bugsnag/Helpers/BSGAppHangDetector.m
@@ -24,7 +24,7 @@
 @property (weak, nonatomic) id<BSGAppHangDetectorDelegate> delegate;
 @property (nonatomic) BOOL recordAllThreads;
 @property (nonatomic) CFRunLoopObserverRef observer;
-@property (nonatomic) dispatch_time_t processingDeadline;
+@property (atomic) dispatch_time_t processingDeadline;
 @property (nonatomic) dispatch_semaphore_t processingStarted;
 @property (nonatomic) dispatch_semaphore_t processingFinished;
 @property (weak, nonatomic) NSThread *thread;

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,9 @@ Changelog
 
 ### Bug fixes
 
+* Fix ThreadSanitizer data race warning in `BSGAppHangDetector`.
+  [#1153](https://github.com/bugsnag/bugsnag-cocoa/pull/1153)
+
 * Remove (duplicated) `user` information from `metaData`.
   [#1151](https://github.com/bugsnag/bugsnag-cocoa/pull/1151)
 


### PR DESCRIPTION
## Goal

To fix data race detected by ThreadSanitizer

```
WARNING: ThreadSanitizer: data race (pid=96119)
  Write of size 8 at 0x7b10000ab9e0 by main thread:
    #0 -[BSGAppHangDetector setProcessingDeadline:] BSGAppHangDetector.m (Bugsnag Test App:x86_64+0x1000353a9)
    #1 __40-[BSGAppHangDetector startWithDelegate:]_block_invoke BSGAppHangDetector.m:76 (Bugsnag Test App:x86_64+0x100033def)
    #2 __CFRUNLOOP_IS_CALLING_OUT_TO_AN_OBSERVER_CALLBACK_FUNCTION__ <null>:2 (CoreFoundation:x86_64+0x9eeb6)
    #3 start <null>:2 (libdyld.dylib:x86_64+0xcf4)

  Previous read of size 8 at 0x7b10000ab9e0 by thread T7:
    #0 -[BSGAppHangDetector processingDeadline] BSGAppHangDetector.m:27 (Bugsnag Test App:x86_64+0x100035325)
    #1 -[BSGAppHangDetector detectAppHangs] BSGAppHangDetector.m:119 (Bugsnag Test App:x86_64+0x10003445b)
    #2 __NSThread__start__ <null>:2 (Foundation:x86_64+0xc90ec)

  Location is heap block of size 64 at 0x7b10000ab9c0 allocated by main thread:
    #0 calloc <null>:2 (libclang_rt.tsan_iossim_dynamic.dylib:x86_64+0x4e852)
    #1 _objc_rootAllocWithZone <null>:2 (libobjc.A.dylib:x86_64+0x14072)
    #2 -[BugsnagClient start] BugsnagClient.m:417 (Bugsnag Test App:x86_64+0x100067e05)
    #3 +[Bugsnag startWithConfiguration:] Bugsnag.m:61 (Bugsnag Test App:x86_64+0x1000510aa)
    #4 +[Bugsnag start] Bugsnag.m:48 (Bugsnag Test App:x86_64+0x100050cf6)
    #5 -[AppDelegate application:didFinishLaunchingWithOptions:] AppDelegate.m:21 (Bugsnag Test App:x86_64+0x1000035da)
    #6 -[UIApplication _handleDelegateCallbacksWithOptions:isSuspended:restoreState:] <null>:2 (UIKitCore:x86_64+0xa8694e)
    #7 start <null>:2 (libdyld.dylib:x86_64+0xcf4)

  Thread T7 (tid=2230994, running) created by main thread at:
    #0 pthread_create <null>:2 (libclang_rt.tsan_iossim_dynamic.dylib:x86_64+0x2aa1d)
    #1 -[NSThread start] <null>:2 (Foundation:x86_64+0xc8c4d)
    #2 -[BugsnagClient startAppHangDetector] BugsnagClient.m:1202 (Bugsnag Test App:x86_64+0x100074ddb)
    #3 -[BugsnagClient start] BugsnagClient.m:417 (Bugsnag Test App:x86_64+0x100067e05)
    #4 +[Bugsnag startWithConfiguration:] Bugsnag.m:61 (Bugsnag Test App:x86_64+0x1000510aa)
    #5 +[Bugsnag start] Bugsnag.m:48 (Bugsnag Test App:x86_64+0x100050cf6)
    #6 -[AppDelegate application:didFinishLaunchingWithOptions:] AppDelegate.m:21 (Bugsnag Test App:x86_64+0x1000035da)
    #7 -[UIApplication _handleDelegateCallbacksWithOptions:isSuspended:restoreState:] <null>:2 (UIKitCore:x86_64+0xa8694e)
    #8 start <null>:2 (libdyld.dylib:x86_64+0xcf4)

SUMMARY: ThreadSanitizer: data race BSGAppHangDetector.m in -[BSGAppHangDetector setProcessingDeadline:]
```

## Changeset

Make `processingDeadline` `atomic` to fix data race.

## Testing

Reproduced issue by enabling Thread Sanitizer in example app.