### PR TITLE
[PLAT-7010 ] Fix strlen crash in bsg_ksmachgetThreadQueueName

### DIFF
--- a/Bugsnag.xcodeproj/project.pbxproj
+++ b/Bugsnag.xcodeproj/project.pbxproj
@@ -171,9 +171,9 @@
 		008967A82486D43700DC48C2 /* KSCrashIdentifierTests.m in Sources */ = {isa = PBXBuildFile; fileRef = 008966E92486D43700DC48C2 /* KSCrashIdentifierTests.m */; };
 		008967A92486D43700DC48C2 /* KSCrashIdentifierTests.m in Sources */ = {isa = PBXBuildFile; fileRef = 008966E92486D43700DC48C2 /* KSCrashIdentifierTests.m */; };
 		008967AA2486D43700DC48C2 /* KSCrashIdentifierTests.m in Sources */ = {isa = PBXBuildFile; fileRef = 008966E92486D43700DC48C2 /* KSCrashIdentifierTests.m */; };
-		008967AB2486D43700DC48C2 /* KSMach_Tests.m in Sources */ = {isa = PBXBuildFile; fileRef = 008966EA2486D43700DC48C2 /* KSMach_Tests.m */; };
-		008967AC2486D43700DC48C2 /* KSMach_Tests.m in Sources */ = {isa = PBXBuildFile; fileRef = 008966EA2486D43700DC48C2 /* KSMach_Tests.m */; };
-		008967AD2486D43700DC48C2 /* KSMach_Tests.m in Sources */ = {isa = PBXBuildFile; fileRef = 008966EA2486D43700DC48C2 /* KSMach_Tests.m */; };
+		008967AB2486D43700DC48C2 /* BSG_KSMachTests.m in Sources */ = {isa = PBXBuildFile; fileRef = 008966EA2486D43700DC48C2 /* BSG_KSMachTests.m */; };
+		008967AC2486D43700DC48C2 /* BSG_KSMachTests.m in Sources */ = {isa = PBXBuildFile; fileRef = 008966EA2486D43700DC48C2 /* BSG_KSMachTests.m */; };
+		008967AD2486D43700DC48C2 /* BSG_KSMachTests.m in Sources */ = {isa = PBXBuildFile; fileRef = 008966EA2486D43700DC48C2 /* BSG_KSMachTests.m */; };
 		008967B42486D9D800DC48C2 /* BugsnagBreadcrumbs.m in Sources */ = {isa = PBXBuildFile; fileRef = 008967B22486D9D700DC48C2 /* BugsnagBreadcrumbs.m */; };
 		008967B52486D9D800DC48C2 /* BugsnagBreadcrumbs.m in Sources */ = {isa = PBXBuildFile; fileRef = 008967B22486D9D700DC48C2 /* BugsnagBreadcrumbs.m */; };
 		008967B62486D9D800DC48C2 /* BugsnagBreadcrumbs.m in Sources */ = {isa = PBXBuildFile; fileRef = 008967B22486D9D700DC48C2 /* BugsnagBreadcrumbs.m */; };
@@ -1132,7 +1132,7 @@
 		008966E72486D43700DC48C2 /* KSCrashSentry_Signal_Tests.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; path = KSCrashSentry_Signal_Tests.m; sourceTree = "<group>"; };
 		008966E82486D43700DC48C2 /* KSString_Tests.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; path = KSString_Tests.m; sourceTree = "<group>"; };
 		008966E92486D43700DC48C2 /* KSCrashIdentifierTests.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; path = KSCrashIdentifierTests.m; sourceTree = "<group>"; };
-		008966EA2486D43700DC48C2 /* KSMach_Tests.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; path = KSMach_Tests.m; sourceTree = "<group>"; };
+		008966EA2486D43700DC48C2 /* BSG_KSMachTests.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; path = BSG_KSMachTests.m; sourceTree = "<group>"; };
 		008967AE2486D6E100DC48C2 /* Makefile */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = text; path = Makefile; sourceTree = SOURCE_ROOT; };
 		008967B22486D9D700DC48C2 /* BugsnagBreadcrumbs.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; path = BugsnagBreadcrumbs.m; sourceTree = "<group>"; };
 		008967B32486D9D700DC48C2 /* BugsnagBreadcrumbs.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = BugsnagBreadcrumbs.h; sourceTree = "<group>"; };
@@ -1478,6 +1478,8 @@
 		008966D32486D43700DC48C2 /* KSCrash */ = {
 			isa = PBXGroup;
 			children = (
+				008966D82486D43700DC48C2 /* BSG_KSMachHeadersTests.m */,
+				008966EA2486D43700DC48C2 /* BSG_KSMachTests.m */,
 				008966D62486D43700DC48C2 /* FileBasedTestCase.h */,
 				008966E42486D43700DC48C2 /* FileBasedTestCase.m */,
 				008966E92486D43700DC48C2 /* KSCrashIdentifierTests.m */,
@@ -1489,8 +1491,6 @@
 				008966E52486D43700DC48C2 /* KSFileUtils_Tests.m */,
 				008966E02486D43700DC48C2 /* KSJSONCodec_Tests.m */,
 				008966DA2486D43700DC48C2 /* KSLogger_Tests.m */,
-				008966EA2486D43700DC48C2 /* KSMach_Tests.m */,
-				008966D82486D43700DC48C2 /* BSG_KSMachHeadersTests.m */,
 				008966E12486D43700DC48C2 /* KSSignalInfo_Tests.m */,
 				008966E82486D43700DC48C2 /* KSString_Tests.m */,
 				008966D52486D43700DC48C2 /* KSSysCtl_Tests.m */,
@@ -2704,7 +2704,7 @@
 				008967542486D43700DC48C2 /* BugsnagOnCrashTest.m in Sources */,
 				008967152486D43700DC48C2 /* BugsnagCollectionsTests.m in Sources */,
 				01E8765E256684E700F4B70A /* URLSessionMock.m in Sources */,
-				008967AB2486D43700DC48C2 /* KSMach_Tests.m in Sources */,
+				008967AB2486D43700DC48C2 /* BSG_KSMachTests.m in Sources */,
 				0089672A2486D43700DC48C2 /* BugsnagStacktraceTest.m in Sources */,
 				01847DAC26441A5E00ADA4C7 /* BSGInternalErrorReporterTests.m in Sources */,
 				0163BF5925823D8D008DC28B /* NotificationBreadcrumbTests.m in Sources */,
@@ -2858,7 +2858,7 @@
 				008967012486D43700DC48C2 /* BugsnagEventPersistLoadTest.m in Sources */,
 				008967702486D43700DC48C2 /* NSError+SimpleConstructor_Tests.m in Sources */,
 				0089671C2486D43700DC48C2 /* BugsnagSessionTest.m in Sources */,
-				008967AC2486D43700DC48C2 /* KSMach_Tests.m in Sources */,
+				008967AC2486D43700DC48C2 /* BSG_KSMachTests.m in Sources */,
 				0163BF5A25823D8D008DC28B /* NotificationBreadcrumbTests.m in Sources */,
 				01BDB1FD25DEBFB300A91FAF /* BSGEventUploadKSCrashReportOperationTests.m in Sources */,
 				00896A452486DBF000DC48C2 /* BugsnagConfigurationTests.m in Sources */,
@@ -3022,7 +3022,7 @@
 				008967022486D43700DC48C2 /* BugsnagEventPersistLoadTest.m in Sources */,
 				008967712486D43700DC48C2 /* NSError+SimpleConstructor_Tests.m in Sources */,
 				0089671D2486D43700DC48C2 /* BugsnagSessionTest.m in Sources */,
-				008967AD2486D43700DC48C2 /* KSMach_Tests.m in Sources */,
+				008967AD2486D43700DC48C2 /* BSG_KSMachTests.m in Sources */,
 				00896A462486DBF000DC48C2 /* BugsnagConfigurationTests.m in Sources */,
 				0089674A2486D43700DC48C2 /* BugsnagUserTest.m in Sources */,
 				0089673B2486D43700DC48C2 /* BugsnagEventFromKSCrashReportTest.m in Sources */,

--- a/Bugsnag.xcodeproj/xcshareddata/xcschemes/Bugsnag-iOS.xcscheme
+++ b/Bugsnag.xcodeproj/xcshareddata/xcschemes/Bugsnag-iOS.xcscheme
@@ -28,6 +28,13 @@
       selectedLauncherIdentifier = "Xcode.DebuggerFoundation.Launcher.LLDB"
       shouldUseLaunchSchemeArgsEnv = "YES"
       codeCoverageEnabled = "YES">
+      <AdditionalOptions>
+         <AdditionalOption
+            key = "MallocScribble"
+            value = ""
+            isEnabled = "YES">
+         </AdditionalOption>
+      </AdditionalOptions>
       <Testables>
          <TestableReference
             skipped = "NO">

--- a/Bugsnag.xcodeproj/xcshareddata/xcschemes/Bugsnag-macOS.xcscheme
+++ b/Bugsnag.xcodeproj/xcshareddata/xcschemes/Bugsnag-macOS.xcscheme
@@ -28,6 +28,13 @@
       selectedLauncherIdentifier = "Xcode.DebuggerFoundation.Launcher.LLDB"
       shouldUseLaunchSchemeArgsEnv = "YES"
       codeCoverageEnabled = "YES">
+      <AdditionalOptions>
+         <AdditionalOption
+            key = "MallocScribble"
+            value = ""
+            isEnabled = "YES">
+         </AdditionalOption>
+      </AdditionalOptions>
       <Testables>
          <TestableReference
             skipped = "NO">

--- a/Bugsnag.xcodeproj/xcshareddata/xcschemes/Bugsnag-tvOS.xcscheme
+++ b/Bugsnag.xcodeproj/xcshareddata/xcschemes/Bugsnag-tvOS.xcscheme
@@ -28,6 +28,13 @@
       selectedLauncherIdentifier = "Xcode.DebuggerFoundation.Launcher.LLDB"
       shouldUseLaunchSchemeArgsEnv = "YES"
       codeCoverageEnabled = "YES">
+      <AdditionalOptions>
+         <AdditionalOption
+            key = "MallocScribble"
+            value = ""
+            isEnabled = "YES">
+         </AdditionalOption>
+      </AdditionalOptions>
       <Testables>
          <TestableReference
             skipped = "NO">

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,13 @@
 Changelog
 =========
 
+## TBD
+
+### Bug fixes
+
+* Fix another rare crash in `bsg_ksmachgetThreadQueueName`.
+  [#1157](https://github.com/bugsnag/bugsnag-cocoa/pull/1157)
+
 ## 6.10.2 (2021-07-14)
 
 ### Bug fixes


### PR DESCRIPTION
## Goal

Fixes a (rare) crash in `bsg_ksmachgetThreadQueueName` when calling `strlen` for a dispatch queue label.

```
Exception Type:        EXC_BAD_ACCESS (SIGSEGV)
Exception Codes:       EXC_I386_GPFLT

Thread 0 Crashed:: Dispatch queue: com.apple.main-thread
0   libsystem_c.dylib    0x111c07172 strlen + 18
1   com.bugsnag.Bugsnag  0x12075d21a bsg_ksmachgetThreadQueueName + 442 (BSG_KSMach.c:336)
2   com.bugsnag.Bugsnag  0x12074b1a7 -[BugsnagThread initWithMachThread:backtraceAddresses:backtraceLength:errorReportingThread:index:] + 231
3   com.bugsnag.Bugsnag  0x12074aa62 +[BugsnagThread allThreadsWithCurrentThreadBacktrace:] + 690 BugsnagThread.m:247)
4   com.bugsnag.Bugsnag  0x12074a6c3 +[BugsnagThread allThreads:callStackReturnAddresses:] + 51 (BugsnagThread.m:206)
5   com.bugsnag.Bugsnag  0x120721c71 -[BugsnagClient notify:handledState:block:] + 497 (BugsnagClient.m:856)
6   com.bugsnag.Bugsnag  0x120720f01 -[BugsnagClient notifyError:] + 385 (BugsnagClient.m:766)
```

## Analysis

When a thread is being destroyed, its `dispatch_queue`'s memory may be deallocated (and reused for something else) while `bsg_ksmachgetThreadQueueName` is executing, resulting in calling `dispatch_queue_get_label` with an invalid pointer. 

Previous fixes ensured that the `dispatch_queue` points to readable memory, but since `dispatch_queue_get_label` simply [returns a pointer from an offset](https://github.com/apple/swift-corelibs-libdispatch/blob/swift-5.4.2-RELEASE/src/queue.c#L3158-L3165) into the struct, an invalid pointer could be returned that would cause `strlen` to crash.

## Changeset

`vm_read_overwrite` is now used to safely read from the pointer returned by `dispatch_queue_get_label`.

## Testing

A unit test case has been added that is able to reliably reproduce the crash (without the fix in place) when `MallocScribble` is enabled.

See https://buildkite.com/bugsnag/bugsnag-cocoa/builds/3068 for positive detection of the crash without the fix in place.