### PR TITLE
Internal error reporting improvements

### DIFF
--- a/Bugsnag/Delivery/BSGEventUploadKSCrashReportOperation.m
+++ b/Bugsnag/Delivery/BSGEventUploadKSCrashReportOperation.m
@@ -54,6 +54,7 @@ static void ReportInternalError(NSString *errorClass, NSString *message, NSDicti
     if (!json) {
         NSMutableDictionary *diagnostics = [NSMutableDictionary dictionary];
         diagnostics[@"data"] = [data base64EncodedStringWithOptions:0];
+        diagnostics[@"file"] = self.file;
         ReportInternalError(@"JSON parsing error", BSGErrorDescription(error), diagnostics);
         if (errorPtr) {
             *errorPtr = error;

--- a/features/internal_error_reporting.feature
+++ b/features/internal_error_reporting.feature
@@ -14,6 +14,7 @@ Feature: Internal error reporting
     And the event "groupingHash" equals "BSGEventUploadKSCrashReportOperation.m: JSON parsing error: NSCocoaErrorDomain 3840: No string key for value in object"
     And the event "metaData.BugsnagDiagnostics.apiKey" equals "12312312312312312312312312312312"
     And the event "metaData.BugsnagDiagnostics.data" is not null
+    And the event "metaData.BugsnagDiagnostics.file" is not null
     And the event "unhandled" is false
     And the exception "errorClass" equals "JSON parsing error"
     And the exception "message" matches "NSCocoaErrorDomain 3840: No string key for value in object around character \d+."


### PR DESCRIPTION
## Goal

Aid diagnosis and investigation of internal error reports.

## Changeset

* Captures the file path for JSON errors, to identify if unexpected files are being processed.
* Reports a new type of error if the storage subdirectories cannot be created successfully.

## Testing

JSON error file path is covered by E2E tests (tested locally)