### PR TITLE
[PLAT-7101 ] Fix ThreadSanitizer data race in BugsnagBreadcrumbs

### DIFF
--- a/Bugsnag/Breadcrumbs/BugsnagBreadcrumbs.m
+++ b/Bugsnag/Breadcrumbs/BugsnagBreadcrumbs.m
@@ -157,8 +157,11 @@ static struct bsg_breadcrumb_list_item *g_breadcrumbs_head;
         dispatch_async(BSGGlobalsFileSystemQueue(), ^{
             // Avoid writing breadcrumbs that have already been deleted from the in-memory store.
             // This can occur when breadcrumbs are being added faster than they can be written.
-            unsigned int nextFileNumber = self.nextFileNumber;
-            BOOL isStale = (self.maxBreadcrumbs < nextFileNumber) && (fileNumber < (nextFileNumber - self.maxBreadcrumbs));
+            BOOL isStale;
+            @synchronized (self) {
+                unsigned int nextFileNumber = self.nextFileNumber;
+                isStale = (self.maxBreadcrumbs < nextFileNumber) && (fileNumber < (nextFileNumber - self.maxBreadcrumbs));
+            }
             
             NSError *error = nil;
             

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,13 @@
 Changelog
 =========
 
+## TBD
+
+### Bug fixes
+
+* Fix ThreadSanitizer data race in `BugsnagBreadcrumbs`.
+  [#1160](https://github.com/bugsnag/bugsnag-cocoa/pull/1160)
+
 ## 6.10.3 (2021-08-04)
 
 ### Bug fixes

--- a/Tests/BugsnagBreadcrumbsTest.m
+++ b/Tests/BugsnagBreadcrumbsTest.m
@@ -451,6 +451,10 @@ BSGBreadcrumbType BSGBreadcrumbTypeFromString(NSString *value);
 }
 
 - (void)testCrashReportWriterConcurrency {
+#if defined(__has_feature) && __has_feature(thread_sanitizer)
+    NSLog(@"Skipping test because ThreadSanitizer deadlocks if other threads are suspended");
+    return;
+#endif
     //
     // The aim of this test is to ensure that BugsnagBreadcrumbsWriteCrashReport will insert only valid JSON
     // into a crash report when other threads are (paused while) updating the breadcrumbs linked list.


### PR DESCRIPTION
## Goal

Fix a data race detected by [ThreadSanitizer](https://github.com/google/sanitizers/wiki/ThreadSanitizerCppManual).

## Changeset

Wraps access to `nextFileNumber` in a `@synchronized (self)` block to prevent simultaneous read and write.

Skips `testCrashReportWriterConcurrency` when ThreadSanitizer is enabled because suspending threads causes deadlocks in TSan's code (which uses locking primitives.)

## Testing

Reproduced issue by running `BugsnagBreadcrumbsTest` with ThreadSanitizer enabled, confirmed that data race is no longer reported.