### PR TITLE
[PLAT-7110] Add breadcrumbs for UIScene notifications

### DIFF
--- a/Bugsnag.xcodeproj/project.pbxproj
+++ b/Bugsnag.xcodeproj/project.pbxproj
@@ -633,6 +633,11 @@
 		0126F7BF25DD512B008483C2 /* BSGEventUploadKSCrashReportOperation.m in Sources */ = {isa = PBXBuildFile; fileRef = 0126F7BA25DD512B008483C2 /* BSGEventUploadKSCrashReportOperation.m */; };
 		0126F7C025DD512B008483C2 /* BSGEventUploadKSCrashReportOperation.m in Sources */ = {isa = PBXBuildFile; fileRef = 0126F7BA25DD512B008483C2 /* BSGEventUploadKSCrashReportOperation.m */; };
 		0126F7C125DD512B008483C2 /* BSGEventUploadKSCrashReportOperation.m in Sources */ = {isa = PBXBuildFile; fileRef = 0126F7BA25DD512B008483C2 /* BSGEventUploadKSCrashReportOperation.m */; };
+		013D9CD126C5262F0077F0AD /* UISceneStub.h in Headers */ = {isa = PBXBuildFile; fileRef = 013D9CCF26C5262F0077F0AD /* UISceneStub.h */; };
+		013D9CD226C5262F0077F0AD /* UISceneStub.h in Headers */ = {isa = PBXBuildFile; fileRef = 013D9CCF26C5262F0077F0AD /* UISceneStub.h */; };
+		013D9CD326C5262F0077F0AD /* UISceneStub.h in Headers */ = {isa = PBXBuildFile; fileRef = 013D9CCF26C5262F0077F0AD /* UISceneStub.h */; };
+		013D9CD426C5262F0077F0AD /* UISceneStub.m in Sources */ = {isa = PBXBuildFile; fileRef = 013D9CD026C5262F0077F0AD /* UISceneStub.m */; };
+		013D9CD626C5262F0077F0AD /* UISceneStub.m in Sources */ = {isa = PBXBuildFile; fileRef = 013D9CD026C5262F0077F0AD /* UISceneStub.m */; };
 		0140D29A25767C9A00FD0306 /* BugsnagApiClientTest.m in Sources */ = {isa = PBXBuildFile; fileRef = CB9103632502320A00E9D1E2 /* BugsnagApiClientTest.m */; };
 		01447605256684500018AB94 /* BugsnagApiClientTest.m in Sources */ = {isa = PBXBuildFile; fileRef = CB9103632502320A00E9D1E2 /* BugsnagApiClientTest.m */; };
 		01468F5225876DC1002B0519 /* BSGNotificationBreadcrumbs.h in Headers */ = {isa = PBXBuildFile; fileRef = 01468F5025876DC1002B0519 /* BSGNotificationBreadcrumbs.h */; };
@@ -646,9 +651,9 @@
 		015F528525C15BB7000D1915 /* MRCCanary.m in Sources */ = {isa = PBXBuildFile; fileRef = 015F528325C15BB7000D1915 /* MRCCanary.m */; settings = {COMPILER_FLAGS = "-fno-objc-arc"; }; };
 		015F528625C15BB7000D1915 /* MRCCanary.m in Sources */ = {isa = PBXBuildFile; fileRef = 015F528325C15BB7000D1915 /* MRCCanary.m */; settings = {COMPILER_FLAGS = "-fno-objc-arc"; }; };
 		015F528725C15BB7000D1915 /* MRCCanary.m in Sources */ = {isa = PBXBuildFile; fileRef = 015F528325C15BB7000D1915 /* MRCCanary.m */; settings = {COMPILER_FLAGS = "-fno-objc-arc"; }; };
-		0163BF5925823D8D008DC28B /* NotificationBreadcrumbTests.m in Sources */ = {isa = PBXBuildFile; fileRef = 0163BF5825823D8D008DC28B /* NotificationBreadcrumbTests.m */; };
-		0163BF5A25823D8D008DC28B /* NotificationBreadcrumbTests.m in Sources */ = {isa = PBXBuildFile; fileRef = 0163BF5825823D8D008DC28B /* NotificationBreadcrumbTests.m */; };
-		0163BF5B25823D8D008DC28B /* NotificationBreadcrumbTests.m in Sources */ = {isa = PBXBuildFile; fileRef = 0163BF5825823D8D008DC28B /* NotificationBreadcrumbTests.m */; };
+		0163BF5925823D8D008DC28B /* BSGNotificationBreadcrumbsTests.m in Sources */ = {isa = PBXBuildFile; fileRef = 0163BF5825823D8D008DC28B /* BSGNotificationBreadcrumbsTests.m */; };
+		0163BF5A25823D8D008DC28B /* BSGNotificationBreadcrumbsTests.m in Sources */ = {isa = PBXBuildFile; fileRef = 0163BF5825823D8D008DC28B /* BSGNotificationBreadcrumbsTests.m */; };
+		0163BF5B25823D8D008DC28B /* BSGNotificationBreadcrumbsTests.m in Sources */ = {isa = PBXBuildFile; fileRef = 0163BF5825823D8D008DC28B /* BSGNotificationBreadcrumbsTests.m */; };
 		016875C6258D003200DFFF69 /* NSUserDefaultsStub.m in Sources */ = {isa = PBXBuildFile; fileRef = 016875C5258D003200DFFF69 /* NSUserDefaultsStub.m */; };
 		016875C7258D003200DFFF69 /* NSUserDefaultsStub.m in Sources */ = {isa = PBXBuildFile; fileRef = 016875C5258D003200DFFF69 /* NSUserDefaultsStub.m */; };
 		016875C8258D003200DFFF69 /* NSUserDefaultsStub.m in Sources */ = {isa = PBXBuildFile; fileRef = 016875C5258D003200DFFF69 /* NSUserDefaultsStub.m */; };
@@ -1301,11 +1306,13 @@
 		0126F7BA25DD512B008483C2 /* BSGEventUploadKSCrashReportOperation.m */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.objc; path = BSGEventUploadKSCrashReportOperation.m; sourceTree = "<group>"; };
 		0134524A256BCF7C0088C548 /* BugsnagError+Private.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; path = "BugsnagError+Private.h"; sourceTree = "<group>"; };
 		0134524B256BD00A0088C548 /* BugsnagThread+Private.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; path = "BugsnagThread+Private.h"; sourceTree = "<group>"; };
+		013D9CCF26C5262F0077F0AD /* UISceneStub.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; path = UISceneStub.h; sourceTree = "<group>"; };
+		013D9CD026C5262F0077F0AD /* UISceneStub.m */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.objc; path = UISceneStub.m; sourceTree = "<group>"; };
 		0140D24725765F8F00FD0306 /* BSGUIKit.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; path = BSGUIKit.h; sourceTree = "<group>"; };
 		01468F5025876DC1002B0519 /* BSGNotificationBreadcrumbs.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = BSGNotificationBreadcrumbs.h; sourceTree = "<group>"; };
 		01468F5125876DC1002B0519 /* BSGNotificationBreadcrumbs.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; path = BSGNotificationBreadcrumbs.m; sourceTree = "<group>"; };
 		015F528325C15BB7000D1915 /* MRCCanary.m */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.objc; path = MRCCanary.m; sourceTree = "<group>"; };
-		0163BF5825823D8D008DC28B /* NotificationBreadcrumbTests.m */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.objc; path = NotificationBreadcrumbTests.m; sourceTree = "<group>"; };
+		0163BF5825823D8D008DC28B /* BSGNotificationBreadcrumbsTests.m */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.objc; path = BSGNotificationBreadcrumbsTests.m; sourceTree = "<group>"; };
 		016875C4258D003200DFFF69 /* NSUserDefaultsStub.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; path = NSUserDefaultsStub.h; sourceTree = "<group>"; };
 		016875C5258D003200DFFF69 /* NSUserDefaultsStub.m */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.objc; path = NSUserDefaultsStub.m; sourceTree = "<group>"; };
 		017824BD262D65A000D18AFA /* Bugsnag.xcconfig */ = {isa = PBXFileReference; lastKnownFileType = text.xcconfig; path = Bugsnag.xcconfig; sourceTree = "<group>"; };
@@ -1704,6 +1711,7 @@
 				01BDB1CE25DEBF4600A91FAF /* BSGEventUploadKSCrashReportOperationTests.m */,
 				01847DAB26441A5E00ADA4C7 /* BSGInternalErrorReporterTests.m */,
 				CBCF77AA250142E0004AF22A /* BSGJSONSerializationTests.m */,
+				0163BF5825823D8D008DC28B /* BSGNotificationBreadcrumbsTests.m */,
 				008966C82486D43600DC48C2 /* BSGOutOfMemoryTests.m */,
 				CB6419AA25A73E8C00613D25 /* BSGStorageMigratorTests.m */,
 				CB9103632502320A00E9D1E2 /* BugsnagApiClientTest.m */,
@@ -1751,13 +1759,14 @@
 				008966D32486D43700DC48C2 /* KSCrash */,
 				016875C4258D003200DFFF69 /* NSUserDefaultsStub.h */,
 				016875C5258D003200DFFF69 /* NSUserDefaultsStub.m */,
-				0163BF5825823D8D008DC28B /* NotificationBreadcrumbTests.m */,
 				01B14C55251CE55F00118748 /* report-react-native-promise-rejection.json */,
 				008966B72486D43500DC48C2 /* report.json */,
 				CB6419B325A7419400613D25 /* v0_files */,
 				008966AE2486D43500DC48C2 /* Swift Tests */,
 				CBA22499251E429C00B87416 /* TestSupport.h */,
 				CBA2249A251E429C00B87416 /* TestSupport.m */,
+				013D9CCF26C5262F0077F0AD /* UISceneStub.h */,
+				013D9CD026C5262F0077F0AD /* UISceneStub.m */,
 				01E8765C256684E700F4B70A /* URLSessionMock.h */,
 				01E8765D256684E700F4B70A /* URLSessionMock.m */,
 				012482A225627B51003F7243 /* UIKitTests.m */,
@@ -2056,6 +2065,7 @@
 				008968F42486DAB800DC48C2 /* BugsnagSessionFileStore.h in Headers */,
 				008968882486DA9600DC48C2 /* BugsnagHandledState.h in Headers */,
 				CBCF77A325010648004AF22A /* BSGJSONSerialization.h in Headers */,
+				013D9CD126C5262F0077F0AD /* UISceneStub.h in Headers */,
 				00896A082486DAD100DC48C2 /* BSG_KSCrashSentry_Private.h in Headers */,
 				008969722486DAD000DC48C2 /* BSG_KSSignalInfo.h in Headers */,
 				008967C22486DA1900DC48C2 /* BugsnagClient+Private.h in Headers */,
@@ -2159,6 +2169,7 @@
 				0126F79C25DD510E008483C2 /* BSGEventUploadObjectOperation.h in Headers */,
 				008968892486DA9600DC48C2 /* BugsnagHandledState.h in Headers */,
 				00896A092486DAD100DC48C2 /* BSG_KSCrashSentry_Private.h in Headers */,
+				013D9CD226C5262F0077F0AD /* UISceneStub.h in Headers */,
 				CBCF77A425010648004AF22A /* BSGJSONSerialization.h in Headers */,
 				008969732486DAD000DC48C2 /* BSG_KSSignalInfo.h in Headers */,
 				008967C32486DA1900DC48C2 /* BugsnagClient+Private.h in Headers */,
@@ -2262,6 +2273,7 @@
 				0126F79D25DD510E008483C2 /* BSGEventUploadObjectOperation.h in Headers */,
 				0089688A2486DA9600DC48C2 /* BugsnagHandledState.h in Headers */,
 				00896A0A2486DAD100DC48C2 /* BSG_KSCrashSentry_Private.h in Headers */,
+				013D9CD326C5262F0077F0AD /* UISceneStub.h in Headers */,
 				CBCF77A525010648004AF22A /* BSGJSONSerialization.h in Headers */,
 				008969742486DAD100DC48C2 /* BSG_KSSignalInfo.h in Headers */,
 				008967C42486DA1900DC48C2 /* BugsnagClient+Private.h in Headers */,
@@ -2624,6 +2636,7 @@
 				CBAB4DD82510D2460092CBAA /* BugsnagKVStoreObjC.m in Sources */,
 				008968A72486DA9600DC48C2 /* BugsnagSession.m in Sources */,
 				0089683A2486DA6C00DC48C2 /* BugsnagMetadata.m in Sources */,
+				013D9CD426C5262F0077F0AD /* UISceneStub.m in Sources */,
 				008969F62486DAD100DC48C2 /* BSG_KSCrash.m in Sources */,
 				0089695D2486DAD000DC48C2 /* BSG_KSMach_x86_32.c in Sources */,
 				00896A1A2486DAD100DC48C2 /* BSG_KSCrashSentry_MachException.c in Sources */,
@@ -2707,7 +2720,7 @@
 				008967AB2486D43700DC48C2 /* BSG_KSMachTests.m in Sources */,
 				0089672A2486D43700DC48C2 /* BugsnagStacktraceTest.m in Sources */,
 				01847DAC26441A5E00ADA4C7 /* BSGInternalErrorReporterTests.m in Sources */,
-				0163BF5925823D8D008DC28B /* NotificationBreadcrumbTests.m in Sources */,
+				0163BF5925823D8D008DC28B /* BSGNotificationBreadcrumbsTests.m in Sources */,
 				008967392486D43700DC48C2 /* BugsnagEventFromKSCrashReportTest.m in Sources */,
 				008967182486D43700DC48C2 /* BugsnagErrorTest.m in Sources */,
 				004E35352487AFDC007FBAE4 /* BugsnagHandledStateTest.m in Sources */,
@@ -2859,7 +2872,7 @@
 				008967702486D43700DC48C2 /* NSError+SimpleConstructor_Tests.m in Sources */,
 				0089671C2486D43700DC48C2 /* BugsnagSessionTest.m in Sources */,
 				008967AC2486D43700DC48C2 /* BSG_KSMachTests.m in Sources */,
-				0163BF5A25823D8D008DC28B /* NotificationBreadcrumbTests.m in Sources */,
+				0163BF5A25823D8D008DC28B /* BSGNotificationBreadcrumbsTests.m in Sources */,
 				01BDB1FD25DEBFB300A91FAF /* BSGEventUploadKSCrashReportOperationTests.m in Sources */,
 				00896A452486DBF000DC48C2 /* BugsnagConfigurationTests.m in Sources */,
 				008967492486D43700DC48C2 /* BugsnagUserTest.m in Sources */,
@@ -2961,6 +2974,7 @@
 				CBAB4DDA2510D2460092CBAA /* BugsnagKVStoreObjC.m in Sources */,
 				008968A92486DA9600DC48C2 /* BugsnagSession.m in Sources */,
 				0089683C2486DA6C00DC48C2 /* BugsnagMetadata.m in Sources */,
+				013D9CD626C5262F0077F0AD /* UISceneStub.m in Sources */,
 				008969F82486DAD100DC48C2 /* BSG_KSCrash.m in Sources */,
 				0089695F2486DAD000DC48C2 /* BSG_KSMach_x86_32.c in Sources */,
 				00896A1C2486DAD100DC48C2 /* BSG_KSCrashSentry_MachException.c in Sources */,
@@ -3039,7 +3053,7 @@
 				E701FAB12490EFE8008D842F /* ConfigurationApiValidationTest.m in Sources */,
 				0089677D2486D43700DC48C2 /* RFC3339DateTool_Tests.m in Sources */,
 				CBCF77AD250142E0004AF22A /* BSGJSONSerializationTests.m in Sources */,
-				0163BF5B25823D8D008DC28B /* NotificationBreadcrumbTests.m in Sources */,
+				0163BF5B25823D8D008DC28B /* BSGNotificationBreadcrumbsTests.m in Sources */,
 				008967562486D43700DC48C2 /* BugsnagOnCrashTest.m in Sources */,
 				008967A12486D43700DC48C2 /* KSCrashSentry_Tests.m in Sources */,
 				008967442486D43700DC48C2 /* BugsnagSessionTrackerStopTest.m in Sources */,

--- a/Bugsnag/Helpers/BSGUIKit.h
+++ b/Bugsnag/Helpers/BSGUIKit.h
@@ -14,6 +14,7 @@
 // Calling code should be prepared for classes to not be found when UIKit is not linked.
 #define UIAPPLICATION                                       NSClassFromString(@"UIApplication")
 #define UIDEVICE                                            NSClassFromString(@"UIDevice")
+#define UISCENE                                             NSClassFromString(@"UIScene")
 
 #define UIApplicationDidBecomeActiveNotification            @"UIApplicationDidBecomeActiveNotification"
 #define UIApplicationDidEnterBackgroundNotification         @"UIApplicationDidEnterBackgroundNotification"
@@ -29,6 +30,12 @@
 #define UIKeyboardDidShowNotification                       @"UIKeyboardDidShowNotification"
 #define UIMenuControllerDidHideMenuNotification             @"UIMenuControllerDidHideMenuNotification"
 #define UIMenuControllerDidShowMenuNotification             @"UIMenuControllerDidShowMenuNotification"
+#define UISceneWillConnectNotification                      @"UISceneWillConnectNotification"
+#define UISceneDidDisconnectNotification                    @"UISceneDidDisconnectNotification"
+#define UISceneDidActivateNotification                      @"UISceneDidActivateNotification"
+#define UISceneWillDeactivateNotification                   @"UISceneWillDeactivateNotification"
+#define UISceneWillEnterForegroundNotification              @"UISceneWillEnterForegroundNotification"
+#define UISceneDidEnterBackgroundNotification               @"UISceneDidEnterBackgroundNotification"
 #define UIScreenBrightnessDidChangeNotification             @"UIScreenBrightnessDidChangeNotification"
 #define UITableViewSelectionDidChangeNotification           @"UITableViewSelectionDidChangeNotification"
 #define UITextFieldTextDidBeginEditingNotification          @"UITextFieldTextDidBeginEditingNotification"

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,13 @@
 Changelog
 =========
 
+## TBD
+
+### Enhancements
+
+* Add breadcrumbs for `UIScene` notifications.
+  [#1165](https://github.com/bugsnag/bugsnag-cocoa/pull/1165)
+
 ## 6.10.4 (2021-08-11)
 
 ### Bug fixes

--- a/Tests/BSGNotificationBreadcrumbsTests.m
+++ b/Tests/BSGNotificationBreadcrumbsTests.m
@@ -1,5 +1,5 @@
 //
-//  NotificationBreadcrumbTests.m
+//  BSGNotificationBreadcrumbsTests.m
 //  Bugsnag
 //
 //  Created by Nick Dowell on 10/12/2020.
@@ -13,8 +13,12 @@
 #import "BSGNotificationBreadcrumbs.h"
 #import "BugsnagBreadcrumb+Private.h"
 
+#if TARGET_OS_IOS || TARGET_OS_TV
+#import "UISceneStub.h"
+#endif
 
-@interface NotificationBreadcrumbTests : XCTestCase <BSGBreadcrumbSink>
+
+@interface BSGNotificationBreadcrumbsTests : XCTestCase <BSGBreadcrumbSink>
 
 @property NSNotificationCenter *notificationCenter;
 @property id notificationObject;
@@ -28,7 +32,7 @@
 
 #pragma mark -
 
-@implementation NotificationBreadcrumbTests
+@implementation BSGNotificationBreadcrumbsTests
 
 #pragma mark Setup
 
@@ -61,13 +65,20 @@
 
 #define TEST(__NAME__, __TYPE__, __MESSAGE__, __METADATA__) do { \
     BugsnagBreadcrumb *breadcrumb = [self breadcrumbForNotificationWithName:__NAME__]; \
-    XCTAssertNotNil(breadcrumb); \
+    XCTAssert([NSJSONSerialization isValidJSONObject:breadcrumb.metadata]); \
     if (breadcrumb) { \
         XCTAssertEqual(breadcrumb.type, __TYPE__); \
         XCTAssertEqualObjects(breadcrumb.message, __MESSAGE__); \
         XCTAssertEqualObjects(breadcrumb.metadata, __METADATA__); \
     } \
 } while (0)
+
+#pragma mark Tests
+
+- (void)testNSUndoManagerNotifications {
+    TEST(NSUndoManagerDidRedoChangeNotification, BSGBreadcrumbTypeState, @"Redo Operation", @{});
+    TEST(NSUndoManagerDidUndoChangeNotification, BSGBreadcrumbTypeState, @"Undo Operation", @{});
+}
 
 #pragma mark iOS Tests
 
@@ -112,11 +123,32 @@
 
 #if TARGET_OS_IOS || TARGET_OS_TV
 
-// This should be on macOS too!
-- (void)testNSUndoManagerNotifications {
-    TEST(NSUndoManagerDidRedoChangeNotification, BSGBreadcrumbTypeState, @"Redo Operation", @{});
-    TEST(NSUndoManagerDidUndoChangeNotification, BSGBreadcrumbTypeState, @"Undo Operation", @{});
+#if (defined(__IPHONE_13_0) && __IPHONE_OS_VERSION_MAX_ALLOWED >= __IPHONE_13_0) || \
+    (defined(__TVOS_13_0) && __TV_OS_VERSION_MAX_ALLOWED >= __TVOS_13_0)
+
+- (void)testUISceneNotifications API_AVAILABLE(ios(13.0), tvos(13.0)) {
+    self.notificationObject = [[UISceneStub alloc] initWithConfiguration:@"Default Configuration"
+                                                           delegateClass:[BSGNotificationBreadcrumbsTests class]
+                                                                    role:UIWindowSceneSessionRoleApplication
+                                                              sceneClass:[UISceneStub class]
+                                                                   title:@"Home"];
+    
+    TEST(UISceneWillConnectNotification, BSGBreadcrumbTypeState, @"Scene Will Connect",
+         (@{@"configuration": @"Default Configuration",
+            @"delegateClass": @"BSGNotificationBreadcrumbsTests",
+            @"role": @"UIWindowSceneSessionRoleApplication",
+            @"sceneClass": @"UISceneStub",
+            @"title": @"Home"}));
+    
+    self.notificationObject = nil;
+    TEST(UISceneDidDisconnectNotification, BSGBreadcrumbTypeState, @"Scene Disconnected", @{});
+    TEST(UISceneDidActivateNotification, BSGBreadcrumbTypeState, @"Scene Activated", @{});
+    TEST(UISceneWillDeactivateNotification, BSGBreadcrumbTypeState, @"Scene Will Deactivate", @{});
+    TEST(UISceneWillEnterForegroundNotification, BSGBreadcrumbTypeState, @"Scene Will Enter Foreground", @{});
+    TEST(UISceneDidEnterBackgroundNotification, BSGBreadcrumbTypeState, @"Scene Entered Background", @{});
 }
+
+#endif
 
 - (void)testUITableViewNotifications {
     TEST(UITableViewSelectionDidChangeNotification, BSGBreadcrumbTypeNavigation, @"TableView Select Change", @{});

--- a/Tests/UIKitTests.m
+++ b/Tests/UIKitTests.m
@@ -43,6 +43,16 @@
     ASSERT_NOTIFICATION_NAME(UIWindowDidBecomeKeyNotification);
     ASSERT_NOTIFICATION_NAME(UIWindowDidBecomeVisibleNotification);
     ASSERT_NOTIFICATION_NAME(UIWindowDidResignKeyNotification);
+
+#if (defined(__IPHONE_13_0) && __IPHONE_OS_VERSION_MAX_ALLOWED >= __IPHONE_13_0) || \
+    (defined(__TVOS_13_0) && __TV_OS_VERSION_MAX_ALLOWED >= __TVOS_13_0)
+    ASSERT_NOTIFICATION_NAME(UISceneWillConnectNotification);
+    ASSERT_NOTIFICATION_NAME(UISceneDidDisconnectNotification);
+    ASSERT_NOTIFICATION_NAME(UISceneDidActivateNotification);
+    ASSERT_NOTIFICATION_NAME(UISceneWillDeactivateNotification);
+    ASSERT_NOTIFICATION_NAME(UISceneWillEnterForegroundNotification);
+    ASSERT_NOTIFICATION_NAME(UISceneDidEnterBackgroundNotification);
+#endif
 }
 
 @end

--- a/Tests/UISceneStub.h
+++ b/Tests/UISceneStub.h
@@ -1,0 +1,29 @@
+//
+//  UISceneStub.h
+//  BugsnagTests
+//
+//  Created by Nick Dowell on 12/08/2021.
+//  Copyright © 2021 Bugsnag Inc. All rights reserved.
+//
+
+#import <UIKit/UIKit.h>
+
+#if (defined(__IPHONE_13_0) && __IPHONE_OS_VERSION_MAX_ALLOWED >= __IPHONE_13_0) || \
+    (defined(__TVOS_13_0) && __TV_OS_VERSION_MAX_ALLOWED >= __TVOS_13_0)
+
+NS_ASSUME_NONNULL_BEGIN
+
+API_AVAILABLE(ios(13.0), tvos(13.0))
+@interface UISceneStub : NSObject
+
+- (instancetype)initWithConfiguration:(NSString *)configuration
+                        delegateClass:(Class)delegateClass
+                                 role:(UISceneSessionRole)role
+                           sceneClass:(Class)sceneClass
+                                title:(NSString *)title;
+
+@end
+
+NS_ASSUME_NONNULL_END
+
+#endif

--- a/Tests/UISceneStub.m
+++ b/Tests/UISceneStub.m
@@ -1,0 +1,59 @@
+//
+//  UISceneStub.m
+//  BugsnagTests
+//
+//  Created by Nick Dowell on 12/08/2021.
+//  Copyright © 2021 Bugsnag Inc. All rights reserved.
+//
+
+#import "UISceneStub.h"
+
+#if (defined(__IPHONE_13_0) && __IPHONE_OS_VERSION_MAX_ALLOWED >= __IPHONE_13_0) || \
+    (defined(__TVOS_13_0) && __TV_OS_VERSION_MAX_ALLOWED >= __TVOS_13_0)
+
+@interface UISceneStub ()
+
+@property (nonatomic) NSString *configurationName;
+@property (weak, nonatomic) Class delegateClass;
+@property (nonatomic) UISceneSessionRole role;
+@property (nonatomic) Class sceneClass;
+@property (nonatomic) NSString *title;
+
+@end
+
+@implementation UISceneStub
+
+- (instancetype)initWithConfiguration:(NSString *)configuration
+                        delegateClass:(Class)delegateClass
+                                 role:(UISceneSessionRole)role
+                           sceneClass:(Class)sceneClass
+                                title:(NSString *)title {
+    if ((self = [super init])) {
+        _configurationName = configuration;
+        _delegateClass = delegateClass;
+        _role = role;
+        _sceneClass = sceneClass;
+        _title = title;
+    }
+    return self;
+}
+
+- (id)session {
+    return self;
+}
+
+- (id)configuration {
+    return self;
+}
+
+- (NSString *)name {
+    return self.configurationName;
+}
+
+- (BOOL)isKindOfClass:(Class)aClass {
+    return [NSStringFromClass(aClass) isEqualToString:@"UIScene"] || [super isKindOfClass:aClass];
+}
+
+@end
+
+#endif

--- a/features/breadcrumbs.feature
+++ b/features/breadcrumbs.feature
@@ -39,3 +39,18 @@ Feature: Attaching a series of notable events leading up to errors
     When I run "ModifyBreadcrumbInNotify"
     And I wait to receive an error
     Then the event has a "manual" breadcrumb named "Cache locked"
+
+  @skip_below_os_version_13
+  @skip_macos
+  Scenario: State breadcrumbs
+    When I configure Bugsnag for "HandledErrorScenario"
+    And I background the app for 2 seconds
+    And I click the element "run_scenario"
+    And I wait to receive an error
+    Then the event has a "state" breadcrumb named "Bugsnag loaded"
+    # Bugsnag has been started too late to capture some early notifications
+    And the event has a "state" breadcrumb named "App Did Enter Background"
+    And the event has a "state" breadcrumb named "App Will Enter Foreground"
+    And the event has a "state" breadcrumb named "Scene Entered Background"
+    And the event has a "state" breadcrumb named "Scene Will Enter Foreground"
+    And the event has a "state" breadcrumb named "Scene Activated"

--- a/features/support/env.rb
+++ b/features/support/env.rb
@@ -10,6 +10,11 @@ AfterConfiguration do |_config|
   Maze.config.receive_requests_wait = 180 unless ENV['STRESS_TEST'].nil?
 end
 
+# Maze.config.os is not set when running on BrowserStack so cannot implement @skip_below_ios_13 :-(
+Before('@skip_below_os_version_13') do |scenario|
+  skip_this_scenario("Skipping scenario") if Maze.config.os_version < 13
+end
+
 # Skip stress tests unless STRESS_TEST env var is set
 Before('@stress_test') do |_scenario|
   skip_this_scenario('Skipping: Run is not configured for stress tests') if ENV['STRESS_TEST'].nil?


### PR DESCRIPTION
## Goal

Add breadcrumbs for [UIScene life-cycle](https://developer.apple.com/documentation/uikit/app_and_environment/scenes/specifying_the_scenes_your_app_supports) notifications.

## Testing

Tested manually using example app.

Adds unit tests to verify all notifications produce expected breadcrumbs.

Adds an E2E scenario to verify that expected breadcrumbs are left when app move to / from background.