### PR TITLE
Additional logging

### DIFF
--- a/Tests/BugsnagBreadcrumbsTest.m
+++ b/Tests/BugsnagBreadcrumbsTest.m
@@ -503,7 +503,14 @@ BSGBreadcrumbType BSGBreadcrumbTypeFromString(NSString *value);
         
         NSError *error = nil;
         NSData *data = [NSData dataWithBytesNoCopy:buffer.buffer length:buffer.length freeWhenDone:NO];
-        XCTAssert([NSJSONSerialization JSONObjectWithData:data options:0 error:&error], @"%@", error);
+        if (![NSJSONSerialization JSONObjectWithData:data options:0 error:&error]) {
+            [self addAttachment:[XCTAttachment attachmentWithUniformTypeIdentifier:@"public.plain-text"
+                                                                              name:@"breadcrumbs.json"
+                                                                           payload:data
+                                                                          userInfo:nil]];
+            XCTFail(@"Breadcrumbs JSON could not be parsed: %@", error);
+            break;
+        }
     }
     
     free(buffer.buffer);

--- a/features/fixtures/macos/macOSTestApp/MainWindowController.m
+++ b/features/fixtures/macos/macOSTestApp/MainWindowController.m
@@ -51,6 +51,8 @@
 }
 
 - (IBAction)runScenario:(id)sender {
+    NSLog(@"%s %@", __PRETTY_FUNCTION__, self.scenarioName);
+
     if (!self.scenario) {
         self.scenario = [Scenario createScenarioNamed:self.scenarioName withConfig:[self configuration]];
         self.scenario.eventMode = self.scenarioMetadata;
@@ -70,6 +72,8 @@
 }
 
 - (IBAction)startBugsnag:(id)sender {
+    NSLog(@"%s %@", __PRETTY_FUNCTION__, self.scenarioName);
+
     self.scenario = [Scenario createScenarioNamed:self.scenarioName withConfig:[self configuration]];
     self.scenario.eventMode = self.scenarioMetadata;
 

--- a/features/fixtures/macos/macOSTestApp/main.m
+++ b/features/fixtures/macos/macOSTestApp/main.m
@@ -8,6 +8,20 @@
 
 #import <Cocoa/Cocoa.h>
 
+void NotificationCallback(CFNotificationCenterRef center, void *observer, CFNotificationName cfName, const void *object, CFDictionaryRef userInfo) {
+    NSString *name = (__bridge NSString *)cfName;
+    // Ignore high-frequency notifications
+    if (name == NSMenuDidAddItemNotification ||
+        name == NSMenuDidChangeItemNotification ||
+        name == NSViewDidUpdateTrackingAreasNotification ||
+        name == NSViewFrameDidChangeNotification ||
+        [name hasSuffix:@"UpdateNotification"] ||
+        false) {
+        return;
+    }
+    NSLog(@"%@", name);
+}
+
 int main(int argc, const char * argv[]) {
     [[NSUserDefaults standardUserDefaults] registerDefaults:@{
         // Disable state restoration to prevent the following dialog being shown after crashes
@@ -18,6 +32,11 @@ int main(int argc, const char * argv[]) {
         // Stop NSApplication swallowing NSExceptions thrown on the main thread.
         @"NSApplicationCrashOnExceptions": @YES,
     }];
+    
+    // Log (almost) all notifications to aid in diagnosing Appium test flakes
+    CFNotificationCenterAddObserver(CFNotificationCenterGetLocalCenter(),
+                                    NULL, NotificationCallback, NULL, NULL,
+                                    CFNotificationSuspensionBehaviorDeliverImmediately);
     
     return NSApplicationMain(argc, argv);
 }


### PR DESCRIPTION
## Goal

Add some additional logging to help track down the cause of some intermittent test failures, after discussion with @twometresteve 

## Changeset

* Adds verbose logging to the mac E2E test fixture which should help determine whether some failures are caused by the app losing focus or failing to receive all key presses.
* Attaches the invalid JSON from testCrashReportWriterConcurrency upon failure, to allow further investigation (have not been able to reproduce this locally.)

## Testing

Tested locally