### PR TITLE
Thread capture improvements

### DIFF
--- a/Bugsnag/KSCrash/Source/KSCrash/Recording/Tools/BSG_KSMach.c
+++ b/Bugsnag/KSCrash/Source/KSCrash/Recording/Tools/BSG_KSMach.c
@@ -286,6 +286,9 @@ bool bsg_ksmachgetThreadName(const thread_t thread, char *const buffer,
     // WARNING: This implementation is no longer async-safe!
 
     const pthread_t pthread = pthread_from_mach_thread_np(thread);
+    if (pthread == NULL) {
+        return false;
+    }
     return pthread_getname_np(pthread, buffer, bufLength) == 0;
 }
 


### PR DESCRIPTION
## Goal

The previous fixes have drastically reduced crashes in BSGAppHangDetector, but there are some edge cases that could still trip up the crash handler.

## Design

The thread backtrace capture code now does the following:
- Get the list of current threads just to count them.
- Allocate space to store thread data + some extra in case more threads get allocated before we stop the world
- Stop the world
- Get the list of current threads again
- Record thread info into our allocated space
- Start the world
- Store thread info in ObjC objects and return it

## Testing

Tested manually by triggering ANRs, re-ran existing tests.
