### PR TITLE
Make sure pthread_from_mach_thread_np returns a valid thread pointer

### DIFF
--- a/Bugsnag/KSCrash/Source/KSCrash/Recording/Tools/BSG_KSMach.c
+++ b/Bugsnag/KSCrash/Source/KSCrash/Recording/Tools/BSG_KSMach.c
@@ -286,6 +286,9 @@ bool bsg_ksmachgetThreadName(const thread_t thread, char *const buffer,
     // WARNING: This implementation is no longer async-safe!
 
     const pthread_t pthread = pthread_from_mach_thread_np(thread);
+    if (pthread == NULL) {
+        return false;
+    }
     return pthread_getname_np(pthread, buffer, bufLength) == 0;
 }
 


### PR DESCRIPTION
## Goal

On rare occasions, `pthread_from_mach_thread_np` returns NULL, and failing to check for that leads to a crash.

## Testing

Tested manually using the example app, and tested using unit and e2e tests.
