### PR TITLE
Increase default max breadcrumbs

### DIFF
--- a/Bugsnag/Configuration/BugsnagConfiguration.m
+++ b/Bugsnag/Configuration/BugsnagConfiguration.m
@@ -180,7 +180,7 @@ static NSUserDefaults *userDefaults;
     _enabledBreadcrumbTypes = BSGEnabledBreadcrumbTypeAll;
     _launchDurationMillis = 5000;
     _sendLaunchCrashesSynchronously = YES;
-    _maxBreadcrumbs = 25;
+    _maxBreadcrumbs = 50;
     _maxPersistedEvents = 32;
     _maxPersistedSessions = 128;
     _autoTrackSessions = YES;

--- a/Tests/BSGConfigurationBuilderTests.m
+++ b/Tests/BSGConfigurationBuilderTests.m
@@ -57,7 +57,7 @@
     XCTAssertTrue(config.autoTrackSessions);
     XCTAssertEqual(config.maxPersistedEvents, 32);
     XCTAssertEqual(config.maxPersistedSessions, 128);
-    XCTAssertEqual(config.maxBreadcrumbs, 25);
+    XCTAssertEqual(config.maxBreadcrumbs, 50);
     XCTAssertTrue(config.persistUser);
     XCTAssertEqualObjects(@[@"password"], [config.redactedKeys allObjects]);
     XCTAssertEqual(BSGThreadSendPolicyAlways, config.sendThreads);

--- a/Tests/BugsnagConfigurationTests.m
+++ b/Tests/BugsnagConfigurationTests.m
@@ -577,7 +577,7 @@ NSString * const kBugsnagUserUserId = @"BugsnagUserUserId";
 
 - (void)testMaxBreadcrumb {
     BugsnagConfiguration *config = [[BugsnagConfiguration alloc] initWithApiKey:DUMMY_APIKEY_32CHAR_1];
-    XCTAssertEqual(25, config.maxBreadcrumbs);
+    XCTAssertEqual(50, config.maxBreadcrumbs);
 
     // alter to valid value
     config.maxBreadcrumbs = 10;
@@ -631,7 +631,7 @@ NSString * const kBugsnagUserUserId = @"BugsnagUserUserId";
     XCTAssertNil(config.enabledReleaseStages);
     XCTAssertEqualObjects(@"https://notify.bugsnag.com", config.endpoints.notify);
     XCTAssertEqualObjects(@"https://sessions.bugsnag.com", config.endpoints.sessions);
-    XCTAssertEqual(25, config.maxBreadcrumbs);
+    XCTAssertEqual(50, config.maxBreadcrumbs);
     XCTAssertTrue(config.persistUser);
     XCTAssertEqual(1, [config.redactedKeys count]);
     XCTAssertEqualObjects(@"password", [config.redactedKeys allObjects][0]);


### PR DESCRIPTION
## Goal

PLAT-7130: Increase default max breadcrumbs from 25 to 50.

## Testing

Re-ran all tests
