### PR TITLE
Danger: check source branch when targeting master

### DIFF
--- a/Dangerfile
+++ b/Dangerfile
@@ -59,6 +59,10 @@ end
 
 ###
 
+if github.branch_for_base == "master"
+  failure "Only release PRs should target the master branch" unless github.branch_for_head.start_with?("release-")
+end
+
 parse_infer_results('infer-out/report.json')
 
 parse_oclint_results('oclint.json')


### PR DESCRIPTION
## Goal

Prevent accidentally merging features or fixes directly onto the `master` branch (which is the default.)

## Changeset

If a PR targets `master` the `Dangerfile` now checks that the source branch is a `release-*` branch, and reports an error if not.

Note that after retargeting a PR, the GitHub Action needs to be manually re-run to run Danger again.

## Testing

Tested by opening this PR against `master`

<img width="510" alt="Screenshot 2021-08-25 at 09 33 47" src="https://user-images.githubusercontent.com/61777/130756993-b6b8d66c-fcd3-4e1a-b17d-8a37dbd82d04.png">

Verified locally that the test passes with a release PR by running

```
bundle exec danger pr https://github.com/bugsnag/bugsnag-cocoa/pull/1168
```