### PR TITLE
Add base network breadcrumbs plugin scaffolding

### DIFF
--- a/.buildkite/pipeline.yml
+++ b/.buildkite/pipeline.yml
@@ -40,7 +40,7 @@ steps:
       - make build_ios_static
 
   - label: Carthage
-    timeout_in_minutes: 10
+    timeout_in_minutes: 15
     agents:
       queue: opensource-mac-cocoa-11
     concurrency: 3

--- a/BUGSNAG-PLUGIN.md
+++ b/BUGSNAG-PLUGIN.md
@@ -7,19 +7,30 @@ Making a plugin that plays nice with the major package managers can be tricky. H
 Creating the Plugin
 -------------------
 
-#### Add a new target for your plugin:
+**Note**: Xcode project files are very fragile and buggy, and tend to break when you make changes to them. Usually you'll end up with phantom targets, or crashes after which the project file won't load anymore. You may have to quit Xcode, wipe out all changes and start over a few times:
+
+```
+git restore --staged .
+git checkout .
+git clean -df
+```
+
+Once your project is properly set up, quit Xcode and then reopen the workspace to make sure the project file is okay.
+
+#### Add a new project for your plugin
 
 - Open `Bugsnag.xcworkspace`
-- Select the `Bugsnag` project
-- In the `Targets` pane, click `+`
+- From the menu, select `File` -> `New` -> `Project`
 - Use the `Framework` template (ios)
 - Give it a name like `BugsnagXYZ`
+- Make sure it is part of workspace `Bugsnag`
 - Select the `BugsnagXYZ` target
-- Under `General` -> `Frameworks and Libraries`, click `+` and add the `Bugsnag.framework` for your architecture (ios)
+- Under `General` -> `Frameworks and Libraries`, click `+` and add the `Bugsnag.framework` for your architecture (ios). Set its `Embed` type to `Do not embed`.
+- Under `General` -> `Deployment Info`, make sure `Deployment Target` matches the targets in the main `Bugsnag` project (you may need to manually edit the `.pbxproj` file in a text editor to change the various `xyz_DEPLOYMENT_TARGET` fields).
 
 #### Apply fixups and workarounds:
 
-In the targets pane (`Bugsnag` project in the left pane, `Targets` list in the middle pane):
+In the targets pane (`BugsnagXYZ` project in the left pane, `Targets` list in the middle pane):
 - Rename the `BugsnagXYZ` target to `BugsnagXYZ-iOS`
 - Rename the `BugsnagXYZTests` target to `BugsnagXYZ-iOSTests`
 
@@ -29,7 +40,8 @@ In the target's build settings (`Bugsnag` project in the left pane, `Targets` li
 In the schemes manager (Click the schemes selector in the middle pane -> `Manage Schemes`):
 - Rename the `BugsnagXYZ `scheme to `BugsnagXYZ-iOS`
 - Untick and re-tick the new scheme's `Shared` checkbox (this generates the needed .xcscheme file)
-- Click `+` and add the `BugsnagXYZ-iOSTests` target.
+- Edit the scheme and make sure under the `Tests` section it has the target `BugsnagXYZ-iOSTests` (use `+` to add it if it's missing)
+- Use the `+` button to add the `BugsnagXYZ-iOSTests` scheme (Cocoapods generates a broken project if there's no test scheme)
 
 #### You should now have:
 
@@ -37,17 +49,24 @@ In the schemes manager (Click the schemes selector in the middle pane -> `Manage
 - New schemes: `BugsnagXYZ-iOS` and `BugsnagXYZ-iOSTests`
 - New top-level directories: `BugsnagXYZ` and `BugsnagXYZTests`
 
+#### Add other targets:
+
+You must add support for the following platforms: `macOS`, `tvOS`. Your additional targets will share the same base directories `BugsnagXYZ` and `BugsnagXYZTests`.
+
+- Select the `BugsnagXYZ` project, then in the center pane in the `Targets` list, click `+`
+- Select a platform (macOS, tvOS, etc) and choose the `Framework` template
+- Call it `BugsnagXYZ` like you did for the main target
+- Delete the extra `BugsnagXYZ` and `BugsnagXYZTests` groups that were added to the `BugsnatXYZ` project (remove references only).
+- Apply fixups and workarounds like you did for the iOS target
+
 #### Add your code:
 
 - Place all new code inside the `BugsnagXYZ` directory.
 - Make sure your new files have appropriate `BugsnagXYZ-nnn` membership in the right-side pane.
-- Create the directory `BugsnagXYZ/include/Bugsnag` and place all public headers in there.
+- Create the directory `BugsnagXYZ/BugsnagXYZ/include/BugsnagXYZ` and place all public headers in there.
+- Add the `include` directory as a group in your project.
 - Make sure all public headers are marked as public in the right-side pane (they're `Project` by default).
 - When importing from the main Bugsnag library, use angle bracket style (`#import <Bugsnag/whatever.h>`)
-
-#### Add other platform targets:
-
-You must also make targets and schemes for the other platforms (macOS, tvOS) pointing to the same `BugsnagXYZ` codebase, similar to what's done in the main Bugsnag library. Do so by creating a new `BugsnagXYZ` target for each platform, then renaming to e.g. `BugsnagXYZ-macOS` like you did for iOS, then updating existing source files to include membership in the new target.
 
 
 Supporting Carthage
@@ -81,13 +100,13 @@ Add a new entry to `products`:
         .library(name: "BugsnagXYZ", targets: ["BugsnagXYZ"]),
 ```
 
-Add a new entry to `targets`:
+Add a new entry to `targets` (note `BugsnagXYZ/BugsnagXYZ` because of how Xcode structures the project):
 
 ```
         .target(
             name: "BugsnagXYZ",
             dependencies: ["Bugsnag"],
-            path: "BugsnagXYZ",
+            path: "BugsnagXYZ/BugsnagXYZ",
             publicHeadersPath: "include",
             cSettings: [
                 .headerSearchPath("."),
@@ -107,43 +126,44 @@ Once your changes are pushed, users can reference the new plugin.
 Supporting Cocoapods
 --------------------
 
-Create a `BugsnagXYZ.podspec` file similar to the existing `Bugsnag.podspec` file:
+Create a `BugsnagXYZ.podspec.json` file similar to the existing `Bugsnag.podspec.json` file:
 
 ```
-Pod::Spec.new do |s|
-  s.name             = 'BugsnagXYZ'
-  s.version          = '6.11.0'
-  s.summary          = 'Bugsnag XYZ plugin.'
-
-  s.description      = <<-DESC
-A plugin that does XYZ.
-                       DESC
-
-  s.homepage         = 'https://bugsnag.com'
-  s.license          = 'MIT'
-  s.authors          = { 'Bugsnag': 'notifiers@bugsnag.com' }
-
-  s.source           = {
-    :git => 'https://github.com/bugsnag/bugsnag-cocoa.git',
-    :tag => 'v' + s.version.to_s
-  }
-
-  s.ios.deployment_target = '9.3'
-  s.osx.deployment_target = '10.11'
-  s.tvos.deployment_target = '9.2'
-
-  s.cocoapods_version = '>= 1.4.0'
-
-  s.dependency 'Bugsnag', '~> ' + s.version.to_s
-
-  s.source_files = "BugsnagXYZ/{**/,}*.{m,h,mm,c}"
-  s.requires_arc = true
-  s.prefix_header_file = false
-  s.public_header_files = "BugsnagXYZ/include/Bugsnag/*.h"
-end
+{
+  "name": "BugsnagXYZ",
+  "version": "6.11.0",
+  "summary": "A Bugsnag plugin that does XYZ.",
+  "homepage": "https://bugsnag.com",
+  "license": "MIT",
+  "authors": {
+    "Bugsnag": "notifiers@bugsnag.com"
+  },
+  "source": {
+    "git": "https://github.com/bugsnag/bugsnag-cocoa.git",
+    "tag": "v6.11.0"
+  },
+  "dependencies": {
+    "Bugsnag": "6.11.0"
+  },
+  "platforms": {
+    "ios": "9.3",
+    "osx": "10.11",
+    "tvos": "9.2"
+  },
+  "source_files": [
+    "BugsnagXYZ/BugsnagXYZ/{**/,}*.{m,h,mm,c}"
+  ],
+  "requires_arc": true,
+  "prefix_header_file": false,
+  "public_header_files": [
+    "BugsnagXYZ/BugsnagXYZ/include/Bugsnag/*.h"
+  ]
+}
 ```
 
-**Note**: The plugin podspec version must remain lockstep with the main `Bugsnag.podspec` version.
+**Notes**:
+- The plugin podspec version must remain lockstep with the main `Bugsnag.podspec.json` version.
+- The source files will have the directory structure `BugsnagXYZ/BugsnagXYZ` because of how Xcode structures the project.
 
 ### Using in a local testing app
 

--- a/Bugsnag.xcworkspace/contents.xcworkspacedata
+++ b/Bugsnag.xcworkspace/contents.xcworkspacedata
@@ -4,4 +4,7 @@
    <FileRef
       location = "group:Bugsnag.xcodeproj">
    </FileRef>
+   <FileRef
+      location = "group:BugsnagRequestMonitor/BugsnagRequestMonitor.xcodeproj">
+   </FileRef>
 </Workspace>

--- a/BugsnagRequestMonitor.podspec.json
+++ b/BugsnagRequestMonitor.podspec.json
@@ -1,0 +1,30 @@
+{
+  "name": "BugsnagRequestMonitor",
+  "version": "6.11.0",
+  "summary": "Network request monitoring support for Bugsnag.",
+  "homepage": "https://bugsnag.com",
+  "license": "MIT",
+  "authors": {
+    "Bugsnag": "notifiers@bugsnag.com"
+  },
+  "source": {
+    "git": "https://github.com/bugsnag/bugsnag-cocoa.git",
+    "tag": "v6.11.0"
+  },
+  "dependencies": {
+    "Bugsnag": "6.11.0"
+  },
+  "platforms": {
+    "ios": "9.3",
+    "osx": "10.11",
+    "tvos": "9.2"
+  },
+  "source_files": [
+    "BugsnagRequestMonitor/BugsnagRequestMonitor/{**/,}*.{m,h,mm,c}"
+  ],
+  "requires_arc": true,
+  "prefix_header_file": false,
+  "public_header_files": [
+    "BugsnagRequestMonitor/BugsnagRequestMonitor/include/BugsnagRequestMonitor/*.h"
+  ]
+}

--- a/BugsnagRequestMonitor/BugsnagRequestMonitor.xcodeproj/project.pbxproj
+++ b/BugsnagRequestMonitor/BugsnagRequestMonitor.xcodeproj/project.pbxproj
@@ -1,0 +1,937 @@
+// !$*UTF8*$!
+{
+	archiveVersion = 1;
+	classes = {
+	};
+	objectVersion = 50;
+	objects = {
+
+/* Begin PBXBuildFile section */
+		CB487A6326D7B109004F6B87 /* BugsnagRequestMonitor.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = CB487A5926D7B109004F6B87 /* BugsnagRequestMonitor.framework */; };
+		CB487A7526D7B12F004F6B87 /* Bugsnag.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = CB487A7426D7B12F004F6B87 /* Bugsnag.framework */; };
+		CB487A8626D7B144004F6B87 /* BugsnagRequestMonitor.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = CB487A7D26D7B144004F6B87 /* BugsnagRequestMonitor.framework */; };
+		CB487A9526D7B166004F6B87 /* Bugsnag.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = CB487A9426D7B166004F6B87 /* Bugsnag.framework */; };
+		CB487AA626D7B172004F6B87 /* BugsnagRequestMonitor.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = CB487A9D26D7B172004F6B87 /* BugsnagRequestMonitor.framework */; };
+		CB487AB526D7B191004F6B87 /* Bugsnag.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = CB487AB426D7B191004F6B87 /* Bugsnag.framework */; };
+		CB487ABF26D7B295004F6B87 /* BugsnagRequestMonitor.m in Sources */ = {isa = PBXBuildFile; fileRef = CB487ABE26D7B295004F6B87 /* BugsnagRequestMonitor.m */; };
+		CB487AC026D7B295004F6B87 /* BugsnagRequestMonitor.m in Sources */ = {isa = PBXBuildFile; fileRef = CB487ABE26D7B295004F6B87 /* BugsnagRequestMonitor.m */; };
+		CB487AC126D7B295004F6B87 /* BugsnagRequestMonitor.m in Sources */ = {isa = PBXBuildFile; fileRef = CB487ABE26D7B295004F6B87 /* BugsnagRequestMonitor.m */; };
+		CB487AC226D7B9DB004F6B87 /* BugsnagRequestMonitorTests.m in Sources */ = {isa = PBXBuildFile; fileRef = CB487A6726D7B109004F6B87 /* BugsnagRequestMonitorTests.m */; };
+		CB487AC326D7B9DC004F6B87 /* BugsnagRequestMonitorTests.m in Sources */ = {isa = PBXBuildFile; fileRef = CB487A6726D7B109004F6B87 /* BugsnagRequestMonitorTests.m */; };
+		CB487AC426D7B9DD004F6B87 /* BugsnagRequestMonitorTests.m in Sources */ = {isa = PBXBuildFile; fileRef = CB487A6726D7B109004F6B87 /* BugsnagRequestMonitorTests.m */; };
+		CB487C3026DE3EFB004F6B87 /* BugsnagRequestMonitor.h in Headers */ = {isa = PBXBuildFile; fileRef = CB487C2F26DE3EFB004F6B87 /* BugsnagRequestMonitor.h */; settings = {ATTRIBUTES = (Public, ); }; };
+		CB487C3126DE3EFB004F6B87 /* BugsnagRequestMonitor.h in Headers */ = {isa = PBXBuildFile; fileRef = CB487C2F26DE3EFB004F6B87 /* BugsnagRequestMonitor.h */; settings = {ATTRIBUTES = (Public, ); }; };
+		CB487C3226DE3EFB004F6B87 /* BugsnagRequestMonitor.h in Headers */ = {isa = PBXBuildFile; fileRef = CB487C2F26DE3EFB004F6B87 /* BugsnagRequestMonitor.h */; settings = {ATTRIBUTES = (Public, ); }; };
+/* End PBXBuildFile section */
+
+/* Begin PBXContainerItemProxy section */
+		CB487A6426D7B109004F6B87 /* PBXContainerItemProxy */ = {
+			isa = PBXContainerItemProxy;
+			containerPortal = CB487A5026D7B109004F6B87 /* Project object */;
+			proxyType = 1;
+			remoteGlobalIDString = CB487A5826D7B109004F6B87;
+			remoteInfo = BugsnagRequestMonitor;
+		};
+		CB487A8726D7B144004F6B87 /* PBXContainerItemProxy */ = {
+			isa = PBXContainerItemProxy;
+			containerPortal = CB487A5026D7B109004F6B87 /* Project object */;
+			proxyType = 1;
+			remoteGlobalIDString = CB487A7C26D7B144004F6B87;
+			remoteInfo = BugsnagRequestMonitor;
+		};
+		CB487AA726D7B172004F6B87 /* PBXContainerItemProxy */ = {
+			isa = PBXContainerItemProxy;
+			containerPortal = CB487A5026D7B109004F6B87 /* Project object */;
+			proxyType = 1;
+			remoteGlobalIDString = CB487A9C26D7B172004F6B87;
+			remoteInfo = BugsnagRequestMonitor;
+		};
+/* End PBXContainerItemProxy section */
+
+/* Begin PBXFileReference section */
+		CB487A5926D7B109004F6B87 /* BugsnagRequestMonitor.framework */ = {isa = PBXFileReference; explicitFileType = wrapper.framework; includeInIndex = 0; path = BugsnagRequestMonitor.framework; sourceTree = BUILT_PRODUCTS_DIR; };
+		CB487A5D26D7B109004F6B87 /* Info.plist */ = {isa = PBXFileReference; lastKnownFileType = text.plist.xml; path = Info.plist; sourceTree = "<group>"; };
+		CB487A6226D7B109004F6B87 /* BugsnagRequestMonitor-iOSTests.xctest */ = {isa = PBXFileReference; explicitFileType = wrapper.cfbundle; includeInIndex = 0; path = "BugsnagRequestMonitor-iOSTests.xctest"; sourceTree = BUILT_PRODUCTS_DIR; };
+		CB487A6726D7B109004F6B87 /* BugsnagRequestMonitorTests.m */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.objc; path = BugsnagRequestMonitorTests.m; sourceTree = "<group>"; };
+		CB487A6926D7B109004F6B87 /* Info.plist */ = {isa = PBXFileReference; lastKnownFileType = text.plist.xml; path = Info.plist; sourceTree = "<group>"; };
+		CB487A7426D7B12F004F6B87 /* Bugsnag.framework */ = {isa = PBXFileReference; explicitFileType = wrapper.framework; path = Bugsnag.framework; sourceTree = BUILT_PRODUCTS_DIR; };
+		CB487A7D26D7B144004F6B87 /* BugsnagRequestMonitor.framework */ = {isa = PBXFileReference; explicitFileType = wrapper.framework; includeInIndex = 0; path = BugsnagRequestMonitor.framework; sourceTree = BUILT_PRODUCTS_DIR; };
+		CB487A8526D7B144004F6B87 /* BugsnagRequestMonitor-macOSTests.xctest */ = {isa = PBXFileReference; explicitFileType = wrapper.cfbundle; includeInIndex = 0; path = "BugsnagRequestMonitor-macOSTests.xctest"; sourceTree = BUILT_PRODUCTS_DIR; };
+		CB487A9426D7B166004F6B87 /* Bugsnag.framework */ = {isa = PBXFileReference; explicitFileType = wrapper.framework; path = Bugsnag.framework; sourceTree = BUILT_PRODUCTS_DIR; };
+		CB487A9D26D7B172004F6B87 /* BugsnagRequestMonitor.framework */ = {isa = PBXFileReference; explicitFileType = wrapper.framework; includeInIndex = 0; path = BugsnagRequestMonitor.framework; sourceTree = BUILT_PRODUCTS_DIR; };
+		CB487AA526D7B172004F6B87 /* BugsnagRequestMonitor-tvOSTests.xctest */ = {isa = PBXFileReference; explicitFileType = wrapper.cfbundle; includeInIndex = 0; path = "BugsnagRequestMonitor-tvOSTests.xctest"; sourceTree = BUILT_PRODUCTS_DIR; };
+		CB487AB426D7B191004F6B87 /* Bugsnag.framework */ = {isa = PBXFileReference; explicitFileType = wrapper.framework; path = Bugsnag.framework; sourceTree = BUILT_PRODUCTS_DIR; };
+		CB487ABE26D7B295004F6B87 /* BugsnagRequestMonitor.m */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.objc; path = BugsnagRequestMonitor.m; sourceTree = "<group>"; };
+		CB487C2F26DE3EFB004F6B87 /* BugsnagRequestMonitor.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = BugsnagRequestMonitor.h; sourceTree = "<group>"; };
+/* End PBXFileReference section */
+
+/* Begin PBXFrameworksBuildPhase section */
+		CB487A5626D7B109004F6B87 /* Frameworks */ = {
+			isa = PBXFrameworksBuildPhase;
+			buildActionMask = 2147483647;
+			files = (
+				CB487A7526D7B12F004F6B87 /* Bugsnag.framework in Frameworks */,
+			);
+			runOnlyForDeploymentPostprocessing = 0;
+		};
+		CB487A5F26D7B109004F6B87 /* Frameworks */ = {
+			isa = PBXFrameworksBuildPhase;
+			buildActionMask = 2147483647;
+			files = (
+				CB487A6326D7B109004F6B87 /* BugsnagRequestMonitor.framework in Frameworks */,
+			);
+			runOnlyForDeploymentPostprocessing = 0;
+		};
+		CB487A7A26D7B144004F6B87 /* Frameworks */ = {
+			isa = PBXFrameworksBuildPhase;
+			buildActionMask = 2147483647;
+			files = (
+				CB487A9526D7B166004F6B87 /* Bugsnag.framework in Frameworks */,
+			);
+			runOnlyForDeploymentPostprocessing = 0;
+		};
+		CB487A8226D7B144004F6B87 /* Frameworks */ = {
+			isa = PBXFrameworksBuildPhase;
+			buildActionMask = 2147483647;
+			files = (
+				CB487A8626D7B144004F6B87 /* BugsnagRequestMonitor.framework in Frameworks */,
+			);
+			runOnlyForDeploymentPostprocessing = 0;
+		};
+		CB487A9A26D7B172004F6B87 /* Frameworks */ = {
+			isa = PBXFrameworksBuildPhase;
+			buildActionMask = 2147483647;
+			files = (
+				CB487AB526D7B191004F6B87 /* Bugsnag.framework in Frameworks */,
+			);
+			runOnlyForDeploymentPostprocessing = 0;
+		};
+		CB487AA226D7B172004F6B87 /* Frameworks */ = {
+			isa = PBXFrameworksBuildPhase;
+			buildActionMask = 2147483647;
+			files = (
+				CB487AA626D7B172004F6B87 /* BugsnagRequestMonitor.framework in Frameworks */,
+			);
+			runOnlyForDeploymentPostprocessing = 0;
+		};
+/* End PBXFrameworksBuildPhase section */
+
+/* Begin PBXGroup section */
+		CB487A4F26D7B109004F6B87 = {
+			isa = PBXGroup;
+			children = (
+				CB487A5B26D7B109004F6B87 /* BugsnagRequestMonitor */,
+				CB487A6626D7B109004F6B87 /* BugsnagRequestMonitorTests */,
+				CB487A5A26D7B109004F6B87 /* Products */,
+				CB487A7326D7B12F004F6B87 /* Frameworks */,
+			);
+			sourceTree = "<group>";
+		};
+		CB487A5A26D7B109004F6B87 /* Products */ = {
+			isa = PBXGroup;
+			children = (
+				CB487A5926D7B109004F6B87 /* BugsnagRequestMonitor.framework */,
+				CB487A6226D7B109004F6B87 /* BugsnagRequestMonitor-iOSTests.xctest */,
+				CB487A7D26D7B144004F6B87 /* BugsnagRequestMonitor.framework */,
+				CB487A8526D7B144004F6B87 /* BugsnagRequestMonitor-macOSTests.xctest */,
+				CB487A9D26D7B172004F6B87 /* BugsnagRequestMonitor.framework */,
+				CB487AA526D7B172004F6B87 /* BugsnagRequestMonitor-tvOSTests.xctest */,
+			);
+			name = Products;
+			sourceTree = "<group>";
+		};
+		CB487A5B26D7B109004F6B87 /* BugsnagRequestMonitor */ = {
+			isa = PBXGroup;
+			children = (
+				CB487A5D26D7B109004F6B87 /* Info.plist */,
+				CB487C2D26DE3EFB004F6B87 /* include */,
+				CB487ABE26D7B295004F6B87 /* BugsnagRequestMonitor.m */,
+			);
+			path = BugsnagRequestMonitor;
+			sourceTree = "<group>";
+		};
+		CB487A6626D7B109004F6B87 /* BugsnagRequestMonitorTests */ = {
+			isa = PBXGroup;
+			children = (
+				CB487A6726D7B109004F6B87 /* BugsnagRequestMonitorTests.m */,
+				CB487A6926D7B109004F6B87 /* Info.plist */,
+			);
+			path = BugsnagRequestMonitorTests;
+			sourceTree = "<group>";
+		};
+		CB487A7326D7B12F004F6B87 /* Frameworks */ = {
+			isa = PBXGroup;
+			children = (
+				CB487AB426D7B191004F6B87 /* Bugsnag.framework */,
+				CB487A9426D7B166004F6B87 /* Bugsnag.framework */,
+				CB487A7426D7B12F004F6B87 /* Bugsnag.framework */,
+			);
+			name = Frameworks;
+			sourceTree = "<group>";
+		};
+		CB487C2D26DE3EFB004F6B87 /* include */ = {
+			isa = PBXGroup;
+			children = (
+				CB487C2E26DE3EFB004F6B87 /* BugsnagRequestMonitor */,
+			);
+			path = include;
+			sourceTree = "<group>";
+		};
+		CB487C2E26DE3EFB004F6B87 /* BugsnagRequestMonitor */ = {
+			isa = PBXGroup;
+			children = (
+				CB487C2F26DE3EFB004F6B87 /* BugsnagRequestMonitor.h */,
+			);
+			path = BugsnagRequestMonitor;
+			sourceTree = "<group>";
+		};
+/* End PBXGroup section */
+
+/* Begin PBXHeadersBuildPhase section */
+		CB487A5426D7B109004F6B87 /* Headers */ = {
+			isa = PBXHeadersBuildPhase;
+			buildActionMask = 2147483647;
+			files = (
+				CB487C3026DE3EFB004F6B87 /* BugsnagRequestMonitor.h in Headers */,
+			);
+			runOnlyForDeploymentPostprocessing = 0;
+		};
+		CB487A7826D7B144004F6B87 /* Headers */ = {
+			isa = PBXHeadersBuildPhase;
+			buildActionMask = 2147483647;
+			files = (
+				CB487C3126DE3EFB004F6B87 /* BugsnagRequestMonitor.h in Headers */,
+			);
+			runOnlyForDeploymentPostprocessing = 0;
+		};
+		CB487A9826D7B172004F6B87 /* Headers */ = {
+			isa = PBXHeadersBuildPhase;
+			buildActionMask = 2147483647;
+			files = (
+				CB487C3226DE3EFB004F6B87 /* BugsnagRequestMonitor.h in Headers */,
+			);
+			runOnlyForDeploymentPostprocessing = 0;
+		};
+/* End PBXHeadersBuildPhase section */
+
+/* Begin PBXNativeTarget section */
+		CB487A5826D7B109004F6B87 /* BugsnagRequestMonitor-iOS */ = {
+			isa = PBXNativeTarget;
+			buildConfigurationList = CB487A6D26D7B109004F6B87 /* Build configuration list for PBXNativeTarget "BugsnagRequestMonitor-iOS" */;
+			buildPhases = (
+				CB487A5426D7B109004F6B87 /* Headers */,
+				CB487A5526D7B109004F6B87 /* Sources */,
+				CB487A5626D7B109004F6B87 /* Frameworks */,
+				CB487A5726D7B109004F6B87 /* Resources */,
+			);
+			buildRules = (
+			);
+			dependencies = (
+			);
+			name = "BugsnagRequestMonitor-iOS";
+			productName = BugsnagRequestMonitor;
+			productReference = CB487A5926D7B109004F6B87 /* BugsnagRequestMonitor.framework */;
+			productType = "com.apple.product-type.framework";
+		};
+		CB487A6126D7B109004F6B87 /* BugsnagRequestMonitor-iOSTests */ = {
+			isa = PBXNativeTarget;
+			buildConfigurationList = CB487A7026D7B109004F6B87 /* Build configuration list for PBXNativeTarget "BugsnagRequestMonitor-iOSTests" */;
+			buildPhases = (
+				CB487A5E26D7B109004F6B87 /* Sources */,
+				CB487A5F26D7B109004F6B87 /* Frameworks */,
+				CB487A6026D7B109004F6B87 /* Resources */,
+			);
+			buildRules = (
+			);
+			dependencies = (
+				CB487A6526D7B109004F6B87 /* PBXTargetDependency */,
+			);
+			name = "BugsnagRequestMonitor-iOSTests";
+			productName = BugsnagRequestMonitorTests;
+			productReference = CB487A6226D7B109004F6B87 /* BugsnagRequestMonitor-iOSTests.xctest */;
+			productType = "com.apple.product-type.bundle.unit-test";
+		};
+		CB487A7C26D7B144004F6B87 /* BugsnagRequestMonitor-macOS */ = {
+			isa = PBXNativeTarget;
+			buildConfigurationList = CB487A8E26D7B144004F6B87 /* Build configuration list for PBXNativeTarget "BugsnagRequestMonitor-macOS" */;
+			buildPhases = (
+				CB487A7826D7B144004F6B87 /* Headers */,
+				CB487A7926D7B144004F6B87 /* Sources */,
+				CB487A7A26D7B144004F6B87 /* Frameworks */,
+				CB487A7B26D7B144004F6B87 /* Resources */,
+			);
+			buildRules = (
+			);
+			dependencies = (
+			);
+			name = "BugsnagRequestMonitor-macOS";
+			productName = BugsnagRequestMonitor;
+			productReference = CB487A7D26D7B144004F6B87 /* BugsnagRequestMonitor.framework */;
+			productType = "com.apple.product-type.framework";
+		};
+		CB487A8426D7B144004F6B87 /* BugsnagRequestMonitor-macOSTests */ = {
+			isa = PBXNativeTarget;
+			buildConfigurationList = CB487A9126D7B144004F6B87 /* Build configuration list for PBXNativeTarget "BugsnagRequestMonitor-macOSTests" */;
+			buildPhases = (
+				CB487A8126D7B144004F6B87 /* Sources */,
+				CB487A8226D7B144004F6B87 /* Frameworks */,
+				CB487A8326D7B144004F6B87 /* Resources */,
+			);
+			buildRules = (
+			);
+			dependencies = (
+				CB487A8826D7B144004F6B87 /* PBXTargetDependency */,
+			);
+			name = "BugsnagRequestMonitor-macOSTests";
+			productName = BugsnagRequestMonitorTests;
+			productReference = CB487A8526D7B144004F6B87 /* BugsnagRequestMonitor-macOSTests.xctest */;
+			productType = "com.apple.product-type.bundle.unit-test";
+		};
+		CB487A9C26D7B172004F6B87 /* BugsnagRequestMonitor-tvOS */ = {
+			isa = PBXNativeTarget;
+			buildConfigurationList = CB487AAE26D7B172004F6B87 /* Build configuration list for PBXNativeTarget "BugsnagRequestMonitor-tvOS" */;
+			buildPhases = (
+				CB487A9826D7B172004F6B87 /* Headers */,
+				CB487A9926D7B172004F6B87 /* Sources */,
+				CB487A9A26D7B172004F6B87 /* Frameworks */,
+				CB487A9B26D7B172004F6B87 /* Resources */,
+			);
+			buildRules = (
+			);
+			dependencies = (
+			);
+			name = "BugsnagRequestMonitor-tvOS";
+			productName = BugsnagRequestMonitor;
+			productReference = CB487A9D26D7B172004F6B87 /* BugsnagRequestMonitor.framework */;
+			productType = "com.apple.product-type.framework";
+		};
+		CB487AA426D7B172004F6B87 /* BugsnagRequestMonitor-tvOSTests */ = {
+			isa = PBXNativeTarget;
+			buildConfigurationList = CB487AB126D7B172004F6B87 /* Build configuration list for PBXNativeTarget "BugsnagRequestMonitor-tvOSTests" */;
+			buildPhases = (
+				CB487AA126D7B172004F6B87 /* Sources */,
+				CB487AA226D7B172004F6B87 /* Frameworks */,
+				CB487AA326D7B172004F6B87 /* Resources */,
+			);
+			buildRules = (
+			);
+			dependencies = (
+				CB487AA826D7B172004F6B87 /* PBXTargetDependency */,
+			);
+			name = "BugsnagRequestMonitor-tvOSTests";
+			productName = BugsnagRequestMonitorTests;
+			productReference = CB487AA526D7B172004F6B87 /* BugsnagRequestMonitor-tvOSTests.xctest */;
+			productType = "com.apple.product-type.bundle.unit-test";
+		};
+/* End PBXNativeTarget section */
+
+/* Begin PBXProject section */
+		CB487A5026D7B109004F6B87 /* Project object */ = {
+			isa = PBXProject;
+			attributes = {
+				LastUpgradeCheck = 1250;
+				TargetAttributes = {
+					CB487A5826D7B109004F6B87 = {
+						CreatedOnToolsVersion = 12.5.1;
+					};
+					CB487A6126D7B109004F6B87 = {
+						CreatedOnToolsVersion = 12.5.1;
+					};
+					CB487A7C26D7B144004F6B87 = {
+						CreatedOnToolsVersion = 12.5.1;
+					};
+					CB487A8426D7B144004F6B87 = {
+						CreatedOnToolsVersion = 12.5.1;
+					};
+					CB487A9C26D7B172004F6B87 = {
+						CreatedOnToolsVersion = 12.5.1;
+					};
+					CB487AA426D7B172004F6B87 = {
+						CreatedOnToolsVersion = 12.5.1;
+					};
+				};
+			};
+			buildConfigurationList = CB487A5326D7B109004F6B87 /* Build configuration list for PBXProject "BugsnagRequestMonitor" */;
+			compatibilityVersion = "Xcode 9.3";
+			developmentRegion = en;
+			hasScannedForEncodings = 0;
+			knownRegions = (
+				en,
+				Base,
+			);
+			mainGroup = CB487A4F26D7B109004F6B87;
+			productRefGroup = CB487A5A26D7B109004F6B87 /* Products */;
+			projectDirPath = "";
+			projectRoot = "";
+			targets = (
+				CB487A5826D7B109004F6B87 /* BugsnagRequestMonitor-iOS */,
+				CB487A6126D7B109004F6B87 /* BugsnagRequestMonitor-iOSTests */,
+				CB487A7C26D7B144004F6B87 /* BugsnagRequestMonitor-macOS */,
+				CB487A8426D7B144004F6B87 /* BugsnagRequestMonitor-macOSTests */,
+				CB487A9C26D7B172004F6B87 /* BugsnagRequestMonitor-tvOS */,
+				CB487AA426D7B172004F6B87 /* BugsnagRequestMonitor-tvOSTests */,
+			);
+		};
+/* End PBXProject section */
+
+/* Begin PBXResourcesBuildPhase section */
+		CB487A5726D7B109004F6B87 /* Resources */ = {
+			isa = PBXResourcesBuildPhase;
+			buildActionMask = 2147483647;
+			files = (
+			);
+			runOnlyForDeploymentPostprocessing = 0;
+		};
+		CB487A6026D7B109004F6B87 /* Resources */ = {
+			isa = PBXResourcesBuildPhase;
+			buildActionMask = 2147483647;
+			files = (
+			);
+			runOnlyForDeploymentPostprocessing = 0;
+		};
+		CB487A7B26D7B144004F6B87 /* Resources */ = {
+			isa = PBXResourcesBuildPhase;
+			buildActionMask = 2147483647;
+			files = (
+			);
+			runOnlyForDeploymentPostprocessing = 0;
+		};
+		CB487A8326D7B144004F6B87 /* Resources */ = {
+			isa = PBXResourcesBuildPhase;
+			buildActionMask = 2147483647;
+			files = (
+			);
+			runOnlyForDeploymentPostprocessing = 0;
+		};
+		CB487A9B26D7B172004F6B87 /* Resources */ = {
+			isa = PBXResourcesBuildPhase;
+			buildActionMask = 2147483647;
+			files = (
+			);
+			runOnlyForDeploymentPostprocessing = 0;
+		};
+		CB487AA326D7B172004F6B87 /* Resources */ = {
+			isa = PBXResourcesBuildPhase;
+			buildActionMask = 2147483647;
+			files = (
+			);
+			runOnlyForDeploymentPostprocessing = 0;
+		};
+/* End PBXResourcesBuildPhase section */
+
+/* Begin PBXSourcesBuildPhase section */
+		CB487A5526D7B109004F6B87 /* Sources */ = {
+			isa = PBXSourcesBuildPhase;
+			buildActionMask = 2147483647;
+			files = (
+				CB487ABF26D7B295004F6B87 /* BugsnagRequestMonitor.m in Sources */,
+			);
+			runOnlyForDeploymentPostprocessing = 0;
+		};
+		CB487A5E26D7B109004F6B87 /* Sources */ = {
+			isa = PBXSourcesBuildPhase;
+			buildActionMask = 2147483647;
+			files = (
+				CB487AC226D7B9DB004F6B87 /* BugsnagRequestMonitorTests.m in Sources */,
+			);
+			runOnlyForDeploymentPostprocessing = 0;
+		};
+		CB487A7926D7B144004F6B87 /* Sources */ = {
+			isa = PBXSourcesBuildPhase;
+			buildActionMask = 2147483647;
+			files = (
+				CB487AC026D7B295004F6B87 /* BugsnagRequestMonitor.m in Sources */,
+			);
+			runOnlyForDeploymentPostprocessing = 0;
+		};
+		CB487A8126D7B144004F6B87 /* Sources */ = {
+			isa = PBXSourcesBuildPhase;
+			buildActionMask = 2147483647;
+			files = (
+				CB487AC326D7B9DC004F6B87 /* BugsnagRequestMonitorTests.m in Sources */,
+			);
+			runOnlyForDeploymentPostprocessing = 0;
+		};
+		CB487A9926D7B172004F6B87 /* Sources */ = {
+			isa = PBXSourcesBuildPhase;
+			buildActionMask = 2147483647;
+			files = (
+				CB487AC126D7B295004F6B87 /* BugsnagRequestMonitor.m in Sources */,
+			);
+			runOnlyForDeploymentPostprocessing = 0;
+		};
+		CB487AA126D7B172004F6B87 /* Sources */ = {
+			isa = PBXSourcesBuildPhase;
+			buildActionMask = 2147483647;
+			files = (
+				CB487AC426D7B9DD004F6B87 /* BugsnagRequestMonitorTests.m in Sources */,
+			);
+			runOnlyForDeploymentPostprocessing = 0;
+		};
+/* End PBXSourcesBuildPhase section */
+
+/* Begin PBXTargetDependency section */
+		CB487A6526D7B109004F6B87 /* PBXTargetDependency */ = {
+			isa = PBXTargetDependency;
+			target = CB487A5826D7B109004F6B87 /* BugsnagRequestMonitor-iOS */;
+			targetProxy = CB487A6426D7B109004F6B87 /* PBXContainerItemProxy */;
+		};
+		CB487A8826D7B144004F6B87 /* PBXTargetDependency */ = {
+			isa = PBXTargetDependency;
+			target = CB487A7C26D7B144004F6B87 /* BugsnagRequestMonitor-macOS */;
+			targetProxy = CB487A8726D7B144004F6B87 /* PBXContainerItemProxy */;
+		};
+		CB487AA826D7B172004F6B87 /* PBXTargetDependency */ = {
+			isa = PBXTargetDependency;
+			target = CB487A9C26D7B172004F6B87 /* BugsnagRequestMonitor-tvOS */;
+			targetProxy = CB487AA726D7B172004F6B87 /* PBXContainerItemProxy */;
+		};
+/* End PBXTargetDependency section */
+
+/* Begin XCBuildConfiguration section */
+		CB487A6B26D7B109004F6B87 /* Debug */ = {
+			isa = XCBuildConfiguration;
+			buildSettings = {
+				ALWAYS_SEARCH_USER_PATHS = NO;
+				CLANG_ANALYZER_NONNULL = YES;
+				CLANG_ANALYZER_NUMBER_OBJECT_CONVERSION = YES_AGGRESSIVE;
+				CLANG_CXX_LANGUAGE_STANDARD = "gnu++14";
+				CLANG_CXX_LIBRARY = "libc++";
+				CLANG_ENABLE_MODULES = YES;
+				CLANG_ENABLE_OBJC_ARC = YES;
+				CLANG_ENABLE_OBJC_WEAK = YES;
+				CLANG_WARN_BLOCK_CAPTURE_AUTORELEASING = YES;
+				CLANG_WARN_BOOL_CONVERSION = YES;
+				CLANG_WARN_COMMA = YES;
+				CLANG_WARN_CONSTANT_CONVERSION = YES;
+				CLANG_WARN_DEPRECATED_OBJC_IMPLEMENTATIONS = YES;
+				CLANG_WARN_DIRECT_OBJC_ISA_USAGE = YES_ERROR;
+				CLANG_WARN_DOCUMENTATION_COMMENTS = YES;
+				CLANG_WARN_EMPTY_BODY = YES;
+				CLANG_WARN_ENUM_CONVERSION = YES;
+				CLANG_WARN_INFINITE_RECURSION = YES;
+				CLANG_WARN_INT_CONVERSION = YES;
+				CLANG_WARN_NON_LITERAL_NULL_CONVERSION = YES;
+				CLANG_WARN_OBJC_IMPLICIT_RETAIN_SELF = YES;
+				CLANG_WARN_OBJC_LITERAL_CONVERSION = YES;
+				CLANG_WARN_OBJC_ROOT_CLASS = YES_ERROR;
+				CLANG_WARN_QUOTED_INCLUDE_IN_FRAMEWORK_HEADER = YES;
+				CLANG_WARN_RANGE_LOOP_ANALYSIS = YES;
+				CLANG_WARN_STRICT_PROTOTYPES = YES;
+				CLANG_WARN_SUSPICIOUS_MOVE = YES;
+				CLANG_WARN_UNGUARDED_AVAILABILITY = YES_AGGRESSIVE;
+				CLANG_WARN_UNREACHABLE_CODE = YES;
+				CLANG_WARN__DUPLICATE_METHOD_MATCH = YES;
+				COPY_PHASE_STRIP = NO;
+				CURRENT_PROJECT_VERSION = 1;
+				DEBUG_INFORMATION_FORMAT = dwarf;
+				ENABLE_STRICT_OBJC_MSGSEND = YES;
+				ENABLE_TESTABILITY = YES;
+				GCC_C_LANGUAGE_STANDARD = gnu11;
+				GCC_DYNAMIC_NO_PIC = NO;
+				GCC_NO_COMMON_BLOCKS = YES;
+				GCC_OPTIMIZATION_LEVEL = 0;
+				GCC_PREPROCESSOR_DEFINITIONS = (
+					"DEBUG=1",
+					"$(inherited)",
+				);
+				GCC_WARN_64_TO_32_BIT_CONVERSION = YES;
+				GCC_WARN_ABOUT_RETURN_TYPE = YES_ERROR;
+				GCC_WARN_UNDECLARED_SELECTOR = YES;
+				GCC_WARN_UNINITIALIZED_AUTOS = YES_AGGRESSIVE;
+				GCC_WARN_UNUSED_FUNCTION = YES;
+				GCC_WARN_UNUSED_VARIABLE = YES;
+				IPHONEOS_DEPLOYMENT_TARGET = 9.3;
+				MTL_ENABLE_DEBUG_INFO = INCLUDE_SOURCE;
+				MTL_FAST_MATH = YES;
+				ONLY_ACTIVE_ARCH = YES;
+				SDKROOT = iphoneos;
+				VERSIONING_SYSTEM = "apple-generic";
+				VERSION_INFO_PREFIX = "";
+			};
+			name = Debug;
+		};
+		CB487A6C26D7B109004F6B87 /* Release */ = {
+			isa = XCBuildConfiguration;
+			buildSettings = {
+				ALWAYS_SEARCH_USER_PATHS = NO;
+				CLANG_ANALYZER_NONNULL = YES;
+				CLANG_ANALYZER_NUMBER_OBJECT_CONVERSION = YES_AGGRESSIVE;
+				CLANG_CXX_LANGUAGE_STANDARD = "gnu++14";
+				CLANG_CXX_LIBRARY = "libc++";
+				CLANG_ENABLE_MODULES = YES;
+				CLANG_ENABLE_OBJC_ARC = YES;
+				CLANG_ENABLE_OBJC_WEAK = YES;
+				CLANG_WARN_BLOCK_CAPTURE_AUTORELEASING = YES;
+				CLANG_WARN_BOOL_CONVERSION = YES;
+				CLANG_WARN_COMMA = YES;
+				CLANG_WARN_CONSTANT_CONVERSION = YES;
+				CLANG_WARN_DEPRECATED_OBJC_IMPLEMENTATIONS = YES;
+				CLANG_WARN_DIRECT_OBJC_ISA_USAGE = YES_ERROR;
+				CLANG_WARN_DOCUMENTATION_COMMENTS = YES;
+				CLANG_WARN_EMPTY_BODY = YES;
+				CLANG_WARN_ENUM_CONVERSION = YES;
+				CLANG_WARN_INFINITE_RECURSION = YES;
+				CLANG_WARN_INT_CONVERSION = YES;
+				CLANG_WARN_NON_LITERAL_NULL_CONVERSION = YES;
+				CLANG_WARN_OBJC_IMPLICIT_RETAIN_SELF = YES;
+				CLANG_WARN_OBJC_LITERAL_CONVERSION = YES;
+				CLANG_WARN_OBJC_ROOT_CLASS = YES_ERROR;
+				CLANG_WARN_QUOTED_INCLUDE_IN_FRAMEWORK_HEADER = YES;
+				CLANG_WARN_RANGE_LOOP_ANALYSIS = YES;
+				CLANG_WARN_STRICT_PROTOTYPES = YES;
+				CLANG_WARN_SUSPICIOUS_MOVE = YES;
+				CLANG_WARN_UNGUARDED_AVAILABILITY = YES_AGGRESSIVE;
+				CLANG_WARN_UNREACHABLE_CODE = YES;
+				CLANG_WARN__DUPLICATE_METHOD_MATCH = YES;
+				COPY_PHASE_STRIP = NO;
+				CURRENT_PROJECT_VERSION = 1;
+				DEBUG_INFORMATION_FORMAT = "dwarf-with-dsym";
+				ENABLE_NS_ASSERTIONS = NO;
+				ENABLE_STRICT_OBJC_MSGSEND = YES;
+				GCC_C_LANGUAGE_STANDARD = gnu11;
+				GCC_NO_COMMON_BLOCKS = YES;
+				GCC_WARN_64_TO_32_BIT_CONVERSION = YES;
+				GCC_WARN_ABOUT_RETURN_TYPE = YES_ERROR;
+				GCC_WARN_UNDECLARED_SELECTOR = YES;
+				GCC_WARN_UNINITIALIZED_AUTOS = YES_AGGRESSIVE;
+				GCC_WARN_UNUSED_FUNCTION = YES;
+				GCC_WARN_UNUSED_VARIABLE = YES;
+				IPHONEOS_DEPLOYMENT_TARGET = 9.3;
+				MTL_ENABLE_DEBUG_INFO = NO;
+				MTL_FAST_MATH = YES;
+				SDKROOT = iphoneos;
+				VALIDATE_PRODUCT = YES;
+				VERSIONING_SYSTEM = "apple-generic";
+				VERSION_INFO_PREFIX = "";
+			};
+			name = Release;
+		};
+		CB487A6E26D7B109004F6B87 /* Debug */ = {
+			isa = XCBuildConfiguration;
+			buildSettings = {
+				CODE_SIGN_STYLE = Automatic;
+				DEFINES_MODULE = YES;
+				DEVELOPMENT_TEAM = 372ZUL2ZB7;
+				DYLIB_COMPATIBILITY_VERSION = 1;
+				DYLIB_CURRENT_VERSION = 1;
+				DYLIB_INSTALL_NAME_BASE = "@rpath";
+				INFOPLIST_FILE = BugsnagRequestMonitor/Info.plist;
+				INSTALL_PATH = "$(LOCAL_LIBRARY_DIR)/Frameworks";
+				IPHONEOS_DEPLOYMENT_TARGET = 9.3;
+				LD_RUNPATH_SEARCH_PATHS = (
+					"$(inherited)",
+					"@executable_path/Frameworks",
+					"@loader_path/Frameworks",
+				);
+				PRODUCT_BUNDLE_IDENTIFIER = com.bugsnag.BugsnagRequestMonitor;
+				PRODUCT_NAME = BugsnagRequestMonitor;
+				SKIP_INSTALL = YES;
+				TARGETED_DEVICE_FAMILY = "1,2";
+			};
+			name = Debug;
+		};
+		CB487A6F26D7B109004F6B87 /* Release */ = {
+			isa = XCBuildConfiguration;
+			buildSettings = {
+				CODE_SIGN_STYLE = Automatic;
+				DEFINES_MODULE = YES;
+				DEVELOPMENT_TEAM = 372ZUL2ZB7;
+				DYLIB_COMPATIBILITY_VERSION = 1;
+				DYLIB_CURRENT_VERSION = 1;
+				DYLIB_INSTALL_NAME_BASE = "@rpath";
+				INFOPLIST_FILE = BugsnagRequestMonitor/Info.plist;
+				INSTALL_PATH = "$(LOCAL_LIBRARY_DIR)/Frameworks";
+				IPHONEOS_DEPLOYMENT_TARGET = 9.3;
+				LD_RUNPATH_SEARCH_PATHS = (
+					"$(inherited)",
+					"@executable_path/Frameworks",
+					"@loader_path/Frameworks",
+				);
+				PRODUCT_BUNDLE_IDENTIFIER = com.bugsnag.BugsnagRequestMonitor;
+				PRODUCT_NAME = BugsnagRequestMonitor;
+				SKIP_INSTALL = YES;
+				TARGETED_DEVICE_FAMILY = "1,2";
+			};
+			name = Release;
+		};
+		CB487A7126D7B109004F6B87 /* Debug */ = {
+			isa = XCBuildConfiguration;
+			buildSettings = {
+				CODE_SIGN_STYLE = Automatic;
+				DEVELOPMENT_TEAM = 372ZUL2ZB7;
+				INFOPLIST_FILE = BugsnagRequestMonitorTests/Info.plist;
+				LD_RUNPATH_SEARCH_PATHS = (
+					"$(inherited)",
+					"@executable_path/Frameworks",
+					"@loader_path/Frameworks",
+				);
+				PRODUCT_BUNDLE_IDENTIFIER = com.bugsnag.BugsnagRequestMonitorTests;
+				PRODUCT_NAME = "$(TARGET_NAME)";
+				TARGETED_DEVICE_FAMILY = "1,2";
+			};
+			name = Debug;
+		};
+		CB487A7226D7B109004F6B87 /* Release */ = {
+			isa = XCBuildConfiguration;
+			buildSettings = {
+				CODE_SIGN_STYLE = Automatic;
+				DEVELOPMENT_TEAM = 372ZUL2ZB7;
+				INFOPLIST_FILE = BugsnagRequestMonitorTests/Info.plist;
+				LD_RUNPATH_SEARCH_PATHS = (
+					"$(inherited)",
+					"@executable_path/Frameworks",
+					"@loader_path/Frameworks",
+				);
+				PRODUCT_BUNDLE_IDENTIFIER = com.bugsnag.BugsnagRequestMonitorTests;
+				PRODUCT_NAME = "$(TARGET_NAME)";
+				TARGETED_DEVICE_FAMILY = "1,2";
+			};
+			name = Release;
+		};
+		CB487A8F26D7B144004F6B87 /* Debug */ = {
+			isa = XCBuildConfiguration;
+			buildSettings = {
+				CODE_SIGN_STYLE = Automatic;
+				COMBINE_HIDPI_IMAGES = YES;
+				DEFINES_MODULE = YES;
+				DEVELOPMENT_TEAM = 372ZUL2ZB7;
+				DYLIB_COMPATIBILITY_VERSION = 1;
+				DYLIB_CURRENT_VERSION = 1;
+				DYLIB_INSTALL_NAME_BASE = "@rpath";
+				INFOPLIST_FILE = BugsnagRequestMonitor/Info.plist;
+				INSTALL_PATH = "$(LOCAL_LIBRARY_DIR)/Frameworks";
+				LD_RUNPATH_SEARCH_PATHS = (
+					"$(inherited)",
+					"@executable_path/../Frameworks",
+					"@loader_path/Frameworks",
+				);
+				MACOSX_DEPLOYMENT_TARGET = 10.11;
+				PRODUCT_BUNDLE_IDENTIFIER = com.bugsnag.BugsnagRequestMonitor;
+				PRODUCT_NAME = BugsnagRequestMonitor;
+				SDKROOT = macosx;
+				SKIP_INSTALL = YES;
+			};
+			name = Debug;
+		};
+		CB487A9026D7B144004F6B87 /* Release */ = {
+			isa = XCBuildConfiguration;
+			buildSettings = {
+				CODE_SIGN_STYLE = Automatic;
+				COMBINE_HIDPI_IMAGES = YES;
+				DEFINES_MODULE = YES;
+				DEVELOPMENT_TEAM = 372ZUL2ZB7;
+				DYLIB_COMPATIBILITY_VERSION = 1;
+				DYLIB_CURRENT_VERSION = 1;
+				DYLIB_INSTALL_NAME_BASE = "@rpath";
+				INFOPLIST_FILE = BugsnagRequestMonitor/Info.plist;
+				INSTALL_PATH = "$(LOCAL_LIBRARY_DIR)/Frameworks";
+				LD_RUNPATH_SEARCH_PATHS = (
+					"$(inherited)",
+					"@executable_path/../Frameworks",
+					"@loader_path/Frameworks",
+				);
+				MACOSX_DEPLOYMENT_TARGET = 10.11;
+				PRODUCT_BUNDLE_IDENTIFIER = com.bugsnag.BugsnagRequestMonitor;
+				PRODUCT_NAME = BugsnagRequestMonitor;
+				SDKROOT = macosx;
+				SKIP_INSTALL = YES;
+			};
+			name = Release;
+		};
+		CB487A9226D7B144004F6B87 /* Debug */ = {
+			isa = XCBuildConfiguration;
+			buildSettings = {
+				CODE_SIGN_STYLE = Automatic;
+				COMBINE_HIDPI_IMAGES = YES;
+				DEVELOPMENT_TEAM = 372ZUL2ZB7;
+				INFOPLIST_FILE = BugsnagRequestMonitorTests/Info.plist;
+				LD_RUNPATH_SEARCH_PATHS = (
+					"$(inherited)",
+					"@executable_path/../Frameworks",
+					"@loader_path/../Frameworks",
+				);
+				MACOSX_DEPLOYMENT_TARGET = 10.11;
+				PRODUCT_BUNDLE_IDENTIFIER = com.bugsnag.BugsnagRequestMonitorTests;
+				PRODUCT_NAME = "$(TARGET_NAME)";
+				SDKROOT = macosx;
+			};
+			name = Debug;
+		};
+		CB487A9326D7B144004F6B87 /* Release */ = {
+			isa = XCBuildConfiguration;
+			buildSettings = {
+				CODE_SIGN_STYLE = Automatic;
+				COMBINE_HIDPI_IMAGES = YES;
+				DEVELOPMENT_TEAM = 372ZUL2ZB7;
+				INFOPLIST_FILE = BugsnagRequestMonitorTests/Info.plist;
+				LD_RUNPATH_SEARCH_PATHS = (
+					"$(inherited)",
+					"@executable_path/../Frameworks",
+					"@loader_path/../Frameworks",
+				);
+				MACOSX_DEPLOYMENT_TARGET = 10.11;
+				PRODUCT_BUNDLE_IDENTIFIER = com.bugsnag.BugsnagRequestMonitorTests;
+				PRODUCT_NAME = "$(TARGET_NAME)";
+				SDKROOT = macosx;
+			};
+			name = Release;
+		};
+		CB487AAF26D7B172004F6B87 /* Debug */ = {
+			isa = XCBuildConfiguration;
+			buildSettings = {
+				CODE_SIGN_STYLE = Automatic;
+				DEFINES_MODULE = YES;
+				DEVELOPMENT_TEAM = 372ZUL2ZB7;
+				DYLIB_COMPATIBILITY_VERSION = 1;
+				DYLIB_CURRENT_VERSION = 1;
+				DYLIB_INSTALL_NAME_BASE = "@rpath";
+				INFOPLIST_FILE = BugsnagRequestMonitor/Info.plist;
+				INSTALL_PATH = "$(LOCAL_LIBRARY_DIR)/Frameworks";
+				LD_RUNPATH_SEARCH_PATHS = (
+					"$(inherited)",
+					"@executable_path/Frameworks",
+					"@loader_path/Frameworks",
+				);
+				PRODUCT_BUNDLE_IDENTIFIER = com.bugsnag.BugsnagRequestMonitor;
+				PRODUCT_NAME = BugsnagRequestMonitor;
+				SDKROOT = appletvos;
+				SKIP_INSTALL = YES;
+				TARGETED_DEVICE_FAMILY = 3;
+				TVOS_DEPLOYMENT_TARGET = 9.2;
+			};
+			name = Debug;
+		};
+		CB487AB026D7B172004F6B87 /* Release */ = {
+			isa = XCBuildConfiguration;
+			buildSettings = {
+				CODE_SIGN_STYLE = Automatic;
+				DEFINES_MODULE = YES;
+				DEVELOPMENT_TEAM = 372ZUL2ZB7;
+				DYLIB_COMPATIBILITY_VERSION = 1;
+				DYLIB_CURRENT_VERSION = 1;
+				DYLIB_INSTALL_NAME_BASE = "@rpath";
+				INFOPLIST_FILE = BugsnagRequestMonitor/Info.plist;
+				INSTALL_PATH = "$(LOCAL_LIBRARY_DIR)/Frameworks";
+				LD_RUNPATH_SEARCH_PATHS = (
+					"$(inherited)",
+					"@executable_path/Frameworks",
+					"@loader_path/Frameworks",
+				);
+				PRODUCT_BUNDLE_IDENTIFIER = com.bugsnag.BugsnagRequestMonitor;
+				PRODUCT_NAME = BugsnagRequestMonitor;
+				SDKROOT = appletvos;
+				SKIP_INSTALL = YES;
+				TARGETED_DEVICE_FAMILY = 3;
+				TVOS_DEPLOYMENT_TARGET = 9.2;
+			};
+			name = Release;
+		};
+		CB487AB226D7B172004F6B87 /* Debug */ = {
+			isa = XCBuildConfiguration;
+			buildSettings = {
+				CODE_SIGN_STYLE = Automatic;
+				DEVELOPMENT_TEAM = 372ZUL2ZB7;
+				INFOPLIST_FILE = BugsnagRequestMonitorTests/Info.plist;
+				LD_RUNPATH_SEARCH_PATHS = (
+					"$(inherited)",
+					"@executable_path/Frameworks",
+					"@loader_path/Frameworks",
+				);
+				PRODUCT_BUNDLE_IDENTIFIER = com.bugsnag.BugsnagRequestMonitorTests;
+				PRODUCT_NAME = "$(TARGET_NAME)";
+				SDKROOT = appletvos;
+				TARGETED_DEVICE_FAMILY = 3;
+				TVOS_DEPLOYMENT_TARGET = 9.2;
+			};
+			name = Debug;
+		};
+		CB487AB326D7B172004F6B87 /* Release */ = {
+			isa = XCBuildConfiguration;
+			buildSettings = {
+				CODE_SIGN_STYLE = Automatic;
+				DEVELOPMENT_TEAM = 372ZUL2ZB7;
+				INFOPLIST_FILE = BugsnagRequestMonitorTests/Info.plist;
+				LD_RUNPATH_SEARCH_PATHS = (
+					"$(inherited)",
+					"@executable_path/Frameworks",
+					"@loader_path/Frameworks",
+				);
+				PRODUCT_BUNDLE_IDENTIFIER = com.bugsnag.BugsnagRequestMonitorTests;
+				PRODUCT_NAME = "$(TARGET_NAME)";
+				SDKROOT = appletvos;
+				TARGETED_DEVICE_FAMILY = 3;
+				TVOS_DEPLOYMENT_TARGET = 9.2;
+			};
+			name = Release;
+		};
+/* End XCBuildConfiguration section */
+
+/* Begin XCConfigurationList section */
+		CB487A5326D7B109004F6B87 /* Build configuration list for PBXProject "BugsnagRequestMonitor" */ = {
+			isa = XCConfigurationList;
+			buildConfigurations = (
+				CB487A6B26D7B109004F6B87 /* Debug */,
+				CB487A6C26D7B109004F6B87 /* Release */,
+			);
+			defaultConfigurationIsVisible = 0;
+			defaultConfigurationName = Release;
+		};
+		CB487A6D26D7B109004F6B87 /* Build configuration list for PBXNativeTarget "BugsnagRequestMonitor-iOS" */ = {
+			isa = XCConfigurationList;
+			buildConfigurations = (
+				CB487A6E26D7B109004F6B87 /* Debug */,
+				CB487A6F26D7B109004F6B87 /* Release */,
+			);
+			defaultConfigurationIsVisible = 0;
+			defaultConfigurationName = Release;
+		};
+		CB487A7026D7B109004F6B87 /* Build configuration list for PBXNativeTarget "BugsnagRequestMonitor-iOSTests" */ = {
+			isa = XCConfigurationList;
+			buildConfigurations = (
+				CB487A7126D7B109004F6B87 /* Debug */,
+				CB487A7226D7B109004F6B87 /* Release */,
+			);
+			defaultConfigurationIsVisible = 0;
+			defaultConfigurationName = Release;
+		};
+		CB487A8E26D7B144004F6B87 /* Build configuration list for PBXNativeTarget "BugsnagRequestMonitor-macOS" */ = {
+			isa = XCConfigurationList;
+			buildConfigurations = (
+				CB487A8F26D7B144004F6B87 /* Debug */,
+				CB487A9026D7B144004F6B87 /* Release */,
+			);
+			defaultConfigurationIsVisible = 0;
+			defaultConfigurationName = Release;
+		};
+		CB487A9126D7B144004F6B87 /* Build configuration list for PBXNativeTarget "BugsnagRequestMonitor-macOSTests" */ = {
+			isa = XCConfigurationList;
+			buildConfigurations = (
+				CB487A9226D7B144004F6B87 /* Debug */,
+				CB487A9326D7B144004F6B87 /* Release */,
+			);
+			defaultConfigurationIsVisible = 0;
+			defaultConfigurationName = Release;
+		};
+		CB487AAE26D7B172004F6B87 /* Build configuration list for PBXNativeTarget "BugsnagRequestMonitor-tvOS" */ = {
+			isa = XCConfigurationList;
+			buildConfigurations = (
+				CB487AAF26D7B172004F6B87 /* Debug */,
+				CB487AB026D7B172004F6B87 /* Release */,
+			);
+			defaultConfigurationIsVisible = 0;
+			defaultConfigurationName = Release;
+		};
+		CB487AB126D7B172004F6B87 /* Build configuration list for PBXNativeTarget "BugsnagRequestMonitor-tvOSTests" */ = {
+			isa = XCConfigurationList;
+			buildConfigurations = (
+				CB487AB226D7B172004F6B87 /* Debug */,
+				CB487AB326D7B172004F6B87 /* Release */,
+			);
+			defaultConfigurationIsVisible = 0;
+			defaultConfigurationName = Release;
+		};
+/* End XCConfigurationList section */
+	};
+	rootObject = CB487A5026D7B109004F6B87 /* Project object */;
+}

--- a/BugsnagRequestMonitor/BugsnagRequestMonitor.xcodeproj/xcshareddata/xcschemes/BugsnagRequestMonitor-iOS.xcscheme
+++ b/BugsnagRequestMonitor/BugsnagRequestMonitor.xcodeproj/xcshareddata/xcschemes/BugsnagRequestMonitor-iOS.xcscheme
@@ -1,0 +1,77 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<Scheme
+   LastUpgradeVersion = "1250"
+   version = "1.3">
+   <BuildAction
+      parallelizeBuildables = "YES"
+      buildImplicitDependencies = "YES">
+      <BuildActionEntries>
+         <BuildActionEntry
+            buildForTesting = "YES"
+            buildForRunning = "YES"
+            buildForProfiling = "YES"
+            buildForArchiving = "YES"
+            buildForAnalyzing = "YES">
+            <BuildableReference
+               BuildableIdentifier = "primary"
+               BlueprintIdentifier = "CB487A5826D7B109004F6B87"
+               BuildableName = "BugsnagRequestMonitor.framework"
+               BlueprintName = "BugsnagRequestMonitor-iOS"
+               ReferencedContainer = "container:BugsnagRequestMonitor.xcodeproj">
+            </BuildableReference>
+         </BuildActionEntry>
+      </BuildActionEntries>
+   </BuildAction>
+   <TestAction
+      buildConfiguration = "Debug"
+      selectedDebuggerIdentifier = "Xcode.DebuggerFoundation.Debugger.LLDB"
+      selectedLauncherIdentifier = "Xcode.DebuggerFoundation.Launcher.LLDB"
+      shouldUseLaunchSchemeArgsEnv = "YES">
+      <Testables>
+         <TestableReference
+            skipped = "NO">
+            <BuildableReference
+               BuildableIdentifier = "primary"
+               BlueprintIdentifier = "CB487A6126D7B109004F6B87"
+               BuildableName = "BugsnagRequestMonitor-iOSTests.xctest"
+               BlueprintName = "BugsnagRequestMonitor-iOSTests"
+               ReferencedContainer = "container:BugsnagRequestMonitor.xcodeproj">
+            </BuildableReference>
+         </TestableReference>
+      </Testables>
+   </TestAction>
+   <LaunchAction
+      buildConfiguration = "Debug"
+      selectedDebuggerIdentifier = "Xcode.DebuggerFoundation.Debugger.LLDB"
+      selectedLauncherIdentifier = "Xcode.DebuggerFoundation.Launcher.LLDB"
+      launchStyle = "0"
+      useCustomWorkingDirectory = "NO"
+      ignoresPersistentStateOnLaunch = "NO"
+      debugDocumentVersioning = "YES"
+      debugServiceExtension = "internal"
+      allowLocationSimulation = "YES">
+   </LaunchAction>
+   <ProfileAction
+      buildConfiguration = "Release"
+      shouldUseLaunchSchemeArgsEnv = "YES"
+      savedToolIdentifier = ""
+      useCustomWorkingDirectory = "NO"
+      debugDocumentVersioning = "YES">
+      <MacroExpansion>
+         <BuildableReference
+            BuildableIdentifier = "primary"
+            BlueprintIdentifier = "CB487A5826D7B109004F6B87"
+            BuildableName = "BugsnagRequestMonitor.framework"
+            BlueprintName = "BugsnagRequestMonitor-iOS"
+            ReferencedContainer = "container:BugsnagRequestMonitor.xcodeproj">
+         </BuildableReference>
+      </MacroExpansion>
+   </ProfileAction>
+   <AnalyzeAction
+      buildConfiguration = "Debug">
+   </AnalyzeAction>
+   <ArchiveAction
+      buildConfiguration = "Release"
+      revealArchiveInOrganizer = "YES">
+   </ArchiveAction>
+</Scheme>

--- a/BugsnagRequestMonitor/BugsnagRequestMonitor.xcodeproj/xcshareddata/xcschemes/BugsnagRequestMonitor-macOS.xcscheme
+++ b/BugsnagRequestMonitor/BugsnagRequestMonitor.xcodeproj/xcshareddata/xcschemes/BugsnagRequestMonitor-macOS.xcscheme
@@ -1,0 +1,77 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<Scheme
+   LastUpgradeVersion = "1250"
+   version = "1.3">
+   <BuildAction
+      parallelizeBuildables = "YES"
+      buildImplicitDependencies = "YES">
+      <BuildActionEntries>
+         <BuildActionEntry
+            buildForTesting = "YES"
+            buildForRunning = "YES"
+            buildForProfiling = "YES"
+            buildForArchiving = "YES"
+            buildForAnalyzing = "YES">
+            <BuildableReference
+               BuildableIdentifier = "primary"
+               BlueprintIdentifier = "CB487A7C26D7B144004F6B87"
+               BuildableName = "BugsnagRequestMonitor.framework"
+               BlueprintName = "BugsnagRequestMonitor-macOS"
+               ReferencedContainer = "container:BugsnagRequestMonitor.xcodeproj">
+            </BuildableReference>
+         </BuildActionEntry>
+      </BuildActionEntries>
+   </BuildAction>
+   <TestAction
+      buildConfiguration = "Debug"
+      selectedDebuggerIdentifier = "Xcode.DebuggerFoundation.Debugger.LLDB"
+      selectedLauncherIdentifier = "Xcode.DebuggerFoundation.Launcher.LLDB"
+      shouldUseLaunchSchemeArgsEnv = "YES">
+      <Testables>
+         <TestableReference
+            skipped = "NO">
+            <BuildableReference
+               BuildableIdentifier = "primary"
+               BlueprintIdentifier = "CB487A8426D7B144004F6B87"
+               BuildableName = "BugsnagRequestMonitor-macOSTests.xctest"
+               BlueprintName = "BugsnagRequestMonitor-macOSTests"
+               ReferencedContainer = "container:BugsnagRequestMonitor.xcodeproj">
+            </BuildableReference>
+         </TestableReference>
+      </Testables>
+   </TestAction>
+   <LaunchAction
+      buildConfiguration = "Debug"
+      selectedDebuggerIdentifier = "Xcode.DebuggerFoundation.Debugger.LLDB"
+      selectedLauncherIdentifier = "Xcode.DebuggerFoundation.Launcher.LLDB"
+      launchStyle = "0"
+      useCustomWorkingDirectory = "NO"
+      ignoresPersistentStateOnLaunch = "NO"
+      debugDocumentVersioning = "YES"
+      debugServiceExtension = "internal"
+      allowLocationSimulation = "YES">
+   </LaunchAction>
+   <ProfileAction
+      buildConfiguration = "Release"
+      shouldUseLaunchSchemeArgsEnv = "YES"
+      savedToolIdentifier = ""
+      useCustomWorkingDirectory = "NO"
+      debugDocumentVersioning = "YES">
+      <MacroExpansion>
+         <BuildableReference
+            BuildableIdentifier = "primary"
+            BlueprintIdentifier = "CB487A7C26D7B144004F6B87"
+            BuildableName = "BugsnagRequestMonitor.framework"
+            BlueprintName = "BugsnagRequestMonitor-macOS"
+            ReferencedContainer = "container:BugsnagRequestMonitor.xcodeproj">
+         </BuildableReference>
+      </MacroExpansion>
+   </ProfileAction>
+   <AnalyzeAction
+      buildConfiguration = "Debug">
+   </AnalyzeAction>
+   <ArchiveAction
+      buildConfiguration = "Release"
+      revealArchiveInOrganizer = "YES">
+   </ArchiveAction>
+</Scheme>

--- a/BugsnagRequestMonitor/BugsnagRequestMonitor.xcodeproj/xcshareddata/xcschemes/BugsnagRequestMonitor-tvOS.xcscheme
+++ b/BugsnagRequestMonitor/BugsnagRequestMonitor.xcodeproj/xcshareddata/xcschemes/BugsnagRequestMonitor-tvOS.xcscheme
@@ -1,0 +1,77 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<Scheme
+   LastUpgradeVersion = "1250"
+   version = "1.3">
+   <BuildAction
+      parallelizeBuildables = "YES"
+      buildImplicitDependencies = "YES">
+      <BuildActionEntries>
+         <BuildActionEntry
+            buildForTesting = "YES"
+            buildForRunning = "YES"
+            buildForProfiling = "YES"
+            buildForArchiving = "YES"
+            buildForAnalyzing = "YES">
+            <BuildableReference
+               BuildableIdentifier = "primary"
+               BlueprintIdentifier = "CB487A9C26D7B172004F6B87"
+               BuildableName = "BugsnagRequestMonitor.framework"
+               BlueprintName = "BugsnagRequestMonitor-tvOS"
+               ReferencedContainer = "container:BugsnagRequestMonitor.xcodeproj">
+            </BuildableReference>
+         </BuildActionEntry>
+      </BuildActionEntries>
+   </BuildAction>
+   <TestAction
+      buildConfiguration = "Debug"
+      selectedDebuggerIdentifier = "Xcode.DebuggerFoundation.Debugger.LLDB"
+      selectedLauncherIdentifier = "Xcode.DebuggerFoundation.Launcher.LLDB"
+      shouldUseLaunchSchemeArgsEnv = "YES">
+      <Testables>
+         <TestableReference
+            skipped = "NO">
+            <BuildableReference
+               BuildableIdentifier = "primary"
+               BlueprintIdentifier = "CB487AA426D7B172004F6B87"
+               BuildableName = "BugsnagRequestMonitor-tvOSTests.xctest"
+               BlueprintName = "BugsnagRequestMonitor-tvOSTests"
+               ReferencedContainer = "container:BugsnagRequestMonitor.xcodeproj">
+            </BuildableReference>
+         </TestableReference>
+      </Testables>
+   </TestAction>
+   <LaunchAction
+      buildConfiguration = "Debug"
+      selectedDebuggerIdentifier = "Xcode.DebuggerFoundation.Debugger.LLDB"
+      selectedLauncherIdentifier = "Xcode.DebuggerFoundation.Launcher.LLDB"
+      launchStyle = "0"
+      useCustomWorkingDirectory = "NO"
+      ignoresPersistentStateOnLaunch = "NO"
+      debugDocumentVersioning = "YES"
+      debugServiceExtension = "internal"
+      allowLocationSimulation = "YES">
+   </LaunchAction>
+   <ProfileAction
+      buildConfiguration = "Release"
+      shouldUseLaunchSchemeArgsEnv = "YES"
+      savedToolIdentifier = ""
+      useCustomWorkingDirectory = "NO"
+      debugDocumentVersioning = "YES">
+      <MacroExpansion>
+         <BuildableReference
+            BuildableIdentifier = "primary"
+            BlueprintIdentifier = "CB487A9C26D7B172004F6B87"
+            BuildableName = "BugsnagRequestMonitor.framework"
+            BlueprintName = "BugsnagRequestMonitor-tvOS"
+            ReferencedContainer = "container:BugsnagRequestMonitor.xcodeproj">
+         </BuildableReference>
+      </MacroExpansion>
+   </ProfileAction>
+   <AnalyzeAction
+      buildConfiguration = "Debug">
+   </AnalyzeAction>
+   <ArchiveAction
+      buildConfiguration = "Release"
+      revealArchiveInOrganizer = "YES">
+   </ArchiveAction>
+</Scheme>

--- a/BugsnagRequestMonitor/BugsnagRequestMonitor/BugsnagRequestMonitor.m
+++ b/BugsnagRequestMonitor/BugsnagRequestMonitor/BugsnagRequestMonitor.m
@@ -1,0 +1,8 @@
+//
+//  BugsnagRequestMonitor.m
+//  BugsnagRequestMonitor
+//
+//  Created by Karl Stenerud on 26.08.21.
+//
+
+#import "BugsnagRequestMonitor.h"

--- a/BugsnagRequestMonitor/BugsnagRequestMonitor/Info.plist
+++ b/BugsnagRequestMonitor/BugsnagRequestMonitor/Info.plist
@@ -1,0 +1,22 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
+<plist version="1.0">
+<dict>
+	<key>CFBundleDevelopmentRegion</key>
+	<string>$(DEVELOPMENT_LANGUAGE)</string>
+	<key>CFBundleExecutable</key>
+	<string>$(EXECUTABLE_NAME)</string>
+	<key>CFBundleIdentifier</key>
+	<string>$(PRODUCT_BUNDLE_IDENTIFIER)</string>
+	<key>CFBundleInfoDictionaryVersion</key>
+	<string>6.0</string>
+	<key>CFBundleName</key>
+	<string>$(PRODUCT_NAME)</string>
+	<key>CFBundlePackageType</key>
+	<string>$(PRODUCT_BUNDLE_PACKAGE_TYPE)</string>
+	<key>CFBundleShortVersionString</key>
+	<string>1.0</string>
+	<key>CFBundleVersion</key>
+	<string>$(CURRENT_PROJECT_VERSION)</string>
+</dict>
+</plist>

--- a/BugsnagRequestMonitor/BugsnagRequestMonitor/include/BugsnagRequestMonitor/BugsnagRequestMonitor.h
+++ b/BugsnagRequestMonitor/BugsnagRequestMonitor/include/BugsnagRequestMonitor/BugsnagRequestMonitor.h
@@ -1,0 +1,9 @@
+//
+//  BugsnagRequestMonitor.h
+//  BugsnagRequestMonitor
+//
+//  Created by Karl Stenerud on 26.08.21.
+//
+
+#import <Foundation/Foundation.h>
+#import <Bugsnag/Bugsnag.h>

--- a/BugsnagRequestMonitor/BugsnagRequestMonitorTests/BugsnagRequestMonitorTests.m
+++ b/BugsnagRequestMonitor/BugsnagRequestMonitorTests/BugsnagRequestMonitorTests.m
@@ -1,0 +1,19 @@
+//
+//  BugsnagRequestMonitorTests.m
+//  BugsnagRequestMonitorTests
+//
+//  Created by Karl Stenerud on 26.08.21.
+//
+
+#import <XCTest/XCTest.h>
+
+@interface BugsnagRequestMonitorTests : XCTestCase
+
+@end
+
+@implementation BugsnagRequestMonitorTests
+
+- (void)testExample {
+}
+
+@end

--- a/BugsnagRequestMonitor/BugsnagRequestMonitorTests/Info.plist
+++ b/BugsnagRequestMonitor/BugsnagRequestMonitorTests/Info.plist
@@ -1,0 +1,22 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
+<plist version="1.0">
+<dict>
+	<key>CFBundleDevelopmentRegion</key>
+	<string>$(DEVELOPMENT_LANGUAGE)</string>
+	<key>CFBundleExecutable</key>
+	<string>$(EXECUTABLE_NAME)</string>
+	<key>CFBundleIdentifier</key>
+	<string>$(PRODUCT_BUNDLE_IDENTIFIER)</string>
+	<key>CFBundleInfoDictionaryVersion</key>
+	<string>6.0</string>
+	<key>CFBundleName</key>
+	<string>$(PRODUCT_NAME)</string>
+	<key>CFBundlePackageType</key>
+	<string>$(PRODUCT_BUNDLE_PACKAGE_TYPE)</string>
+	<key>CFBundleShortVersionString</key>
+	<string>1.0</string>
+	<key>CFBundleVersion</key>
+	<string>1</string>
+</dict>
+</plist>

--- a/Package.swift
+++ b/Package.swift
@@ -10,6 +10,7 @@ let package = Package(
     ],
     products: [
         .library(name: "Bugsnag", targets: ["Bugsnag"]),
+        .library(name: "BugsnagRequestMonitor", targets: ["BugsnagRequestMonitor"]),
     ],
     dependencies: [],
     targets: [
@@ -39,6 +40,16 @@ let package = Package(
             linkerSettings: [
                 .linkedLibrary("z"),
                 .linkedLibrary("c++"),
+            ]
+        ),
+        .target(
+            name: "BugsnagRequestMonitor",
+            dependencies: ["Bugsnag"],
+            path: "BugsnagRequestMonitor/BugsnagRequestMonitor",
+            publicHeadersPath: "include",
+            cSettings: [
+                .headerSearchPath("."),
+                .headerSearchPath("include/BugsnagRequestMonitor"),
             ]
         ),
     ],


### PR DESCRIPTION
## Goal

This adds the base project structure required for the Bugsnag network breadcrumbs plugin so that we can set up CI for it independently of the upcoming implementation.

## Design

Follows the setup laid out in BUGSNAG-PLUGIN.md

## Testing

Comes with a single basic unit test that does nothing and then passes.
