### PR TITLE
Add network breadcrumbs plugin logic

### DIFF
--- a/BugsnagRequestMonitor/BugsnagRequestMonitor.xcodeproj/project.pbxproj
+++ b/BugsnagRequestMonitor/BugsnagRequestMonitor.xcodeproj/project.pbxproj
@@ -22,6 +22,117 @@
 		CB487C3026DE3EFB004F6B87 /* BugsnagRequestMonitor.h in Headers */ = {isa = PBXBuildFile; fileRef = CB487C2F26DE3EFB004F6B87 /* BugsnagRequestMonitor.h */; settings = {ATTRIBUTES = (Public, ); }; };
 		CB487C3126DE3EFB004F6B87 /* BugsnagRequestMonitor.h in Headers */ = {isa = PBXBuildFile; fileRef = CB487C2F26DE3EFB004F6B87 /* BugsnagRequestMonitor.h */; settings = {ATTRIBUTES = (Public, ); }; };
 		CB487C3226DE3EFB004F6B87 /* BugsnagRequestMonitor.h in Headers */ = {isa = PBXBuildFile; fileRef = CB487C2F26DE3EFB004F6B87 /* BugsnagRequestMonitor.h */; settings = {ATTRIBUTES = (Public, ); }; };
+		CB487E9126E11922004F6B87 /* BSGULObjectSwizzler+Internal.h in Headers */ = {isa = PBXBuildFile; fileRef = CB487E6926E11922004F6B87 /* BSGULObjectSwizzler+Internal.h */; };
+		CB487E9226E11922004F6B87 /* BSGULObjectSwizzler+Internal.h in Headers */ = {isa = PBXBuildFile; fileRef = CB487E6926E11922004F6B87 /* BSGULObjectSwizzler+Internal.h */; };
+		CB487E9326E11922004F6B87 /* BSGULObjectSwizzler+Internal.h in Headers */ = {isa = PBXBuildFile; fileRef = CB487E6926E11922004F6B87 /* BSGULObjectSwizzler+Internal.h */; };
+		CB487E9426E11922004F6B87 /* BSGULSwizzledObject.h in Headers */ = {isa = PBXBuildFile; fileRef = CB487E6A26E11922004F6B87 /* BSGULSwizzledObject.h */; };
+		CB487E9526E11922004F6B87 /* BSGULSwizzledObject.h in Headers */ = {isa = PBXBuildFile; fileRef = CB487E6A26E11922004F6B87 /* BSGULSwizzledObject.h */; };
+		CB487E9626E11922004F6B87 /* BSGULSwizzledObject.h in Headers */ = {isa = PBXBuildFile; fileRef = CB487E6A26E11922004F6B87 /* BSGULSwizzledObject.h */; };
+		CB487E9726E11922004F6B87 /* BSGULSwizzler.m in Sources */ = {isa = PBXBuildFile; fileRef = CB487E6B26E11922004F6B87 /* BSGULSwizzler.m */; };
+		CB487E9826E11922004F6B87 /* BSGULSwizzler.m in Sources */ = {isa = PBXBuildFile; fileRef = CB487E6B26E11922004F6B87 /* BSGULSwizzler.m */; };
+		CB487E9926E11922004F6B87 /* BSGULSwizzler.m in Sources */ = {isa = PBXBuildFile; fileRef = CB487E6B26E11922004F6B87 /* BSGULSwizzler.m */; };
+		CB487E9A26E11922004F6B87 /* BSGULObjectSwizzler.h in Headers */ = {isa = PBXBuildFile; fileRef = CB487E6C26E11922004F6B87 /* BSGULObjectSwizzler.h */; };
+		CB487E9B26E11922004F6B87 /* BSGULObjectSwizzler.h in Headers */ = {isa = PBXBuildFile; fileRef = CB487E6C26E11922004F6B87 /* BSGULObjectSwizzler.h */; };
+		CB487E9C26E11922004F6B87 /* BSGULObjectSwizzler.h in Headers */ = {isa = PBXBuildFile; fileRef = CB487E6C26E11922004F6B87 /* BSGULObjectSwizzler.h */; };
+		CB487E9D26E11922004F6B87 /* BSGULOriginalIMPConvenienceMacros.h in Headers */ = {isa = PBXBuildFile; fileRef = CB487E6D26E11922004F6B87 /* BSGULOriginalIMPConvenienceMacros.h */; };
+		CB487E9E26E11922004F6B87 /* BSGULOriginalIMPConvenienceMacros.h in Headers */ = {isa = PBXBuildFile; fileRef = CB487E6D26E11922004F6B87 /* BSGULOriginalIMPConvenienceMacros.h */; };
+		CB487E9F26E11922004F6B87 /* BSGULOriginalIMPConvenienceMacros.h in Headers */ = {isa = PBXBuildFile; fileRef = CB487E6D26E11922004F6B87 /* BSGULOriginalIMPConvenienceMacros.h */; };
+		CB487EA026E11922004F6B87 /* BSGULSwizzledObject.m in Sources */ = {isa = PBXBuildFile; fileRef = CB487E6E26E11922004F6B87 /* BSGULSwizzledObject.m */; };
+		CB487EA126E11922004F6B87 /* BSGULSwizzledObject.m in Sources */ = {isa = PBXBuildFile; fileRef = CB487E6E26E11922004F6B87 /* BSGULSwizzledObject.m */; };
+		CB487EA226E11922004F6B87 /* BSGULSwizzledObject.m in Sources */ = {isa = PBXBuildFile; fileRef = CB487E6E26E11922004F6B87 /* BSGULSwizzledObject.m */; };
+		CB487EA326E11922004F6B87 /* BSGULSwizzler.h in Headers */ = {isa = PBXBuildFile; fileRef = CB487E6F26E11922004F6B87 /* BSGULSwizzler.h */; };
+		CB487EA426E11922004F6B87 /* BSGULSwizzler.h in Headers */ = {isa = PBXBuildFile; fileRef = CB487E6F26E11922004F6B87 /* BSGULSwizzler.h */; };
+		CB487EA526E11922004F6B87 /* BSGULSwizzler.h in Headers */ = {isa = PBXBuildFile; fileRef = CB487E6F26E11922004F6B87 /* BSGULSwizzler.h */; };
+		CB487EA626E11922004F6B87 /* BSGULObjectSwizzler.m in Sources */ = {isa = PBXBuildFile; fileRef = CB487E7026E11922004F6B87 /* BSGULObjectSwizzler.m */; };
+		CB487EA726E11922004F6B87 /* BSGULObjectSwizzler.m in Sources */ = {isa = PBXBuildFile; fileRef = CB487E7026E11922004F6B87 /* BSGULObjectSwizzler.m */; };
+		CB487EA826E11922004F6B87 /* BSGULObjectSwizzler.m in Sources */ = {isa = PBXBuildFile; fileRef = CB487E7026E11922004F6B87 /* BSGULObjectSwizzler.m */; };
+		CB487EA926E11922004F6B87 /* BSFPRConsoleLogger.h in Headers */ = {isa = PBXBuildFile; fileRef = CB487E7226E11922004F6B87 /* BSFPRConsoleLogger.h */; };
+		CB487EAA26E11922004F6B87 /* BSFPRConsoleLogger.h in Headers */ = {isa = PBXBuildFile; fileRef = CB487E7226E11922004F6B87 /* BSFPRConsoleLogger.h */; };
+		CB487EAB26E11922004F6B87 /* BSFPRConsoleLogger.h in Headers */ = {isa = PBXBuildFile; fileRef = CB487E7226E11922004F6B87 /* BSFPRConsoleLogger.h */; };
+		CB487EAC26E11922004F6B87 /* BSFPRInstrument.h in Headers */ = {isa = PBXBuildFile; fileRef = CB487E7326E11922004F6B87 /* BSFPRInstrument.h */; };
+		CB487EAD26E11922004F6B87 /* BSFPRInstrument.h in Headers */ = {isa = PBXBuildFile; fileRef = CB487E7326E11922004F6B87 /* BSFPRInstrument.h */; };
+		CB487EAE26E11922004F6B87 /* BSFPRInstrument.h in Headers */ = {isa = PBXBuildFile; fileRef = CB487E7326E11922004F6B87 /* BSFPRInstrument.h */; };
+		CB487EAF26E11922004F6B87 /* BSFPRClassInstrumentor_Private.h in Headers */ = {isa = PBXBuildFile; fileRef = CB487E7426E11922004F6B87 /* BSFPRClassInstrumentor_Private.h */; };
+		CB487EB026E11922004F6B87 /* BSFPRClassInstrumentor_Private.h in Headers */ = {isa = PBXBuildFile; fileRef = CB487E7426E11922004F6B87 /* BSFPRClassInstrumentor_Private.h */; };
+		CB487EB126E11922004F6B87 /* BSFPRClassInstrumentor_Private.h in Headers */ = {isa = PBXBuildFile; fileRef = CB487E7426E11922004F6B87 /* BSFPRClassInstrumentor_Private.h */; };
+		CB487EB226E11922004F6B87 /* BSFPRTraceBackgroundActivityTracker.m in Sources */ = {isa = PBXBuildFile; fileRef = CB487E7526E11922004F6B87 /* BSFPRTraceBackgroundActivityTracker.m */; };
+		CB487EB326E11922004F6B87 /* BSFPRTraceBackgroundActivityTracker.m in Sources */ = {isa = PBXBuildFile; fileRef = CB487E7526E11922004F6B87 /* BSFPRTraceBackgroundActivityTracker.m */; };
+		CB487EB426E11922004F6B87 /* BSFPRTraceBackgroundActivityTracker.m in Sources */ = {isa = PBXBuildFile; fileRef = CB487E7526E11922004F6B87 /* BSFPRTraceBackgroundActivityTracker.m */; };
+		CB487EB526E11922004F6B87 /* BSFPRProxyObjectHelper.m in Sources */ = {isa = PBXBuildFile; fileRef = CB487E7626E11922004F6B87 /* BSFPRProxyObjectHelper.m */; };
+		CB487EB626E11922004F6B87 /* BSFPRProxyObjectHelper.m in Sources */ = {isa = PBXBuildFile; fileRef = CB487E7626E11922004F6B87 /* BSFPRProxyObjectHelper.m */; };
+		CB487EB726E11922004F6B87 /* BSFPRProxyObjectHelper.m in Sources */ = {isa = PBXBuildFile; fileRef = CB487E7626E11922004F6B87 /* BSFPRProxyObjectHelper.m */; };
+		CB487EB826E11922004F6B87 /* BSFPRClassInstrumentor.h in Headers */ = {isa = PBXBuildFile; fileRef = CB487E7726E11922004F6B87 /* BSFPRClassInstrumentor.h */; };
+		CB487EB926E11922004F6B87 /* BSFPRClassInstrumentor.h in Headers */ = {isa = PBXBuildFile; fileRef = CB487E7726E11922004F6B87 /* BSFPRClassInstrumentor.h */; };
+		CB487EBA26E11922004F6B87 /* BSFPRClassInstrumentor.h in Headers */ = {isa = PBXBuildFile; fileRef = CB487E7726E11922004F6B87 /* BSFPRClassInstrumentor.h */; };
+		CB487EBB26E11922004F6B87 /* BSFPRNSURLSessionInstrument.m in Sources */ = {isa = PBXBuildFile; fileRef = CB487E7926E11922004F6B87 /* BSFPRNSURLSessionInstrument.m */; };
+		CB487EBC26E11922004F6B87 /* BSFPRNSURLSessionInstrument.m in Sources */ = {isa = PBXBuildFile; fileRef = CB487E7926E11922004F6B87 /* BSFPRNSURLSessionInstrument.m */; };
+		CB487EBD26E11922004F6B87 /* BSFPRNSURLSessionInstrument.m in Sources */ = {isa = PBXBuildFile; fileRef = CB487E7926E11922004F6B87 /* BSFPRNSURLSessionInstrument.m */; };
+		CB487EBE26E11922004F6B87 /* BSFPRNetworkTrace.m in Sources */ = {isa = PBXBuildFile; fileRef = CB487E7A26E11922004F6B87 /* BSFPRNetworkTrace.m */; };
+		CB487EBF26E11922004F6B87 /* BSFPRNetworkTrace.m in Sources */ = {isa = PBXBuildFile; fileRef = CB487E7A26E11922004F6B87 /* BSFPRNetworkTrace.m */; };
+		CB487EC026E11922004F6B87 /* BSFPRNetworkTrace.m in Sources */ = {isa = PBXBuildFile; fileRef = CB487E7A26E11922004F6B87 /* BSFPRNetworkTrace.m */; };
+		CB487EC126E11922004F6B87 /* BSFPRNetworkInstrumentHelpers.m in Sources */ = {isa = PBXBuildFile; fileRef = CB487E7B26E11922004F6B87 /* BSFPRNetworkInstrumentHelpers.m */; };
+		CB487EC226E11922004F6B87 /* BSFPRNetworkInstrumentHelpers.m in Sources */ = {isa = PBXBuildFile; fileRef = CB487E7B26E11922004F6B87 /* BSFPRNetworkInstrumentHelpers.m */; };
+		CB487EC326E11922004F6B87 /* BSFPRNetworkInstrumentHelpers.m in Sources */ = {isa = PBXBuildFile; fileRef = CB487E7B26E11922004F6B87 /* BSFPRNetworkInstrumentHelpers.m */; };
+		CB487EC426E11922004F6B87 /* BSFPRNSURLSessionInstrument.h in Headers */ = {isa = PBXBuildFile; fileRef = CB487E7C26E11922004F6B87 /* BSFPRNSURLSessionInstrument.h */; };
+		CB487EC526E11922004F6B87 /* BSFPRNSURLSessionInstrument.h in Headers */ = {isa = PBXBuildFile; fileRef = CB487E7C26E11922004F6B87 /* BSFPRNSURLSessionInstrument.h */; };
+		CB487EC626E11922004F6B87 /* BSFPRNSURLSessionInstrument.h in Headers */ = {isa = PBXBuildFile; fileRef = CB487E7C26E11922004F6B87 /* BSFPRNSURLSessionInstrument.h */; };
+		CB487EC726E11922004F6B87 /* BSFPRNSURLSessionDelegate.h in Headers */ = {isa = PBXBuildFile; fileRef = CB487E7E26E11922004F6B87 /* BSFPRNSURLSessionDelegate.h */; };
+		CB487EC826E11922004F6B87 /* BSFPRNSURLSessionDelegate.h in Headers */ = {isa = PBXBuildFile; fileRef = CB487E7E26E11922004F6B87 /* BSFPRNSURLSessionDelegate.h */; };
+		CB487EC926E11922004F6B87 /* BSFPRNSURLSessionDelegate.h in Headers */ = {isa = PBXBuildFile; fileRef = CB487E7E26E11922004F6B87 /* BSFPRNSURLSessionDelegate.h */; };
+		CB487ECA26E11922004F6B87 /* BSFPRNSURLSessionDelegateInstrument.m in Sources */ = {isa = PBXBuildFile; fileRef = CB487E7F26E11922004F6B87 /* BSFPRNSURLSessionDelegateInstrument.m */; };
+		CB487ECB26E11922004F6B87 /* BSFPRNSURLSessionDelegateInstrument.m in Sources */ = {isa = PBXBuildFile; fileRef = CB487E7F26E11922004F6B87 /* BSFPRNSURLSessionDelegateInstrument.m */; };
+		CB487ECC26E11922004F6B87 /* BSFPRNSURLSessionDelegateInstrument.m in Sources */ = {isa = PBXBuildFile; fileRef = CB487E7F26E11922004F6B87 /* BSFPRNSURLSessionDelegateInstrument.m */; };
+		CB487ECD26E11922004F6B87 /* BSFPRNSURLSessionDelegate.m in Sources */ = {isa = PBXBuildFile; fileRef = CB487E8026E11922004F6B87 /* BSFPRNSURLSessionDelegate.m */; };
+		CB487ECE26E11922004F6B87 /* BSFPRNSURLSessionDelegate.m in Sources */ = {isa = PBXBuildFile; fileRef = CB487E8026E11922004F6B87 /* BSFPRNSURLSessionDelegate.m */; };
+		CB487ECF26E11922004F6B87 /* BSFPRNSURLSessionDelegate.m in Sources */ = {isa = PBXBuildFile; fileRef = CB487E8026E11922004F6B87 /* BSFPRNSURLSessionDelegate.m */; };
+		CB487ED026E11922004F6B87 /* BSFPRNSURLSessionDelegateInstrument.h in Headers */ = {isa = PBXBuildFile; fileRef = CB487E8126E11922004F6B87 /* BSFPRNSURLSessionDelegateInstrument.h */; };
+		CB487ED126E11922004F6B87 /* BSFPRNSURLSessionDelegateInstrument.h in Headers */ = {isa = PBXBuildFile; fileRef = CB487E8126E11922004F6B87 /* BSFPRNSURLSessionDelegateInstrument.h */; };
+		CB487ED226E11922004F6B87 /* BSFPRNSURLSessionDelegateInstrument.h in Headers */ = {isa = PBXBuildFile; fileRef = CB487E8126E11922004F6B87 /* BSFPRNSURLSessionDelegateInstrument.h */; };
+		CB487ED326E11922004F6B87 /* BSFPRNetworkTrace.h in Headers */ = {isa = PBXBuildFile; fileRef = CB487E8226E11922004F6B87 /* BSFPRNetworkTrace.h */; };
+		CB487ED426E11922004F6B87 /* BSFPRNetworkTrace.h in Headers */ = {isa = PBXBuildFile; fileRef = CB487E8226E11922004F6B87 /* BSFPRNetworkTrace.h */; };
+		CB487ED526E11922004F6B87 /* BSFPRNetworkTrace.h in Headers */ = {isa = PBXBuildFile; fileRef = CB487E8226E11922004F6B87 /* BSFPRNetworkTrace.h */; };
+		CB487ED626E11922004F6B87 /* BSFPRNetworkInstrumentHelpers.h in Headers */ = {isa = PBXBuildFile; fileRef = CB487E8326E11922004F6B87 /* BSFPRNetworkInstrumentHelpers.h */; };
+		CB487ED726E11922004F6B87 /* BSFPRNetworkInstrumentHelpers.h in Headers */ = {isa = PBXBuildFile; fileRef = CB487E8326E11922004F6B87 /* BSFPRNetworkInstrumentHelpers.h */; };
+		CB487ED826E11922004F6B87 /* BSFPRNetworkInstrumentHelpers.h in Headers */ = {isa = PBXBuildFile; fileRef = CB487E8326E11922004F6B87 /* BSFPRNetworkInstrumentHelpers.h */; };
+		CB487ED926E11922004F6B87 /* BSFPRNSURLSessionInstrument_Private.h in Headers */ = {isa = PBXBuildFile; fileRef = CB487E8426E11922004F6B87 /* BSFPRNSURLSessionInstrument_Private.h */; };
+		CB487EDA26E11922004F6B87 /* BSFPRNSURLSessionInstrument_Private.h in Headers */ = {isa = PBXBuildFile; fileRef = CB487E8426E11922004F6B87 /* BSFPRNSURLSessionInstrument_Private.h */; };
+		CB487EDB26E11922004F6B87 /* BSFPRNSURLSessionInstrument_Private.h in Headers */ = {isa = PBXBuildFile; fileRef = CB487E8426E11922004F6B87 /* BSFPRNSURLSessionInstrument_Private.h */; };
+		CB487EDC26E11922004F6B87 /* BSFPRDataUtils.m in Sources */ = {isa = PBXBuildFile; fileRef = CB487E8526E11922004F6B87 /* BSFPRDataUtils.m */; };
+		CB487EDD26E11922004F6B87 /* BSFPRDataUtils.m in Sources */ = {isa = PBXBuildFile; fileRef = CB487E8526E11922004F6B87 /* BSFPRDataUtils.m */; };
+		CB487EDE26E11922004F6B87 /* BSFPRDataUtils.m in Sources */ = {isa = PBXBuildFile; fileRef = CB487E8526E11922004F6B87 /* BSFPRDataUtils.m */; };
+		CB487EDF26E11922004F6B87 /* BSFPRSelectorInstrumentor.h in Headers */ = {isa = PBXBuildFile; fileRef = CB487E8626E11922004F6B87 /* BSFPRSelectorInstrumentor.h */; };
+		CB487EE026E11922004F6B87 /* BSFPRSelectorInstrumentor.h in Headers */ = {isa = PBXBuildFile; fileRef = CB487E8626E11922004F6B87 /* BSFPRSelectorInstrumentor.h */; };
+		CB487EE126E11922004F6B87 /* BSFPRSelectorInstrumentor.h in Headers */ = {isa = PBXBuildFile; fileRef = CB487E8626E11922004F6B87 /* BSFPRSelectorInstrumentor.h */; };
+		CB487EE226E11922004F6B87 /* BSFPRObjectInstrumentor.h in Headers */ = {isa = PBXBuildFile; fileRef = CB487E8726E11922004F6B87 /* BSFPRObjectInstrumentor.h */; };
+		CB487EE326E11922004F6B87 /* BSFPRObjectInstrumentor.h in Headers */ = {isa = PBXBuildFile; fileRef = CB487E8726E11922004F6B87 /* BSFPRObjectInstrumentor.h */; };
+		CB487EE426E11922004F6B87 /* BSFPRObjectInstrumentor.h in Headers */ = {isa = PBXBuildFile; fileRef = CB487E8726E11922004F6B87 /* BSFPRObjectInstrumentor.h */; };
+		CB487EE526E11922004F6B87 /* BSFPRInstrument.m in Sources */ = {isa = PBXBuildFile; fileRef = CB487E8826E11922004F6B87 /* BSFPRInstrument.m */; };
+		CB487EE626E11922004F6B87 /* BSFPRInstrument.m in Sources */ = {isa = PBXBuildFile; fileRef = CB487E8826E11922004F6B87 /* BSFPRInstrument.m */; };
+		CB487EE726E11922004F6B87 /* BSFPRInstrument.m in Sources */ = {isa = PBXBuildFile; fileRef = CB487E8826E11922004F6B87 /* BSFPRInstrument.m */; };
+		CB487EE826E11922004F6B87 /* BSFPRConsoleLogger.m in Sources */ = {isa = PBXBuildFile; fileRef = CB487E8926E11922004F6B87 /* BSFPRConsoleLogger.m */; };
+		CB487EE926E11922004F6B87 /* BSFPRConsoleLogger.m in Sources */ = {isa = PBXBuildFile; fileRef = CB487E8926E11922004F6B87 /* BSFPRConsoleLogger.m */; };
+		CB487EEA26E11922004F6B87 /* BSFPRConsoleLogger.m in Sources */ = {isa = PBXBuildFile; fileRef = CB487E8926E11922004F6B87 /* BSFPRConsoleLogger.m */; };
+		CB487EEB26E11922004F6B87 /* BSFPRInstrument_Private.h in Headers */ = {isa = PBXBuildFile; fileRef = CB487E8A26E11922004F6B87 /* BSFPRInstrument_Private.h */; };
+		CB487EEC26E11922004F6B87 /* BSFPRInstrument_Private.h in Headers */ = {isa = PBXBuildFile; fileRef = CB487E8A26E11922004F6B87 /* BSFPRInstrument_Private.h */; };
+		CB487EED26E11922004F6B87 /* BSFPRInstrument_Private.h in Headers */ = {isa = PBXBuildFile; fileRef = CB487E8A26E11922004F6B87 /* BSFPRInstrument_Private.h */; };
+		CB487EEE26E11922004F6B87 /* BSFPRTraceBackgroundActivityTracker.h in Headers */ = {isa = PBXBuildFile; fileRef = CB487E8B26E11922004F6B87 /* BSFPRTraceBackgroundActivityTracker.h */; };
+		CB487EEF26E11922004F6B87 /* BSFPRTraceBackgroundActivityTracker.h in Headers */ = {isa = PBXBuildFile; fileRef = CB487E8B26E11922004F6B87 /* BSFPRTraceBackgroundActivityTracker.h */; };
+		CB487EF026E11922004F6B87 /* BSFPRTraceBackgroundActivityTracker.h in Headers */ = {isa = PBXBuildFile; fileRef = CB487E8B26E11922004F6B87 /* BSFPRTraceBackgroundActivityTracker.h */; };
+		CB487EF126E11922004F6B87 /* BSFPRClassInstrumentor.m in Sources */ = {isa = PBXBuildFile; fileRef = CB487E8C26E11922004F6B87 /* BSFPRClassInstrumentor.m */; };
+		CB487EF226E11922004F6B87 /* BSFPRClassInstrumentor.m in Sources */ = {isa = PBXBuildFile; fileRef = CB487E8C26E11922004F6B87 /* BSFPRClassInstrumentor.m */; };
+		CB487EF326E11922004F6B87 /* BSFPRClassInstrumentor.m in Sources */ = {isa = PBXBuildFile; fileRef = CB487E8C26E11922004F6B87 /* BSFPRClassInstrumentor.m */; };
+		CB487EF426E11922004F6B87 /* BSFPRProxyObjectHelper.h in Headers */ = {isa = PBXBuildFile; fileRef = CB487E8D26E11922004F6B87 /* BSFPRProxyObjectHelper.h */; };
+		CB487EF526E11922004F6B87 /* BSFPRProxyObjectHelper.h in Headers */ = {isa = PBXBuildFile; fileRef = CB487E8D26E11922004F6B87 /* BSFPRProxyObjectHelper.h */; };
+		CB487EF626E11922004F6B87 /* BSFPRProxyObjectHelper.h in Headers */ = {isa = PBXBuildFile; fileRef = CB487E8D26E11922004F6B87 /* BSFPRProxyObjectHelper.h */; };
+		CB487EF726E11922004F6B87 /* BSFPRObjectInstrumentor.m in Sources */ = {isa = PBXBuildFile; fileRef = CB487E8E26E11922004F6B87 /* BSFPRObjectInstrumentor.m */; };
+		CB487EF826E11922004F6B87 /* BSFPRObjectInstrumentor.m in Sources */ = {isa = PBXBuildFile; fileRef = CB487E8E26E11922004F6B87 /* BSFPRObjectInstrumentor.m */; };
+		CB487EF926E11922004F6B87 /* BSFPRObjectInstrumentor.m in Sources */ = {isa = PBXBuildFile; fileRef = CB487E8E26E11922004F6B87 /* BSFPRObjectInstrumentor.m */; };
+		CB487EFA26E11922004F6B87 /* BSFPRSelectorInstrumentor.m in Sources */ = {isa = PBXBuildFile; fileRef = CB487E8F26E11922004F6B87 /* BSFPRSelectorInstrumentor.m */; };
+		CB487EFB26E11922004F6B87 /* BSFPRSelectorInstrumentor.m in Sources */ = {isa = PBXBuildFile; fileRef = CB487E8F26E11922004F6B87 /* BSFPRSelectorInstrumentor.m */; };
+		CB487EFC26E11922004F6B87 /* BSFPRSelectorInstrumentor.m in Sources */ = {isa = PBXBuildFile; fileRef = CB487E8F26E11922004F6B87 /* BSFPRSelectorInstrumentor.m */; };
+		CB487EFD26E11922004F6B87 /* BSFPRDataUtils.h in Headers */ = {isa = PBXBuildFile; fileRef = CB487E9026E11922004F6B87 /* BSFPRDataUtils.h */; };
+		CB487EFE26E11922004F6B87 /* BSFPRDataUtils.h in Headers */ = {isa = PBXBuildFile; fileRef = CB487E9026E11922004F6B87 /* BSFPRDataUtils.h */; };
+		CB487EFF26E11922004F6B87 /* BSFPRDataUtils.h in Headers */ = {isa = PBXBuildFile; fileRef = CB487E9026E11922004F6B87 /* BSFPRDataUtils.h */; };
 /* End PBXBuildFile section */
 
 /* Begin PBXContainerItemProxy section */
@@ -63,6 +174,43 @@
 		CB487AB426D7B191004F6B87 /* Bugsnag.framework */ = {isa = PBXFileReference; explicitFileType = wrapper.framework; path = Bugsnag.framework; sourceTree = BUILT_PRODUCTS_DIR; };
 		CB487ABE26D7B295004F6B87 /* BugsnagRequestMonitor.m */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.objc; path = BugsnagRequestMonitor.m; sourceTree = "<group>"; };
 		CB487C2F26DE3EFB004F6B87 /* BugsnagRequestMonitor.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = BugsnagRequestMonitor.h; sourceTree = "<group>"; };
+		CB487E6926E11922004F6B87 /* BSGULObjectSwizzler+Internal.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = "BSGULObjectSwizzler+Internal.h"; sourceTree = "<group>"; };
+		CB487E6A26E11922004F6B87 /* BSGULSwizzledObject.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = BSGULSwizzledObject.h; sourceTree = "<group>"; };
+		CB487E6B26E11922004F6B87 /* BSGULSwizzler.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; path = BSGULSwizzler.m; sourceTree = "<group>"; };
+		CB487E6C26E11922004F6B87 /* BSGULObjectSwizzler.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = BSGULObjectSwizzler.h; sourceTree = "<group>"; };
+		CB487E6D26E11922004F6B87 /* BSGULOriginalIMPConvenienceMacros.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = BSGULOriginalIMPConvenienceMacros.h; sourceTree = "<group>"; };
+		CB487E6E26E11922004F6B87 /* BSGULSwizzledObject.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; path = BSGULSwizzledObject.m; sourceTree = "<group>"; };
+		CB487E6F26E11922004F6B87 /* BSGULSwizzler.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = BSGULSwizzler.h; sourceTree = "<group>"; };
+		CB487E7026E11922004F6B87 /* BSGULObjectSwizzler.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; path = BSGULObjectSwizzler.m; sourceTree = "<group>"; };
+		CB487E7226E11922004F6B87 /* BSFPRConsoleLogger.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = BSFPRConsoleLogger.h; sourceTree = "<group>"; };
+		CB487E7326E11922004F6B87 /* BSFPRInstrument.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = BSFPRInstrument.h; sourceTree = "<group>"; };
+		CB487E7426E11922004F6B87 /* BSFPRClassInstrumentor_Private.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = BSFPRClassInstrumentor_Private.h; sourceTree = "<group>"; };
+		CB487E7526E11922004F6B87 /* BSFPRTraceBackgroundActivityTracker.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; path = BSFPRTraceBackgroundActivityTracker.m; sourceTree = "<group>"; };
+		CB487E7626E11922004F6B87 /* BSFPRProxyObjectHelper.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; path = BSFPRProxyObjectHelper.m; sourceTree = "<group>"; };
+		CB487E7726E11922004F6B87 /* BSFPRClassInstrumentor.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = BSFPRClassInstrumentor.h; sourceTree = "<group>"; };
+		CB487E7926E11922004F6B87 /* BSFPRNSURLSessionInstrument.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; path = BSFPRNSURLSessionInstrument.m; sourceTree = "<group>"; };
+		CB487E7A26E11922004F6B87 /* BSFPRNetworkTrace.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; path = BSFPRNetworkTrace.m; sourceTree = "<group>"; };
+		CB487E7B26E11922004F6B87 /* BSFPRNetworkInstrumentHelpers.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; path = BSFPRNetworkInstrumentHelpers.m; sourceTree = "<group>"; };
+		CB487E7C26E11922004F6B87 /* BSFPRNSURLSessionInstrument.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = BSFPRNSURLSessionInstrument.h; sourceTree = "<group>"; };
+		CB487E7E26E11922004F6B87 /* BSFPRNSURLSessionDelegate.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = BSFPRNSURLSessionDelegate.h; sourceTree = "<group>"; };
+		CB487E7F26E11922004F6B87 /* BSFPRNSURLSessionDelegateInstrument.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; path = BSFPRNSURLSessionDelegateInstrument.m; sourceTree = "<group>"; };
+		CB487E8026E11922004F6B87 /* BSFPRNSURLSessionDelegate.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; path = BSFPRNSURLSessionDelegate.m; sourceTree = "<group>"; };
+		CB487E8126E11922004F6B87 /* BSFPRNSURLSessionDelegateInstrument.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = BSFPRNSURLSessionDelegateInstrument.h; sourceTree = "<group>"; };
+		CB487E8226E11922004F6B87 /* BSFPRNetworkTrace.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = BSFPRNetworkTrace.h; sourceTree = "<group>"; };
+		CB487E8326E11922004F6B87 /* BSFPRNetworkInstrumentHelpers.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = BSFPRNetworkInstrumentHelpers.h; sourceTree = "<group>"; };
+		CB487E8426E11922004F6B87 /* BSFPRNSURLSessionInstrument_Private.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = BSFPRNSURLSessionInstrument_Private.h; sourceTree = "<group>"; };
+		CB487E8526E11922004F6B87 /* BSFPRDataUtils.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; path = BSFPRDataUtils.m; sourceTree = "<group>"; };
+		CB487E8626E11922004F6B87 /* BSFPRSelectorInstrumentor.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = BSFPRSelectorInstrumentor.h; sourceTree = "<group>"; };
+		CB487E8726E11922004F6B87 /* BSFPRObjectInstrumentor.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = BSFPRObjectInstrumentor.h; sourceTree = "<group>"; };
+		CB487E8826E11922004F6B87 /* BSFPRInstrument.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; path = BSFPRInstrument.m; sourceTree = "<group>"; };
+		CB487E8926E11922004F6B87 /* BSFPRConsoleLogger.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; path = BSFPRConsoleLogger.m; sourceTree = "<group>"; };
+		CB487E8A26E11922004F6B87 /* BSFPRInstrument_Private.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = BSFPRInstrument_Private.h; sourceTree = "<group>"; };
+		CB487E8B26E11922004F6B87 /* BSFPRTraceBackgroundActivityTracker.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = BSFPRTraceBackgroundActivityTracker.h; sourceTree = "<group>"; };
+		CB487E8C26E11922004F6B87 /* BSFPRClassInstrumentor.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; path = BSFPRClassInstrumentor.m; sourceTree = "<group>"; };
+		CB487E8D26E11922004F6B87 /* BSFPRProxyObjectHelper.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = BSFPRProxyObjectHelper.h; sourceTree = "<group>"; };
+		CB487E8E26E11922004F6B87 /* BSFPRObjectInstrumentor.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; path = BSFPRObjectInstrumentor.m; sourceTree = "<group>"; };
+		CB487E8F26E11922004F6B87 /* BSFPRSelectorInstrumentor.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; path = BSFPRSelectorInstrumentor.m; sourceTree = "<group>"; };
+		CB487E9026E11922004F6B87 /* BSFPRDataUtils.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = BSFPRDataUtils.h; sourceTree = "<group>"; };
 /* End PBXFileReference section */
 
 /* Begin PBXFrameworksBuildPhase section */
@@ -143,6 +291,8 @@
 		CB487A5B26D7B109004F6B87 /* BugsnagRequestMonitor */ = {
 			isa = PBXGroup;
 			children = (
+				CB487E7126E11922004F6B87 /* Instrumentation */,
+				CB487E6826E11922004F6B87 /* Swizzle */,
 				CB487A5D26D7B109004F6B87 /* Info.plist */,
 				CB487C2D26DE3EFB004F6B87 /* include */,
 				CB487ABE26D7B295004F6B87 /* BugsnagRequestMonitor.m */,
@@ -185,6 +335,73 @@
 			path = BugsnagRequestMonitor;
 			sourceTree = "<group>";
 		};
+		CB487E6826E11922004F6B87 /* Swizzle */ = {
+			isa = PBXGroup;
+			children = (
+				CB487E6926E11922004F6B87 /* BSGULObjectSwizzler+Internal.h */,
+				CB487E6A26E11922004F6B87 /* BSGULSwizzledObject.h */,
+				CB487E6B26E11922004F6B87 /* BSGULSwizzler.m */,
+				CB487E6C26E11922004F6B87 /* BSGULObjectSwizzler.h */,
+				CB487E6D26E11922004F6B87 /* BSGULOriginalIMPConvenienceMacros.h */,
+				CB487E6E26E11922004F6B87 /* BSGULSwizzledObject.m */,
+				CB487E6F26E11922004F6B87 /* BSGULSwizzler.h */,
+				CB487E7026E11922004F6B87 /* BSGULObjectSwizzler.m */,
+			);
+			path = Swizzle;
+			sourceTree = SOURCE_ROOT;
+		};
+		CB487E7126E11922004F6B87 /* Instrumentation */ = {
+			isa = PBXGroup;
+			children = (
+				CB487E7226E11922004F6B87 /* BSFPRConsoleLogger.h */,
+				CB487E7326E11922004F6B87 /* BSFPRInstrument.h */,
+				CB487E7426E11922004F6B87 /* BSFPRClassInstrumentor_Private.h */,
+				CB487E7526E11922004F6B87 /* BSFPRTraceBackgroundActivityTracker.m */,
+				CB487E7626E11922004F6B87 /* BSFPRProxyObjectHelper.m */,
+				CB487E7726E11922004F6B87 /* BSFPRClassInstrumentor.h */,
+				CB487E7826E11922004F6B87 /* Network */,
+				CB487E8526E11922004F6B87 /* BSFPRDataUtils.m */,
+				CB487E8626E11922004F6B87 /* BSFPRSelectorInstrumentor.h */,
+				CB487E8726E11922004F6B87 /* BSFPRObjectInstrumentor.h */,
+				CB487E8826E11922004F6B87 /* BSFPRInstrument.m */,
+				CB487E8926E11922004F6B87 /* BSFPRConsoleLogger.m */,
+				CB487E8A26E11922004F6B87 /* BSFPRInstrument_Private.h */,
+				CB487E8B26E11922004F6B87 /* BSFPRTraceBackgroundActivityTracker.h */,
+				CB487E8C26E11922004F6B87 /* BSFPRClassInstrumentor.m */,
+				CB487E8D26E11922004F6B87 /* BSFPRProxyObjectHelper.h */,
+				CB487E8E26E11922004F6B87 /* BSFPRObjectInstrumentor.m */,
+				CB487E8F26E11922004F6B87 /* BSFPRSelectorInstrumentor.m */,
+				CB487E9026E11922004F6B87 /* BSFPRDataUtils.h */,
+			);
+			path = Instrumentation;
+			sourceTree = SOURCE_ROOT;
+		};
+		CB487E7826E11922004F6B87 /* Network */ = {
+			isa = PBXGroup;
+			children = (
+				CB487E7926E11922004F6B87 /* BSFPRNSURLSessionInstrument.m */,
+				CB487E7A26E11922004F6B87 /* BSFPRNetworkTrace.m */,
+				CB487E7B26E11922004F6B87 /* BSFPRNetworkInstrumentHelpers.m */,
+				CB487E7C26E11922004F6B87 /* BSFPRNSURLSessionInstrument.h */,
+				CB487E7D26E11922004F6B87 /* Delegates */,
+				CB487E8226E11922004F6B87 /* BSFPRNetworkTrace.h */,
+				CB487E8326E11922004F6B87 /* BSFPRNetworkInstrumentHelpers.h */,
+				CB487E8426E11922004F6B87 /* BSFPRNSURLSessionInstrument_Private.h */,
+			);
+			path = Network;
+			sourceTree = "<group>";
+		};
+		CB487E7D26E11922004F6B87 /* Delegates */ = {
+			isa = PBXGroup;
+			children = (
+				CB487E7E26E11922004F6B87 /* BSFPRNSURLSessionDelegate.h */,
+				CB487E7F26E11922004F6B87 /* BSFPRNSURLSessionDelegateInstrument.m */,
+				CB487E8026E11922004F6B87 /* BSFPRNSURLSessionDelegate.m */,
+				CB487E8126E11922004F6B87 /* BSFPRNSURLSessionDelegateInstrument.h */,
+			);
+			path = Delegates;
+			sourceTree = "<group>";
+		};
 /* End PBXGroup section */
 
 /* Begin PBXHeadersBuildPhase section */
@@ -192,7 +409,28 @@
 			isa = PBXHeadersBuildPhase;
 			buildActionMask = 2147483647;
 			files = (
+				CB487EA326E11922004F6B87 /* BSGULSwizzler.h in Headers */,
+				CB487EE226E11922004F6B87 /* BSFPRObjectInstrumentor.h in Headers */,
+				CB487E9426E11922004F6B87 /* BSGULSwizzledObject.h in Headers */,
+				CB487EDF26E11922004F6B87 /* BSFPRSelectorInstrumentor.h in Headers */,
+				CB487EFD26E11922004F6B87 /* BSFPRDataUtils.h in Headers */,
+				CB487EEE26E11922004F6B87 /* BSFPRTraceBackgroundActivityTracker.h in Headers */,
+				CB487EC426E11922004F6B87 /* BSFPRNSURLSessionInstrument.h in Headers */,
+				CB487ED926E11922004F6B87 /* BSFPRNSURLSessionInstrument_Private.h in Headers */,
+				CB487ED326E11922004F6B87 /* BSFPRNetworkTrace.h in Headers */,
+				CB487E9A26E11922004F6B87 /* BSGULObjectSwizzler.h in Headers */,
+				CB487E9D26E11922004F6B87 /* BSGULOriginalIMPConvenienceMacros.h in Headers */,
+				CB487EC726E11922004F6B87 /* BSFPRNSURLSessionDelegate.h in Headers */,
+				CB487E9126E11922004F6B87 /* BSGULObjectSwizzler+Internal.h in Headers */,
+				CB487EAC26E11922004F6B87 /* BSFPRInstrument.h in Headers */,
+				CB487EA926E11922004F6B87 /* BSFPRConsoleLogger.h in Headers */,
+				CB487EB826E11922004F6B87 /* BSFPRClassInstrumentor.h in Headers */,
 				CB487C3026DE3EFB004F6B87 /* BugsnagRequestMonitor.h in Headers */,
+				CB487ED626E11922004F6B87 /* BSFPRNetworkInstrumentHelpers.h in Headers */,
+				CB487EF426E11922004F6B87 /* BSFPRProxyObjectHelper.h in Headers */,
+				CB487EEB26E11922004F6B87 /* BSFPRInstrument_Private.h in Headers */,
+				CB487EAF26E11922004F6B87 /* BSFPRClassInstrumentor_Private.h in Headers */,
+				CB487ED026E11922004F6B87 /* BSFPRNSURLSessionDelegateInstrument.h in Headers */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};
@@ -200,7 +438,28 @@
 			isa = PBXHeadersBuildPhase;
 			buildActionMask = 2147483647;
 			files = (
+				CB487EA426E11922004F6B87 /* BSGULSwizzler.h in Headers */,
+				CB487EE326E11922004F6B87 /* BSFPRObjectInstrumentor.h in Headers */,
+				CB487E9526E11922004F6B87 /* BSGULSwizzledObject.h in Headers */,
+				CB487EE026E11922004F6B87 /* BSFPRSelectorInstrumentor.h in Headers */,
+				CB487EFE26E11922004F6B87 /* BSFPRDataUtils.h in Headers */,
+				CB487EEF26E11922004F6B87 /* BSFPRTraceBackgroundActivityTracker.h in Headers */,
+				CB487EC526E11922004F6B87 /* BSFPRNSURLSessionInstrument.h in Headers */,
+				CB487EDA26E11922004F6B87 /* BSFPRNSURLSessionInstrument_Private.h in Headers */,
+				CB487ED426E11922004F6B87 /* BSFPRNetworkTrace.h in Headers */,
+				CB487E9B26E11922004F6B87 /* BSGULObjectSwizzler.h in Headers */,
+				CB487E9E26E11922004F6B87 /* BSGULOriginalIMPConvenienceMacros.h in Headers */,
+				CB487EC826E11922004F6B87 /* BSFPRNSURLSessionDelegate.h in Headers */,
+				CB487E9226E11922004F6B87 /* BSGULObjectSwizzler+Internal.h in Headers */,
+				CB487EAD26E11922004F6B87 /* BSFPRInstrument.h in Headers */,
+				CB487EAA26E11922004F6B87 /* BSFPRConsoleLogger.h in Headers */,
+				CB487EB926E11922004F6B87 /* BSFPRClassInstrumentor.h in Headers */,
 				CB487C3126DE3EFB004F6B87 /* BugsnagRequestMonitor.h in Headers */,
+				CB487ED726E11922004F6B87 /* BSFPRNetworkInstrumentHelpers.h in Headers */,
+				CB487EF526E11922004F6B87 /* BSFPRProxyObjectHelper.h in Headers */,
+				CB487EEC26E11922004F6B87 /* BSFPRInstrument_Private.h in Headers */,
+				CB487EB026E11922004F6B87 /* BSFPRClassInstrumentor_Private.h in Headers */,
+				CB487ED126E11922004F6B87 /* BSFPRNSURLSessionDelegateInstrument.h in Headers */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};
@@ -208,7 +467,28 @@
 			isa = PBXHeadersBuildPhase;
 			buildActionMask = 2147483647;
 			files = (
+				CB487EA526E11922004F6B87 /* BSGULSwizzler.h in Headers */,
+				CB487EE426E11922004F6B87 /* BSFPRObjectInstrumentor.h in Headers */,
+				CB487E9626E11922004F6B87 /* BSGULSwizzledObject.h in Headers */,
+				CB487EE126E11922004F6B87 /* BSFPRSelectorInstrumentor.h in Headers */,
+				CB487EFF26E11922004F6B87 /* BSFPRDataUtils.h in Headers */,
+				CB487EF026E11922004F6B87 /* BSFPRTraceBackgroundActivityTracker.h in Headers */,
+				CB487EC626E11922004F6B87 /* BSFPRNSURLSessionInstrument.h in Headers */,
+				CB487EDB26E11922004F6B87 /* BSFPRNSURLSessionInstrument_Private.h in Headers */,
+				CB487ED526E11922004F6B87 /* BSFPRNetworkTrace.h in Headers */,
+				CB487E9C26E11922004F6B87 /* BSGULObjectSwizzler.h in Headers */,
+				CB487E9F26E11922004F6B87 /* BSGULOriginalIMPConvenienceMacros.h in Headers */,
+				CB487EC926E11922004F6B87 /* BSFPRNSURLSessionDelegate.h in Headers */,
+				CB487E9326E11922004F6B87 /* BSGULObjectSwizzler+Internal.h in Headers */,
+				CB487EAE26E11922004F6B87 /* BSFPRInstrument.h in Headers */,
+				CB487EAB26E11922004F6B87 /* BSFPRConsoleLogger.h in Headers */,
+				CB487EBA26E11922004F6B87 /* BSFPRClassInstrumentor.h in Headers */,
 				CB487C3226DE3EFB004F6B87 /* BugsnagRequestMonitor.h in Headers */,
+				CB487ED826E11922004F6B87 /* BSFPRNetworkInstrumentHelpers.h in Headers */,
+				CB487EF626E11922004F6B87 /* BSFPRProxyObjectHelper.h in Headers */,
+				CB487EED26E11922004F6B87 /* BSFPRInstrument_Private.h in Headers */,
+				CB487EB126E11922004F6B87 /* BSFPRClassInstrumentor_Private.h in Headers */,
+				CB487ED226E11922004F6B87 /* BSFPRNSURLSessionDelegateInstrument.h in Headers */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};
@@ -424,7 +704,23 @@
 			isa = PBXSourcesBuildPhase;
 			buildActionMask = 2147483647;
 			files = (
+				CB487EC126E11922004F6B87 /* BSFPRNetworkInstrumentHelpers.m in Sources */,
+				CB487EA026E11922004F6B87 /* BSGULSwizzledObject.m in Sources */,
+				CB487EF726E11922004F6B87 /* BSFPRObjectInstrumentor.m in Sources */,
 				CB487ABF26D7B295004F6B87 /* BugsnagRequestMonitor.m in Sources */,
+				CB487ECD26E11922004F6B87 /* BSFPRNSURLSessionDelegate.m in Sources */,
+				CB487ECA26E11922004F6B87 /* BSFPRNSURLSessionDelegateInstrument.m in Sources */,
+				CB487EA626E11922004F6B87 /* BSGULObjectSwizzler.m in Sources */,
+				CB487EB526E11922004F6B87 /* BSFPRProxyObjectHelper.m in Sources */,
+				CB487EF126E11922004F6B87 /* BSFPRClassInstrumentor.m in Sources */,
+				CB487EBE26E11922004F6B87 /* BSFPRNetworkTrace.m in Sources */,
+				CB487EBB26E11922004F6B87 /* BSFPRNSURLSessionInstrument.m in Sources */,
+				CB487EE826E11922004F6B87 /* BSFPRConsoleLogger.m in Sources */,
+				CB487E9726E11922004F6B87 /* BSGULSwizzler.m in Sources */,
+				CB487EFA26E11922004F6B87 /* BSFPRSelectorInstrumentor.m in Sources */,
+				CB487EE526E11922004F6B87 /* BSFPRInstrument.m in Sources */,
+				CB487EB226E11922004F6B87 /* BSFPRTraceBackgroundActivityTracker.m in Sources */,
+				CB487EDC26E11922004F6B87 /* BSFPRDataUtils.m in Sources */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};
@@ -440,7 +736,23 @@
 			isa = PBXSourcesBuildPhase;
 			buildActionMask = 2147483647;
 			files = (
+				CB487EC226E11922004F6B87 /* BSFPRNetworkInstrumentHelpers.m in Sources */,
+				CB487EA126E11922004F6B87 /* BSGULSwizzledObject.m in Sources */,
+				CB487EF826E11922004F6B87 /* BSFPRObjectInstrumentor.m in Sources */,
 				CB487AC026D7B295004F6B87 /* BugsnagRequestMonitor.m in Sources */,
+				CB487ECE26E11922004F6B87 /* BSFPRNSURLSessionDelegate.m in Sources */,
+				CB487ECB26E11922004F6B87 /* BSFPRNSURLSessionDelegateInstrument.m in Sources */,
+				CB487EA726E11922004F6B87 /* BSGULObjectSwizzler.m in Sources */,
+				CB487EB626E11922004F6B87 /* BSFPRProxyObjectHelper.m in Sources */,
+				CB487EF226E11922004F6B87 /* BSFPRClassInstrumentor.m in Sources */,
+				CB487EBF26E11922004F6B87 /* BSFPRNetworkTrace.m in Sources */,
+				CB487EBC26E11922004F6B87 /* BSFPRNSURLSessionInstrument.m in Sources */,
+				CB487EE926E11922004F6B87 /* BSFPRConsoleLogger.m in Sources */,
+				CB487E9826E11922004F6B87 /* BSGULSwizzler.m in Sources */,
+				CB487EFB26E11922004F6B87 /* BSFPRSelectorInstrumentor.m in Sources */,
+				CB487EE626E11922004F6B87 /* BSFPRInstrument.m in Sources */,
+				CB487EB326E11922004F6B87 /* BSFPRTraceBackgroundActivityTracker.m in Sources */,
+				CB487EDD26E11922004F6B87 /* BSFPRDataUtils.m in Sources */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};
@@ -456,7 +768,23 @@
 			isa = PBXSourcesBuildPhase;
 			buildActionMask = 2147483647;
 			files = (
+				CB487EC326E11922004F6B87 /* BSFPRNetworkInstrumentHelpers.m in Sources */,
+				CB487EA226E11922004F6B87 /* BSGULSwizzledObject.m in Sources */,
+				CB487EF926E11922004F6B87 /* BSFPRObjectInstrumentor.m in Sources */,
 				CB487AC126D7B295004F6B87 /* BugsnagRequestMonitor.m in Sources */,
+				CB487ECF26E11922004F6B87 /* BSFPRNSURLSessionDelegate.m in Sources */,
+				CB487ECC26E11922004F6B87 /* BSFPRNSURLSessionDelegateInstrument.m in Sources */,
+				CB487EA826E11922004F6B87 /* BSGULObjectSwizzler.m in Sources */,
+				CB487EB726E11922004F6B87 /* BSFPRProxyObjectHelper.m in Sources */,
+				CB487EF326E11922004F6B87 /* BSFPRClassInstrumentor.m in Sources */,
+				CB487EC026E11922004F6B87 /* BSFPRNetworkTrace.m in Sources */,
+				CB487EBD26E11922004F6B87 /* BSFPRNSURLSessionInstrument.m in Sources */,
+				CB487EEA26E11922004F6B87 /* BSFPRConsoleLogger.m in Sources */,
+				CB487E9926E11922004F6B87 /* BSGULSwizzler.m in Sources */,
+				CB487EFC26E11922004F6B87 /* BSFPRSelectorInstrumentor.m in Sources */,
+				CB487EE726E11922004F6B87 /* BSFPRInstrument.m in Sources */,
+				CB487EB426E11922004F6B87 /* BSFPRTraceBackgroundActivityTracker.m in Sources */,
+				CB487EDE26E11922004F6B87 /* BSFPRDataUtils.m in Sources */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};

--- a/BugsnagRequestMonitor/BugsnagRequestMonitor/BugsnagRequestMonitor.m
+++ b/BugsnagRequestMonitor/BugsnagRequestMonitor/BugsnagRequestMonitor.m
@@ -6,3 +6,23 @@
 //
 
 #import "BugsnagRequestMonitor.h"
+
+#import "BSFPRNSURLSessionInstrument.h"
+
+
+@interface BugsnagRequestMonitor: NSObject
+@end
+
+@implementation BugsnagRequestMonitor
+
++ (void)load {
+    static BSFPRNSURLSessionInstrument *instrument;
+    instrument = [[BSFPRNSURLSessionInstrument alloc]
+                    initWithTraceCallback:^(BSFPRNetworkTrace * _Nonnull trace) {
+        NSLog(@"### REQUEST: %@", trace);
+        // TODO: Leave breadcrumb
+    }];
+    [instrument registerInstrumentors];
+}
+
+@end

--- a/BugsnagRequestMonitor/BugsnagRequestMonitor/include/BugsnagRequestMonitor/BugsnagRequestMonitor.h
+++ b/BugsnagRequestMonitor/BugsnagRequestMonitor/include/BugsnagRequestMonitor/BugsnagRequestMonitor.h
@@ -6,4 +6,3 @@
 //
 
 #import <Foundation/Foundation.h>
-#import <Bugsnag/Bugsnag.h>

--- a/BugsnagRequestMonitor/Instrumentation/BSFPRClassInstrumentor.h
+++ b/BugsnagRequestMonitor/Instrumentation/BSFPRClassInstrumentor.h
@@ -1,0 +1,62 @@
+// Copyright 2020 Google LLC
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+#import <Foundation/Foundation.h>
+
+@class BSFPRSelectorInstrumentor;
+
+NS_ASSUME_NONNULL_BEGIN
+
+/**
+ * Each instrumented class (even classes within class clusters) needs to have its own instrumentor.
+ */
+@interface BSFPRClassInstrumentor : NSObject
+
+/** The class being instrumented. */
+@property(nonatomic, readonly) Class instrumentedClass;
+
+/** Please use the designated initializer. */
+- (instancetype)init NS_UNAVAILABLE;
+
+/** Initializes with a class name and stores a reference to that string. This is the designated
+ *  initializer.
+ *
+ *  @param aClass The class to be instrumented.
+ *  @return An instance of this class.
+ */
+- (instancetype)initWithClass:(Class)aClass NS_DESIGNATED_INITIALIZER;
+
+/** Creates and adds a class selector instrumentor to this class instrumentor.
+ *
+ *  @param selector The selector to build and add to this class instrumentor;
+ *  @return An BSFPRSelectorInstrumentor if the class/selector combination exists, nil otherwise.
+ */
+- (nullable BSFPRSelectorInstrumentor *)instrumentorForClassSelector:(SEL)selector;
+
+/** Creates and adds an instance selector instrumentor to this class instrumentor.
+ *
+ *  @param selector The selector to build and add to this class instrumentor;
+ *  @return An BSFPRSelectorInstrumentor if the class/selector combination exists, nil otherwise.
+ */
+- (nullable BSFPRSelectorInstrumentor *)instrumentorForInstanceSelector:(SEL)selector;
+
+/** Swizzles the set of selector instrumentors. */
+- (void)swizzle;
+
+/** Removes all selector instrumentors and unswizzles their implementations. */
+- (BOOL)unswizzle;
+
+@end
+
+NS_ASSUME_NONNULL_END

--- a/BugsnagRequestMonitor/Instrumentation/BSFPRClassInstrumentor.m
+++ b/BugsnagRequestMonitor/Instrumentation/BSFPRClassInstrumentor.m
@@ -1,0 +1,102 @@
+// Copyright 2020 Google LLC
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+#import "BSFPRClassInstrumentor.h"
+#import "BSFPRClassInstrumentor_Private.h"
+
+#import "BSFPRSelectorInstrumentor.h"
+
+/** Use ivars instead of properties to reduce message sending overhead. */
+@interface BSFPRClassInstrumentor () {
+  // The selector instrumentors associated with this class.
+  NSMutableSet<BSFPRSelectorInstrumentor *> *_selectorInstrumentors;
+}
+
+@end
+
+@implementation BSFPRClassInstrumentor
+
+#pragma mark - Public methods
+
+- (instancetype)init {
+  NSAssert(NO, @"%@: please use the designated initializer.", NSStringFromClass([self class]));
+  return nil;
+}
+
+- (instancetype)initWithClass:(Class)aClass {
+  self = [super init];
+  if (self) {
+    NSAssert(aClass, @"You must supply a class in order to instrument its methods");
+    _instrumentedClass = aClass;
+    _selectorInstrumentors = [[NSMutableSet<BSFPRSelectorInstrumentor *> alloc] init];
+  }
+  return self;
+}
+
+- (nullable BSFPRSelectorInstrumentor *)instrumentorForClassSelector:(SEL)selector {
+  return [self buildAndAddSelectorInstrumentorForSelector:selector isClassSelector:YES];
+}
+
+- (nullable BSFPRSelectorInstrumentor *)instrumentorForInstanceSelector:(SEL)selector {
+  return [self buildAndAddSelectorInstrumentorForSelector:selector isClassSelector:NO];
+}
+
+- (void)swizzle {
+  for (BSFPRSelectorInstrumentor *selectorInstrumentor in _selectorInstrumentors) {
+    [selectorInstrumentor swizzle];
+  }
+}
+
+- (BOOL)unswizzle {
+  for (BSFPRSelectorInstrumentor *selectorInstrumentor in _selectorInstrumentors) {
+    [selectorInstrumentor unswizzle];
+  }
+  [_selectorInstrumentors removeAllObjects];
+  return _selectorInstrumentors.count == 0;
+}
+
+#pragma mark - Private methods
+
+/** Creates and adds a selector instrumentor to this class instrumentor.
+ *
+ *  @param selector The selector to build and add to this class instrumentor;
+ *  @param isClassSelector If YES, then the selector is a class selector.
+ *  @return An BSFPRSelectorInstrumentor if the class/selector combination exists, nil otherwise.
+ */
+- (nullable BSFPRSelectorInstrumentor *)buildAndAddSelectorInstrumentorForSelector:(SEL)selector
+                                                                 isClassSelector:
+                                                                     (BOOL)isClassSelector {
+  BSFPRSelectorInstrumentor *selectorInstrumentor =
+      [[BSFPRSelectorInstrumentor alloc] initWithSelector:selector
+                                                  class:_instrumentedClass
+                                        isClassSelector:isClassSelector];
+  if (selectorInstrumentor) {
+    [self addSelectorInstrumentor:selectorInstrumentor];
+  }
+  return selectorInstrumentor;
+}
+
+/** Adds a selector instrumentors to an existing running list of instrumented selectors.
+ *
+ *  @param selectorInstrumentor A non-nil selector instrumentor, whose SEL objects will be swizzled.
+ */
+- (void)addSelectorInstrumentor:(nonnull BSFPRSelectorInstrumentor *)selectorInstrumentor {
+  if ([_selectorInstrumentors containsObject:selectorInstrumentor]) {
+    NSAssert(NO, @"You cannot instrument the same selector (%@) twice",
+              NSStringFromSelector(selectorInstrumentor.selector));
+  }
+  [_selectorInstrumentors addObject:selectorInstrumentor];
+}
+
+@end

--- a/BugsnagRequestMonitor/Instrumentation/BSFPRClassInstrumentor_Private.h
+++ b/BugsnagRequestMonitor/Instrumentation/BSFPRClassInstrumentor_Private.h
@@ -1,0 +1,24 @@
+// Copyright 2020 Google LLC
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+NS_ASSUME_NONNULL_BEGIN
+
+@interface BSFPRClassInstrumentor ()
+
+/** The set of selector instrumentors on this class. Only used for testing. */
+@property(nonatomic, readonly) NSSet *selectorInstrumentors;
+
+@end
+
+NS_ASSUME_NONNULL_END

--- a/BugsnagRequestMonitor/Instrumentation/BSFPRConsoleLogger.h
+++ b/BugsnagRequestMonitor/Instrumentation/BSFPRConsoleLogger.h
@@ -1,0 +1,91 @@
+// Copyright 2020 Google LLC
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+//#import ""FirebaseCore/Sources/Private/BSFIRLogger.h"
+#import <Foundation/Foundation.h>
+
+NS_ASSUME_NONNULL_BEGIN
+
+#define BSFPRLogDebug(messageCode, ...) NSLog(__VA_ARGS__)
+#define BSFPRLogError(messageCode, ...) NSLog(__VA_ARGS__)
+#define BSFPRLogInfo(messageCode, ...) NSLog(__VA_ARGS__)
+#define BSFPRLogNotice(messageCode, ...) NSLog(__VA_ARGS__)
+#define BSFPRLogWarning(messageCode, ...) NSLog(__VA_ARGS__)
+
+// BSFPR Client message codes.
+FOUNDATION_EXTERN NSString* const kBSFPRClientInitialize;
+FOUNDATION_EXTERN NSString* const kBSFPRClientTempDirectory;
+FOUNDATION_EXTERN NSString* const kBSFPRClientCreateWorkingDirectory;
+FOUNDATION_EXTERN NSString* const kBSFPRClientClearcutUpload;
+FOUNDATION_EXTERN NSString* const kBSFPRClientInstanceIDNotAvailable;
+FOUNDATION_EXTERN NSString* const kBSFPRClientNameTruncated;
+FOUNDATION_EXTERN NSString* const kBSFPRClientNameReserved;
+FOUNDATION_EXTERN NSString* const kBSFPRClientInvalidTrace;
+FOUNDATION_EXTERN NSString* const kBSFPRClientMetricLogged;
+FOUNDATION_EXTERN NSString* const kBSFPRClientDataUpload;
+FOUNDATION_EXTERN NSString* const kBSFPRClientNameLengthCheckFailed;
+FOUNDATION_EXTERN NSString* const kBSFPRClientPerfNotConfigured;
+FOUNDATION_EXTERN NSString* const kBSFPRClientSDKDisabled;
+
+// BSFPR Trace message codes.
+FOUNDATION_EXTERN NSString* const kBSFPRTraceNoName;
+FOUNDATION_EXTERN NSString* const kBSFPRTraceAlreadyStopped;
+FOUNDATION_EXTERN NSString* const kBSFPRTraceNotStarted;
+FOUNDATION_EXTERN NSString* const kBSFPRTraceDisabled;
+FOUNDATION_EXTERN NSString* const kBSFPRTraceEmptyName;
+FOUNDATION_EXTERN NSString* const kBSFPRTraceStartedNotStopped;
+FOUNDATION_EXTERN NSString* const kBSFPRTraceNotCreated;
+FOUNDATION_EXTERN NSString* const kBSFPRTraceInvalidName;
+
+// BSFPR NetworkTrace message codes.
+FOUNDATION_EXTERN NSString* const kBSFPRNetworkTraceFileError;
+FOUNDATION_EXTERN NSString* const kBSFPRNetworkTraceInvalidInputs;
+FOUNDATION_EXTERN NSString* const kBSFPRNetworkTraceURLLengthExceeds;
+FOUNDATION_EXTERN NSString* const kBSFPRNetworkTraceURLLengthTruncation;
+FOUNDATION_EXTERN NSString* const kBSFPRNetworkTraceNotTrackable;
+
+// BSFPR LogSampler message codes.
+FOUNDATION_EXTERN NSString* const kBSFPRSamplerInvalidConfigs;
+
+// BSFPR attributes message codes.
+FOUNDATION_EXTERN NSString* const kBSFPRAttributeNoName;
+FOUNDATION_EXTERN NSString* const kBSFPRAttributeNoValue;
+FOUNDATION_EXTERN NSString* const kBSFPRMaxAttributesReached;
+FOUNDATION_EXTERN NSString* const kBSFPRAttributeNameIllegalCharacters;
+
+// Manual network instrumentation codes.
+FOUNDATION_EXTERN NSString* const kBSFPRInstrumentationInvalidInputs;
+FOUNDATION_EXTERN NSString* const kBSFPRInstrumentationDisabledAfterConfigure;
+
+// BSFPR diagnostic message codes.
+FOUNDATION_EXTERN NSString* const kBSFPRDiagnosticInfo;
+FOUNDATION_EXTERN NSString* const kBSFPRDiagnosticFailure;
+FOUNDATION_EXTERN NSString* const kBSFPRDiagnosticLog;
+
+// BSFPR Configuration related error codes.
+FOUNDATION_EXTERN NSString* const kBSFPRConfigurationFetchFailure;
+
+// BSFPR URL filtering message codes.
+FOUNDATION_EXTERN NSString* const kBSFPRURLAllowlistingEnabled;
+
+// BSFPR Gauge manager codes.
+FOUNDATION_EXTERN NSString* const kBSFPRGaugeManagerDataCollected;
+FOUNDATION_EXTERN NSString* const kBSFPRSessionId;
+FOUNDATION_EXTERN NSString* const kBSFPRCPUCollection;
+FOUNDATION_EXTERN NSString* const kBSFPRMemoryCollection;
+
+// BSFPRSDKConfiguration message codes.
+FOUNDATION_EXTERN NSString* const kBSFPRSDKFeaturesBlock;
+
+NS_ASSUME_NONNULL_END

--- a/BugsnagRequestMonitor/Instrumentation/BSFPRConsoleLogger.m
+++ b/BugsnagRequestMonitor/Instrumentation/BSFPRConsoleLogger.m
@@ -1,0 +1,80 @@
+// Copyright 2020 Google LLC
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+#import "BSFPRConsoleLogger.h"
+
+// BSFPR Client message codes.
+NSString* const kBSFPRClientInitialize = @"I-PRF100001";
+NSString* const kBSFPRClientTempDirectory = @"I-PRF100002";
+NSString* const kBSFPRClientCreateWorkingDirectory = @"I-PRF100003";
+NSString* const kBSFPRClientClearcutUpload = @"I-PRF100004";
+NSString* const kBSFPRClientInstanceIDNotAvailable = @"I-PRF100005";
+NSString* const kBSFPRClientNameTruncated = @"I-PRF100006";
+NSString* const kBSFPRClientNameReserved = @"I-PRF100007";
+NSString* const kBSFPRClientInvalidTrace = @"I-PRF100008";
+NSString* const kBSFPRClientMetricLogged = @"I-PRF100009";
+NSString* const kBSFPRClientDataUpload = @"I-PRF100010";
+NSString* const kBSFPRClientNameLengthCheckFailed = @"I-PRF100012";
+NSString* const kBSFPRClientPerfNotConfigured = @"I-PRF100013";
+NSString* const kBSFPRClientSDKDisabled = @"I-PRF100014";
+
+// BSFPR Trace message codes.
+NSString* const kBSFPRTraceNoName = @"I-PRF200001";
+NSString* const kBSFPRTraceAlreadyStopped = @"I-PRF200002";
+NSString* const kBSFPRTraceNotStarted = @"I-PRF200003";
+NSString* const kBSFPRTraceDisabled = @"I-PRF200004";
+NSString* const kBSFPRTraceEmptyName = @"I-PRF200005";
+NSString* const kBSFPRTraceStartedNotStopped = @"I-PRF200006";
+NSString* const kBSFPRTraceNotCreated = @"I-PRF200007";
+NSString* const kBSFPRTraceInvalidName = @"I-PRF200008";
+
+// BSFPR NetworkTrace message codes.
+NSString* const kBSFPRNetworkTraceFileError = @"I-PRF300001";
+NSString* const kBSFPRNetworkTraceInvalidInputs = @"I-PRF300002";
+NSString* const kBSFPRNetworkTraceURLLengthExceeds = @"I-PRF300003";
+NSString* const kBSFPRNetworkTraceNotTrackable = @"I-PRF300004";
+NSString* const kBSFPRNetworkTraceURLLengthTruncation = @"I-PRF300005";
+
+// BSFPR LogSampler message codes.
+NSString* const kBSFPRSamplerInvalidConfigs = @"I-PRF400001";
+
+// BSFPR Attributes message codes.
+NSString* const kBSFPRAttributeNoName = @"I-PRF500001";
+NSString* const kBSFPRAttributeNoValue = @"I-PRF500002";
+NSString* const kBSFPRMaxAttributesReached = @"I-PRF500003";
+NSString* const kBSFPRAttributeNameIllegalCharacters = @"I-PRF500004";
+
+// Manual network instrumentation codes.
+NSString* const kBSFPRInstrumentationInvalidInputs = @"I-PRF600001";
+NSString* const kBSFPRInstrumentationDisabledAfterConfigure = @"I-PRF600002";
+
+// BSFPR diagnostic message codes.
+NSString* const kBSFPRDiagnosticInfo = @"I-PRF700001";
+NSString* const kBSFPRDiagnosticFailure = @"I-PRF700002";
+NSString* const kBSFPRDiagnosticLog = @"I-PRF700003";
+
+// BSFPR Configuration related error codes.
+NSString* const kBSFPRConfigurationFetchFailure = @"I-PRF710001";
+
+// BSFPR URL filtering message codes.
+NSString* const kBSFPRURLAllowlistingEnabled = @"I-PRF800001";
+
+// BSFPR Gauge manager codes.
+NSString* const kBSFPRGaugeManagerDataCollected = @"I-PRF900001";
+NSString* const kBSFPRSessionId = @"I-PRF900002";
+NSString* const kBSFPRCPUCollection = @"I-PRF900003";
+NSString* const kBSFPRMemoryCollection = @"I-PRF900004";
+
+// BSFPRSDKConfiguration message codes.
+NSString* const kBSFPRSDKFeaturesBlock = @"I-PRF910001";

--- a/BugsnagRequestMonitor/Instrumentation/BSFPRDataUtils.h
+++ b/BugsnagRequestMonitor/Instrumentation/BSFPRDataUtils.h
@@ -1,0 +1,28 @@
+// Copyright 2020 Google LLC
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+#import <Foundation/Foundation.h>
+
+
+/** Truncates the URL string if the length of the URL going beyond the defined limit. The truncation
+ *  will happen upto the end of a complete query sub path whose length is less than limit.
+ *  For example: If the URL is abc.com/one/two/three/four and if the URL max length is 20, trimmed
+ *  URL will be to abc.com/one/two and not abc.com/one/two/thre (three is incomplete).
+ *  If the domain name goes beyond 2000 characters (which is unlikely), that might result in an
+ *  empty string being returned.
+ *
+ *  @param URLString A URL string.
+ *  @return The unchanged url string or a truncated version if the length goes beyond the limit.
+ */
+FOUNDATION_EXTERN NSString *BSFPRTruncatedURLString(NSString *URLString);

--- a/BugsnagRequestMonitor/Instrumentation/BSFPRDataUtils.m
+++ b/BugsnagRequestMonitor/Instrumentation/BSFPRDataUtils.m
@@ -1,0 +1,41 @@
+// Copyright 2020 Google LLC
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+#import "BSFPRDataUtils.h"
+
+#import "BSFPRConsoleLogger.h"
+
+#pragma mark - Public functions
+
+int const kBSFPRMaxURLLength = 2000;
+
+NSString *BSFPRTruncatedURLString(NSString *URLString) {
+  NSString *truncatedURLString = URLString;
+  NSString *pathSeparator = @"/";
+  if (truncatedURLString.length > kBSFPRMaxURLLength) {
+    NSString *truncationCharacter =
+        [truncatedURLString substringWithRange:NSMakeRange(kBSFPRMaxURLLength, 1)];
+
+    truncatedURLString = [URLString substringToIndex:kBSFPRMaxURLLength];
+    if (![pathSeparator isEqual:truncationCharacter]) {
+      NSRange rangeOfTruncation = [truncatedURLString rangeOfString:pathSeparator
+                                                            options:NSBackwardsSearch];
+      truncatedURLString = [URLString substringToIndex:rangeOfTruncation.location];
+    }
+
+    BSFPRLogWarning(kBSFPRClientNameTruncated, @"URL exceeds %d characters. Truncated url: %@",
+                  kBSFPRMaxURLLength, truncatedURLString);
+  }
+  return truncatedURLString;
+}

--- a/BugsnagRequestMonitor/Instrumentation/BSFPRInstrument.h
+++ b/BugsnagRequestMonitor/Instrumentation/BSFPRInstrument.h
@@ -1,0 +1,59 @@
+// Copyright 2020 Google LLC
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+#import <Foundation/Foundation.h>
+
+@class BSFPRClassInstrumentor;
+
+NS_ASSUME_NONNULL_BEGIN
+
+/** BSFPRInstrument instances can instrument many different classes, but should try to instrument
+ *  only a single class in the general case. Due to class clusters, BSFPRInstruments need to be able
+ *  to support logical groups of classes, even if the public API is a single class (e.g.
+ *  NSDictionary or NSURLSession. BSFPRInstrument is expected to be subclassed by other classes that
+ *  actually implement the instrument. Subclasses should provide their own implementations of
+ *  registerInstrumentor
+ */
+@interface BSFPRInstrument : NSObject
+
+/** The list of class instrumentors. count should == 1 in most cases, and be > 1 for class clusters.
+ */
+@property(nonatomic, readonly) NSArray<BSFPRClassInstrumentor *> *classInstrumentors;
+
+/** A set of the instrumented classes. */
+@property(nonatomic, readonly) NSSet<Class> *instrumentedClasses;
+
+/**
+ * Checks if the given object is instrumentable and returns YES if instrumentable. NO, otherwise.
+ *
+ * @param object Object that needs to be validated.
+ * @return Yes if instrumentable, NO otherwise.
+ */
+- (BOOL)isObjectInstrumentable:(id)object;
+
+/** Registers all instrumentors this instrument will utilize. Should be instrumented in a subclass.
+ *
+ *  @note This method is thread-safe.
+ */
+- (void)registerInstrumentors;
+
+/** Deregisters the instrumentors by using API provided by BSFPRClassInstrumentor. Called by dealloc.
+ *
+ *  @note This method is thread-safe.
+ */
+- (void)deregisterInstrumentors;
+
+@end
+
+NS_ASSUME_NONNULL_END

--- a/BugsnagRequestMonitor/Instrumentation/BSFPRInstrument.m
+++ b/BugsnagRequestMonitor/Instrumentation/BSFPRInstrument.m
@@ -1,0 +1,77 @@
+// Copyright 2020 Google LLC
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+#import "BSFPRInstrument.h"
+#import "BSFPRInstrument_Private.h"
+
+#import "BSFPRClassInstrumentor.h"
+#import "BSFPRObjectInstrumentor.h"
+
+@implementation BSFPRInstrument {
+  NSMutableArray<BSFPRClassInstrumentor *> *_classInstrumentors;
+
+  NSMutableSet<Class> *_instrumentedClasses;
+}
+
+- (instancetype)init {
+  self = [super init];
+  if (self) {
+    _classInstrumentors = [[NSMutableArray<BSFPRClassInstrumentor *> alloc] init];
+    _instrumentedClasses = [[NSMutableSet<Class> alloc] init];
+  }
+  return self;
+}
+
+- (NSMutableArray<BSFPRClassInstrumentor *> *)classInstrumentors {
+  return _classInstrumentors;
+}
+
+- (NSMutableSet<Class> *)instrumentedClasses {
+  return _instrumentedClasses;
+}
+
+- (void)registerInstrumentors {
+  NSAssert(NO, @"registerInstrumentors should be implemented in a concrete subclass.");
+}
+
+- (BOOL)isObjectInstrumentable:(id)object {
+  if ([object isKindOfClass:[NSOperation class]]) {
+    return NO;
+  }
+  return YES;
+}
+
+- (BOOL)registerClassInstrumentor:(BSFPRClassInstrumentor *)instrumentor {
+  @synchronized(self) {
+    if ([_instrumentedClasses containsObject:instrumentor.instrumentedClass] ||
+        [instrumentor.instrumentedClass instancesRespondToSelector:@selector(gul_class)]) {
+      return NO;
+    }
+    [_instrumentedClasses addObject:instrumentor.instrumentedClass];
+    [_classInstrumentors addObject:instrumentor];
+    return YES;
+  }
+}
+
+- (void)deregisterInstrumentors {
+  @synchronized(self) {
+    for (BSFPRClassInstrumentor *classInstrumentor in self.classInstrumentors) {
+      [classInstrumentor unswizzle];
+    }
+    [_classInstrumentors removeAllObjects];
+    [_instrumentedClasses removeAllObjects];
+  }
+}
+
+@end

--- a/BugsnagRequestMonitor/Instrumentation/BSFPRInstrument_Private.h
+++ b/BugsnagRequestMonitor/Instrumentation/BSFPRInstrument_Private.h
@@ -1,0 +1,30 @@
+// Copyright 2020 Google LLC
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+#import "BSFPRInstrument.h"
+
+NS_ASSUME_NONNULL_BEGIN
+
+@interface BSFPRInstrument ()
+
+/** Registers an instrumentor for a class. Should be called by subclasses.
+ *
+ *  @param instrumentor The instrumentor to register.
+ *  @return NO if the class has already been instrumented, YES otherwise.
+ */
+- (BOOL)registerClassInstrumentor:(BSFPRClassInstrumentor *)instrumentor;
+
+@end
+
+NS_ASSUME_NONNULL_END

--- a/BugsnagRequestMonitor/Instrumentation/BSFPRObjectInstrumentor.h
+++ b/BugsnagRequestMonitor/Instrumentation/BSFPRObjectInstrumentor.h
@@ -1,0 +1,74 @@
+// Copyright 2020 Google LLC
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+#import "BSFPRInstrument.h"
+
+#import "BSGULSwizzledObject.h"
+
+@class BSFPRSelectorInstrumentor;
+
+NS_ASSUME_NONNULL_BEGIN
+
+/** Defines the interface that an instrumentor should implement if they are going to instrument
+ *  objects.
+ */
+@protocol BSFPRObjectInstrumentorProtocol <NSObject>
+
+@required
+
+/** Registers an instance of the delegate class to be instrumented.
+ *
+ *  @param object The instance to instrument.
+ */
+- (void)registerObject:(id)object;
+
+@end
+
+/** This class allows the instrumentation of specific objects by isa swizzling specific instances
+ *  with a dynamically generated subclass of the object's original class and installing methods
+ *  onto this new class.
+ */
+@interface BSFPRObjectInstrumentor : BSFPRInstrument
+
+/** The instrumented object. */
+@property(nonatomic, weak) id instrumentedObject;
+
+/** YES if there is reason to swizzle, NO if swizzling is not needed. */
+@property(nonatomic) BOOL hasModifications;
+
+/** Please use the designated initializer. */
+- (instancetype)init NS_UNAVAILABLE;
+
+/** Instantiates an instance of this class. The designated initializer.
+ *
+ *  @param object The object to be instrumented.
+ *  @return An instance of this class.
+ */
+- (instancetype)initWithObject:(id)object NS_DESIGNATED_INITIALIZER;
+
+/** Attempts to copy a selector from a donor class onto the dynamically generated subclass that the
+ *  object will adopt when -swizzle is called.
+ *
+ *  @param selector The selector to use.
+ *  @param aClass The class to copy the selector from.
+ *  @param isClassSelector YES if the selector is a class selector, NO otherwise.
+ */
+- (void)copySelector:(SEL)selector fromClass:(Class)aClass isClassSelector:(BOOL)isClassSelector;
+
+/** Swizzles the isa of the object and sets its class to the dynamically created subclass. */
+- (void)swizzle;
+
+@end
+
+NS_ASSUME_NONNULL_END

--- a/BugsnagRequestMonitor/Instrumentation/BSFPRObjectInstrumentor.m
+++ b/BugsnagRequestMonitor/Instrumentation/BSFPRObjectInstrumentor.m
@@ -1,0 +1,59 @@
+// Copyright 2020 Google LLC
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+#import "BSFPRObjectInstrumentor.h"
+
+#import "BSFPRInstrument_Private.h"
+#import "BSFPRSelectorInstrumentor.h"
+
+#import "BSGULObjectSwizzler.h"
+
+@interface BSFPRObjectInstrumentor () {
+  // The object swizzler instance this instrumentor will use.
+  BSGULObjectSwizzler *_objectSwizzler;
+}
+
+@end
+
+@implementation BSFPRObjectInstrumentor
+
+- (instancetype)init {
+  NSAssert(NO, @"%@: Please use the designated initializer.", NSStringFromClass([self class]));
+  return nil;
+}
+
+- (instancetype)initWithObject:(id)object {
+  self = [super init];
+  if (self) {
+    _objectSwizzler = [[BSGULObjectSwizzler alloc] initWithObject:object];
+    _instrumentedObject = object;
+  }
+  return self;
+}
+
+- (void)copySelector:(SEL)selector fromClass:(Class)aClass isClassSelector:(BOOL)isClassSelector {
+  __strong id instrumentedObject = _instrumentedObject;
+  if (instrumentedObject && ![instrumentedObject respondsToSelector:selector]) {
+    _hasModifications = YES;
+    [_objectSwizzler copySelector:selector fromClass:aClass isClassSelector:isClassSelector];
+  }
+}
+
+- (void)swizzle {
+  if (_hasModifications) {
+    [_objectSwizzler swizzle];
+  }
+}
+
+@end

--- a/BugsnagRequestMonitor/Instrumentation/BSFPRProxyObjectHelper.h
+++ b/BugsnagRequestMonitor/Instrumentation/BSFPRProxyObjectHelper.h
@@ -1,0 +1,34 @@
+// Copyright 2020 Google LLC
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+#import <Foundation/Foundation.h>
+
+/** This class helps the instrumentation deal with objects that have been wrapped with NSProxy
+ *  objects after being swizzled by other SDKs. In particular, Crittercism swizzles NSURLSessions
+ *  and makes every NSURLSession initialization method return an NSProxy subclass.
+ */
+@interface BSFPRProxyObjectHelper : NSObject
+
+/** Registers a proxy object for a given class and runs the onSuccess block whenever an ivar of the
+ *  given class is discovered on the proxy object.
+ *
+ *  @param proxy The proxy object whose ivars will be iterated.
+ *  @param superclass The superclass all ivars will be compared against. See varFoundHandler.
+ *  @param varFoundHandler The block to run when an ivar isKindOfClass:aClass.
+ */
++ (void)registerProxyObject:(id)proxy
+              forSuperclass:(Class)superclass
+            varFoundHandler:(void (^)(id ivar))varFoundHandler;
+
+@end

--- a/BugsnagRequestMonitor/Instrumentation/BSFPRProxyObjectHelper.m
+++ b/BugsnagRequestMonitor/Instrumentation/BSFPRProxyObjectHelper.m
@@ -1,0 +1,32 @@
+// Copyright 2020 Google LLC
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+#import "BSFPRProxyObjectHelper.h"
+
+#import "BSGULSwizzler.h"
+
+@implementation BSFPRProxyObjectHelper
+
++ (void)registerProxyObject:(id)proxy
+              forSuperclass:(Class)superclass
+            varFoundHandler:(void (^)(id ivar))varFoundHandler {
+  NSArray<id> *ivars = [BSGULSwizzler ivarObjectsForObject:proxy];
+  for (id ivar in ivars) {
+    if ([ivar isKindOfClass:superclass]) {
+      varFoundHandler(ivar);
+    }
+  }
+}
+
+@end

--- a/BugsnagRequestMonitor/Instrumentation/BSFPRSelectorInstrumentor.h
+++ b/BugsnagRequestMonitor/Instrumentation/BSFPRSelectorInstrumentor.h
@@ -1,0 +1,65 @@
+// Copyright 2020 Google LLC
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+#import <Foundation/Foundation.h>
+
+NS_ASSUME_NONNULL_BEGIN
+
+/** This class is used to manage the swizzling of selectors on classes. An instance of this class
+ *  should be created for every selector that is being swizzled.
+ */
+@interface BSFPRSelectorInstrumentor : NSObject
+
+/** The swizzled selector. */
+@property(nonatomic, readonly) SEL selector;
+
+/** Please use designated initializer. */
+- (instancetype)init NS_UNAVAILABLE;
+
+/** Initializes an instance of this class. The designated initializer.
+ *
+ *  @note Capture the current IMP outside the replacing block which will be the originalIMP once we
+ *      swizzle.
+ *
+ *  @param selector The selector pointer.
+ *  @param aClass The class to operate on.
+ *  @param isClassSelector YES specifies that the selector is a class selector.
+ *  @return An instance of this class.
+ */
+- (instancetype)initWithSelector:(SEL)selector
+                           class:(Class)aClass
+                 isClassSelector:(BOOL)isClassSelector NS_DESIGNATED_INITIALIZER;
+
+/** Sets the instrumentor's replacing block. To be used in conjunction with initWithSelector:.
+ *
+ *  @param block The block to replace the original implementation with. Make sure to call
+ *      originalImp in your replacing block.
+ */
+- (void)setReplacingBlock:(id)block;
+
+/** The current IMP of the swizzled selector.
+ *
+ *  @return The current IMP for the class, SEL of the BSFPRSelectorInstrumentor.
+ */
+- (IMP)currentIMP;
+
+/** Swizzles the selector. */
+- (void)swizzle;
+
+/** Causes the original implementation to be run. */
+- (void)unswizzle;
+
+@end
+
+NS_ASSUME_NONNULL_END

--- a/BugsnagRequestMonitor/Instrumentation/BSFPRSelectorInstrumentor.m
+++ b/BugsnagRequestMonitor/Instrumentation/BSFPRSelectorInstrumentor.m
@@ -1,0 +1,105 @@
+// Copyright 2020 Google LLC
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+#import "BSFPRSelectorInstrumentor.h"
+
+#import "BSGULSwizzler.h"
+#ifdef UNSWIZZLE_AVAILABLE
+#import "BSGULSwizzler+Unswizzle.h"
+#endif
+
+@implementation BSFPRSelectorInstrumentor {
+  // The class this instrumentor operates on.
+  Class _class;
+
+  // The selector this instrumentor operates on.
+  SEL _selector;
+
+  // YES indicates the selector swizzled is a class selector, as opposed to an instance selector.
+  BOOL _isClassSelector;
+
+  // YES indicates that this selector instrumentor has been swizzled.
+  BOOL _swizzled;
+
+  // A block to replace the original implementation. Can't be used with before/after blocks.
+  id _replacingBlock;
+}
+
+- (instancetype)init {
+  NSAssert(NO, @"%@: Please use the designated initializer", NSStringFromClass([self class]));
+  return nil;
+}
+
+- (instancetype)initWithSelector:(SEL)selector
+                           class:(Class)aClass
+                 isClassSelector:(BOOL)isClassSelector {
+  if (![BSGULSwizzler selector:selector existsInClass:aClass isClassSelector:isClassSelector]) {
+    return nil;
+  }
+  self = [super init];
+  if (self) {
+    _selector = selector;
+    _class = aClass;
+    _isClassSelector = isClassSelector;
+    NSAssert(_selector, @"A selector to swizzle must be provided.");
+    NSAssert(_class, @"You can't swizzle a class that doesn't exist");
+  }
+  return self;
+}
+
+- (void)setReplacingBlock:(id)block {
+  _replacingBlock = [block copy];
+}
+
+- (void)swizzle {
+  _swizzled = YES;
+  NSAssert(_replacingBlock, @"A replacingBlock needs to be set.");
+
+  [BSGULSwizzler swizzleClass:_class
+                   selector:_selector
+            isClassSelector:_isClassSelector
+                  withBlock:_replacingBlock];
+}
+
+- (void)unswizzle {
+  _swizzled = NO;
+#ifdef UNSWIZZLE_AVAILABLE
+  [BSGULSwizzler unswizzleClass:_class selector:_selector isClassSelector:_isClassSelector];
+#else
+  NSAssert(NO, @"Unswizzling is disabled.");
+#endif
+}
+
+- (IMP)currentIMP {
+  return [BSGULSwizzler currentImplementationForClass:_class
+                                           selector:_selector
+                                    isClassSelector:_isClassSelector];
+}
+
+- (BOOL)isEqual:(id)object {
+  if ([object isKindOfClass:[BSFPRSelectorInstrumentor class]]) {
+    BSFPRSelectorInstrumentor *otherObject = object;
+    return otherObject->_class == _class && otherObject->_selector == _selector &&
+           otherObject->_isClassSelector == _isClassSelector && otherObject->_swizzled == _swizzled;
+  }
+  return NO;
+}
+
+- (NSUInteger)hash {
+  return [[NSString stringWithFormat:@"%@%@%d%d", NSStringFromClass(_class),
+                                     NSStringFromSelector(_selector), _isClassSelector, _swizzled]
+      hash];
+}
+
+@end

--- a/BugsnagRequestMonitor/Instrumentation/BSFPRTraceBackgroundActivityTracker.h
+++ b/BugsnagRequestMonitor/Instrumentation/BSFPRTraceBackgroundActivityTracker.h
@@ -1,0 +1,41 @@
+// Copyright 2020 Google LLC
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+#import <Foundation/Foundation.h>
+
+/** Different background states of a trace. */
+typedef NS_ENUM(NSInteger, BSFPRTraceState) {
+  BSFPRTraceStateUnknown,
+
+  /** Background only trace. */
+  BSFPRTraceStateBackgroundOnly,
+
+  /** Foreground only trace. */
+  BSFPRTraceStateForegroundOnly,
+
+  /** Background and foreground trace. */
+  BSFPRTraceStateBackgroundAndForeground,
+};
+
+/**
+ * This class is used to track the app activity and track the background and foreground state of the
+ * object. This object will be used by a trace to determine its application state if the lifecycle
+ * of the trace is backgrounded, foregrounded or both.
+ */
+@interface BSFPRTraceBackgroundActivityTracker : NSObject
+
+/** Background state of the tracker. */
+@property(nonatomic, readonly) BSFPRTraceState traceBackgroundState;
+
+@end

--- a/BugsnagRequestMonitor/Instrumentation/BSFPRTraceBackgroundActivityTracker.m
+++ b/BugsnagRequestMonitor/Instrumentation/BSFPRTraceBackgroundActivityTracker.m
@@ -1,0 +1,75 @@
+// Copyright 2020 Google LLC
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+#import "BSFPRTraceBackgroundActivityTracker.h"
+
+#import <Foundation/Foundation.h>
+#import <UIKit/UIKit.h>
+
+//#import "BSFPRAppActivityTracker.h"
+
+@interface BSFPRTraceBackgroundActivityTracker ()
+
+@property(nonatomic, readwrite) BSFPRTraceState traceBackgroundState;
+
+@end
+
+@implementation BSFPRTraceBackgroundActivityTracker
+
+- (instancetype)init {
+  self = [super init];
+  if (self) {
+    [[NSNotificationCenter defaultCenter] addObserver:self
+                                             selector:@selector(applicationDidBecomeActive:)
+                                                 name:UIApplicationDidBecomeActiveNotification
+                                               object:[UIApplication sharedApplication]];
+
+    [[NSNotificationCenter defaultCenter] addObserver:self
+                                             selector:@selector(applicationDidEnterBackground:)
+                                                 name:UIApplicationDidEnterBackgroundNotification
+                                               object:[UIApplication sharedApplication]];
+  }
+  return self;
+}
+
+- (void)dealloc {
+  // Remove all the notification observers registered.
+  [[NSNotificationCenter defaultCenter] removeObserver:self];
+}
+
+#pragma mark - UIApplicationDelegate events
+
+/**
+ * This gets called whenever the app becomes active.
+ *
+ * @param notification Notification received during app launch.
+ */
+- (void)applicationDidBecomeActive:(NSNotification *)notification {
+  if (_traceBackgroundState == BSFPRTraceStateBackgroundOnly) {
+    _traceBackgroundState = BSFPRTraceStateBackgroundAndForeground;
+  }
+}
+
+/**
+ * This gets called whenever the app enters background.
+ *
+ * @param notification Notification received when the app enters background.
+ */
+- (void)applicationDidEnterBackground:(NSNotification *)notification {
+  if (_traceBackgroundState == BSFPRTraceStateForegroundOnly) {
+    _traceBackgroundState = BSFPRTraceStateBackgroundAndForeground;
+  }
+}
+
+@end

--- a/BugsnagRequestMonitor/Instrumentation/Network/BSFPRNSURLSessionInstrument.h
+++ b/BugsnagRequestMonitor/Instrumentation/Network/BSFPRNSURLSessionInstrument.h
@@ -1,0 +1,32 @@
+// Copyright 2020 Google LLC
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+#import "BSFPRInstrument.h"
+#import "BSFPRNetworkTrace.h"
+
+NS_ASSUME_NONNULL_BEGIN
+
+
+/** This class instruments the NSURLSession class cluster. As new classes are discovered, they will
+ *  be swizzled on a shared queue. Completion blocks and delegate methods are also wrapped.
+ */
+@interface BSFPRNSURLSessionInstrument : BSFPRInstrument
+
+- (instancetype)initWithTraceCallback:(NetworkTraceCallback _Nonnull)onRequestCompleted NS_DESIGNATED_INITIALIZER;
+
+- (nullable instancetype)init NS_UNAVAILABLE;
+
+@end
+
+NS_ASSUME_NONNULL_END

--- a/BugsnagRequestMonitor/Instrumentation/Network/BSFPRNSURLSessionInstrument.m
+++ b/BugsnagRequestMonitor/Instrumentation/Network/BSFPRNSURLSessionInstrument.m
@@ -1,0 +1,693 @@
+// Copyright 2020 Google LLC
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+/** NSURLSession is a class cluster and the type of class you get back from the various
+ *  initialization methods might not actually be NSURLSession. Inside those methods, this class
+ *  keeps track of seen NSURLSession subclasses and lazily swizzles them if they've not been seen.
+ *  Consequently, swizzling needs to occur on a serial queue for thread safety.
+ */
+
+#import "BSFPRNSURLSessionInstrument.h"
+#import "BSFPRNSURLSessionInstrument_Private.h"
+
+#import "BSFPRClassInstrumentor.h"
+#import "BSFPRInstrument_Private.h"
+#import "BSFPRNetworkTrace.h"
+#import "BSFPRProxyObjectHelper.h"
+#import "BSFPRSelectorInstrumentor.h"
+#import "BSFPRNSURLSessionDelegate.h"
+#import "BSFPRNetworkInstrumentHelpers.h"
+
+#import "BSGULObjectSwizzler.h"
+
+// Declared for use in instrumentation functions below.
+@interface BSFPRNSURLSessionInstrument ()
+
+@property(nonatomic, readwrite) NetworkTraceCallback onRequestCompleted;
+
+/** Registers an instrumentor for an NSURLSession subclass if it hasn't yet been instrumented.
+ *
+ *  @param aClass The class we wish to instrument.
+ */
+- (void)registerInstrumentorForClass:(Class)aClass;
+
+/** Registers an instrumentor for an NSURLSession proxy object if it hasn't yet been instrumented.
+ *
+ *  @param proxy The proxy object we wish to instrument.
+ */
+- (void)registerProxyObject:(id)proxy;
+
+@end
+
+/** Returns the dispatch queue for all instrumentation to occur on. */
+static dispatch_queue_t GetInstrumentationQueue() {
+  static dispatch_queue_t queue = nil;
+  static dispatch_once_t token = 0;
+  dispatch_once(&token, ^{
+    queue =
+        dispatch_queue_create("com.bugsnag.BSFPRNSURLSessionInstrumentation", DISPATCH_QUEUE_SERIAL);
+  });
+  return queue;
+}
+
+// This completion handler type is commonly used throughout NSURLSession.
+typedef void (^BSFPRDataTaskCompletionHandler)(NSData *_Nullable,
+                                             NSURLResponse *_Nullable,
+                                             NSError *_Nullable);
+
+typedef void (^BSFPRDownloadTaskCompletionHandler)(NSURL *_Nullable location,
+                                                 NSURLResponse *_Nullable response,
+                                                 NSError *_Nullable error);
+
+#pragma mark - Instrumentation Functions
+
+/** Wraps +sharedSession.
+ *
+ *  @param instrument The BSFPRNSURLSessionInstrument instance.
+ *  @param instrumentor The BSFPRClassInstrumentor to add the selector instrumentor to.
+ */
+FOUNDATION_STATIC_INLINE
+void InstrumentSharedSession(BSFPRNSURLSessionInstrument *instrument,
+                             BSFPRClassInstrumentor *instrumentor) {
+  SEL selector = @selector(sharedSession);
+  Class instrumentedClass = instrumentor.instrumentedClass;
+  BSFPRSelectorInstrumentor *selectorInstrumentor = SelectorInstrumentor(selector, instrumentor, YES);
+  __weak BSFPRNSURLSessionInstrument *weakInstrument = instrument;
+  IMP currentIMP = selectorInstrumentor.currentIMP;
+  [selectorInstrumentor setReplacingBlock:^(id session) {
+    __strong BSFPRNSURLSessionInstrument *strongInstrument = weakInstrument;
+    if (!strongInstrument) {
+      ThrowExceptionBecauseInstrumentHasBeenDeallocated(selector, instrumentedClass);
+    }
+    typedef NSURLSession *(*OriginalImp)(id, SEL);
+    NSURLSession *sharedSession = ((OriginalImp)currentIMP)(session, selector);
+    if ([sharedSession isProxy]) {
+      [strongInstrument registerProxyObject:sharedSession];
+    } else {
+      [strongInstrument registerInstrumentorForClass:[sharedSession class]];
+    }
+    return sharedSession;
+  }];
+}
+
+/** Wraps +sessionWithConfiguration:.
+ *
+ *  @param instrument The BSFPRNSURLSessionInstrument instance.
+ *  @param instrumentor The BSFPRClassInstrumentor to add the selector instrumentor to.
+ */
+FOUNDATION_STATIC_INLINE
+void InstrumentSessionWithConfiguration(BSFPRNSURLSessionInstrument *instrument,
+                                        BSFPRClassInstrumentor *instrumentor) {
+  SEL selector = @selector(sessionWithConfiguration:);
+  Class instrumentedClass = instrumentor.instrumentedClass;
+  BSFPRSelectorInstrumentor *selectorInstrumentor = SelectorInstrumentor(selector, instrumentor, YES);
+  __weak BSFPRNSURLSessionInstrument *weakInstrument = instrument;
+  IMP currentIMP = selectorInstrumentor.currentIMP;
+  [selectorInstrumentor setReplacingBlock:^(id session, NSURLSessionConfiguration *configuration) {
+    __strong BSFPRNSURLSessionInstrument *strongInstrument = weakInstrument;
+    if (!strongInstrument) {
+      ThrowExceptionBecauseInstrumentHasBeenDeallocated(selector, instrumentedClass);
+    }
+    typedef NSURLSession *(*OriginalImp)(id, SEL, NSURLSessionConfiguration *);
+    NSURLSession *sessionInstance = ((OriginalImp)currentIMP)(session, selector, configuration);
+    if ([sessionInstance isProxy]) {
+      [strongInstrument registerProxyObject:sessionInstance];
+    } else {
+      [strongInstrument registerInstrumentorForClass:[sessionInstance class]];
+    }
+    return sessionInstance;
+  }];
+}
+
+/** Wraps +sessionWithConfiguration:delegate:delegateQueue:.
+ *
+ *  @param instrument The BSFPRNSURLSessionInstrument instance.
+ *  @param instrumentor The BSFPRClassInstrumentor to add the selector instrumentor to.
+ *  @param delegateInstrument The BSFPRNSURLSessionDelegateInstrument that will track the delegate
+ *      selectors.
+ */
+FOUNDATION_STATIC_INLINE
+void InstrumentSessionWithConfigurationDelegateDelegateQueue(
+    BSFPRNSURLSessionInstrument *instrument,
+    BSFPRClassInstrumentor *instrumentor,
+    BSFPRNSURLSessionDelegateInstrument *delegateInstrument) {
+  SEL selector = @selector(sessionWithConfiguration:delegate:delegateQueue:);
+  Class instrumentedClass = instrumentor.instrumentedClass;
+  BSFPRSelectorInstrumentor *selectorInstrumentor = SelectorInstrumentor(selector, instrumentor, YES);
+  __weak BSFPRNSURLSessionInstrument *weakInstrument = instrument;
+  IMP currentIMP = selectorInstrumentor.currentIMP;
+  [selectorInstrumentor
+      setReplacingBlock:^(id session, NSURLSessionConfiguration *configuration,
+                          id<NSURLSessionDelegate> delegate, NSOperationQueue *queue) {
+        __strong BSFPRNSURLSessionInstrument *strongInstrument = weakInstrument;
+        if (!strongInstrument) {
+          ThrowExceptionBecauseInstrumentHasBeenDeallocated(selector, instrumentedClass);
+        }
+        if (delegate) {
+          [delegateInstrument registerClass:[delegate class]];
+          [delegateInstrument registerObject:delegate];
+
+        } else {
+          delegate = [[BSFPRNSURLSessionDelegate alloc] init];
+        }
+        typedef NSURLSession *(*OriginalImp)(id, SEL, NSURLSessionConfiguration *,
+                                             id<NSURLSessionDelegate>, NSOperationQueue *);
+        NSURLSession *sessionInstance =
+            ((OriginalImp)currentIMP)([session class], selector, configuration, delegate, queue);
+        if ([sessionInstance isProxy]) {
+          [strongInstrument registerProxyObject:sessionInstance];
+        } else {
+          [strongInstrument registerInstrumentorForClass:[sessionInstance class]];
+        }
+        return sessionInstance;
+      }];
+}
+
+/** Wraps -dataTaskWithURL:.
+ *
+ *  @param instrument The BSFPRNSURLSessionInstrument instance.
+ *  @param instrumentor The BSFPRClassInstrumentor to add the selector instrumentor to.
+ */
+
+FOUNDATION_STATIC_INLINE
+void InstrumentDataTaskWithURL(BSFPRNSURLSessionInstrument *instrument,
+                               BSFPRClassInstrumentor *instrumentor) {
+  SEL selector = @selector(dataTaskWithURL:);
+  BSFPRSelectorInstrumentor *selectorInstrumentor = SelectorInstrumentor(selector, instrumentor, NO);
+  __weak BSFPRNSURLSessionInstrument *weakInstrument = instrument;
+  IMP currentIMP = selectorInstrumentor.currentIMP;
+  [selectorInstrumentor setReplacingBlock:^(id session, NSURL *url) {
+    __strong BSFPRNSURLSessionInstrument *strongInstrument = weakInstrument;
+    if (!strongInstrument) {
+      ThrowExceptionBecauseInstrumentHasBeenDeallocated(selector, instrumentor.instrumentedClass);
+    }
+    typedef NSURLSessionDataTask *(*OriginalImp)(id, SEL, NSURL *);
+    NSURLSessionDataTask *dataTask = ((OriginalImp)currentIMP)(session, selector, url);
+    if (dataTask.originalRequest) {
+      BSFPRNetworkTrace *trace =
+          [[BSFPRNetworkTrace alloc] initWithURLRequest:dataTask.originalRequest completionCallback:weakInstrument.onRequestCompleted];
+      [trace start];
+      [trace checkpointState:BSFPRNetworkTraceCheckpointStateInitiated];
+      [BSFPRNetworkTrace addNetworkTrace:trace toObject:dataTask];
+    }
+
+    return dataTask;
+  }];
+}
+
+/** Instruments -dataTaskWithURL:completionHandler:.
+ *
+ *  @param instrument The BSFPRNSURLSessionInstrument instance.
+ *  @param instrumentor The BSFPRClassInstrumentor to add the selector instrumentor to.
+ */
+FOUNDATION_STATIC_INLINE
+void InstrumentDataTaskWithURLCompletionHandler(BSFPRNSURLSessionInstrument *instrument,
+                                                BSFPRClassInstrumentor *instrumentor) {
+  SEL selector = @selector(dataTaskWithURL:completionHandler:);
+  BSFPRSelectorInstrumentor *selectorInstrumentor = SelectorInstrumentor(selector, instrumentor, NO);
+  __weak BSFPRNSURLSessionInstrument *weakInstrument = instrument;
+  IMP currentIMP = selectorInstrumentor.currentIMP;
+  [selectorInstrumentor setReplacingBlock:^(id session, NSURL *URL,
+                                            BSFPRDataTaskCompletionHandler completionHandler) {
+    __block NSURLSessionDataTask *task = nil;
+    BSFPRDataTaskCompletionHandler wrappedCompletionHandler = nil;
+    if (completionHandler) {
+      wrappedCompletionHandler = ^(NSData *data, NSURLResponse *response, NSError *error) {
+        BSFPRNetworkTrace *trace = [BSFPRNetworkTrace networkTraceFromObject:task];
+        [trace didReceiveData:data];
+        [trace didCompleteRequestWithResponse:response error:error];
+        [BSFPRNetworkTrace removeNetworkTraceFromObject:task];
+        completionHandler(data, response, error);
+      };
+    }
+    typedef NSURLSessionDataTask *(*OriginalImp)(id, SEL, NSURL *, BSFPRDataTaskCompletionHandler);
+    task = ((OriginalImp)currentIMP)(session, selector, URL, wrappedCompletionHandler);
+
+    // Add the network trace object only when the trace object is not added to the task object.
+    if ([BSFPRNetworkTrace networkTraceFromObject:task] == nil) {
+      BSFPRNetworkTrace *trace = [[BSFPRNetworkTrace alloc] initWithURLRequest:task.originalRequest completionCallback:weakInstrument.onRequestCompleted];
+      [trace start];
+      [trace checkpointState:BSFPRNetworkTraceCheckpointStateInitiated];
+      [BSFPRNetworkTrace addNetworkTrace:trace toObject:task];
+    }
+    return task;
+  }];
+}
+
+/** Wraps -dataTaskWithRequest:.
+ *
+ *  @param instrument The BSFPRNSURLSessionInstrument instance.
+ *  @param instrumentor The BSFPRClassInstrumentor to add the selector instrumentor to.
+ */
+
+FOUNDATION_STATIC_INLINE
+void InstrumentDataTaskWithRequest(BSFPRNSURLSessionInstrument *instrument,
+                                   BSFPRClassInstrumentor *instrumentor) {
+  SEL selector = @selector(dataTaskWithRequest:);
+  BSFPRSelectorInstrumentor *selectorInstrumentor = SelectorInstrumentor(selector, instrumentor, NO);
+  __weak BSFPRNSURLSessionInstrument *weakInstrument = instrument;
+  IMP currentIMP = selectorInstrumentor.currentIMP;
+  [selectorInstrumentor setReplacingBlock:^(id session, NSURLRequest *request) {
+    __strong BSFPRNSURLSessionInstrument *strongInstrument = weakInstrument;
+    if (!strongInstrument) {
+      ThrowExceptionBecauseInstrumentHasBeenDeallocated(selector, instrumentor.instrumentedClass);
+    }
+    typedef NSURLSessionDataTask *(*OriginalImp)(id, SEL, NSURLRequest *);
+    NSURLSessionDataTask *dataTask = ((OriginalImp)currentIMP)(session, selector, request);
+    if (dataTask.originalRequest) {
+      BSFPRNetworkTrace *trace =
+          [[BSFPRNetworkTrace alloc] initWithURLRequest:dataTask.originalRequest completionCallback:weakInstrument.onRequestCompleted];
+      [trace start];
+      [trace checkpointState:BSFPRNetworkTraceCheckpointStateInitiated];
+      [BSFPRNetworkTrace addNetworkTrace:trace toObject:dataTask];
+    }
+
+    return dataTask;
+  }];
+}
+
+/** Instruments -dataTaskWithRequest:completionHandler:.
+ *
+ *  @param instrument The BSFPRNSURLSessionInstrument instance.
+ *  @param instrumentor The BSFPRClassInstrumentor to add the selector instrumentor to.
+ */
+FOUNDATION_STATIC_INLINE
+void InstrumentDataTaskWithRequestCompletionHandler(BSFPRNSURLSessionInstrument *instrument,
+                                                    BSFPRClassInstrumentor *instrumentor) {
+  SEL selector = @selector(dataTaskWithRequest:completionHandler:);
+  BSFPRSelectorInstrumentor *selectorInstrumentor = SelectorInstrumentor(selector, instrumentor, NO);
+  __weak BSFPRNSURLSessionInstrument *weakInstrument = instrument;
+  IMP currentIMP = selectorInstrumentor.currentIMP;
+  [selectorInstrumentor setReplacingBlock:^(id session, NSURLRequest *request,
+                                            BSFPRDataTaskCompletionHandler completionHandler) {
+    __block NSURLSessionDataTask *task = nil;
+    BSFPRDataTaskCompletionHandler wrappedCompletionHandler = nil;
+    if (completionHandler) {
+      wrappedCompletionHandler = ^(NSData *data, NSURLResponse *response, NSError *error) {
+        BSFPRNetworkTrace *trace = [BSFPRNetworkTrace networkTraceFromObject:task];
+        [trace didReceiveData:data];
+        [trace didCompleteRequestWithResponse:response error:error];
+        [BSFPRNetworkTrace removeNetworkTraceFromObject:task];
+        completionHandler(data, response, error);
+      };
+    }
+    typedef NSURLSessionDataTask *(*OriginalImp)(id, SEL, NSURLRequest *,
+                                                 BSFPRDataTaskCompletionHandler);
+    task = ((OriginalImp)currentIMP)(session, selector, request, wrappedCompletionHandler);
+
+    // Add the network trace object only when the trace object is not added to the task object.
+    if ([BSFPRNetworkTrace networkTraceFromObject:task] == nil) {
+      BSFPRNetworkTrace *trace = [[BSFPRNetworkTrace alloc] initWithURLRequest:task.originalRequest completionCallback:weakInstrument.onRequestCompleted];
+      [trace start];
+      [trace checkpointState:BSFPRNetworkTraceCheckpointStateInitiated];
+      [BSFPRNetworkTrace addNetworkTrace:trace toObject:task];
+    }
+    return task;
+  }];
+}
+
+/** Instruments -uploadTaskWithRequest:fromFile:.
+ *
+ *  @param instrument The BSFPRNSURLSessionInstrument instance.
+ *  @param instrumentor The BSFPRClassInstrumentor to add the selector instrumentor to.
+ */
+FOUNDATION_STATIC_INLINE
+void InstrumentUploadTaskWithRequestFromFile(BSFPRNSURLSessionInstrument *instrument,
+                                             BSFPRClassInstrumentor *instrumentor) {
+  SEL selector = @selector(uploadTaskWithRequest:fromFile:);
+  BSFPRSelectorInstrumentor *selectorInstrumentor = SelectorInstrumentor(selector, instrumentor, NO);
+  __weak BSFPRNSURLSessionInstrument *weakInstrument = instrument;
+  IMP currentIMP = selectorInstrumentor.currentIMP;
+  [selectorInstrumentor setReplacingBlock:^(id session, NSURLRequest *request, NSURL *fileURL) {
+    __strong BSFPRNSURLSessionInstrument *strongInstrument = weakInstrument;
+    if (!strongInstrument) {
+      ThrowExceptionBecauseInstrumentHasBeenDeallocated(selector, instrumentor.instrumentedClass);
+    }
+    typedef NSURLSessionUploadTask *(*OriginalImp)(id, SEL, NSURLRequest *, NSURL *);
+    NSURLSessionUploadTask *uploadTask =
+        ((OriginalImp)currentIMP)(session, selector, request, fileURL);
+    if (uploadTask.originalRequest) {
+      BSFPRNetworkTrace *trace =
+          [[BSFPRNetworkTrace alloc] initWithURLRequest:uploadTask.originalRequest completionCallback:weakInstrument.onRequestCompleted];
+      [trace start];
+      [trace checkpointState:BSFPRNetworkTraceCheckpointStateInitiated];
+      [BSFPRNetworkTrace addNetworkTrace:trace toObject:uploadTask];
+    }
+    return uploadTask;
+  }];
+}
+
+/** Instruments -uploadTaskWithRequest:fromFile:completionHandler:.
+ *
+ *  @param instrument The BSFPRNSURLSessionInstrument instance.
+ *  @param instrumentor The BSFPRClassInstrumentor to add the selector instrumentor to.
+ */
+FOUNDATION_STATIC_INLINE
+void InstrumentUploadTaskWithRequestFromFileCompletionHandler(BSFPRNSURLSessionInstrument *instrument,
+                                                              BSFPRClassInstrumentor *instrumentor) {
+  SEL selector = @selector(uploadTaskWithRequest:fromFile:completionHandler:);
+  BSFPRSelectorInstrumentor *selectorInstrumentor = SelectorInstrumentor(selector, instrumentor, NO);
+  __weak BSFPRNSURLSessionInstrument *weakInstrument = instrument;
+  IMP currentIMP = selectorInstrumentor.currentIMP;
+  [selectorInstrumentor setReplacingBlock:^(id session, NSURLRequest *request, NSURL *fileURL,
+                                            BSFPRDataTaskCompletionHandler completionHandler) {
+    BSFPRNetworkTrace *trace = [[BSFPRNetworkTrace alloc] initWithURLRequest:request completionCallback:weakInstrument.onRequestCompleted];
+    [trace start];
+    [trace checkpointState:BSFPRNetworkTraceCheckpointStateInitiated];
+    [trace didUploadFileWithURL:fileURL];
+    BSFPRDataTaskCompletionHandler wrappedCompletionHandler = nil;
+    if (completionHandler) {
+      wrappedCompletionHandler = ^(NSData *data, NSURLResponse *response, NSError *error) {
+        [trace didReceiveData:data];
+        [trace didCompleteRequestWithResponse:response error:error];
+        completionHandler(data, response, error);
+      };
+    }
+    typedef NSURLSessionUploadTask *(*OriginalImp)(id, SEL, NSURLRequest *, NSURL *,
+                                                   BSFPRDataTaskCompletionHandler);
+    return ((OriginalImp)currentIMP)(session, selector, request, fileURL, wrappedCompletionHandler);
+  }];
+}
+
+/** Instruments -uploadTaskWithRequest:fromData:.
+ *
+ *  @param instrument The BSFPRNSURLSessionInstrument instance.
+ *  @param instrumentor The BSFPRClassInstrumentor to add the selector instrumentor to.
+ */
+FOUNDATION_STATIC_INLINE
+void InstrumentUploadTaskWithRequestFromData(BSFPRNSURLSessionInstrument *instrument,
+                                             BSFPRClassInstrumentor *instrumentor) {
+  SEL selector = @selector(uploadTaskWithRequest:fromData:);
+  BSFPRSelectorInstrumentor *selectorInstrumentor = SelectorInstrumentor(selector, instrumentor, NO);
+  __weak BSFPRNSURLSessionInstrument *weakInstrument = instrument;
+  IMP currentIMP = selectorInstrumentor.currentIMP;
+  [selectorInstrumentor setReplacingBlock:^(id session, NSURLRequest *request, NSData *bodyData) {
+    __strong BSFPRNSURLSessionInstrument *strongInstrument = weakInstrument;
+    if (!strongInstrument) {
+      ThrowExceptionBecauseInstrumentHasBeenDeallocated(selector, instrumentor.instrumentedClass);
+    }
+    typedef NSURLSessionUploadTask *(*OriginalImp)(id, SEL, NSURLRequest *, NSData *);
+    NSURLSessionUploadTask *uploadTask =
+        ((OriginalImp)currentIMP)(session, selector, request, bodyData);
+    if (uploadTask.originalRequest) {
+      BSFPRNetworkTrace *trace =
+          [[BSFPRNetworkTrace alloc] initWithURLRequest:uploadTask.originalRequest completionCallback:weakInstrument.onRequestCompleted];
+      [trace start];
+      trace.requestSize = bodyData.length;
+      [trace checkpointState:BSFPRNetworkTraceCheckpointStateInitiated];
+      [BSFPRNetworkTrace addNetworkTrace:trace toObject:uploadTask];
+    }
+    return uploadTask;
+  }];
+}
+
+/** Instruments -uploadTaskWithRequest:fromData:completionHandler:.
+ *
+ *  @param instrument The BSFPRNSURLSessionInstrument instance.
+ *  @param instrumentor The BSFPRClassInstrumentor to add the selector instrumentor to.
+ */
+FOUNDATION_STATIC_INLINE
+void InstrumentUploadTaskWithRequestFromDataCompletionHandler(BSFPRNSURLSessionInstrument *instrument,
+                                                              BSFPRClassInstrumentor *instrumentor) {
+  SEL selector = @selector(uploadTaskWithRequest:fromData:completionHandler:);
+  BSFPRSelectorInstrumentor *selectorInstrumentor = SelectorInstrumentor(selector, instrumentor, NO);
+  __weak BSFPRNSURLSessionInstrument *weakInstrument = instrument;
+  IMP currentIMP = selectorInstrumentor.currentIMP;
+  [selectorInstrumentor setReplacingBlock:^(id session, NSURLRequest *request, NSData *bodyData,
+                                            BSFPRDataTaskCompletionHandler completionHandler) {
+    BSFPRNetworkTrace *trace = [[BSFPRNetworkTrace alloc] initWithURLRequest:request completionCallback:weakInstrument.onRequestCompleted];
+    [trace start];
+    trace.requestSize = bodyData.length;
+    [trace checkpointState:BSFPRNetworkTraceCheckpointStateInitiated];
+    BSFPRDataTaskCompletionHandler wrappedCompletionHandler = nil;
+    if (completionHandler) {
+      wrappedCompletionHandler = ^(NSData *data, NSURLResponse *response, NSError *error) {
+        [trace didReceiveData:data];
+        [trace didCompleteRequestWithResponse:response error:error];
+        completionHandler(data, response, error);
+      };
+    }
+    typedef NSURLSessionUploadTask *(*OriginalImp)(id, SEL, NSURLRequest *, NSData *,
+                                                   BSFPRDataTaskCompletionHandler);
+    return ((OriginalImp)currentIMP)(session, selector, request, bodyData,
+                                     wrappedCompletionHandler);
+  }];
+}
+
+/** Instruments -uploadTaskWithStreamedRequest:.
+ *
+ *  @param instrument The BSFPRNSURLSessionInstrument instance.
+ *  @param instrumentor The BSFPRClassInstrumentor to add the selector instrumentor to.
+ */
+FOUNDATION_STATIC_INLINE
+void InstrumentUploadTaskWithStreamedRequest(BSFPRNSURLSessionInstrument *instrument,
+                                             BSFPRClassInstrumentor *instrumentor) {
+  SEL selector = @selector(uploadTaskWithStreamedRequest:);
+  BSFPRSelectorInstrumentor *selectorInstrumentor = SelectorInstrumentor(selector, instrumentor, NO);
+  __weak BSFPRNSURLSessionInstrument *weakInstrument = instrument;
+  IMP currentIMP = selectorInstrumentor.currentIMP;
+  [selectorInstrumentor setReplacingBlock:^(id session, NSURLRequest *request) {
+    __strong BSFPRNSURLSessionInstrument *strongInstrument = weakInstrument;
+    if (!strongInstrument) {
+      ThrowExceptionBecauseInstrumentHasBeenDeallocated(selector, instrumentor.instrumentedClass);
+    }
+    typedef NSURLSessionUploadTask *(*OriginalImp)(id, SEL, NSURLRequest *);
+    NSURLSessionUploadTask *uploadTask = ((OriginalImp)currentIMP)(session, selector, request);
+    if (uploadTask.originalRequest) {
+      BSFPRNetworkTrace *trace =
+          [[BSFPRNetworkTrace alloc] initWithURLRequest:uploadTask.originalRequest completionCallback:weakInstrument.onRequestCompleted];
+      [trace start];
+      [trace checkpointState:BSFPRNetworkTraceCheckpointStateInitiated];
+      [BSFPRNetworkTrace addNetworkTrace:trace toObject:uploadTask];
+    }
+    return uploadTask;
+  }];
+}
+
+/** Instruments -downloadTaskWithURL:.
+ *
+ *  @param instrument The BSFPRNSURLSessionInstrument instance.
+ *  @param instrumentor The BSFPRClassInstrumentor to add the selector instrumentor to.
+ */
+FOUNDATION_STATIC_INLINE
+void InstrumentDownloadTaskWithURL(BSFPRNSURLSessionInstrument *instrument,
+                                   BSFPRClassInstrumentor *instrumentor) {
+  SEL selector = @selector(downloadTaskWithURL:);
+  BSFPRSelectorInstrumentor *selectorInstrumentor = SelectorInstrumentor(selector, instrumentor, NO);
+  __weak BSFPRNSURLSessionInstrument *weakInstrument = instrument;
+  IMP currentIMP = selectorInstrumentor.currentIMP;
+  [selectorInstrumentor setReplacingBlock:^(id session, NSURL *url) {
+    __strong BSFPRNSURLSessionInstrument *strongInstrument = weakInstrument;
+    if (!strongInstrument) {
+      ThrowExceptionBecauseInstrumentHasBeenDeallocated(selector, instrumentor.instrumentedClass);
+    }
+    typedef NSURLSessionDownloadTask *(*OriginalImp)(id, SEL, NSURL *);
+    NSURLSessionDownloadTask *downloadTask = ((OriginalImp)currentIMP)(session, selector, url);
+    if (downloadTask.originalRequest) {
+      BSFPRNetworkTrace *trace =
+          [[BSFPRNetworkTrace alloc] initWithURLRequest:downloadTask.originalRequest completionCallback:weakInstrument.onRequestCompleted];
+      [trace start];
+      [trace checkpointState:BSFPRNetworkTraceCheckpointStateInitiated];
+      [BSFPRNetworkTrace addNetworkTrace:trace toObject:downloadTask];
+    }
+    return downloadTask;
+  }];
+}
+
+/** Instruments -downloadTaskWithURL:completionHandler:.
+ *
+ *  @param instrument The BSFPRNSURLSessionInstrument instance.
+ *  @param instrumentor The BSFPRClassInstrumentor to add the selector instrumentor to.
+ */
+FOUNDATION_STATIC_INLINE
+void InstrumentDownloadTaskWithURLCompletionHandler(BSFPRNSURLSessionInstrument *instrument,
+                                                    BSFPRClassInstrumentor *instrumentor) {
+  SEL selector = @selector(downloadTaskWithURL:completionHandler:);
+  BSFPRSelectorInstrumentor *selectorInstrumentor = SelectorInstrumentor(selector, instrumentor, NO);
+  __weak BSFPRNSURLSessionInstrument *weakInstrument = instrument;
+  IMP currentIMP = selectorInstrumentor.currentIMP;
+  [selectorInstrumentor setReplacingBlock:^(id session, NSURL *URL,
+                                            BSFPRDownloadTaskCompletionHandler completionHandler) {
+    __block NSURLSessionDownloadTask *downloadTask = nil;
+    BSFPRDownloadTaskCompletionHandler wrappedCompletionHandler = nil;
+    if (completionHandler) {
+      wrappedCompletionHandler = ^(NSURL *location, NSURLResponse *response, NSError *error) {
+        BSFPRNetworkTrace *trace = [BSFPRNetworkTrace networkTraceFromObject:downloadTask];
+        [trace didReceiveFileURL:location];
+        [trace didCompleteRequestWithResponse:response error:error];
+        completionHandler(location, response, error);
+      };
+    }
+    typedef NSURLSessionDownloadTask *(*OriginalImp)(id, SEL, NSURL *,
+                                                     BSFPRDownloadTaskCompletionHandler);
+    downloadTask = ((OriginalImp)currentIMP)(session, selector, URL, wrappedCompletionHandler);
+
+    // Add the network trace object only when the trace object is not added to the task object.
+    if ([BSFPRNetworkTrace networkTraceFromObject:downloadTask] == nil) {
+      BSFPRNetworkTrace *trace =
+          [[BSFPRNetworkTrace alloc] initWithURLRequest:downloadTask.originalRequest completionCallback:weakInstrument.onRequestCompleted];
+      [trace start];
+      [trace checkpointState:BSFPRNetworkTraceCheckpointStateInitiated];
+      [BSFPRNetworkTrace addNetworkTrace:trace toObject:downloadTask];
+    }
+    return downloadTask;
+  }];
+}
+
+/** Instruments -downloadTaskWithRequest:.
+ *
+ *  @param instrument The BSFPRNSURLSessionInstrument instance.
+ *  @param instrumentor The BSFPRClassInstrumentor to add the selector instrumentor to.
+ */
+FOUNDATION_STATIC_INLINE
+void InstrumentDownloadTaskWithRequest(BSFPRNSURLSessionInstrument *instrument,
+                                       BSFPRClassInstrumentor *instrumentor) {
+  SEL selector = @selector(downloadTaskWithRequest:);
+  BSFPRSelectorInstrumentor *selectorInstrumentor = SelectorInstrumentor(selector, instrumentor, NO);
+  __weak BSFPRNSURLSessionInstrument *weakInstrument = instrument;
+  IMP currentIMP = selectorInstrumentor.currentIMP;
+  [selectorInstrumentor setReplacingBlock:^(id session, NSURLRequest *request) {
+    __strong BSFPRNSURLSessionInstrument *strongInstrument = weakInstrument;
+    if (!strongInstrument) {
+      ThrowExceptionBecauseInstrumentHasBeenDeallocated(selector, instrumentor.instrumentedClass);
+    }
+    typedef NSURLSessionDownloadTask *(*OriginalImp)(id, SEL, NSURLRequest *);
+    NSURLSessionDownloadTask *downloadTask = ((OriginalImp)currentIMP)(session, selector, request);
+    if (downloadTask.originalRequest) {
+      BSFPRNetworkTrace *trace =
+          [[BSFPRNetworkTrace alloc] initWithURLRequest:downloadTask.originalRequest completionCallback:weakInstrument.onRequestCompleted];
+      [trace start];
+      [trace checkpointState:BSFPRNetworkTraceCheckpointStateInitiated];
+      [BSFPRNetworkTrace addNetworkTrace:trace toObject:downloadTask];
+    }
+    return downloadTask;
+  }];
+}
+
+/** Instruments -downloadTaskWithRequest:completionHandler:.
+ *
+ *  @param instrument The BSFPRNSURLSessionInstrument instance.
+ *  @param instrumentor The BSFPRClassInstrumentor to add the selector instrumentor to.
+ */
+FOUNDATION_STATIC_INLINE
+void InstrumentDownloadTaskWithRequestCompletionHandler(BSFPRNSURLSessionInstrument *instrument,
+                                                        BSFPRClassInstrumentor *instrumentor) {
+  SEL selector = @selector(downloadTaskWithRequest:completionHandler:);
+  BSFPRSelectorInstrumentor *selectorInstrumentor = SelectorInstrumentor(selector, instrumentor, NO);
+  __weak BSFPRNSURLSessionInstrument *weakInstrument = instrument;
+  IMP currentIMP = selectorInstrumentor.currentIMP;
+  [selectorInstrumentor setReplacingBlock:^(id session, NSURLRequest *request,
+                                            BSFPRDownloadTaskCompletionHandler completionHandler) {
+    __block NSURLSessionDownloadTask *downloadTask = nil;
+    BSFPRDownloadTaskCompletionHandler wrappedCompletionHandler = nil;
+
+    if (completionHandler) {
+      wrappedCompletionHandler = ^(NSURL *location, NSURLResponse *response, NSError *error) {
+        BSFPRNetworkTrace *trace = [BSFPRNetworkTrace networkTraceFromObject:downloadTask];
+        [trace didReceiveFileURL:location];
+        [trace didCompleteRequestWithResponse:response error:error];
+        completionHandler(location, response, error);
+      };
+    }
+    typedef NSURLSessionDownloadTask *(*OriginalImp)(id, SEL, NSURLRequest *,
+                                                     BSFPRDownloadTaskCompletionHandler);
+    downloadTask = ((OriginalImp)currentIMP)(session, selector, request, wrappedCompletionHandler);
+
+    // Add the network trace object only when the trace object is not added to the task object.
+    if ([BSFPRNetworkTrace networkTraceFromObject:downloadTask] == nil) {
+      BSFPRNetworkTrace *trace =
+          [[BSFPRNetworkTrace alloc] initWithURLRequest:downloadTask.originalRequest completionCallback:weakInstrument.onRequestCompleted];
+      [trace start];
+      [trace checkpointState:BSFPRNetworkTraceCheckpointStateInitiated];
+      [BSFPRNetworkTrace addNetworkTrace:trace toObject:downloadTask];
+    }
+    return downloadTask;
+  }];
+}
+
+#pragma mark - BSFPRNSURLSessionInstrument
+
+@implementation BSFPRNSURLSessionInstrument
+
+- (instancetype)initWithTraceCallback:(NetworkTraceCallback)onRequestCompleted {
+    self = [super init];
+    if (self) {
+      self.onRequestCompleted = onRequestCompleted;
+      _delegateInstrument = [[BSFPRNSURLSessionDelegateInstrument alloc] init];
+      [_delegateInstrument registerInstrumentors];
+    }
+    return self;
+}
+
+- (instancetype)init {
+  NSAssert(NO, @"Not a designated initializer.");
+  return nil;
+}
+
+- (void)registerInstrumentors {
+  [self registerInstrumentorForClass:[NSURLSession class]];
+}
+
+- (void)deregisterInstrumentors {
+  [_delegateInstrument deregisterInstrumentors];
+  [super deregisterInstrumentors];
+}
+
+- (void)registerInstrumentorForClass:(Class)aClass {
+  dispatch_sync(GetInstrumentationQueue(), ^{
+    NSAssert([aClass isSubclassOfClass:[NSURLSession class]],
+              @"Class %@ is not a subclass of "
+               "NSURLSession",
+              aClass);
+    // If this class has already been instrumented, just return.
+    BSFPRClassInstrumentor *instrumentor = [[BSFPRClassInstrumentor alloc] initWithClass:aClass];
+    if (![self registerClassInstrumentor:instrumentor]) {
+      return;
+    }
+
+    InstrumentSharedSession(self, instrumentor);
+
+    InstrumentSessionWithConfiguration(self, instrumentor);
+    InstrumentSessionWithConfigurationDelegateDelegateQueue(self, instrumentor,
+                                                            _delegateInstrument);
+
+    InstrumentDataTaskWithURL(self, instrumentor);
+    InstrumentDataTaskWithURLCompletionHandler(self, instrumentor);
+    InstrumentDataTaskWithRequest(self, instrumentor);
+    InstrumentDataTaskWithRequestCompletionHandler(self, instrumentor);
+
+    InstrumentUploadTaskWithRequestFromFile(self, instrumentor);
+    InstrumentUploadTaskWithRequestFromFileCompletionHandler(self, instrumentor);
+    InstrumentUploadTaskWithRequestFromData(self, instrumentor);
+    InstrumentUploadTaskWithRequestFromDataCompletionHandler(self, instrumentor);
+    InstrumentUploadTaskWithStreamedRequest(self, instrumentor);
+
+    InstrumentDownloadTaskWithURL(self, instrumentor);
+    InstrumentDownloadTaskWithURLCompletionHandler(self, instrumentor);
+    InstrumentDownloadTaskWithRequest(self, instrumentor);
+    InstrumentDownloadTaskWithRequestCompletionHandler(self, instrumentor);
+
+    [instrumentor swizzle];
+  });
+}
+
+- (void)registerProxyObject:(id)proxy {
+  [BSFPRProxyObjectHelper registerProxyObject:proxy
+                              forSuperclass:[NSURLSession class]
+                            varFoundHandler:^(id ivar) {
+                              [self registerInstrumentorForClass:[ivar class]];
+                            }];
+}
+
+@end

--- a/BugsnagRequestMonitor/Instrumentation/Network/BSFPRNSURLSessionInstrument_Private.h
+++ b/BugsnagRequestMonitor/Instrumentation/Network/BSFPRNSURLSessionInstrument_Private.h
@@ -1,0 +1,28 @@
+// Copyright 2020 Google LLC
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+#import "BSFPRNSURLSessionInstrument.h"
+
+#import "BSFPRNSURLSessionDelegateInstrument.h"
+
+NS_ASSUME_NONNULL_BEGIN
+
+@interface BSFPRNSURLSessionInstrument ()
+
+/** The delegate instrument. */
+@property(nonatomic) BSFPRNSURLSessionDelegateInstrument *delegateInstrument;
+
+@end
+
+NS_ASSUME_NONNULL_END

--- a/BugsnagRequestMonitor/Instrumentation/Network/BSFPRNetworkInstrumentHelpers.h
+++ b/BugsnagRequestMonitor/Instrumentation/Network/BSFPRNetworkInstrumentHelpers.h
@@ -1,0 +1,73 @@
+// Copyright 2020 Google LLC
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+#import <Foundation/Foundation.h>
+
+@class BSFPRSelectorInstrumentor;
+@class BSFPRClassInstrumentor;
+
+/** Throws an exception declaring that the selector was not found on the class. This is a
+ *  convenience function.
+ *
+ *  This should only be invoked when one of two things has happened:
+ *  - The underlying iOS implementation removes a method on a class and we haven't detected it yet.
+ *  - We instrument a new method using the wrong selector/class combo and don't discover that
+ *    through unit tests or other kinds of testing or development.
+ *
+ *  @param selector The selector being invoked.
+ *  @param aClass The class the selector belongs to.
+ *  @throws An exception if invoked.
+ */
+FOUNDATION_EXTERN
+void ThrowExceptionBecauseSelectorNotFoundOnClass(SEL selector, Class aClass);
+
+/** Throws an exception declaring that the selector instrumentor has been deallocated. This is a
+ *  convenience function.
+ *
+ *  This should only be invoked when the selector instrumentor has been deallocated, but for some
+ *  reason -unswizzle was not called.
+ *
+ *  @param selector The selector being invoked.
+ *  @param aClass The class the selector belongs to.
+ *  @throws An exception if invoked.
+ */
+FOUNDATION_EXTERN
+void ThrowExceptionBecauseSelectorInstrumentorHasBeenDeallocated(SEL selector, Class aClass);
+
+/** Throws an exception declaring that the instrument attempting to register a class has been
+ *  deallocated.
+ *
+ *  This should only be invoked when the instrument of an iOS class cluster has been deallocated,
+ *  but not unswizzled.
+ *
+ *  @param selector The selector being invoked.
+ *  @param aClass The class the selector belongs to.
+ *  @throws An exception if invoked.
+ */
+FOUNDATION_EXTERN
+void ThrowExceptionBecauseInstrumentHasBeenDeallocated(SEL selector, Class aClass);
+
+/** Returns an BSFPRSelectorInstrumentor given a SEL and BSFPRClassInstrumentor. This is a convenience
+ *  function.
+ *
+ *  @param selector The selector to instrument.
+ *  @param instrumentor The class instrumentor to generate the selector instrumentor from.
+ *  @param isClassSelector YES if the selector is a class selector, NO otherwise.
+ *  @return An BSFPRSelectorInstrumentor instance if the selector is on the class.
+ *  @throws An exception if the selector is NOT found on the class.
+ */
+FOUNDATION_EXTERN
+BSFPRSelectorInstrumentor *SelectorInstrumentor(SEL selector,
+                                              BSFPRClassInstrumentor *instrumentor,
+                                              BOOL isClassSelector);

--- a/BugsnagRequestMonitor/Instrumentation/Network/BSFPRNetworkInstrumentHelpers.m
+++ b/BugsnagRequestMonitor/Instrumentation/Network/BSFPRNetworkInstrumentHelpers.m
@@ -1,0 +1,61 @@
+// Copyright 2020 Google LLC
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+#import "BSFPRNetworkInstrumentHelpers.h"
+
+#import "BSFPRClassInstrumentor.h"
+#import "BSFPRSelectorInstrumentor.h"
+
+FOUNDATION_EXTERN_INLINE
+void ThrowExceptionBecauseSelectorNotFoundOnClass(SEL selector, Class aClass) {
+  [NSException raise:NSInternalInconsistencyException
+              format:@"Selector %@ not found on class %@", NSStringFromSelector(selector),
+                     NSStringFromClass(aClass)];
+}
+
+FOUNDATION_EXTERN_INLINE
+void ThrowExceptionBecauseSelectorInstrumentorHasBeenDeallocated(SEL selector, Class aClass) {
+  [NSException raise:NSInternalInconsistencyException
+              format:@"Selector instrumentor has been deallocated: %@|%@",
+                     NSStringFromSelector(selector), NSStringFromClass(aClass)];
+}
+
+FOUNDATION_EXTERN_INLINE
+void ThrowExceptionBecauseInstrumentHasBeenDeallocated(SEL selector, Class aClass) {
+  [NSException raise:NSInternalInconsistencyException
+              format:@"The instrument has been deallocated: %@|%@", NSStringFromSelector(selector),
+                     NSStringFromClass(aClass)];
+}
+
+/** Returns an BSFPRSelectorInstrumentor given a SEL and BSFPRClassInstrumentor. This is a convenience
+ *  function.
+ *
+ *  @param selector The selector to instrument.
+ *  @param instrumentor The class instrumentor to generate the selector instrumentor from.
+ *  @param isClassSelector YES if the selector is a class selector, NO otherwise.
+ *  @return An BSFPRSelectorInstrumentor instance if the selector is on the class.
+ *  @throws An exception if the selector is NOT found on the class.
+ */
+FOUNDATION_EXTERN_INLINE
+BSFPRSelectorInstrumentor *SelectorInstrumentor(SEL selector,
+                                              BSFPRClassInstrumentor *instrumentor,
+                                              BOOL isClassSelector) {
+  BSFPRSelectorInstrumentor *selectorInstrumentor =
+      isClassSelector ? [instrumentor instrumentorForClassSelector:selector]
+                      : [instrumentor instrumentorForInstanceSelector:selector];
+  if (!selectorInstrumentor) {
+    ThrowExceptionBecauseSelectorNotFoundOnClass(selector, instrumentor.instrumentedClass);
+  }
+  return selectorInstrumentor;
+}

--- a/BugsnagRequestMonitor/Instrumentation/Network/BSFPRNetworkTrace.h
+++ b/BugsnagRequestMonitor/Instrumentation/Network/BSFPRNetworkTrace.h
@@ -1,0 +1,182 @@
+// Copyright 2020 Google LLC
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+#import "BSFPRTraceBackgroundActivityTracker.h"
+
+/** Possible checkpoint states of network trace */
+typedef NS_ENUM(NSInteger, BSFPRNetworkTraceCheckpointState) {
+  BSFPRNetworkTraceCheckpointStateUnknown,
+
+  // Network request has been initiated.
+  BSFPRNetworkTraceCheckpointStateInitiated,
+
+  // Network request is completed (All necessary uploads for the request is complete).
+  BSFPRNetworkTraceCheckpointStateRequestCompleted,
+
+  // Network request has received its first response. There could be more.
+  BSFPRNetworkTraceCheckpointStateResponseReceived,
+
+  // Network request has completed (Could be network error/request successful completion).
+  BSFPRNetworkTraceCheckpointStateResponseCompleted
+};
+
+@protocol BSFPRNetworkResponseHandler <NSObject>
+
+/**
+ * Records the size of the file that is uploaded during the request.
+ *
+ * @param URL The URL object that is being used for uploading from the network request.
+ */
+- (void)didUploadFileWithURL:(nullable NSURL *)URL;
+
+/**
+ * Records the amount of data that is fetched during the request. This can be called multiple times
+ * when the network delegate comes back with some data.
+ *
+ * @param data The data object as received from the network request.
+ */
+- (void)didReceiveData:(nullable NSData *)data;
+
+/**
+ * Records the size of the file that is fetched during the request. This can be called multiple
+ * times when the network delegate comes back with some data.
+ *
+ * @param URL The URL object as received from the network request.
+ */
+- (void)didReceiveFileURL:(nullable NSURL *)URL;
+
+/**
+ * Records the end state of the network request. This is usually called at the end of the network
+ * request with a valid response or an error.
+ *
+ * @param response Response of the network request.
+ * @param error Error with the network request.
+ */
+- (void)didCompleteRequestWithResponse:(nullable NSURLResponse *)response
+                                 error:(nullable NSError *)error;
+
+@end
+
+
+@class BSFPRNetworkTrace;
+typedef void (^NetworkTraceCallback)(BSFPRNetworkTrace *_Nonnull);
+
+/**
+ * BSFPRNetworkTrace object contains information about an NSURLRequest. Every object contains
+ * information about the URL, type of request, and details of the response.
+ */
+@interface BSFPRNetworkTrace : NSObject <BSFPRNetworkResponseHandler>
+
+/** @brief Start time of the trace since epoch. */
+@property(nonatomic, assign, readonly) NSTimeInterval startTimeSinceEpoch;
+
+/** @brief The size of the request. The value is in bytes. */
+@property(nonatomic) int64_t requestSize;
+
+/** @brief The response size for the request. The value is in bytes. */
+@property(nonatomic) int64_t responseSize;
+
+/** @brief The HTTP response code for the request. */
+@property(nonatomic) int32_t responseCode;
+
+/** @brief Yes if a valid response code is set, NO otherwise. */
+@property(nonatomic) BOOL hasValidResponseCode;
+
+/** @brief The content type of the request as received from the server. */
+@property(nonatomic, copy, nullable) NSString *responseContentType;
+
+/** @brief The checkpoint states for the request. The key to the dictionary is the value referred in
+ * enum BSFPRNetworkTraceCheckpointState mentioned above. The value is the number of seconds since the
+ * reference date.
+ */
+@property(nonatomic, readonly, nullable) NSDictionary<NSString *, NSNumber *> *checkpointStates;
+
+/** @brief The network request object. */
+@property(nonatomic, readonly, nullable) NSURLRequest *URLRequest;
+
+/** @brief The URL string with all the query params cleaned. The URL string will be of the format:
+ *  scheme:[//[user:password@]host[:port]][/]path.
+ */
+@property(nonatomic, readonly, nullable) NSString *trimmedURLString;
+
+/** @brief Error object received with the network response. */
+@property(nonatomic, readonly, nullable) NSError *responseError;
+
+/** Background state of the trace. */
+@property(nonatomic, readonly) BSFPRTraceState backgroundTraceState;
+
+/**
+ * Associate a network trace to an object project. This uses ObjC runtime to associate the network
+ * trace with the object provided.
+ *
+ * @param networkTrace Network trace object to be associated with the provided object.
+ * @param object The provided object to whom the network trace object will be associated with.
+ */
++ (void)addNetworkTrace:(nonnull BSFPRNetworkTrace *)networkTrace toObject:(nonnull id)object;
+
+/**
+ * Gets the network trace associated with the provided object. If the network trace is not
+ * associated with the object, return nil. This uses ObjC runtime to fetch the object.
+ *
+ * @param object The provided object from which the network object would be fetched.
+ * @return The network trace object associated with the provided object.
+ */
++ (nullable BSFPRNetworkTrace *)networkTraceFromObject:(nonnull id)object;
+
+/**
+ * Remove the network trace associated with the provided object. If the network trace is not
+ * associated with the object, does nothing. This uses ObjC runtime to remove the object.
+ *
+ * @param object The provided object from which the network object would be removed.
+ */
++ (void)removeNetworkTraceFromObject:(nonnull id)object;
+
+/**
+ * Creates an instance of the BSFPRNetworkTrace with the provided URL and the HTTP method.
+ *
+ * @param URLRequest NSURLRequest object.
+ * @return An instance of BSFPRNetworkTrace.
+ */
+- (nullable instancetype)initWithURLRequest:(nonnull NSURLRequest *)URLRequest completionCallback:(NetworkTraceCallback _Nonnull )onRequestCompleted
+    NS_DESIGNATED_INITIALIZER;
+
+- (nullable instancetype)init NS_UNAVAILABLE;
+
+/**
+ * Records the begining of the network request. This is usually called just before initiating the
+ * request.
+ */
+- (void)start;
+
+/**
+ * Checkpoints a particular state of the network request. Checkpoint states are listed in the enum
+ * BSFPRNetworkTraceCheckpointState mentioned above.
+ *
+ * @param state A state as mentioned in enum BSFPRNetworkTraceCheckpointState.
+ */
+- (void)checkpointState:(BSFPRNetworkTraceCheckpointState)state;
+
+/**
+ * Provides the time difference between the provided checkpoint states in seconds. If the starting
+ * checkpoint state is greater than the ending checkpoint state, the return value will be negative.
+ * If either of the states does not exist, returns 0.
+ *
+ * @param startState The starting checkpoint state.
+ * @param endState The ending checkpoint state.
+ * @return Difference between the ending checkpoint state and starting checkpoint state in seconds.
+ */
+- (NSTimeInterval)timeIntervalBetweenCheckpointState:(BSFPRNetworkTraceCheckpointState)startState
+                                            andState:(BSFPRNetworkTraceCheckpointState)endState;
+
+@end

--- a/BugsnagRequestMonitor/Instrumentation/Network/BSFPRNetworkTrace.m
+++ b/BugsnagRequestMonitor/Instrumentation/Network/BSFPRNetworkTrace.m
@@ -1,0 +1,306 @@
+// Copyright 2020 Google LLC
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+#import "BSFPRNetworkTrace.h"
+
+#import "BSFPRConsoleLogger.h"
+#import "BSFPRDataUtils.h"
+
+#import "BSGULObjectSwizzler.h"
+
+NSString *const kBSFPRNetworkTracePropertyName = @"fpr_networkTrace";
+
+@interface BSFPRNetworkTrace ()
+
+@property(nonatomic, readwrite) NetworkTraceCallback onRequestCompleted;
+
+/** Serial queue to manage concurrency. */
+@property(nonatomic, readwrite, nonnull) dispatch_queue_t syncQueue;
+
+@property(nonatomic, readwrite) NSURLRequest *URLRequest;
+
+@property(nonatomic, readwrite, nullable) NSError *responseError;
+
+/** State to know if the trace has started. */
+@property(nonatomic) BOOL traceStarted;
+
+/** State to know if the trace has completed. */
+@property(nonatomic) BOOL traceCompleted;
+
+/** Background activity tracker to know the background state of the trace. */
+@property(nonatomic) BSFPRTraceBackgroundActivityTracker *backgroundActivityTracker;
+
+/** Custom attribute managed internally. */
+@property(nonatomic) NSMutableDictionary<NSString *, NSString *> *customAttributes;
+
+@end
+
+@implementation BSFPRNetworkTrace {
+  /**
+   * @brief Object containing different states of the network request. Stores the information about
+   * the state of a network request (defined in BSFPRNetworkTraceCheckpointState) and the time at
+   * which the event happened.
+   */
+  NSMutableDictionary<NSString *, NSNumber *> *_states;
+}
+
+- (nullable instancetype)initWithURLRequest:(NSURLRequest *)URLRequest completionCallback:(NetworkTraceCallback _Nonnull )onRequestCompleted{
+  if (URLRequest.URL == nil) {
+    BSFPRLogError(kBSFPRNetworkTraceInvalidInputs, @"Invalid URL. URL is nil.");
+    return nil;
+  }
+
+  NSString *trimmedURLString = [BSFPRNetworkTrace stringByTrimmingURLString:URLRequest];
+  if (!trimmedURLString || trimmedURLString.length <= 0) {
+    BSFPRLogInfo(kBSFPRNetworkTraceURLLengthExceeds, @"URL length outside limits, returning nil.");
+    return nil;
+  }
+
+  if (![URLRequest.URL.absoluteString isEqualToString:trimmedURLString]) {
+    BSFPRLogInfo(kBSFPRNetworkTraceURLLengthTruncation,
+               @"URL length exceeds limits, truncating recorded URL - %@.", trimmedURLString);
+  }
+
+  self = [super init];
+  if (self) {
+    _onRequestCompleted = onRequestCompleted;
+    _URLRequest = URLRequest;
+    _trimmedURLString = trimmedURLString;
+    _states = [[NSMutableDictionary<NSString *, NSNumber *> alloc] init];
+    _hasValidResponseCode = NO;
+    _customAttributes = [[NSMutableDictionary<NSString *, NSString *> alloc] init];
+    _syncQueue =
+        dispatch_queue_create("com.bugsnag.perf.networkTrace.metric", DISPATCH_QUEUE_SERIAL);
+    if (![BSFPRNetworkTrace isCompleteAndValidTrimmedURLString:_trimmedURLString
+                                                  URLRequest:_URLRequest]) {
+      return nil;
+    };
+  }
+  return self;
+}
+
+- (instancetype)init {
+  NSAssert(NO, @"Not a designated initializer.");
+  return nil;
+}
+
+- (NSString *)description {
+    return [NSString stringWithFormat:@"{ Request: %@ (length %lld), Response: %d (length %lld)",
+          _URLRequest, _requestSize, _responseCode, _responseSize];
+}
+
+- (NSDictionary<NSString *, NSNumber *> *)checkpointStates {
+  __block NSDictionary<NSString *, NSNumber *> *copiedStates;
+  dispatch_sync(self.syncQueue, ^{
+    copiedStates = [_states copy];
+  });
+  return copiedStates;
+}
+
+- (void)checkpointState:(BSFPRNetworkTraceCheckpointState)state {
+  if (!self.traceCompleted && self.traceStarted) {
+    NSString *stateKey = @(state).stringValue;
+    if (stateKey) {
+      dispatch_sync(self.syncQueue, ^{
+        NSNumber *existingState = _states[stateKey];
+
+        if (existingState == nil) {
+          double intervalSinceEpoch = [[NSDate date] timeIntervalSince1970];
+          [_states setObject:@(intervalSinceEpoch) forKey:stateKey];
+        }
+      });
+    } else {
+      NSAssert(NO, @"stateKey wasn't created for checkpoint state %ld", (long)state);
+    }
+  }
+}
+
+- (void)start {
+  if (!self.traceCompleted) {
+    self.traceStarted = YES;
+    self.backgroundActivityTracker = [[BSFPRTraceBackgroundActivityTracker alloc] init];
+    [self checkpointState:BSFPRNetworkTraceCheckpointStateInitiated];
+  }
+}
+
+- (BSFPRTraceState)backgroundTraceState {
+  BSFPRTraceBackgroundActivityTracker *backgroundActivityTracker = self.backgroundActivityTracker;
+  if (backgroundActivityTracker) {
+    return backgroundActivityTracker.traceBackgroundState;
+  }
+
+  return BSFPRTraceStateUnknown;
+}
+
+- (NSTimeInterval)startTimeSinceEpoch {
+  NSString *stateKey =
+      [NSString stringWithFormat:@"%lu", (unsigned long)BSFPRNetworkTraceCheckpointStateInitiated];
+  __block NSTimeInterval timeSinceEpoch;
+  dispatch_sync(self.syncQueue, ^{
+    timeSinceEpoch = [[_states objectForKey:stateKey] doubleValue];
+  });
+  return timeSinceEpoch;
+}
+
+#pragma mark - Overrides
+
+- (void)setResponseCode:(int32_t)responseCode {
+  _responseCode = responseCode;
+  if (responseCode != 0) {
+    _hasValidResponseCode = YES;
+  }
+}
+
+#pragma mark - BSFPRNetworkResponseHandler methods
+
+- (void)didCompleteRequestWithResponse:(NSURLResponse *)response error:(NSError *)error {
+  if (!self.traceCompleted && self.traceStarted) {
+    // Extract needed fields for the trace object.
+    if ([response isKindOfClass:[NSHTTPURLResponse class]]) {
+      NSHTTPURLResponse *HTTPResponse = (NSHTTPURLResponse *)response;
+      self.responseCode = (int32_t)HTTPResponse.statusCode;
+    }
+    self.responseError = error;
+    self.responseContentType = response.MIMEType;
+    [self checkpointState:BSFPRNetworkTraceCheckpointStateResponseCompleted];
+
+    self.traceCompleted = YES;
+    self.onRequestCompleted(self);
+  }
+}
+
+- (void)didUploadFileWithURL:(NSURL *)URL {
+  NSNumber *value = nil;
+  NSError *error = nil;
+
+  if ([URL getResourceValue:&value forKey:NSURLFileSizeKey error:&error]) {
+    if (error) {
+      BSFPRLogNotice(kBSFPRNetworkTraceFileError, @"Unable to determine the size of file.");
+    } else {
+      self.requestSize = value.unsignedIntegerValue;
+    }
+  }
+}
+
+- (void)didReceiveData:(NSData *)data {
+  self.responseSize = data.length;
+}
+
+- (void)didReceiveFileURL:(NSURL *)URL {
+  NSNumber *value = nil;
+  NSError *error = nil;
+
+  if ([URL getResourceValue:&value forKey:NSURLFileSizeKey error:&error]) {
+    if (error) {
+      BSFPRLogNotice(kBSFPRNetworkTraceFileError, @"Unable to determine the size of file.");
+    } else {
+      self.responseSize = value.unsignedIntegerValue;
+    }
+  }
+}
+
+- (NSTimeInterval)timeIntervalBetweenCheckpointState:(BSFPRNetworkTraceCheckpointState)startState
+                                            andState:(BSFPRNetworkTraceCheckpointState)endState {
+  __block NSNumber *startStateTime;
+  __block NSNumber *endStateTime;
+  dispatch_sync(self.syncQueue, ^{
+    startStateTime = [_states objectForKey:[@(startState) stringValue]];
+    endStateTime = [_states objectForKey:[@(endState) stringValue]];
+  });
+  // Fail fast. If any of the times do not exist, return 0.
+  if (startStateTime == nil || endStateTime == nil) {
+    return 0;
+  }
+
+  NSTimeInterval timeDiff = (endStateTime.doubleValue - startStateTime.doubleValue);
+  return timeDiff;
+}
+
+/** Trims and validates the URL string of a given NSURLRequest.
+ *
+ *  @param URLRequest The NSURLRequest containing the URL string to trim.
+ *  @return The trimmed string.
+ */
++ (NSString *)stringByTrimmingURLString:(NSURLRequest *)URLRequest {
+  NSURLComponents *components = [NSURLComponents componentsWithURL:URLRequest.URL
+                                           resolvingAgainstBaseURL:NO];
+  components.query = nil;
+  components.fragment = nil;
+  components.user = nil;
+  components.password = nil;
+  NSURL *trimmedURL = [components URL];
+  NSString *truncatedURLString = BSFPRTruncatedURLString(trimmedURL.absoluteString);
+
+  NSURL *truncatedURL = [NSURL URLWithString:truncatedURLString];
+  if (!truncatedURL || truncatedURL.host == nil) {
+    return nil;
+  }
+  return truncatedURLString;
+}
+
+/** Validates the trace object by checking that it's http or https, and not a denied URL.
+ *
+ *  @param trimmedURLString A trimmed URL string from the URLRequest.
+ *  @param URLRequest The NSURLRequest that this trace will operate on.
+ *  @return YES if the trace object is valid, NO otherwise.
+ */
++ (BOOL)isCompleteAndValidTrimmedURLString:(NSString *)trimmedURLString
+                                URLRequest:(NSURLRequest *)URLRequest {
+  // Check the URL begins with http or https.
+  NSURLComponents *components = [NSURLComponents componentsWithURL:URLRequest.URL
+                                           resolvingAgainstBaseURL:NO];
+  NSString *scheme = components.scheme;
+  if (!scheme || !([scheme caseInsensitiveCompare:@"HTTP"] == NSOrderedSame ||
+                   [scheme caseInsensitiveCompare:@"HTTPS"] == NSOrderedSame)) {
+    BSFPRLogError(kBSFPRNetworkTraceInvalidInputs, @"Invalid URL - %@, returning nil.", URLRequest.URL);
+    return NO;
+  }
+
+  return YES;
+}
+
+#pragma mark - Class methods related to object association.
+
++ (void)addNetworkTrace:(BSFPRNetworkTrace *)networkTrace toObject:(id)object {
+  if (object != nil && networkTrace != nil) {
+    [BSGULObjectSwizzler setAssociatedObject:object
+                                       key:kBSFPRNetworkTracePropertyName
+                                     value:networkTrace
+                               association:BSGUL_ASSOCIATION_RETAIN_NONATOMIC];
+  }
+}
+
++ (BSFPRNetworkTrace *)networkTraceFromObject:(id)object {
+  BSFPRNetworkTrace *networkTrace = nil;
+  if (object != nil) {
+    id traceObject = [BSGULObjectSwizzler getAssociatedObject:object
+                                                        key:kBSFPRNetworkTracePropertyName];
+    if ([traceObject isKindOfClass:[BSFPRNetworkTrace class]]) {
+      networkTrace = (BSFPRNetworkTrace *)traceObject;
+    }
+  }
+
+  return networkTrace;
+}
+
++ (void)removeNetworkTraceFromObject:(id)object {
+  if (object != nil) {
+    [BSGULObjectSwizzler setAssociatedObject:object
+                                       key:kBSFPRNetworkTracePropertyName
+                                     value:nil
+                               association:BSGUL_ASSOCIATION_RETAIN_NONATOMIC];
+  }
+}
+
+@end

--- a/BugsnagRequestMonitor/Instrumentation/Network/Delegates/BSFPRNSURLSessionDelegate.h
+++ b/BugsnagRequestMonitor/Instrumentation/Network/Delegates/BSFPRNSURLSessionDelegate.h
@@ -1,0 +1,26 @@
+// Copyright 2020 Google LLC
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+#import <Foundation/Foundation.h>
+
+/** This class exists as a supplier of implementations for delegates that do not implement all
+ *  methods. While swizzling a delegate, if their class doesn't implement the below methods, these
+ *  implementations will be copied onto the delegate class.
+ */
+@interface BSFPRNSURLSessionDelegate : NSObject <NSURLSessionDelegate,
+                                               NSURLSessionDataDelegate,
+                                               NSURLSessionTaskDelegate,
+                                               NSURLSessionDownloadDelegate>
+
+@end

--- a/BugsnagRequestMonitor/Instrumentation/Network/Delegates/BSFPRNSURLSessionDelegate.m
+++ b/BugsnagRequestMonitor/Instrumentation/Network/Delegates/BSFPRNSURLSessionDelegate.m
@@ -1,0 +1,88 @@
+// Copyright 2020 Google LLC
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+#import "BSFPRNSURLSessionDelegate.h"
+
+#import "BSFPRConsoleLogger.h"
+#import "BSFPRNetworkTrace.h"
+
+@implementation BSFPRNSURLSessionDelegate
+
+- (void)URLSession:(NSURLSession *)session
+                    task:(NSURLSessionTask *)task
+    didCompleteWithError:(NSError *)error {
+  @try {
+    BSFPRNetworkTrace *trace = [BSFPRNetworkTrace networkTraceFromObject:task];
+    [trace didCompleteRequestWithResponse:task.response error:error];
+    [BSFPRNetworkTrace removeNetworkTraceFromObject:task];
+  } @catch (NSException *exception) {
+    BSFPRLogInfo(kBSFPRNetworkTraceNotTrackable, @"Unable to track network request.");
+  }
+}
+
+- (void)URLSession:(NSURLSession *)session
+                        task:(NSURLSessionTask *)task
+             didSendBodyData:(int64_t)bytesSent
+              totalBytesSent:(int64_t)totalBytesSent
+    totalBytesExpectedToSend:(int64_t)totalBytesExpectedToSend {
+  @try {
+    BSFPRNetworkTrace *trace = [BSFPRNetworkTrace networkTraceFromObject:task];
+    trace.requestSize = totalBytesSent;
+    if (totalBytesSent >= totalBytesExpectedToSend) {
+      if ([task.response isKindOfClass:[NSHTTPURLResponse class]]) {
+        NSHTTPURLResponse *response = (NSHTTPURLResponse *)task.response;
+        [trace didCompleteRequestWithResponse:response error:task.error];
+        [BSFPRNetworkTrace removeNetworkTraceFromObject:task];
+      }
+    }
+  } @catch (NSException *exception) {
+    BSFPRLogInfo(kBSFPRNetworkTraceNotTrackable, @"Unable to track network request.");
+  }
+}
+
+- (void)URLSession:(NSURLSession *)session
+          dataTask:(NSURLSessionDataTask *)dataTask
+    didReceiveData:(NSData *)data {
+  BSFPRNetworkTrace *trace = [BSFPRNetworkTrace networkTraceFromObject:dataTask];
+  [trace didReceiveData:data];
+  [trace checkpointState:BSFPRNetworkTraceCheckpointStateResponseReceived];
+}
+
+- (void)URLSession:(NSURLSession *)session
+                 downloadTask:(NSURLSessionDownloadTask *)downloadTask
+    didFinishDownloadingToURL:(NSURL *)location {
+  BSFPRNetworkTrace *trace = [BSFPRNetworkTrace networkTraceFromObject:downloadTask];
+  [trace didReceiveFileURL:location];
+  [trace didCompleteRequestWithResponse:downloadTask.response error:downloadTask.error];
+  [BSFPRNetworkTrace removeNetworkTraceFromObject:downloadTask];
+}
+
+- (void)URLSession:(NSURLSession *)session
+                 downloadTask:(NSURLSessionDownloadTask *)downloadTask
+                 didWriteData:(int64_t)bytesWritten
+            totalBytesWritten:(int64_t)totalBytesWritten
+    totalBytesExpectedToWrite:(int64_t)totalBytesExpectedToWrite {
+  BSFPRNetworkTrace *trace = [BSFPRNetworkTrace networkTraceFromObject:downloadTask];
+  [trace checkpointState:BSFPRNetworkTraceCheckpointStateResponseReceived];
+  trace.responseSize = totalBytesWritten;
+  if (totalBytesWritten >= totalBytesExpectedToWrite) {
+    if ([downloadTask.response isKindOfClass:[NSHTTPURLResponse class]]) {
+      NSHTTPURLResponse *response = (NSHTTPURLResponse *)downloadTask.response;
+      [trace didCompleteRequestWithResponse:response error:downloadTask.error];
+      [BSFPRNetworkTrace removeNetworkTraceFromObject:downloadTask];
+    }
+  }
+}
+
+@end

--- a/BugsnagRequestMonitor/Instrumentation/Network/Delegates/BSFPRNSURLSessionDelegateInstrument.h
+++ b/BugsnagRequestMonitor/Instrumentation/Network/Delegates/BSFPRNSURLSessionDelegateInstrument.h
@@ -1,0 +1,35 @@
+// Copyright 2020 Google LLC
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+#import "BSFPRInstrument.h"
+
+#import "BSFPRObjectInstrumentor.h"
+
+NS_ASSUME_NONNULL_BEGIN
+
+/** This class instruments the delegate methods needed to start/stop traces correctly. This class is
+ *  not intended to be used standalone--it should only be used by BSFPRNSURLSessionInstrument.
+ */
+@interface BSFPRNSURLSessionDelegateInstrument : BSFPRInstrument <BSFPRObjectInstrumentorProtocol>
+
+/** Registers an instrumentor for a delegate class if it hasn't yet been instrumented.
+ *
+ *  @note This method is thread-safe.
+ *  @param aClass The class to instrument.
+ */
+- (void)registerClass:(Class)aClass;
+
+@end
+
+NS_ASSUME_NONNULL_END

--- a/BugsnagRequestMonitor/Instrumentation/Network/Delegates/BSFPRNSURLSessionDelegateInstrument.m
+++ b/BugsnagRequestMonitor/Instrumentation/Network/Delegates/BSFPRNSURLSessionDelegateInstrument.m
@@ -1,0 +1,264 @@
+// Copyright 2020 Google LLC
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+#import "BSFPRNSURLSessionDelegateInstrument.h"
+
+#import "BSFPRConsoleLogger.h"
+#import "BSFPRClassInstrumentor.h"
+#import "BSFPRInstrument_Private.h"
+#import "BSFPRNetworkTrace.h"
+#import "BSFPRSelectorInstrumentor.h"
+#import "BSFPRNSURLSessionDelegate.h"
+#import "BSFPRNetworkInstrumentHelpers.h"
+
+/** Returns the dispatch queue for all instrumentation to occur on. */
+static dispatch_queue_t GetInstrumentationQueue() {
+  static dispatch_queue_t queue;
+  static dispatch_once_t token;
+  dispatch_once(&token, ^{
+    queue = dispatch_queue_create("com.bugsnag.BSFPRNSURLSessionDelegateInstrument",
+                                  DISPATCH_QUEUE_SERIAL);
+  });
+  return queue;
+}
+
+#pragma mark - NSURLSessionTaskDelegate methods
+
+/** Instruments URLSession:task:didCompleteWithError:.
+ *
+ *  @param instrumentor The BSFPRClassInstrumentor to add the selector instrumentor to.
+ */
+FOUNDATION_STATIC_INLINE
+void InstrumentURLSessionTaskDidCompleteWithError(BSFPRClassInstrumentor *instrumentor) {
+  SEL selector = @selector(URLSession:task:didCompleteWithError:);
+  BSFPRSelectorInstrumentor *selectorInstrumentor =
+      [instrumentor instrumentorForInstanceSelector:selector];
+  if (selectorInstrumentor) {
+    IMP currentIMP = selectorInstrumentor.currentIMP;
+    [selectorInstrumentor setReplacingBlock:^(id object, NSURLSession *session,
+                                              NSURLSessionTask *task, NSError *error) {
+      @try {
+        BSFPRNetworkTrace *trace = [BSFPRNetworkTrace networkTraceFromObject:task];
+        [trace didCompleteRequestWithResponse:task.response error:error];
+        [BSFPRNetworkTrace removeNetworkTraceFromObject:task];
+      } @catch (NSException *exception) {
+        BSFPRLogInfo(kBSFPRNetworkTraceNotTrackable, @"Unable to track network request.");
+      } @finally {
+        typedef void (*OriginalImp)(id, SEL, NSURLSession *, NSURLSessionTask *, NSError *);
+        ((OriginalImp)currentIMP)(object, selector, session, task, error);
+      }
+    }];
+  }
+}
+
+/** Instruments URLSession:task:didSendBodyData:totalBytesSent:totalBytesExpectedToSend:.
+ *
+ *  @param instrumentor The BSFPRClassInstrumentor to add the selector instrumentor to.
+ */
+FOUNDATION_STATIC_INLINE
+void InstrumentURLSessionTaskDidSendBodyDataTotalBytesSentTotalBytesExpectedToSend(
+    BSFPRClassInstrumentor *instrumentor) {
+  SEL selector = @selector(URLSession:
+                                 task:didSendBodyData:totalBytesSent:totalBytesExpectedToSend:);
+  BSFPRSelectorInstrumentor *selectorInstrumentor =
+      [instrumentor instrumentorForInstanceSelector:selector];
+  if (selectorInstrumentor) {
+    IMP currentIMP = selectorInstrumentor.currentIMP;
+    [selectorInstrumentor
+        setReplacingBlock:^(id object, NSURLSession *session, NSURLSessionTask *task,
+                            int64_t bytesSent, int64_t totalBytesSent,
+                            int64_t totalBytesExpectedToSend) {
+          @try {
+            BSFPRNetworkTrace *trace = [BSFPRNetworkTrace networkTraceFromObject:task];
+            trace.requestSize = totalBytesSent;
+            if (totalBytesSent >= totalBytesExpectedToSend) {
+              if ([task.response isKindOfClass:[NSHTTPURLResponse class]]) {
+                NSHTTPURLResponse *response = (NSHTTPURLResponse *)task.response;
+                [trace didCompleteRequestWithResponse:response error:task.error];
+                [BSFPRNetworkTrace removeNetworkTraceFromObject:task];
+              }
+            }
+          } @catch (NSException *exception) {
+            BSFPRLogInfo(kBSFPRNetworkTraceNotTrackable, @"Unable to track network request.");
+          } @finally {
+            typedef void (*OriginalImp)(id, SEL, NSURLSession *, NSURLSessionTask *, int64_t,
+                                        int64_t, int64_t);
+            ((OriginalImp)currentIMP)(object, selector, session, task, bytesSent, totalBytesSent,
+                                      totalBytesExpectedToSend);
+          }
+        }];
+  }
+}
+
+#pragma mark - NSURLSessionDataDelegate methods
+
+/** Instruments URLSession:dataTask:didReceiveData:.
+ *
+ *  @param instrumentor The BSFPRClassInstrumentor to add the selector instrumentor to.
+ */
+FOUNDATION_STATIC_INLINE
+void InstrumentURLSessionDataTaskDidReceiveData(BSFPRClassInstrumentor *instrumentor) {
+  SEL selector = @selector(URLSession:dataTask:didReceiveData:);
+  BSFPRSelectorInstrumentor *selectorInstrumentor =
+      [instrumentor instrumentorForInstanceSelector:selector];
+  if (selectorInstrumentor) {
+    IMP currentIMP = selectorInstrumentor.currentIMP;
+    [selectorInstrumentor setReplacingBlock:^(id object, NSURLSession *session,
+                                              NSURLSessionDataTask *dataTask, NSData *data) {
+      BSFPRNetworkTrace *trace = [BSFPRNetworkTrace networkTraceFromObject:dataTask];
+      [trace didReceiveData:data];
+      [trace checkpointState:BSFPRNetworkTraceCheckpointStateResponseReceived];
+      typedef void (*OriginalImp)(id, SEL, NSURLSession *, NSURLSessionDataTask *, NSData *);
+      ((OriginalImp)currentIMP)(object, selector, session, dataTask, data);
+    }];
+  }
+}
+
+#pragma mark - NSURLSessionDownloadDelegate methods.
+
+/** Instruments URLSession:downloadTask:didFinishDownloadingToURL:.
+ *
+ *  @param instrumentor The BSFPRClassInstrumentor to add the selector instrumentor to.
+ */
+FOUNDATION_STATIC_INLINE
+void InstrumentURLSessionDownloadTaskDidFinishDownloadToURL(BSFPRClassInstrumentor *instrumentor) {
+  SEL selector = @selector(URLSession:downloadTask:didFinishDownloadingToURL:);
+  BSFPRSelectorInstrumentor *selectorInstrumentor =
+      [instrumentor instrumentorForInstanceSelector:selector];
+  if (selectorInstrumentor) {
+    IMP currentIMP = selectorInstrumentor.currentIMP;
+    [selectorInstrumentor
+        setReplacingBlock:^(id object, NSURLSession *session,
+                            NSURLSessionDownloadTask *downloadTask, NSURL *location) {
+          BSFPRNetworkTrace *trace = [BSFPRNetworkTrace networkTraceFromObject:downloadTask];
+          [trace didReceiveFileURL:location];
+          [trace didCompleteRequestWithResponse:downloadTask.response error:downloadTask.error];
+          [BSFPRNetworkTrace removeNetworkTraceFromObject:downloadTask];
+          typedef void (*OriginalImp)(id, SEL, NSURLSession *, NSURLSessionDownloadTask *, NSURL *);
+          ((OriginalImp)currentIMP)(object, selector, session, downloadTask, location);
+        }];
+  }
+}
+
+/** Instruments URLSession:downloadTask:didWriteData:totalBytesWritten:totalBytesExpectedToWrite:.
+ *
+ *  @param instrumentor The BSFPRClassInstrumentor to add the selector instrumentor to.
+ */
+FOUNDATION_STATIC_INLINE
+void InstrumentURLSessionDownloadTaskDidWriteDataTotalBytesWrittenTotalBytesExpectedToWrite(
+    BSFPRClassInstrumentor *instrumentor) {
+  SEL selector = @selector(URLSession:
+                         downloadTask:didWriteData:totalBytesWritten:totalBytesExpectedToWrite:);
+  BSFPRSelectorInstrumentor *selectorInstrumentor =
+      [instrumentor instrumentorForInstanceSelector:selector];
+  if (selectorInstrumentor) {
+    IMP currentIMP = selectorInstrumentor.currentIMP;
+    [selectorInstrumentor
+        setReplacingBlock:^(id object, NSURLSession *session,
+                            NSURLSessionDownloadTask *downloadTask, int64_t bytesWritten,
+                            int64_t totalBytesWritten, int64_t totalBytesExpectedToWrite) {
+          BSFPRNetworkTrace *trace = [BSFPRNetworkTrace networkTraceFromObject:downloadTask];
+          [trace checkpointState:BSFPRNetworkTraceCheckpointStateResponseReceived];
+          trace.responseSize = totalBytesWritten;
+          if (totalBytesWritten >= totalBytesExpectedToWrite) {
+            if ([downloadTask.response isKindOfClass:[NSHTTPURLResponse class]]) {
+              NSHTTPURLResponse *response = (NSHTTPURLResponse *)downloadTask.response;
+              [trace didCompleteRequestWithResponse:response error:downloadTask.error];
+              [BSFPRNetworkTrace removeNetworkTraceFromObject:downloadTask];
+            }
+          }
+          typedef void (*OriginalImp)(id, SEL, NSURLSession *, NSURLSessionDownloadTask *, int64_t,
+                                      int64_t, int64_t);
+          ((OriginalImp)currentIMP)(object, selector, session, downloadTask, bytesWritten,
+                                    totalBytesWritten, totalBytesExpectedToWrite);
+        }];
+  }
+}
+
+#pragma mark - Helper functions
+
+FOUNDATION_STATIC_INLINE
+void CopySelector(SEL selector, BSFPRObjectInstrumentor *instrumentor) {
+  static Class fromClass = Nil;
+  static dispatch_once_t onceToken;
+  dispatch_once(&onceToken, ^{
+    fromClass = [BSFPRNSURLSessionDelegate class];
+  });
+  if (![instrumentor.instrumentedObject respondsToSelector:selector]) {
+    [instrumentor copySelector:selector fromClass:fromClass isClassSelector:NO];
+  }
+}
+
+#pragma mark - BSFPRNSURLSessionDelegateInstrument
+
+@implementation BSFPRNSURLSessionDelegateInstrument
+
+- (void)registerInstrumentors {
+  // Do nothing by default; classes will be instrumented on-demand upon discovery.
+}
+
+- (void)registerClass:(Class)aClass {
+  dispatch_sync(GetInstrumentationQueue(), ^{
+    // If this class has already been instrumented, just return.
+    BSFPRClassInstrumentor *instrumentor = [[BSFPRClassInstrumentor alloc] initWithClass:aClass];
+    if (![self registerClassInstrumentor:instrumentor]) {
+      return;
+    }
+
+    // NSURLSessionTaskDelegate methods.
+    InstrumentURLSessionTaskDidCompleteWithError(instrumentor);
+    InstrumentURLSessionTaskDidSendBodyDataTotalBytesSentTotalBytesExpectedToSend(instrumentor);
+
+    // NSURLSessionDataDelegate methods.
+    InstrumentURLSessionDataTaskDidReceiveData(instrumentor);
+
+    // NSURLSessionDownloadDelegate methods.
+    InstrumentURLSessionDownloadTaskDidFinishDownloadToURL(instrumentor);
+    InstrumentURLSessionDownloadTaskDidWriteDataTotalBytesWrittenTotalBytesExpectedToWrite(
+        instrumentor);
+
+    [instrumentor swizzle];
+  });
+}
+
+- (void)registerObject:(id)object {
+  dispatch_sync(GetInstrumentationQueue(), ^{
+    if ([object respondsToSelector:@selector(gul_class)]) {
+      return;
+    }
+    BSFPRObjectInstrumentor *instrumentor = [[BSFPRObjectInstrumentor alloc] initWithObject:object];
+
+    // Register the non-swizzled versions of these methods.
+    // NSURLSessionTaskDelegate methods.
+    CopySelector(@selector(URLSession:task:didCompleteWithError:), instrumentor);
+    CopySelector(@selector(URLSession:
+                                 task:didSendBodyData:totalBytesSent:totalBytesExpectedToSend:),
+                 instrumentor);
+
+    // NSURLSessionDataDelegate methods.
+    CopySelector(@selector(URLSession:dataTask:didReceiveData:), instrumentor);
+
+    // NSURLSessionDownloadDelegate methods.
+    CopySelector(@selector(URLSession:downloadTask:didFinishDownloadingToURL:), instrumentor);
+    CopySelector(@selector(URLSession:downloadTask:didResumeAtOffset:expectedTotalBytes:),
+                 instrumentor);
+    CopySelector(@selector(URLSession:
+                         downloadTask:didWriteData:totalBytesWritten:totalBytesExpectedToWrite:),
+                 instrumentor);
+
+    [instrumentor swizzle];
+  });
+}
+
+@end

--- a/BugsnagRequestMonitor/Swizzle/BSGULObjectSwizzler+Internal.h
+++ b/BugsnagRequestMonitor/Swizzle/BSGULObjectSwizzler+Internal.h
@@ -1,0 +1,23 @@
+// Copyright 2019 Google LLC
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+#import "BSGULObjectSwizzler.h"
+
+FOUNDATION_EXPORT NSString *kBSGULSwizzlerAssociatedObjectKey;
+
+@interface BSGULObjectSwizzler (Internal)
+
+- (void)swizzledObjectHasBeenDeallocatedWithGeneratedSubclass:(BOOL)isInstanceOfGeneratedSubclass;
+
+@end

--- a/BugsnagRequestMonitor/Swizzle/BSGULObjectSwizzler.h
+++ b/BugsnagRequestMonitor/Swizzle/BSGULObjectSwizzler.h
@@ -1,0 +1,123 @@
+/*
+ * Copyright 2018 Google LLC
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+#import <Foundation/Foundation.h>
+
+NS_ASSUME_NONNULL_BEGIN
+
+/** Enums that map to their OBJC-prefixed counterparts. */
+typedef OBJC_ENUM(uintptr_t, BSGUL_ASSOCIATION){
+
+    // Is a weak association.
+    BSGUL_ASSOCIATION_ASSIGN,
+
+    // Is a nonatomic strong association.
+    BSGUL_ASSOCIATION_RETAIN_NONATOMIC,
+
+    // Is a nonatomic copy association.
+    BSGUL_ASSOCIATION_COPY_NONATOMIC,
+
+    // Is an atomic strong association.
+    BSGUL_ASSOCIATION_RETAIN,
+
+    // Is an atomic copy association.
+    BSGUL_ASSOCIATION_COPY};
+
+/** This class handles swizzling a specific instance of a class by generating a
+ *  dynamic subclass and installing selectors and properties onto the dynamic
+ *  subclass. Then, the instance's class is set to the dynamic subclass. There
+ *  should be a 1:1 ratio of object swizzlers to swizzled instances.
+ */
+@interface BSGULObjectSwizzler : NSObject
+
+/** The subclass that is generated. */
+@property(nullable, nonatomic, readonly) Class generatedClass;
+
+/** Sets an associated object in the runtime. This mechanism can be used to
+ *  simulate adding properties.
+ *
+ *  @param object The object that will be queried for the associated object.
+ *  @param key The key of the associated object.
+ *  @param value The value to associate to the swizzled object.
+ *  @param association The mechanism to use when associating the objects.
+ */
++ (void)setAssociatedObject:(id)object
+                        key:(NSString *)key
+                      value:(nullable id)value
+                association:(BSGUL_ASSOCIATION)association;
+
+/** Gets an associated object in the runtime. This mechanism can be used to
+ *  simulate adding properties.
+ *
+ *  @param object The object that will be queried for the associated object.
+ *  @param key The key of the associated object.
+ */
++ (nullable id)getAssociatedObject:(id)object key:(NSString *)key;
+
+/** Please use the designated initializer. */
+- (instancetype)init NS_UNAVAILABLE;
+
+/** Instantiates an object swizzler using an object it will operate on.
+ *  Generates a new class pair.
+ *
+ *  @note There is no need to store this object. After calling -swizzle, this
+ *  object can be found by calling -gul_objectSwizzler
+ *
+ *  @param object The object to be swizzled.
+ *  @return An instance of this class.
+ */
+- (instancetype)initWithObject:(id)object NS_DESIGNATED_INITIALIZER;
+
+/** Sets an associated object in the runtime. This mechanism can be used to
+ *  simulate adding properties.
+ *
+ *  @param key The key of the associated object.
+ *  @param value The value to associate to the swizzled object.
+ *  @param association The mechanism to use when associating the objects.
+ */
+- (void)setAssociatedObjectWithKey:(NSString *)key
+                             value:(id)value
+                       association:(BSGUL_ASSOCIATION)association;
+
+/** Gets an associated object in the runtime. This mechanism can be used to
+ *  simulate adding properties.
+ *
+ *  @param key The key of the associated object.
+ */
+- (nullable id)getAssociatedObjectForKey:(NSString *)key;
+
+/** Copies a selector from an existing class onto the generated dynamic subclass
+ *  that this object will adopt. This mechanism can be used to add methods to
+ *  specific instances of a class.
+ *
+ *  @note Should not be called after calling -swizzle.
+ *  @param selector The selector to add to the instance.
+ *  @param aClass The class supplying an implementation of the method.
+ *  @param isClassSelector A BOOL specifying whether the selector is a class or
+ * instance selector.
+ */
+- (void)copySelector:(SEL)selector fromClass:(Class)aClass isClassSelector:(BOOL)isClassSelector;
+
+/** Swizzles the object, changing its class to the generated class. Registers
+ *  the class pair. */
+- (void)swizzle;
+
+/** @return The value of -[objectBeingSwizzled isProxy] */
+- (BOOL)isSwizzlingProxyObject;
+
+@end
+
+NS_ASSUME_NONNULL_END

--- a/BugsnagRequestMonitor/Swizzle/BSGULObjectSwizzler.m
+++ b/BugsnagRequestMonitor/Swizzle/BSGULObjectSwizzler.m
@@ -1,0 +1,199 @@
+// Copyright 2018 Google LLC
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+#import "BSGULObjectSwizzler.h"
+
+#import <objc/runtime.h>
+
+#import "BSGULObjectSwizzler+Internal.h"
+#import "BSGULSwizzledObject.h"
+
+@implementation BSGULObjectSwizzler {
+  // The swizzled object.
+  __weak id _swizzledObject;
+
+  // The original class of the object.
+  Class _originalClass;
+
+  // The dynamically generated subclass of _originalClass.
+  Class _generatedClass;
+}
+
+#pragma mark - Class methods
+
++ (void)setAssociatedObject:(id)object
+                        key:(NSString *)key
+                      value:(nullable id)value
+                association:(BSGUL_ASSOCIATION)association {
+  objc_AssociationPolicy resolvedAssociation;
+  switch (association) {
+    case BSGUL_ASSOCIATION_ASSIGN:
+      resolvedAssociation = OBJC_ASSOCIATION_ASSIGN;
+      break;
+
+    case BSGUL_ASSOCIATION_RETAIN_NONATOMIC:
+      resolvedAssociation = OBJC_ASSOCIATION_RETAIN_NONATOMIC;
+      break;
+
+    case BSGUL_ASSOCIATION_COPY_NONATOMIC:
+      resolvedAssociation = OBJC_ASSOCIATION_COPY_NONATOMIC;
+      break;
+
+    case BSGUL_ASSOCIATION_RETAIN:
+      resolvedAssociation = OBJC_ASSOCIATION_RETAIN;
+      break;
+
+    case BSGUL_ASSOCIATION_COPY:
+      resolvedAssociation = OBJC_ASSOCIATION_COPY;
+      break;
+
+    default:
+      break;
+  }
+  objc_setAssociatedObject(object, key.UTF8String, value, resolvedAssociation);
+}
+
++ (nullable id)getAssociatedObject:(id)object key:(NSString *)key {
+  return objc_getAssociatedObject(object, key.UTF8String);
+}
+
+#pragma mark - Instance methods
+
+/** Instantiates an instance of this class.
+ *
+ *  @param object The object to swizzle.
+ *  @return An instance of this class.
+ */
+- (instancetype)initWithObject:(id)object {
+  if (object == nil) {
+    return nil;
+  }
+
+  BSGULObjectSwizzler *existingSwizzler =
+      [[self class] getAssociatedObject:object key:kBSGULSwizzlerAssociatedObjectKey];
+  if ([existingSwizzler isKindOfClass:[BSGULObjectSwizzler class]]) {
+    // The object has been swizzled already, no need to swizzle again.
+    return existingSwizzler;
+  }
+
+  self = [super init];
+  if (self) {
+    _swizzledObject = object;
+    _originalClass = object_getClass(object);
+    NSString *newClassName = [NSString stringWithFormat:@"fir_%@_%@", [[NSUUID UUID] UUIDString],
+                                                        NSStringFromClass(_originalClass)];
+    _generatedClass = objc_allocateClassPair(_originalClass, newClassName.UTF8String, 0);
+    NSAssert(_generatedClass, @"Wasn't able to allocate the class pair.");
+  }
+  return self;
+}
+
+- (void)copySelector:(SEL)selector fromClass:(Class)aClass isClassSelector:(BOOL)isClassSelector {
+  NSAssert(_generatedClass, @"This object has already been unswizzled.");
+  Method method = isClassSelector ? class_getClassMethod(aClass, selector)
+                                  : class_getInstanceMethod(aClass, selector);
+  Class targetClass = isClassSelector ? object_getClass(_generatedClass) : _generatedClass;
+  IMP implementation = method_getImplementation(method);
+
+  const char *typeEncoding = method_getTypeEncoding(method);
+  class_replaceMethod(targetClass, selector, implementation, typeEncoding);
+}
+
+- (void)setAssociatedObjectWithKey:(NSString *)key
+                             value:(id)value
+                       association:(BSGUL_ASSOCIATION)association {
+  __strong id swizzledObject = _swizzledObject;
+  if (swizzledObject) {
+    [[self class] setAssociatedObject:swizzledObject key:key value:value association:association];
+  }
+}
+
+- (nullable id)getAssociatedObjectForKey:(NSString *)key {
+  __strong id swizzledObject = _swizzledObject;
+  if (swizzledObject) {
+    return [[self class] getAssociatedObject:swizzledObject key:key];
+  }
+  return nil;
+}
+
+- (void)swizzle {
+  __strong id swizzledObject = _swizzledObject;
+
+  BSGULObjectSwizzler *existingSwizzler =
+      [[self class] getAssociatedObject:swizzledObject key:kBSGULSwizzlerAssociatedObjectKey];
+  if (existingSwizzler != nil) {
+    NSAssert(existingSwizzler == self, @"The swizzled object has a different swizzler.");
+    // The object has been swizzled already.
+    return;
+  }
+
+  if (swizzledObject) {
+    [BSGULObjectSwizzler setAssociatedObject:swizzledObject
+                                       key:kBSGULSwizzlerAssociatedObjectKey
+                                     value:self
+                               association:BSGUL_ASSOCIATION_RETAIN];
+
+    [BSGULSwizzledObject copyDonorSelectorsUsingObjectSwizzler:self];
+
+    NSAssert(_originalClass == object_getClass(swizzledObject),
+             @"The original class is not the reported class now.");
+    NSAssert(class_getInstanceSize(_originalClass) == class_getInstanceSize(_generatedClass),
+             @"The instance size of the generated class must be equal to the original class.");
+    objc_registerClassPair(_generatedClass);
+    Class doubleCheckOriginalClass __unused = object_setClass(_swizzledObject, _generatedClass);
+    NSAssert(_originalClass == doubleCheckOriginalClass,
+             @"The original class must be the same as the class returned by object_setClass");
+  } else {
+    NSAssert(NO, @"You can't swizzle a nil object");
+  }
+}
+
+- (void)dealloc {
+  if (_generatedClass) {
+    if (_swizzledObject == nil) {
+      // The swizzled object has been deallocated already, so the generated class can be disposed
+      // now.
+      objc_disposeClassPair(_generatedClass);
+      return;
+    }
+
+    // BSGULSwizzledObject is retained by the swizzled object which means that the swizzled object is
+    // being deallocated now. Let's see if we should schedule the generated class disposal.
+
+    // If the swizzled object has a different class, it most likely indicates that the object was
+    // ISA swizzled one more time. In this case it is not safe to dispose the generated class. We
+    // will have to keep it to prevent a crash.
+
+    // TODO: Consider adding a flag that can be set by the host application to dispose the class
+    // pair unconditionally. It may be used by apps that use ISA Swizzling themself and are
+    // confident in disposing their subclasses.
+    BOOL isSwizzledObjectInstanceOfGeneratedClass =
+        object_getClass(_swizzledObject) == _generatedClass;
+
+    if (isSwizzledObjectInstanceOfGeneratedClass) {
+      Class generatedClass = _generatedClass;
+
+      // Schedule the generated class disposal after the swizzled object has been deallocated.
+      dispatch_async(dispatch_get_main_queue(), ^{
+        objc_disposeClassPair(generatedClass);
+      });
+    }
+  }
+}
+
+- (BOOL)isSwizzlingProxyObject {
+  return [_swizzledObject isProxy];
+}
+
+@end

--- a/BugsnagRequestMonitor/Swizzle/BSGULOriginalIMPConvenienceMacros.h
+++ b/BugsnagRequestMonitor/Swizzle/BSGULOriginalIMPConvenienceMacros.h
@@ -1,0 +1,207 @@
+/*
+ * Copyright 2018 Google LLC
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+/**
+ * BSGULOriginalIMPConvenienceMacros.h
+ *
+ * This header contains convenience macros for invoking the original IMP of a swizzled method.
+ */
+
+/**
+ *  Invokes original IMP when the original selector takes no arguments.
+ *
+ *  @param __receivingObject The object on which the IMP is invoked.
+ *  @param __swizzledSEL The selector used for swizzling.
+ *  @param __returnType  The return type of the original implementation.
+ *  @param __originalIMP The original IMP.
+ */
+#define BSGUL_INVOKE_ORIGINAL_IMP0(__receivingObject, __swizzledSEL, __returnType, __originalIMP) \
+  ((__returnType(*)(id, SEL))__originalIMP)(__receivingObject, __swizzledSEL)
+
+/**
+ *  Invokes original IMP when the original selector takes 1 argument.
+ *
+ *  @param __receivingObject The object on which the IMP is invoked.
+ *  @param __swizzledSEL The selector used for swizzling.
+ *  @param __returnType  The return type of the original implementation.
+ *  @param __originalIMP The original IMP.
+ *  @param __arg1 The first argument.
+ */
+#define BSGUL_INVOKE_ORIGINAL_IMP1(__receivingObject, __swizzledSEL, __returnType, __originalIMP,   \
+                                 __arg1)                                                          \
+  ((__returnType(*)(id, SEL, __typeof__(__arg1)))__originalIMP)(__receivingObject, __swizzledSEL, \
+                                                                __arg1)
+
+/**
+ *  Invokes original IMP when the original selector takes 2 arguments.
+ *
+ *  @param __receivingObject The object on which the IMP is invoked.
+ *  @param __swizzledSEL The selector used for swizzling.
+ *  @param __returnType  The return type of the original implementation.
+ *  @param __originalIMP The original IMP.
+ *  @param __arg1 The first argument.
+ *  @param __arg2 The second argument.
+ */
+#define BSGUL_INVOKE_ORIGINAL_IMP2(__receivingObject, __swizzledSEL, __returnType, __originalIMP, \
+                                 __arg1, __arg2)                                                \
+  ((__returnType(*)(id, SEL, __typeof__(__arg1), __typeof__(__arg2)))__originalIMP)(            \
+      __receivingObject, __swizzledSEL, __arg1, __arg2)
+
+/**
+ *  Invokes original IMP when the original selector takes 3 arguments.
+ *
+ *  @param __receivingObject The object on which the IMP is invoked.
+ *  @param __swizzledSEL The selector used for swizzling.
+ *  @param __returnType  The return type of the original implementation.
+ *  @param __originalIMP The original IMP.
+ *  @param __arg1 The first argument.
+ *  @param __arg2 The second argument.
+ *  @param __arg3 The third argument.
+ */
+#define BSGUL_INVOKE_ORIGINAL_IMP3(__receivingObject, __swizzledSEL, __returnType, __originalIMP,  \
+                                 __arg1, __arg2, __arg3)                                         \
+  ((__returnType(*)(id, SEL, __typeof__(__arg1), __typeof__(__arg2),                             \
+                    __typeof__(__arg3)))__originalIMP)(__receivingObject, __swizzledSEL, __arg1, \
+                                                       __arg2, __arg3)
+
+/**
+ *  Invokes original IMP when the original selector takes 4 arguments.
+ *
+ *  @param __receivingObject The object on which the IMP is invoked.
+ *  @param __swizzledSEL The selector used for swizzling.
+ *  @param __returnType  The return type of the original implementation.
+ *  @param __originalIMP The original IMP.
+ *  @param __arg1 The first argument.
+ *  @param __arg2 The second argument.
+ *  @param __arg3 The third argument.
+ *  @param __arg4 The fourth argument.
+ */
+#define BSGUL_INVOKE_ORIGINAL_IMP4(__receivingObject, __swizzledSEL, __returnType, __originalIMP,  \
+                                 __arg1, __arg2, __arg3, __arg4)                                 \
+  ((__returnType(*)(id, SEL, __typeof__(__arg1), __typeof__(__arg2), __typeof__(__arg3),         \
+                    __typeof__(__arg4)))__originalIMP)(__receivingObject, __swizzledSEL, __arg1, \
+                                                       __arg2, __arg3, __arg4)
+
+/**
+ *  Invokes original IMP when the original selector takes 5 arguments.
+ *
+ *  @param __receivingObject The object on which the IMP is invoked.
+ *  @param __swizzledSEL The selector used for swizzling.
+ *  @param __returnType  The return type of the original implementation.
+ *  @param __originalIMP The original IMP.
+ *  @param __arg1 The first argument.
+ *  @param __arg2 The second argument.
+ *  @param __arg3 The third argument.
+ *  @param __arg4 The fourth argument.
+ *  @param __arg5 The fifth argument.
+ */
+#define BSGUL_INVOKE_ORIGINAL_IMP5(__receivingObject, __swizzledSEL, __returnType, __originalIMP, \
+                                 __arg1, __arg2, __arg3, __arg4, __arg5)                        \
+  ((__returnType(*)(id, SEL, __typeof__(__arg1), __typeof__(__arg2), __typeof__(__arg3),        \
+                    __typeof__(__arg4), __typeof__(__arg5)))__originalIMP)(                     \
+      __receivingObject, __swizzledSEL, __arg1, __arg2, __arg3, __arg4, __arg5)
+
+/**
+ *  Invokes original IMP when the original selector takes 6 arguments.
+ *
+ *  @param __receivingObject The object on which the IMP is invoked.
+ *  @param __swizzledSEL The selector used for swizzling.
+ *  @param __returnType  The return type of the original implementation.
+ *  @param __originalIMP The original IMP.
+ *  @param __arg1 The first argument.
+ *  @param __arg2 The second argument.
+ *  @param __arg3 The third argument.
+ *  @param __arg4 The fourth argument.
+ *  @param __arg5 The fifth argument.
+ *  @param __arg6 The sixth argument.
+ */
+#define BSGUL_INVOKE_ORIGINAL_IMP6(__receivingObject, __swizzledSEL, __returnType, __originalIMP, \
+                                 __arg1, __arg2, __arg3, __arg4, __arg5, __arg6)                \
+  ((__returnType(*)(id, SEL, __typeof__(__arg1), __typeof__(__arg2), __typeof__(__arg3),        \
+                    __typeof__(__arg4), __typeof__(__arg5), __typeof__(__arg6)))__originalIMP)( \
+      __receivingObject, __swizzledSEL, __arg1, __arg2, __arg3, __arg4, __arg5, __arg6)
+
+/**
+ *  Invokes original IMP when the original selector takes 7 arguments.
+ *
+ *  @param __receivingObject The object on which the IMP is invoked.
+ *  @param __swizzledSEL The selector used for swizzling.
+ *  @param __returnType  The return type of the original implementation.
+ *  @param __originalIMP The original IMP.
+ *  @param __arg1 The first argument.
+ *  @param __arg2 The second argument.
+ *  @param __arg3 The third argument.
+ *  @param __arg4 The fourth argument.
+ *  @param __arg5 The fifth argument.
+ *  @param __arg6 The sixth argument.
+ *  @param __arg7 The seventh argument.
+ */
+#define BSGUL_INVOKE_ORIGINAL_IMP7(__receivingObject, __swizzledSEL, __returnType, __originalIMP, \
+                                 __arg1, __arg2, __arg3, __arg4, __arg5, __arg6, __arg7)        \
+  ((__returnType(*)(id, SEL, __typeof__(__arg1), __typeof__(__arg2), __typeof__(__arg3),        \
+                    __typeof__(__arg4), __typeof__(__arg5), __typeof__(__arg6),                 \
+                    __typeof__(__arg7)))__originalIMP)(                                         \
+      __receivingObject, __swizzledSEL, __arg1, __arg2, __arg3, __arg4, __arg5, __arg6, __arg7)
+
+/**
+ *  Invokes original IMP when the original selector takes 8 arguments.
+ *
+ *  @param __receivingObject The object on which the IMP is invoked.
+ *  @param __swizzledSEL The selector used for swizzling.
+ *  @param __returnType  The return type of the original implementation.
+ *  @param __originalIMP The original IMP.
+ *  @param __arg1 The first argument.
+ *  @param __arg2 The second argument.
+ *  @param __arg3 The third argument.
+ *  @param __arg4 The fourth argument.
+ *  @param __arg5 The fifth argument.
+ *  @param __arg6 The sixth argument.
+ *  @param __arg7 The seventh argument.
+ *  @param __arg8 The eighth argument.
+ */
+#define BSGUL_INVOKE_ORIGINAL_IMP8(__receivingObject, __swizzledSEL, __returnType, __originalIMP,  \
+                                 __arg1, __arg2, __arg3, __arg4, __arg5, __arg6, __arg7, __arg8) \
+  ((__returnType(*)(id, SEL, __typeof__(__arg1), __typeof__(__arg2), __typeof__(__arg3),         \
+                    __typeof__(__arg4), __typeof__(__arg5), __typeof__(__arg6),                  \
+                    __typeof__(__arg7), __typeof__(__arg8)))__originalIMP)(                      \
+      __receivingObject, __swizzledSEL, __arg1, __arg2, __arg3, __arg4, __arg5, __arg6, __arg7,  \
+      __arg8)
+
+/**
+ *  Invokes original IMP when the original selector takes 9 arguments.
+ *
+ *  @param __receivingObject The object on which the IMP is invoked.
+ *  @param __swizzledSEL The selector used for swizzling.
+ *  @param __returnType  The return type of the original implementation.
+ *  @param __originalIMP The original IMP.
+ *  @param __arg1 The first argument.
+ *  @param __arg2 The second argument.
+ *  @param __arg3 The third argument.
+ *  @param __arg4 The fourth argument.
+ *  @param __arg5 The fifth argument.
+ *  @param __arg6 The sixth argument.
+ *  @param __arg7 The seventh argument.
+ *  @param __arg8 The eighth argument.
+ *  @param __arg9 The ninth argument.
+ */
+#define BSGUL_INVOKE_ORIGINAL_IMP9(__receivingObject, __swizzledSEL, __returnType, __originalIMP,  \
+                                 __arg1, __arg2, __arg3, __arg4, __arg5, __arg6, __arg7, __arg8, \
+                                 __arg9)                                                         \
+  ((__returnType(*)(id, SEL, __typeof__(__arg1), __typeof__(__arg2), __typeof__(__arg3),         \
+                    __typeof__(__arg4), __typeof__(__arg5), __typeof__(__arg6),                  \
+                    __typeof__(__arg7), __typeof__(__arg8), __typeof__(__arg9)))__originalIMP)(  \
+      __receivingObject, __swizzledSEL, __arg1, __arg2, __arg3, __arg4, __arg5, __arg6, __arg7,  \
+      __arg8, __arg9)

--- a/BugsnagRequestMonitor/Swizzle/BSGULSwizzledObject.h
+++ b/BugsnagRequestMonitor/Swizzle/BSGULSwizzledObject.h
@@ -1,0 +1,42 @@
+/*
+ * Copyright 2018 Google LLC
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+#import <Foundation/Foundation.h>
+
+@class BSGULObjectSwizzler;
+
+/** This class exists as a method donor. These methods will be added to all objects that are
+ *  swizzled by the object swizzler. This class should not be instantiated.
+ */
+@interface BSGULSwizzledObject : NSObject
+
+- (instancetype)init NS_UNAVAILABLE;
+
+/** Copies the methods below to the swizzled object.
+ *
+ *  @param objectSwizzler The swizzler to use when adding the methods below.
+ */
++ (void)copyDonorSelectorsUsingObjectSwizzler:(BSGULObjectSwizzler *)objectSwizzler;
+
+#pragma mark - Donor methods.
+
+/** @return The generated subclass. Used in respondsToSelector: calls. */
+- (Class)gul_class;
+
+/** @return The object swizzler that manages this object. */
+- (BSGULObjectSwizzler *)gul_objectSwizzler;
+
+@end

--- a/BugsnagRequestMonitor/Swizzle/BSGULSwizzledObject.m
+++ b/BugsnagRequestMonitor/Swizzle/BSGULSwizzledObject.m
@@ -1,0 +1,64 @@
+// Copyright 2018 Google LLC
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+#import <objc/runtime.h>
+
+#import "BSGULObjectSwizzler+Internal.h"
+#import "BSGULSwizzledObject.h"
+
+NSString *kBSGULSwizzlerAssociatedObjectKey = @"gul_objectSwizzler";
+
+@interface BSGULSwizzledObject ()
+
+@end
+
+@implementation BSGULSwizzledObject
+
++ (void)copyDonorSelectorsUsingObjectSwizzler:(BSGULObjectSwizzler *)objectSwizzler {
+  [objectSwizzler copySelector:@selector(gul_objectSwizzler) fromClass:self isClassSelector:NO];
+  [objectSwizzler copySelector:@selector(gul_class) fromClass:self isClassSelector:NO];
+
+  // This is needed because NSProxy objects usually override -[NSObjectProtocol respondsToSelector:]
+  // and ask this question to the underlying object. Since we don't swizzle the underlying object
+  // but swizzle the proxy, when someone calls -[NSObjectProtocol respondsToSelector:] on the proxy,
+  // the answer ends up being NO even if we added new methods to the subclass through ISA Swizzling.
+  // To solve that, we override -[NSObjectProtocol respondsToSelector:] in such a way that takes
+  // into account the fact that we've added new methods.
+  if ([objectSwizzler isSwizzlingProxyObject]) {
+    [objectSwizzler copySelector:@selector(respondsToSelector:) fromClass:self isClassSelector:NO];
+  }
+}
+
+- (instancetype)init {
+  NSAssert(NO, @"Do not instantiate this class, it's only a donor class");
+  return nil;
+}
+
+- (BSGULObjectSwizzler *)gul_objectSwizzler {
+  return [BSGULObjectSwizzler getAssociatedObject:self key:kBSGULSwizzlerAssociatedObjectKey];
+}
+
+#pragma mark - Donor methods
+
+- (Class)gul_class {
+  return [[self gul_objectSwizzler] generatedClass];
+}
+
+// Only added to a class when we detect it is a proxy.
+- (BOOL)respondsToSelector:(SEL)aSelector {
+  Class gulClass = [[self gul_objectSwizzler] generatedClass];
+  return [gulClass instancesRespondToSelector:aSelector] || [super respondsToSelector:aSelector];
+}
+
+@end

--- a/BugsnagRequestMonitor/Swizzle/BSGULSwizzler.h
+++ b/BugsnagRequestMonitor/Swizzle/BSGULSwizzler.h
@@ -1,0 +1,71 @@
+/*
+ * Copyright 2018 Google LLC
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+#import <Foundation/Foundation.h>
+
+NS_ASSUME_NONNULL_BEGIN
+
+/** This class handles the runtime manipulation necessary to instrument selectors. It stores the
+ *  classes and selectors that have been swizzled, and runs all operations on its own queue.
+ */
+@interface BSGULSwizzler : NSObject
+
+/** Manipulates the Objective-C runtime to replace the original IMP with the supplied block.
+ *
+ *  @param aClass The class to swizzle.
+ *  @param selector The selector of the class to swizzle.
+ *  @param isClassSelector A BOOL specifying whether the selector is a class or instance selector.
+ *  @param block The block that replaces the original IMP.
+ */
++ (void)swizzleClass:(Class)aClass
+            selector:(SEL)selector
+     isClassSelector:(BOOL)isClassSelector
+           withBlock:(nullable id)block;
+
+/** Returns the current IMP for the given class and selector.
+ *
+ *  @param aClass The class to use.
+ *  @param selector The selector to find the implementation of.
+ *  @param isClassSelector A BOOL specifying whether the selector is a class or instance selector.
+ *  @return The implementation of the selector in the runtime.
+ */
++ (nullable IMP)currentImplementationForClass:(Class)aClass
+                                     selector:(SEL)selector
+                              isClassSelector:(BOOL)isClassSelector;
+
+/** Checks the runtime to see if a selector exists on a class. If a property is declared as
+ *  @dynamic, we have a reverse swizzling situation, where the implementation of a method exists
+ *  only in concrete subclasses, and NOT in the superclass. We can detect that situation using
+ *  this helper method. Similarly, we can detect situations where a class doesn't implement a
+ *  protocol method.
+ *
+ *  @param selector The selector to check for.
+ *  @param aClass The class to check.
+ *  @param isClassSelector A BOOL specifying whether the selector is a class or instance selector.
+ *  @return YES if the method was found in this selector/class combination, NO otherwise.
+ */
++ (BOOL)selector:(SEL)selector existsInClass:(Class)aClass isClassSelector:(BOOL)isClassSelector;
+
+/** Returns a list of all Objective-C (and not primitive) ivars contained by the given object.
+ *
+ *  @param object The object whose ivars will be iterated.
+ *  @return The list of ivar objects.
+ */
++ (NSArray<id> *)ivarObjectsForObject:(id)object;
+
+@end
+
+NS_ASSUME_NONNULL_END

--- a/BugsnagRequestMonitor/Swizzle/BSGULSwizzler.m
+++ b/BugsnagRequestMonitor/Swizzle/BSGULSwizzler.m
@@ -1,0 +1,150 @@
+// Copyright 2018 Google LLC
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+#import "BSGULSwizzler.h"
+
+#import <objc/runtime.h>
+
+#ifdef DEBUG
+//#import "GoogleUtilities/Common/BSGULLoggerCodes.h"
+//#import "GoogleUtilities/Logger/Public/GoogleUtilities/BSGULLogger.h"
+
+//static BSGULLoggerService kBSGULLoggerSwizzler = @"[GoogleUtilities/MethodSwizzler]";
+#endif
+
+dispatch_queue_t GetBSGULSwizzlingQueue(void) {
+  static dispatch_queue_t queue;
+  static dispatch_once_t onceToken;
+  dispatch_once(&onceToken, ^{
+    queue = dispatch_queue_create("com.bugsnag.BSGULSwizzler", DISPATCH_QUEUE_SERIAL);
+  });
+  return queue;
+}
+
+@implementation BSGULSwizzler
+
++ (void)swizzleClass:(Class)aClass
+            selector:(SEL)selector
+     isClassSelector:(BOOL)isClassSelector
+           withBlock:(nullable id)block {
+  dispatch_sync(GetBSGULSwizzlingQueue(), ^{
+    NSAssert(selector, @"The selector cannot be NULL");
+    NSAssert(aClass, @"The class cannot be Nil");
+    Class resolvedClass = aClass;
+    Method method = nil;
+    if (isClassSelector) {
+      method = class_getClassMethod(aClass, selector);
+      resolvedClass = object_getClass(aClass);
+    } else {
+      method = class_getInstanceMethod(aClass, selector);
+    }
+    NSAssert(method, @"You're attempting to swizzle a method that doesn't exist. (%@, %@)",
+             NSStringFromClass(resolvedClass), NSStringFromSelector(selector));
+    IMP newImp = imp_implementationWithBlock(block);
+#ifdef DEBUG
+    IMP currentImp = class_getMethodImplementation(resolvedClass, selector);
+    Class class = NSClassFromString(@"BSGULSwizzlingCache");
+    if (class) {
+      SEL cacheSelector = NSSelectorFromString(@"cacheCurrentIMP:forNewIMP:forClass:withSelector:");
+      NSMethodSignature *methodSignature = [class methodSignatureForSelector:cacheSelector];
+      if (methodSignature != nil) {
+        NSInvocation *inv = [NSInvocation invocationWithMethodSignature:methodSignature];
+        [inv setSelector:cacheSelector];
+        [inv setTarget:class];
+        [inv setArgument:&(currentImp) atIndex:2];
+        [inv setArgument:&(newImp) atIndex:3];
+        [inv setArgument:&(resolvedClass) atIndex:4];
+        [inv setArgument:(void *_Nonnull)&(selector) atIndex:5];
+        [inv invoke];
+      }
+    }
+#endif
+
+    const char *typeEncoding = method_getTypeEncoding(method);
+    __unused IMP originalImpOfClass =
+        class_replaceMethod(resolvedClass, selector, newImp, typeEncoding);
+
+#ifdef DEBUG
+    // If !originalImpOfClass, then the IMP came from a superclass.
+    if (originalImpOfClass) {
+      SEL selector = NSSelectorFromString(@"originalIMPOfCurrentIMP:");
+      NSMethodSignature *methodSignature = [class methodSignatureForSelector:selector];
+      if (methodSignature != nil) {
+        NSInvocation *inv = [NSInvocation invocationWithMethodSignature:methodSignature];
+        [inv setSelector:selector];
+        [inv setTarget:class];
+        [inv setArgument:&(currentImp) atIndex:2];
+        [inv invoke];
+        IMP testOriginal;
+        [inv getReturnValue:&testOriginal];
+        if (originalImpOfClass != testOriginal) {
+          NSLog(@"Swizzling class: %@ SEL:%@ after it has been previously been swizzled.",
+                        NSStringFromClass(resolvedClass), NSStringFromSelector(selector));
+        }
+      }
+    }
+#endif
+  });
+}
+
++ (nullable IMP)currentImplementationForClass:(Class)aClass
+                                     selector:(SEL)selector
+                              isClassSelector:(BOOL)isClassSelector {
+  NSAssert(selector, @"The selector cannot be NULL");
+  NSAssert(aClass, @"The class cannot be Nil");
+  if (selector == NULL || aClass == nil) {
+    return nil;
+  }
+  __block IMP currentIMP = nil;
+  dispatch_sync(GetBSGULSwizzlingQueue(), ^{
+    Method method = nil;
+    if (isClassSelector) {
+      method = class_getClassMethod(aClass, selector);
+    } else {
+      method = class_getInstanceMethod(aClass, selector);
+    }
+    NSAssert(method, @"The Method for this class/selector combo doesn't exist (%@, %@).",
+             NSStringFromClass(aClass), NSStringFromSelector(selector));
+    if (method == nil) {
+      return;
+    }
+    currentIMP = method_getImplementation(method);
+    NSAssert(currentIMP, @"The IMP for this class/selector combo doesn't exist (%@, %@).",
+             NSStringFromClass(aClass), NSStringFromSelector(selector));
+  });
+  return currentIMP;
+}
+
++ (BOOL)selector:(SEL)selector existsInClass:(Class)aClass isClassSelector:(BOOL)isClassSelector {
+  Method method = isClassSelector ? class_getClassMethod(aClass, selector)
+                                  : class_getInstanceMethod(aClass, selector);
+  return method != nil;
+}
+
++ (NSArray<id> *)ivarObjectsForObject:(id)object {
+  NSMutableArray *array = [NSMutableArray array];
+  unsigned int count;
+  Ivar *vars = class_copyIvarList([object class], &count);
+  for (NSUInteger i = 0; i < count; i++) {
+    const char *typeEncoding = ivar_getTypeEncoding(vars[i]);
+    // Check to see if the ivar is an object.
+    if (strncmp(typeEncoding, "@", 1) == 0) {
+      id ivarObject = object_getIvar(object, vars[i]);
+      [array addObject:ivarObject];
+    }
+  }
+  free(vars);
+  return array;
+}
+@end


### PR DESCRIPTION
Uses the Firebase instrumentation code to implement network breadcrumbs.

`BugsnagRequestMonitor.m` initialises the instrumentation code on `+load` so that networking gets instrumented simply by including the framework.

`BSFPRNSURLSessionInstrument` takes care of injecting itself into the `NSURLSession` class cluster. I've added a callback mechanism to make it easier to integrate into the breadcrumbs system. Currently it just prints information about the request once it completes (see `BugsnagRequestMonitor.m`).

The plugin's project only has the default compiler settings (no enhanced warnings, etc). It doesn't warn on the defaults, but it WILL warn plenty once we amp up the settings. We'll need to decide what's the best way to integrate this code. For example, they access ivars directly everywhere...

Note: Ignore the logging stuff for now... That will be replaced.

One other thing: The instrumentation code is set to throw exceptions if anything goes wrong. I think we probably shouldn't crash from that, but rather just stop the network tracing instead. I'm not sure how much work that would be to get going though.

The testing framework for this will also be tricky I think. I'm not really sure how to set things up for this.
