### PR TITLE
[PLAT-7190] Add BugsnagConfiguration.notifier

### DIFF
--- a/Bugsnag/Client/BugsnagClient+Private.h
+++ b/Bugsnag/Client/BugsnagClient+Private.h
@@ -68,7 +68,7 @@ NS_ASSUME_NONNULL_BEGIN
 
 @property (nullable, nonatomic) NSDictionary *metadataFromLastLaunch;
 
-@property (strong, nonatomic) BugsnagNotifier *notifier; // Used in BugsnagReactNative
+@property (readonly, nonatomic) BugsnagNotifier *notifier; // Used in BugsnagReactNative
 
 @property (strong, nonatomic) BugsnagPluginClient *pluginClient;
 

--- a/Bugsnag/Client/BugsnagClient.m
+++ b/Bugsnag/Client/BugsnagClient.m
@@ -208,7 +208,7 @@ __attribute__((annotate("oclint:suppress[too many methods]")))
             BSGKeyApp: @{BSGKeyIsLaunching: @YES},
             BSGKeyClient: BSGDictionaryWithKeyAndObject(BSGKeyContext, _configuration.context)
         }];
-        self.notifier = [BugsnagNotifier new];
+        _notifier = configuration.notifier ?: [[BugsnagNotifier alloc] init];
         self.systemState = [[BugsnagSystemState alloc] initWithConfiguration:configuration];
 
         BSGFileLocations *fileLocations = [BSGFileLocations current];

--- a/Bugsnag/Configuration/BugsnagConfiguration+Private.h
+++ b/Bugsnag/Configuration/BugsnagConfiguration+Private.h
@@ -8,6 +8,8 @@
 
 #import <Bugsnag/BugsnagConfiguration.h>
 
+@class BugsnagNotifier;
+
 NS_ASSUME_NONNULL_BEGIN
 
 @interface BugsnagConfiguration ()
@@ -24,6 +26,8 @@ NS_ASSUME_NONNULL_BEGIN
 @property (readonly, nonatomic) NSDictionary<NSString *, id> *dictionaryRepresentation;
 
 @property (copy, nonatomic) BugsnagMetadata *metadata;
+
+@property (nullable, nonatomic) BugsnagNotifier *notifier;
 
 @property (readonly, nullable, nonatomic) NSURL *notifyURL;
 

--- a/Bugsnag/Payload/BugsnagNotifier.h
+++ b/Bugsnag/Payload/BugsnagNotifier.h
@@ -12,10 +12,18 @@ NS_ASSUME_NONNULL_BEGIN
 
 @interface BugsnagNotifier : NSObject
 
+/// Initializes the object with details of the Cocoa notifier.
+- (instancetype)init NS_DESIGNATED_INITIALIZER;
+
+- (instancetype)initWithName:(NSString *)name
+                     version:(NSString *)version
+                         url:(NSString *)url
+                dependencies:(NSArray<BugsnagNotifier *> *)dependencies NS_DESIGNATED_INITIALIZER;
+
 @property (copy, nonatomic) NSString *name;
 @property (copy, nonatomic) NSString *version;
 @property (copy, nonatomic) NSString *url;
-@property (nonatomic) NSMutableArray<BugsnagNotifier *> *dependencies;
+@property (copy, nonatomic) NSArray<BugsnagNotifier *> *dependencies;
 
 - (NSDictionary *)toDict;
 

--- a/Bugsnag/Payload/BugsnagNotifier.m
+++ b/Bugsnag/Payload/BugsnagNotifier.m
@@ -15,17 +15,30 @@
 - (instancetype)init {
     if ((self = [super init])) {
 #if BSG_PLATFORM_TVOS
-        self.name = @"tvOS Bugsnag Notifier";
+        _name = @"tvOS Bugsnag Notifier";
 #elif BSG_PLATFORM_IOS
-        self.name = @"iOS Bugsnag Notifier";
+        _name = @"iOS Bugsnag Notifier";
 #elif BSG_PLATFORM_OSX
-        self.name = @"OSX Bugsnag Notifier";
+        _name = @"OSX Bugsnag Notifier";
 #else
-        self.name = @"Bugsnag Objective-C";
+        _name = @"Bugsnag Objective-C";
 #endif
-        self.version = @"6.12.0";
-        self.url = @"https://github.com/bugsnag/bugsnag-cocoa";
-        self.dependencies = [NSMutableArray new];
+        _version = @"6.12.0";
+        _url = @"https://github.com/bugsnag/bugsnag-cocoa";
+        _dependencies = @[];
+    }
+    return self;
+}
+
+- (instancetype)initWithName:(NSString *)name
+                     version:(NSString *)version
+                         url:(NSString *)url
+                dependencies:(NSArray<BugsnagNotifier *> *)dependencies {
+    if ((self = [super init])) {
+        _name = [name copy];
+        _version = [version copy];
+        _url = [url copy];
+        _dependencies = [dependencies copy];
     }
     return self;
 }

--- a/Makefile
+++ b/Makefile
@@ -168,7 +168,7 @@ endif
 	@echo $(VERSION) > VERSION
 	@sed -i '' "s/\"version\": .*,/\"version\": \"$(VERSION)\",/" Bugsnag.podspec.json
 	@sed -i '' "s/\"tag\": .*/\"tag\": \"v$(VERSION)\"/" Bugsnag.podspec.json
-	@sed -i '' "s/self.version = .*;/self.version = @\"$(VERSION)\";/" Bugsnag/Payload/BugsnagNotifier.m
+	@sed -i '' "s/_version = @\".*\";/_version = @\"$(VERSION)\";/" Bugsnag/Payload/BugsnagNotifier.m
 	@sed -i '' "s/## TBD/## $(VERSION) ($(shell date '+%Y-%m-%d'))/" CHANGELOG.md
 	@sed -i '' -E "s/[0-9]+.[0-9]+.[0-9]+/$(VERSION)/g" .jazzy.yaml
 	@agvtool new-marketing-version $(VERSION)

--- a/Tests/BugsnagNotifierTest.m
+++ b/Tests/BugsnagNotifierTest.m
@@ -43,7 +43,7 @@
     dep.name = @"COBOL Notifier";
     dep.version = @"1.0.0";
     dep.url = @"https://github.com/bugsnag/bugsnag-cobol";
-    [self.notifier.dependencies addObject:dep];
+    self.notifier.dependencies = @[dep];
 
     NSDictionary *dict = [self.notifier toDict];
     XCTAssertEqualObjects(@"https://github.com/bugsnag/bugsnag-cocoa", dict[@"url"]);


### PR DESCRIPTION
## Goal

Allow the Unity (and any other dependant) Bugsnag implementation to override the `notifier` property before starting Bugsnag - ensuring that all events and sessions contain the desired notifier info.

## Changeset

Adds a private `notifier` property to `BugsnagConfiguration` which is then used in `BugsnagClient`'s initialization.

A new `BugsnagNotifier` initializer has been added to facilitate creating custom instances.

## Testing

Tested with bugsnag-unity
* https://github.com/bugsnag/bugsnag-unity/commit/4735bf72fd9998215fc27829d167c2b010d8b0b2
* https://buildkite.com/bugsnag/bugsnag-unity/builds/1039