### PR TITLE
[PLAT-7253] Fix flake in crashprobe.feature:68: Stack overflow

### DIFF
--- a/features/crashprobe.feature
+++ b/features/crashprobe.feature
@@ -67,8 +67,7 @@ Feature: Reporting crash events
 
   Scenario: Stack overflow
     When I run "StackOverflowScenario"
-    # Present to allow the scenario to crash
-    And I wait for 3 seconds
+    And the app is not running
     And I relaunch the app
     And I configure Bugsnag for "StackOverflowScenario"
     And I wait to receive an error


### PR DESCRIPTION
## Goal

Fixes an E2E test failure that has started affecting one of the Mac test runners.

`feature/crashprobe.feature:68` was failing because the test app was being killed and relaunched before the crash report had been fully written. Stack overflows generate larger crash reports which take longer to serialize.

## Changeset

Removes the fixed 3 second sleep and instead waits for the test app to stop running before relaunching.

## Testing

Was not able to reproduce the failure on demand.

Checked that scenario passes on affected Mac: https://buildkite.com/bugsnag/bugsnag-cocoa/builds/3291