### PR TITLE
Swift fatal error improvements

### DIFF
--- a/.buildkite/pipeline.yml
+++ b/.buildkite/pipeline.yml
@@ -178,6 +178,27 @@ steps:
         - exit_status: -1  # Agent was lost
           limit: 2
 
+  - label: 'macOS 10.13 barebones E2E tests'
+    depends_on:
+      - cocoa_fixture
+    timeout_in_minutes: 10
+    agents:
+      queue: opensource-mac-cocoa-10.13
+    plugins:
+      artifacts#v1.3.0:
+        download: ["features/fixtures/macos/output/macOSTestApp.zip"]
+        upload: ["macOSTestApp.log", "appium_server.log", "maze_output/failed/**/*"]
+    commands:
+      - bundle install
+      - bundle exec maze-runner
+        features/barebone_tests.feature
+        --farm=local
+        --os=macos
+        --os-version=10.13
+        --app=macOSTestApp
+        --fail-fast
+        --order=random
+
   - label: 'macOS 10.15 barebones E2E tests'
     depends_on:
       - cocoa_fixture

--- a/Bugsnag/Payload/BugsnagError.m
+++ b/Bugsnag/Payload/BugsnagError.m
@@ -132,11 +132,24 @@ NSString *BSGParseErrorMessage(NSDictionary *report, NSDictionary *error, NSStri
 
 - (void)updateWithCrashInfoMessage:(NSString *)crashInfoMessage {
     NSArray<NSString *> *patterns = @[
-        // From Swift 2.2: https://github.com/apple/swift/blob/swift-2.2-RELEASE/stdlib/public/stubs/Assert.cpp#L24-L39
+        // From Swift 2.2:
+        //
+        // https://github.com/apple/swift/blob/swift-2.2-RELEASE/stdlib/public/stubs/Assert.cpp#L24-L39
         @"^(assertion failed|fatal error|precondition failed): ((.+): )?file .+, line \\d+\n$",
+        // https://github.com/apple/swift/blob/swift-2.2-RELEASE/stdlib/public/stubs/Assert.cpp#L41-L55
+        @"^(assertion failed|fatal error|precondition failed): ((.+))?\n$",
+        
         // From Swift 4.1: https://github.com/apple/swift/commit/d03a575279cf5c523779ef68f8d7903f09ba901e
+        //
+        // https://github.com/apple/swift/blob/swift-4.1-RELEASE/stdlib/public/stubs/Assert.cpp#L75-L95
         @"^(Assertion failed|Fatal error|Precondition failed): ((.+): )?file .+, line \\d+\n$",
+        // https://github.com/apple/swift/blob/swift-4.1-RELEASE/stdlib/public/stubs/Assert.cpp#L97-L112
+        // https://github.com/apple/swift/blob/swift-5.4-RELEASE/stdlib/public/stubs/Assert.cpp#L65-L80
+        @"^(Assertion failed|Fatal error|Precondition failed): ((.+))?\n$",
+        
         // From Swift 5.4: https://github.com/apple/swift/commit/1a051719e3b1b7c37a856684dd037d482fef8e59
+        //
+        // https://github.com/apple/swift/blob/swift-5.4-RELEASE/stdlib/public/stubs/Assert.cpp#L43-L63
         @"^.+:\\d+: (Assertion failed|Fatal error|Precondition failed)(: (.+))?\n$",
     ];
     

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,13 @@
 Changelog
 =========
 
+## TBD
+
+### Bug fixes
+
+* Fix Swift fatal error parsing for messages with no filename.
+  [#1186](https://github.com/bugsnag/bugsnag-cocoa/pull/1186)
+
 ## 6.12.1 (2021-09-15)
 
 ### Bug fixes

--- a/Tests/BugsnagErrorTest.m
+++ b/Tests/BugsnagErrorTest.m
@@ -194,6 +194,12 @@ NSString *BSGParseErrorMessage(NSDictionary *report, NSDictionary *error, NSStri
     
     error.errorClass = nil;
     error.errorMessage = nil;
+    [error updateWithCrashInfoMessage:@"Fatal error: Unexpectedly found nil while unwrapping an Optional value\n"];
+    XCTAssertEqualObjects(error.errorClass, @"Fatal error");
+    XCTAssertEqualObjects(error.errorMessage, @"Unexpectedly found nil while unwrapping an Optional value");
+    
+    error.errorClass = nil;
+    error.errorMessage = nil;
     [error updateWithCrashInfoMessage:@"Precondition failed:   : strange formatting 😱::: file bugsnag_example/AnotherClass.swift, line 24\n"];
     XCTAssertEqualObjects(error.errorClass, @"Precondition failed");
     XCTAssertEqualObjects(error.errorMessage, @"  : strange formatting 😱::");

--- a/features/barebone_tests.feature
+++ b/features/barebone_tests.feature
@@ -101,7 +101,7 @@ Feature: Barebone tests
     And the event "severityReason.type" equals "handledError"
     And the event "severityReason.unhandledOverridden" is null
     And the event "unhandled" is false
-    And the exception "errorClass" equals "__SwiftNativeNSError"
+    And the exception "errorClass" matches "SwiftNativeNSError"
     And the exception "message" equals "The data couldn’t be read because it isn’t in the correct format."
     And the exception "type" equals "cocoa"
     And the "method" of stack frame 0 matches "BareboneTestHandledScenario"
@@ -153,7 +153,7 @@ Feature: Barebone tests
     And the event "severityReason.unhandledOverridden" is null
     And the event "threads.0.errorReportingThread" is true
     And the event "threads.0.id" equals "0"
-    And the event "threads.0.stacktrace.0.method" matches "(assertionFailure|<redacted>)"
+    And the event "threads.0.stacktrace.0.method" matches "(assertionFailure|fatalErrorMessage|<redacted>)"
     And the event "unhandled" is true
     And the event "user.email" equals "barfoo@example.com"
     And the event "user.id" equals "barfoo"
@@ -170,7 +170,7 @@ Feature: Barebone tests
     And the error payload field "events.0.device.totalMemory" is an integer
     And the error payload field "events.0.threads" is a non-empty array
     And the error payload field "events.0.threads.1" is not null
-    And the "method" of stack frame 0 matches "(assertionFailure|<redacted>)"
+    And the "method" of stack frame 0 matches "(assertionFailure|fatalErrorMessage|<redacted>)"
     And the stacktrace is valid for the event
 
   @skip_macos


### PR DESCRIPTION
## Goal

Improve parsing of Swift fatal error messages.

One of our E2E tests was failing on certain OS / Swift versions because the "Unexpectedly found nil while unwrapping an Optional value" message did not contain file name and line information, which `BugsnagError` was expecting.

## Changeset

* Adds matching patterns for Swift fatal error message variants with no file name / line number info.
* Adjusts tests to be more tolerant of slight differences between Swift versions - the class name can be `__SwiftNativeNSError` or `_SwiftNativeNSError`, and the name of internal methods can vary.

## Testing

Added macOS 10.13 barebones tests (which were failing) to the standard pipeline. Tests now pass 🎉 