### PR TITLE
[PLAT-7126] Stop dropping breadcrumbs with invalid metadata

### DIFF
--- a/Bugsnag/Client/BugsnagClient.m
+++ b/Bugsnag/Client/BugsnagClient.m
@@ -585,9 +585,13 @@ __attribute__((annotate("oclint:suppress[too many methods]")))
 - (void)leaveBreadcrumbWithMessage:(NSString *_Nonnull)message
                           metadata:(NSDictionary *_Nullable)metadata
                            andType:(BSGBreadcrumbType)type {
+    NSDictionary *JSONMetadata = BSGJSONDictionary(metadata ?: @{});
+    if (JSONMetadata != metadata && metadata) {
+        bsg_log_warn("Breadcrumb metadata is not a valid JSON object: %@", metadata);
+    }
     [self addBreadcrumbWithBlock:^(BugsnagBreadcrumb *_Nonnull crumbs) {
         crumbs.message = message;
-        crumbs.metadata = metadata ?: @{};
+        crumbs.metadata = JSONMetadata;
         crumbs.type = type;
     }];
 }

--- a/Bugsnag/Helpers/BugsnagCollections.h
+++ b/Bugsnag/Helpers/BugsnagCollections.h
@@ -50,9 +50,9 @@ NSDictionary * BSGDictionaryWithKeyAndObject(NSString *key, id _Nullable object)
  */
 NSDictionary *BSGDictMerge(NSDictionary *source, NSDictionary *destination);
 
-/// Returns a representation of the dictionary that contains only valid JSON.
+/// Returns the dictionary if it contains only valid JSON, or a new dictionary
+/// where invalid values have been replaced by their descriptions.
 /// Any dictionary keys that are not strings will be ignored.
-/// Any values that are not valid JSON will be replaced by a string description.
 NSDictionary * BSGJSONDictionary(NSDictionary *dictionary);
 
 // MARK: - NSSet

--- a/Bugsnag/include/Bugsnag/Bugsnag.h
+++ b/Bugsnag/include/Bugsnag/Bugsnag.h
@@ -182,7 +182,8 @@
  * a type.
  *
  * @param message The log message to leave.
- * @param metadata Additional metadata included with the breadcrumb.
+ * @param metadata Diagnostic data relating to the breadcrumb.
+ *                 Values should be serializable to JSON with NSJSONSerialization.
  * @param type A BSGBreadcrumbTypeValue denoting the type of breadcrumb.
  */
 + (void)leaveBreadcrumbWithMessage:(NSString *_Nonnull)message

--- a/Bugsnag/include/Bugsnag/BugsnagClient.h
+++ b/Bugsnag/include/Bugsnag/BugsnagClient.h
@@ -109,7 +109,8 @@
  * a type.
  *
  * @param message The log message to leave.
- * @param metadata Additional metadata included with the breadcrumb.
+ * @param metadata Diagnostic data relating to the breadcrumb.
+ *                 Values should be serializable to JSON with NSJSONSerialization.
  * @param type A BSGBreadcrumbTypeValue denoting the type of breadcrumb.
  */
 - (void)leaveBreadcrumbWithMessage:(NSString *_Nonnull)message

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,9 @@ Changelog
 
 ### Bug fixes
 
+* Stop dropping breadcrumbs when provided invalid metadata (that is not JSON convertible.)
+  [#1187](https://github.com/bugsnag/bugsnag-cocoa/pull/1187)
+
 * Fix Swift fatal error parsing for messages with no filename.
   [#1186](https://github.com/bugsnag/bugsnag-cocoa/pull/1186)
 

--- a/Tests/BugsnagBreadcrumbsTest.m
+++ b/Tests/BugsnagBreadcrumbsTest.m
@@ -399,6 +399,11 @@ BSGBreadcrumbType BSGBreadcrumbTypeFromString(NSString *value);
 
     XCTAssertEqualObjects(bc7[@"name"], @"user message");
     XCTAssertEqualObjects(bc7[@"type"], @"user");
+
+    [client leaveBreadcrumbWithMessage:@"Invalid metadata" metadata:@{@"date": [NSDate distantFuture]} andType:BSGBreadcrumbTypeUser];
+    XCTAssertEqual(client.breadcrumbs.breadcrumbs.count, 9, @"Invalid metadata should not prevent a breadcrumb being left");
+    XCTAssertEqualObjects(client.breadcrumbs.breadcrumbs[8].message, @"Invalid metadata");
+    XCTAssertEqualObjects(client.breadcrumbs.breadcrumbs[8].metadata.allKeys, @[@"date"]);
 }
 
 /**

--- a/Tests/BugsnagClientTests.m
+++ b/Tests/BugsnagClientTests.m
@@ -302,16 +302,10 @@ NSString *BSGFormatSeverity(BSGSeverity severity);
     BugsnagClient *client = [[BugsnagClient alloc] initWithConfiguration:configuration];
     [client start];
 
-    XCTAssertEqual(client.breadcrumbs.breadcrumbs.count, 0);
-
     id badMetadata = @{
         @"test": @"string key is fine",
         @85 : @"numeric key would break JSON"
     };
-
-    [client leaveBreadcrumbWithMessage:@"test msg" metadata:badMetadata andType:BSGBreadcrumbTypeUser];
-
-    XCTAssertEqual(client.breadcrumbs.breadcrumbs.count, 0, @"A breadcrumb with invalid JSON payload should be rejected");
 
     [client notifyError:[NSError errorWithDomain:@"test" code:0 userInfo:badMetadata]];
 }


### PR DESCRIPTION
## Goal

Stop dropping breadcrumbs when invalid metadata is provided by the app / developer.

## Changeset

Documentation for `leaveBreadcrumbWithMessage:metadata:andType:` has been added to clarify that metadata should contain only valid JSON (i.e. convertible by `NSJSONSerialization`.)

Breadcrumb metadata is now converted to valid JSON if required by replacing invalid objects with their descriptions, and an explicit warning is logged.

## Testing

Amended existing unit tests to verify this change in behaviour.