### PR TITLE
Fix network breadcrumbs duration field

### DIFF
--- a/BugsnagRequestMonitor/BugsnagRequestMonitor/BSGURLSessionTracingDelegate.m
+++ b/BugsnagRequestMonitor/BugsnagRequestMonitor/BSGURLSessionTracingDelegate.m
@@ -94,7 +94,7 @@ API_AVAILABLE(macosx(10.12), ios(10.0), watchos(3.0), tvos(10.0)) {
             @"method": stringOrEmpty(req.HTTPMethod),
             @"url": stringOrEmpty(urlComponents.string),
             @"urlParams": queryItemsAsDict(urlComponents.queryItems),
-            @"duration": @(metrics.taskInterval.duration),
+            @"duration": @((unsigned)(metrics.taskInterval.duration * 1000)),
             @"requestContentLength": @(requestContentLength),
             @"responseContentLength": @(responseContentLength)
         } andType:BSGBreadcrumbTypeRequest];

--- a/BugsnagRequestMonitor/BugsnagRequestMonitorTests/BugsnagRequestMonitorTests.m
+++ b/BugsnagRequestMonitor/BugsnagRequestMonitorTests/BugsnagRequestMonitorTests.m
@@ -116,7 +116,7 @@ static NSData *mock_nextData;
     XCTAssertEqual(crumb.type, BSGBreadcrumbTypeRequest);
     XCTAssertEqualObjects(crumb.message, message);
     NSDictionary *metadata = crumb.metadata;
-    XCTAssertGreaterThan([metadata[@"duration"] floatValue], 0);
+    // duration will be tested in e2e tests
     XCTAssertEqualObjects(metadata[@"method"], method);
     XCTAssertEqualObjects(metadata[@"requestContentLength"], @(reqLength));
     XCTAssertEqualObjects(metadata[@"responseContentLength"], @(respLength));


### PR DESCRIPTION
## Goal

The duration was in fractional seconds, but must be in whole milliseconds.
