### PR TITLE
Network breadcrumbs fixes

### DIFF
--- a/BugsnagNetworkRequestPlugin/BugsnagNetworkRequestPlugin.xcodeproj/project.pbxproj
+++ b/BugsnagNetworkRequestPlugin/BugsnagNetworkRequestPlugin.xcodeproj/project.pbxproj
@@ -7,6 +7,9 @@
 	objects = {
 
 /* Begin PBXBuildFile section */
+		0196AA1026FB395E008E54FC /* BSGURLSessionTracingDelegateTests.m in Sources */ = {isa = PBXBuildFile; fileRef = 0196AA0F26FB395E008E54FC /* BSGURLSessionTracingDelegateTests.m */; };
+		0196AA1126FB395E008E54FC /* BSGURLSessionTracingDelegateTests.m in Sources */ = {isa = PBXBuildFile; fileRef = 0196AA0F26FB395E008E54FC /* BSGURLSessionTracingDelegateTests.m */; };
+		0196AA1226FB395E008E54FC /* BSGURLSessionTracingDelegateTests.m in Sources */ = {isa = PBXBuildFile; fileRef = 0196AA0F26FB395E008E54FC /* BSGURLSessionTracingDelegateTests.m */; };
 		CB487A6326D7B109004F6B87 /* BugsnagNetworkRequestPlugin.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = CB487A5926D7B109004F6B87 /* BugsnagNetworkRequestPlugin.framework */; };
 		CB487A7526D7B12F004F6B87 /* Bugsnag.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = CB487A7426D7B12F004F6B87 /* Bugsnag.framework */; };
 		CB487A8626D7B144004F6B87 /* BugsnagNetworkRequestPlugin.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = CB487A7D26D7B144004F6B87 /* BugsnagNetworkRequestPlugin.framework */; };
@@ -67,6 +70,7 @@
 /* End PBXContainerItemProxy section */
 
 /* Begin PBXFileReference section */
+		0196AA0F26FB395E008E54FC /* BSGURLSessionTracingDelegateTests.m */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.objc; path = BSGURLSessionTracingDelegateTests.m; sourceTree = "<group>"; };
 		CB487A5926D7B109004F6B87 /* BugsnagNetworkRequestPlugin.framework */ = {isa = PBXFileReference; explicitFileType = wrapper.framework; includeInIndex = 0; path = BugsnagNetworkRequestPlugin.framework; sourceTree = BUILT_PRODUCTS_DIR; };
 		CB487A5D26D7B109004F6B87 /* Info.plist */ = {isa = PBXFileReference; lastKnownFileType = text.plist.xml; path = Info.plist; sourceTree = "<group>"; };
 		CB487A6226D7B109004F6B87 /* BugsnagNetworkRequestPlugin-iOSTests.xctest */ = {isa = PBXFileReference; explicitFileType = wrapper.cfbundle; includeInIndex = 0; path = "BugsnagNetworkRequestPlugin-iOSTests.xctest"; sourceTree = BUILT_PRODUCTS_DIR; };
@@ -183,6 +187,7 @@
 		CB487A6626D7B109004F6B87 /* BugsnagNetworkRequestPluginTests */ = {
 			isa = PBXGroup;
 			children = (
+				0196AA0F26FB395E008E54FC /* BSGURLSessionTracingDelegateTests.m */,
 				CB487A6726D7B109004F6B87 /* BugsnagNetworkRequestPluginTests.m */,
 				CB487A6926D7B109004F6B87 /* Info.plist */,
 			);
@@ -475,6 +480,7 @@
 			buildActionMask = 2147483647;
 			files = (
 				CB487AC226D7B9DB004F6B87 /* BugsnagNetworkRequestPluginTests.m in Sources */,
+				0196AA1026FB395E008E54FC /* BSGURLSessionTracingDelegateTests.m in Sources */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};
@@ -494,6 +500,7 @@
 			buildActionMask = 2147483647;
 			files = (
 				CB487AC326D7B9DC004F6B87 /* BugsnagNetworkRequestPluginTests.m in Sources */,
+				0196AA1126FB395E008E54FC /* BSGURLSessionTracingDelegateTests.m in Sources */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};
@@ -513,6 +520,7 @@
 			buildActionMask = 2147483647;
 			files = (
 				CB487AC426D7B9DD004F6B87 /* BugsnagNetworkRequestPluginTests.m in Sources */,
+				0196AA1226FB395E008E54FC /* BSGURLSessionTracingDelegateTests.m in Sources */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};

--- a/BugsnagNetworkRequestPlugin/BugsnagNetworkRequestPlugin/BSGURLSessionTracingDelegate.h
+++ b/BugsnagNetworkRequestPlugin/BugsnagNetworkRequestPlugin/BSGURLSessionTracingDelegate.h
@@ -24,6 +24,8 @@ NS_ASSUME_NONNULL_BEGIN
  */
 + (void)setSink:(nullable id<BSGBreadcrumbSink>) sink;
 
++ (nonnull NSString *)URLStringWithoutQueryForComponents:(nonnull NSURLComponents *)URLComponents;
+
 @property(nonatomic, assign, readonly) BOOL canTrace;
 
 @end

--- a/BugsnagNetworkRequestPlugin/BugsnagNetworkRequestPlugin/BSGURLSessionTracingDelegate.h
+++ b/BugsnagNetworkRequestPlugin/BugsnagNetworkRequestPlugin/BSGURLSessionTracingDelegate.h
@@ -24,6 +24,8 @@ NS_ASSUME_NONNULL_BEGIN
  */
 + (void)setSink:(nullable id<BSGBreadcrumbSink>) sink;
 
++ (nullable NSDictionary<NSString *, id> *)urlParamsForQueryItems:(nullable NSArray<NSURLQueryItem *> *)queryItems;
+
 + (nonnull NSString *)URLStringWithoutQueryForComponents:(nonnull NSURLComponents *)URLComponents;
 
 @property(nonatomic, assign, readonly) BOOL canTrace;

--- a/BugsnagNetworkRequestPlugin/BugsnagNetworkRequestPlugin/BSGURLSessionTracingDelegate.m
+++ b/BugsnagNetworkRequestPlugin/BugsnagNetworkRequestPlugin/BSGURLSessionTracingDelegate.m
@@ -88,7 +88,10 @@ API_AVAILABLE(macosx(10.12), ios(10.0), watchos(3.0), tvos(10.0)) {
         metadata[@"method"] = req.HTTPMethod;
         metadata[@"url"] = [BSGURLSessionTracingDelegate URLStringWithoutQueryForComponents:urlComponents];
         metadata[@"urlParams"] = [BSGURLSessionTracingDelegate urlParamsForQueryItems:urlComponents.queryItems];
-        if (req.HTTPBody) {
+        if (task.countOfBytesSent) {
+            metadata[@"requestContentLength"] = @(task.countOfBytesSent);
+        } else if (req.HTTPBody) {
+            // Fall back because task.countOfBytesSent is 0 when a custom NSURLProtocol is used
             metadata[@"requestContentLength"] = @(req.HTTPBody.length);
         }
         if (httpResp) {

--- a/BugsnagNetworkRequestPlugin/BugsnagNetworkRequestPlugin/BSGURLSessionTracingDelegate.m
+++ b/BugsnagNetworkRequestPlugin/BugsnagNetworkRequestPlugin/BSGURLSessionTracingDelegate.m
@@ -51,12 +51,20 @@ static id<BSGBreadcrumbSink> g_sink;
     }
     NSMutableDictionary *result = [NSMutableDictionary new];
     for (NSURLQueryItem *item in queryItems) {
+        // - note: If a NSURLQueryItem name-value pair is empty (i.e. the query string starts with '&', ends
+        // with '&', or has "&&" within it), you get a NSURLQueryItem with a zero-length name and a nil value.
+        // If a NSURLQueryItem name-value pair has nothing before the equals sign, you get a zero-length name.
+        // If a NSURLQueryItem name-value pair has nothing after the equals sign, you get a zero-length value.
+        // If a NSURLQueryItem name-value pair has no equals sign, the NSURLQueryItem name-value pair string
+        // is the name and you get a nil value.
+        id value = item.value ? item.value : [NSNull null];
+        
         if ([result[item.name] isKindOfClass:[NSMutableArray class]]) {
-            [result[item.name] addObject:item.value];
+            [result[item.name] addObject:value];
         } else if (result[item.name]) {
-            result[item.name] = [NSMutableArray arrayWithObjects:result[item.name], item.value, nil];
+            result[item.name] = [NSMutableArray arrayWithObjects:result[item.name], value, nil];
         } else {
-            result[item.name] = item.value;
+            result[item.name] = value;
         }
     }
     return result;

--- a/BugsnagNetworkRequestPlugin/BugsnagNetworkRequestPlugin/BSGURLSessionTracingDelegate.m
+++ b/BugsnagNetworkRequestPlugin/BugsnagNetworkRequestPlugin/BSGURLSessionTracingDelegate.m
@@ -45,13 +45,19 @@ static id<BSGBreadcrumbSink> g_sink;
     return @"NSURLSession error";
 }
 
-+ (nullable NSDictionary<NSString *, NSString *> *)urlParamsForQueryItems:(nullable NSArray<NSURLQueryItem *> *)queryItems {
++ (nullable NSDictionary<NSString *, id> *)urlParamsForQueryItems:(nullable NSArray<NSURLQueryItem *> *)queryItems {
     if (!queryItems) {
         return nil;
     }
     NSMutableDictionary *result = [NSMutableDictionary new];
     for (NSURLQueryItem *item in queryItems) {
-        result[item.name] = item.value;
+        if ([result[item.name] isKindOfClass:[NSMutableArray class]]) {
+            [result[item.name] addObject:item.value];
+        } else if (result[item.name]) {
+            result[item.name] = [NSMutableArray arrayWithObjects:result[item.name], item.value, nil];
+        } else {
+            result[item.name] = item.value;
+        }
     }
     return result;
 }

--- a/BugsnagNetworkRequestPlugin/BugsnagNetworkRequestPluginTests/BSGURLSessionTracingDelegateTests.m
+++ b/BugsnagNetworkRequestPlugin/BugsnagNetworkRequestPluginTests/BSGURLSessionTracingDelegateTests.m
@@ -15,6 +15,27 @@
 
 @implementation BSGURLSessionTracingDelegateTests
 
+- (void)testUrlParamsForQueryItems {
+#define TEST(url, expected) \
+XCTAssertEqualObjects([BSGURLSessionTracingDelegate urlParamsForQueryItems:[NSURLComponents componentsWithString:url].queryItems], expected)
+    
+    TEST(@"http://example.com", nil);
+    
+    TEST(@"http://example.com?", @{});
+    
+    TEST(@"http://example.com?foo=bar", @{@"foo": @"bar"});
+    
+    TEST(@"http://example.com?foo=bar&bar=baz", (@{@"foo": @"bar", @"bar": @"baz"}));
+    
+    // Multiple query items with the same name should be represented as arrays.
+    TEST(@"http://example.com?foo=bar&foo=baz", (@{@"foo": @[@"bar", @"baz"]}));
+    
+    // Query items with no value should be represented as empty string.
+    TEST(@"http://example.com?foo=bar&foo=baz&foo=&sort=name", (@{@"foo": @[@"bar", @"baz", @""], @"sort": @"name"}));
+
+#undef TEST
+}
+
 - (void)testURLStringWithoutQueryForComponents {
 #define TEST(url, expected) \
 XCTAssertEqualObjects([BSGURLSessionTracingDelegate URLStringWithoutQueryForComponents:[NSURLComponents componentsWithString:url]], expected)

--- a/BugsnagNetworkRequestPlugin/BugsnagNetworkRequestPluginTests/BSGURLSessionTracingDelegateTests.m
+++ b/BugsnagNetworkRequestPlugin/BugsnagNetworkRequestPluginTests/BSGURLSessionTracingDelegateTests.m
@@ -32,6 +32,14 @@ XCTAssertEqualObjects([BSGURLSessionTracingDelegate urlParamsForQueryItems:[NSUR
     
     // Query items with no value should be represented as empty string.
     TEST(@"http://example.com?foo=bar&foo=baz&foo=&sort=name", (@{@"foo": @[@"bar", @"baz", @""], @"sort": @"name"}));
+    
+    TEST(@"http://example.com?foo", @{});
+    
+    TEST(@"http://example.com?=bar", @{@"": @"bar"});
+    
+    TEST(@"http://example.com?foo=bar&", @{@"foo": @"bar"});
+    
+    TEST(@"http://example.com?foo=bar&baz", @{@"foo": @"bar"});
 
 #undef TEST
 }

--- a/BugsnagNetworkRequestPlugin/BugsnagNetworkRequestPluginTests/BSGURLSessionTracingDelegateTests.m
+++ b/BugsnagNetworkRequestPlugin/BugsnagNetworkRequestPluginTests/BSGURLSessionTracingDelegateTests.m
@@ -33,14 +33,16 @@ XCTAssertEqualObjects([BSGURLSessionTracingDelegate urlParamsForQueryItems:[NSUR
     // Query items with no value should be represented as empty string.
     TEST(@"http://example.com?foo=bar&foo=baz&foo=&sort=name", (@{@"foo": @[@"bar", @"baz", @""], @"sort": @"name"}));
     
-    TEST(@"http://example.com?foo", @{});
+    TEST(@"http://example.com?foo", @{@"foo": [NSNull null]});
     
     TEST(@"http://example.com?=bar", @{@"": @"bar"});
     
-    TEST(@"http://example.com?foo=bar&", @{@"foo": @"bar"});
+    TEST(@"http://example.com?foo=bar&", (@{@"foo": @"bar", @"": [NSNull null]}));
     
-    TEST(@"http://example.com?foo=bar&baz", @{@"foo": @"bar"});
-
+    TEST(@"http://example.com?foo=bar&baz", (@{@"foo": @"bar", @"baz": [NSNull null]}));
+    
+    TEST(@"http://example.com?foo=bar&baz&baz", (@{@"foo": @"bar", @"baz": @[[NSNull null], [NSNull null]]}));
+    
 #undef TEST
 }
 

--- a/BugsnagNetworkRequestPlugin/BugsnagNetworkRequestPluginTests/BSGURLSessionTracingDelegateTests.m
+++ b/BugsnagNetworkRequestPlugin/BugsnagNetworkRequestPluginTests/BSGURLSessionTracingDelegateTests.m
@@ -1,0 +1,47 @@
+//
+//  BSGURLSessionTracingDelegateTests.m
+//  BugsnagNetworkRequestPlugin
+//
+//  Created by Nick Dowell on 22/09/2021.
+//
+
+#import "BSGURLSessionTracingDelegate.h"
+
+#import <XCTest/XCTest.h>
+
+@interface BSGURLSessionTracingDelegateTests : XCTestCase
+
+@end
+
+@implementation BSGURLSessionTracingDelegateTests
+
+- (void)testURLStringWithoutQueryForComponents {
+#define TEST(url, expected) \
+XCTAssertEqualObjects([BSGURLSessionTracingDelegate URLStringWithoutQueryForComponents:[NSURLComponents componentsWithString:url]], expected)
+    
+    TEST(@"http://example.com",
+         @"http://example.com");
+    
+    TEST(@"http://example.com/",
+         @"http://example.com/");
+    
+    TEST(@"http://example.com?foo=bar",
+         @"http://example.com");
+    
+    TEST(@"http://example.com/?foo=bar",
+         @"http://example.com/");
+    
+    TEST(@"http://example.com/page.html?foo=bar",
+         @"http://example.com/page.html");
+    
+    TEST(@"http://example.com/page.html?foo=bar#some-anchor",
+         @"http://example.com/page.html#some-anchor");
+    
+    // In this example what look like query parameters are actually part of the fragment
+    TEST(@"http://example.com/page.html#some-anchor?foo=bar",
+         @"http://example.com/page.html#some-anchor?foo=bar");
+    
+#undef TEST
+}
+
+@end

--- a/BugsnagNetworkRequestPlugin/BugsnagNetworkRequestPluginTests/BugsnagNetworkRequestPluginTests.m
+++ b/BugsnagNetworkRequestPlugin/BugsnagNetworkRequestPluginTests/BugsnagNetworkRequestPluginTests.m
@@ -125,6 +125,12 @@ static NSData *mock_nextData;
     XCTAssertEqualObjects(metadata[@"urlParams"], params);
 }
 
+- (void)waitForTask:(NSURLSessionTask *)task {
+    while (task.state == NSURLSessionTaskStateRunning) {
+        [NSThread sleepForTimeInterval:0.01];
+    }
+}
+
 typedef void (^CompletionHandler)(NSData *data, NSURLResponse *response, NSError *error);
 
 #pragma mark Basic Fetch
@@ -150,7 +156,7 @@ typedef void (^CompletionHandler)(NSData *data, NSURLResponse *response, NSError
     NSURL *url = [NSURL URLWithString:urlString];
     NSURLSessionDataTask * task = [session dataTaskWithURL:url];
     [task resume];
-    [NSThread sleepForTimeInterval:0.01];
+    [self waitForTask:task];
 }
 
 - (void)runDataTaskWithSession:(NSURLSession *)session
@@ -170,7 +176,7 @@ typedef void (^CompletionHandler)(NSData *data, NSURLResponse *response, NSError
                        request:(NSURLRequest *)request {
     NSURLSessionDataTask * task = [session dataTaskWithRequest:request];
     [task resume];
-    [NSThread sleepForTimeInterval:0.01];
+    [self waitForTask:task];
 }
 
 - (void)runDataTaskWithSession:(NSURLSession *)session
@@ -268,7 +274,7 @@ typedef void (^CompletionHandler)(NSData *data, NSURLResponse *response, NSError
     NSURL *url = [NSURL URLWithString:urlString];
     NSURLSessionDownloadTask *task = [session downloadTaskWithURL:url];
     [task resume];
-    [NSThread sleepForTimeInterval:0.01];
+    [self waitForTask:task];
 }
 
 - (void)runDownloadTaskWithSession:(NSURLSession *)session
@@ -288,7 +294,7 @@ typedef void (^CompletionHandler)(NSData *data, NSURLResponse *response, NSError
                            request:(NSURLRequest *)request {
     NSURLSessionDownloadTask * task = [session downloadTaskWithRequest:request];
     [task resume];
-    [NSThread sleepForTimeInterval:0.01];
+    [self waitForTask:task];
 }
 
 - (void)runDownloadTaskWithSession:(NSURLSession *)session
@@ -341,7 +347,7 @@ typedef void (^CompletionHandler)(NSData *data, NSURLResponse *response, NSError
                         fromData:(NSData *)fromData {
     NSURLSessionUploadTask * task = [session uploadTaskWithRequest:request fromData:fromData];
     [task resume];
-    [NSThread sleepForTimeInterval:0.01];
+    [self waitForTask:task];
 }
 
 - (void)runUploadTaskWithSession:(NSURLSession *)session
@@ -375,6 +381,7 @@ typedef void (^CompletionHandler)(NSData *data, NSURLResponse *response, NSError
     }];
     validator();
 }
+
 #pragma mark Unit Tests
 
 - (void)testBadURL {

--- a/BugsnagNetworkRequestPlugin/BugsnagNetworkRequestPluginTests/BugsnagNetworkRequestPluginTests.m
+++ b/BugsnagNetworkRequestPlugin/BugsnagNetworkRequestPluginTests/BugsnagNetworkRequestPluginTests.m
@@ -105,12 +105,12 @@ static NSData *mock_nextData;
 }
 
 - (void)expectMessage:(NSString *)message
-                method:(NSString *)method
-             reqLength:(NSUInteger)reqLength
-            respLength:(NSUInteger)respLength
-                status:(NSInteger)statusCode
-                   url:(NSString *)urlString
-                params:(NSDictionary *)params {
+               method:(NSString *)method
+            reqLength:(NSNumber *)reqLength
+           respLength:(NSNumber *)respLength
+               status:(NSNumber *)statusCode
+                  url:(NSString *)urlString
+               params:(NSDictionary *)params {
     XCTAssertEqual(self.breadcrumbs.count, 1);
     BugsnagBreadcrumb *crumb = self.breadcrumbs.lastObject;
     XCTAssertEqual(crumb.type, BSGBreadcrumbTypeRequest);
@@ -118,9 +118,9 @@ static NSData *mock_nextData;
     NSDictionary *metadata = crumb.metadata;
     // duration will be tested in e2e tests
     XCTAssertEqualObjects(metadata[@"method"], method);
-    XCTAssertEqualObjects(metadata[@"requestContentLength"], @(reqLength));
-    XCTAssertEqualObjects(metadata[@"responseContentLength"], @(respLength));
-    XCTAssertEqualObjects(metadata[@"status"], @(statusCode));
+    XCTAssertEqualObjects(metadata[@"requestContentLength"], reqLength);
+    XCTAssertEqualObjects(metadata[@"responseContentLength"], respLength);
+    XCTAssertEqualObjects(metadata[@"status"], statusCode);
     XCTAssertEqualObjects(metadata[@"url"], urlString);
     XCTAssertEqualObjects(metadata[@"urlParams"], params);
 }
@@ -389,11 +389,11 @@ typedef void (^CompletionHandler)(NSData *data, NSURLResponse *response, NSError
     [self fetchAndWaitURL:@"xxxxxxx" usingConfig:self.defaultConfig];
     [self expectMessage:@"NSURLSession error"
                  method:@"GET"
-              reqLength:0
-             respLength:0
-                 status:0
+              reqLength:nil
+             respLength:nil
+                 status:nil
                     url:@"xxxxxxx"
-                 params:@{}];
+                 params:nil];
 }
 
 - (void)testDataTaskEmpty {
@@ -406,11 +406,11 @@ typedef void (^CompletionHandler)(NSData *data, NSURLResponse *response, NSError
                     validator:^{
         [self expectMessage:@"NSURLSession succeeded"
                      method:@"GET"
-                  reqLength:0
-                 respLength:0
-                     status:200
+                  reqLength:nil
+                 respLength:@0
+                     status:@200
                         url:urlString
-                     params:@{}];
+                     params:nil];
     }];
 }
 
@@ -424,11 +424,11 @@ typedef void (^CompletionHandler)(NSData *data, NSURLResponse *response, NSError
                     validator:^{
         [self expectMessage:@"NSURLSession succeeded"
                      method:@"GET"
-                  reqLength:0
-                 respLength:10
-                     status:200
+                  reqLength:nil
+                 respLength:@10
+                     status:@200
                         url:urlString
-                     params:@{}];
+                     params:nil];
     }];
 }
 
@@ -455,11 +455,11 @@ typedef void (^CompletionHandler)(NSData *data, NSURLResponse *response, NSError
                         validator:^{
             [self expectMessage:expectedMessage
                          method:@"GET"
-                      reqLength:0
-                     respLength:0
-                         status:statusCode
+                      reqLength:nil
+                     respLength:@0
+                         status:@(statusCode)
                             url:urlString
-                         params:@{}];
+                         params:nil];
         }];
 
         [self resetBreadcrumbs];
@@ -470,11 +470,11 @@ typedef void (^CompletionHandler)(NSData *data, NSURLResponse *response, NSError
                         validator:^{
             [self expectMessage:expectedMessage
                          method:@"GET"
-                      reqLength:100347 // Length of multipart content
-                     respLength:10
-                         status:statusCode
+                      reqLength:@100347 // Length of multipart content
+                     respLength:@10
+                         status:@(statusCode)
                             url:urlString
-                         params:@{}];
+                         params:nil];
         }];
 
         [self resetBreadcrumbs];
@@ -485,11 +485,11 @@ typedef void (^CompletionHandler)(NSData *data, NSURLResponse *response, NSError
                         validator:^{
             [self expectMessage:expectedMessage
                          method:@"GET"
-                      reqLength:0
-                     respLength:100
-                         status:statusCode
+                      reqLength:nil
+                     respLength:@100
+                         status:@(statusCode)
                             url:urlString
-                         params:@{}];
+                         params:nil];
         }];
 
         [self resetBreadcrumbs];
@@ -499,45 +499,44 @@ typedef void (^CompletionHandler)(NSData *data, NSURLResponse *response, NSError
                         validator:^{
             [self expectMessage:expectedMessage
                          method:@"GET"
-                      reqLength:0
-                     respLength:5109
-                         status:statusCode
+                      reqLength:nil
+                     respLength:@5109
+                         status:@(statusCode)
                             url:urlString
-                         params:@{}];
+                         params:nil];
         }];
     }
 }
 
 - (void)testTaskMethods {
     for (NSString *method in @[@"GET", @"HEAD", @"POST", @"PUT", @"DELETE", @"CONNECT", @"OPTIONS", @"TRACE", @"PATCH"]) {
-        NSString *urlString = @"https://bugsnag.com/?a=b&c=d";
         [self resetBreadcrumbs];
-        [self runDataTasksWithURL:urlString
+        [self runDataTasksWithURL:@"https://bugsnag.com/?a=b&c=d"
                            method:method
                        statusCode:200
                              data:[self dataOfLength:0]
                         validator:^{
             [self expectMessage:@"NSURLSession succeeded"
                          method:method
-                      reqLength:0
-                     respLength:0
-                         status:200
-                            url:urlString
+                      reqLength:nil
+                     respLength:@0
+                         status:@200
+                            url:@"https://bugsnag.com/"
                          params:@{@"a": @"b", @"c": @"d"}];
         }];
-
+        
         [self resetBreadcrumbs];
-        [self runDownloadTasksWithURL:urlString
-                           method:method
-                       statusCode:200
-                             data:[self dataOfLength:0]
-                        validator:^{
+        [self runDownloadTasksWithURL:@"https://bugsnag.com?a=b&c=d"
+                               method:method
+                           statusCode:200
+                                 data:[self dataOfLength:0]
+                            validator:^{
             [self expectMessage:@"NSURLSession succeeded"
                          method:method
-                      reqLength:0
-                     respLength:0
-                         status:200
-                            url:urlString
+                      reqLength:nil
+                     respLength:@0
+                         status:@200
+                            url:@"https://bugsnag.com"
                          params:@{@"a": @"b", @"c": @"d"}];
         }];
     }


### PR DESCRIPTION
## Goal

Fix the following issues:
* PLAT-7288 Omit urlParams from network breadcrumbs if no params in request
* PLAT-7320 Status and response length should be omitted on error
* PLAT-7321 Strip query params from URL
* PLAT-7322 Reported request length varies depending on status code

## Changeset

`urlParams` are now omitted (rather than including `{}`) if there are no query parameters.

If there are multiple query items with the same name, the values will now be combined into an array.

`status` and `responseContentLength` are now omitted if no response was received - i.e. in the case of a network error.

`requestContentLength` now represents the length of the request's body **excluding** protocol-specific framing, transfer encoding, and content encoding. The NSURLSessionTasks's `countOfBytesSent` is used when available, falling back to `HTTPBody.length` otherwise (which is necessary during unit testing with the custom NSURLProtocol.)

`responseContentLength` now represents the length of the **body** of the response (i.e. the data provided to the completion handler / delegate) rather than the length of the whole encoded request including headers, and is now fetched from the `NSURLSessionTask` object (which reports the correct data when an `NSURLProtocol` is in use, unlike `NSURLSessionTaskTransactionMetrics`.)

`url` no longer includes the query string.

`conclusionForResponseCode:` was renamed to `messageForResponse:` and the logic changed to ensure that status codes outside of the normal range would not produce unexpected results (e.g. the original logic would have returned "NSURLSession succeeded" with 1400 as its input.)

## Testing

Updated existing unit tests to very new behaviour.

Added test cases to verify stripping of query params from URL.