### PR TITLE
Decorate BugsnagNetworkRequestPlugin with API_AVAILABLE

### DIFF
--- a/BugsnagNetworkRequestPlugin/BugsnagNetworkRequestPlugin/BugsnagNetworkRequestPlugin.m
+++ b/BugsnagNetworkRequestPlugin/BugsnagNetworkRequestPlugin/BugsnagNetworkRequestPlugin.m
@@ -10,12 +10,12 @@
 // `URLSession:task:didFinishCollectingMetrics:` so that we can generate network
 // breadcrumbs from all requests.
 
-#import <Bugsnag/BugsnagClient.h>
-#import <Bugsnag/BugsnagPlugin.h>
+#import "BugsnagNetworkRequestPlugin.h"
 
 #import "BSGURLSessionTracingDelegate.h"
-#import "BugsnagNetworkRequestPlugin.h"
 #import "NSURLSession+Tracing.h"
+
+#import <Bugsnag/BugsnagClient.h>
 
 @implementation BugsnagNetworkRequestPlugin
 

--- a/BugsnagNetworkRequestPlugin/BugsnagNetworkRequestPlugin/include/BugsnagNetworkRequestPlugin/BugsnagNetworkRequestPlugin.h
+++ b/BugsnagNetworkRequestPlugin/BugsnagNetworkRequestPlugin/include/BugsnagNetworkRequestPlugin/BugsnagNetworkRequestPlugin.h
@@ -5,17 +5,11 @@
 //  Created by Karl Stenerud on 26.08.21.
 //
 
-#import <Foundation/Foundation.h>
-
-@protocol BugsnagPlugin;
+#import <Bugsnag/BugsnagPlugin.h>
 
 /**
  * BugsnagNetworkRequestPlugin produces network breadcrumbs for all URL requests made via NSURLSession.
- *
- * Note: This plugin will only report breadcrumbs in the following operating system versions:
- * - iOS 10.0+
- * - tvOS 10.0+
- * - macOS 10.12+
  */
+API_AVAILABLE(macosx(10.12), ios(10.0), watchos(3.0), tvos(10.0))
 @interface BugsnagNetworkRequestPlugin : NSObject<BugsnagPlugin>
 @end


### PR DESCRIPTION
## Goal

Use `API_AVAILABLE` macro to annotate and document BugsnagNetworkRequestPlugin's OS version requirements.

## Testing

Verified that all test fixtures and example apps build successfully - https://buildkite.com/bugsnag/bugsnag-cocoa/builds/3370