### PR TITLE
[PLAT-7263] Disable app hang detection in app extensions

### DIFF
--- a/Bugsnag/Client/BugsnagClient.m
+++ b/Bugsnag/Client/BugsnagClient.m
@@ -384,9 +384,8 @@ __attribute__((annotate("oclint:suppress[too many methods]")))
     [self.eventUploader uploadStoredEvents];
     
     // App hang detector deliberately started after sendLaunchCrashSynchronously (which by design may itself trigger an app hang)
-    if (self.configuration.enabledErrorTypes.appHangs) {
-        [self startAppHangDetector];
-    }
+    // Note: BSGAppHangDetector itself checks configuration.enabledErrorTypes.appHangs
+    [self startAppHangDetector];
     
     self.configMetadataFromLastLaunch = nil;
     self.metadataFromLastLaunch = nil;

--- a/Bugsnag/Helpers/BSGAppHangDetector.m
+++ b/Bugsnag/Helpers/BSGAppHangDetector.m
@@ -45,6 +45,14 @@
         return;
     }
     
+    if ([BSG_KSSystemInfo isRunningInAppExtension]) {
+        // App extensions have a different life cycle and environment that make the hang detection mechanism unsuitable.
+        // * Depending on the type of extension, the run loop is not necessarily dedicated to UI.
+        // * The host app or other extensions run by it may trigger false positives.
+        // * The system may kill app extensions without any notification.
+        return;
+    }
+    
     if (NSProcessInfo.processInfo.environment[@"XCTestConfigurationFilePath"]) {
         // Disable functionality during unit testing to avoid crashes that can occur due to there
         // being many leaked BugsnagClient instances and BSGAppHangDetectors running while global

--- a/Bugsnag/KSCrash/Source/KSCrash/Recording/BSG_KSSystemInfo.m
+++ b/Bugsnag/KSCrash/Source/KSCrash/Recording/BSG_KSSystemInfo.m
@@ -441,23 +441,14 @@ static NSDictionary * bsg_systemversion() {
 }
 
 + (BOOL)isRunningInAppExtension {
-#if BSG_PLATFORM_IOS
-    NSBundle *mainBundle = [NSBundle mainBundle];
-    // From the App Extension Programming Guide:
-    // > When you build an extension based on an Xcode template, you get an
-    // > extension bundle that ends in .appex.
-    return [[mainBundle executablePath] containsString:@".appex"]
-        // In the case that the extension bundle was renamed or generated
-        // outside of the Xcode template, check the Bundle OS Type Code:
-        // > This key consists of a four-letter code for the bundle type. For
-        // > apps, the code is APPL, for frameworks, it's FMWK, and for bundles,
-        // > it's BNDL.
-        // If the main bundle type is not "APPL", assume this is an extension
-        // context.
-        || ![[mainBundle infoDictionary][@"CFBundlePackageType"] isEqualToString:@"APPL"];
-#else
-    return NO;
-#endif
+    // From "Information Property List Key Reference" > "App Extension Keys"
+    // https://developer.apple.com/library/archive/documentation/General/Reference/InfoPlistKeyReference/Articles/AppExtensionKeys.html
+    //
+    // NSExtensionPointIdentifier
+    // String - iOS, macOS. Specifies the extension point that supports an app extension, in reverse-DNS notation.
+    // This key is required for every app extension, and must be placed as an immediate child of the NSExtension key.
+    // Each Xcode app extension template is preconfigured with the appropriate extension point identifier key.
+    return NSBundle.mainBundle.infoDictionary[@"NSExtension"][@"NSExtensionPointIdentifier"] != nil;
 }
 
 #if BSG_PLATFORM_IOS || BSG_PLATFORM_TVOS

--- a/Bugsnag/include/Bugsnag/BugsnagErrorTypes.h
+++ b/Bugsnag/include/Bugsnag/BugsnagErrorTypes.h
@@ -17,6 +17,8 @@
  * Determines whether App Hang events should be reported to bugsnag.
  *
  * This flag is true by default.
+ *
+ * Note: this flag is ignored in App Extensions, where app hang detection is always disabled.
  */
 @property (nonatomic) BOOL appHangs;
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,13 @@
 Changelog
 =========
 
+## TBD
+
+### Bug fixes
+
+* Disable app hang detection for app extensions.
+  [#1198](https://github.com/bugsnag/bugsnag-cocoa/pull/1198)
+
 ## 6.13.0 (2021-09-29)
 
 ### Enhancements


### PR DESCRIPTION
## Goal

App extensions have a different life cycle and environment that make the hang detection mechanism unsuitable.
* Depending on the type of extension, the run loop is not necessarily dedicated to UI.
* The host app or other extensions run by it may trigger false positives.
* The system may kill app extensions without any notification.

## Changeset

Disables app hang detection in app extensions.

Improves the logic of `+[BSG_KSSystemInfo isRunningInAppExtension]` by querying the Info.plist's [NSExtensionPointIdentifier](https://developer.apple.com/library/archive/documentation/General/Reference/InfoPlistKeyReference/Articles/AppExtensionKeys.html#//apple_ref/doc/uid/TP40014212-SW15) rather than `CFBundlePackageType` (which would erroneously cause YES to be returned for some versions of Xcode's xctest unit test runner.)

## Testing

Manually verified in a Widget app extension.