### PR TITLE
Add support for getting thread run state

### DIFF
--- a/Bugsnag.xcodeproj/project.pbxproj
+++ b/Bugsnag.xcodeproj/project.pbxproj
@@ -792,6 +792,16 @@
 		CB10E53F250BA8DE00AF5824 /* BugsnagKVStoreTest.m in Sources */ = {isa = PBXBuildFile; fileRef = CBAA6AB9250BA6B100713376 /* BugsnagKVStoreTest.m */; };
 		CB10E540250BA8DF00AF5824 /* BugsnagKVStoreTest.m in Sources */ = {isa = PBXBuildFile; fileRef = CBAA6AB9250BA6B100713376 /* BugsnagKVStoreTest.m */; };
 		CB10E541250BA8E000AF5824 /* BugsnagKVStoreTest.m in Sources */ = {isa = PBXBuildFile; fileRef = CBAA6AB9250BA6B100713376 /* BugsnagKVStoreTest.m */; };
+		CB156241270707740097334C /* KSCrashNames_Test.m in Sources */ = {isa = PBXBuildFile; fileRef = CB156240270707740097334C /* KSCrashNames_Test.m */; };
+		CB156242270707740097334C /* KSCrashNames_Test.m in Sources */ = {isa = PBXBuildFile; fileRef = CB156240270707740097334C /* KSCrashNames_Test.m */; };
+		CB156243270707740097334C /* KSCrashNames_Test.m in Sources */ = {isa = PBXBuildFile; fileRef = CB156240270707740097334C /* KSCrashNames_Test.m */; };
+		CB33CCFE2703438400C76656 /* BSG_KSCrashNames.h in Headers */ = {isa = PBXBuildFile; fileRef = CB33CCFC2703438400C76656 /* BSG_KSCrashNames.h */; };
+		CB33CCFF2703438400C76656 /* BSG_KSCrashNames.h in Headers */ = {isa = PBXBuildFile; fileRef = CB33CCFC2703438400C76656 /* BSG_KSCrashNames.h */; };
+		CB33CD002703438400C76656 /* BSG_KSCrashNames.h in Headers */ = {isa = PBXBuildFile; fileRef = CB33CCFC2703438400C76656 /* BSG_KSCrashNames.h */; };
+		CB33CD012703438400C76656 /* BSG_KSCrashNames.c in Sources */ = {isa = PBXBuildFile; fileRef = CB33CCFD2703438400C76656 /* BSG_KSCrashNames.c */; };
+		CB33CD022703438400C76656 /* BSG_KSCrashNames.c in Sources */ = {isa = PBXBuildFile; fileRef = CB33CCFD2703438400C76656 /* BSG_KSCrashNames.c */; };
+		CB33CD032703438400C76656 /* BSG_KSCrashNames.c in Sources */ = {isa = PBXBuildFile; fileRef = CB33CCFD2703438400C76656 /* BSG_KSCrashNames.c */; };
+		CB33CD042703438400C76656 /* BSG_KSCrashNames.c in Sources */ = {isa = PBXBuildFile; fileRef = CB33CCFD2703438400C76656 /* BSG_KSCrashNames.c */; };
 		CB6419AB25A73E8C00613D25 /* BSGStorageMigratorTests.m in Sources */ = {isa = PBXBuildFile; fileRef = CB6419AA25A73E8C00613D25 /* BSGStorageMigratorTests.m */; };
 		CB6419B425A7419400613D25 /* v0_files in Resources */ = {isa = PBXBuildFile; fileRef = CB6419B325A7419400613D25 /* v0_files */; };
 		CB6419B525A7419400613D25 /* v0_files in Resources */ = {isa = PBXBuildFile; fileRef = CB6419B325A7419400613D25 /* v0_files */; };
@@ -1366,6 +1376,9 @@
 		3A700A9124A63A8E0068CD1B /* BugsnagError.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; path = BugsnagError.h; sourceTree = "<group>"; };
 		3A700A9224A63A8E0068CD1B /* BugsnagDeviceWithState.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; path = BugsnagDeviceWithState.h; sourceTree = "<group>"; };
 		3A700A9324A63A8E0068CD1B /* BugsnagMetadata.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; path = BugsnagMetadata.h; sourceTree = "<group>"; };
+		CB156240270707740097334C /* KSCrashNames_Test.m */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.objc; path = KSCrashNames_Test.m; sourceTree = "<group>"; };
+		CB33CCFC2703438400C76656 /* BSG_KSCrashNames.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; path = BSG_KSCrashNames.h; sourceTree = "<group>"; };
+		CB33CCFD2703438400C76656 /* BSG_KSCrashNames.c */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.c; path = BSG_KSCrashNames.c; sourceTree = "<group>"; };
 		CB6419AA25A73E8C00613D25 /* BSGStorageMigratorTests.m */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.objc; path = BSGStorageMigratorTests.m; sourceTree = "<group>"; };
 		CB6419B325A7419400613D25 /* v0_files */ = {isa = PBXFileReference; lastKnownFileType = folder; path = v0_files; sourceTree = "<group>"; };
 		CB9103632502320A00E9D1E2 /* BugsnagApiClientTest.m */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.objc; path = BugsnagApiClientTest.m; sourceTree = "<group>"; };
@@ -1509,6 +1522,7 @@
 				008966D92486D43700DC48C2 /* RFC3339DateTool_Tests.m */,
 				008966E22486D43700DC48C2 /* XCTestCase+KSCrash.h */,
 				008966D72486D43700DC48C2 /* XCTestCase+KSCrash.m */,
+				CB156240270707740097334C /* KSCrashNames_Test.m */,
 			);
 			path = KSCrash;
 			sourceTree = "<group>";
@@ -1559,6 +1573,7 @@
 		008968FF2486DAD000DC48C2 /* Recording */ = {
 			isa = PBXGroup;
 			children = (
+				CBD50F6025DA72EC00DF0314 /* BSG_Jailbreak.h */,
 				0089692D2486DAD000DC48C2 /* BSG_KSCrash.h */,
 				008969362486DAD000DC48C2 /* BSG_KSCrash.m */,
 				008969382486DAD000DC48C2 /* BSG_KSCrashAdvanced.h */,
@@ -1569,6 +1584,8 @@
 				008969002486DAD000DC48C2 /* BSG_KSCrashDoctor.m */,
 				0089694A2486DAD000DC48C2 /* BSG_KSCrashIdentifier.h */,
 				008969302486DAD000DC48C2 /* BSG_KSCrashIdentifier.m */,
+				CB33CCFD2703438400C76656 /* BSG_KSCrashNames.c */,
+				CB33CCFC2703438400C76656 /* BSG_KSCrashNames.h */,
 				008969492486DAD000DC48C2 /* BSG_KSCrashReport.c */,
 				008969322486DAD000DC48C2 /* BSG_KSCrashReport.h */,
 				008969342486DAD000DC48C2 /* BSG_KSCrashReportFields.h */,
@@ -1580,7 +1597,6 @@
 				0089692F2486DAD000DC48C2 /* BSG_KSSystemInfo.h */,
 				0089694C2486DAD000DC48C2 /* BSG_KSSystemInfo.m */,
 				008969312486DAD000DC48C2 /* BSG_KSSystemInfoC.h */,
-				CBD50F6025DA72EC00DF0314 /* BSG_Jailbreak.h */,
 				0089693A2486DAD000DC48C2 /* Sentry */,
 				008969012486DAD000DC48C2 /* Tools */,
 			);
@@ -2091,6 +2107,7 @@
 				008967D72486DA2D00DC48C2 /* BSGConfigurationBuilder.h in Headers */,
 				008969812486DAD100DC48C2 /* BSG_KSObjC.h in Headers */,
 				008969A22486DAD100DC48C2 /* BSG_KSDynamicLinker.h in Headers */,
+				CB33CCFE2703438400C76656 /* BSG_KSCrashNames.h in Headers */,
 				008969B42486DAD100DC48C2 /* BSG_KSObjCApple.h in Headers */,
 				CBE9062A25A34DAB0045B965 /* BSGStorageMigratorV0V1.h in Headers */,
 				008969932486DAD100DC48C2 /* BSG_KSLogger.h in Headers */,
@@ -2195,6 +2212,7 @@
 				008967D82486DA2D00DC48C2 /* BSGConfigurationBuilder.h in Headers */,
 				008969822486DAD100DC48C2 /* BSG_KSObjC.h in Headers */,
 				008969A32486DAD100DC48C2 /* BSG_KSDynamicLinker.h in Headers */,
+				CB33CCFF2703438400C76656 /* BSG_KSCrashNames.h in Headers */,
 				008969B52486DAD100DC48C2 /* BSG_KSObjCApple.h in Headers */,
 				008969942486DAD100DC48C2 /* BSG_KSLogger.h in Headers */,
 				CBE9062B25A34DAB0045B965 /* BSGStorageMigratorV0V1.h in Headers */,
@@ -2299,6 +2317,7 @@
 				008967D92486DA2D00DC48C2 /* BSGConfigurationBuilder.h in Headers */,
 				008969832486DAD100DC48C2 /* BSG_KSObjC.h in Headers */,
 				008969A42486DAD100DC48C2 /* BSG_KSDynamicLinker.h in Headers */,
+				CB33CD002703438400C76656 /* BSG_KSCrashNames.h in Headers */,
 				008969B62486DAD100DC48C2 /* BSG_KSObjCApple.h in Headers */,
 				008969952486DAD100DC48C2 /* BSG_KSLogger.h in Headers */,
 				CBE9062C25A34DAB0045B965 /* BSGStorageMigratorV0V1.h in Headers */,
@@ -2587,6 +2606,7 @@
 				008969902486DAD100DC48C2 /* BSG_RFC3339DateTool.m in Sources */,
 				008968AB2486DA9600DC48C2 /* BugsnagStateEvent.m in Sources */,
 				008968E12486DAA700DC48C2 /* BugsnagPluginClient.m in Sources */,
+				CB33CD012703438400C76656 /* BSG_KSCrashNames.c in Sources */,
 				008968842486DA9600DC48C2 /* BugsnagNotifier.m in Sources */,
 				CBCF77A625010648004AF22A /* BSGJSONSerialization.m in Sources */,
 				008968912486DA9600DC48C2 /* BugsnagError.m in Sources */,
@@ -2704,6 +2724,7 @@
 				00896A442486DBF000DC48C2 /* BugsnagConfigurationTests.m in Sources */,
 				0089674E2486D43700DC48C2 /* BugsnagPluginTest.m in Sources */,
 				00896A402486DBDD00DC48C2 /* BSGConfigurationBuilderTests.m in Sources */,
+				CB156241270707740097334C /* KSCrashNames_Test.m in Sources */,
 				0089679F2486D43700DC48C2 /* KSCrashSentry_Tests.m in Sources */,
 				008967872486D43700DC48C2 /* KSCrashSentry_NSException_Tests.m in Sources */,
 				0089679C2486D43700DC48C2 /* KSFileUtils_Tests.m in Sources */,
@@ -2749,6 +2770,7 @@
 			buildActionMask = 2147483647;
 			files = (
 				CBAA6AB6250BA01D00713376 /* BugsnagKVStore.c in Sources */,
+				CB33CD022703438400C76656 /* BSG_KSCrashNames.c in Sources */,
 				0089699A2486DAD100DC48C2 /* BSG_KSMach_Arm64.c in Sources */,
 				008967E92486DA2D00DC48C2 /* BugsnagErrorTypes.m in Sources */,
 				008968732486DA9500DC48C2 /* BugsnagDevice.m in Sources */,
@@ -2873,6 +2895,7 @@
 				008967822486D43700DC48C2 /* KSSystemInfo_Tests.m in Sources */,
 				008967612486D43700DC48C2 /* BugsnagBreadcrumbsTest.m in Sources */,
 				01DE903D26CEAF9E00455213 /* BSGUtilsTests.m in Sources */,
+				CB156242270707740097334C /* KSCrashNames_Test.m in Sources */,
 				008967012486D43700DC48C2 /* BugsnagEventPersistLoadTest.m in Sources */,
 				008967702486D43700DC48C2 /* NSError+SimpleConstructor_Tests.m in Sources */,
 				0089671C2486D43700DC48C2 /* BugsnagSessionTest.m in Sources */,
@@ -2927,6 +2950,7 @@
 				008969922486DAD100DC48C2 /* BSG_RFC3339DateTool.m in Sources */,
 				008968AD2486DA9600DC48C2 /* BugsnagStateEvent.m in Sources */,
 				008968E32486DAA700DC48C2 /* BugsnagPluginClient.m in Sources */,
+				CB33CD032703438400C76656 /* BSG_KSCrashNames.c in Sources */,
 				008968862486DA9600DC48C2 /* BugsnagNotifier.m in Sources */,
 				008968932486DA9600DC48C2 /* BugsnagError.m in Sources */,
 				CBCF77A825010648004AF22A /* BSGJSONSerialization.m in Sources */,
@@ -3056,6 +3080,7 @@
 				01DE903E26CEAF9E00455213 /* BSGUtilsTests.m in Sources */,
 				0089679E2486D43700DC48C2 /* KSFileUtils_Tests.m in Sources */,
 				008967A42486D43700DC48C2 /* KSCrashSentry_Signal_Tests.m in Sources */,
+				CB156243270707740097334C /* KSCrashNames_Test.m in Sources */,
 				E701FAB12490EFE8008D842F /* ConfigurationApiValidationTest.m in Sources */,
 				0089677D2486D43700DC48C2 /* RFC3339DateTool_Tests.m in Sources */,
 				CBCF77AD250142E0004AF22A /* BSGJSONSerializationTests.m in Sources */,
@@ -3087,6 +3112,7 @@
 			buildActionMask = 2147483647;
 			files = (
 				CBAA6AB8250BA01D00713376 /* BugsnagKVStore.c in Sources */,
+				CB33CD042703438400C76656 /* BSG_KSCrashNames.c in Sources */,
 				E7462909248907E500F92D67 /* BSG_KSMach_x86_32.c in Sources */,
 				E746290A248907E500F92D67 /* BSG_KSDynamicLinker.c in Sources */,
 				E746290B248907E500F92D67 /* BSG_KSMach_Arm.c in Sources */,

--- a/Bugsnag/KSCrash/Source/KSCrash/Recording/BSG_KSCrash.m
+++ b/Bugsnag/KSCrash/Source/KSCrash/Recording/BSG_KSCrash.m
@@ -96,6 +96,7 @@
     static id sharedInstance;
     static dispatch_once_t onceToken;
     dispatch_once(&onceToken, ^{
+        bsg_kscrash_init();
         sharedInstance = [[self alloc] init];
     });
     return sharedInstance;

--- a/Bugsnag/KSCrash/Source/KSCrash/Recording/BSG_KSCrashC.c
+++ b/Bugsnag/KSCrash/Source/KSCrash/Recording/BSG_KSCrashC.c
@@ -42,12 +42,14 @@
 #pragma mark - Globals -
 // ============================================================================
 
+/** True if BSG_KSCrash has been initialised. */
+static volatile sig_atomic_t bsg_g_initialised = 0;
+
 /** True if BSG_KSCrash has been installed. */
 static volatile sig_atomic_t bsg_g_installed = 0;
 
 /** Single, global crash context. */
-static BSG_KSCrash_Context bsg_g_crashReportContext = {
-    .config = {.handlingCrashTypes = BSG_KSCrashTypeProductionSafe}};
+static BSG_KSCrash_Context bsg_g_crashReportContext;
 
 /** Path to store the state file. */
 static char *bsg_g_stateFilePath;
@@ -55,6 +57,7 @@ static char *bsg_g_stateFilePath;
 // ============================================================================
 #pragma mark - Utility -
 // ============================================================================
+
 BSG_KSCrash_Context *crashContext(void) {
     return &bsg_g_crashReportContext;
 }
@@ -89,6 +92,13 @@ void bsg_kscrash_i_onCrash(BSG_KSCrash_Context *context) {
 // ============================================================================
 #pragma mark - API -
 // ============================================================================
+
+void bsg_kscrash_init(void) {
+    if (!bsg_g_initialised) {
+        bsg_g_initialised = true;
+        bsg_g_crashReportContext.config.handlingCrashTypes = BSG_KSCrashTypeProductionSafe;
+    }
+}
 
 BSG_KSCrashType bsg_kscrash_install(const char *const crashReportFilePath,
                                     const char *const recrashReportFilePath,

--- a/Bugsnag/KSCrash/Source/KSCrash/Recording/BSG_KSCrashC.h
+++ b/Bugsnag/KSCrash/Source/KSCrash/Recording/BSG_KSCrashC.h
@@ -38,6 +38,11 @@ extern "C" {
 
 #include <stdbool.h>
 
+/** Initialize the KSCrash system. Call this once, before any other function.
+ * Note: This gets called automatically by [BSG_KSCrash sharedInstance].
+ */
+void bsg_kscrash_init(void);
+
 /** Install the crash reporter. The reporter will record the next crash and then
  * terminate the program.
  *

--- a/Bugsnag/KSCrash/Source/KSCrash/Recording/BSG_KSCrashNames.c
+++ b/Bugsnag/KSCrash/Source/KSCrash/Recording/BSG_KSCrashNames.c
@@ -1,0 +1,28 @@
+//
+//  BSG_KSCrashNames.c
+//  Bugsnag
+//
+//  Created by Karl Stenerud on 28.09.21.
+//  Copyright © 2021 Bugsnag Inc. All rights reserved.
+//
+
+#include "BSG_KSCrashNames.h"
+#include <mach/thread_info.h>
+
+static const char* thread_state_names[] = {
+    // Defined in mach/thread_info.h
+    NULL,
+    "TH_STATE_RUNNING",
+    "TH_STATE_STOPPED",
+    "TH_STATE_WAITING",
+    "TH_STATE_UNINTERRUPTIBLE",
+    "TH_STATE_HALTED",
+};
+static const int thread_state_names_count = sizeof(thread_state_names) / sizeof(*thread_state_names);
+
+const char *bsg_kscrashthread_state_name(integer_t state) {
+    if (state < 1 || state >= thread_state_names_count) {
+        return NULL;
+    }
+    return thread_state_names[state];
+}

--- a/Bugsnag/KSCrash/Source/KSCrash/Recording/BSG_KSCrashNames.h
+++ b/Bugsnag/KSCrash/Source/KSCrash/Recording/BSG_KSCrashNames.h
@@ -1,0 +1,24 @@
+//
+//  BSG_KSCrashNames.h
+//  Bugsnag
+//
+//  Created by Karl Stenerud on 28.09.21.
+//  Copyright © 2021 Bugsnag Inc. All rights reserved.
+//
+
+#ifndef BSG_KSCrashNames_h
+#define BSG_KSCrashNames_h
+
+#ifdef __cplusplus
+extern "C" {
+#endif
+
+#include <mach/machine/vm_types.h>
+
+const char *bsg_kscrashthread_state_name(integer_t state);
+
+#ifdef __cplusplus
+}
+#endif
+
+#endif /* BSG_KSCrashNames_h */

--- a/Bugsnag/KSCrash/Source/KSCrash/Recording/BSG_KSCrashReport.c
+++ b/Bugsnag/KSCrash/Source/KSCrash/Recording/BSG_KSCrashReport.c
@@ -37,6 +37,7 @@
 #include "BSG_KSSignalInfo.h"
 #include "BSG_KSString.h"
 #include "BSG_KSMachHeaders.h"
+#include "BSG_KSCrashNames.h"
 
 //#define BSG_kSLogger_LocalLevel TRACE
 #include "BSG_KSLogger.h"
@@ -990,13 +991,16 @@ void bsg_kscrw_i_writeCrashInfoMessage(const BSG_KSCrashReportWriter *const writ
 void bsg_kscrw_i_writeThread(const BSG_KSCrashReportWriter *const writer,
                              const char *const key,
                              const BSG_KSCrash_SentryContext *const crash,
-                             const thread_t thread, const int index,
+                             const thread_t thread,
+                             const int index,
+                             const integer_t threadRunState,
                              const bool writeNotableAddresses) {
     bool isCrashedThread = thread == crash->offendingThread;
     BSG_STRUCT_MCONTEXT_L machineContextBuffer;
     uintptr_t backtraceBuffer[BSG_kMaxBacktraceDepth];
     int backtraceLength = sizeof(backtraceBuffer) / sizeof(*backtraceBuffer);
     int skippedEntries = 0;
+    const char* state = bsg_kscrashthread_state_name(threadRunState);
 
     BSG_STRUCT_MCONTEXT_L *machineContext =
         bsg_kscrw_i_getMachineContext(crash, thread, &machineContextBuffer);
@@ -1015,6 +1019,9 @@ void bsg_kscrw_i_writeThread(const BSG_KSCrashReportWriter *const writer,
         if (machineContext != NULL && isCrashedThread) {
             bsg_kscrw_i_writeRegisters(writer, BSG_KSCrashField_Registers,
                                        machineContext, isCrashedThread);
+        }
+        if (state != NULL) {
+            writer->addStringElement(writer, BSG_KSCrashField_State, state);
         }
         writer->addIntegerElement(writer, BSG_KSCrashField_Index, index);
         writer->addBooleanElement(writer, BSG_KSCrashField_Crashed,
@@ -1050,34 +1057,18 @@ void bsg_kscrw_i_writeAllThreads(const BSG_KSCrashReportWriter *const writer,
                                  const char *const key,
                                  const BSG_KSCrash_SentryContext *const crash,
                                  bool writeNotableAddresses) {
-    const task_t thisTask = mach_task_self();
-    thread_act_array_t threads;
-    mach_msg_type_number_t numThreads;
-    kern_return_t kr;
-
-    if ((kr = task_threads(thisTask, &threads, &numThreads)) != KERN_SUCCESS) {
-        BSG_KSLOG_ERROR("task_threads: %s", mach_error_string(kr));
-        return;
-    }
-
     // Fetch info for all threads.
     writer->beginArray(writer, key);
     {
-        for (mach_msg_type_number_t i = 0; i < numThreads; i++) {
-            thread_t thread = threads[i];
+        for (unsigned i = 0; i < crash->allThreadsCount; i++) {
+            thread_t thread = crash->allThreads[i];
+            integer_t threadRunState = crash->allThreadRunStates[i];
             if (crash->threadTracingEnabled || thread == crash->offendingThread) {
-                bsg_kscrw_i_writeThread(writer, NULL, crash, thread, (int) i, writeNotableAddresses);
+                bsg_kscrw_i_writeThread(writer, NULL, crash, thread, (int) i, threadRunState, writeNotableAddresses);
             }
         }
     }
     writer->endContainer(writer);
-
-    // Clean up.
-    for (mach_msg_type_number_t i = 0; i < numThreads; i++) {
-        mach_port_deallocate(thisTask, threads[i]);
-    }
-    vm_deallocate(thisTask, (vm_address_t)threads,
-                  sizeof(thread_t) * numThreads);
 }
 
 /** Get the index of a thread.
@@ -1088,29 +1079,20 @@ void bsg_kscrw_i_writeAllThreads(const BSG_KSCrashReportWriter *const writer,
  */
 int bsg_kscrw_i_threadIndex(const thread_t thread) {
     int index = -1;
-    const task_t thisTask = mach_task_self();
-    thread_act_array_t threads;
-    mach_msg_type_number_t numThreads;
-    kern_return_t kr;
-
-    if ((kr = task_threads(thisTask, &threads, &numThreads)) != KERN_SUCCESS) {
-        BSG_KSLOG_ERROR("task_threads: %s", mach_error_string(kr));
+    unsigned threadCount = 0;
+    thread_t *threads = bsg_ksmachgetAllThreads(&threadCount);
+    if (threads == NULL) {
         return -1;
     }
 
-    for (mach_msg_type_number_t i = 0; i < numThreads; i++) {
+    for (unsigned i = 0; i < threadCount; i++) {
         if (threads[i] == thread) {
             index = (int)i;
             break;
         }
     }
 
-    // Clean up.
-    for (mach_msg_type_number_t i = 0; i < numThreads; i++) {
-        mach_port_deallocate(thisTask, threads[i]);
-    }
-    vm_deallocate(thisTask, (vm_address_t)threads,
-                  sizeof(thread_t) * numThreads);
+    bsg_ksmachfreeThreads(threads, threadCount);
 
     return index;
 }
@@ -1520,6 +1502,7 @@ void bsg_kscrashreport_writeMinimalReport(
             bsg_kscrw_i_writeThread(
                 writer, BSG_KSCrashField_CrashedThread, &crashContext->crash,
                 crashContext->crash.offendingThread,
+                0,
                 bsg_kscrw_i_threadIndex(crashContext->crash.offendingThread),
                 false);
             bsg_kscrw_i_writeError(writer, BSG_KSCrashField_Error,

--- a/Bugsnag/KSCrash/Source/KSCrash/Recording/Sentry/BSG_KSCrashSentry.h
+++ b/Bugsnag/KSCrash/Source/KSCrash/Recording/Sentry/BSG_KSCrashSentry.h
@@ -42,6 +42,10 @@ extern "C" {
 #include <signal.h>
 #include <stdbool.h>
 
+// Some structures must be pre-allocated, so we must set an upper limit.
+// Note: Memory usage = 16 bytes per thread, pre-allocated once.
+#define MAX_CAPTURED_THREADS 1000
+
 typedef CF_ENUM(unsigned, BSG_KSCrashReservedTheadType) {
     BSG_KSCrashReservedThreadTypeMachPrimary,
     BSG_KSCrashReservedThreadTypeMachSecondary,
@@ -100,6 +104,19 @@ typedef struct BSG_KSCrash_SentryContext {
 
     /** Length of the stack trace. */
     int stackTraceLength;
+
+    /** All threads at the time of the crash.
+     * Note: This will be a kernel-allocated array that must be manually kernel-deallocated.
+     */
+    thread_t *allThreads;
+    unsigned allThreadsCount;
+
+    /** The run states of all threads at the time of the crash. */
+    integer_t allThreadRunStates[MAX_CAPTURED_THREADS];
+
+    /** Threads that we intend to resume after processing a crash. */
+    thread_t threadsToResume[MAX_CAPTURED_THREADS];
+    unsigned threadsToResumeCount;
 
     struct {
         /** The mach exception type. */

--- a/Bugsnag/KSCrash/Source/KSCrash/Recording/Tools/BSG_KSMach.c
+++ b/Bugsnag/KSCrash/Source/KSCrash/Recording/Tools/BSG_KSMach.c
@@ -368,13 +368,31 @@ bool bsg_ksmachgetThreadQueueName(const thread_t thread, char *const buffer,
     return true;
 }
 
+integer_t bsg_ksmachgetThreadState(const thread_t thread) {
+    integer_t infoBuffer[THREAD_BASIC_INFO_COUNT] = {0};
+    thread_info_t info = infoBuffer;
+    mach_msg_type_number_t inOutSize = THREAD_BASIC_INFO_COUNT;
+    kern_return_t kr = 0;
+
+    kr = thread_info(thread, THREAD_BASIC_INFO, info, &inOutSize);
+    if (kr != KERN_SUCCESS) {
+        BSG_KSLOG_TRACE("Error getting thread_info with flavor "
+                        "THREAD_BASIC_INFO from mach thread : %s",
+                        mach_error_string(kr));
+        return -1;
+    }
+
+    thread_basic_info_t basicInfo = (thread_basic_info_t)info;
+    return basicInfo->run_state;
+}
+
 // ============================================================================
 #pragma mark - Utility -
 // ============================================================================
 
 static inline bool isThreadInList(thread_t thread, thread_t *list,
-                                  int listCount) {
-    for (int i = 0; i < listCount; i++) {
+                                  unsigned listCount) {
+    for (unsigned i = 0; i < listCount; i++) {
         if (list[i] == thread) {
             return true;
         }
@@ -382,86 +400,91 @@ static inline bool isThreadInList(thread_t thread, thread_t *list,
     return false;
 }
 
-bool bsg_ksmachsuspendAllThreads(void) {
-    return bsg_ksmachsuspendAllThreadsExcept(NULL, 0);
-}
-
-bool bsg_ksmachsuspendAllThreadsExcept(thread_t *exceptThreads,
-                                       int exceptThreadsCount) {
+thread_t *bsg_ksmachgetAllThreads(unsigned *threadCount) {
     kern_return_t kr;
     const task_t thisTask = mach_task_self();
-    const thread_t thisThread = bsg_ksmachthread_self();
     thread_act_array_t threads;
     mach_msg_type_number_t numThreads;
 
     if ((kr = task_threads(thisTask, &threads, &numThreads)) != KERN_SUCCESS) {
         BSG_KSLOG_ERROR("task_threads: %s", mach_error_string(kr));
-        return false;
+        return NULL;
     }
 
-    for (mach_msg_type_number_t i = 0; i < numThreads; i++) {
-        thread_t thread = threads[i];
-        if (thread != thisThread &&
-            !isThreadInList(thread, exceptThreads, exceptThreadsCount)) {
-            if ((kr = thread_suspend(thread)) != KERN_SUCCESS) {
-                // The thread may have completed running already
-                // Don't treat this as a fatal error.
-                BSG_KSLOG_DEBUG("thread_suspend (%08x): %s", thread,
-                                mach_error_string(kr));
-                // Suppress dead store warning when log level > debug
-                (void)kr;
-            }
-        }
-    }
-
-    for (mach_msg_type_number_t i = 0; i < numThreads; i++) {
-        mach_port_deallocate(thisTask, threads[i]);
-    }
-    vm_deallocate(thisTask, (vm_address_t)threads,
-                  sizeof(thread_t) * numThreads);
-
-    return true;
+    *threadCount = numThreads;
+    return threads;
 }
 
-bool bsg_ksmachresumeAllThreads(void) {
-    return bsg_ksmachresumeAllThreadsExcept(NULL, 0);
-}
-
-bool bsg_ksmachresumeAllThreadsExcept(thread_t *exceptThreads,
-                                      int exceptThreadsCount) {
-    kern_return_t kr;
+void bsg_ksmachfreeThreads(thread_t *threads, unsigned threadCount) {
     const task_t thisTask = mach_task_self();
-    const thread_t thisThread = bsg_ksmachthread_self();
-    thread_act_array_t threads;
-    mach_msg_type_number_t numThreads;
-
-    if ((kr = task_threads(thisTask, &threads, &numThreads)) != KERN_SUCCESS) {
-        BSG_KSLOG_ERROR("task_threads: %s", mach_error_string(kr));
-        return false;
-    }
-
-    for (mach_msg_type_number_t i = 0; i < numThreads; i++) {
-        thread_t thread = threads[i];
-        if (thread != thisThread &&
-            !isThreadInList(thread, exceptThreads, exceptThreadsCount)) {
-            if ((kr = thread_resume(thread)) != KERN_SUCCESS) {
-                // The thread may have completed running already
-                // Don't treat this as a fatal error.
-                BSG_KSLOG_DEBUG("thread_resume (%08x): %s", thread,
-                                 mach_error_string(kr));
-                // Suppress dead store warning when log level > debug
-                (void)kr;
-            }
-        }
-    }
-
-    for (mach_msg_type_number_t i = 0; i < numThreads; i++) {
+    for (unsigned i = 0; i < threadCount; i++) {
         mach_port_deallocate(thisTask, threads[i]);
     }
     vm_deallocate(thisTask, (vm_address_t)threads,
-                  sizeof(thread_t) * numThreads);
+                  sizeof(*threads) * threadCount);
+}
 
-    return true;
+void bsg_ksmachgetThreadStates(thread_t *threads, integer_t *states, unsigned threadCount) {
+    for (unsigned i = 0; i < threadCount; i++) {
+        states[i] = bsg_ksmachgetThreadState(threads[i]);
+    }
+}
+
+unsigned bsg_ksmachremoveThreadsFromList(thread_t *srcThreads, unsigned srcThreadCount,
+                                         thread_t *omitThreads, unsigned omitThreadsCount,
+                                         thread_t *dstThreads, unsigned maxDstThreads) {
+    unsigned int iDst = 0;
+    for (unsigned iSrc = 0; iSrc < srcThreadCount; iSrc++) {
+        if (isThreadInList(srcThreads[iSrc], omitThreads, omitThreadsCount)) {
+            continue;
+        }
+        dstThreads[iDst] = srcThreads[iSrc];
+        iDst++;
+        if (iDst >= maxDstThreads) {
+            break;
+        }
+    }
+    return iDst;
+}
+
+void bsg_ksmachsuspendThreads(thread_t *threads, unsigned threadsCount) {
+    const thread_t thisThread = bsg_ksmachthread_self();
+    for (unsigned i = 0; i < threadsCount; i++) {
+        thread_t thread = threads[i];
+        // IMPORTANT: Never suspend the current thread even if it's in the list!
+        if (thread == thisThread) {
+            continue;
+        }
+        kern_return_t kr = thread_suspend(thread);
+        if (kr != KERN_SUCCESS) {
+            // The thread may have completed running already
+            // Don't treat this as a fatal error.
+            BSG_KSLOG_DEBUG("thread_suspend (%08x): %s", thread,
+                            mach_error_string(kr));
+            // Suppress dead store warning when log level > debug
+            (void)kr;
+        }
+    }
+}
+
+void bsg_ksmachresumeThreads(thread_t *threads, unsigned threadsCount) {
+    const thread_t thisThread = bsg_ksmachthread_self();
+    for (unsigned i = 0; i < threadsCount; i++) {
+        thread_t thread = threads[i];
+        // IMPORTANT: Never resume the current thread even if it's in the list!
+        if (thread == thisThread) {
+            continue;
+        }
+        kern_return_t kr = thread_resume(thread);
+        if (kr != KERN_SUCCESS) {
+            // The thread may have completed running already
+            // Don't treat this as a fatal error.
+            BSG_KSLOG_DEBUG("thread_resume (%08x): %s", thread,
+                            mach_error_string(kr));
+            // Suppress dead store warning when log level > debug
+            (void)kr;
+        }
+    }
 }
 
 kern_return_t bsg_ksmachcopyMem(const void *const src, void *const dst,

--- a/Bugsnag/KSCrash/Source/KSCrash/Recording/Tools/BSG_KSMach.h
+++ b/Bugsnag/KSCrash/Source/KSCrash/Recording/Tools/BSG_KSMach.h
@@ -268,6 +268,15 @@ bool bsg_ksmachgetThreadName(const thread_t thread, char *const buffer,
 bool bsg_ksmachgetThreadQueueName(thread_t thread, char *buffer,
                                   size_t bufLength);
 
+/**
+ * Get a thread's current run state.
+ *
+ * @param thread The thread whose queue name to get.
+ *
+ * @return The thread's run state or -1 if an error occurred.
+ */
+integer_t bsg_ksmachgetThreadState(const thread_t thread);
+
 // ============================================================================
 #pragma mark - Utility -
 // ============================================================================
@@ -297,39 +306,69 @@ pthread_t bsg_ksmachpthreadFromMachThread(const thread_t thread);
  */
 thread_t bsg_ksmachmachThreadFromPThread(const pthread_t pthread);
 
-/** Suspend all threads except for the current one.
+/** Get a list of all current threads. This list is kernel-allocated, and so must be freed using bsg_ksmachfreeThreads.
  *
- * @return true if thread suspention was at least partially successful.
+ * @param threadCount pointer to location to store the count of all threads.
+ *
+ * @return A list of threads.
  */
-bool bsg_ksmachsuspendAllThreads(void);
+thread_t *bsg_ksmachgetAllThreads(unsigned *threadCount);
 
-/** Suspend all threads except for the current one and the specified threads.
+/** Free a previously allocated thread list. This should only be called on a thread list allocated from bsg_ksmachgetAllThreads.
  *
- * @param exceptThreads The threads to avoid suspending.
+ * @param threads The list of threads to free.
  *
- * @param exceptThreadsCount The number of threads to avoid suspending.
- *
- * @return true if thread suspention was at least partially successful.
+ * @param threadCount The number of threads in the list.
  */
-bool bsg_ksmachsuspendAllThreadsExcept(thread_t *exceptThreads,
-                                       int exceptThreadsCount);
+void bsg_ksmachfreeThreads(thread_t *threads, unsigned threadCount);
 
-/** Resume all threads except for the current one.
+/** Get the run states of a list of threads.
  *
- * @return true if thread resumption was at least partially successful.
+ * @param threads The threads to get states for.
+ *
+ * @param states A buffer to hold the states.
+ *
+ * @param threadCount The number of threads in the threads list.
  */
-bool bsg_ksmachresumeAllThreads(void);
+void bsg_ksmachgetThreadStates(thread_t *threads, integer_t *states, unsigned threadCount);
 
-/** Resume all threads except for the current one and the specified threads.
+/** Fill out a list containing a source list's contents, with certain threads removed.
  *
- * @param exceptThreads The threads to avoid resuming.
+ * @param srcThreads The threads list to copy.
  *
- * @param exceptThreadsCount The number of threads to avoid resuming.
+ * @param srcThreadCount The number of threads in the source list.
  *
- * @return true if thread resumption was at least partially successful.
+ * @param omitThreads The list of threads to omit when generating the final list.
+ *
+ * @param omitThreadsCount The number of threads in the omit list.
+ *
+ * @param dstThreads The destination list to fill out. Must have at least srcThreadCount entries of space.
+ *
+ * @param maxDstThreads The maximum number of threads that can be stored in dstThreads.
+ *
+ * @return The number of threads put into the destination list.
  */
-bool bsg_ksmachresumeAllThreadsExcept(thread_t *exceptThreads,
-                                      int exceptThreadsCount);
+unsigned bsg_ksmachremoveThreadsFromList(thread_t *srcThreads, unsigned srcThreadCount,
+                                         thread_t *omitThreads, unsigned omitThreadsCount,
+                                         thread_t *dstThreads, unsigned maxDstThreads);
+
+/** Suspend a list of threads.
+ * Note: The current thread cannot be suspended via this function.
+ *
+ * @param threads The list of threads to suspend.
+ *
+ * @param threadsCount The number of threads in the list.
+ */
+void bsg_ksmachsuspendThreads(thread_t *threads, unsigned threadsCount);
+
+/** Resume a list of threads.
+ * Note: The current thread cannot be resumed via this function.
+ *
+ * @param threads The list of threads to suspend.
+ *
+ * @param threadsCount The number of threads in the list.
+ */
+void bsg_ksmachresumeThreads(thread_t *threads, unsigned threadsCount);
 
 /** Copy memory safely. If the memory is not accessible, returns false
  * rather than crashing.

--- a/Bugsnag/Payload/BugsnagThread+Private.h
+++ b/Bugsnag/Payload/BugsnagThread+Private.h
@@ -16,6 +16,7 @@ NS_ASSUME_NONNULL_BEGIN
                       name:(nullable NSString *)name
       errorReportingThread:(BOOL)errorReportingThread
                       type:(BSGThreadType)type
+                     state:(nullable NSString *)state
                 stacktrace:(NSArray<BugsnagStackframe *> *)stacktrace;
 
 - (instancetype)initWithThread:(NSDictionary *)thread binaryImages:(NSArray *)binaryImages;

--- a/Bugsnag/include/Bugsnag/BugsnagThread.h
+++ b/Bugsnag/include/Bugsnag/BugsnagThread.h
@@ -36,6 +36,11 @@ typedef NS_OPTIONS(NSUInteger, BSGThreadType) {
 @property (readonly, nonatomic) BOOL errorReportingThread;
 
 /**
+ * The current state of this thread
+ */
+@property (copy, nullable, nonatomic) NSString *state;
+
+/**
  * Sets a representation of this thread's stacktrace
  */
 @property (copy, nonnull, nonatomic) NSArray<BugsnagStackframe *> *stacktrace;

--- a/Tests/BugsnagErrorTest.m
+++ b/Tests/BugsnagErrorTest.m
@@ -28,6 +28,7 @@ NSString *BSGParseErrorMessage(NSDictionary *report, NSDictionary *error, NSStri
             @"current_thread": @YES,
             @"crashed": @YES,
             @"index": @4,
+            @"state": @"TH_STATE_RUNNING",
             @"backtrace": @{
                     @"skipped": @0,
                     @"contents": @[

--- a/Tests/BugsnagThreadSerializationTest.m
+++ b/Tests/BugsnagThreadSerializationTest.m
@@ -35,7 +35,8 @@
             },
                     @"crashed": @YES,
                     @"current_thread": @YES,
-                    @"index": @0
+                    @"index": @0,
+                    @"state": @"TH_STATE_RUNNING"
             },
             @{
                     @"backtrace": @{
@@ -52,7 +53,8 @@
             },
                     @"crashed": @NO,
                     @"current_thread": @NO,
-                    @"index": @1
+                    @"index": @1,
+                    @"state": @"TH_STATE_WAITING"
             },
     ];
 
@@ -64,6 +66,7 @@
     NSDictionary *firstThread = threads[0];
     XCTAssertEqualObjects(@"0", firstThread[@"id"]);
     XCTAssertEqualObjects(@"cocoa", firstThread[@"type"]);
+    XCTAssertEqualObjects(@"TH_STATE_RUNNING", firstThread[@"state"]);
     XCTAssertNotNil(firstThread[@"stacktrace"]);
     XCTAssertTrue(firstThread[@"errorReportingThread"]);
 
@@ -71,6 +74,7 @@
     NSDictionary *secondThread = threads[1];
     XCTAssertEqualObjects(@"1", secondThread[@"id"]);
     XCTAssertEqualObjects(@"cocoa", secondThread[@"type"]);
+    XCTAssertEqualObjects(@"TH_STATE_WAITING", secondThread[@"state"]);
     XCTAssertNotNil(secondThread[@"stacktrace"]);
     XCTAssertFalse([secondThread[@"errorReportingThread"] boolValue]);
 }

--- a/Tests/BugsnagThreadTests.m
+++ b/Tests/BugsnagThreadTests.m
@@ -31,6 +31,7 @@
             @"current_thread": @YES,
             @"crashed": @YES,
             @"index": @4,
+            @"state": @"TH_STATE_RUNNING",
             @"backtrace": @{
                     @"skipped": @0,
                     @"contents": @[
@@ -78,6 +79,7 @@
     XCTAssertEqualObjects(@"4", dict[@"id"]);
     XCTAssertEqualObjects(@"bugsnag-thread-1", dict[@"name"]);
     XCTAssertEqualObjects(@"cocoa", dict[@"type"]);
+    XCTAssertEqualObjects(@"TH_STATE_RUNNING", dict[@"state"]);
     XCTAssertTrue([dict[@"errorReportingThread"] boolValue]);
 
     // validate stacktrace
@@ -248,6 +250,7 @@
     XCTAssertEqual(threads.count, 1);
     XCTAssertTrue(threads[0].errorReportingThread);
     XCTAssertEqualObjects(threads[0].id, @"0");
+    XCTAssertEqualObjects(threads[0].state, @"TH_STATE_RUNNING");
     XCTAssertEqualObjects(threads[0].name, @"com.apple.main-thread");
     XCTAssertEqualObjects(threads[0].stacktrace.firstObject.method, @(__PRETTY_FUNCTION__));
 }
@@ -264,6 +267,7 @@
     XCTAssertTrue(thread.errorReportingThread);
     XCTAssertGreaterThan(thread.id.intValue, 0);
     XCTAssertNotNil(thread.name);
+    XCTAssertNotNil(thread.state);
     XCTAssertNotEqualObjects(thread.name, @"com.apple.main-thread");
     XCTAssert([thread.stacktrace.firstObject.method hasSuffix:@"_block_invoke"]);
 }
@@ -292,6 +296,7 @@
     }
     XCTAssertTrue(thread.errorReportingThread);
     XCTAssertEqualObjects(thread.id, @"0");
+    XCTAssertEqualObjects(thread.state, @"TH_STATE_RUNNING");
     XCTAssertEqualObjects(thread.name, @"com.apple.main-thread");
     XCTAssertEqualObjects(thread.stacktrace.firstObject.method, @(__PRETTY_FUNCTION__));
 }

--- a/Tests/KSCrash/BSG_KSMachTests.m
+++ b/Tests/KSCrash/BSG_KSMachTests.m
@@ -115,11 +115,11 @@ void * executeBlock(void *ptr)
 
 - (void) testSuspendThreads
 {
-    bool success;
-    success = bsg_ksmachsuspendAllThreads();
-    XCTAssertTrue(success, @"");
-    success = bsg_ksmachresumeAllThreads();
-    XCTAssertTrue(success, @"");
+    // Just make sure that suspending and resuming doesn't hang the process.
+    unsigned threadsCount = 0;
+    thread_t *threads = bsg_ksmachgetAllThreads(&threadsCount);
+    bsg_ksmachsuspendThreads(threads, threadsCount);
+    bsg_ksmachresumeThreads(threads, threadsCount);
 }
 
 - (void) testCopyMem
@@ -363,6 +363,44 @@ void * executeBlock(void *ptr)
 - (void) testStackGrowDirection
 {
     bsg_ksmachstackGrowDirection();
+}
+
+- (void) testRemoveThreadsFromList
+{
+    thread_t src[] = {1, 2, 3};
+    thread_t dst[] = {0, 0, 0};
+    bsg_ksmachremoveThreadsFromList(src, 3, NULL, 0, dst, 2);
+    XCTAssertEqual(1, dst[0]);
+    XCTAssertEqual(2, dst[1]);
+    XCTAssertEqual(0, dst[2]);
+}
+
+- (void) testRemoveThreadsFromList2
+{
+    thread_t src[] = {1, 2, 3, 4};
+    thread_t omit[] = {2, 4};
+    thread_t dst[] = {0, 0, 0, 0};
+    int count = bsg_ksmachremoveThreadsFromList(src, 4, omit, 2, dst, 3);
+    XCTAssertEqual(1, dst[0]);
+    XCTAssertEqual(3, dst[1]);
+    XCTAssertEqual(0, dst[2]);
+    XCTAssertEqual(0, dst[3]);
+    XCTAssertEqual(2, count);
+}
+
+- (void) testRemoveThreadsFromList3
+{
+    thread_t src[] = {1, 2, 3, 4, 5, 6};
+    thread_t omit[] = {2, 4};
+    thread_t dst[] = {0, 0, 0, 0, 0, 0};
+    int count = bsg_ksmachremoveThreadsFromList(src, 6, omit, 2, dst, 3);
+    XCTAssertEqual(1, dst[0]);
+    XCTAssertEqual(3, dst[1]);
+    XCTAssertEqual(5, dst[2]);
+    XCTAssertEqual(0, dst[3]);
+    XCTAssertEqual(0, dst[4]);
+    XCTAssertEqual(0, dst[5]);
+    XCTAssertEqual(3, count);
 }
 
 @end

--- a/Tests/KSCrash/KSCrashNames_Test.m
+++ b/Tests/KSCrash/KSCrashNames_Test.m
@@ -1,0 +1,50 @@
+//
+//  KSCrashNames_Test.m
+//  Bugsnag
+//
+//  Created by Karl Stenerud on 01.10.21.
+//  Copyright © 2021 Bugsnag Inc. All rights reserved.
+//
+
+#import <XCTest/XCTest.h>
+#import "BSG_KSCrashNames.h"
+#include <mach/thread_info.h>
+
+@interface KSCrashNames_Test : XCTestCase
+
+@end
+
+@implementation KSCrashNames_Test
+
+- (void)setUp {
+    // Put setup code here. This method is called before the invocation of each test method in the class.
+}
+
+- (void)tearDown {
+    // Put teardown code here. This method is called after the invocation of each test method in the class.
+}
+
+- (void)testValidStates {
+    XCTAssertTrue(strcmp(bsg_kscrashthread_state_name(TH_STATE_RUNNING), "TH_STATE_RUNNING") == 0);
+    XCTAssertTrue(strcmp(bsg_kscrashthread_state_name(TH_STATE_STOPPED), "TH_STATE_STOPPED") == 0);
+    XCTAssertTrue(strcmp(bsg_kscrashthread_state_name(TH_STATE_WAITING), "TH_STATE_WAITING") == 0);
+    XCTAssertTrue(strcmp(bsg_kscrashthread_state_name(TH_STATE_UNINTERRUPTIBLE), "TH_STATE_UNINTERRUPTIBLE") == 0);
+    XCTAssertTrue(strcmp(bsg_kscrashthread_state_name(TH_STATE_HALTED), "TH_STATE_HALTED") == 0);
+}
+
+- (void)testInvalidStates {
+    for (integer_t i = -100; i <= 100; i++) {
+        switch (i) {
+            case TH_STATE_RUNNING:
+            case TH_STATE_STOPPED:
+            case TH_STATE_WAITING:
+            case TH_STATE_UNINTERRUPTIBLE:
+            case TH_STATE_HALTED:
+                continue;
+            default:
+                XCTAssert(bsg_kscrashthread_state_name(i) == NULL);
+        }
+    }
+}
+
+@end

--- a/Tests/KSCrash/KSCrashSentry_Tests.m
+++ b/Tests/KSCrash/KSCrashSentry_Tests.m
@@ -35,16 +35,15 @@ static void onCrash(void *context)
     // Do nothing
 }
 
+static BSG_KSCrash_SentryContext context;
+
 @interface KSCrashSentry_Tests : XCTestCase @end
 
 
 @implementation KSCrashSentry_Tests
 
-- (void) testInstallUninstall
-{
-    BSG_KSCrash_SentryContext context;
+- (void) setUp {
     bsg_kscrashsentry_installWithContext(&context, BSG_KSCrashTypeAll, onCrash);
-    bsg_kscrashsentry_uninstall(BSG_KSCrashTypeAll);
 }
 
 - (void) testSuspendResumeThreads

--- a/features/barebone_tests.feature
+++ b/features/barebone_tests.feature
@@ -153,6 +153,7 @@ Feature: Barebone tests
     And the event "severityReason.unhandledOverridden" is null
     And the event "threads.0.errorReportingThread" is true
     And the event "threads.0.id" equals "0"
+    And the event "threads.0.state" is not null
     And the event "threads.0.stacktrace.0.method" matches "(assertionFailure|fatalErrorMessage|<redacted>)"
     And the event "unhandled" is true
     And the event "user.email" equals "barfoo@example.com"


### PR DESCRIPTION
## Goal

PLAT-7316: Record thread run state in cocoa.

## Design

Per ROAD-1307

## Testing

* Updated unit tests and e2e tests to also check for thread run state.
* Added new unit test for run state to string conversion code and thread list manipulation.
