### PR TITLE
[PLAT-7269] Logging async safety

### DIFF
--- a/Bugsnag.xcodeproj/project.pbxproj
+++ b/Bugsnag.xcodeproj/project.pbxproj
@@ -464,9 +464,9 @@
 		008969C32486DAD100DC48C2 /* BSG_KSObjC.c in Sources */ = {isa = PBXBuildFile; fileRef = 008969252486DAD000DC48C2 /* BSG_KSObjC.c */; };
 		008969C42486DAD100DC48C2 /* BSG_KSObjC.c in Sources */ = {isa = PBXBuildFile; fileRef = 008969252486DAD000DC48C2 /* BSG_KSObjC.c */; };
 		008969C52486DAD100DC48C2 /* BSG_KSObjC.c in Sources */ = {isa = PBXBuildFile; fileRef = 008969252486DAD000DC48C2 /* BSG_KSObjC.c */; };
-		008969C62486DAD100DC48C2 /* BSG_KSLogger.m in Sources */ = {isa = PBXBuildFile; fileRef = 008969262486DAD000DC48C2 /* BSG_KSLogger.m */; };
-		008969C72486DAD100DC48C2 /* BSG_KSLogger.m in Sources */ = {isa = PBXBuildFile; fileRef = 008969262486DAD000DC48C2 /* BSG_KSLogger.m */; };
-		008969C82486DAD100DC48C2 /* BSG_KSLogger.m in Sources */ = {isa = PBXBuildFile; fileRef = 008969262486DAD000DC48C2 /* BSG_KSLogger.m */; };
+		008969C62486DAD100DC48C2 /* BSG_KSLogger.c in Sources */ = {isa = PBXBuildFile; fileRef = 008969262486DAD000DC48C2 /* BSG_KSLogger.c */; };
+		008969C72486DAD100DC48C2 /* BSG_KSLogger.c in Sources */ = {isa = PBXBuildFile; fileRef = 008969262486DAD000DC48C2 /* BSG_KSLogger.c */; };
+		008969C82486DAD100DC48C2 /* BSG_KSLogger.c in Sources */ = {isa = PBXBuildFile; fileRef = 008969262486DAD000DC48C2 /* BSG_KSLogger.c */; };
 		008969C92486DAD100DC48C2 /* BSG_RFC3339DateTool.h in Headers */ = {isa = PBXBuildFile; fileRef = 008969272486DAD000DC48C2 /* BSG_RFC3339DateTool.h */; };
 		008969CA2486DAD100DC48C2 /* BSG_RFC3339DateTool.h in Headers */ = {isa = PBXBuildFile; fileRef = 008969272486DAD000DC48C2 /* BSG_RFC3339DateTool.h */; };
 		008969CB2486DAD100DC48C2 /* BSG_RFC3339DateTool.h in Headers */ = {isa = PBXBuildFile; fileRef = 008969272486DAD000DC48C2 /* BSG_RFC3339DateTool.h */; };
@@ -864,6 +864,7 @@
 		E74628FF248907C100F92D67 /* BSG_KSMachHeaders.c in Sources */ = {isa = PBXBuildFile; fileRef = 008969102486DAD000DC48C2 /* BSG_KSMachHeaders.c */; };
 		E7462900248907C100F92D67 /* NSError+BSG_SimpleConstructor.m in Sources */ = {isa = PBXBuildFile; fileRef = 0089691E2486DAD000DC48C2 /* NSError+BSG_SimpleConstructor.m */; };
 		E7462901248907C100F92D67 /* BSG_KSLogger.m in Sources */ = {isa = PBXBuildFile; fileRef = 008969262486DAD000DC48C2 /* BSG_KSLogger.m */; };
+		E7462901248907C100F92D67 /* BSG_KSLogger.c in Sources */ = {isa = PBXBuildFile; fileRef = 008969262486DAD000DC48C2 /* BSG_KSLogger.c */; };
 		E7462902248907C100F92D67 /* BSG_KSCrashState.m in Sources */ = {isa = PBXBuildFile; fileRef = 008969292486DAD000DC48C2 /* BSG_KSCrashState.m */; };
 		E7462904248907C100F92D67 /* BSG_KSCrashIdentifier.m in Sources */ = {isa = PBXBuildFile; fileRef = 008969302486DAD000DC48C2 /* BSG_KSCrashIdentifier.m */; };
 		E7462905248907C100F92D67 /* BSG_KSCrash.m in Sources */ = {isa = PBXBuildFile; fileRef = 008969362486DAD000DC48C2 /* BSG_KSCrash.m */; };
@@ -1229,7 +1230,7 @@
 		008969232486DAD000DC48C2 /* BSG_KSMachHeaders.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = BSG_KSMachHeaders.h; sourceTree = "<group>"; };
 		008969242486DAD000DC48C2 /* BSG_KSString.c */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.c; path = BSG_KSString.c; sourceTree = "<group>"; };
 		008969252486DAD000DC48C2 /* BSG_KSObjC.c */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.c; path = BSG_KSObjC.c; sourceTree = "<group>"; };
-		008969262486DAD000DC48C2 /* BSG_KSLogger.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; path = BSG_KSLogger.m; sourceTree = "<group>"; };
+		008969262486DAD000DC48C2 /* BSG_KSLogger.c */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.c; path = BSG_KSLogger.c; sourceTree = "<group>"; };
 		008969272486DAD000DC48C2 /* BSG_RFC3339DateTool.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = BSG_RFC3339DateTool.h; sourceTree = "<group>"; };
 		008969282486DAD000DC48C2 /* BSG_KSMach.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = BSG_KSMach.h; sourceTree = "<group>"; };
 		008969292486DAD000DC48C2 /* BSG_KSCrashState.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; path = BSG_KSCrashState.m; sourceTree = "<group>"; };
@@ -1603,7 +1604,7 @@
 				008969192486DAD000DC48C2 /* BSG_KSJSONCodecObjC.h */,
 				008969082486DAD000DC48C2 /* BSG_KSJSONCodecObjC.m */,
 				008969152486DAD000DC48C2 /* BSG_KSLogger.h */,
-				008969262486DAD000DC48C2 /* BSG_KSLogger.m */,
+				008969262486DAD000DC48C2 /* BSG_KSLogger.c */,
 				008969072486DAD000DC48C2 /* BSG_KSMach_Arm.c */,
 				008969172486DAD000DC48C2 /* BSG_KSMach_Arm64.c */,
 				008969032486DAD000DC48C2 /* BSG_KSMach_x86_32.c */,
@@ -2625,7 +2626,7 @@
 				0089686B2486DA9500DC48C2 /* BugsnagEvent.m in Sources */,
 				008969A82486DAD100DC48C2 /* BSG_KSSysCtl.c in Sources */,
 				008969692486DAD000DC48C2 /* BSG_KSMach_Arm.c in Sources */,
-				008969C62486DAD100DC48C2 /* BSG_KSLogger.m in Sources */,
+				008969C62486DAD100DC48C2 /* BSG_KSLogger.c in Sources */,
 				008969662486DAD000DC48C2 /* BSG_KSDynamicLinker.c in Sources */,
 				008969C02486DAD100DC48C2 /* BSG_KSString.c in Sources */,
 				0126F79E25DD510E008483C2 /* BSGEventUploadObjectOperation.m in Sources */,
@@ -2796,7 +2797,7 @@
 				0089686C2486DA9500DC48C2 /* BugsnagEvent.m in Sources */,
 				008969A92486DAD100DC48C2 /* BSG_KSSysCtl.c in Sources */,
 				0089696A2486DAD000DC48C2 /* BSG_KSMach_Arm.c in Sources */,
-				008969C72486DAD100DC48C2 /* BSG_KSLogger.m in Sources */,
+				008969C72486DAD100DC48C2 /* BSG_KSLogger.c in Sources */,
 				008969672486DAD000DC48C2 /* BSG_KSDynamicLinker.c in Sources */,
 				008969C12486DAD100DC48C2 /* BSG_KSString.c in Sources */,
 				0126F79F25DD510E008483C2 /* BSGEventUploadObjectOperation.m in Sources */,
@@ -2965,7 +2966,7 @@
 				0089686D2486DA9500DC48C2 /* BugsnagEvent.m in Sources */,
 				008969AA2486DAD100DC48C2 /* BSG_KSSysCtl.c in Sources */,
 				0089696B2486DAD000DC48C2 /* BSG_KSMach_Arm.c in Sources */,
-				008969C82486DAD100DC48C2 /* BSG_KSLogger.m in Sources */,
+				008969C82486DAD100DC48C2 /* BSG_KSLogger.c in Sources */,
 				008969682486DAD000DC48C2 /* BSG_KSDynamicLinker.c in Sources */,
 				008969C22486DAD100DC48C2 /* BSG_KSString.c in Sources */,
 				0126F7A025DD510E008483C2 /* BSGEventUploadObjectOperation.m in Sources */,
@@ -3115,6 +3116,7 @@
 				E74628FF248907C100F92D67 /* BSG_KSMachHeaders.c in Sources */,
 				E7462900248907C100F92D67 /* NSError+BSG_SimpleConstructor.m in Sources */,
 				E7462901248907C100F92D67 /* BSG_KSLogger.m in Sources */,
+				E7462901248907C100F92D67 /* BSG_KSLogger.c in Sources */,
 				E7462902248907C100F92D67 /* BSG_KSCrashState.m in Sources */,
 				E7462904248907C100F92D67 /* BSG_KSCrashIdentifier.m in Sources */,
 				CBCAF70025A457F90095771F /* BSGFileLocations.m in Sources */,

--- a/Bugsnag/KSCrash/Source/KSCrash/Recording/BSG_KSCrash.h
+++ b/Bugsnag/KSCrash/Source/KSCrash/Recording/BSG_KSCrash.h
@@ -36,14 +36,6 @@
  */
 @interface BSG_KSCrash : NSObject
 
-/** A dictionary containing any info you'd like to appear in crash reports. Must
- * contain only JSON-safe data: NSString for keys, and NSDictionary, NSArray,
- * NSString, NSDate, and NSNumber for values.
- *
- * Default: nil
- */
-@property(nonatomic, readwrite, retain) NSDictionary *userInfo;
-
 /** If YES, introspect memory contents during a crash.
  * Any Objective-C objects or C strings near the stack pointer or referenced by
  * cpu registers or exceptions will be recorded in the crash report, along with

--- a/Bugsnag/KSCrash/Source/KSCrash/Recording/BSG_KSCrash.m
+++ b/Bugsnag/KSCrash/Source/KSCrash/Recording/BSG_KSCrash.m
@@ -78,7 +78,6 @@
 #pragma mark - Properties -
 // ============================================================================
 
-@synthesize userInfo = _userInfo;
 @synthesize printTraceToStdout = _printTraceToStdout;
 @synthesize onCrash = _onCrash;
 @synthesize logFilePath = _logFilePath;
@@ -114,24 +113,6 @@
 // ============================================================================
 #pragma mark - API -
 // ============================================================================
-
-- (void)setUserInfo:(NSDictionary *)userInfo {
-    NSError *error = nil;
-    NSData *userInfoJSON = nil;
-    if (userInfo != nil) {
-        userInfoJSON = [self
-            nullTerminated:[BSG_KSJSONCodec encode:userInfo
-                                           options:BSG_KSJSONEncodeOptionSorted
-                                             error:&error]];
-        if (error != NULL) {
-            BSG_KSLOG_ERROR(@"Could not serialize user info: %@", error);
-            return;
-        }
-    }
-
-    _userInfo = userInfo;
-    bsg_kscrash_setUserInfoJSON([userInfoJSON bytes]);
-}
 
 - (void)setPrintTraceToStdout:(bool)printTraceToStdout {
     _printTraceToStdout = printTraceToStdout;
@@ -255,36 +236,6 @@ BSG_SYNTHESIZE_CRASH_STATE_PROPERTY(BOOL, crashedLastLaunch)
         return YES;
     }
     return NO;
-}
-
-// ============================================================================
-#pragma mark - Utility -
-// ============================================================================
-
-
-- (NSMutableData *)nullTerminated:(NSData *)data {
-    if (data == nil) {
-        return NULL;
-    }
-    NSMutableData *mutable = [NSMutableData dataWithData:data];
-    [mutable appendBytes:"\0" length:1];
-    return mutable;
-}
-
-- (const char *)encodeAsJSONString:(id)object {
-    if (object == nil) {
-        return NULL;
-    }
-    NSError *error = nil;
-    NSData *jsonData = [BSG_KSJSONCodec encode:object options:0 error:&error];
-    if (jsonData == nil || error != nil) {
-        BSG_KSLOG_ERROR(@"Error encoding object to JSON: %@", error);
-        // we can still record other useful information from the report
-        return NULL;
-    }
-    NSString *jsonString =
-    [[NSString alloc] initWithData:jsonData encoding:NSUTF8StringEncoding];
-    return [jsonString cStringUsingEncoding:NSUTF8StringEncoding];
 }
 
 // ============================================================================

--- a/Bugsnag/KSCrash/Source/KSCrash/Recording/BSG_KSCrashC.c
+++ b/Bugsnag/KSCrash/Source/KSCrash/Recording/BSG_KSCrashC.c
@@ -162,12 +162,6 @@ BSG_KSCrashType bsg_kscrash_setHandlingCrashTypes(BSG_KSCrashType crashTypes) {
     return crashTypes;
 }
 
-void bsg_kscrash_setUserInfoJSON(const char *const userInfoJSON) {
-    BSG_KSLOG_TRACE("set userInfoJSON to %p", userInfoJSON);
-    BSG_KSCrash_Context *context = crashContext();
-    bsg_ksstring_replace(&context->config.userInfoJSON, userInfoJSON);
-}
-
 void bsg_kscrash_setPrintTraceToStdout(bool printTraceToStdout) {
     crashContext()->config.printTraceToStdout = printTraceToStdout;
 }

--- a/Bugsnag/KSCrash/Source/KSCrash/Recording/BSG_KSCrashC.h
+++ b/Bugsnag/KSCrash/Source/KSCrash/Recording/BSG_KSCrashC.h
@@ -87,13 +87,6 @@ void bsg_kscrash_reinstall(const char *const crashReportFilePath,
                            const char *const stateFilePath,
                            const char *const crashID);
 
-/** Set the user-supplied data in JSON format.
- *
- * @param userInfoJSON Pre-baked JSON containing user-supplied information.
- *                     NULL = delete.
- */
-void bsg_kscrash_setUserInfoJSON(const char *const userInfoJSON);
-
 /** Set whether or not to print a stack trace to stdout when a crash occurs.
  *
  * Default: false

--- a/Bugsnag/KSCrash/Source/KSCrash/Recording/BSG_KSCrashContext.h
+++ b/Bugsnag/KSCrash/Source/KSCrash/Recording/BSG_KSCrashContext.h
@@ -60,9 +60,6 @@ typedef struct {
     /** System information in JSON format (to be written to the report). */
     char *systemInfoJSON;
 
-    /** User information in JSON format (to be written to the report). */
-    char *userInfoJSON;
-
     /** When writing the crash report, print a stack trace to STDOUT as well. */
     bool printTraceToStdout;
 

--- a/Bugsnag/KSCrash/Source/KSCrash/Recording/BSG_KSCrashReport.c
+++ b/Bugsnag/KSCrash/Source/KSCrash/Recording/BSG_KSCrashReport.c
@@ -1597,10 +1597,6 @@ void bsg_kscrashreport_writeKSCrashFields(BSG_KSCrash_Context *crashContext, BSG
     }
     writer->endContainer(writer);
 
-    if (crashContext->config.userInfoJSON != NULL) {
-        bsg_kscrw_i_addJSONElement(writer, BSG_KSCrashField_User,
-                crashContext->config.userInfoJSON);
-    }
     bsg_kscrw_i_writeTraceInfo(crashContext, writer);
 }
 

--- a/Bugsnag/KSCrash/Source/KSCrash/Recording/BSG_KSCrashState.m
+++ b/Bugsnag/KSCrash/Source/KSCrash/Recording/BSG_KSCrashState.m
@@ -108,7 +108,7 @@ int bsg_kscrashstate_i_onIntegerElement(const char *const name,
 
     if (strcmp(name, BSG_kKeyFormatVersion) == 0) {
         if (value != BSG_kFormatVersion) {
-            BSG_KSLOG_ERROR(@"Expected version 1 but got %lld", value);
+            bsg_log_err(@"Expected version 1 but got %lld", value);
             return BSG_KSJSON_ERROR_INVALID_DATA;
         }
     } else if (strcmp(name, BSG_kKeyLaunchesSinceLastCrash) == 0) {
@@ -178,20 +178,20 @@ bool bsg_kscrashstate_i_loadState(BSG_KSCrash_State *const context,
     }
     NSString *file = [NSFileManager.defaultManager stringWithFileSystemRepresentation:path length:strlen(path)];
     if (!file) {
-        BSG_KSLOG_ERROR(@"Invalid path: %s", path);
+        bsg_log_err(@"Invalid path: %s", path);
         return false;
     }
     NSError *error = nil;
     NSData *data = [NSData dataWithContentsOfFile:file options:0 error:&error];
     if (error != nil) {
         if (!(error.domain == NSCocoaErrorDomain && error.code == NSFileReadNoSuchFileError)) {
-            BSG_KSLOG_ERROR(@"%s: Could not load file: %@", path, error);
+            bsg_log_err(@"%s: Could not load file: %@", path, error);
         }
         return false;
     }
     id objectContext = [BSG_KSJSONCodec decode:data error:&error];
     if (error != nil) {
-        BSG_KSLOG_ERROR(@"%s: Could not load file: %@", path, error);
+        bsg_log_err(@"%s: Could not load file: %@", path, error);
         return false;
     }
 
@@ -223,8 +223,7 @@ bool bsg_kscrashstate_i_saveState(const BSG_KSCrash_State *const state,
                                   const char *const path) {
     int fd = open(path, O_RDWR | O_CREAT | O_TRUNC, 0644);
     if (fd < 0) {
-        BSG_KSLOG_ERROR(@"Could not open file %s for writing: %s", path,
-                        strerror(errno));
+        bsg_log_err(@"Could not open file %s for writing: %s", path, strerror(errno));
         return false;
     }
 
@@ -273,7 +272,7 @@ done:
     close(fd);
 
     if (result != BSG_KSJSON_OK) {
-        BSG_KSLOG_ERROR(@"%s: %s", path, bsg_ksjsonstringForError(result));
+        bsg_log_err(@"%s: %s", path, bsg_ksjsonstringForError(result));
         return false;
     }
     return true;

--- a/Bugsnag/KSCrash/Source/KSCrash/Recording/BSG_KSSystemInfo.m
+++ b/Bugsnag/KSCrash/Source/KSCrash/Recording/BSG_KSSystemInfo.m
@@ -77,20 +77,20 @@ static NSDictionary * bsg_systemversion() {
     const char *file = "/System/Library/CoreServices/SystemVersion.plist";
     bsg_syscall_open(file, O_RDONLY, 0, &fd);
     if (fd < 0) {
-        BSG_KSLOG_ERROR("Could not open SystemVersion.plist");
+        bsg_log_err(@"Could not open SystemVersion.plist");
         return nil;
     }
     ssize_t length = read(fd, buffer, sizeof(buffer));
     close(fd);
     if (length < 0 || length == sizeof(buffer)) {
-        BSG_KSLOG_ERROR("Could not read SystemVersion.plist");
+        bsg_log_err(@"Could not read SystemVersion.plist");
         return nil;
     }
     NSData *data = [NSData
                     dataWithBytesNoCopy:buffer
                     length:(NSUInteger)length freeWhenDone:NO];
     if (!data) {
-        BSG_KSLOG_ERROR("Could not read SystemVersion.plist");
+        bsg_log_err(@"Could not read SystemVersion.plist");
         return nil;
     }
     NSError *error = nil;
@@ -98,7 +98,7 @@ static NSDictionary * bsg_systemversion() {
                                    propertyListWithData:data
                                    options:0 format:NULL error:&error];
     if (!systemVersion) {
-        BSG_KSLOG_ERROR("Could not read SystemVersion.plist: %@", error);
+        bsg_log_err(@"Could not read SystemVersion.plist: %@", error);
     }
     return systemVersion;
 }
@@ -509,7 +509,7 @@ char *bsg_kssysteminfo_toJSON(void) {
                                          options:BSG_KSJSONEncodeOptionSorted
                                            error:&error];
     if (error != nil) {
-        BSG_KSLOG_ERROR(@"Could not serialize system info: %@", error);
+        bsg_log_err(@"Could not serialize system info: %@", error);
         return NULL;
     }
     if (![jsonData isKindOfClass:[NSMutableData class]]) {

--- a/Bugsnag/KSCrash/Source/KSCrash/Recording/Sentry/BSG_KSCrashSentry_CPPException.mm
+++ b/Bugsnag/KSCrash/Source/KSCrash/Recording/Sentry/BSG_KSCrashSentry_CPPException.mm
@@ -102,14 +102,14 @@ void __cxa_throw(void *thrown_exception, std::type_info *tinfo,
 }
 
 static void CPPExceptionTerminate(void) {
-    BSG_KSLOG_DEBUG(@"Trapped c++ exception");
+    BSG_KSLOG_DEBUG("Trapped c++ exception");
 
     bool isNSException = false;
     char descriptionBuff[DESCRIPTION_BUFFER_LENGTH];
     const char *name = NULL;
     const char *description = NULL;
 
-    BSG_KSLOG_DEBUG(@"Get exception type name.");
+    BSG_KSLOG_DEBUG("Get exception type name.");
     std::type_info *tinfo = __cxxabiv1::__cxa_current_exception_type();
     if (tinfo != NULL) {
         name = tinfo->name();
@@ -118,14 +118,13 @@ static void CPPExceptionTerminate(void) {
     description = descriptionBuff;
     descriptionBuff[0] = 0;
 
-    BSG_KSLOG_DEBUG(@"Discovering what kind of exception was thrown.");
+    BSG_KSLOG_DEBUG("Discovering what kind of exception was thrown.");
     bsg_g_captureNextStackTrace = false;
     try {
         throw;
     } catch (NSException *exception) {
-        BSG_KSLOG_DEBUG(@"Detected NSException. Recording details "
-                        @"and letting the current "
-                        @"NSException handler deal with it.");
+        BSG_KSLOG_DEBUG("Detected NSException. Recording details and letting "
+                        "the current NSException handler deal with it.");
         isNSException = true;
         bsg_recordException(exception);
     } catch (std::exception &exc) {
@@ -162,13 +161,13 @@ static void CPPExceptionTerminate(void) {
         bsg_kscrashsentry_beginHandlingCrash(bsg_g_context);
 
         if (wasHandlingCrash) {
-            BSG_KSLOG_INFO(@"Detected crash in the crash reporter. Restoring "
-                           @"original handlers.");
+            BSG_KSLOG_INFO("Detected crash in the crash reporter. "
+                           "Restoring original handlers.");
             bsg_g_context->crashedDuringCrashHandling = true;
             bsg_kscrashsentry_uninstall((BSG_KSCrashType)BSG_KSCrashTypeAll);
         }
 
-        BSG_KSLOG_DEBUG(@"Suspending all threads.");
+        BSG_KSLOG_DEBUG("Suspending all threads.");
         bsg_kscrashsentry_suspendThreads();
 
         bsg_g_context->crashType = BSG_KSCrashTypeCPPException;
@@ -180,11 +179,11 @@ static void CPPExceptionTerminate(void) {
         bsg_g_context->CPPException.name = name;
         bsg_g_context->crashReason = description;
 
-        BSG_KSLOG_DEBUG(@"Calling main crash handler.");
+        BSG_KSLOG_DEBUG("Calling main crash handler.");
         bsg_g_context->onCrash(crashContext());
 
         BSG_KSLOG_DEBUG(
-            @"Crash handling complete. Restoring original handlers.");
+            "Crash handling complete. Restoring original handlers.");
         bsg_kscrashsentry_uninstall((BSG_KSCrashType)BSG_KSCrashTypeAll);
         bsg_kscrashsentry_resumeThreads();
     }
@@ -199,7 +198,7 @@ static void CPPExceptionTerminate(void) {
 
 extern "C" bool bsg_kscrashsentry_installCPPExceptionHandler(
     BSG_KSCrash_SentryContext *context) {
-    BSG_KSLOG_DEBUG(@"Installing C++ exception handler.");
+    BSG_KSLOG_DEBUG("Installing C++ exception handler.");
 
     if (bsg_g_installed) {
         return true;
@@ -214,7 +213,7 @@ extern "C" bool bsg_kscrashsentry_installCPPExceptionHandler(
 }
 
 extern "C" void bsg_kscrashsentry_uninstallCPPExceptionHandler(void) {
-    BSG_KSLOG_DEBUG(@"Uninstalling C++ exception handler.");
+    BSG_KSLOG_DEBUG("Uninstalling C++ exception handler.");
     if (!bsg_g_installed) {
         return;
     }

--- a/Bugsnag/KSCrash/Source/KSCrash/Recording/Tools/BSG_KSJSONCodecObjC.m
+++ b/Bugsnag/KSCrash/Source/KSCrash/Recording/Tools/BSG_KSJSONCodecObjC.m
@@ -514,7 +514,7 @@ int bsg_ksjsoncodecobjc_i_encodeObject(BSG_KSJSONCodec *codec, id object,
         }
         return result == BSG_KSJSON_OK ? data : nil;
     } @catch (NSException *exception) {
-        BSG_KSLOG_ERROR(@"Could not encode JSON object: %@", exception.description);
+        BSG_KSLOG_ERROR("Could not encode JSON object: %s", exception.description.UTF8String);
         if (error != nil) {
             *error = [NSErrorBSG bsg_errorWithDomain:@"KSJSONCodecObjC" code:0 description:@"%@", exception.description];
         }
@@ -529,7 +529,7 @@ int bsg_ksjsoncodecobjc_i_encodeObject(BSG_KSJSONCodec *codec, id object,
     @try {
         result = [NSJSONSerialization JSONObjectWithData:JSONData options:0 error:error];
     } @catch (NSException *exception) {
-        BSG_KSLOG_ERROR(@"Could not decode JSON object: %@", exception.description);
+        BSG_KSLOG_ERROR("Could not decode JSON object: %s", exception.description.UTF8String);
         if (error != nil) {
             *error = [NSErrorBSG bsg_errorWithDomain:@"KSJSONCodecObjC" code:0 description:@"%@", exception.description];
         }

--- a/Bugsnag/KSCrash/Source/KSCrash/Recording/Tools/BSG_KSLogger.c
+++ b/Bugsnag/KSCrash/Source/KSCrash/Recording/Tools/BSG_KSLogger.c
@@ -1,5 +1,5 @@
 //
-//  BSG_KSLogger.m
+//  BSG_KSLogger.c
 //
 //  Created by Karl Stenerud on 11-06-25.
 //
@@ -24,7 +24,14 @@
 // THE SOFTWARE.
 //
 
-#import "BSG_KSLogger.h"
+#include "BSG_KSLogger.h"
+
+#include <stdarg.h>
+#include <stdio.h>
+#include <string.h>
+#include <sys/errno.h>
+#include <sys/fcntl.h>
+#include <unistd.h>
 
 // ===========================================================================
 #pragma mark - Common -
@@ -216,7 +223,7 @@ __printflike(5, 6)
 void bsg_i_kslog_logC(const char *const level, const char *const file,
                       const int line, const char *const function,
                       const char *const fmt, ...) {
-    writeFmtToLog("%s: %s (%u): %s: ", level, lastPathEntry(file), line,
+    writeFmtToLog("%s: %s:%u: %s(): ", level, lastPathEntry(file), line,
                   function);
     va_list args;
     va_start(args, fmt);
@@ -224,47 +231,4 @@ void bsg_i_kslog_logC(const char *const level, const char *const file,
     va_end(args);
     writeToLog("\n");
     flushLog();
-}
-
-// ===========================================================================
-#pragma mark - Objective-C -
-// ===========================================================================
-
-void bsg_i_kslog_logObjCBasic(NSString *fmt, ...) {
-    if (fmt == nil) {
-        writeToLog("(null)");
-        return;
-    }
-
-    va_list args;
-    va_start(args, fmt);
-    CFStringRef entry = CFStringCreateWithFormatAndArguments(
-        NULL, NULL, (__bridge CFStringRef)fmt, args);
-    va_end(args);
-
-    writeToLog([(__bridge NSString *)entry UTF8String]);
-    writeToLog("\n");
-
-    CFRelease(entry);
-}
-
-void bsg_i_kslog_logObjC(const char *const level, const char *const file,
-                         const int line, const char *const function,
-                         NSString *fmt, ...) {
-    if (fmt == nil) {
-        bsg_i_kslog_logObjCBasic(@"%s: %s (%u): %s: (null)", level,
-                                 lastPathEntry(file), line, function);
-    } else {
-        va_list args;
-        va_start(args, fmt);
-        CFStringRef entry = CFStringCreateWithFormatAndArguments(
-            NULL, NULL, (__bridge CFStringRef)fmt, args);
-        va_end(args);
-
-        bsg_i_kslog_logObjCBasic(@"%s: %s (%u): %s: %@", level,
-                                 lastPathEntry(file), line, function,
-                                 (__bridge id)entry);
-
-        CFRelease(entry);
-    }
 }

--- a/Bugsnag/KSCrash/Source/KSCrash/Recording/Tools/BSG_KSMach.c
+++ b/Bugsnag/KSCrash/Source/KSCrash/Recording/Tools/BSG_KSMach.c
@@ -253,7 +253,7 @@ thread_t bsg_ksmachmachThreadFromPThread(const pthread_t pthread) {
     thread_t machThread = 0;
     if (bsg_ksmachcopyMem(&threadStruct->kernel_thread, &machThread,
                           sizeof(machThread)) != KERN_SUCCESS) {
-        BSG_KSLOG_TRACE("Could not copy mach thread from %p",
+        BSG_KSLOG_TRACE("Could not copy mach thread from %u",
                         threadStruct->kernel_thread);
         return 0;
     }
@@ -325,7 +325,7 @@ bool bsg_ksmachgetThreadQueueName(const thread_t thread, char *const buffer,
         bsg_ksmachcopyMem((const void *)dispatch_queue, &junk,
                           sizeof(junk)) != KERN_SUCCESS) {
         BSG_KSLOG_TRACE(
-            "This thread doesn't have a dispatch queue attached : %p", thread);
+            "This thread doesn't have a dispatch queue attached : %u", thread);
         return false;
     }
 

--- a/Tests/KSCrash/KSLogger_Tests.m
+++ b/Tests/KSCrash/KSLogger_Tests.m
@@ -55,12 +55,12 @@
 
 - (void) testLogError
 {
-    BSG_KSLOG_ERROR(@"TEST");
+    BSG_KSLOG_ERROR("TEST");
 }
 
 - (void) testLogAlways
 {
-    BSG_KSLOG_ALWAYS(@"TEST");
+    BSG_KSLOG_ALWAYS("TEST");
 }
 
 - (void) testLogAlwaysNull
@@ -70,7 +70,7 @@
 
 - (void) testLogBasicError
 {
-    BSG_KSLOGBASIC_ERROR(@"TEST");
+    BSG_KSLOGBASIC_ERROR("TEST");
 }
 
 - (void) testLogBasicErrorNull
@@ -80,7 +80,7 @@
 
 - (void) testLogBasicAlways
 {
-    BSG_KSLOGBASIC_ALWAYS(@"TEST");
+    BSG_KSLOGBASIC_ALWAYS("TEST");
 }
 
 - (void) testLogBasicAlwaysNull
@@ -93,7 +93,7 @@
     NSString* expected = @"TEST";
     NSString* logFileName = [self.tempDir stringByAppendingPathComponent:@"log.txt"];
     bsg_kslog_setLogFilename([logFileName UTF8String], true);
-    BSG_KSLOGBASIC_ALWAYS(expected);
+    BSG_KSLOGBASIC_ALWAYS("TEST");
     bsg_kslog_setLogFilename(nil, true);
 
     NSError* error = nil;
@@ -102,7 +102,7 @@
     result = [result componentsSeparatedByString:@"\x0a"][0];
     XCTAssertEqualObjects(result, expected, @"");
 
-    BSG_KSLOGBASIC_ALWAYS(@"blah blah");
+    BSG_KSLOGBASIC_ALWAYS("blah blah");
     result = [NSString stringWithContentsOfFile:logFileName encoding:NSUTF8StringEncoding error:&error];
     result = [result componentsSeparatedByString:@"\x0a"][0];
     XCTAssertNil(error, @"");


### PR DESCRIPTION
## Goal

Prevent the Objective-C runtime being used when writing log statements from crash handlers `BSG_KSCrashSentry_CPPException.mm` and `BSG_KSCrashSentry_NSException.m`.

This is to prevent the possibility of the crash handlers deadlocking - mostly a concern when running tests with extra logging enabled.

## Changeset

* Removes Objective-C based logging from `BSG_KSLogger`.

* Tweaks the logging format to be slightly less verbose, from

```
DEBUG: BSG_KSCrashSentry.c (104): BSG_KSCrashType bsg_kscrashsentry_installWithContext(
BSG_KSCrash_SentryContext *, BSG_KSCrashType, void (*)(void *)): Installing handlers with context
0x106e187c8, crash types 0xf.
```
to

```
DEBUG: BSG_KSCrashSentry.c:104: bsg_kscrashsentry_installWithContext(): Installing handlers with context
0x10fa3a398, crash types 0xf.
```

* Switches some code over to the `bsg_log_*` macros where Objective-C level logging is desired.

* Removes the now-unused `userInfo` storage on `BSG_KSCrash`.

* Fixes some format string build errors.

## Testing

Tested manually using example app with full trace-level logging enabled.