### PR TITLE
[PLAT-7396] Redact breadcrumb metadata

### DIFF
--- a/Bugsnag/Helpers/BugsnagKeys.h
+++ b/Bugsnag/Helpers/BugsnagKeys.h
@@ -74,7 +74,6 @@ extern NSString *const BSGKeyPersistUser;
 extern NSString *const BSGKeyProduction;
 extern NSString *const BSGKeyReason;
 extern NSString *const BSGKeyRedactedKeys;
-extern NSString *const BSGKeyRedaction;
 extern NSString *const BSGKeyReleaseStage;
 extern NSString *const BSGKeySendThreads;
 extern NSString *const BSGKeySession;

--- a/Bugsnag/Helpers/BugsnagKeys.m
+++ b/Bugsnag/Helpers/BugsnagKeys.m
@@ -73,7 +73,6 @@ NSString *const BSGKeyPersistUser = @"persistUser";
 NSString *const BSGKeyProduction = @"production";
 NSString *const BSGKeyReason = @"reason";
 NSString *const BSGKeyRedactedKeys = @"redactedKeys";
-NSString *const BSGKeyRedaction = @"[REDACTED]";
 NSString *const BSGKeyReleaseStage = @"releaseStage";
 NSString *const BSGKeySendThreads = @"sendThreads";
 NSString *const BSGKeySession = @"session";

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,13 @@
 Changelog
 =========
 
+## TBD
+
+### Bug fixes
+
+* Apply `redactedKeys` to breadcrumb metadata.
+  [#1204](https://github.com/bugsnag/bugsnag-cocoa/pull/1204)
+
 ## 6.14.0 (2021-10-06)
 
 ### Enhancements

--- a/Makefile
+++ b/Makefile
@@ -120,6 +120,10 @@ test-fixtures: ## Build the end-to-end test fixture
 	@./features/scripts/export_ios_app.sh
 	@./features/scripts/export_mac_app.sh
 
+e2e_macos:
+	./features/scripts/export_mac_app.sh
+	bundle exec maze-runner --app=macOSTestApp --farm=local --os=macOS --os-version=11 $(FEATURES)
+
 #--------------------------------------------------------------------------
 # Release
 #

--- a/features/breadcrumbs.feature
+++ b/features/breadcrumbs.feature
@@ -65,6 +65,7 @@ Feature: Attaching a series of notable events leading up to errors
     And the event "breadcrumbs.0.metaData.method" equals "GET"
     And the event "breadcrumbs.0.metaData.url" equals "http://bs-local.com:9340/reflect/"
     And the event "breadcrumbs.0.metaData.urlParams.status" equals "444"
+    And the event "breadcrumbs.0.metaData.urlParams.password" equals "[REDACTED]"
     And the event "breadcrumbs.0.metaData.status" equals 444
     And the event "breadcrumbs.0.metaData.duration" is greater than 0
     And the event "breadcrumbs.0.metaData.requestContentLength" is null

--- a/features/fixtures/shared/scenarios/NetworkBreadcrumbsScenario.swift
+++ b/features/fixtures/shared/scenarios/NetworkBreadcrumbsScenario.swift
@@ -23,9 +23,8 @@ class NetworkBreadcrumbsScenario : Scenario {
     }
 
     override func run() {
-
         // Make some network requests so that automatic network breadcrumbs are left
-        query(address: "http://bs-local.com:9340/reflect/?status=444")
+        query(address: "http://bs-local.com:9340/reflect/?status=444&password=T0p5ecr3t")
         query(address: "http://bs-local.com:9340/reflect/?delay_ms=3000")
 
         // Send a handled error


### PR DESCRIPTION
## Goal

Apply `redactedKeys` to breadcrumb metadata.

## Changeset

BugsnagEvent's `-serializeBreadcrumbs` has been renamed to `-serializeBreadcrumbsWithRedactedKeys:` and now uses the same redaction logic applied to event metadata.

Methods that implement redaction have been renamed for clarity.

## Testing

Added unit test case to verify that breabcrumb metadata is redacted when serialized as part of an event.

Amended network breadcrumb E2E scenario to verify that `urlParams` are redacted.
Ran the test locally using `make e2e_macos FEATURES=features/breadcrumbs.feature:58`