### PR TITLE
[PLAT-7268] Stop falling back to invalid storage paths

### DIFF
--- a/Bugsnag/Helpers/BSGInternalErrorReporter.h
+++ b/Bugsnag/Helpers/BSGInternalErrorReporter.h
@@ -39,6 +39,9 @@ FOUNDATION_EXPORT NSString *BSGErrorDescription(NSError *error);
 
 @property (class, nonatomic) BSGInternalErrorReporter *sharedInstance;
 
+/// Runs the block immediately if sharedInstance exists, otherwise runs the block once sharedInstance has been created.
++ (void)performBlock:(void (^)(BSGInternalErrorReporter *))block;
+
 - (instancetype)initWithDataSource:(id<BSGInternalErrorReporterDataSource>)dataSource NS_DESIGNATED_INITIALIZER;
 
 - (instancetype)init UNAVAILABLE_ATTRIBUTE;

--- a/Bugsnag/Helpers/BSGInternalErrorReporter.m
+++ b/Bugsnag/Helpers/BSGInternalErrorReporter.m
@@ -51,6 +51,7 @@ NSString *BSGErrorDescription(NSError *error) {
 @implementation BSGInternalErrorReporter
 
 static BSGInternalErrorReporter *sharedInstance_;
+static void (^ startupBlock_)(BSGInternalErrorReporter *);
 
 + (BSGInternalErrorReporter *)sharedInstance {
     return sharedInstance_;
@@ -58,6 +59,18 @@ static BSGInternalErrorReporter *sharedInstance_;
 
 + (void)setSharedInstance:(BSGInternalErrorReporter *)sharedInstance {
     sharedInstance_ = sharedInstance;
+    if (startupBlock_ && sharedInstance_) {
+        startupBlock_(sharedInstance_);
+        startupBlock_ = nil;
+    }
+}
+
++ (void)performBlock:(void (^)(BSGInternalErrorReporter *))block {
+    if (sharedInstance_) {
+        block(sharedInstance_);
+    } else {
+        startupBlock_ = [block copy];
+    }
 }
 
 - (instancetype)initWithDataSource:(id<BSGInternalErrorReporterDataSource>)dataSource {

--- a/Bugsnag/Storage/BSGFileLocations.m
+++ b/Bugsnag/Storage/BSGFileLocations.m
@@ -15,7 +15,9 @@ static void ReportInternalError(NSString *errorClass, NSError *error) {
     NSString *file = @(__FILE__).lastPathComponent;
     NSString *message = BSGErrorDescription(error);
     NSString *groupingHash = [NSString stringWithFormat:@"%@: %@: %@ %ld", file, errorClass, error.domain, (long)error.code];
-    [BSGInternalErrorReporter.sharedInstance reportErrorWithClass:errorClass message:message diagnostics:error.userInfo groupingHash:groupingHash];
+    [BSGInternalErrorReporter performBlock:^(BSGInternalErrorReporter *reporter) {
+        [reporter reportErrorWithClass:errorClass message:message diagnostics:error.userInfo groupingHash:groupingHash];
+    }];
 }
 
 static BOOL ensureDirExists(NSString *path) {


### PR DESCRIPTION
## Goal

Prevent `BSGFileLocations` returning the same paths for subdirectories (e.g. `breadcrumbs`, `events`, etc) in the event of being unable to create any of them.

Falling back to the parent directory has been observed to cause bugs in the notifier due to breaking the assumption that particular directories contain only certain kinds of files.

## Changeset

* `getAndCreateSubdir()` now returns the subdir path in the event it could not be created.
* `rootDirectory()` now passes `create:NO` so that we won't fail to get the root path if the directory cannot be created.
* Fixes an issue where internal error reports were not being sent due to being reported prior to `BSGInternalErrorReporter`'s creation.

## Testing

Tested manually to ensure directories are still created in normal conditions.

Verified manually that internal error reporting now works, and added unit test case for new functionality.