### PR TITLE
[PLAT-7406] Change message to "NSURLSession request succeeded"

### DIFF
--- a/BugsnagNetworkRequestPlugin/BugsnagNetworkRequestPlugin/BSGURLSessionTracingDelegate.m
+++ b/BugsnagNetworkRequestPlugin/BugsnagNetworkRequestPlugin/BSGURLSessionTracingDelegate.m
@@ -36,13 +36,13 @@ static id<BSGBreadcrumbSink> g_sink;
 + (nonnull NSString *)messageForResponse:(NSHTTPURLResponse *)response {
     if (response) {
         if (100 <= response.statusCode && response.statusCode < 400) {
-            return @"NSURLSession succeeded";
+            return @"NSURLSession request succeeded";
         }
         if (400 <= response.statusCode && response.statusCode < 500) {
-            return @"NSURLSession failed";
+            return @"NSURLSession request failed";
         }
     }
-    return @"NSURLSession error";
+    return @"NSURLSession request error";
 }
 
 + (nullable NSDictionary<NSString *, id> *)urlParamsForQueryItems:(nullable NSArray<NSURLQueryItem *> *)queryItems {

--- a/BugsnagNetworkRequestPlugin/BugsnagNetworkRequestPluginTests/BugsnagNetworkRequestPluginTests.m
+++ b/BugsnagNetworkRequestPlugin/BugsnagNetworkRequestPluginTests/BugsnagNetworkRequestPluginTests.m
@@ -387,7 +387,7 @@ typedef void (^CompletionHandler)(NSData *data, NSURLResponse *response, NSError
 - (void)testBadURL {
     [self resetBreadcrumbs];
     [self fetchAndWaitURL:@"xxxxxxx" usingConfig:self.defaultConfig];
-    [self expectMessage:@"NSURLSession error"
+    [self expectMessage:@"NSURLSession request error"
                  method:@"GET"
               reqLength:nil
              respLength:nil
@@ -404,7 +404,7 @@ typedef void (^CompletionHandler)(NSData *data, NSURLResponse *response, NSError
                    statusCode:200
                          data:[self dataOfLength:0]
                     validator:^{
-        [self expectMessage:@"NSURLSession succeeded"
+        [self expectMessage:@"NSURLSession request succeeded"
                      method:@"GET"
                   reqLength:nil
                  respLength:@0
@@ -422,7 +422,7 @@ typedef void (^CompletionHandler)(NSData *data, NSURLResponse *response, NSError
                    statusCode:200
                          data:[self dataOfLength:10]
                     validator:^{
-        [self expectMessage:@"NSURLSession succeeded"
+        [self expectMessage:@"NSURLSession request succeeded"
                      method:@"GET"
                   reqLength:nil
                  respLength:@10
@@ -435,11 +435,11 @@ typedef void (^CompletionHandler)(NSData *data, NSURLResponse *response, NSError
 - (void)testTaskStatusCodes {
     NSArray *expectedMessages = @[
         @"",
-        @"NSURLSession succeeded",
-        @"NSURLSession succeeded",
-        @"NSURLSession succeeded",
-        @"NSURLSession failed",
-        @"NSURLSession error",
+        @"NSURLSession request succeeded",
+        @"NSURLSession request succeeded",
+        @"NSURLSession request succeeded",
+        @"NSURLSession request failed",
+        @"NSURLSession request error",
     ];
     NSString *urlString = @"https://bugsnag.com";
 
@@ -516,7 +516,7 @@ typedef void (^CompletionHandler)(NSData *data, NSURLResponse *response, NSError
                        statusCode:200
                              data:[self dataOfLength:0]
                         validator:^{
-            [self expectMessage:@"NSURLSession succeeded"
+            [self expectMessage:@"NSURLSession request succeeded"
                          method:method
                       reqLength:nil
                      respLength:@0
@@ -531,7 +531,7 @@ typedef void (^CompletionHandler)(NSData *data, NSURLResponse *response, NSError
                            statusCode:200
                                  data:[self dataOfLength:0]
                             validator:^{
-            [self expectMessage:@"NSURLSession succeeded"
+            [self expectMessage:@"NSURLSession request succeeded"
                          method:method
                       reqLength:nil
                      respLength:@0

--- a/Makefile
+++ b/Makefile
@@ -120,6 +120,10 @@ test-fixtures: ## Build the end-to-end test fixture
 	@./features/scripts/export_ios_app.sh
 	@./features/scripts/export_mac_app.sh
 
+e2e_ios_local:
+	@./features/scripts/export_ios_app.sh
+	bundle exec maze-runner --app=features/fixtures/ios/output/iOSTestApp.ipa --farm=local --os=ios --os-version=14 --apple-team-id=372ZUL2ZB7 --udid="$(shell idevice_id -l)" $(FEATURES)
+
 e2e_macos:
 	./features/scripts/export_mac_app.sh
 	bundle exec maze-runner --app=macOSTestApp --farm=local --os=macOS --os-version=11 $(FEATURES)

--- a/features/breadcrumbs.feature
+++ b/features/breadcrumbs.feature
@@ -60,7 +60,7 @@ Feature: Attaching a series of notable events leading up to errors
     And I run "NetworkBreadcrumbsScenario"
     Then I wait to receive an error
     And the event "breadcrumbs.0.timestamp" is a timestamp
-    And the event "breadcrumbs.0.name" equals "NSURLSession failed"
+    And the event "breadcrumbs.0.name" equals "NSURLSession request failed"
     And the event "breadcrumbs.0.type" equals "request"
     And the event "breadcrumbs.0.metaData.method" equals "GET"
     And the event "breadcrumbs.0.metaData.url" equals "http://bs-local.com:9340/reflect/"
@@ -71,7 +71,7 @@ Feature: Attaching a series of notable events leading up to errors
     And the event "breadcrumbs.0.metaData.requestContentLength" is null
     And the event "breadcrumbs.0.metaData.responseContentLength" is greater than 0
     And the event "breadcrumbs.1.timestamp" is a timestamp
-    And the event "breadcrumbs.1.name" equals "NSURLSession succeeded"
+    And the event "breadcrumbs.1.name" equals "NSURLSession request succeeded"
     And the event "breadcrumbs.1.type" equals "request"
     And the event "breadcrumbs.1.metaData.method" equals "GET"
     And the event "breadcrumbs.1.metaData.url" equals "http://bs-local.com:9340/reflect/"


### PR DESCRIPTION
## Changeset

Changes the network request breadcrumb message to e.g. `NSURLSession request succeeded`

## Testing

Amends unit and E2E tests to verify new message.

Adds the `e2e_ios_local` Makefile target to ease running tests.