### PR TITLE
[PLAT-7412] Improve logging around debugger being attached

### DIFF
--- a/Bugsnag/KSCrash/Source/KSCrash/Recording/BSG_KSCrashC.c
+++ b/Bugsnag/KSCrash/Source/KSCrash/Recording/BSG_KSCrashC.c
@@ -165,8 +165,10 @@ BSG_KSCrashType bsg_kscrash_setHandlingCrashTypes(BSG_KSCrashType crashTypes) {
 
     if (bsg_g_installed) {
         bsg_kscrashsentry_uninstall(~crashTypes);
-        crashTypes = bsg_kscrashsentry_installWithContext(
-            &context->crash, crashTypes, (void(*)(void *))bsg_kscrash_i_onCrash);
+        if (crashTypes) {
+            crashTypes = bsg_kscrashsentry_installWithContext(
+                &context->crash, crashTypes, (void(*)(void *))bsg_kscrash_i_onCrash);
+        }
     }
 
     return crashTypes;


### PR DESCRIPTION
## Goal

Log a less intimidating message when Bugsnag is started with a debugger attached.

The current message `[Bugsnag] [ERROR] Failed to install crash handler. No exceptions will be reported!` is a little alarming and indicates that there has been an error when this is actually expected behaviour when a debugger is attached.

## Changeset

If a debugger is attached and autoDetectErrors was enabled, a less alarming message is now shown:

```
[Bugsnag] [INFO] Unhandled errors will not be detected because a debugger is attached
```

`bsg_kscrashsentry_installWithContext()` is now only called if crash handlers should be installed, to prevent unnecessary warnings being logged about a debugger being attached.

Removed the exclamation mark from the error message for failure to install crash handlers.

## Testing

Tested with example app.