### PR TITLE
Use '#import <Bugsnag/*.h>' in private headers

### DIFF
--- a/Bugsnag/Bugsnag+Private.h
+++ b/Bugsnag/Bugsnag+Private.h
@@ -6,7 +6,7 @@
 //  Copyright © 2020 Bugsnag Inc. All rights reserved.
 //
 
-#import "Bugsnag.h"
+#import <Bugsnag/Bugsnag.h>
 
 NS_ASSUME_NONNULL_BEGIN
 

--- a/Bugsnag/BugsnagSessionTracker.h
+++ b/Bugsnag/BugsnagSessionTracker.h
@@ -8,8 +8,8 @@
 
 #import <Foundation/Foundation.h>
 
-#import "BugsnagSession.h"
-#import "BugsnagConfiguration.h"
+#import <Bugsnag/BugsnagConfiguration.h>
+#import <Bugsnag/BugsnagSession.h>
 
 NS_ASSUME_NONNULL_BEGIN
 

--- a/Bugsnag/BugsnagSystemState.h
+++ b/Bugsnag/BugsnagSystemState.h
@@ -8,7 +8,8 @@
 
 #import <Foundation/Foundation.h>
 
-#import "BugsnagConfiguration.h"
+#import <Bugsnag/BugsnagConfiguration.h>
+
 #import "BugsnagKeys.h"
 
 #define SYSTEMSTATE_KEY_APP @"app"

--- a/Bugsnag/Metadata/BugsnagMetadata+Private.h
+++ b/Bugsnag/Metadata/BugsnagMetadata+Private.h
@@ -6,7 +6,7 @@
 //  Copyright © 2020 Bugsnag Inc. All rights reserved.
 //
 
-#import "BugsnagMetadata.h"
+#import <Bugsnag/BugsnagMetadata.h>
 
 @class BugsnagStateEvent;
 

--- a/Bugsnag/Payload/BugsnagApp+Private.h
+++ b/Bugsnag/Payload/BugsnagApp+Private.h
@@ -6,7 +6,7 @@
 //  Copyright © 2020 Bugsnag Inc. All rights reserved.
 //
 
-#import "BugsnagApp.h"
+#import <Bugsnag/BugsnagApp.h>
 
 @class BugsnagConfiguration;
 

--- a/Bugsnag/Payload/BugsnagAppWithState+Private.h
+++ b/Bugsnag/Payload/BugsnagAppWithState+Private.h
@@ -6,7 +6,8 @@
 //  Copyright © 2020 Bugsnag Inc. All rights reserved.
 //
 
-#import "BugsnagAppWithState.h"
+#import <Bugsnag/BugsnagAppWithState.h>
+
 #import "BugsnagApp+Private.h"
 
 @class BugsnagConfiguration;

--- a/Bugsnag/Payload/BugsnagBreadcrumb+Private.h
+++ b/Bugsnag/Payload/BugsnagBreadcrumb+Private.h
@@ -6,7 +6,7 @@
 //  Copyright © 2020 Bugsnag Inc. All rights reserved.
 //
 
-#import "BugsnagBreadcrumb.h"
+#import <Bugsnag/BugsnagBreadcrumb.h>
 
 NS_ASSUME_NONNULL_BEGIN
 

--- a/Bugsnag/Payload/BugsnagDevice+Private.h
+++ b/Bugsnag/Payload/BugsnagDevice+Private.h
@@ -6,7 +6,7 @@
 //  Copyright © 2020 Bugsnag Inc. All rights reserved.
 //
 
-#import "BugsnagDevice.h"
+#import <Bugsnag/BugsnagDevice.h>
 
 NS_ASSUME_NONNULL_BEGIN
 

--- a/Bugsnag/Payload/BugsnagDeviceWithState+Private.h
+++ b/Bugsnag/Payload/BugsnagDeviceWithState+Private.h
@@ -6,7 +6,7 @@
 //  Copyright © 2020 Bugsnag Inc. All rights reserved.
 //
 
-#import "BugsnagDeviceWithState.h"
+#import <Bugsnag/BugsnagDeviceWithState.h>
 
 NS_ASSUME_NONNULL_BEGIN
 

--- a/Bugsnag/Payload/BugsnagHandledState.h
+++ b/Bugsnag/Payload/BugsnagHandledState.h
@@ -6,8 +6,9 @@
 //  Copyright © 2017 Bugsnag. All rights reserved.
 //
 
-#import "BugsnagEvent.h"
 #import <Foundation/Foundation.h>
+
+#import <Bugsnag/BugsnagEvent.h>
 
 typedef NS_ENUM(NSUInteger, SeverityReasonType) {
     UnhandledException,

--- a/Bugsnag/Payload/BugsnagSession+Private.h
+++ b/Bugsnag/Payload/BugsnagSession+Private.h
@@ -6,7 +6,7 @@
 //  Copyright © 2020 Bugsnag Inc. All rights reserved.
 //
 
-#import "BugsnagSession.h"
+#import <Bugsnag/BugsnagSession.h>
 
 NS_ASSUME_NONNULL_BEGIN
 

--- a/Bugsnag/Payload/BugsnagSessionTrackingPayload.h
+++ b/Bugsnag/Payload/BugsnagSessionTrackingPayload.h
@@ -7,7 +7,8 @@
 //
 
 #import <Foundation/Foundation.h>
-#import "BugsnagSession.h"
+
+#import <Bugsnag/BugsnagSession.h>
 
 @class BugsnagConfiguration;
 @class BugsnagNotifier;

--- a/Bugsnag/Payload/BugsnagUser+Private.h
+++ b/Bugsnag/Payload/BugsnagUser+Private.h
@@ -6,7 +6,7 @@
 //  Copyright © 2020 Bugsnag Inc. All rights reserved.
 //
 
-#import "BugsnagUser.h"
+#import <Bugsnag/BugsnagUser.h>
 
 NS_ASSUME_NONNULL_BEGIN
 

--- a/Bugsnag/Plugins/BugsnagPluginClient.h
+++ b/Bugsnag/Plugins/BugsnagPluginClient.h
@@ -8,7 +8,7 @@
 
 #import <Foundation/Foundation.h>
 
-#import "BugsnagPlugin.h"
+#import <Bugsnag/BugsnagPlugin.h>
 
 NS_ASSUME_NONNULL_BEGIN
 

--- a/Bugsnag/Storage/BugsnagSessionFileStore.h
+++ b/Bugsnag/Storage/BugsnagSessionFileStore.h
@@ -5,8 +5,9 @@
 
 #import <Foundation/Foundation.h>
 
+#import <Bugsnag/BugsnagSession.h>
+
 #import "BugsnagFileStore.h"
-#import "BugsnagSession.h"
 
 @interface BugsnagSessionFileStore : BugsnagFileStore
 + (BugsnagSessionFileStore *)storeWithPath:(NSString *)path


### PR DESCRIPTION
Use the `#import <Bugsnag/Header.h>` syntax whenever public headers are imported from private headers.

This makes it easier to include Bugsnag in external build processes where, for example, the directory structure needs to be flattened to support building without a header map.