### PR TITLE
Pipeline: Fix exclusionary regexes to only exclude feature files

### DIFF
--- a/.buildkite/pipeline.full.yml
+++ b/.buildkite/pipeline.full.yml
@@ -24,7 +24,7 @@ steps:
           - "--device=IOS_13"
           - "--appium-version=1.17.0"
           - "--fail-fast"
-          - "--exclude=features/[h-z].*.feature"
+          - "--exclude=features/[h-z].*.feature$"
           - "--order=random"
     concurrency: 9
     concurrency_group: browserstack-app
@@ -51,7 +51,7 @@ steps:
           - "--device=IOS_13"
           - "--appium-version=1.17.0"
           - "--fail-fast"
-          - "--exclude=features/[a-g].*.feature"
+          - "--exclude=features/[a-g].*.feature$"
           - "--order=random"
     concurrency: 9
     concurrency_group: browserstack-app
@@ -78,7 +78,7 @@ steps:
           - "--device=IOS_12"
           - "--appium-version=1.17.0"
           - "--fail-fast"
-          - "--exclude=features/[h-z].*.feature"
+          - "--exclude=features/[h-z].*.feature$"
           - "--order=random"
     concurrency: 9
     concurrency_group: browserstack-app
@@ -105,7 +105,7 @@ steps:
           - "--device=IOS_12"
           - "--appium-version=1.17.0"
           - "--fail-fast"
-          - "--exclude=features/[a-g].*.feature"
+          - "--exclude=features/[a-g].*.feature$"
           - "--order=random"
     concurrency: 9
     concurrency_group: browserstack-app
@@ -134,7 +134,7 @@ steps:
           - "--device=IOS_11_0_IPHONE_8_PLUS"
           - "--appium-version=1.8.0"
           - "--fail-fast"
-          - "--exclude=features/[h-z].*.feature"
+          - "--exclude=features/[h-z].*.feature$"
           - "--order=random"
     concurrency: 9
     concurrency_group: browserstack-app
@@ -163,7 +163,7 @@ steps:
           - "--device=IOS_11_0_IPHONE_8_PLUS"
           - "--appium-version=1.8.0"
           - "--fail-fast"
-          - "--exclude=features/[a-g].*.feature"
+          - "--exclude=features/[a-g].*.feature$"
           - "--order=random"
     concurrency: 9
     concurrency_group: browserstack-app

--- a/.buildkite/pipeline.quick.yml
+++ b/.buildkite/pipeline.quick.yml
@@ -152,7 +152,7 @@ steps:
           - "--device=IOS_14"
           - "--appium-version=1.17.0"
           - "--fail-fast"
-          - "--exclude=features/[h-z].*.feature"
+          - "--exclude=features/[h-z].*.feature$"
           - "--order=random"
     concurrency: 9
     concurrency_group: browserstack-app
@@ -180,7 +180,7 @@ steps:
           - "--device=IOS_14"
           - "--appium-version=1.17.0"
           - "--fail-fast"
-          - "--exclude=features/[a-g].*.feature"
+          - "--exclude=features/[a-g].*.feature$"
           - "--order=random"
     concurrency: 9
     concurrency_group: browserstack-app
@@ -208,7 +208,7 @@ steps:
           - "--device=IOS_10"
           - "--appium-version=1.8.0"
           - "--fail-fast"
-          - "--exclude=features/[h-z].*.feature"
+          - "--exclude=features/[h-z].*.feature$"
           - "--order=random"
     concurrency: 9
     concurrency_group: browserstack-app
@@ -236,7 +236,7 @@ steps:
           - "--device=IOS_10"
           - "--appium-version=1.8.0"
           - "--fail-fast"
-          - "--exclude=features/[a-g].*.feature"
+          - "--exclude=features/[a-g].*.feature$"
           - "--order=random"
     concurrency: 9
     concurrency_group: browserstack-app


### PR DESCRIPTION
## Goal
The regex present in the exclude flag was excluding a recently added step definitions file, causing the tests on the base branch to fail.  This changes the regex to specifically require a file ending in `feature` by adding an end of line character. 