### PR TITLE
Remove --fail-fast from iOS 10 e2e test steps

### DIFF
--- a/.buildkite/pipeline.quick.yml
+++ b/.buildkite/pipeline.quick.yml
@@ -207,7 +207,6 @@ steps:
           - "--farm=bs"
           - "--device=IOS_10"
           - "--appium-version=1.8.0"
-          - "--fail-fast"
           - "--exclude=features/[h-z].*.feature"
           - "--order=random"
     concurrency: 9
@@ -235,7 +234,6 @@ steps:
           - "--farm=bs"
           - "--device=IOS_10"
           - "--appium-version=1.8.0"
-          - "--fail-fast"
           - "--exclude=features/[a-g].*.feature"
           - "--order=random"
     concurrency: 9

--- a/.buildkite/pipeline.yml
+++ b/.buildkite/pipeline.yml
@@ -172,7 +172,6 @@ steps:
           - "--farm=bs"
           - "--device=IOS_10"
           - "--appium-version=1.8.0"
-          - "--fail-fast"
           - "--order=random"
     concurrency: 9
     concurrency_group: browserstack-app


### PR DESCRIPTION
## Goal

Remove --fail-fast from iOS 10 e2e test steps to see if network failures we're currently experiencing are blips or more prolonged outages.