### PR TITLE
Only upload the e2e test app once

### DIFF
--- a/.buildkite/pipeline.full.yml
+++ b/.buildkite/pipeline.full.yml
@@ -15,11 +15,12 @@ steps:
       queue: opensource
     plugins:
       artifacts#v1.3.0:
-        download: ["features/fixtures/ios/output/iOSTestApp.ipa"]
+        download: "features/fixtures/ios/output/ipa_url.txt"
+        upload: "maze_output/failed/**/*"
       docker-compose#v3.3.0:
         run: cocoa-maze-runner
         command:
-          - "--app=/app/build/iOSTestApp.ipa"
+          - "--app=@build/ipa_url.txt"
           - "--farm=bs"
           - "--device=IOS_13"
           - "--appium-version=1.17.0"
@@ -42,11 +43,12 @@ steps:
       queue: opensource
     plugins:
       artifacts#v1.3.0:
-        download: ["features/fixtures/ios/output/iOSTestApp.ipa"]
+        download: "features/fixtures/ios/output/ipa_url.txt"
+        upload: "maze_output/failed/**/*"
       docker-compose#v3.3.0:
         run: cocoa-maze-runner
         command:
-          - "--app=/app/build/iOSTestApp.ipa"
+          - "--app=@build/ipa_url.txt"
           - "--farm=bs"
           - "--device=IOS_13"
           - "--appium-version=1.17.0"
@@ -69,11 +71,12 @@ steps:
       queue: opensource
     plugins:
       artifacts#v1.3.0:
-        download: ["features/fixtures/ios/output/iOSTestApp.ipa"]
+        download: "features/fixtures/ios/output/ipa_url.txt"
+        upload: "maze_output/failed/**/*"
       docker-compose#v3.3.0:
         run: cocoa-maze-runner
         command:
-          - "--app=/app/build/iOSTestApp.ipa"
+          - "--app=@build/ipa_url.txt"
           - "--farm=bs"
           - "--device=IOS_12"
           - "--appium-version=1.17.0"
@@ -96,11 +99,12 @@ steps:
       queue: opensource
     plugins:
       artifacts#v1.3.0:
-        download: ["features/fixtures/ios/output/iOSTestApp.ipa"]
+        download: "features/fixtures/ios/output/ipa_url.txt"
+        upload: "maze_output/failed/**/*"
       docker-compose#v3.3.0:
         run: cocoa-maze-runner
         command:
-          - "--app=/app/build/iOSTestApp.ipa"
+          - "--app=@build/ipa_url.txt"
           - "--farm=bs"
           - "--device=IOS_12"
           - "--appium-version=1.17.0"
@@ -125,11 +129,12 @@ steps:
       queue: opensource
     plugins:
       artifacts#v1.3.0:
-        download: ["features/fixtures/ios/output/iOSTestApp.ipa"]
+        download: "features/fixtures/ios/output/ipa_url.txt"
+        upload: "maze_output/failed/**/*"
       docker-compose#v3.3.0:
         run: cocoa-maze-runner
         command:
-          - "--app=/app/build/iOSTestApp.ipa"
+          - "--app=@build/ipa_url.txt"
           - "--farm=bs"
           - "--device=IOS_11_0_IPHONE_8_PLUS"
           - "--appium-version=1.8.0"
@@ -154,11 +159,12 @@ steps:
       queue: opensource
     plugins:
       artifacts#v1.3.0:
-        download: ["features/fixtures/ios/output/iOSTestApp.ipa"]
+        download: "features/fixtures/ios/output/ipa_url.txt"
+        upload: "maze_output/failed/**/*"
       docker-compose#v3.3.0:
         run: cocoa-maze-runner
         command:
-          - "--app=/app/build/iOSTestApp.ipa"
+          - "--app=@build/ipa_url.txt"
           - "--farm=bs"
           - "--device=IOS_11_0_IPHONE_8_PLUS"
           - "--appium-version=1.8.0"

--- a/.buildkite/pipeline.quick.yml
+++ b/.buildkite/pipeline.quick.yml
@@ -142,12 +142,12 @@ steps:
       queue: opensource
     plugins:
       artifacts#v1.3.0:
-        download: ["features/fixtures/ios/output/iOSTestApp.ipa"]
-        upload: ["maze_output/failed/**/*"]
+        download: "features/fixtures/ios/output/ipa_url.txt"
+        upload: "maze_output/failed/**/*"
       docker-compose#v3.3.0:
         run: cocoa-maze-runner
         command:
-          - "--app=/app/build/iOSTestApp.ipa"
+          - "--app=@build/ipa_url.txt"
           - "--farm=bs"
           - "--device=IOS_14"
           - "--appium-version=1.17.0"
@@ -170,12 +170,12 @@ steps:
       queue: opensource
     plugins:
       artifacts#v1.3.0:
-        download: ["features/fixtures/ios/output/iOSTestApp.ipa"]
-        upload: ["maze_output/failed/**/*"]
+        download: "features/fixtures/ios/output/ipa_url.txt"
+        upload: "maze_output/failed/**/*"
       docker-compose#v3.3.0:
         run: cocoa-maze-runner
         command:
-          - "--app=/app/build/iOSTestApp.ipa"
+          - "--app=@build/ipa_url.txt"
           - "--farm=bs"
           - "--device=IOS_14"
           - "--appium-version=1.17.0"
@@ -198,12 +198,12 @@ steps:
       queue: opensource
     plugins:
       artifacts#v1.3.0:
-        download: ["features/fixtures/ios/output/iOSTestApp.ipa"]
-        upload: ["maze_output/failed/**/*"]
+        download: "features/fixtures/ios/output/ipa_url.txt"
+        upload: "maze_output/failed/**/*"
       docker-compose#v3.3.0:
         run: cocoa-maze-runner
         command:
-          - "--app=/app/build/iOSTestApp.ipa"
+          - "--app=@build/ipa_url.txt"
           - "--farm=bs"
           - "--device=IOS_10"
           - "--appium-version=1.8.0"
@@ -226,12 +226,12 @@ steps:
       queue: opensource
     plugins:
       artifacts#v1.3.0:
-        download: ["features/fixtures/ios/output/iOSTestApp.ipa"]
-        upload: ["maze_output/failed/**/*"]
+        download: "features/fixtures/ios/output/ipa_url.txt"
+        upload: "maze_output/failed/**/*"
       docker-compose#v3.3.0:
         run: cocoa-maze-runner
         command:
-          - "--app=/app/build/iOSTestApp.ipa"
+          - "--app=@build/ipa_url.txt"
           - "--farm=bs"
           - "--device=IOS_10"
           - "--appium-version=1.8.0"

--- a/.buildkite/pipeline.yml
+++ b/.buildkite/pipeline.yml
@@ -23,11 +23,10 @@ steps:
     agents:
       queue: opensource-mac-cocoa-11
     artifact_paths:
-      - features/fixtures/ios/output/iOSTestApp.ipa
       - features/fixtures/macos/output/macOSTestApp.zip
+      - features/fixtures/ios/output/ipa_url.txt
     commands:
-      - ./features/scripts/export_ios_app.sh
-      - ./features/scripts/export_mac_app.sh
+      - ./features/scripts/build_and_upload_app.rb
 
   - label: Static framework and Swift Package Manager builds
     timeout_in_minutes: 10
@@ -49,7 +48,7 @@ steps:
       - ./scripts/build-carthage.sh
     plugins:
       artifacts#v1.3.0:
-        upload: ["features/fixtures/carthage/carthage-*.log"]
+        upload: "features/fixtures/carthage/carthage-*.log"
 
   ##############################################################################
   #
@@ -134,13 +133,13 @@ steps:
       queue: opensource
     plugins:
       artifacts#v1.3.0:
-        download: ["features/fixtures/ios/output/iOSTestApp.ipa"]
-        upload: ["maze_output/failed/**/*"]
+        download: "features/fixtures/ios/output/ipa_url.txt"
+        upload: "maze_output/failed/**/*"
       docker-compose#v3.3.0:
         run: cocoa-maze-runner
         command:
           - "features/barebone_tests.feature"
-          - "--app=/app/build/iOSTestApp.ipa"
+          - "--app=@build/ipa_url.txt"
           - "--farm=bs"
           - "--device=IOS_14"
           - "--appium-version=1.17.0"
@@ -162,13 +161,13 @@ steps:
       queue: opensource
     plugins:
       artifacts#v1.3.0:
-        download: ["features/fixtures/ios/output/iOSTestApp.ipa"]
-        upload: ["maze_output/failed/**/*"]
+        download: "features/fixtures/ios/output/ipa_url.txt"
+        upload: "maze_output/failed/**/*"
       docker-compose#v3.3.0:
         run: cocoa-maze-runner
         command:
           - "features/barebone_tests.feature"
-          - "--app=/app/build/iOSTestApp.ipa"
+          - "--app=@build/ipa_url.txt"
           - "--farm=bs"
           - "--device=IOS_10"
           - "--appium-version=1.8.0"
@@ -190,8 +189,11 @@ steps:
       queue: opensource-mac-cocoa-10.13
     plugins:
       artifacts#v1.3.0:
-        download: ["features/fixtures/macos/output/macOSTestApp.zip"]
-        upload: ["macOSTestApp.log", "appium_server.log", "maze_output/failed/**/*"]
+        download: "features/fixtures/macos/output/macOSTestApp.zip"
+        upload:
+          - "macOSTestApp.log"
+          - "appium_server.log"
+          - "maze_output/failed/**/*"
     commands:
       - bundle install
       - bundle exec maze-runner
@@ -211,8 +213,11 @@ steps:
       queue: opensource-mac-cocoa-10.15
     plugins:
       artifacts#v1.3.0:
-        download: ["features/fixtures/macos/output/macOSTestApp.zip"]
-        upload: ["macOSTestApp.log", "appium_server.log", "maze_output/failed/**/*"]
+        download: "features/fixtures/macos/output/macOSTestApp.zip"
+        upload:
+          - "macOSTestApp.log"
+          - "appium_server.log"
+          - "maze_output/failed/**/*"
     commands:
       - bundle install
       - bundle exec maze-runner
@@ -234,8 +239,11 @@ steps:
       queue: opensource-m1-mac-cocoa-11
     plugins:
       artifacts#v1.3.0:
-        download: ["features/fixtures/macos/output/macOSTestApp.zip"]
-        upload: ["macOSTestApp.log", "appium_server.log", "maze_output/failed/**/*"]
+        download: "features/fixtures/macos/output/macOSTestApp.zip"
+        upload:
+          - "macOSTestApp.log"
+          - "appium_server.log"
+          - "maze_output/failed/**/*"
     commands:
       - bundle config set --local path 'vendor/bundle'
       - bundle install

--- a/.buildkite/pipeline.yml
+++ b/.buildkite/pipeline.yml
@@ -23,6 +23,7 @@ steps:
     agents:
       queue: opensource-mac-cocoa-11
     artifact_paths:
+      - features/fixtures/ios/output/iOSTestApp.ipa
       - features/fixtures/macos/output/macOSTestApp.zip
       - features/fixtures/ios/output/ipa_url.txt
     commands:

--- a/Gemfile
+++ b/Gemfile
@@ -7,7 +7,7 @@ gem 'xcpretty'
 
 # A reference to Maze Runner is only needed for running tests locally and if committed it must be
 # portable for CI, e.g. a specific release.  However, leaving it commented out would mean quicker CI.
-gem 'bugsnag-maze-runner', git: 'https://github.com/bugsnag/maze-runner', tag: 'v6.3.0'
+gem 'bugsnag-maze-runner', git: 'https://github.com/bugsnag/maze-runner', tag: 'v6.5.0'
 
 # Use a development branch
 #gem 'bugsnag-maze-runner', git: 'https://github.com/bugsnag/maze-runner', branch: 'tms/update-cucumber'

--- a/Gemfile
+++ b/Gemfile
@@ -7,7 +7,7 @@ gem 'xcpretty'
 
 # A reference to Maze Runner is only needed for running tests locally and if committed it must be
 # portable for CI, e.g. a specific release.  However, leaving it commented out would mean quicker CI.
-gem 'bugsnag-maze-runner', git: 'https://github.com/bugsnag/maze-runner', tag: 'v6.0.0'
+gem 'bugsnag-maze-runner', git: 'https://github.com/bugsnag/maze-runner', tag: 'v6.3.0'
 
 # Use a development branch
 #gem 'bugsnag-maze-runner', git: 'https://github.com/bugsnag/maze-runner', branch: 'tms/update-cucumber'

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -1,10 +1,11 @@
 GIT
   remote: https://github.com/bugsnag/maze-runner
-  revision: c9d5240f9ccbc5a3440e8aa72330f52cbdc6a082
-  tag: v6.3.0
+  revision: fd33f19db2d0b03be857fecb55f1aa4d4033de6c
+  tag: v6.5.0
   specs:
-    bugsnag-maze-runner (6.3.0)
+    bugsnag-maze-runner (6.5.0)
       appium_lib (~> 11.2.0)
+      bugsnag (~> 6.24)
       cucumber (~> 7.1)
       cucumber-expressions (~> 6.0.0)
       curb (~> 0.9.6)
@@ -40,6 +41,8 @@ GEM
       faye-websocket (~> 0.11.0)
       selenium-webdriver (~> 3.14, >= 3.14.1)
     atomos (0.1.3)
+    bugsnag (6.24.0)
+      concurrent-ruby (~> 1.0)
     builder (3.2.4)
     childprocess (3.0.0)
     claide (1.0.3)
@@ -105,7 +108,7 @@ GEM
       cucumber-gherkin (~> 22.0, >= 22.0.0)
       cucumber-messages (~> 17.1, >= 17.1.1)
       cucumber-tag-expressions (~> 4.0, >= 4.0.2)
-    cucumber-create-meta (6.0.2)
+    cucumber-create-meta (6.0.4)
       cucumber-messages (~> 17.1, >= 17.1.1)
       sys-uname (~> 1.2, >= 1.2.2)
     cucumber-cucumber-expressions (14.0.0)
@@ -188,9 +191,9 @@ GEM
     kramdown-parser-gfm (1.1.0)
       kramdown (~> 2.0)
     liferaft (0.0.6)
-    mime-types (3.3.1)
+    mime-types (3.4.1)
       mime-types-data (~> 3.2015)
-    mime-types-data (3.2021.0901)
+    mime-types-data (3.2021.1115)
     mini_portile2 (2.6.1)
     minitest (5.14.4)
     molinillo (0.8.0)

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -1,9 +1,9 @@
 GIT
   remote: https://github.com/bugsnag/maze-runner
-  revision: 772e63f26bdb5a9e2b0893765763fdcc54e83cd4
-  tag: v6.0.0
+  revision: c9d5240f9ccbc5a3440e8aa72330f52cbdc6a082
+  tag: v6.3.0
   specs:
-    bugsnag-maze-runner (6.0.0)
+    bugsnag-maze-runner (6.3.0)
       appium_lib (~> 11.2.0)
       cucumber (~> 7.1)
       cucumber-expressions (~> 6.0.0)
@@ -214,7 +214,7 @@ GEM
     os (1.0.1)
     power_assert (2.0.1)
     public_suffix (4.0.6)
-    racc (1.5.2)
+    racc (1.6.0)
     rake (12.3.3)
     rchardet (1.8.0)
     redcarpet (3.5.1)

--- a/features/scripts/build_and_upload_app.rb
+++ b/features/scripts/build_and_upload_app.rb
@@ -1,0 +1,35 @@
+#!/usr/bin/env ruby
+require 'json'
+require 'net/http'
+
+def upload_app(username, access_key, app)
+  upload_uri = 'https://api-cloud.browserstack.com/app-automate/upload'
+  uri = URI(upload_uri)
+  request = Net::HTTP::Post.new(uri)
+  request.basic_auth(username, access_key)
+  request.set_form({ 'file' => File.new(app, 'rb') }, 'multipart/form-data')
+
+  puts "Uploading #{app} to #{upload_uri}"
+  res = Net::HTTP.start(uri.hostname, uri.port, use_ssl: true) do |http|
+    http.request(request)
+  end
+
+  begin
+    body = res.body
+    response = JSON.parse body
+    raise "Upload failed due to error: #{response['error']}" if response.include?('error')
+    raise "Upload failed, response did not include and app_url: #{res}" unless response.include?('app_url')
+  rescue JSON::ParserError
+    raise "Error: expected JSON response, received: #{body}"
+  end
+
+  response['app_url']
+end
+
+# Build the test fixture apps
+`make test-fixtures`
+
+# Upload the IPA to BrowserStack
+url = upload_app ENV['BROWSER_STACK_USERNAME'], ENV['BROWSER_STACK_ACCESS_KEY'], 'features/fixtures/ios/output/iOSTestApp.ipa'
+puts "BrowserStack URL is #{url}"
+File.write('features/fixtures/ios/output/ipa_url.txt', url)

--- a/features/scripts/build_and_upload_app.rb
+++ b/features/scripts/build_and_upload_app.rb
@@ -2,6 +2,7 @@
 require 'json'
 require 'net/http'
 
+# TODO: PLAT-7647 Remove once Maze Runner has support for --upload-app
 def upload_app(username, access_key, app)
   upload_uri = 'https://api-cloud.browserstack.com/app-automate/upload'
   uri = URI(upload_uri)


### PR DESCRIPTION
## Goal

Upload the e2e test fixture app to BrowserStack just once for each build, instead of in every e2e test step.  Uploads can occasionally fail, causing test flakes, so doing fewer uploads should reduce the chance of that.

## Design

The IPA build step now also uploads the built app to BrowserStack (using code adapted from Maze Runner).  It captures the `bs://` URL that's returned and writes it to a file that's then shared as a build artifact.  Whilst it's a little convoluted, it's the easiest way to pass information like this between build steps and, critically, into Maze Runner.

## Changeset

- New Ruby script to control the build and upload to BrowserStack
- IPA build artifact replaced with text file containing URL of uploaded app

## Testing

Covered by a full CI run.