### PR TITLE
Enable network logs on iOS 10

### DIFF
--- a/.buildkite/pipeline.quick.yml
+++ b/.buildkite/pipeline.quick.yml
@@ -207,6 +207,7 @@ steps:
           - "--farm=bs"
           - "--device=IOS_10"
           - "--appium-version=1.8.0"
+          - "--capabilities={\"browserstack.networkLogs\":\"true\"}"
           - "--exclude=features/[h-z].*.feature"
           - "--order=random"
     concurrency: 9
@@ -234,6 +235,7 @@ steps:
           - "--farm=bs"
           - "--device=IOS_10"
           - "--appium-version=1.8.0"
+          - "--capabilities={\"browserstack.networkLogs\":\"true\"}"
           - "--exclude=features/[a-g].*.feature"
           - "--order=random"
     concurrency: 9

--- a/.buildkite/pipeline.yml
+++ b/.buildkite/pipeline.yml
@@ -172,6 +172,7 @@ steps:
           - "--farm=bs"
           - "--device=IOS_10"
           - "--appium-version=1.8.0"
+          - "--capabilities={\"browserstack.networkLogs\":\"true\"}"
           - "--order=random"
     concurrency: 9
     concurrency_group: browserstack-app


### PR DESCRIPTION
## Goal

Enable network logs on iOS 10 tests to hopefully help diagnostic intermittent network failures.