### PR TITLE
Gather more useful information for breadcrumbs about windows

### DIFF
--- a/Bugsnag/Helpers/BSGAppKit.h
+++ b/Bugsnag/Helpers/BSGAppKit.h
@@ -15,6 +15,7 @@
 #define NSAPPLICATION                                       NSClassFromString(@"NSApplication")
 #define NSMENUITEM                                          NSClassFromString(@"NSMenuItem")
 #define NSWORKSPACE                                         NSClassFromString(@"NSWorkspace")
+#define NSWINDOW                                            NSClassFromString(@"NSWindow")
 
 #define NSApplicationDidBecomeActiveNotification            @"NSApplicationDidBecomeActiveNotification"
 #define NSApplicationDidFinishLaunchingNotification         @"NSApplicationDidFinishLaunchingNotification"

--- a/Bugsnag/Helpers/BSGUIKit.h
+++ b/Bugsnag/Helpers/BSGUIKit.h
@@ -15,6 +15,7 @@
 #define UIAPPLICATION                                       NSClassFromString(@"UIApplication")
 #define UIDEVICE                                            NSClassFromString(@"UIDevice")
 #define UISCENE                                             NSClassFromString(@"UIScene")
+#define UIWINDOW                                            NSClassFromString(@"UIWindow")
 
 #define UIApplicationDidBecomeActiveNotification            @"UIApplicationDidBecomeActiveNotification"
 #define UIApplicationDidEnterBackgroundNotification         @"UIApplicationDidEnterBackgroundNotification"

--- a/Bugsnag/Helpers/BSGUtils.h
+++ b/Bugsnag/Helpers/BSGUtils.h
@@ -28,3 +28,7 @@ NSString *_Nullable BSGStringFromThermalState(NSProcessInfoThermalState thermalS
 NS_ASSUME_NONNULL_END
 
 __END_DECLS
+
+static inline NSString * _Nullable bsg_string_from_class(Class _Nullable cls) {
+    return cls ? NSStringFromClass((Class _Nonnull)cls) : nil;
+}


### PR DESCRIPTION
## Goal

PLAT-7627

## Design

Capture window name, window class, and window description (when available) and add the information to breadcrumbs about windows.

This gives us information such as:


<img width="512" alt="Screenshot 2021-11-22 at 11 51 40" src="https://user-images.githubusercontent.com/245857/142848847-bbca3f68-bf4b-4fff-a0ab-805f4e1cb612.png">
<img width="1177" alt="Screenshot 2021-11-22 at 11 51 32" src="https://user-images.githubusercontent.com/245857/142848851-fed6b4cc-b25f-4fc7-96b8-344103472fa2.png">

## Testing

Manual testing + reran existing tests.