### PR TITLE
Build e2e test fixtures on ARM

### DIFF
--- a/.buildkite/pipeline.full.yml
+++ b/.buildkite/pipeline.full.yml
@@ -207,17 +207,19 @@ steps:
       queue: opensource-arm-mac-cocoa-12
     plugins:
       artifacts#v1.3.0:
-        download: ["features/fixtures/macos/output/macOSTestApp.zip"]
-        upload: ["macOSTestApp.log", "appium_server.log", "maze_output/failed/**/*"]
+        download: "features/fixtures/macos/output/macOSTestApp.zip"
+        upload:
+          - "macOSTestApp.log"
+          - "appium_server.log"
+          - "maze_output/failed/**/*"
     commands:
       - bundle config set --local path 'vendor/bundle'
       - bundle install
       - bundle exec maze-runner
         --farm=local
         --os=macos
-        --os-version=11
+        --os-version=12
         --app=macOSTestApp
-        --fail-fast
         --order=random
 
   - label: 'macOS 10.13 E2E tests'

--- a/.buildkite/pipeline.full.yml
+++ b/.buildkite/pipeline.full.yml
@@ -199,14 +199,12 @@ steps:
         --fail-fast
         --order=random
 
-  # TODO: Skip penmding PLAT-6822
-  - label: 'ARM macOS 11.0 E2E tests'
-    skip: Pending PLAT-6822
+  - label: 'ARM macOS 12.0 E2E tests'
     depends_on:
       - cocoa_fixture
     timeout_in_minutes: 60
     agents:
-      queue: opensource-m1-mac-cocoa-11
+      queue: opensource-arm-mac-cocoa-12
     plugins:
       artifacts#v1.3.0:
         download: ["features/fixtures/macos/output/macOSTestApp.zip"]

--- a/.buildkite/pipeline.yml
+++ b/.buildkite/pipeline.yml
@@ -17,11 +17,11 @@ steps:
   # Build
   #
 
-  - label: Build cocoa IPA
+  - label: Build test fixtures
     key: cocoa_fixture
-    timeout_in_minutes: 20
+    timeout_in_minutes: 30
     agents:
-      queue: opensource-mac-cocoa-11
+      queue: opensource-arm-mac-cocoa-12
     artifact_paths:
       - features/fixtures/ios/output/iOSTestApp.ipa
       - features/fixtures/macos/output/macOSTestApp.zip
@@ -59,7 +59,7 @@ steps:
   - label: ARM macOS 11 unit tests
     timeout_in_minutes: 10
     agents:
-      queue: opensource-m1-mac-cocoa-11
+      queue: opensource-arm-mac-cocoa-12
     commands:
       - ./scripts/run-unit-tests.sh PLATFORM=macOS
     artifact_paths:
@@ -230,14 +230,12 @@ steps:
         --fail-fast
         --order=random
 
-  # TODO: Skip pending PLAT-6822
-  - label: 'ARM macOS 11 barebones E2E tests'
-    skip: Pending PLAT-6822
+  - label: 'ARM macOS 12 barebones E2E tests'
     depends_on:
       - cocoa_fixture
     timeout_in_minutes: 10
     agents:
-      queue: opensource-m1-mac-cocoa-11
+      queue: opensource-arm-mac-cocoa-12
     plugins:
       artifacts#v1.3.0:
         download: "features/fixtures/macos/output/macOSTestApp.zip"

--- a/.buildkite/pipeline.yml
+++ b/.buildkite/pipeline.yml
@@ -250,9 +250,8 @@ steps:
         features/barebone_tests.feature
         --farm=local
         --os=macos
-        --os-version=11
+        --os-version=12
         --app=macOSTestApp
-        --fail-fast
         --order=random
 
   - label: 'macOS 10.15 stress test'

--- a/features/fixtures/macos/Podfile
+++ b/features/fixtures/macos/Podfile
@@ -19,11 +19,5 @@ post_install do |installer|
         end
       end
     end
-
-    if target.name == "Bugsnag" || target.name == "BugsnagNetworkRequestPlugin"
-      target.build_configurations.each do |config|
-        config.build_settings['ONLY_ACTIVE_ARCH'] = 'NO'
-      end
-    end
   end
 end

--- a/features/fixtures/macos/Podfile
+++ b/features/fixtures/macos/Podfile
@@ -19,5 +19,11 @@ post_install do |installer|
         end
       end
     end
+
+    if target.name == "Bugsnag" || target.name == "BugsnagNetworkRequestPlugin"
+      target.build_configurations.each do |config|
+        config.build_settings['ONLY_ACTIVE_ARCH'] = 'NO'
+      end
+    end
   end
 end

--- a/features/scripts/export_mac_app.sh
+++ b/features/scripts/export_mac_app.sh
@@ -16,7 +16,8 @@ xcrun xcodebuild \
   -configuration Debug \
   -archivePath archive/macOSTestApp.xcarchive \
   -quiet \
-  archive
+  archive \
+  ONLY_ACTIVE_ARCH=NO
 
 echo "--- macOSTestApp: xcodebuild -exportArchive"
 

--- a/features/support/env.rb
+++ b/features/support/env.rb
@@ -24,6 +24,12 @@ BeforeAll do
       `cd #{fixture_dir} && unzip #{zip_name}`
     end
 
+    # Remove test fixture from /Applications if present from an earlier run
+    if File.exist?("#{app_dir}/#{app_name}")
+      $logger.warn("Removing existing app from #{app_dir}/#{app_name}")
+      FileUtils.rm_rf "#{app_dir}/#{app_name}"
+    end
+
     FileUtils.mv("#{fixture_dir}/#{app_name}", "#{app_dir}/#{app_name}")
   end
 end


### PR DESCRIPTION
## Goal

Build e2e test fixtures on ARM and add e2e tests for macOS 12 (on ARM).

## Design

The tracks were already laid in terms on basic/full CI builds, so the changes here result from the addition of ARM-based build servers.

## Changeset

- iOS/macOS test fixtures now built on ARM with XCode 13
- Barebones and full e2e tests enabled for macOS 12/ARM
- (Not directly related fix) delete any test fixture app found in `/Applications` before copying the new one

## Testing

Covered by CI.
