### PR TITLE
[PLAT-7270] Capture KSCrash logs for E2E runs

### DIFF
--- a/features/fixtures/ios/iOSTestApp/AppDelegate.swift
+++ b/features/fixtures/ios/iOSTestApp/AppDelegate.swift
@@ -6,6 +6,8 @@ class AppDelegate: UIResponder, UIApplicationDelegate {
     var window: UIWindow?
 
     func application(_ application: UIApplication, didFinishLaunchingWithOptions launchOptions: [UIApplication.LaunchOptionsKey: Any]?) -> Bool {
+        let documents = NSSearchPathForDirectoriesInDomains(.documentDirectory, .userDomainMask, true)[0] as NSString
+        bsg_kslog_setLogFilename(documents.appendingPathComponent("kscrash.log"), true)
         return true
     }
 }

--- a/features/fixtures/ios/iOSTestApp/Info.plist
+++ b/features/fixtures/ios/iOSTestApp/Info.plist
@@ -25,6 +25,8 @@
 		<key>NSAllowsArbitraryLoads</key>
 		<true/>
 	</dict>
+	<key>UIFileSharingEnabled</key>
+	<true/>
 	<key>UILaunchStoryboardName</key>
 	<string>LaunchScreen</string>
 	<key>UIMainStoryboardFile</key>
@@ -48,19 +50,19 @@
 	</array>
 	<key>bugsnag</key>
 	<dict>
-		<key>endpoints</key>
-		<dict>
-			<key>sessions</key>
-			<string>http://bs-local.com:9339/sessions</string>
-			<key>notify</key>
-			<string>http://bs-local.com:9339/notify</string>
-		</dict>
 		<key>apiKey</key>
 		<string>0192837465afbecd0192837465afbecd</string>
-		<key>releaseStage</key>
-		<string>beta2</string>
 		<key>autoTrackSessions</key>
 		<true/>
+		<key>endpoints</key>
+		<dict>
+			<key>notify</key>
+			<string>http://bs-local.com:9339/notify</string>
+			<key>sessions</key>
+			<string>http://bs-local.com:9339/sessions</string>
+		</dict>
+		<key>releaseStage</key>
+		<string>beta2</string>
 	</dict>
 </dict>
 </plist>

--- a/features/fixtures/ios/iOSTestApp/iOSTestApp-Bridging-Header.h
+++ b/features/fixtures/ios/iOSTestApp/iOSTestApp-Bridging-Header.h
@@ -5,3 +5,5 @@
 #import "Scenario.h"
 #import <Bugsnag/Bugsnag.h>
 #import <BugsnagNetworkRequestPlugin/BugsnagNetworkRequestPlugin.h>
+
+extern bool bsg_kslog_setLogFilename(const char *filename, bool overwrite);

--- a/features/support/env.rb
+++ b/features/support/env.rb
@@ -57,3 +57,21 @@ end
 Before('@stress_test') do |_scenario|
   skip_this_scenario('Skipping: Run is not configured for stress tests') if ENV['STRESS_TEST'].nil?
 end
+
+Maze.hooks.after do |scenario|
+  if Maze.driver.capabilities['platformName'] == 'iOS'
+    data = Maze.driver.pull_file '@com.bugsnag.iOSTestApp/Documents/kscrash.log'
+
+    folder1 = File.join(Dir.pwd, 'maze_output')
+    folder2 = scenario.failed? ? 'failed' : 'passed'
+    folder3 = scenario.name.gsub(/[:"& ]/, "_").gsub(/_+/, "_")
+
+    path = File.join(folder1, folder2, folder3)
+
+    FileUtils.makedirs(path)
+
+    File.open(File.join(path, 'kscrash.log'), 'wb') { |file| file << data }
+  end
+rescue
+  # pull_file can fail on BrowserStack iOS 10 with "Error: Command 'umount' not found"
+end


### PR DESCRIPTION
## Goal

Capture the KSCrash logs when running E2E tests, to help diagnose failures.

## Design

Uses Appium's [file pulling functionality](https://appium.io/docs/en/writing-running-appium/ios/ios-xctest-file-movement/) to fetch KSCrash logs, which are now written to disk.

## Testing

Sample failure with logs: https://buildkite.com/bugsnag/bugsnag-cocoa/builds/3949#2a097acf-c586-447a-a9be-5e86aab3aa87

Note that `pull_file` doesn't work on BrowserStack's iOS 10 devices.