### PR TITLE
Plat 7627 window descriptions

### DIFF
--- a/Bugsnag/Helpers/BSGAppKit.h
+++ b/Bugsnag/Helpers/BSGAppKit.h
@@ -15,6 +15,7 @@
 #define NSAPPLICATION                                       NSClassFromString(@"NSApplication")
 #define NSMENUITEM                                          NSClassFromString(@"NSMenuItem")
 #define NSWORKSPACE                                         NSClassFromString(@"NSWorkspace")
+#define NSWINDOW                                            NSClassFromString(@"NSWindow")
 
 #define NSApplicationDidBecomeActiveNotification            @"NSApplicationDidBecomeActiveNotification"
 #define NSApplicationDidFinishLaunchingNotification         @"NSApplicationDidFinishLaunchingNotification"

--- a/Bugsnag/Helpers/BSGUIKit.h
+++ b/Bugsnag/Helpers/BSGUIKit.h
@@ -15,6 +15,7 @@
 #define UIAPPLICATION                                       NSClassFromString(@"UIApplication")
 #define UIDEVICE                                            NSClassFromString(@"UIDevice")
 #define UISCENE                                             NSClassFromString(@"UIScene")
+#define UIWINDOW                                            NSClassFromString(@"UIWindow")
 
 #define UIApplicationDidBecomeActiveNotification            @"UIApplicationDidBecomeActiveNotification"
 #define UIApplicationDidEnterBackgroundNotification         @"UIApplicationDidEnterBackgroundNotification"

--- a/Bugsnag/Helpers/BSGUtils.h
+++ b/Bugsnag/Helpers/BSGUtils.h
@@ -25,10 +25,10 @@ NSString *_Nullable BSGStringFromDeviceOrientation(UIDeviceOrientation orientati
 API_AVAILABLE(ios(11.0), tvos(11.0))
 NSString *_Nullable BSGStringFromThermalState(NSProcessInfoThermalState thermalState);
 
+static inline NSString * _Nullable BSGStringFromClass(Class _Nullable cls) {
+    return cls ? NSStringFromClass((Class _Nonnull)cls) : nil;
+}
+
 NS_ASSUME_NONNULL_END
 
 __END_DECLS
-
-static inline NSString * _Nullable bsg_string_from_class(Class _Nullable cls) {
-    return cls ? NSStringFromClass((Class _Nonnull)cls) : nil;
-}

--- a/Bugsnag/Helpers/BSGUtils.h
+++ b/Bugsnag/Helpers/BSGUtils.h
@@ -28,3 +28,7 @@ NSString *_Nullable BSGStringFromThermalState(NSProcessInfoThermalState thermalS
 NS_ASSUME_NONNULL_END
 
 __END_DECLS
+
+static inline NSString * _Nullable bsg_string_from_class(Class _Nullable cls) {
+    return cls ? NSStringFromClass((Class _Nonnull)cls) : nil;
+}


### PR DESCRIPTION
## Goal

PLAT-7627

Add more information to window-oriented breadcrumbs.

## Design

Grab the window description, title, subtitle, and view controller information and include them in the metadata for window-related breadcrumbs.

## Testing

* New unit tests
* Manual testing