### PR TITLE
[PLAT-7596] Fix E2E failures on iOS 15

### DIFF
--- a/Bugsnag/Delivery/BSGEventUploadKSCrashReportOperation.m
+++ b/Bugsnag/Delivery/BSGEventUploadKSCrashReportOperation.m
@@ -27,10 +27,17 @@ static void ReportInternalError(NSString *errorClass, NSString *message, NSDicti
     // offsets which would lead to some types of errors not being grouped at all; e.g.
     // - "Invalid value around character 229194."
     // - "No string key for value in object around character 94208."
+    // - "No string key for value in object around line 1, column 161315." (iOS 15+)
     // - "Unable to convert data to string around character 158259."
     // - "Unterminated string around character 22568."
     //
-    NSString *groupingMessage = [message componentsSeparatedByString:@" around character "].firstObject;
+    NSString *groupingMessage = message;
+    for (NSString *separator in @[@" around character ", @" around line"]) {
+        if ([message containsString:separator]) {
+            groupingMessage = [message componentsSeparatedByString:separator].firstObject;
+            break;
+        }
+    }
     NSString *groupingHash = [NSString stringWithFormat:@"BSGEventUploadKSCrashReportOperation.m: %@: %@", errorClass, groupingMessage];
     [BSGInternalErrorReporter.sharedInstance reportErrorWithClass:errorClass message:message diagnostics:diagnostics groupingHash:groupingHash];
 }

--- a/Bugsnag/KSCrash/Source/KSCrash/Recording/BSG_KSCrashReport.c
+++ b/Bugsnag/KSCrash/Source/KSCrash/Recording/BSG_KSCrashReport.c
@@ -535,15 +535,15 @@ void bsg_kscrw_i_logBacktraceEntry(const int entryNum, const uintptr_t address,
     char faddrBuff[20];
     char saddrBuff[20];
 
-    const char *fname = bsg_ksfulastPathEntry(info->image->name);
-    if (fname == NULL) {
+    const char *fname = info->image ? bsg_ksfulastPathEntry(info->image->name) : NULL;
+    if (fname == NULL && info->image) {
         sprintf(faddrBuff, BSG_POINTER_FMT, (uintptr_t)info->image->header);
         fname = faddrBuff;
     }
 
     uintptr_t offset = address - (uintptr_t)info->function_address;
     const char *sname = info->function_name;
-    if (sname == NULL) {
+    if (sname == NULL && info->image) {
         sprintf(saddrBuff, BSG_POINTER_SHORT_FMT, (uintptr_t)info->image->header);
         sname = saddrBuff;
         offset = address - (uintptr_t)info->image->header;

--- a/Bugsnag/KSCrash/Source/KSCrash/Recording/Tools/BSG_KSMachHeaders.c
+++ b/Bugsnag/KSCrash/Source/KSCrash/Recording/Tools/BSG_KSMachHeaders.c
@@ -14,6 +14,7 @@
 #include <dispatch/dispatch.h>
 #include <dlfcn.h>
 #include <mach-o/dyld.h>
+#include <mach-o/dyld_images.h>
 #include <stdlib.h>
 
 // Copied from https://github.com/apple/swift/blob/swift-5.0-RELEASE/include/swift/Runtime/Debug.h#L28-L40
@@ -32,6 +33,13 @@ struct crashreporter_annotations_t {
     uint64_t abort_cause;      // unsigned int
 };
 
+static void bsg_mach_headers_register_dyld_images(void);
+static void bsg_mach_headers_register_for_changes(void);
+static intptr_t bsg_mach_headers_compute_slide(const struct mach_header *header);
+static const char * bsg_mach_headers_get_path(const struct mach_header *header);
+
+static const struct dyld_all_image_infos *g_all_image_infos;
+
 // MARK: - Mach Header Linked List
 
 static BSG_Mach_Header_Info *bsg_g_mach_headers_images_head;
@@ -41,6 +49,7 @@ static dispatch_queue_t bsg_g_serial_queue;
 BSG_Mach_Header_Info *bsg_mach_headers_get_images() {
     if (!bsg_g_mach_headers_images_head) {
         bsg_mach_headers_initialize();
+        bsg_mach_headers_register_dyld_images();
         bsg_mach_headers_register_for_changes();
     }
     return bsg_g_mach_headers_images_head;
@@ -68,14 +77,38 @@ void bsg_mach_headers_initialize() {
     bsg_g_serial_queue = dispatch_queue_create("com.bugsnag.mach-headers", DISPATCH_QUEUE_SERIAL);
 }
 
-void bsg_mach_headers_register_for_changes() {
-    
+static void bsg_mach_headers_register_dyld_images() {
+    // /usr/lib/dyld's mach header is is not exposed via the _dyld APIs, so to be able to include information
+    // about stack frames in dyld`start (for example) we need to acess "_dyld_all_image_infos"
+    task_dyld_info_data_t dyld_info = {0};
+    mach_msg_type_number_t count = TASK_DYLD_INFO_COUNT;
+    kern_return_t kr = task_info(mach_task_self(), TASK_DYLD_INFO, (task_info_t)&dyld_info, &count);
+    if (kr == KERN_SUCCESS && dyld_info.all_image_info_addr) {
+        g_all_image_infos = (const void *)dyld_info.all_image_info_addr;
+
+        intptr_t dyldImageSlide = bsg_mach_headers_compute_slide(g_all_image_infos->dyldImageLoadAddress);
+        bsg_mach_headers_add_image(g_all_image_infos->dyldImageLoadAddress, dyldImageSlide);
+
+#if TARGET_IPHONE_SIMULATOR
+        // Get the mach header for `dyld_sim` which is not exposed via the _dyld APIs
+        // Note: dladdr() returns `/usr/lib/dyld` as the dli_fname for this image :-?
+        if (g_all_image_infos->infoArray &&
+            strstr(g_all_image_infos->infoArray->imageFilePath, "/usr/lib/dyld_sim")) {
+            const struct mach_header *header = g_all_image_infos->infoArray->imageLoadAddress;
+            bsg_mach_headers_add_image(header, bsg_mach_headers_compute_slide(header));
+        }
+#endif
+    } else {
+        BSG_KSLOG_ERROR("task_info TASK_DYLD_INFO failed: %s", mach_error_string(kr));
+    }
+}
+
+static void bsg_mach_headers_register_for_changes() {
     // Register for binary images being loaded and unloaded. dyld calls the add function once
     // for each library that has already been loaded and then keeps this cache up-to-date
     // with future changes
     _dyld_register_func_for_add_image(&bsg_mach_headers_add_image);
     _dyld_register_func_for_remove_image(&bsg_mach_headers_remove_image);
-
 }
 
 /**
@@ -93,14 +126,14 @@ bool bsg_mach_headers_populate_info(const struct mach_header *header, intptr_t s
     // 1. We can't find a sensible Mach command
     uintptr_t cmdPtr = bsg_mach_headers_first_cmd_after_header(header);
     if (cmdPtr == 0) {
+        BSG_KSLOG_ERROR("Invalid mach header @ %p", header);
         return false;
     }
 
     // 2. The image doesn't have a name.  Note: running with a debugger attached causes this condition to match.
-    Dl_info DlInfo = (const Dl_info) { 0 };
-    dladdr(header, &DlInfo);
-    const char *imageName = DlInfo.dli_fname;
+    const char *imageName = bsg_mach_headers_get_path(header);
     if (!imageName) {
+        BSG_KSLOG_ERROR("Could not find name for mach header @ %p", header);
         return false;
     }
     
@@ -137,7 +170,9 @@ bool bsg_mach_headers_populate_info(const struct mach_header *header, intptr_t s
         }
         case LC_MAIN:
         case LC_UNIXTHREAD:
-            info->isMain = true;
+            if (!strstr(imageName, "/usr/lib/dyld")) {
+                info->isMain = true;
+            }
             break;
         }
         cmdPtr += loadCmd->cmdsize;
@@ -146,9 +181,6 @@ bool bsg_mach_headers_populate_info(const struct mach_header *header, intptr_t s
     // Sanity checks that should never fail
     if (((uintptr_t)imageVmAddr + (uintptr_t)slide) != (uintptr_t)header) {
         BSG_KSLOG_ERROR("Mach header != (vmaddr + slide) for %s; symbolication will be compromised.", imageName);
-    }
-    if ((uintptr_t)DlInfo.dli_fbase != (uintptr_t)header) {
-        BSG_KSLOG_ERROR("Mach header != dli_fbase for %s", imageName);
     }
     
     info->header = header;
@@ -312,5 +344,51 @@ const char *bsg_mach_headers_get_crash_info_message(const BSG_Mach_Header_Info *
             return (const char *)info.message;
         }
     }
+    return NULL;
+}
+
+static intptr_t bsg_mach_headers_compute_slide(const struct mach_header *header) {
+    uintptr_t cmdPtr = bsg_mach_headers_first_cmd_after_header(header);
+    if (!cmdPtr) {
+        return 0;
+    }
+    for (uint32_t iCmd = 0; iCmd < header->ncmds; iCmd++) {
+        struct load_command *loadCmd = (void *)cmdPtr;
+        switch (loadCmd->cmd) {
+            case LC_SEGMENT: {
+                struct segment_command *segCmd = (void *)cmdPtr;
+                if (strcmp(segCmd->segname, SEG_TEXT) == 0) {
+                    return (intptr_t)header - (intptr_t)segCmd->vmaddr;
+                }
+            }
+            case LC_SEGMENT_64: {
+                struct segment_command_64 *segCmd = (void *)cmdPtr;
+                if (strcmp(segCmd->segname, SEG_TEXT) == 0) {
+                    return (intptr_t)header - (intptr_t)segCmd->vmaddr;
+                }
+            }
+        }
+        cmdPtr += loadCmd->cmdsize;
+    }
+    return 0;
+}
+
+static const char * bsg_mach_headers_get_path(const struct mach_header *header) {
+    Dl_info DlInfo = {0};
+    dladdr(header, &DlInfo);
+    if (DlInfo.dli_fname) {
+        return DlInfo.dli_fname;
+    }
+    if (g_all_image_infos &&
+        header == g_all_image_infos->dyldImageLoadAddress) {
+        return g_all_image_infos->dyldPath;
+    }
+#if TARGET_IPHONE_SIMULATOR
+    if (g_all_image_infos &&
+        g_all_image_infos->infoArray &&
+        header == g_all_image_infos->infoArray[0].imageLoadAddress) {
+        return g_all_image_infos->infoArray[0].imageFilePath;
+    }
+#endif
     return NULL;
 }

--- a/Bugsnag/KSCrash/Source/KSCrash/Recording/Tools/BSG_KSMachHeaders.h
+++ b/Bugsnag/KSCrash/Source/KSCrash/Recording/Tools/BSG_KSMachHeaders.h
@@ -63,11 +63,6 @@ typedef struct bsg_mach_image {
 void bsg_mach_headers_initialize(void);
 
 /**
-  * Registers with dyld to keep data updated when libraries are loaded and unloaded
- */
-void bsg_mach_headers_register_for_changes(void);
-
-/**
  * Returns the head of the link list of headers
  */
 BSG_Mach_Header_Info *bsg_mach_headers_get_images(void);

--- a/Tests/BugsnagTests/BugsnagStackframeTest.m
+++ b/Tests/BugsnagTests/BugsnagStackframeTest.m
@@ -156,7 +156,9 @@
 }
 
 - (void)testInvalidFrame {
-    BugsnagStackframe *frame = [BugsnagStackframe frameFromDict:self.frameDict withImages:@[]];
+    // Sample 2nd frame from EXC_BREAKPOINT mach exception
+    NSDictionary *dict = @{@"instruction_addr": @"0x232e968186bc223c", @"isLR": @YES};
+    BugsnagStackframe *frame = [BugsnagStackframe frameFromDict:dict withImages:@[]];
     XCTAssertNil(frame);
 }
 

--- a/Tests/BugsnagTests/BugsnagStackframeTest.m
+++ b/Tests/BugsnagTests/BugsnagStackframeTest.m
@@ -223,7 +223,7 @@
 
 - (void)testRealCallStackSymbols {
     bsg_mach_headers_initialize();
-    bsg_mach_headers_register_for_changes(); // Ensure call stack can be symbolicated
+    bsg_mach_headers_get_images(); // Ensure call stack can be symbolicated
     
     NSArray<NSString *> *callStackSymbols = [NSThread callStackSymbols];
     NSArray<BugsnagStackframe *> *stackframes = [BugsnagStackframe stackframesWithCallStackSymbols:callStackSymbols];
@@ -234,23 +234,8 @@
         XCTAssertNotNil(stackframe.machoFile);
         XCTAssertNotNil(stackframe.method);
         XCTAssertTrue([callStackSymbols[idx] containsString:stackframe.method]);
-        if (idx == stackframes.count - 1 &&
-            (stackframe.machoLoadAddress == nil || stackframe.symbolAddress == nil)) {
-            // The last callStackSymbol is often not in any Mach-O image, e.g.
-            // "41  ???                                 0x0000000000000005 0x0 + 5"
-            return;
-        }
-        if (!stackframe.machoUuid && [stackframe.method isEqualToString:@"start_sim"]) {
-            // With Xcode 13 beta's iOS 15 Simulator, the stack trace ends with e.g.
-            //   xctest                              0x00000001030b03ae main + 256,
-            //   dyld                                0x00000001030bfe1e start_sim + 10,
-            //   ???                                 0x0000000000000001 0x0 + 1,
-            //   ???                                 0x0000000000000001 0x0 + 1
-            //
-            // `start_sim` is actually located in dyld_sim according to lldb's `image lookup --address` command
-            // but this image does not show up in the headers returned by `_dyld_get_image_header()`. `dladdr()`
-            // reports this symbol as being in /usr/lib/dyld
-            *stop = YES;
+        if (stackframe.frameAddress.unsignedLongLongValue < 0x1000) {
+            // Stack frames with invalid instruction addresses cannot be resolved to an image or symbol
             return;
         }
         XCTAssertNotNil(stackframe.machoUuid);

--- a/Tests/BugsnagTests/BugsnagThreadTests.m
+++ b/Tests/BugsnagTests/BugsnagThreadTests.m
@@ -23,7 +23,7 @@
 
 + (void)setUp {
     bsg_mach_headers_initialize();
-    bsg_mach_headers_register_for_changes();
+    bsg_mach_headers_get_images(); // Ensure call stack can be symbolicated
 }
 
 - (void)setUp {

--- a/Tests/KSCrashTests/BSG_KSMachHeadersTests.m
+++ b/Tests/KSCrashTests/BSG_KSMachHeadersTests.m
@@ -123,8 +123,6 @@ const struct segment_command command2 = {
             XCTAssertEqual(image->imageVmAddr + image->slide, (uint64_t)dlinfo.dli_fbase);
             XCTAssertEqual(image->name, dlinfo.dli_fname);
             XCTAssertFalse(image->unloaded);
-        } else {
-            XCTAssertEqual(image, NULL);
         }
     }
     

--- a/features/fixtures/ios/iOSTestApp/AppDelegate.swift
+++ b/features/fixtures/ios/iOSTestApp/AppDelegate.swift
@@ -1,13 +1,14 @@
 import UIKit
 
+let kscrashLogURL = FileManager.default.urls(for: .documentDirectory, in: .userDomainMask)[0].appendingPathComponent("kscrash.log")
+
 @UIApplicationMain
 class AppDelegate: UIResponder, UIApplicationDelegate {
 
     var window: UIWindow?
 
     func application(_ application: UIApplication, didFinishLaunchingWithOptions launchOptions: [UIApplication.LaunchOptionsKey: Any]?) -> Bool {
-        let documents = NSSearchPathForDirectoriesInDomains(.documentDirectory, .userDomainMask, true)[0] as NSString
-        bsg_kslog_setLogFilename(documents.appendingPathComponent("kscrash.log"), true)
+        bsg_kslog_setLogFilename(kscrashLogURL.path, false)
         return true
     }
 }

--- a/features/fixtures/ios/iOSTestApp/ViewController.swift
+++ b/features/fixtures/ios/iOSTestApp/ViewController.swift
@@ -27,15 +27,15 @@ class ViewController: UIViewController {
     @IBAction func runTestScenario() {
         scenario = prepareScenario()
 
-        NSLog("Starting Bugsnag for scenario: %@", String(describing: scenario))
+        log("Starting Bugsnag for scenario: \(String(describing: scenario))")
         scenario?.startBugsnag()
-        NSLog("Running scenario: %@", String(describing: scenario))
+        log("Running scenario: \(String(describing: scenario))")
         scenario?.run()
     }
 
     @IBAction func startBugsnag() {
         scenario = prepareScenario()
-        NSLog("Starting Bugsnag for scenario: %@", String(describing: scenario))
+        log("Starting Bugsnag for scenario: \(String(describing: scenario))")
         scenario?.startBugsnag()
     }
 
@@ -56,6 +56,7 @@ class ViewController: UIViewController {
         } catch {
             NSLog("%@", String(describing: error))
         }
+        bsg_kslog_setLogFilename(kscrashLogURL.path, true)
     }
 
     internal func prepareScenario() -> Scenario {
@@ -91,3 +92,7 @@ class ViewController: UIViewController {
     }
 }
 
+private func log(_ message: String) {
+    NSLog("%@", message)
+    kslog("\(Date()) \(message)")
+}

--- a/features/fixtures/ios/iOSTestApp/iOSTestApp-Bridging-Header.h
+++ b/features/fixtures/ios/iOSTestApp/iOSTestApp-Bridging-Header.h
@@ -7,3 +7,9 @@
 #import <BugsnagNetworkRequestPlugin/BugsnagNetworkRequestPlugin.h>
 
 extern bool bsg_kslog_setLogFilename(const char *filename, bool overwrite);
+
+extern void bsg_i_kslog_logCBasic(const char *fmt, ...) __printflike(1, 2);
+
+static inline void kslog(const char *message) {
+    bsg_i_kslog_logCBasic("%s", message);
+}

--- a/features/internal_error_reporting.feature
+++ b/features/internal_error_reporting.feature
@@ -17,4 +17,4 @@ Feature: Internal error reporting
     And the event "metaData.BugsnagDiagnostics.file" is not null
     And the event "unhandled" is false
     And the exception "errorClass" equals "JSON parsing error"
-    And the exception "message" matches "NSCocoaErrorDomain 3840: No string key for value in object around character \d+."
+    And the exception "message" matches "NSCocoaErrorDomain 3840: No string key for value in object around .+\."


### PR DESCRIPTION
## Goal

Fix E2E failures on iOS 15

## Changeset

### iOS 15 fixes

* Update internal error grouping to accommodate changes to `NSJSONSerialization` error messages.
* Use `dyld_all_image_infos` to include mach header info for `/usr/lib/dyld`.
  On iOS 15 we are seeing a `dyld'start` stack frame below `main` which was causing E2E tests to fail when they verify that all stack frames have a `machoFile`.

### Other fixes

* Include crash stack frames for which no image can be found to match the behaviour for handled exceptions.
  * `isLR` stack frames are omitted if the image cannot be found because of invalid instruction addresses.
* Fix a crash in `bsg_kscrw_i_logBacktraceEntry()` when `printTraceToStdout` is enabled.
* Stop `kscrash.log` being overwritten when relaunching fixture after a crash.

## Testing

Tested E2E scenarios locally.