### PR TITLE
[PLAT-7417] Add new APIs for removing Swift callbacks

### DIFF
--- a/Bugsnag/Bugsnag.m
+++ b/Bugsnag/Bugsnag.m
@@ -313,10 +313,18 @@ static BugsnagClient *bsg_g_bugsnag_client = NULL;
     }
 }
 
-+ (void)addOnSessionBlock:(BugsnagOnSessionBlock _Nonnull)block
-{
++ (nonnull BugsnagOnSessionRef)addOnSessionBlock:(nonnull BugsnagOnSessionBlock)block {
     if ([self bugsnagStarted]) {
-        [self.client addOnSessionBlock:block];
+        return [self.client addOnSessionBlock:block];
+    } else {
+        // We need to return something from this nonnull method; simulate what would have happened.
+        return [block copy];
+    }
+}
+
++ (void)removeOnSession:(nonnull BugsnagOnSessionRef)callback {
+    if ([self bugsnagStarted]) {
+        [self.client removeOnSession:callback];
     }
 }
 
@@ -340,9 +348,18 @@ static BugsnagClient *bsg_g_bugsnag_client = NULL;
 // MARK: - OnBreadcrumb
 // =============================================================================
 
-+ (void)addOnBreadcrumbBlock:(BugsnagOnBreadcrumbBlock _Nonnull)block {
++ (nonnull BugsnagOnBreadcrumbRef)addOnBreadcrumbBlock:(nonnull BugsnagOnBreadcrumbBlock)block {
     if ([self bugsnagStarted]) {
-        [self.client addOnBreadcrumbBlock:block];
+        return [self.client addOnBreadcrumbBlock:block];
+    } else {
+        // We need to return something from this nonnull method; simulate what would have happened.
+        return [block copy];
+    }
+}
+
++ (void)removeOnBreadcrumb:(nonnull BugsnagOnBreadcrumbRef)callback {
+    if ([self bugsnagStarted]) {
+        [self.client removeOnBreadcrumb:callback];
     }
 }
 

--- a/Bugsnag/Client/BugsnagClient.m
+++ b/Bugsnag/Client/BugsnagClient.m
@@ -621,24 +621,38 @@ __attribute__((annotate("oclint:suppress[too many methods]")))
 // MARK: - onSession
 // =============================================================================
 
-- (void)addOnSessionBlock:(BugsnagOnSessionBlock _Nonnull)block {
-    [self.configuration addOnSessionBlock:block];
+- (nonnull BugsnagOnSessionRef)addOnSessionBlock:(nonnull BugsnagOnSessionBlock)block {
+    return [self.configuration addOnSessionBlock:block];
+}
+
+- (void)removeOnSession:(nonnull BugsnagOnSessionRef)callback {
+    [self.configuration removeOnSession:callback];
 }
 
 - (void)removeOnSessionBlock:(BugsnagOnSessionBlock _Nonnull )block {
+#pragma clang diagnostic push
+#pragma clang diagnostic ignored "-Wdeprecated-declarations"
     [self.configuration removeOnSessionBlock:block];
+#pragma clang diagnostic pop
 }
 
 // =============================================================================
 // MARK: - onBreadcrumb
 // =============================================================================
 
-- (void)addOnBreadcrumbBlock:(BugsnagOnBreadcrumbBlock _Nonnull)block {
-    [self.configuration addOnBreadcrumbBlock:block];
+- (nonnull BugsnagOnBreadcrumbRef)addOnBreadcrumbBlock:(nonnull BugsnagOnBreadcrumbBlock)block {
+    return [self.configuration addOnBreadcrumbBlock:block];
+}
+
+- (void)removeOnBreadcrumb:(nonnull BugsnagOnBreadcrumbRef)callback {
+    [self.configuration removeOnBreadcrumb:callback];
 }
 
 - (void)removeOnBreadcrumbBlock:(BugsnagOnBreadcrumbBlock _Nonnull)block {
+#pragma clang diagnostic push
+#pragma clang diagnostic ignored "-Wdeprecated-declarations"
     [self.configuration removeOnBreadcrumbBlock:block];
+#pragma clang diagnostic pop
 }
 
 // =============================================================================

--- a/Bugsnag/Configuration/BugsnagConfiguration.m
+++ b/Bugsnag/Configuration/BugsnagConfiguration.m
@@ -279,38 +279,71 @@ static NSUserDefaults *userDefaults;
 // MARK: - onSendBlock
 // =============================================================================
 
-- (void)addOnSendErrorBlock:(BugsnagOnSendErrorBlock _Nonnull)block {
-    [(NSMutableArray *)self.onSendBlocks addObject:[block copy]];
+- (BugsnagOnSendErrorRef)addOnSendErrorBlock:(BugsnagOnSendErrorBlock)block {
+    BugsnagOnSendErrorBlock callback = [block copy];
+    [self.onSendBlocks addObject:callback];
+    return callback;
 }
 
-- (void)removeOnSendErrorBlock:(BugsnagOnSendErrorBlock _Nonnull )block
-{
-    [(NSMutableArray *)self.onSendBlocks removeObject:block];
+- (void)removeOnSendError:(BugsnagOnSendErrorRef)callback {
+    if (![callback isKindOfClass:NSClassFromString(@"NSBlock")]) {
+        bsg_log_err(@"Invalid object type passed to %@", NSStringFromSelector(_cmd));
+        return;
+    }
+    [self.onSendBlocks removeObject:(id)callback];
+}
+
+- (void)removeOnSendErrorBlock:(BugsnagOnSendErrorBlock)block {
+    [self.onSendBlocks removeObject:block];
 }
 
 // =============================================================================
 // MARK: - onSessionBlock
 // =============================================================================
 
-- (void)addOnSessionBlock:(BugsnagOnSessionBlock)block {
-    [(NSMutableArray *)self.onSessionBlocks addObject:[block copy]];
+- (BugsnagOnSessionRef)addOnSessionBlock:(BugsnagOnSessionBlock)block {
+    BugsnagOnSessionBlock callback = [block copy];
+    [self.onSessionBlocks addObject:callback];
+    return callback;
+}
+
+- (void)removeOnSession:(BugsnagOnSessionRef)callback {
+    if (![callback isKindOfClass:NSClassFromString(@"NSBlock")]) {
+        bsg_log_err(@"Invalid object type passed to %@", NSStringFromSelector(_cmd));
+        return;
+    }
+    [self.onSessionBlocks removeObject:(id)callback];
 }
 
 - (void)removeOnSessionBlock:(BugsnagOnSessionBlock)block {
-    [(NSMutableArray *)self.onSessionBlocks removeObject:block];
+    [self.onSessionBlocks removeObject:block];
 }
 
 // =============================================================================
 // MARK: - onBreadcrumbBlock
 // =============================================================================
 
-- (void)addOnBreadcrumbBlock:(BugsnagOnBreadcrumbBlock _Nonnull)block {
-    [(NSMutableArray *)self.onBreadcrumbBlocks addObject:[block copy]];
+- (BugsnagOnBreadcrumbRef)addOnBreadcrumbBlock:(BugsnagOnBreadcrumbBlock)block {
+    BugsnagOnBreadcrumbBlock callback = [block copy];
+    [self.onBreadcrumbBlocks addObject:callback];
+    return callback;
 }
 
-- (void)removeOnBreadcrumbBlock:(BugsnagOnBreadcrumbBlock _Nonnull)block {
-    [(NSMutableArray *)self.onBreadcrumbBlocks removeObject:block];
+- (void)removeOnBreadcrumb:(BugsnagOnBreadcrumbRef)callback {
+    if (![callback isKindOfClass:NSClassFromString(@"NSBlock")]) {
+        bsg_log_err(@"Invalid object type passed to %@", NSStringFromSelector(_cmd));
+        return;
+    }
+    [self.onBreadcrumbBlocks removeObject:(id)callback];
 }
+
+- (void)removeOnBreadcrumbBlock:(BugsnagOnBreadcrumbBlock)block {
+    [self.onBreadcrumbBlocks removeObject:block];
+}
+
+// =============================================================================
+// MARK: -
+// =============================================================================
 
 - (NSDictionary *)sessionApiHeaders {
     return @{BugsnagHTTPHeaderNameApiKey: self.apiKey ?: @"",

--- a/Bugsnag/include/Bugsnag/Bugsnag.h
+++ b/Bugsnag/include/Bugsnag/Bugsnag.h
@@ -102,7 +102,7 @@
 /**
  * @return YES if Bugsnag has been started and the previous launch crashed
  */
-+ (BOOL)appDidCrashLastLaunch __attribute__((deprecated("use 'lastRunInfo.crashed' instead")));
++ (BOOL)appDidCrashLastLaunch BSG_DEPRECATED_WITH_REPLACEMENT("use 'lastRunInfo.crashed' instead");
 
 /**
  * Information about the last run of the app, and whether it crashed.
@@ -301,16 +301,25 @@
  *  Add a callback to be invoked before a session is sent to Bugsnag.
  *
  *  @param block A block which can modify the session
+ *
+ *  @returns An opaque reference to the callback which can be passed to `removeOnSession:`
  */
-+ (void)addOnSessionBlock:(BugsnagOnSessionBlock _Nonnull)block
++ (nonnull BugsnagOnSessionRef)addOnSessionBlock:(nonnull BugsnagOnSessionBlock)block
     NS_SWIFT_NAME(addOnSession(block:));
 
 /**
  * Remove a callback that would be invoked before a session is sent to Bugsnag.
  *
- * @param block The block to be removed.
+ * @param callback The opaque reference of the callback to be removed.
+ */
++ (void)removeOnSession:(nonnull BugsnagOnSessionRef)callback
+    NS_SWIFT_NAME(removeOnSession(_:));
+
+/**
+ * Deprecated
  */
 + (void)removeOnSessionBlock:(BugsnagOnSessionBlock _Nonnull)block
+    BSG_DEPRECATED_WITH_REPLACEMENT("removeOnSession:")
     NS_SWIFT_NAME(removeOnSession(block:));
 
 // =============================================================================
@@ -322,16 +331,25 @@
  *  change the breadcrumb contents as needed
  *
  *  @param block A block which returns YES if the breadcrumb should be captured
+ *
+ *  @returns An opaque reference to the callback which can be passed to `removeOnBreadcrumb:`
  */
-+ (void)addOnBreadcrumbBlock:(BugsnagOnBreadcrumbBlock _Nonnull)block
++ (nonnull BugsnagOnBreadcrumbRef)addOnBreadcrumbBlock:(nonnull BugsnagOnBreadcrumbBlock)block
     NS_SWIFT_NAME(addOnBreadcrumb(block:));
 
 /**
  * Remove the callback that would be invoked when a breadcrumb is captured.
  *
- * @param block The block to be removed.
+ * @param callback The opaque reference of the callback to be removed.
+ */
++ (void)removeOnBreadcrumb:(nonnull BugsnagOnBreadcrumbRef)callback
+    NS_SWIFT_NAME(removeOnBreadcrumb(_:));
+
+/**
+ * Deprecated
  */
 + (void)removeOnBreadcrumbBlock:(BugsnagOnBreadcrumbBlock _Nonnull)block
+    BSG_DEPRECATED_WITH_REPLACEMENT("removeOnBreadcrumb:")
     NS_SWIFT_NAME(removeOnBreadcrumb(block:));
 
 @end

--- a/Bugsnag/include/Bugsnag/Bugsnag.h
+++ b/Bugsnag/include/Bugsnag/Bugsnag.h
@@ -310,7 +310,7 @@
 /**
  * Remove a callback that would be invoked before a session is sent to Bugsnag.
  *
- * @param callback The opaque reference of the callback to be removed.
+ * @param callback The opaque reference of the callback, returned by `addOnSessionBlock:`
  */
 + (void)removeOnSession:(nonnull BugsnagOnSessionRef)callback
     NS_SWIFT_NAME(removeOnSession(_:));
@@ -340,7 +340,7 @@
 /**
  * Remove the callback that would be invoked when a breadcrumb is captured.
  *
- * @param callback The opaque reference of the callback to be removed.
+ * @param callback The opaque reference of the callback, returned by `addOnBreadcrumbBlock:`
  */
 + (void)removeOnBreadcrumb:(nonnull BugsnagOnBreadcrumbRef)callback
     NS_SWIFT_NAME(removeOnBreadcrumb(_:));

--- a/Bugsnag/include/Bugsnag/BugsnagClient.h
+++ b/Bugsnag/include/Bugsnag/BugsnagClient.h
@@ -184,19 +184,28 @@ NS_SWIFT_NAME(leaveBreadcrumb(_:metadata:type:));
 // =============================================================================
 
 /**
-* Add a callback that would be invoked before a session is sent to Bugsnag.
-*
-* @param block The block to be added.
-*/
-- (void)addOnSessionBlock:(BugsnagOnSessionBlock _Nonnull)block
+ *  Add a callback to be invoked before a session is sent to Bugsnag.
+ *
+ *  @param block A block which can modify the session
+ *
+ *  @returns An opaque reference to the callback which can be passed to `removeOnSession:`
+ */
+- (nonnull BugsnagOnSessionRef)addOnSessionBlock:(nonnull BugsnagOnSessionBlock)block
     NS_SWIFT_NAME(addOnSession(block:));
 
 /**
  * Remove a callback that would be invoked before a session is sent to Bugsnag.
  *
- * @param block The block to be removed.
+ * @param callback The opaque reference of the callback to be removed.
+ */
+- (void)removeOnSession:(nonnull BugsnagOnSessionRef)callback
+    NS_SWIFT_NAME(removeOnSession(_:));
+
+/**
+ * Deprecated
  */
 - (void)removeOnSessionBlock:(BugsnagOnSessionBlock _Nonnull )block
+    BSG_DEPRECATED_WITH_REPLACEMENT("removeOnSession:")
     NS_SWIFT_NAME(removeOnSession(block:));
 
 // =============================================================================
@@ -211,7 +220,7 @@ NS_SWIFT_NAME(leaveBreadcrumb(_:metadata:type:));
 /**
  * @return YES if Bugsnag has been started and the previous launch crashed
  */
-- (BOOL)appDidCrashLastLaunch __attribute__((deprecated("use 'lastRunInfo.crashed' instead")));
+- (BOOL)appDidCrashLastLaunch BSG_DEPRECATED_WITH_REPLACEMENT("lastRunInfo.crashed");
 
 /**
  * Information about the last run of the app, and whether it crashed.
@@ -255,16 +264,25 @@ NS_SWIFT_NAME(leaveBreadcrumb(_:metadata:type:));
  *  change the breadcrumb contents as needed
  *
  *  @param block A block which returns YES if the breadcrumb should be captured
+ *
+ *  @returns An opaque reference to the callback which can be passed to `removeOnBreadcrumb:`
  */
-- (void)addOnBreadcrumbBlock:(BugsnagOnBreadcrumbBlock _Nonnull)block
+- (nonnull BugsnagOnBreadcrumbRef)addOnBreadcrumbBlock:(nonnull BugsnagOnBreadcrumbBlock)block
     NS_SWIFT_NAME(addOnBreadcrumb(block:));
 
 /**
  * Remove the callback that would be invoked when a breadcrumb is captured.
  *
- * @param block The block to be removed.
+ * @param callback The opaque reference of the callback to be removed.
+ */
+- (void)removeOnBreadcrumb:(nonnull BugsnagOnBreadcrumbRef)callback
+    NS_SWIFT_NAME(removeOnBreadcrumb(_:));
+
+/**
+ * Deprecated
  */
 - (void)removeOnBreadcrumbBlock:(BugsnagOnBreadcrumbBlock _Nonnull)block
+    BSG_DEPRECATED_WITH_REPLACEMENT("removeOnBreadcrumb:")
     NS_SWIFT_NAME(removeOnBreadcrumb(block:));
 
 @end

--- a/Bugsnag/include/Bugsnag/BugsnagClient.h
+++ b/Bugsnag/include/Bugsnag/BugsnagClient.h
@@ -196,7 +196,7 @@ NS_SWIFT_NAME(leaveBreadcrumb(_:metadata:type:));
 /**
  * Remove a callback that would be invoked before a session is sent to Bugsnag.
  *
- * @param callback The opaque reference of the callback to be removed.
+ * @param callback The opaque reference of the callback, returned by `addOnSessionBlock:`
  */
 - (void)removeOnSession:(nonnull BugsnagOnSessionRef)callback
     NS_SWIFT_NAME(removeOnSession(_:));
@@ -273,7 +273,7 @@ NS_SWIFT_NAME(leaveBreadcrumb(_:metadata:type:));
 /**
  * Remove the callback that would be invoked when a breadcrumb is captured.
  *
- * @param callback The opaque reference of the callback to be removed.
+ * @param callback The opaque reference of the callback, returned by `addOnBreadcrumbBlock:`
  */
 - (void)removeOnBreadcrumb:(nonnull BugsnagOnBreadcrumbRef)callback
     NS_SWIFT_NAME(removeOnBreadcrumb(_:));

--- a/Bugsnag/include/Bugsnag/BugsnagConfiguration.h
+++ b/Bugsnag/include/Bugsnag/BugsnagConfiguration.h
@@ -372,7 +372,7 @@ typedef id<NSObject> BugsnagOnSessionRef;
 /**
  * Remove a callback that would be invoked before a session is sent to Bugsnag.
  *
- * @param callback The opaque reference of the callback to be removed.
+ * @param callback The opaque reference of the callback, returned by `addOnSessionBlock:`
  */
 - (void)removeOnSession:(BugsnagOnSessionRef)callback
     NS_SWIFT_NAME(removeOnSession(_:));
@@ -402,7 +402,7 @@ typedef id<NSObject> BugsnagOnSessionRef;
 /**
  * Remove the callback that would be invoked before an event is sent.
  *
- * @param callback The opaque reference of the callback to be removed.
+ * @param callback The opaque reference of the callback, returned by `addOnSendErrorBlock:`
  */
 - (void)removeOnSendError:(BugsnagOnSendErrorRef)callback
     NS_SWIFT_NAME(removeOnSendError(_:));
@@ -432,7 +432,7 @@ typedef id<NSObject> BugsnagOnSessionRef;
 /**
  * Remove the callback that would be invoked when a breadcrumb is captured.
  *
- * @param callback The opaque reference of the callback to be removed.
+ * @param callback The opaque reference of the callback, returned by `addOnBreadcrumbBlock:`
  */
 - (void)removeOnBreadcrumb:(BugsnagOnBreadcrumbRef)callback
     NS_SWIFT_NAME(removeOnBreadcrumb(_:));

--- a/Bugsnag/include/Bugsnag/BugsnagConfiguration.h
+++ b/Bugsnag/include/Bugsnag/BugsnagConfiguration.h
@@ -33,6 +33,11 @@
 #import <Bugsnag/BugsnagMetadataStore.h>
 #import <Bugsnag/BugsnagPlugin.h>
 
+/**
+ * Annotates methods and properties that will be removed in the next major release of Bugsnag.
+ */
+#define BSG_DEPRECATED_WITH_REPLACEMENT(REPLACEMENT) __attribute__((deprecated("", REPLACEMENT)))
+
 @class BugsnagUser;
 @class BugsnagEndpointConfiguration;
 @class BugsnagErrorTypes;
@@ -87,6 +92,11 @@ typedef BOOL (^BugsnagOnErrorBlock)(BugsnagEvent *_Nonnull event);
 typedef BOOL (^BugsnagOnSendErrorBlock)(BugsnagEvent *_Nonnull event);
 
 /**
+ * An opaque object that identifies and allows the removal of a BugsnagOnSendErrorBlock.
+ */
+typedef id<NSObject> BugsnagOnSendErrorRef;
+
+/**
  *  A configuration block for modifying a captured breadcrumb
  *
  *  @param breadcrumb The breadcrumb
@@ -94,11 +104,21 @@ typedef BOOL (^BugsnagOnSendErrorBlock)(BugsnagEvent *_Nonnull event);
 typedef BOOL (^BugsnagOnBreadcrumbBlock)(BugsnagBreadcrumb *_Nonnull breadcrumb);
 
 /**
+ * An opaque object that identifies and allows the removal of a BugsnagOnBreadcrumbBlock.
+ */
+typedef id<NSObject> BugsnagOnBreadcrumbRef;
+
+/**
  * A configuration block for modifying a session. Intended for internal usage only.
  *
  * @param session The session about to be delivered
  */
 typedef BOOL (^BugsnagOnSessionBlock)(BugsnagSession *_Nonnull session);
+
+/**
+ * An opaque object that identifies and allows the removal of a BugsnagOnSessionBlock.
+ */
+typedef id<NSObject> BugsnagOnSessionRef;
 
 // =============================================================================
 // MARK: - BugsnagConfiguration
@@ -343,16 +363,25 @@ typedef BOOL (^BugsnagOnSessionBlock)(BugsnagSession *_Nonnull session);
  *  Add a callback to be invoked before a session is sent to Bugsnag.
  *
  *  @param block A block which can modify the session
+ *
+ *  @returns An opaque reference to the callback which can be passed to `removeOnSession:`
  */
-- (void)addOnSessionBlock:(BugsnagOnSessionBlock _Nonnull)block
+- (BugsnagOnSessionRef)addOnSessionBlock:(BugsnagOnSessionBlock)block
     NS_SWIFT_NAME(addOnSession(block:));
 
 /**
  * Remove a callback that would be invoked before a session is sent to Bugsnag.
  *
- * @param block The block to be removed.
+ * @param callback The opaque reference of the callback to be removed.
  */
-- (void)removeOnSessionBlock:(BugsnagOnSessionBlock _Nonnull)block
+- (void)removeOnSession:(BugsnagOnSessionRef)callback
+    NS_SWIFT_NAME(removeOnSession(_:));
+
+/**
+ * Deprecated
+ */
+- (void)removeOnSessionBlock:(BugsnagOnSessionBlock)block
+    BSG_DEPRECATED_WITH_REPLACEMENT("removeOnSession:")
     NS_SWIFT_NAME(removeOnSession(block:));
 
 // =============================================================================
@@ -364,16 +393,25 @@ typedef BOOL (^BugsnagOnSessionBlock)(BugsnagSession *_Nonnull session);
  *  change the report contents as needed
  *
  *  @param block A block which returns YES if the report should be sent
+ *
+ *  @returns An opaque reference to the callback which can be passed to `removeOnSendError:`
  */
-- (void)addOnSendErrorBlock:(BugsnagOnSendErrorBlock _Nonnull)block
+- (BugsnagOnSendErrorRef)addOnSendErrorBlock:(BugsnagOnSendErrorBlock)block
     NS_SWIFT_NAME(addOnSendError(block:));
 
 /**
  * Remove the callback that would be invoked before an event is sent.
  *
- * @param block The block to be removed.
+ * @param callback The opaque reference of the callback to be removed.
  */
-- (void)removeOnSendErrorBlock:(BugsnagOnSendErrorBlock _Nonnull)block
+- (void)removeOnSendError:(BugsnagOnSendErrorRef)callback
+    NS_SWIFT_NAME(removeOnSendError(_:));
+
+/**
+ * Deprecated
+ */
+- (void)removeOnSendErrorBlock:(BugsnagOnSendErrorBlock)block
+    BSG_DEPRECATED_WITH_REPLACEMENT("removeOnSendError:")
     NS_SWIFT_NAME(removeOnSendError(block:));
 
 // =============================================================================
@@ -385,18 +423,34 @@ typedef BOOL (^BugsnagOnSessionBlock)(BugsnagSession *_Nonnull session);
  *  change the breadcrumb contents as needed
  *
  *  @param block A block which returns YES if the breadcrumb should be captured
+ *
+ *  @returns An opaque reference to the callback which can be passed to `removeOnBreadcrumb:`
  */
-- (void)addOnBreadcrumbBlock:(BugsnagOnBreadcrumbBlock _Nonnull)block
+- (BugsnagOnBreadcrumbRef)addOnBreadcrumbBlock:(BugsnagOnBreadcrumbBlock)block
     NS_SWIFT_NAME(addOnBreadcrumb(block:));
 
 /**
  * Remove the callback that would be invoked when a breadcrumb is captured.
  *
- * @param block The block to be removed.
+ * @param callback The opaque reference of the callback to be removed.
  */
-- (void)removeOnBreadcrumbBlock:(BugsnagOnBreadcrumbBlock _Nonnull)block
+- (void)removeOnBreadcrumb:(BugsnagOnBreadcrumbRef)callback
+    NS_SWIFT_NAME(removeOnBreadcrumb(_:));
+
+/**
+ * Deprecated
+ */
+- (void)removeOnBreadcrumbBlock:(BugsnagOnBreadcrumbBlock)block
+    BSG_DEPRECATED_WITH_REPLACEMENT("removeOnBreadcrumb:")
     NS_SWIFT_NAME(removeOnBreadcrumb(block:));
 
+// =============================================================================
+// MARK: - Plugins
+// =============================================================================
+
+/**
+ * Internal interface for adding custom behavior :nodoc:
+ */
 - (void)addPlugin:(id<BugsnagPlugin> _Nonnull)plugin;
 
 @end

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,17 @@
 Changelog
 =========
 
+## TBD
+
+### Enhancements
+
+* New APIs to allow `OnBreadcrumb`, `OnSendError` and `OnSession` Swift closures to be removed.
+  The following APIs are now deprecated and will be removed in the next major release:
+  * `removeOnBreadcrumb(block:)`
+  * `removeOnSendError(block:)`
+  * `removeOnSession(block:)`
+  [#1240](https://github.com/bugsnag/bugsnag-cocoa/pull/1240)
+
 ## 6.14.4 (2021-11-22)
 
 ### Bug fixes

--- a/Tests/BugsnagTests/BugsnagApiValidationTest.m
+++ b/Tests/BugsnagTests/BugsnagApiValidationTest.m
@@ -106,19 +106,17 @@
 }
 
 - (void)testValidOnSessionBlock {
-    BOOL (^block)(BugsnagSession *) = ^BOOL(BugsnagSession *session) {
+    BugsnagOnSessionRef callback = [Bugsnag addOnSessionBlock:^BOOL(BugsnagSession *session) {
         return NO;
-    };
-    [Bugsnag addOnSessionBlock:block];
-    [Bugsnag removeOnSessionBlock:block];
+    }];
+    [Bugsnag removeOnSession:callback];
 }
 
 - (void)testValidOnBreadcrumbBlock {
-    BOOL (^block)(BugsnagBreadcrumb *) = ^BOOL(BugsnagBreadcrumb *breadcrumb) {
+    BugsnagOnBreadcrumbRef callback = [Bugsnag addOnBreadcrumbBlock:^BOOL(BugsnagBreadcrumb *breadcrumb) {
         return NO;
-    };
-    [Bugsnag addOnBreadcrumbBlock:block];
-    [Bugsnag removeOnBreadcrumbBlock:block];
+    }];
+    [Bugsnag removeOnBreadcrumb:callback];
 }
 
 - (void)testValidAddMetadata {

--- a/Tests/BugsnagTests/BugsnagConfigurationTests.m
+++ b/Tests/BugsnagTests/BugsnagConfigurationTests.m
@@ -125,9 +125,9 @@
     };
 
     // It's there (and from other tests we know it gets called) and then it's not there
-    [config addOnSessionBlock:sessionBlock];
+    BugsnagOnSessionRef callback = [config addOnSessionBlock:sessionBlock];
     XCTAssertEqual([[config onSessionBlocks] count], 1);
-    [config removeOnSessionBlock:sessionBlock];
+    [config removeOnSession:callback];
     XCTAssertEqual([[config onSessionBlocks] count], 0);
 
     BugsnagClient *client = [[BugsnagClient alloc] initWithConfiguration:config];
@@ -177,7 +177,7 @@
         return true;
     };
 
-    [config addOnSessionBlock:sessionBlock];
+    BugsnagOnSessionRef callback = [config addOnSessionBlock:sessionBlock];
     XCTAssertEqual([[config onSessionBlocks] count], 1);
 
     // Call onSession blocks
@@ -194,7 +194,7 @@
     // Check block is not called after removing and initialisation
     [client pauseSession];
     called++;
-    [config removeOnSessionBlock:sessionBlock];
+    [config removeOnSession:callback];
     [client startSession];
     [self waitForExpectations:@[expectation3] timeout:1.0];
 
@@ -215,15 +215,15 @@
     BugsnagOnSessionBlock sessionBlock1 = ^BOOL(BugsnagSession * _Nonnull sessionPayload) { return true; };
     BugsnagOnSessionBlock sessionBlock2 = ^BOOL(BugsnagSession * _Nonnull sessionPayload) { return true; };
 
-    [config addOnSessionBlock:sessionBlock1];
+    BugsnagOnSessionRef callback = [config addOnSessionBlock:sessionBlock1];
     XCTAssertEqual([[config onSessionBlocks] count], 1);
-    [config removeOnSessionBlock:sessionBlock2];
+    [config removeOnSession:sessionBlock2];
     XCTAssertEqual([[config onSessionBlocks] count], 1);
-    [config removeOnSessionBlock:sessionBlock1];
+    [config removeOnSession:callback];
     XCTAssertEqual([[config onSessionBlocks] count], 0);
-    [config removeOnSessionBlock:sessionBlock2];
+    [config removeOnSession:sessionBlock2];
     XCTAssertEqual([[config onSessionBlocks] count], 0);
-    [config removeOnSessionBlock:sessionBlock1];
+    [config removeOnSession:callback];
     XCTAssertEqual([[config onSessionBlocks] count], 0);
 
     [config addOnSessionBlock:sessionBlock1];
@@ -232,6 +232,18 @@
     XCTAssertEqual([[config onSessionBlocks] count], 2);
     [config addOnSessionBlock:sessionBlock1];
     XCTAssertEqual([[config onSessionBlocks] count], 3);
+}
+
+- (void)testRemoveInvalidOnSessionDoesNotCrash {
+    BugsnagConfiguration *config = [[BugsnagConfiguration alloc] initWithApiKey:DUMMY_APIKEY_32CHAR_1];
+    [config addOnSessionBlock:^BOOL(BugsnagSession *session) { return NO; }];
+#pragma clang diagnostic push
+#pragma clang diagnostic ignored "-Wnonnull"
+    [config removeOnSession:nil];
+#pragma clang diagnostic pop
+    [config removeOnSession:[[NSObject alloc] init]];
+    [config removeOnSession:^{}];
+    XCTAssertEqual(config.onSessionBlocks.count, 1);
 }
 
 // =============================================================================
@@ -796,13 +808,13 @@ NSString * const kBugsnagUserUserId = @"BugsnagUserUserId";
 
     BugsnagOnSendErrorBlock block = ^BOOL(BugsnagEvent * _Nonnull event) { return false; };
 
-    [configuration addOnSendErrorBlock:block];
+    BugsnagOnSendErrorRef callback = [configuration addOnSendErrorBlock:block];
     BugsnagClient *client = [[BugsnagClient alloc] initWithConfiguration:configuration];
     [client start];
 
     XCTAssertEqual([[configuration onSendBlocks] count], 1);
 
-    [configuration removeOnSendErrorBlock:block];
+    [configuration removeOnSendError:callback];
     XCTAssertEqual([[configuration onSendBlocks] count], 0);
 }
 

--- a/Tests/BugsnagTests/BugsnagOnBreadcrumbTest.m
+++ b/Tests/BugsnagTests/BugsnagOnBreadcrumbTest.m
@@ -70,9 +70,9 @@
     };
 
     // It's there (and from other tests we know it gets called) and then it's not there
-    [config addOnBreadcrumbBlock:crumbBlock];
+    BugsnagOnBreadcrumbRef callback = [config addOnBreadcrumbBlock:crumbBlock];
     XCTAssertEqual([[config onBreadcrumbBlocks] count], 1);
-    [config removeOnBreadcrumbBlock:crumbBlock];
+    [config removeOnBreadcrumb:callback];
     XCTAssertEqual([[config onBreadcrumbBlocks] count], 0);
 
     BugsnagClient *client = [[BugsnagClient alloc] initWithConfiguration:config];
@@ -112,7 +112,7 @@
         return YES;
     };
 
-    [config addOnBreadcrumbBlock:crumbBlock];
+    BugsnagOnBreadcrumbRef callback = [config addOnBreadcrumbBlock:crumbBlock];
     XCTAssertEqual([[config onBreadcrumbBlocks] count], 1);
 
     // Call onbreadcrumb blocks
@@ -123,7 +123,7 @@
 
     // Check it's NOT called once the block's deleted
     called++;
-    [client removeOnBreadcrumbBlock:crumbBlock];
+    [client removeOnBreadcrumb:callback];
     
     [client leaveBreadcrumbWithMessage:@"Hello"];
     [self waitForExpectations:@[expectation2] timeout:1.0];
@@ -142,15 +142,15 @@
         return YES;
     };
 
-    [config addOnBreadcrumbBlock:crumbBlock1];
+    BugsnagOnBreadcrumbRef callback1 = [config addOnBreadcrumbBlock:crumbBlock1];
     XCTAssertEqual([[config onBreadcrumbBlocks] count], 1);
-    [config removeOnBreadcrumbBlock:crumbBlock2];
+    [config removeOnBreadcrumb:crumbBlock2];
     XCTAssertEqual([[config onBreadcrumbBlocks] count], 1);
-    [config removeOnBreadcrumbBlock:crumbBlock1];
+    [config removeOnBreadcrumb:callback1];
     XCTAssertEqual([[config onBreadcrumbBlocks] count], 0);
-    [config removeOnBreadcrumbBlock:crumbBlock2];
+    [config removeOnBreadcrumb:crumbBlock2];
     XCTAssertEqual([[config onBreadcrumbBlocks] count], 0);
-    [config removeOnBreadcrumbBlock:crumbBlock1];
+    [config removeOnBreadcrumb:callback1];
     XCTAssertEqual([[config onBreadcrumbBlocks] count], 0);
 
     [config addOnBreadcrumbBlock:crumbBlock1];

--- a/Tests/BugsnagTests/BugsnagSwiftConfigurationTests.swift
+++ b/Tests/BugsnagTests/BugsnagSwiftConfigurationTests.swift
@@ -20,4 +20,43 @@ class BugsnagSwiftConfigurationTests: XCTestCase {
         let config = BugsnagConfiguration(DUMMY_APIKEY_16CHAR)
         XCTAssertEqual(config.apiKey, DUMMY_APIKEY_16CHAR)
     }
+    
+    func testRemoveOnSendError() {
+        let config = BugsnagConfiguration(DUMMY_APIKEY_16CHAR)
+        let onSendBlocks: NSMutableArray = config.value(forKey: "onSendBlocks") as! NSMutableArray
+        XCTAssertEqual(onSendBlocks.count, 0)
+        
+        let onSendError = config.addOnSendError { _ in false }
+        XCTAssertEqual(onSendBlocks.count, 1)
+        
+        config.removeOnSendError(onSendError)
+        XCTAssertEqual(onSendBlocks.count, 0)
+    }
+    
+    func testRemoveOnSendErrorBlockDoesNotWork() {
+        let config = BugsnagConfiguration(DUMMY_APIKEY_16CHAR)
+        let onSendBlocks: NSMutableArray = config.value(forKey: "onSendBlocks") as! NSMutableArray
+        XCTAssertEqual(onSendBlocks.count, 0)
+        
+        let onSendErrorBlock: (BugsnagEvent) -> Bool = { _ in false }
+        config.addOnSendError(block: onSendErrorBlock)
+        XCTAssertEqual(onSendBlocks.count, 1)
+        
+        // Intentionally using the deprecated API
+        config.removeOnSendError(block: onSendErrorBlock)
+        // It's not possible to remove an OnSendError Swift closure because the compiler apparently
+        // creates a new NSBlock each time a closure is passed to an Objective-C method.
+        XCTAssertEqual(onSendBlocks.count, 1)
+    }
+    
+    func testRemoveInvalidOnSendErrorDoesNotCrash() {
+        let config = BugsnagConfiguration(DUMMY_APIKEY_16CHAR)
+        let onSendErrorBlock: (BugsnagEvent) -> Bool = { _ in false }
+        config.addOnSendError(block: onSendErrorBlock)
+        
+        // This does not compile:
+        // config.removeOnSendError(onSendErrorBlock)
+        
+        config.removeOnSendError("" as NSString)
+    }
 }

--- a/Tests/BugsnagTests/BugsnagSwiftPublicAPITests.swift
+++ b/Tests/BugsnagTests/BugsnagSwiftPublicAPITests.swift
@@ -70,17 +70,17 @@ class BugsnagSwiftPublicAPITests: XCTestCase {
         Bugsnag.setUser("me", withEmail: "memail@foo.com", andName: "you")
         let _ = Bugsnag.user()
         
-        Bugsnag.addOnSession(block: sessionBlock)
+        let onSession = Bugsnag.addOnSession(block: sessionBlock)
         Bugsnag.addOnSession { (session: BugsnagSession) -> Bool in
             return true
         }
-        Bugsnag.removeOnSession(block: sessionBlock)
+        Bugsnag.removeOnSession(onSession)
         
-        Bugsnag.addOnBreadcrumb(block: onBreadcrumbBlock)
+        let onBreadcrumb = Bugsnag.addOnBreadcrumb(block: onBreadcrumbBlock)
         Bugsnag.addOnBreadcrumb { (breadcrumb: BugsnagBreadcrumb) -> Bool in
             return true
         }
-        Bugsnag.removeOnBreadcrumb(block: onBreadcrumbBlock)
+        Bugsnag.removeOnBreadcrumb(onBreadcrumb)
     }
 
     func testBugsnagConfigurationClass() throws {
@@ -129,21 +129,21 @@ class BugsnagSwiftPublicAPITests: XCTestCase {
         config.endpoints = BugsnagEndpointConfiguration(notify: "http://test.com", sessions: "http://test.com")
         
         config.setUser("user", withEmail: "email", andName: "name")
-        config.addOnSession(block: sessionBlock)
+        let onSession = config.addOnSession(block: sessionBlock)
         config.addOnSession { (session: BugsnagSession) -> Bool in
             return true
         }
-        config.removeOnSession(block: sessionBlock)
+        config.removeOnSession(onSession)
         config.addOnSendError(block:onSendErrorBlock)
         config.addOnSendError { (event: BugsnagEvent) -> Bool in
             return true
         }
-        config.removeOnSendError(block: onSendErrorBlock)
-        config.addOnBreadcrumb(block: onBreadcrumbBlock)
+        config.removeOnSendError(onSession)
+        let onBreadcrumb = config.addOnBreadcrumb(block: onBreadcrumbBlock)
         config.addOnBreadcrumb { (breadcrumb: BugsnagBreadcrumb) -> Bool in
             return true
         }
-        config.removeOnBreadcrumb(block: onBreadcrumbBlock)
+        config.removeOnBreadcrumb(onBreadcrumb)
         
         let plugin = FakePlugin()
         config.add(plugin)
@@ -273,17 +273,17 @@ class BugsnagSwiftPublicAPITests: XCTestCase {
         client.setUser("me", withEmail: "memail@foo.com", andName: "you")
         let _ = client.user()
         
-        client.addOnSession(block: sessionBlock)
+        let onSession = client.addOnSession(block: sessionBlock)
         client.addOnSession { (session: BugsnagSession) -> Bool in
             return true
         }
-        client.removeOnSession(block: sessionBlock)
+        client.removeOnSession(onSession)
         
-        client.addOnBreadcrumb(block: onBreadcrumbBlock)
+        let onBreadcrumb = client.addOnBreadcrumb(block: onBreadcrumbBlock)
         client.addOnBreadcrumb { (breadcrumb: BugsnagBreadcrumb) -> Bool in
             return true
         }
-        client.removeOnBreadcrumb(block: onBreadcrumbBlock)
+        client.removeOnBreadcrumb(onBreadcrumb)
     }
 
     func testBugsnagDeviceWithStateClass() throws {

--- a/Tests/BugsnagTests/BugsnagTests.m
+++ b/Tests/BugsnagTests/BugsnagTests.m
@@ -253,7 +253,7 @@
         return true;
     };
 
-    [configuration addOnSessionBlock:sessionBlock];
+    BugsnagOnSessionRef callback = [configuration addOnSessionBlock:sessionBlock];
 
     BugsnagClient *client = [[BugsnagClient alloc] initWithConfiguration:configuration];
     [client start];
@@ -261,7 +261,7 @@
     
     [client pauseSession];
     called++;
-    [client removeOnSessionBlock:sessionBlock];
+    [client removeOnSession:callback];
     [client startSession];
     [self waitForExpectations:@[expectation2] timeout:1.0];
 }
@@ -305,14 +305,14 @@
     [client start];
     [client pauseSession];
 
-    [client addOnSessionBlock:sessionBlock];
+    BugsnagOnSessionRef callback = [client addOnSessionBlock:sessionBlock];
     [client startSession];
     [self waitForExpectations:@[expectation1] timeout:1.0];
 
     [client pauseSession];
     called++;
 
-    [client removeOnSessionBlock:sessionBlock];
+    [client removeOnSession:callback];
     [client startSession];
     // This expectation should also NOT be met
     [self waitForExpectations:@[expectation2] timeout:1.0];

--- a/Tests/BugsnagTests/ClientApiValidationTest.m
+++ b/Tests/BugsnagTests/ClientApiValidationTest.m
@@ -103,19 +103,17 @@
 }
 
 - (void)testValidOnSessionBlock {
-    BOOL (^block)(BugsnagSession *) = ^BOOL(BugsnagSession *session) {
+    BugsnagOnSessionRef callback = [self.client addOnSessionBlock:^BOOL(BugsnagSession *session) {
         return NO;
-    };
-    [self.client addOnSessionBlock:block];
-    [self.client removeOnSessionBlock:block];
+    }];
+    [self.client removeOnSession:callback];
 }
 
 - (void)testValidOnBreadcrumbBlock {
-    BOOL (^block)(BugsnagBreadcrumb *) = ^BOOL(BugsnagBreadcrumb *breadcrumb) {
+    BugsnagOnBreadcrumbRef callback = [self.client addOnBreadcrumbBlock:^BOOL(BugsnagBreadcrumb *breadcrumb) {
         return NO;
-    };
-    [self.client addOnBreadcrumbBlock:block];
-    [self.client removeOnBreadcrumbBlock:block];
+    }];
+    [self.client removeOnBreadcrumb:callback];
 }
 
 - (void)testValidAddMetadata {

--- a/Tests/BugsnagTests/ConfigurationApiValidationTest.m
+++ b/Tests/BugsnagTests/ConfigurationApiValidationTest.m
@@ -211,9 +211,9 @@
     BOOL (^block)(BugsnagSession *) = ^BOOL(BugsnagSession *session) {
         return NO;
     };
-    [self.config addOnSessionBlock:block];
+    BugsnagOnSessionRef callback = [self.config addOnSessionBlock:block];
     XCTAssertEqual(1, [self.config.onSessionBlocks count]);
-    [self.config removeOnSessionBlock:block];
+    [self.config removeOnSession:callback];
     XCTAssertEqual(0, [self.config.onSessionBlocks count]);
 }
 
@@ -221,9 +221,9 @@
     BOOL (^block)(BugsnagEvent *) = ^BOOL(BugsnagEvent *event) {
         return NO;
     };
-    [self.config addOnSendErrorBlock:block];
+    BugsnagOnSendErrorRef callback = [self.config addOnSendErrorBlock:block];
     XCTAssertEqual(1, [self.config.onSendBlocks count]);
-    [self.config removeOnSendErrorBlock:block];
+    [self.config removeOnSendError:callback];
     XCTAssertEqual(0, [self.config.onSendBlocks count]);
 }
 
@@ -231,9 +231,9 @@
     BOOL (^block)(BugsnagBreadcrumb *) = ^BOOL(BugsnagBreadcrumb *breadcrumb) {
         return NO;
     };
-    [self.config addOnBreadcrumbBlock:block];
+    BugsnagOnBreadcrumbRef callback = [self.config addOnBreadcrumbBlock:block];
     XCTAssertEqual(1, [self.config.onBreadcrumbBlocks count]);
-    [self.config removeOnBreadcrumbBlock:block];
+    [self.config removeOnBreadcrumb:callback];
     XCTAssertEqual(0, [self.config.onBreadcrumbBlocks count]);
 }
 


### PR DESCRIPTION
## Goal

Make it possible to remove Swift `OnBreadcrumb`, `OnSendError` and `OnSession` closures.

* https://github.com/bugsnag/bugsnag-cocoa/issues/1203

## Design

When a Swift closure is passed to `addOnBreadcrumb(block:)` or `removeOnBreadcrumb(block:)` the compiler creates an `NSBlock` which "wraps" the closure and makes it callable from Objective-C. When Bugsnag is asked to remove a previously added callback, testing the objects for equality always fails and the original block cannot be identified in the array.

This PR makes it possible to remove closures by passing the object from `addOnBreadcrumb(block:)` to a new `removeOnBreadcrumb(_:)` function. For simplicity of implementation, `addOnBreadcrumb(block:)` returns the (copy of the) block that was added to the array.

The old `removeOnBreadcrumb(block:)` function has been marked as deprecated.

The new `removeOnBreadcrumb(_:)` function method accepts an `AnyObject` to cause a compile error if misused by passing it a closure.

Note: all this also applies to `OnSendError` and `OnSession`.

## Testing

Existing unit tests amended to verify new APIs, new test cases added to verify passing invalid values to the remove: APIs.