### PR TITLE
[PLAT-7619] Fix flake in features/last_run_info.feature

### DIFF
--- a/features/fixtures/shared/scenarios/LastRunInfoScenarios.swift
+++ b/features/fixtures/shared/scenarios/LastRunInfoScenarios.swift
@@ -9,6 +9,7 @@
 class LastRunInfoConsecutiveLaunchCrashesScenario: Scenario {
     
     override func startBugsnag() {
+        config.launchDurationMillis = 0
         config.addOnSendError {
             if let lastRunInfo = Bugsnag.lastRunInfo {
                 $0.addMetadata(
@@ -23,6 +24,9 @@ class LastRunInfoConsecutiveLaunchCrashesScenario: Scenario {
     }
     
     override func run() {
+        if Bugsnag.lastRunInfo?.consecutiveLaunchCrashes == 3 {
+            Bugsnag.markLaunchCompleted()
+        }
         fatalError("Oh no, the app crashed!")
     }
 }

--- a/features/last_run_info.feature
+++ b/features/last_run_info.feature
@@ -24,8 +24,6 @@ Feature: Launch detection
     And the event "metaData.lastRunInfo.consecutiveLaunchCrashes" equals 3
     And I discard the oldest error
 
-    And I wait for 5 seconds
-
     And I run the configured scenario and relaunch the crashed app
     And I configure Bugsnag for "LastRunInfoConsecutiveLaunchCrashesScenario"
     And I wait to receive an error


### PR DESCRIPTION
Poor network conditions could cause the delivery of the previous launch's crash event to take longer than the default launch duration of 5 seconds (confirmed by examining device logs.)

This would cause the subsequent crash to have app.isLaunching set to false and fail the test.

Fixes the scenario by manually marking the launch as complete at the appropriate stage in the scenario.