### PR TITLE
Fix flake in features/threads.feature:17

### DIFF
--- a/Bugsnag/Payload/BugsnagStackframe.m
+++ b/Bugsnag/Payload/BugsnagStackframe.m
@@ -64,8 +64,15 @@ static NSString * _Nullable FormatMemoryAddress(NSNumber * _Nullable address) {
 }
 
 + (instancetype)frameFromDict:(NSDictionary<NSString *, id> *)dict withImages:(NSArray<NSDictionary<NSString *, id> *> *)binaryImages {
+    NSNumber *frameAddress = dict[BSGKeyInstructionAddress];
+    if (frameAddress.unsignedLongLongValue == 1) {
+        // We sometimes get a frame address of 0x1 at the bottom of the call stack.
+        // It's not a valid stack frame and causes E2E tests to fail, so should be ignored.
+        return nil;
+    }
+
     BugsnagStackframe *frame = [BugsnagStackframe new];
-    frame.frameAddress = dict[BSGKeyInstructionAddress];
+    frame.frameAddress = frameAddress;
     frame.symbolAddress = dict[BSGKeySymbolAddress];
     frame.machoLoadAddress = dict[BSGKeyObjectAddress];
     frame.machoFile = dict[BSGKeyObjectName];

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -207,7 +207,7 @@ GEM
     nokogiri (1.12.5)
       mini_portile2 (~> 2.6.1)
       racc (~> 1.4)
-    nokogiri (1.12.5-arm64-darwin)
+    nokogiri (1.12.5-x86_64-darwin)
       racc (~> 1.4)
     octokit (4.21.0)
       faraday (>= 0.9)

--- a/Tests/BugsnagTests/BugsnagStackframeTest.m
+++ b/Tests/BugsnagTests/BugsnagStackframeTest.m
@@ -157,9 +157,12 @@
 
 - (void)testInvalidFrame {
     // Sample 2nd frame from EXC_BREAKPOINT mach exception
-    NSDictionary *dict = @{@"instruction_addr": @"0x232e968186bc223c", @"isLR": @YES};
+    NSDictionary *dict = @{@"instruction_addr": @0x232e968186bc223c, @"isLR": @YES};
     BugsnagStackframe *frame = [BugsnagStackframe frameFromDict:dict withImages:@[]];
     XCTAssertNil(frame);
+    
+    // Sample bottom frame from NSException on macOS
+    XCTAssertNil([BugsnagStackframe frameFromDict:@{@"instruction_addr": @0x1} withImages:@[]]);
 }
 
 #define AssertStackframeValues(stackframe_, machoFile_, frameAddress_, method_) \

--- a/features/fixtures/ios/iOSTestApp/AppDelegate.swift
+++ b/features/fixtures/ios/iOSTestApp/AppDelegate.swift
@@ -1,14 +1,11 @@
 import UIKit
 
-let kscrashLogURL = FileManager.default.urls(for: .documentDirectory, in: .userDomainMask)[0].appendingPathComponent("kscrash.log")
-
 @UIApplicationMain
 class AppDelegate: UIResponder, UIApplicationDelegate {
 
     var window: UIWindow?
 
     func application(_ application: UIApplication, didFinishLaunchingWithOptions launchOptions: [UIApplication.LaunchOptionsKey: Any]?) -> Bool {
-        bsg_kslog_setLogFilename(kscrashLogURL.path, false)
         return true
     }
 }

--- a/features/fixtures/ios/iOSTestApp/ViewController.swift
+++ b/features/fixtures/ios/iOSTestApp/ViewController.swift
@@ -40,23 +40,7 @@ class ViewController: UIViewController {
     }
 
     @IBAction func clearPersistentData(_ sender: Any) {
-        NSLog("Clear persistent data")
-        UserDefaults.standard.removePersistentDomain(forName: Bundle.main.bundleIdentifier!)
-        do { // Delete Bugsnag persistent data to prevent sending of OOMS, old crash reports, or old sessions
-            let cachesDirectory = FileManager.default.urls(for: .cachesDirectory, in: .userDomainMask)[0]
-            try FileManager.default.contentsOfDirectory(at: cachesDirectory, includingPropertiesForKeys: []).forEach {
-                do {
-                    try FileManager.default.removeItem(at: $0)
-                } catch {
-                    NSLog("%@", String(describing: error))
-                }
-            }
-            let rootDirectory = FileManager.default.urls(for: .applicationSupportDirectory, in: .userDomainMask)[0].appendingPathComponent("com.bugsnag.Bugsnag")
-            try FileManager.default.removeItem(at: rootDirectory)
-        } catch {
-            NSLog("%@", String(describing: error))
-        }
-        bsg_kslog_setLogFilename(kscrashLogURL.path, true)
+        Scenario.clearPersistentData()
     }
 
     internal func prepareScenario() -> Scenario {

--- a/features/fixtures/ios/iOSTestApp/iOSTestApp-Bridging-Header.h
+++ b/features/fixtures/ios/iOSTestApp/iOSTestApp-Bridging-Header.h
@@ -5,11 +5,3 @@
 #import "Scenario.h"
 #import <Bugsnag/Bugsnag.h>
 #import <BugsnagNetworkRequestPlugin/BugsnagNetworkRequestPlugin.h>
-
-extern bool bsg_kslog_setLogFilename(const char *filename, bool overwrite);
-
-extern void bsg_i_kslog_logCBasic(const char *fmt, ...) __printflike(1, 2);
-
-static inline void kslog(const char *message) {
-    bsg_i_kslog_logCBasic("%s", message);
-}

--- a/features/fixtures/shared/scenarios/Scenario.h
+++ b/features/fixtures/shared/scenarios/Scenario.h
@@ -11,6 +11,8 @@
 
 NS_ASSUME_NONNULL_BEGIN
 
+void kslog(const char *message);
+
 void markErrorHandledCallback(const BSG_KSCrashReportWriter *writer);
 
 @interface Scenario : NSObject
@@ -38,6 +40,8 @@ void markErrorHandledCallback(const BSG_KSCrashReportWriter *writer);
 @property (nonatomic, strong, nullable) NSString *eventMode;
 
 - (void)performBlockAndWaitForEventDelivery:(dispatch_block_t)block NS_SWIFT_NAME(performBlockAndWaitForEventDelivery(_:));
+
++ (void)clearPersistentData;
 
 @end
 

--- a/features/support/env.rb
+++ b/features/support/env.rb
@@ -59,17 +59,18 @@ Before('@stress_test') do |_scenario|
 end
 
 Maze.hooks.after do |scenario|
-  if Maze.driver.capabilities['platformName'] == 'iOS'
+  folder1 = File.join(Dir.pwd, 'maze_output')
+  folder2 = scenario.failed? ? 'failed' : 'passed'
+  folder3 = scenario.name.gsub(/[:"& ]/, "_").gsub(/_+/, "_")
+
+  path = File.join(folder1, folder2, folder3)
+
+  FileUtils.makedirs(path)
+
+  if Maze.config.os == 'macos'
+    FileUtils.mv('/tmp/kscrash.log', path)
+  else
     data = Maze.driver.pull_file '@com.bugsnag.iOSTestApp/Documents/kscrash.log'
-
-    folder1 = File.join(Dir.pwd, 'maze_output')
-    folder2 = scenario.failed? ? 'failed' : 'passed'
-    folder3 = scenario.name.gsub(/[:"& ]/, "_").gsub(/_+/, "_")
-
-    path = File.join(folder1, folder2, folder3)
-
-    FileUtils.makedirs(path)
-
     File.open(File.join(path, 'kscrash.log'), 'wb') { |file| file << data }
   end
 rescue


### PR DESCRIPTION
## Goal

Fix a flake in `features/threads.feature:17` observed on macOS.

## Changeset

Stack frames with a `frameAddress` of 1 are now ignored, matching the behaviour for handled errors.

These stack frames seem to appear at the bottom of an NSException's call stack on macOS, below `dyld'start`

Example:

```
App crashed due to NSException: UnhandledErrorThreadSendAlwaysScenario: UnhandledErrorThreadSendAlwaysScenario
0   CoreFoundation                  0x00007fff5499b0c3 __exceptionPreprocess + 147
1   libobjc.A.dylib                 0x00007fff7bcd7942 objc_exception_throw + 48
2   CoreFoundation                  0x00007fff5499b029 -[NSException raise] + 9
3   macOSTestApp                    0x0000000104d164a9 -[UnhandledErrorThreadSendAlwaysScenario run] + 89
4   macOSTestApp                    0x0000000104d1abcf __36-[MainWindowController runScenario:]_block_invoke + 143
5   libdispatch.dylib               0x00007fff7c8b8db8 _dispatch_client_callout + 8
6   libdispatch.dylib               0x00007fff7c8cbe81 _dispatch_continuation_pop + 472
7   libdispatch.dylib               0x00007fff7c8bb081 _dispatch_source_invoke + 620
8   libdispatch.dylib               0x00007fff7c8c4221 _dispatch_main_queue_callback_4CF + 776
9   CoreFoundation                  0x00007fff54953e09 __CFRUNLOOP_IS_SERVICING_THE_MAIN_DISPATCH_QUEUE__ + 9
10  CoreFoundation                  0x00007fff549165da __CFRunLoopRun + 2586
11  CoreFoundation                  0x00007fff54915927 CFRunLoopRunSpecific + 487
12  HIToolbox                       0x00007fff53bf5d96 RunCurrentEventLoopInMode + 286
13  HIToolbox                       0x00007fff53bf5b06 ReceiveNextEventCommon + 613
14  HIToolbox                       0x00007fff53bf5884 _BlockUntilNextEventMatchingListInModeWithFilter + 64
15  AppKit                          0x00007fff51ea2a3b _DPSNextEvent + 2085
16  AppKit                          0x00007fff52638e34 -[NSApplication(NSEvent) _nextEventMatchingEventMask:untilDate:inMode:dequeue:] + 3044
17  AppKit                          0x00007fff51e9784d -[NSApplication run] + 764
18  AppKit                          0x00007fff51e66a3a NSApplicationMain + 804
19  macOSTestApp                    0x0000000104d1ce19 main + 377
20  libdyld.dylib                   0x00007fff7c8f2015 start + 1
21  (null)                          0x0000000000000001 (null) + 1
```

## Testing

Amended E2E test fixtures to capture kscrash.log on macOS and moved the logic to Scenario.m to avoid duplication.

Replicated failure: https://buildkite.com/bugsnag/bugsnag-cocoa/builds/4019