### PR TITLE
Identify main image with MH_EXECUTE

### DIFF
--- a/Bugsnag/BugsnagSystemState.m
+++ b/Bugsnag/BugsnagSystemState.m
@@ -107,7 +107,7 @@ static NSMutableDictionary* initCurrentState(BugsnagKVStore *kvstore, BugsnagCon
     app[BSGKeyReleaseStage] = config.releaseStage;
     app[BSGKeyVersion] = blankIfNil(systemInfo[@BSG_KSSystemField_BundleShortVersion]);
     app[BSGKeyBundleVersion] = blankIfNil(systemInfo[@BSG_KSSystemField_BundleVersion]);
-    app[BSGKeyMachoUUID] = [BSG_KSSystemInfo appUUID];
+    app[BSGKeyMachoUUID] = systemInfo[@BSG_KSSystemField_AppUUID];
     app[@"binaryArch"] = systemInfo[@BSG_KSSystemField_BinaryArch];
     app[@"inForeground"] = @(isInForeground);
     app[@"isActive"] = @(isActive);

--- a/Bugsnag/KSCrash/Source/KSCrash/Recording/Tools/BSG_KSMachHeaders.c
+++ b/Bugsnag/KSCrash/Source/KSCrash/Recording/Tools/BSG_KSMachHeaders.c
@@ -56,11 +56,12 @@ BSG_Mach_Header_Info *bsg_mach_headers_get_images() {
 }
 
 BSG_Mach_Header_Info *bsg_mach_headers_get_main_image() {
-    BSG_Mach_Header_Info *img = bsg_mach_headers_get_images();
-    while (img && !img->isMain) {
-        img = img->next;
+    for (BSG_Mach_Header_Info *img = bsg_mach_headers_get_images(); img != NULL; img = img->next) {
+        if (img->header->filetype == MH_EXECUTE) {
+            return img;
+        }
     }
-    return img;
+    return NULL;
 }
 
 void bsg_mach_headers_initialize() {
@@ -168,12 +169,6 @@ bool bsg_mach_headers_populate_info(const struct mach_header *header, intptr_t s
             uuid = uuidCmd->uuid;
             break;
         }
-        case LC_MAIN:
-        case LC_UNIXTHREAD:
-            if (!strstr(imageName, "/usr/lib/dyld")) {
-                info->isMain = true;
-            }
-            break;
         }
         cmdPtr += loadCmd->cmdsize;
     }

--- a/Bugsnag/KSCrash/Source/KSCrash/Recording/Tools/BSG_KSMachHeaders.h
+++ b/Bugsnag/KSCrash/Source/KSCrash/Recording/Tools/BSG_KSMachHeaders.h
@@ -48,9 +48,6 @@ typedef struct bsg_mach_image {
     /// True if the image has been unloaded and should be ignored
     bool unloaded;
 
-    /// True if this image is a program with an entry point; i.e. LC_MAIN or LC_UNIXTHREAD
-    bool isMain;
-
     /// The next image in the linked list
     struct bsg_mach_image *next;
 } BSG_Mach_Header_Info;


### PR DESCRIPTION
## Goal

Simplifies the logic of finding the "main" image, which recently got more complicated with the addition of dyld's mach header.

## Changeset

Finds the `mach_header` with filetype `MH_EXECUTE`, instead of locating headers with `LC_MAIN` / `LC_UNIXTHREAD` load commands.

## Testing

Tested locally with unit tests, and with full E2E on CI - https://buildkite.com/bugsnag/bugsnag-cocoa/builds/4027