### PR TITLE
[PLAT-7597] Load config when starting with API key

### DIFF
--- a/Bugsnag/Bugsnag.m
+++ b/Bugsnag/Bugsnag.m
@@ -49,7 +49,8 @@ static BugsnagClient *bsg_g_bugsnag_client = NULL;
 }
 
 + (BugsnagClient *_Nonnull)startWithApiKey:(NSString *_Nonnull)apiKey {
-    BugsnagConfiguration *configuration = [[BugsnagConfiguration alloc] initWithApiKey:apiKey];
+    BugsnagConfiguration *configuration = [BugsnagConfiguration loadConfig];
+    configuration.apiKey = apiKey;
     return [self startWithConfiguration:configuration];
 }
 

--- a/features/app_and_device_attributes.feature
+++ b/features/app_and_device_attributes.feature
@@ -92,6 +92,14 @@ Feature: App and Device attributes present
     And the error payload field "events.0.device.manufacturer" equals "Nokia"
     And the error payload field "events.0.device.modelNumber" equals "0898"
 
+  Scenario: Info.plist settings are used when calling startWithApiKey
+    When I run "AppAndDeviceAttributesScenarioStartWithApiKey"
+    And I wait to receive an error
+    Then the error is valid for the error reporting API
+    And the error "Bugsnag-API-Key" header equals "12312312312312312312312312312312"
+
+    And the error payload field "events.0.app.releaseStage" equals "beta2"
+
   Scenario: Duration value increments as expected
     When I run "AppDurationScenario"
     And I wait to receive 3 errors

--- a/features/fixtures/shared/scenarios/AppAndDeviceAttributesScenario.swift
+++ b/features/fixtures/shared/scenarios/AppAndDeviceAttributesScenario.swift
@@ -78,6 +78,25 @@ class AppAndDeviceAttributesScenarioCallbackOverride: Scenario {
 
 // MARK: -
 
+/**
+ * Call startWithApiKey
+ */
+class AppAndDeviceAttributesScenarioStartWithApiKey: Scenario {
+
+    override func startBugsnag() {
+        Bugsnag.start(withApiKey: "12312312312312312312312312312312")
+
+        super.startBugsnag()
+    }
+
+    override func run() {
+        let error = NSError(domain: "AppAndDeviceAttributesScenarioStartWithApiKey", code: 100, userInfo: nil)
+        Bugsnag.notifyError(error)
+    }
+}
+
+// MARK: -
+
 class AppAndDeviceAttributesInfiniteLaunchDurationScenario: Scenario {
     
     override func startBugsnag() {


### PR DESCRIPTION
## Goal

When calling `Bugsnag.start(withApiKey:)`, it was starting with a fresh configuration and setting the API key. It should instead be loading the config (with everything from the plist) and then setting the API key.

## Testing

Added E2E test that verifies this behavior.
