### PR TITLE
Use Maze Runner helper routine

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -7,10 +7,10 @@ gem 'xcpretty'
 
 # A reference to Maze Runner is only needed for running tests locally and if committed it must be
 # portable for CI, e.g. a specific release.  However, leaving it commented out would mean quicker CI.
-gem 'bugsnag-maze-runner', git: 'https://github.com/bugsnag/maze-runner', tag: 'v6.5.0'
+gem 'bugsnag-maze-runner', git: 'https://github.com/bugsnag/maze-runner', tag: 'v6.6.2'
 
-# Use a development branch
-#gem 'bugsnag-maze-runner', git: 'https://github.com/bugsnag/maze-runner', branch: 'tms/update-cucumber'
+# Use a specific branch
+#gem 'bugsnag-maze-runner', git: 'https://github.com/bugsnag/maze-runner', branch: 'master'
 
 # Locally, you can run against Maze Runner branches and uncommitted changes:
 #gem 'bugsnag-maze-runner', path: '../maze-runner'

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -207,7 +207,7 @@ GEM
     nokogiri (1.12.5)
       mini_portile2 (~> 2.6.1)
       racc (~> 1.4)
-    nokogiri (1.12.5-arm64-darwin)
+    nokogiri (1.12.5-x86_64-darwin)
       racc (~> 1.4)
     octokit (4.21.0)
       faraday (>= 0.9)

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -1,9 +1,9 @@
 GIT
   remote: https://github.com/bugsnag/maze-runner
-  revision: fd33f19db2d0b03be857fecb55f1aa4d4033de6c
-  tag: v6.5.0
+  revision: 9efc4f0c876f050d34e0bef54be2599598076818
+  tag: v6.6.2
   specs:
-    bugsnag-maze-runner (6.5.0)
+    bugsnag-maze-runner (6.6.2)
       appium_lib (~> 11.2.0)
       bugsnag (~> 6.24)
       cucumber (~> 7.1)
@@ -41,7 +41,7 @@ GEM
       faye-websocket (~> 0.11.0)
       selenium-webdriver (~> 3.14, >= 3.14.1)
     atomos (0.1.3)
-    bugsnag (6.24.0)
+    bugsnag (6.24.1)
       concurrent-ruby (~> 1.0)
     builder (3.2.4)
     childprocess (3.0.0)
@@ -207,7 +207,7 @@ GEM
     nokogiri (1.12.5)
       mini_portile2 (~> 2.6.1)
       racc (~> 1.4)
-    nokogiri (1.12.5-x86_64-darwin)
+    nokogiri (1.12.5-arm64-darwin)
       racc (~> 1.4)
     octokit (4.21.0)
       faraday (>= 0.9)

--- a/features/steps/app_steps.rb
+++ b/features/steps/app_steps.rb
@@ -3,8 +3,8 @@ When('I background the app for {int} seconds') do |duration|
 end
 
 When('I relaunch the app') do
-  case Maze.driver.capabilities['platformName']
-  when 'Mac'
+  case Maze::Helper.get_current_platform
+  when 'macos'
     app = Maze.driver.capabilities['app']
     system("killall #{app} > /dev/null && sleep 1")
     Maze.driver.get(app)
@@ -17,8 +17,8 @@ When("I relaunch the app after a crash") do
   # This step should only be used when the app has crashed, but the notifier needs a little
   # time to write the crash report before being forced to reopen.  From trials, 2s was not enough.
   sleep(5)
-  case Maze.driver.capabilities['platformName']
-  when 'Mac'
+  case Maze::Helper.get_current_platform
+  when 'macos'
     Maze.driver.get(Maze.driver.capabilities['app'])
   else
     Maze.driver.launch_app
@@ -48,10 +48,10 @@ end
 
 Then('the app is not running') do
   wait_for_true do
-    case Maze.driver.capabilities['platformName']
-    when 'iOS'
+    case Maze::Helper.get_current_platform
+    when 'ios'
       Maze.driver.app_state('com.bugsnag.iOSTestApp') == :not_running
-    when 'Mac'
+    when 'macos'
       `lsappinfo info -only pid -app com.bugsnag.macOSTestApp`.empty?
     else
       raise "Don't know how to query app state on this platform"

--- a/features/steps/cocoa_steps.rb
+++ b/features/steps/cocoa_steps.rb
@@ -194,7 +194,6 @@ end
 
 Then('the error is valid for the error reporting API') do
   platform = Maze::Helper.get_current_platform
-  STDOUT.puts "platform: #{platform}"
   case platform
   when 'ios'
     steps %(

--- a/features/steps/cocoa_steps.rb
+++ b/features/steps/cocoa_steps.rb
@@ -12,7 +12,7 @@ When("I run {string} and relaunch the app") do |event_type|
     step("I run \"#{event_type}\"")
   rescue StandardError
     # Ignore on macOS - AppiumForMac raises an error when clicking a button causes the app to crash
-    raise unless Maze.driver.capabilities['platformName'].eql?('Mac')
+    raise unless Maze::Helper.get_current_platform.eql?('macos')
 
     $logger.warn 'Ignoring error - this is normal for AppiumForMac if a button click causes the app to crash.'
   end
@@ -25,7 +25,7 @@ When("I run the configured scenario and relaunch the crashed app") do
       Given I click the element "run_scenario"
     )
   rescue StandardError
-    raise unless Maze.driver.capabilities['platformName'].eql?('Mac')
+    raise unless Maze::Helper.get_current_platform.eql?('macos')
     $logger.info 'Ignored error raised by AppiumForMac when clicking run_scenario'
   end
   steps %(
@@ -52,7 +52,7 @@ rescue Selenium::WebDriver::Error::NoSuchElementError
 end
 
 When('I close the keyboard') do
-  unless Maze.driver.capabilities['platformName'].eql?('Mac')
+  unless Maze::Helper.get_current_platform.eql?('macos')
     click_if_present 'close_keyboard'
   end
 end
@@ -193,49 +193,53 @@ Then('the thread information is valid for the event') do
 end
 
 Then('the error is valid for the error reporting API') do
-  case Maze.driver.capabilities['platformName']
-  when 'iOS'
+  platform = Maze::Helper.get_current_platform
+  STDOUT.puts "platform: #{platform}"
+  case platform
+  when 'ios'
     steps %(
       Then the error is valid for the error reporting API version "4.0" for the "iOS Bugsnag Notifier" notifier
       Then the breadcrumb timestamps are valid for the event
     )
-  when 'Mac'
+  when 'macos'
     steps %(
       Then the error is valid for the error reporting API version "4.0" for the "OSX Bugsnag Notifier" notifier
       Then the breadcrumb timestamps are valid for the event
     )
   else
-    raise 'Unknown platformName'
+    raise "Unknown platform: #{platform}"
   end
 end
 
 Then('the error is valid for the error reporting API ignoring breadcrumb timestamps') do
-  case Maze.driver.capabilities['platformName']
-  when 'iOS'
+  platform = Maze::Helper.get_current_platform
+  case platform
+  when 'ios'
     steps %(
       Then the error is valid for the error reporting API version "4.0" for the "iOS Bugsnag Notifier" notifier
     )
-  when 'Mac'
+  when 'macos'
     steps %(
       Then the error is valid for the error reporting API version "4.0" for the "OSX Bugsnag Notifier" notifier
     )
   else
-    raise 'Unknown platformName'
+    raise "Unknown platform: #{platform}"
   end
 end
 
 Then('the session is valid for the session reporting API') do
-  case Maze.driver.capabilities['platformName']
-  when 'iOS'
+  platform = Maze::Helper.get_current_platform
+  case platform
+  when 'ios'
     steps %(
       Then the session is valid for the session reporting API version "1.0" for the "iOS Bugsnag Notifier" notifier
     )
-  when 'Mac'
+  when 'macos'
     steps %(
       Then the session is valid for the session reporting API version "1.0" for the "OSX Bugsnag Notifier" notifier
     )
   else
-    raise 'Unknown platformName'
+    raise "Unknown platform: #{platform}"
   end
 end
 

--- a/features/support/env.rb
+++ b/features/support/env.rb
@@ -44,19 +44,19 @@ AfterAll do
 end
 
 def skip_below(os, version)
-  skip_this_scenario("Skipping scenario") if Maze.driver.capabilities['platformName'] == os and Maze.config.os_version < version
+  skip_this_scenario("Skipping scenario") if Maze::Helper.get_current_platform == os and Maze.config.os_version < version
 end
 
 Before('@skip_below_ios_11') do |scenario|
-  skip_below('iOS', 11)
+  skip_below('ios', 11)
 end
 
 Before('@skip_below_ios_13') do |scenario|
-  skip_below('iOS', 13)
+  skip_below('ios', 13)
 end
 
 Before('@skip_macos') do |scenario|
-  skip_this_scenario("Skipping scenario") if Maze.driver.capabilities['platformName'] == 'Mac'
+  skip_this_scenario("Skipping scenario") if Maze::Helper.get_current_platform == 'macos'
 end
 
 # Skip stress tests unless STRESS_TEST env var is set


### PR DESCRIPTION
## Goal

Use Maze Runner helper routine for determining the current platform.

## Design

Use the `Maze::Helper.get_current_platform` routine added in Maze Runner v6.6.2 to avoid exposing the Cocoa test pipeline to differences between between different device farms in use.

## Testing

Covered by a `[quick ci]` run - any full set of e2e tests.