### PR TITLE
[PLAT-7702] Fix currentAppState when called before UIApplicationMain

### DIFF
--- a/Bugsnag.xcodeproj/project.pbxproj
+++ b/Bugsnag.xcodeproj/project.pbxproj
@@ -659,6 +659,8 @@
 		01847DAD26441A5E00ADA4C7 /* BSGInternalErrorReporterTests.m in Sources */ = {isa = PBXBuildFile; fileRef = 01847DAB26441A5E00ADA4C7 /* BSGInternalErrorReporterTests.m */; };
 		01847DAE26441A5E00ADA4C7 /* BSGInternalErrorReporterTests.m in Sources */ = {isa = PBXBuildFile; fileRef = 01847DAB26441A5E00ADA4C7 /* BSGInternalErrorReporterTests.m */; };
 		0187D464255BD7B800C503D9 /* BugsnagApiClientTest.m in Sources */ = {isa = PBXBuildFile; fileRef = CB9103632502320A00E9D1E2 /* BugsnagApiClientTest.m */; };
+		01935AE2275E68E9007498B3 /* UIApplicationStub.m in Sources */ = {isa = PBXBuildFile; fileRef = 01935AE1275E68E9007498B3 /* UIApplicationStub.m */; };
+		01935AE3275E68E9007498B3 /* UIApplicationStub.m in Sources */ = {isa = PBXBuildFile; fileRef = 01935AE1275E68E9007498B3 /* UIApplicationStub.m */; };
 		019480D42625F3EB00E833ED /* BSGAppKitTests.m in Sources */ = {isa = PBXBuildFile; fileRef = 019480D32625F3EB00E833ED /* BSGAppKitTests.m */; };
 		01A2C542271EB9B400A27B23 /* BSG_Symbolicate.c in Sources */ = {isa = PBXBuildFile; fileRef = 01A2C540271EB9B300A27B23 /* BSG_Symbolicate.c */; };
 		01A2C543271EB9B400A27B23 /* BSG_Symbolicate.c in Sources */ = {isa = PBXBuildFile; fileRef = 01A2C540271EB9B300A27B23 /* BSG_Symbolicate.c */; };
@@ -1336,6 +1338,8 @@
 		01847D942644140F00ADA4C7 /* BSGInternalErrorReporter.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = BSGInternalErrorReporter.h; sourceTree = "<group>"; };
 		01847D952644140F00ADA4C7 /* BSGInternalErrorReporter.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; path = BSGInternalErrorReporter.m; sourceTree = "<group>"; };
 		01847DAB26441A5E00ADA4C7 /* BSGInternalErrorReporterTests.m */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.objc; path = BSGInternalErrorReporterTests.m; sourceTree = "<group>"; };
+		01935AE0275E68E9007498B3 /* UIApplicationStub.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; path = UIApplicationStub.h; sourceTree = "<group>"; };
+		01935AE1275E68E9007498B3 /* UIApplicationStub.m */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.objc; path = UIApplicationStub.m; sourceTree = "<group>"; };
 		01937CF9257A7B4C00F2DE31 /* Bugsnag+Private.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; path = "Bugsnag+Private.h"; sourceTree = "<group>"; };
 		01937D11257A814D00F2DE31 /* BugsnagMetadata+Private.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; path = "BugsnagMetadata+Private.h"; sourceTree = "<group>"; };
 		01937D2E257A83A900F2DE31 /* BugsnagApp+Private.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; path = "BugsnagApp+Private.h"; sourceTree = "<group>"; };
@@ -1795,6 +1799,8 @@
 				004E35392487B375007FBAE4 /* Tests-Bridging-Header.h */,
 				CBA22499251E429C00B87416 /* TestSupport.h */,
 				CBA2249A251E429C00B87416 /* TestSupport.m */,
+				01935AE0275E68E9007498B3 /* UIApplicationStub.h */,
+				01935AE1275E68E9007498B3 /* UIApplicationStub.m */,
 				013D9CCF26C5262F0077F0AD /* UISceneStub.h */,
 				013D9CD026C5262F0077F0AD /* UISceneStub.m */,
 				01E8765C256684E700F4B70A /* URLSessionMock.h */,
@@ -2780,6 +2786,7 @@
 				008967782486D43700DC48C2 /* BSG_KSMachHeadersTests.m in Sources */,
 				0089673F2486D43700DC48C2 /* BugsnagAppTest.m in Sources */,
 				0089675A2486D43700DC48C2 /* BugsnagEnabledBreadcrumbTest.m in Sources */,
+				01935AE2275E68E9007498B3 /* UIApplicationStub.m in Sources */,
 				008967422486D43700DC48C2 /* BugsnagSessionTrackerStopTest.m in Sources */,
 				E701FAAF2490EFE8008D842F /* ConfigurationApiValidationTest.m in Sources */,
 				008967452486D43700DC48C2 /* BugsnagTests.m in Sources */,
@@ -3138,6 +3145,7 @@
 				01847DAE26441A5E00ADA4C7 /* BSGInternalErrorReporterTests.m in Sources */,
 				004E35372487AFF2007FBAE4 /* BugsnagHandledStateTest.m in Sources */,
 				016875C8258D003200DFFF69 /* NSUserDefaultsStub.m in Sources */,
+				01935AE3275E68E9007498B3 /* UIApplicationStub.m in Sources */,
 				01C17AE92542ED7F00C102C9 /* KSCrashReportWriterTests.m in Sources */,
 				00896A422486DBDD00DC48C2 /* BSGConfigurationBuilderTests.m in Sources */,
 				008967682486D43700DC48C2 /* BugsnagNotifierTest.m in Sources */,

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,14 @@
 Changelog
 =========
 
+## TBD
+
+### Bug fixes
+
+* Fix `UIApplicationState` detection when started from a SwiftUI app's `init()` function.
+  This fixes false positive OOMs on iOS 15 for apps that have been prewarmed without transitioning to the foreground.
+  [#1248](https://github.com/bugsnag/bugsnag-cocoa/pull/1248)
+
 ## 6.15.0 (2021-12-01)
 
 ### Enhancements

--- a/Tests/BugsnagTests/BugsnagConfigurationTests.m
+++ b/Tests/BugsnagTests/BugsnagConfigurationTests.m
@@ -103,6 +103,7 @@
     // Call onSession blocks
     BugsnagClient *client = [[BugsnagClient alloc] initWithConfiguration:config];
     [client start];
+    [client resumeSession];
     [self waitForExpectationsWithTimeout:5.0 handler:nil];
 }
 
@@ -183,6 +184,7 @@
     // Call onSession blocks
     BugsnagClient *client = [[BugsnagClient alloc] initWithConfiguration:config];
     [client start];
+    [client resumeSession];
     [self waitForExpectations:@[expectation1] timeout:1.0];
 
     // Check it's called on new session start

--- a/Tests/BugsnagTests/UIApplicationStub.h
+++ b/Tests/BugsnagTests/UIApplicationStub.h
@@ -1,0 +1,26 @@
+//
+//  UIApplicationStub.h
+//  Bugsnag
+//
+//  Created by Nick Dowell on 06/12/2021.
+//  Copyright © 2021 Bugsnag Inc. All rights reserved.
+//
+
+#import <UIKit/UIKit.h>
+#import <XCTest/XCTest.h>
+
+NS_ASSUME_NONNULL_BEGIN
+
+@interface UIApplicationStub : NSObject
+
+@property (nonatomic) UIApplicationState applicationState;
+
+@end
+
+@interface XCTestCase (UIApplicationStub)
+
+- (void)setUpUIApplicationStub;
+
+@end
+
+NS_ASSUME_NONNULL_END

--- a/Tests/BugsnagTests/UIApplicationStub.m
+++ b/Tests/BugsnagTests/UIApplicationStub.m
@@ -1,0 +1,38 @@
+//
+//  UIApplicationStub.m
+//  Bugsnag
+//
+//  Created by Nick Dowell on 06/12/2021.
+//  Copyright © 2021 Bugsnag Inc. All rights reserved.
+//
+
+#import "UIApplicationStub.h"
+
+#import <objc/runtime.h>
+
+
+@implementation UIApplicationStub
+
+- (BOOL)isKindOfClass:(Class)aClass {
+    return aClass == [UIApplication class] || [super isKindOfClass:aClass];
+}
+
+@end
+
+
+@implementation XCTestCase (UIApplicationStub)
+
+- (void)setUpUIApplicationStub {
+    Method method = class_getClassMethod([UIApplication class], @selector(sharedApplication));
+    NSParameterAssert(method != NULL);
+    
+    void *originalImplementation = method_setImplementation(method, imp_implementationWithBlock(^(){
+        return [[UIApplicationStub alloc] init];
+    }));
+    
+    [self addTeardownBlock:^{
+        method_setImplementation(method, originalImplementation);
+    }];
+}
+
+@end

--- a/Tests/KSCrashTests/KSCrashState_Tests.m
+++ b/Tests/KSCrashTests/KSCrashState_Tests.m
@@ -30,12 +30,27 @@
 #import "BSG_KSCrashState.h"
 #import "BSG_KSCrashC.h"
 
+#if TARGET_OS_TV
+#import "UIApplicationStub.h"
+#endif
+
 
 @interface bsg_kscrashstate_Tests : FileBasedTestCase
 @end
 
 
 @implementation bsg_kscrashstate_Tests
+
+#if TARGET_OS_TV // Not needed on iOS because there the tests are injected into a host app
+
+- (void)setUp
+{
+    [self setUpUIApplicationStub]; // These tests assume applicationState == .active
+    
+    [super setUp];
+}
+
+#endif
 
 - (void) testInitRelaunch
 {

--- a/Tests/KSCrashTests/KSSystemInfo_Tests.m
+++ b/Tests/KSCrashTests/KSSystemInfo_Tests.m
@@ -31,6 +31,10 @@
 #import "BSG_KSSystemInfo.h"
 #import "BSG_KSSystemInfoC.h"
 
+#if TARGET_OS_TV
+#import "UIApplicationStub.h"
+#endif
+
 
 @interface KSSystemInfo_Tests : XCTestCase @end
 
@@ -61,7 +65,9 @@
 
 #if BSG_PLATFORM_TVOS || BSG_PLATFORM_IOS
 - (void)testCurrentAppState {
-    // Should default to active as tests aren't in an app bundle
+#if TARGET_OS_TV
+    [self setUpUIApplicationStub];
+#endif
     XCTAssertEqual(UIApplicationStateActive, [BSG_KSSystemInfo currentAppState]);
 }
 


### PR DESCRIPTION
## Goal

Fix detection of foreground / background state when app is [prewarmed](https://developer.apple.com/documentation/uikit/app_and_environment/responding_to_the_launch_of_your_app/about_the_app_launch_sequence).

> In iOS 15 and later, the system may, depending on device conditions, prewarm your app — launch nonrunning application processes to reduce the amount of time the user waits before the app is usable. Prewarming executes an app’s launch sequence up until, but not including, when main() calls UIApplicationMain. This provides the system with an opportunity to build and cache any low-level structures it requires in anticipation of a full launch.

If Bugsnag is started before `UIAppliationMain()` has been called (e.g. from a SwiftUI app's `init()` function) `UIApplication.sharedApplication` will be nil.

When the `applicationState` message is send to nil, a value of 0 (i.e. active) is returned and causes Bugsnag to think the app is running in the foreground, triggering automatic session tracking and resulting in OOMs to be detected if the process gets terminated before the app is launched by the user.

## Changeset

Return `UIApplicationStateBackground` if `sharedApplication` is nil.

## Testing

To cause an app to be prewarmed, install and run on a device and then reboot it. The OS typically runs it soon after starting up again - within a minute on a device with few apps.

Manually verified with a SwiftUI sample app that a session is still started automatically at the correct time (when the relevant notification is sent) but not before the app is opened.

Did not find a way to replicate the false OOMs, because our OOM detection logic checks for and ignores reboots.

Amended unit tests that relied on `applicationState` to be active.