### PR TITLE
Delay running scenario to allow tap event to be handled

### DIFF
--- a/features/fixtures/ios/iOSTestApp/ViewController.swift
+++ b/features/fixtures/ios/iOSTestApp/ViewController.swift
@@ -29,8 +29,13 @@ class ViewController: UIViewController {
 
         log("Starting Bugsnag for scenario: \(String(describing: scenario))")
         scenario?.startBugsnag()
-        log("Running scenario: \(String(describing: scenario))")
-        scenario?.run()
+        
+        log("Will running scenario: \(String(describing: scenario))")
+        // 0.1s delay allows accessibility APIs to finish handling the tap event and return control to the tests framework.
+        DispatchQueue.main.asyncAfter(deadline: .now() + 0.1) {
+            log("Running scenario: \(String(describing: self.scenario))")
+            self.scenario?.run()
+        }
     }
 
     @IBAction func startBugsnag() {


### PR DESCRIPTION
## Goal

Start e2e test scenarios in a separate thread, so that Appium gets a return on its operation.  

## Design

Without this, if the app crashes then Appium can then be left to timeout.  The tests still pass, but it adds a significant amount of time to the run.

Whilst it's my PR, @nickdowell authored the commit, so I'm seeking an alternative reviewer.

## Testing

Covered by a `[quick ci]` run.