### PR TITLE
[PLAT-6163] Fix recrash deadlocks

### DIFF
--- a/Bugsnag/KSCrash/Source/KSCrash/Recording/Sentry/BSG_KSCrashSentry_CPPException.mm
+++ b/Bugsnag/KSCrash/Source/KSCrash/Recording/Sentry/BSG_KSCrashSentry_CPPException.mm
@@ -126,6 +126,8 @@ static void CPPExceptionTerminate(void) {
         BSG_KSLOG_DEBUG("Detected NSException. Recording details and letting "
                         "the current NSException handler deal with it.");
         isNSException = true;
+        // recordException() doesn't call beginHandlingCrash()
+        bsg_kscrashsentry_beginHandlingCrash(bsg_g_context);
         bsg_recordException(exception);
     } catch (std::exception &exc) {
         strlcpy(descriptionBuff, exc.what(), sizeof(descriptionBuff));

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,13 @@
 Changelog
 =========
 
+## TBD
+
+### Bug fixes
+
+* Fix some potential deadlocks that could occur if a crash handler crashes.
+  [#1252](https://github.com/bugsnag/bugsnag-cocoa/pull/1252)
+
 ## 6.15.1 (2021-12-08)
 
 ### Bug fixes


### PR DESCRIPTION
## Goal

Fix deadlocks that could occur if the crash handling code (or the app's `onCrashHandler` callback) crashes.

## Changeset

* Fixes a deadlock caused by the Mach exception handling threads being suspended due to `context->reservedThreads` being clobbered in `bsg_kscrashsentry_clearContext()`.
* Fixes a deadlock due to `thread_terminate` being called on original crashing thread when handling a nested Mach exception.
* Ensures that `bsg_kscrashsentry_beginHandlingCrash()` is called when an unhandled `NSException` is detected, so that crashes during crash handling can be identified.

There remains a deadlock on macOS 10.14 and earlier if a signal handler crashes. This appears to be a bug in the OS and not something we can work around.

<details>
<summary>Sample code</summary>

```c
#include <signal.h>
#include <stdlib.h>

static void signal_handler(int signum) {
  // Crashing the signal handler in this way will deadlock on macOS <= 10.14
  // on more recent versions of macOS the process will terminate as expected.
  static volatile int *ptr;
  *ptr = 42;
}

int main(int argc, const char * argv[]) {
  signal(SIGABRT, signal_handler);
  abort();
  return 0;
}
```
</details>

## Testing

E2E tests have been set up on a separate branch (will be included in a future PR) and passed on CI: https://buildkite.com/bugsnag/bugsnag-cocoa/builds/4195