### PR TITLE
[PLAT-7732] Internal error improvements

### DIFF
--- a/Bugsnag/Delivery/BSGEventUploadKSCrashReportOperation.m
+++ b/Bugsnag/Delivery/BSGEventUploadKSCrashReportOperation.m
@@ -62,6 +62,15 @@ static void ReportInternalError(NSString *errorClass, NSString *message, NSDicti
         NSMutableDictionary *diagnostics = [NSMutableDictionary dictionary];
         diagnostics[@"data"] = [data base64EncodedStringWithOptions:0];
         diagnostics[@"file"] = self.file;
+        NSDictionary<NSFileAttributeKey, id> *fileAttributes = [NSFileManager.defaultManager attributesOfItemAtPath:self.file error:nil];
+        if (fileAttributes) {
+            NSDate *creationDate = fileAttributes[NSFileCreationDate];
+            NSDate *modificationDate = fileAttributes[NSFileModificationDate];
+            if (creationDate && modificationDate) {
+                // The amount of time spent writing the file could indicate why the process never completed
+                diagnostics[@"modificationInterval"] = @([modificationDate timeIntervalSinceDate:creationDate]);
+            }
+        }
         ReportInternalError(@"JSON parsing error", BSGErrorDescription(error), diagnostics);
         if (errorPtr) {
             *errorPtr = error;

--- a/Bugsnag/Helpers/BSGInternalErrorReporter.h
+++ b/Bugsnag/Helpers/BSGInternalErrorReporter.h
@@ -25,8 +25,6 @@ FOUNDATION_EXPORT NSString *BSGErrorDescription(NSError *error);
 
 @property (readonly, nonatomic) BugsnagConfiguration *configuration;
 
-@property (readonly, nonatomic) BugsnagNotifier *notifier;
-
 - (BugsnagAppWithState *)generateAppWithState:(NSDictionary *)systemInfo;
 
 - (BugsnagDeviceWithState *)generateDeviceWithState:(NSDictionary *)systemInfo;

--- a/Bugsnag/Helpers/BSGInternalErrorReporter.m
+++ b/Bugsnag/Helpers/BSGInternalErrorReporter.m
@@ -196,7 +196,7 @@ static void (^ startupBlock_)(BSGInternalErrorReporter *);
     
     NSMutableDictionary *requestPayload = [NSMutableDictionary dictionary];
     requestPayload[BSGKeyEvents] = @[[event toJsonWithRedactedKeys:nil]];
-    requestPayload[BSGKeyNotifier] = [dataSource.notifier toDict];
+    requestPayload[BSGKeyNotifier] = [[[BugsnagNotifier alloc] init] toDict];
     requestPayload[BSGKeyPayloadVersion] = EventPayloadVersion;
     
     NSData *data = [NSJSONSerialization dataWithJSONObject:requestPayload options:0 error:errorPtr];

--- a/Bugsnag/Helpers/BSGInternalErrorReporter.m
+++ b/Bugsnag/Helpers/BSGInternalErrorReporter.m
@@ -117,14 +117,11 @@ static void (^ startupBlock_)(BSGInternalErrorReporter *);
                                    diagnostics:(nullable NSDictionary<NSString *, id> *)diagnostics
                                   groupingHash:(nullable NSString *)groupingHash {
     
-    NSArray<BugsnagStackframe *> *stacktrace = [BugsnagStackframe stackframesWithCallStackReturnAddresses:
-                                                BSGArraySubarrayFromIndex(NSThread.callStackReturnAddresses, 2)];
-    
     BugsnagError *error =
     [[BugsnagError alloc] initWithErrorClass:errorClass
                                 errorMessage:message
                                    errorType:BSGErrorTypeCocoa
-                                  stacktrace:stacktrace];
+                                  stacktrace:nil];
     
     return [self eventWithError:error diagnostics:diagnostics groupingHash:groupingHash];
 }

--- a/Bugsnag/Payload/BugsnagError.m
+++ b/Bugsnag/Payload/BugsnagError.m
@@ -106,7 +106,7 @@ NSString *BSGParseErrorMessage(NSDictionary *report, NSDictionary *error, NSStri
         _errorClass = errorClass;
         _errorMessage = errorMessage;
         _typeString = BSGSerializeErrorType(errorType);
-        _stacktrace = stacktrace;
+        _stacktrace = stacktrace ?: @[];
     }
     return self;
 }

--- a/Tests/BugsnagTests/BSGInternalErrorReporterTests.m
+++ b/Tests/BugsnagTests/BSGInternalErrorReporterTests.m
@@ -17,7 +17,6 @@
 @interface BSGInternalErrorReporterTests : XCTestCase <BSGInternalErrorReporterDataSource>
 
 @property (nonatomic) BugsnagConfiguration *configuration;
-@property (nonatomic) BugsnagNotifier *notifier;
 
 @end
 
@@ -29,7 +28,6 @@
     [BSGInternalErrorReporter setSharedInstance:nil];
 #pragma clang diagnostic pop
     self.configuration = [[BugsnagConfiguration alloc] initWithApiKey:@"0192837465afbecd0192837465afbecd"];
-    self.notifier = [[BugsnagNotifier alloc] init];
 }
 
 - (void)testEventWithErrorClass {

--- a/Tests/BugsnagTests/BSGInternalErrorReporterTests.m
+++ b/Tests/BugsnagTests/BSGInternalErrorReporterTests.m
@@ -39,7 +39,7 @@
     XCTAssertEqualObjects(event.errors[0].errorMessage, @"Something went wrong");
     XCTAssertEqualObjects(event.groupingHash, @"test");
     XCTAssertEqualObjects(event.threads, @[]);
-    XCTAssertGreaterThan(event.errors[0].stacktrace.count, 0);
+    XCTAssertEqual(event.errors[0].stacktrace.count, 0);
     XCTAssertNil(event.apiKey);
     
     NSDictionary *diagnostics = [event.metadata getMetadataFromSection:@"BugsnagDiagnostics"];

--- a/features/fixtures/ios/iOSTestApp.xcodeproj/project.pbxproj
+++ b/features/fixtures/ios/iOSTestApp.xcodeproj/project.pbxproj
@@ -19,7 +19,7 @@
 		01018BA025E40ADD000312C6 /* AsyncSafeMallocScenario.m in Sources */ = {isa = PBXBuildFile; fileRef = 01018B9F25E40ADD000312C6 /* AsyncSafeMallocScenario.m */; };
 		0104085F258CA0A100933C60 /* DispatchCrashScenario.swift in Sources */ = {isa = PBXBuildFile; fileRef = 0104085E258CA0A100933C60 /* DispatchCrashScenario.swift */; };
 		0163BFA72583B3CF008DC28B /* DiscardClassesScenarios.swift in Sources */ = {isa = PBXBuildFile; fileRef = 0163BFA62583B3CF008DC28B /* DiscardClassesScenarios.swift */; };
-		01847DD626453D4E00ADA4C7 /* InternalErrorReportingScenarios.m in Sources */ = {isa = PBXBuildFile; fileRef = 01847DD526453D4E00ADA4C7 /* InternalErrorReportingScenarios.m */; };
+		01847DD626453D4E00ADA4C7 /* InvalidCrashReportScenario.m in Sources */ = {isa = PBXBuildFile; fileRef = 01847DD526453D4E00ADA4C7 /* InvalidCrashReportScenario.m */; };
 		01AF6A53258A112F00FFC803 /* BareboneTestScenarios.swift in Sources */ = {isa = PBXBuildFile; fileRef = 01AF6A52258A112F00FFC803 /* BareboneTestScenarios.swift */; };
 		01B6BB7525D5748800FC4DE6 /* LastRunInfoScenarios.swift in Sources */ = {isa = PBXBuildFile; fileRef = 01B6BB7425D5748800FC4DE6 /* LastRunInfoScenarios.swift */; };
 		01B6BBB625DA82B800FC4DE6 /* SendLaunchCrashesSynchronouslyScenario.swift in Sources */ = {isa = PBXBuildFile; fileRef = 01B6BBB525DA82B700FC4DE6 /* SendLaunchCrashesSynchronouslyScenario.swift */; };
@@ -181,7 +181,7 @@
 		01018B9F25E40ADD000312C6 /* AsyncSafeMallocScenario.m */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.objc; path = AsyncSafeMallocScenario.m; sourceTree = "<group>"; };
 		0104085E258CA0A100933C60 /* DispatchCrashScenario.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = DispatchCrashScenario.swift; sourceTree = "<group>"; };
 		0163BFA62583B3CF008DC28B /* DiscardClassesScenarios.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = DiscardClassesScenarios.swift; sourceTree = "<group>"; };
-		01847DD526453D4E00ADA4C7 /* InternalErrorReportingScenarios.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; path = InternalErrorReportingScenarios.m; sourceTree = "<group>"; };
+		01847DD526453D4E00ADA4C7 /* InvalidCrashReportScenario.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; path = InvalidCrashReportScenario.m; sourceTree = "<group>"; };
 		01AF6A52258A112F00FFC803 /* BareboneTestScenarios.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = BareboneTestScenarios.swift; sourceTree = "<group>"; };
 		01B6BB7425D5748800FC4DE6 /* LastRunInfoScenarios.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = LastRunInfoScenarios.swift; sourceTree = "<group>"; };
 		01B6BBB525DA82B700FC4DE6 /* SendLaunchCrashesSynchronouslyScenario.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = SendLaunchCrashesSynchronouslyScenario.swift; sourceTree = "<group>"; };
@@ -599,7 +599,7 @@
 				01AF6A52258A112F00FFC803 /* BareboneTestScenarios.swift */,
 				01DE903726CE99B800455213 /* CriticalThermalStateScenario.swift */,
 				0163BFA62583B3CF008DC28B /* DiscardClassesScenarios.swift */,
-				01847DD526453D4E00ADA4C7 /* InternalErrorReportingScenarios.m */,
+				01847DD526453D4E00ADA4C7 /* InvalidCrashReportScenario.m */,
 				01E5EAD025B713990066EA8A /* OOMScenario.h */,
 				01E5EAD125B713990066EA8A /* OOMScenario.m */,
 				8AB1081823301FE600672818 /* ReleaseStageScenarios.swift */,
@@ -960,7 +960,7 @@
 				A1117E552535A59100014FDA /* OOMLoadScenario.swift in Sources */,
 				8A840FBA21AF5C450041DBFA /* SwiftAssertion.swift in Sources */,
 				E753F24824927412001FB671 /* OnSendErrorCallbackCrashScenario.swift in Sources */,
-				01847DD626453D4E00ADA4C7 /* InternalErrorReportingScenarios.m in Sources */,
+				01847DD626453D4E00ADA4C7 /* InvalidCrashReportScenario.m in Sources */,
 				001E5502243B8FDA0009E31D /* AutoCaptureRunScenario.m in Sources */,
 				0104085F258CA0A100933C60 /* DispatchCrashScenario.swift in Sources */,
 				E700EE55247D3204008CFFB6 /* OnSendOverwriteScenario.swift in Sources */,

--- a/features/fixtures/macos/macOSTestApp.xcodeproj/project.pbxproj
+++ b/features/fixtures/macos/macOSTestApp.xcodeproj/project.pbxproj
@@ -16,7 +16,7 @@
 		0176C0B6254AE81B0066E0F3 /* MainMenu.xib in Resources */ = {isa = PBXBuildFile; fileRef = 0176C0B4254AE81B0066E0F3 /* MainMenu.xib */; };
 		017FBFB8254B09C300809042 /* MainWindowController.m in Sources */ = {isa = PBXBuildFile; fileRef = 017FBFB6254B09C300809042 /* MainWindowController.m */; };
 		017FBFB9254B09C300809042 /* MainWindowController.xib in Resources */ = {isa = PBXBuildFile; fileRef = 017FBFB7254B09C300809042 /* MainWindowController.xib */; };
-		01847DCD26443DF000ADA4C7 /* InternalErrorReportingScenarios.m in Sources */ = {isa = PBXBuildFile; fileRef = 01847DCC26443DF000ADA4C7 /* InternalErrorReportingScenarios.m */; };
+		01847DCD26443DF000ADA4C7 /* InvalidCrashReportScenario.m in Sources */ = {isa = PBXBuildFile; fileRef = 01847DCC26443DF000ADA4C7 /* InvalidCrashReportScenario.m */; };
 		01AF6A50258A00DE00FFC803 /* BareboneTestScenarios.swift in Sources */ = {isa = PBXBuildFile; fileRef = 01AF6A4F258A00DE00FFC803 /* BareboneTestScenarios.swift */; };
 		01AF6A84258BB38A00FFC803 /* DispatchCrashScenario.swift in Sources */ = {isa = PBXBuildFile; fileRef = 01AF6A83258BB38A00FFC803 /* DispatchCrashScenario.swift */; };
 		01B6BB7225D56CBF00FC4DE6 /* LastRunInfoScenarios.swift in Sources */ = {isa = PBXBuildFile; fileRef = 01B6BB7125D56CBF00FC4DE6 /* LastRunInfoScenarios.swift */; };
@@ -175,7 +175,7 @@
 		017FBFB5254B09C300809042 /* MainWindowController.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; path = MainWindowController.h; sourceTree = "<group>"; };
 		017FBFB6254B09C300809042 /* MainWindowController.m */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.objc; path = MainWindowController.m; sourceTree = "<group>"; };
 		017FBFB7254B09C300809042 /* MainWindowController.xib */ = {isa = PBXFileReference; lastKnownFileType = file.xib; path = MainWindowController.xib; sourceTree = "<group>"; };
-		01847DCC26443DF000ADA4C7 /* InternalErrorReportingScenarios.m */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.objc; path = InternalErrorReportingScenarios.m; sourceTree = "<group>"; };
+		01847DCC26443DF000ADA4C7 /* InvalidCrashReportScenario.m */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.objc; path = InvalidCrashReportScenario.m; sourceTree = "<group>"; };
 		01AF6A4F258A00DE00FFC803 /* BareboneTestScenarios.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = BareboneTestScenarios.swift; sourceTree = "<group>"; };
 		01AF6A83258BB38A00FFC803 /* DispatchCrashScenario.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = DispatchCrashScenario.swift; sourceTree = "<group>"; };
 		01B6BB7125D56CBF00FC4DE6 /* LastRunInfoScenarios.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = LastRunInfoScenarios.swift; sourceTree = "<group>"; };
@@ -442,7 +442,7 @@
 				01F47C4E254B1B2D00B184AD /* HandledErrorScenario.swift */,
 				01F47C28254B1B2C00B184AD /* HandledExceptionScenario.swift */,
 				01F47C55254B1B2E00B184AD /* HandledInternalNotifyScenario.swift */,
-				01847DCC26443DF000ADA4C7 /* InternalErrorReportingScenarios.m */,
+				01847DCC26443DF000ADA4C7 /* InvalidCrashReportScenario.m */,
 				01B6BB7125D56CBF00FC4DE6 /* LastRunInfoScenarios.swift */,
 				01F47C23254B1B2C00B184AD /* LoadConfigFromFileAutoScenario.swift */,
 				01F47C94254B1B2F00B184AD /* LoadConfigFromFileScenario.swift */,
@@ -765,7 +765,7 @@
 				01F47CE9254B1B3100B184AD /* SIGTRAPScenario.m in Sources */,
 				01F47CC8254B1B3100B184AD /* AutoSessionScenario.m in Sources */,
 				01E0DB0625E8E95700A740ED /* AppDurationScenario.swift in Sources */,
-				01847DCD26443DF000ADA4C7 /* InternalErrorReportingScenarios.m in Sources */,
+				01847DCD26443DF000ADA4C7 /* InvalidCrashReportScenario.m in Sources */,
 				01F47D2D254B1B3100B184AD /* OnErrorOverwriteScenario.swift in Sources */,
 				01F47CC7254B1B3100B184AD /* MetadataRedactionDefaultScenario.swift in Sources */,
 				01F47CEC254B1B3100B184AD /* SessionCallbackCrashScenario.swift in Sources */,

--- a/features/fixtures/shared/scenarios/InternalErrorReportingScenarios.m
+++ b/features/fixtures/shared/scenarios/InternalErrorReportingScenarios.m
@@ -14,6 +14,7 @@
 
 static void InternalErrorReportingScenarios_KSCrashReport_CrashHandler(const BSG_KSCrashReportWriter *writer) {
     writer->addJSONElement(writer, "something", "{1: \"Not valid JSON\"}");
+    sleep(1);
 }
 
 @implementation InternalErrorReportingScenarios_KSCrashReport

--- a/features/fixtures/shared/scenarios/InvalidCrashReportScenario.m
+++ b/features/fixtures/shared/scenarios/InvalidCrashReportScenario.m
@@ -1,5 +1,5 @@
 //
-//  InternalErrorReportingScenarios.m
+//  InvalidCrashReportScenario.m
 //  macOSTestApp
 //
 //  Created by Nick Dowell on 07/05/2021.
@@ -8,20 +8,19 @@
 
 #import "Scenario.h"
 
-@interface InternalErrorReportingScenarios_KSCrashReport : Scenario
-
+@interface InvalidCrashReportScenario : Scenario
 @end
 
-static void InternalErrorReportingScenarios_KSCrashReport_CrashHandler(const BSG_KSCrashReportWriter *writer) {
+static void CrashHandler(const BSG_KSCrashReportWriter *writer) {
     writer->addJSONElement(writer, "something", "{1: \"Not valid JSON\"}");
     sleep(1);
 }
 
-@implementation InternalErrorReportingScenarios_KSCrashReport
+@implementation InvalidCrashReportScenario
 
 - (void)startBugsnag {
     self.config.autoTrackSessions = NO;
-    self.config.onCrashHandler = InternalErrorReportingScenarios_KSCrashReport_CrashHandler;
+    self.config.onCrashHandler = CrashHandler;
     
     [super startBugsnag];
 }

--- a/features/internal_error_reporting.feature
+++ b/features/internal_error_reporting.feature
@@ -9,6 +9,7 @@ Feature: Internal error reporting
     And I wait to receive an error
     And the error "Bugsnag-Api-Key" header is null
     And the error "Bugsnag-Internal-Error" header equals "bugsnag-cocoa"
+    And the error payload field "events.0.exceptions.0.stacktrace" is an array with 0 elements
     And the error payload field "events.0.threads" is an array with 0 elements
     And the event "apiKey" is null
     And the event "groupingHash" equals "BSGEventUploadKSCrashReportOperation.m: JSON parsing error: NSCocoaErrorDomain 3840: No string key for value in object"

--- a/features/internal_error_reporting.feature
+++ b/features/internal_error_reporting.feature
@@ -15,6 +15,7 @@ Feature: Internal error reporting
     And the event "metaData.BugsnagDiagnostics.apiKey" equals "12312312312312312312312312312312"
     And the event "metaData.BugsnagDiagnostics.data" is not null
     And the event "metaData.BugsnagDiagnostics.file" is not null
+    And the event "metaData.BugsnagDiagnostics.modificationInterval" is between 1.0 and 2.0
     And the event "unhandled" is false
     And the exception "errorClass" equals "JSON parsing error"
     And the exception "message" matches "NSCocoaErrorDomain 3840: No string key for value in object around .+\."

--- a/features/internal_error_reporting.feature
+++ b/features/internal_error_reporting.feature
@@ -4,8 +4,8 @@ Feature: Internal error reporting
     Given I clear all persistent data
 
   Scenario: An internal error report is sent for invalid KSCrashReport files
-    When I run "InternalErrorReportingScenarios_KSCrashReport" and relaunch the app
-    And I configure Bugsnag for "InternalErrorReportingScenarios_KSCrashReport"
+    When I run "InvalidCrashReportScenario" and relaunch the app
+    And I configure Bugsnag for "InvalidCrashReportScenario"
     And I wait to receive an error
     And the error "Bugsnag-Api-Key" header is null
     And the error "Bugsnag-Internal-Error" header equals "bugsnag-cocoa"


### PR DESCRIPTION
## Goal

Include information about how long was spent writing an invalid crash report file, to give some clues about the reason for failure.

## Changeset

* Adds a `modificationInterval` metadata value which shows the difference between the file's modification and creation time. 
* Always sends the cocoa notifier's version (rather than the RN or Unity notifier version.)
* Omits stack traces from JSON parsing errors, because they cannot be symbolicated and do not contain any useful info.

## Testing

Amended E2E scenario to verify changes.