### PR TITLE
Remove unnecessary automation steps

### DIFF
--- a/features/steps/app_steps.rb
+++ b/features/steps/app_steps.rb
@@ -61,7 +61,6 @@ end
 
 When('I set the app to {string} mode') do |mode|
   steps %(
-    Given the element "scenario_metadata" is present
     When I send the keys "#{mode}" to the element "scenario_metadata"
   )
 end

--- a/features/steps/app_steps.rb
+++ b/features/steps/app_steps.rb
@@ -63,7 +63,6 @@ When('I set the app to {string} mode') do |mode|
   steps %(
     Given the element "scenario_metadata" is present
     When I send the keys "#{mode}" to the element "scenario_metadata"
-    And I close the keyboard
   )
 end
 

--- a/features/steps/cocoa_steps.rb
+++ b/features/steps/cocoa_steps.rb
@@ -2,7 +2,6 @@ When('I run {string}') do |event_type|
   steps %(
     Given the element "scenario_name" is present
     When I send the keys "#{event_type}" to the element "scenario_name"
-    And I close the keyboard
     And I click the element "run_scenario"
   )
 end
@@ -51,17 +50,10 @@ rescue Selenium::WebDriver::Error::NoSuchElementError
   false
 end
 
-When('I close the keyboard') do
-  unless Maze::Helper.get_current_platform.eql?('macos')
-    click_if_present 'close_keyboard'
-  end
-end
-
 When('I configure Bugsnag for {string}') do |event_type|
   steps %(
     Given the element "scenario_name" is present
     When I send the keys "#{event_type}" to the element "scenario_name"
-    And I close the keyboard
     And I click the element "start_bugsnag"
   )
 end

--- a/features/steps/cocoa_steps.rb
+++ b/features/steps/cocoa_steps.rb
@@ -1,6 +1,5 @@
 When('I run {string}') do |event_type|
   steps %(
-    Given the element "scenario_name" is present
     When I send the keys "#{event_type}" to the element "scenario_name"
     And I click the element "run_scenario"
   )
@@ -35,8 +34,7 @@ end
 
 When('I clear all persistent data') do
   steps %(
-    Given the element "clear_persistent_data" is present
-    And I click the element "clear_persistent_data"
+    When I click the element "clear_persistent_data"
   )
 end
 
@@ -52,7 +50,6 @@ end
 
 When('I configure Bugsnag for {string}') do |event_type|
   steps %(
-    Given the element "scenario_name" is present
     When I send the keys "#{event_type}" to the element "scenario_name"
     And I click the element "start_bugsnag"
   )


### PR DESCRIPTION
## Goal

Remove the unnecessary closing of the keyboard and checking that elements are present before interacting with them.  This saves a total of an hour device time per full builds.

## Design

Each Appium `driver.find_element` operation takes about a second and closing the keyboard was taking two.  Losing the steps saves a lot of time and also makes the Appium logs much cleaner.

If we do start getting failures due to elements "missing" (not loaded yet), we can add a simple, reactive, retry.

## Changeset

Removal of unnecessary Cucumber steps.

## Testing

Covered by a full CI run.