### PR TITLE
Reduce time sending keys to test fixture

### DIFF
--- a/features/app_and_device_attributes.feature
+++ b/features/app_and_device_attributes.feature
@@ -69,7 +69,7 @@ Feature: App and Device attributes present
     And the event "app.isLaunching" is false
 
   Scenario: App and Device info is as expected when overridden via config
-    When I run "AppAndDeviceAttributesScenarioConfigOverride"
+    When I run "AppAndDeviceAttributesConfigOverrideScenario"
     And I wait to receive an error
     Then the error is valid for the error reporting API
     And the error "Bugsnag-API-Key" header equals "12312312312312312312312312312312"
@@ -80,7 +80,7 @@ Feature: App and Device attributes present
     And the error payload field "events.0.app.releaseStage" equals "secondStage"
 
   Scenario: App and Device info is as expected when overridden via callback
-    When I run "AppAndDeviceAttributesScenarioCallbackOverride"
+    When I run "AppAndDeviceAttributesCallbackOverrideScenario"
     And I wait to receive an error
     Then the error is valid for the error reporting API
     And the error "Bugsnag-API-Key" header equals "12312312312312312312312312312312"
@@ -93,7 +93,7 @@ Feature: App and Device attributes present
     And the error payload field "events.0.device.modelNumber" equals "0898"
 
   Scenario: Info.plist settings are used when calling startWithApiKey
-    When I run "AppAndDeviceAttributesScenarioStartWithApiKey"
+    When I run "AppAndDeviceAttributesStartWithApiKeyScenario"
     And I wait to receive an error
     Then the error is valid for the error reporting API
     And the error "Bugsnag-API-Key" header equals "12312312312312312312312312312312"

--- a/features/breadcrumbs.feature
+++ b/features/breadcrumbs.feature
@@ -36,7 +36,7 @@ Feature: Attaching a series of notable events leading up to errors
     Then the event has a "manual" breadcrumb named "Cache locked"
 
   Scenario: Modifying a breadcrumb name in callback
-    When I run "ModifyBreadcrumbInNotify"
+    When I run "ModifyBreadcrumbInNotifyScenario"
     And I wait to receive an error
     Then the event has a "manual" breadcrumb named "Cache locked"
 

--- a/features/crashprobe.feature
+++ b/features/crashprobe.feature
@@ -117,8 +117,8 @@ Feature: Reporting crash events
       | Intel | -[ReleasedObjectScenario run]                  |
 
   Scenario: Crash within Swift code
-    When I run "SwiftCrash" and relaunch the app
-    And I configure Bugsnag for "SwiftCrash"
+    When I run "SwiftCrashScenario" and relaunch the app
+    And I configure Bugsnag for "SwiftCrashScenario"
     And I wait to receive an error
     Then the error is valid for the error reporting API
     And the exception "errorClass" equals "Fatal error"
@@ -126,8 +126,8 @@ Feature: Reporting crash events
     And the event "metaData.error.crashInfo" matches "Fatal error: Unexpectedly found nil while unwrapping an Optional value"
 
   Scenario: Assertion failure in Swift code
-    When I run "SwiftAssertion" and relaunch the app
-    And I configure Bugsnag for "SwiftAssertion"
+    When I run "SwiftAssertionScenario" and relaunch the app
+    And I configure Bugsnag for "SwiftAssertionScenario"
     And I wait to receive an error
     Then the error is valid for the error reporting API
     And the exception "errorClass" equals "Fatal error"

--- a/features/event_callbacks.feature
+++ b/features/event_callbacks.feature
@@ -54,7 +54,7 @@ Feature: Callbacks can access and modify event information
     And the event "unhandled" is false
 
   Scenario: An OnSend callback can overwrite information for an unhandled error
-    When I run "SwiftAssertion" and relaunch the app
+    When I run "SwiftAssertionScenario" and relaunch the app
     And I configure Bugsnag for "OnSendOverwriteScenario"
     And I wait to receive an error
     Then the error is valid for the error reporting API

--- a/features/fixtures/ios/iOSTestApp.xcodeproj/project.pbxproj
+++ b/features/fixtures/ios/iOSTestApp.xcodeproj/project.pbxproj
@@ -35,7 +35,7 @@
 		8A32DB8222424E3000EDD92F /* NSExceptionShiftScenario.m in Sources */ = {isa = PBXBuildFile; fileRef = 8A32DB8122424E3000EDD92F /* NSExceptionShiftScenario.m */; };
 		8A38C5D124094D7B00BC4463 /* DiscardedBreadcrumbTypeScenario.swift in Sources */ = {isa = PBXBuildFile; fileRef = 8A38C5D024094D7B00BC4463 /* DiscardedBreadcrumbTypeScenario.swift */; };
 		8A3B5F292407F66700CE4A3A /* ModifyBreadcrumbScenario.swift in Sources */ = {isa = PBXBuildFile; fileRef = 8A3B5F282407F66700CE4A3A /* ModifyBreadcrumbScenario.swift */; };
-		8A3B5F2B240807EE00CE4A3A /* ModifyBreadcrumbInNotify.swift in Sources */ = {isa = PBXBuildFile; fileRef = 8A3B5F2A240807EE00CE4A3A /* ModifyBreadcrumbInNotify.swift */; };
+		8A3B5F2B240807EE00CE4A3A /* ModifyBreadcrumbInNotifyScenario.swift in Sources */ = {isa = PBXBuildFile; fileRef = 8A3B5F2A240807EE00CE4A3A /* ModifyBreadcrumbInNotifyScenario.swift */; };
 		8A42FD35225DEE04007AE561 /* SessionOOMScenario.m in Sources */ = {isa = PBXBuildFile; fileRef = 8A42FD33225DEE04007AE561 /* SessionOOMScenario.m */; };
 		8A530CCC22FDDBF000F0C108 /* ManyConcurrentNotifyScenario.m in Sources */ = {isa = PBXBuildFile; fileRef = 8A530CCB22FDDBF000F0C108 /* ManyConcurrentNotifyScenario.m */; };
 		8A72A0382396574F00328051 /* CustomPluginNotifierDescriptionScenario.m in Sources */ = {isa = PBXBuildFile; fileRef = 8A72A0372396574F00328051 /* CustomPluginNotifierDescriptionScenario.m */; };
@@ -198,7 +198,7 @@
 		8A32DB8122424E3000EDD92F /* NSExceptionShiftScenario.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; path = NSExceptionShiftScenario.m; sourceTree = "<group>"; };
 		8A38C5D024094D7B00BC4463 /* DiscardedBreadcrumbTypeScenario.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = DiscardedBreadcrumbTypeScenario.swift; sourceTree = "<group>"; };
 		8A3B5F282407F66700CE4A3A /* ModifyBreadcrumbScenario.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ModifyBreadcrumbScenario.swift; sourceTree = "<group>"; };
-		8A3B5F2A240807EE00CE4A3A /* ModifyBreadcrumbInNotify.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ModifyBreadcrumbInNotify.swift; sourceTree = "<group>"; };
+		8A3B5F2A240807EE00CE4A3A /* ModifyBreadcrumbInNotifyScenario.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ModifyBreadcrumbInNotifyScenario.swift; sourceTree = "<group>"; };
 		8A42FD33225DEE04007AE561 /* SessionOOMScenario.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; path = SessionOOMScenario.m; sourceTree = "<group>"; };
 		8A42FD34225DEE04007AE561 /* SessionOOMScenario.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = SessionOOMScenario.h; sourceTree = "<group>"; };
 		8A530CCA22FDDBF000F0C108 /* ManyConcurrentNotifyScenario.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; path = ManyConcurrentNotifyScenario.h; sourceTree = "<group>"; };
@@ -534,7 +534,7 @@
 			isa = PBXGroup;
 			children = (
 				8A3B5F282407F66700CE4A3A /* ModifyBreadcrumbScenario.swift */,
-				8A3B5F2A240807EE00CE4A3A /* ModifyBreadcrumbInNotify.swift */,
+				8A3B5F2A240807EE00CE4A3A /* ModifyBreadcrumbInNotifyScenario.swift */,
 				8A38C5D024094D7B00BC4463 /* DiscardedBreadcrumbTypeScenario.swift */,
 				E7A324E5247E9D8D008B0052 /* BreadcrumbCallbackDiscardScenario.swift */,
 				E7A324E7247E9D9A008B0052 /* BreadcrumbCallbackOrderScenario.swift */,
@@ -946,7 +946,7 @@
 				E7FDB6C6264D5AD800BCF881 /* AutoNotifyFalseAbortScenario.swift in Sources */,
 				E7A324EA247E9DA5008B0052 /* BreadcrumbCallbackOverrideScenario.swift in Sources */,
 				F42955DB6D08642528917FAB /* CxxExceptionScenario.mm in Sources */,
-				8A3B5F2B240807EE00CE4A3A /* ModifyBreadcrumbInNotify.swift in Sources */,
+				8A3B5F2B240807EE00CE4A3A /* ModifyBreadcrumbInNotifyScenario.swift in Sources */,
 				CBB787912578FC0C0071BDE4 /* MarkUnhandledHandledScenario.m in Sources */,
 				8A32DB8222424E3000EDD92F /* NSExceptionShiftScenario.m in Sources */,
 				F42954B7318A02824C65C514 /* ObjCMsgSendScenario.m in Sources */,

--- a/features/fixtures/ios/iOSTestApp.xcodeproj/project.pbxproj
+++ b/features/fixtures/ios/iOSTestApp.xcodeproj/project.pbxproj
@@ -39,7 +39,7 @@
 		8A42FD35225DEE04007AE561 /* SessionOOMScenario.m in Sources */ = {isa = PBXBuildFile; fileRef = 8A42FD33225DEE04007AE561 /* SessionOOMScenario.m */; };
 		8A530CCC22FDDBF000F0C108 /* ManyConcurrentNotifyScenario.m in Sources */ = {isa = PBXBuildFile; fileRef = 8A530CCB22FDDBF000F0C108 /* ManyConcurrentNotifyScenario.m */; };
 		8A72A0382396574F00328051 /* CustomPluginNotifierDescriptionScenario.m in Sources */ = {isa = PBXBuildFile; fileRef = 8A72A0372396574F00328051 /* CustomPluginNotifierDescriptionScenario.m */; };
-		8A840FBA21AF5C450041DBFA /* SwiftAssertion.swift in Sources */ = {isa = PBXBuildFile; fileRef = 8A840FB921AF5C450041DBFA /* SwiftAssertion.swift */; };
+		8A840FBA21AF5C450041DBFA /* SwiftAssertionScenario.swift in Sources */ = {isa = PBXBuildFile; fileRef = 8A840FB921AF5C450041DBFA /* SwiftAssertionScenario.swift */; };
 		8A98400320FD11BF0023ECD1 /* AutoSessionCustomVersionScenario.m in Sources */ = {isa = PBXBuildFile; fileRef = 8A98400220FD11BF0023ECD1 /* AutoSessionCustomVersionScenario.m */; };
 		8AB1081923301FE600672818 /* ReleaseStageScenarios.swift in Sources */ = {isa = PBXBuildFile; fileRef = 8AB1081823301FE600672818 /* ReleaseStageScenarios.swift */; };
 		8AB65FCC22DC77CB001200AB /* LoadConfigFromFileScenario.swift in Sources */ = {isa = PBXBuildFile; fileRef = 8AB65FCB22DC77CB001200AB /* LoadConfigFromFileScenario.swift */; };
@@ -136,7 +136,7 @@
 		F42955E0916B8851F074D9B3 /* UserEmailScenario.swift in Sources */ = {isa = PBXBuildFile; fileRef = F4295F595986A279FA3BDEA7 /* UserEmailScenario.swift */; };
 		F429565A951303E2C3136D0D /* UserIdScenario.swift in Sources */ = {isa = PBXBuildFile; fileRef = F42957C58F98EECD3ADD84B2 /* UserIdScenario.swift */; };
 		F4295836C8AF75547C675E8D /* ReleasedObjectScenario.m in Sources */ = {isa = PBXBuildFile; fileRef = F4295E71D7B2DFE77057F3DA /* ReleasedObjectScenario.m */; };
-		F42958881D3F34A76CADE4EC /* SwiftCrash.swift in Sources */ = {isa = PBXBuildFile; fileRef = F4295EEDC00E5ED3C166DBF0 /* SwiftCrash.swift */; };
+		F42958881D3F34A76CADE4EC /* SwiftCrashScenario.swift in Sources */ = {isa = PBXBuildFile; fileRef = F4295EEDC00E5ED3C166DBF0 /* SwiftCrashScenario.swift */; };
 		F42958BE5DDACDBF653CA926 /* ManualSessionScenario.m in Sources */ = {isa = PBXBuildFile; fileRef = F429570EE7A751B53D011481 /* ManualSessionScenario.m */; };
 		F42959124DB949EEF1420957 /* ReadOnlyPageScenario.m in Sources */ = {isa = PBXBuildFile; fileRef = F4295871D1BCF211398CAEBA /* ReadOnlyPageScenario.m */; };
 		F4295968571A4118D6A4606A /* UserEnabledScenario.swift in Sources */ = {isa = PBXBuildFile; fileRef = F42954E2B3FF0C5C0474DA74 /* UserEnabledScenario.swift */; };
@@ -205,7 +205,7 @@
 		8A530CCB22FDDBF000F0C108 /* ManyConcurrentNotifyScenario.m */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.objc; path = ManyConcurrentNotifyScenario.m; sourceTree = "<group>"; };
 		8A72A0362396574F00328051 /* CustomPluginNotifierDescriptionScenario.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; path = CustomPluginNotifierDescriptionScenario.h; sourceTree = "<group>"; };
 		8A72A0372396574F00328051 /* CustomPluginNotifierDescriptionScenario.m */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.objc; path = CustomPluginNotifierDescriptionScenario.m; sourceTree = "<group>"; };
-		8A840FB921AF5C450041DBFA /* SwiftAssertion.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = SwiftAssertion.swift; sourceTree = "<group>"; };
+		8A840FB921AF5C450041DBFA /* SwiftAssertionScenario.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = SwiftAssertionScenario.swift; sourceTree = "<group>"; };
 		8A98400120FD11BF0023ECD1 /* AutoSessionCustomVersionScenario.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; path = AutoSessionCustomVersionScenario.h; sourceTree = "<group>"; };
 		8A98400220FD11BF0023ECD1 /* AutoSessionCustomVersionScenario.m */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.objc; path = AutoSessionCustomVersionScenario.m; sourceTree = "<group>"; };
 		8AB1081823301FE600672818 /* ReleaseStageScenarios.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = ReleaseStageScenarios.swift; sourceTree = "<group>"; };
@@ -357,7 +357,7 @@
 		F4295E71D7B2DFE77057F3DA /* ReleasedObjectScenario.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; path = ReleasedObjectScenario.m; sourceTree = "<group>"; };
 		F4295E86DC0BE9DC731B0D1C /* NullPointerScenario.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; path = NullPointerScenario.m; sourceTree = "<group>"; };
 		F4295EE3B0BD05E5FE513B20 /* AutoSessionScenario.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; path = AutoSessionScenario.m; sourceTree = "<group>"; };
-		F4295EEDC00E5ED3C166DBF0 /* SwiftCrash.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = SwiftCrash.swift; sourceTree = "<group>"; };
+		F4295EEDC00E5ED3C166DBF0 /* SwiftCrashScenario.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = SwiftCrashScenario.swift; sourceTree = "<group>"; };
 		F4295F13EBCAC9CB0ABC4008 /* NonExistentMethodScenario.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; path = NonExistentMethodScenario.m; sourceTree = "<group>"; };
 		F4295F22AA1863213F4A5F51 /* AutoSessionScenario.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = AutoSessionScenario.h; sourceTree = "<group>"; };
 		F4295F595986A279FA3BDEA7 /* UserEmailScenario.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = UserEmailScenario.swift; sourceTree = "<group>"; };
@@ -674,7 +674,7 @@
 				F4295E71D7B2DFE77057F3DA /* ReleasedObjectScenario.m */,
 				F42952BCC8A05EFAAE503E3D /* StackOverflowScenario.h */,
 				F4295493796EA93321E5CDDB /* StackOverflowScenario.m */,
-				F4295EEDC00E5ED3C166DBF0 /* SwiftCrash.swift */,
+				F4295EEDC00E5ED3C166DBF0 /* SwiftCrashScenario.swift */,
 				F4295A4EF5288C60F978676F /* UndefinedInstructionScenario.h */,
 				F429538D19421F28D8EB0446 /* UndefinedInstructionScenario.m */,
 			);
@@ -745,7 +745,7 @@
 			isa = PBXGroup;
 			children = (
 				8A32DB8022424E3000EDD92F /* NSExceptionShiftScenario.h */,
-				8A840FB921AF5C450041DBFA /* SwiftAssertion.swift */,
+				8A840FB921AF5C450041DBFA /* SwiftAssertionScenario.swift */,
 				F4295A364B3851D3811BC648 /* HandledErrorScenario.swift */,
 				F4295FA8EBBA645EECF7B483 /* HandledErrorOverrideScenario.swift */,
 				F429526319377A8848136413 /* HandledExceptionScenario.swift */,
@@ -942,7 +942,7 @@
 				F4295836C8AF75547C675E8D /* ReleasedObjectScenario.m in Sources */,
 				01E5EAD225B713990066EA8A /* OOMScenario.m in Sources */,
 				8A530CCC22FDDBF000F0C108 /* ManyConcurrentNotifyScenario.m in Sources */,
-				F42958881D3F34A76CADE4EC /* SwiftCrash.swift in Sources */,
+				F42958881D3F34A76CADE4EC /* SwiftCrashScenario.swift in Sources */,
 				E7FDB6C6264D5AD800BCF881 /* AutoNotifyFalseAbortScenario.swift in Sources */,
 				E7A324EA247E9DA5008B0052 /* BreadcrumbCallbackOverrideScenario.swift in Sources */,
 				F42955DB6D08642528917FAB /* CxxExceptionScenario.mm in Sources */,
@@ -958,7 +958,7 @@
 				E700EE6C247D793A008CFFB6 /* SIGPIPEScenario.m in Sources */,
 				E700EE50247D15DE008CFFB6 /* UserFromConfigSessionScenario.swift in Sources */,
 				A1117E552535A59100014FDA /* OOMLoadScenario.swift in Sources */,
-				8A840FBA21AF5C450041DBFA /* SwiftAssertion.swift in Sources */,
+				8A840FBA21AF5C450041DBFA /* SwiftAssertionScenario.swift in Sources */,
 				E753F24824927412001FB671 /* OnSendErrorCallbackCrashScenario.swift in Sources */,
 				01847DD626453D4E00ADA4C7 /* InvalidCrashReportScenario.m in Sources */,
 				001E5502243B8FDA0009E31D /* AutoCaptureRunScenario.m in Sources */,

--- a/features/fixtures/ios/iOSTestApp/Base.lproj/Main.storyboard
+++ b/features/fixtures/ios/iOSTestApp/Base.lproj/Main.storyboard
@@ -1,9 +1,9 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<document type="com.apple.InterfaceBuilder3.CocoaTouch.Storyboard.XIB" version="3.0" toolsVersion="16097" targetRuntime="iOS.CocoaTouch" propertyAccessControl="none" useAutolayout="YES" useTraitCollections="YES" useSafeAreas="YES" colorMatched="YES" initialViewController="BYZ-38-t0r">
+<document type="com.apple.InterfaceBuilder3.CocoaTouch.Storyboard.XIB" version="3.0" toolsVersion="19455" targetRuntime="iOS.CocoaTouch" propertyAccessControl="none" useAutolayout="YES" useTraitCollections="YES" useSafeAreas="YES" colorMatched="YES" initialViewController="BYZ-38-t0r">
     <device id="retina6_1" orientation="portrait" appearance="light"/>
     <dependencies>
         <deployment identifier="iOS"/>
-        <plugIn identifier="com.apple.InterfaceBuilder.IBCocoaTouchPlugin" version="16087"/>
+        <plugIn identifier="com.apple.InterfaceBuilder.IBCocoaTouchPlugin" version="19454"/>
         <capability name="Safe area layout guides" minToolsVersion="9.0"/>
         <capability name="documents saved in the Xcode 8 format" minToolsVersion="8.0"/>
     </dependencies>
@@ -35,7 +35,7 @@
                                 <fontDescription key="fontDescription" type="system" pointSize="14"/>
                                 <textInputTraits key="textInputTraits"/>
                             </textField>
-                            <button opaque="NO" contentMode="scaleToFill" contentHorizontalAlignment="center" contentVerticalAlignment="center" buttonType="roundedRect" lineBreakMode="middleTruncation" translatesAutoresizingMaskIntoConstraints="NO" id="Oym-db-43x">
+                            <button opaque="NO" contentMode="scaleToFill" contentHorizontalAlignment="center" contentVerticalAlignment="center" buttonType="system" lineBreakMode="middleTruncation" translatesAutoresizingMaskIntoConstraints="NO" id="Oym-db-43x">
                                 <rect key="frame" x="20" y="243" width="374" height="30"/>
                                 <accessibility key="accessibilityConfiguration" identifier="run_scenario"/>
                                 <state key="normal" title="Start Scenario"/>
@@ -43,7 +43,7 @@
                                     <action selector="runTestScenario" destination="BYZ-38-t0r" eventType="primaryActionTriggered" id="tlB-VZ-ZdP"/>
                                 </connections>
                             </button>
-                            <button opaque="NO" contentMode="scaleToFill" contentHorizontalAlignment="center" contentVerticalAlignment="center" buttonType="roundedRect" lineBreakMode="middleTruncation" translatesAutoresizingMaskIntoConstraints="NO" id="2z0-6z-4u6">
+                            <button opaque="NO" contentMode="scaleToFill" contentHorizontalAlignment="center" contentVerticalAlignment="center" buttonType="system" lineBreakMode="middleTruncation" translatesAutoresizingMaskIntoConstraints="NO" id="2z0-6z-4u6">
                                 <rect key="frame" x="20" y="293" width="374" height="30"/>
                                 <accessibility key="accessibilityConfiguration" identifier="start_bugsnag"/>
                                 <state key="normal" title="Start Bugsnag"/>
@@ -51,7 +51,7 @@
                                     <action selector="startBugsnag" destination="BYZ-38-t0r" eventType="primaryActionTriggered" id="Wv1-OW-OOt"/>
                                 </connections>
                             </button>
-                            <button opaque="NO" contentMode="scaleToFill" contentHorizontalAlignment="center" contentVerticalAlignment="center" buttonType="roundedRect" lineBreakMode="middleTruncation" translatesAutoresizingMaskIntoConstraints="NO" id="zEv-jB-Vej">
+                            <button opaque="NO" contentMode="scaleToFill" contentHorizontalAlignment="center" contentVerticalAlignment="center" buttonType="system" lineBreakMode="middleTruncation" translatesAutoresizingMaskIntoConstraints="NO" id="zEv-jB-Vej">
                                 <rect key="frame" x="20" y="343" width="374" height="30"/>
                                 <accessibility key="accessibilityConfiguration" identifier="clear_persistent_data"/>
                                 <state key="normal" title="Clear Persistent Data"/>
@@ -72,6 +72,7 @@
                                 <textInputTraits key="textInputTraits"/>
                             </textField>
                         </subviews>
+                        <viewLayoutGuide key="safeArea" id="41A-zo-0gw"/>
                         <color key="backgroundColor" white="1" alpha="1" colorSpace="custom" customColorSpace="genericGamma22GrayColorSpace"/>
                         <constraints>
                             <constraint firstItem="41A-zo-0gw" firstAttribute="trailing" secondItem="KtB-q4-GVd" secondAttribute="trailing" constant="20" id="0xf-jy-64A"/>
@@ -99,7 +100,6 @@
                             <constraint firstItem="IN4-CK-eEf" firstAttribute="leading" secondItem="41A-zo-0gw" secondAttribute="leading" constant="20" id="wJi-PV-dqy"/>
                             <constraint firstItem="RWZ-At-akB" firstAttribute="top" secondItem="41A-zo-0gw" secondAttribute="top" constant="50" id="zbP-F5-B9p"/>
                         </constraints>
-                        <viewLayoutGuide key="safeArea" id="41A-zo-0gw"/>
                     </view>
                     <connections>
                         <outlet property="apiKeyField" destination="KtB-q4-GVd" id="B66-s4-9bV"/>

--- a/features/fixtures/macos/macOSTestApp.xcodeproj/project.pbxproj
+++ b/features/fixtures/macos/macOSTestApp.xcodeproj/project.pbxproj
@@ -78,7 +78,7 @@
 		01F47CF5254B1B3100B184AD /* StoppedSessionScenario.swift in Sources */ = {isa = PBXBuildFile; fileRef = 01F47C74254B1B2E00B184AD /* StoppedSessionScenario.swift */; };
 		01F47CF6254B1B3100B184AD /* UserEmailScenario.swift in Sources */ = {isa = PBXBuildFile; fileRef = 01F47C75254B1B2E00B184AD /* UserEmailScenario.swift */; };
 		01F47CF7254B1B3100B184AD /* OnSendErrorCallbackCrashScenario.swift in Sources */ = {isa = PBXBuildFile; fileRef = 01F47C76254B1B2E00B184AD /* OnSendErrorCallbackCrashScenario.swift */; };
-		01F47CF8254B1B3100B184AD /* ModifyBreadcrumbInNotify.swift in Sources */ = {isa = PBXBuildFile; fileRef = 01F47C78254B1B2F00B184AD /* ModifyBreadcrumbInNotify.swift */; };
+		01F47CF8254B1B3100B184AD /* ModifyBreadcrumbInNotifyScenario.swift in Sources */ = {isa = PBXBuildFile; fileRef = 01F47C78254B1B2F00B184AD /* ModifyBreadcrumbInNotifyScenario.swift */; };
 		01F47CF9254B1B3100B184AD /* BreadcrumbCallbackDiscardScenario.swift in Sources */ = {isa = PBXBuildFile; fileRef = 01F47C79254B1B2F00B184AD /* BreadcrumbCallbackDiscardScenario.swift */; };
 		01F47CFA254B1B3100B184AD /* BreadcrumbCallbackOrderScenario.swift in Sources */ = {isa = PBXBuildFile; fileRef = 01F47C7A254B1B2F00B184AD /* BreadcrumbCallbackOrderScenario.swift */; };
 		01F47CFB254B1B3100B184AD /* ReleaseStageScenarios.swift in Sources */ = {isa = PBXBuildFile; fileRef = 01F47C7D254B1B2F00B184AD /* ReleaseStageScenarios.swift */; };
@@ -137,8 +137,8 @@
 		01F47D30254B1B3100B184AD /* AutoContextNSExceptionScenario.swift in Sources */ = {isa = PBXBuildFile; fileRef = 01F47CBF254B1B3000B184AD /* AutoContextNSExceptionScenario.swift */; };
 		01F47D31254B1B3100B184AD /* OverwriteLinkRegisterScenario.m in Sources */ = {isa = PBXBuildFile; fileRef = 01F47CC0254B1B3000B184AD /* OverwriteLinkRegisterScenario.m */; };
 		01F47D32254B1B3100B184AD /* ResumeSessionOOMScenario.m in Sources */ = {isa = PBXBuildFile; fileRef = 01F47CC1254B1B3000B184AD /* ResumeSessionOOMScenario.m */; };
-		AAFEF9EC26EB536D00980A10 /* NetworkBreadcrumbsScenario.swift in Sources */ = {isa = PBXBuildFile; fileRef = AAFEF9EB26EB536D00980A10 /* NetworkBreadcrumbsScenario.swift */; };
 		01FA9EC626D64FFF0059FF4A /* AppHangInTerminationScenario.swift in Sources */ = {isa = PBXBuildFile; fileRef = 01FA9EC526D64FFF0059FF4A /* AppHangInTerminationScenario.swift */; };
+		AAFEF9EC26EB536D00980A10 /* NetworkBreadcrumbsScenario.swift in Sources */ = {isa = PBXBuildFile; fileRef = AAFEF9EB26EB536D00980A10 /* NetworkBreadcrumbsScenario.swift */; };
 		CBB7878E2578FB3F0071BDE4 /* MarkUnhandledHandledScenario.m in Sources */ = {isa = PBXBuildFile; fileRef = CBB7878C2578FB3F0071BDE4 /* MarkUnhandledHandledScenario.m */; };
 		E780377D264D703500430C11 /* AutoNotifyReenabledScenario.swift in Sources */ = {isa = PBXBuildFile; fileRef = E7803779264D703500430C11 /* AutoNotifyReenabledScenario.swift */; };
 		E780377E264D703500430C11 /* AutoNotifyFalseHandledScenario.swift in Sources */ = {isa = PBXBuildFile; fileRef = E780377A264D703500430C11 /* AutoNotifyFalseHandledScenario.swift */; };
@@ -272,7 +272,7 @@
 		01F47C75254B1B2E00B184AD /* UserEmailScenario.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = UserEmailScenario.swift; sourceTree = "<group>"; };
 		01F47C76254B1B2E00B184AD /* OnSendErrorCallbackCrashScenario.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = OnSendErrorCallbackCrashScenario.swift; sourceTree = "<group>"; };
 		01F47C77254B1B2E00B184AD /* CustomPluginNotifierDescriptionScenario.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = CustomPluginNotifierDescriptionScenario.h; sourceTree = "<group>"; };
-		01F47C78254B1B2F00B184AD /* ModifyBreadcrumbInNotify.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = ModifyBreadcrumbInNotify.swift; sourceTree = "<group>"; };
+		01F47C78254B1B2F00B184AD /* ModifyBreadcrumbInNotifyScenario.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = ModifyBreadcrumbInNotifyScenario.swift; sourceTree = "<group>"; };
 		01F47C79254B1B2F00B184AD /* BreadcrumbCallbackDiscardScenario.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = BreadcrumbCallbackDiscardScenario.swift; sourceTree = "<group>"; };
 		01F47C7A254B1B2F00B184AD /* BreadcrumbCallbackOrderScenario.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = BreadcrumbCallbackOrderScenario.swift; sourceTree = "<group>"; };
 		01F47C7B254B1B2F00B184AD /* NSExceptionShiftScenario.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = NSExceptionShiftScenario.h; sourceTree = "<group>"; };
@@ -461,7 +461,7 @@
 				01F47C29254B1B2C00B184AD /* MetadataRedactionDefaultScenario.swift */,
 				01F47C80254B1B2F00B184AD /* MetadataRedactionNestedScenario.swift */,
 				01F47C58254B1B2E00B184AD /* MetadataRedactionRegexScenario.swift */,
-				01F47C78254B1B2F00B184AD /* ModifyBreadcrumbInNotify.swift */,
+				01F47C78254B1B2F00B184AD /* ModifyBreadcrumbInNotifyScenario.swift */,
 				01F47C87254B1B2F00B184AD /* ModifyBreadcrumbScenario.swift */,
 				01F47CA0254B1B3000B184AD /* NewSessionScenario.swift */,
 				01F47C24254B1B2C00B184AD /* NonExistentMethodScenario.h */,
@@ -843,7 +843,7 @@
 				01F47CFA254B1B3100B184AD /* BreadcrumbCallbackOrderScenario.swift in Sources */,
 				E780377D264D703500430C11 /* AutoNotifyReenabledScenario.swift in Sources */,
 				01F47CF3254B1B3100B184AD /* AutoCaptureRunScenario.m in Sources */,
-				01F47CF8254B1B3100B184AD /* ModifyBreadcrumbInNotify.swift in Sources */,
+				01F47CF8254B1B3100B184AD /* ModifyBreadcrumbInNotifyScenario.swift in Sources */,
 				01F47D14254B1B3100B184AD /* OOMEnabledErrorTypesScenario.swift in Sources */,
 				01F47CDA254B1B3100B184AD /* NonExistentMethodScenario.m in Sources */,
 				01F47CFE254B1B3100B184AD /* MetadataRedactionNestedScenario.swift in Sources */,

--- a/features/fixtures/macos/macOSTestApp.xcodeproj/project.pbxproj
+++ b/features/fixtures/macos/macOSTestApp.xcodeproj/project.pbxproj
@@ -56,7 +56,7 @@
 		01F47CDF254B1B3100B184AD /* AbortScenario.m in Sources */ = {isa = PBXBuildFile; fileRef = 01F47C54254B1B2E00B184AD /* AbortScenario.m */; };
 		01F47CE0254B1B3100B184AD /* HandledInternalNotifyScenario.swift in Sources */ = {isa = PBXBuildFile; fileRef = 01F47C55254B1B2E00B184AD /* HandledInternalNotifyScenario.swift */; };
 		01F47CE1254B1B3100B184AD /* ManualSessionWithUserScenario.m in Sources */ = {isa = PBXBuildFile; fileRef = 01F47C56254B1B2E00B184AD /* ManualSessionWithUserScenario.m */; };
-		01F47CE2254B1B3100B184AD /* SwiftCrash.swift in Sources */ = {isa = PBXBuildFile; fileRef = 01F47C57254B1B2E00B184AD /* SwiftCrash.swift */; };
+		01F47CE2254B1B3100B184AD /* SwiftCrashScenario.swift in Sources */ = {isa = PBXBuildFile; fileRef = 01F47C57254B1B2E00B184AD /* SwiftCrashScenario.swift */; };
 		01F47CE3254B1B3100B184AD /* MetadataRedactionRegexScenario.swift in Sources */ = {isa = PBXBuildFile; fileRef = 01F47C58254B1B2E00B184AD /* MetadataRedactionRegexScenario.swift */; };
 		01F47CE4254B1B3100B184AD /* AutoDetectFalseNSExceptionScenario.swift in Sources */ = {isa = PBXBuildFile; fileRef = 01F47C59254B1B2E00B184AD /* AutoDetectFalseNSExceptionScenario.swift */; };
 		01F47CE5254B1B3100B184AD /* AccessNonObjectScenario.m in Sources */ = {isa = PBXBuildFile; fileRef = 01F47C5B254B1B2E00B184AD /* AccessNonObjectScenario.m */; };
@@ -121,7 +121,7 @@
 		01F47D20254B1B3100B184AD /* ObjCMsgSendScenario.m in Sources */ = {isa = PBXBuildFile; fileRef = 01F47CAB254B1B3000B184AD /* ObjCMsgSendScenario.m */; };
 		01F47D21254B1B3100B184AD /* SIGFPEScenario.m in Sources */ = {isa = PBXBuildFile; fileRef = 01F47CAD254B1B3000B184AD /* SIGFPEScenario.m */; };
 		01F47D22254B1B3100B184AD /* BreadcrumbCallbackRemovalScenario.m in Sources */ = {isa = PBXBuildFile; fileRef = 01F47CAE254B1B3000B184AD /* BreadcrumbCallbackRemovalScenario.m */; };
-		01F47D23254B1B3100B184AD /* SwiftAssertion.swift in Sources */ = {isa = PBXBuildFile; fileRef = 01F47CAF254B1B3000B184AD /* SwiftAssertion.swift */; };
+		01F47D23254B1B3100B184AD /* SwiftAssertionScenario.swift in Sources */ = {isa = PBXBuildFile; fileRef = 01F47CAF254B1B3000B184AD /* SwiftAssertionScenario.swift */; };
 		01F47D24254B1B3100B184AD /* UserSessionOverrideScenario.swift in Sources */ = {isa = PBXBuildFile; fileRef = 01F47CB0254B1B3000B184AD /* UserSessionOverrideScenario.swift */; };
 		01F47D25254B1B3100B184AD /* AutoContextNSErrorScenario.swift in Sources */ = {isa = PBXBuildFile; fileRef = 01F47CB1254B1B3000B184AD /* AutoContextNSErrorScenario.swift */; };
 		01F47D26254B1B3100B184AD /* PrivilegedInstructionScenario.m in Sources */ = {isa = PBXBuildFile; fileRef = 01F47CB2254B1B3000B184AD /* PrivilegedInstructionScenario.m */; };
@@ -239,7 +239,7 @@
 		01F47C54254B1B2E00B184AD /* AbortScenario.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; path = AbortScenario.m; sourceTree = "<group>"; };
 		01F47C55254B1B2E00B184AD /* HandledInternalNotifyScenario.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = HandledInternalNotifyScenario.swift; sourceTree = "<group>"; };
 		01F47C56254B1B2E00B184AD /* ManualSessionWithUserScenario.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; path = ManualSessionWithUserScenario.m; sourceTree = "<group>"; };
-		01F47C57254B1B2E00B184AD /* SwiftCrash.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = SwiftCrash.swift; sourceTree = "<group>"; };
+		01F47C57254B1B2E00B184AD /* SwiftCrashScenario.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = SwiftCrashScenario.swift; sourceTree = "<group>"; };
 		01F47C58254B1B2E00B184AD /* MetadataRedactionRegexScenario.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = MetadataRedactionRegexScenario.swift; sourceTree = "<group>"; };
 		01F47C59254B1B2E00B184AD /* AutoDetectFalseNSExceptionScenario.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = AutoDetectFalseNSExceptionScenario.swift; sourceTree = "<group>"; };
 		01F47C5A254B1B2E00B184AD /* AutoSessionScenario.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = AutoSessionScenario.h; sourceTree = "<group>"; };
@@ -327,7 +327,7 @@
 		01F47CAC254B1B3000B184AD /* BugsnagHooks.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = BugsnagHooks.h; sourceTree = "<group>"; };
 		01F47CAD254B1B3000B184AD /* SIGFPEScenario.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; path = SIGFPEScenario.m; sourceTree = "<group>"; };
 		01F47CAE254B1B3000B184AD /* BreadcrumbCallbackRemovalScenario.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; path = BreadcrumbCallbackRemovalScenario.m; sourceTree = "<group>"; };
-		01F47CAF254B1B3000B184AD /* SwiftAssertion.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = SwiftAssertion.swift; sourceTree = "<group>"; };
+		01F47CAF254B1B3000B184AD /* SwiftAssertionScenario.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = SwiftAssertionScenario.swift; sourceTree = "<group>"; };
 		01F47CB0254B1B3000B184AD /* UserSessionOverrideScenario.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = UserSessionOverrideScenario.swift; sourceTree = "<group>"; };
 		01F47CB1254B1B3000B184AD /* AutoContextNSErrorScenario.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = AutoContextNSErrorScenario.swift; sourceTree = "<group>"; };
 		01F47CB2254B1B3000B184AD /* PrivilegedInstructionScenario.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; path = PrivilegedInstructionScenario.m; sourceTree = "<group>"; };
@@ -538,8 +538,8 @@
 				01F47C74254B1B2E00B184AD /* StoppedSessionScenario.swift */,
 				01F47C3F254B1B2D00B184AD /* StopSessionOOMScenario.h */,
 				01F47C51254B1B2D00B184AD /* StopSessionOOMScenario.m */,
-				01F47CAF254B1B3000B184AD /* SwiftAssertion.swift */,
-				01F47C57254B1B2E00B184AD /* SwiftCrash.swift */,
+				01F47CAF254B1B3000B184AD /* SwiftAssertionScenario.swift */,
+				01F47C57254B1B2E00B184AD /* SwiftCrashScenario.swift */,
 				011B7A4B26CD52080071C3EB /* ThermalStateBreadcrumbScenario.swift */,
 				01F47C22254B1B2C00B184AD /* ThreadScenarios.h */,
 				01F47CA4254B1B3000B184AD /* ThreadScenarios.m */,
@@ -746,7 +746,7 @@
 				01F47D27254B1B3100B184AD /* UserDisabledScenario.swift in Sources */,
 				01F47D0D254B1B3100B184AD /* LoadConfigFromFileScenario.swift in Sources */,
 				01F47CF5254B1B3100B184AD /* StoppedSessionScenario.swift in Sources */,
-				01F47D23254B1B3100B184AD /* SwiftAssertion.swift in Sources */,
+				01F47D23254B1B3100B184AD /* SwiftAssertionScenario.swift in Sources */,
 				01F47D0E254B1B3100B184AD /* UserIdScenario.swift in Sources */,
 				01F47D1C254B1B3100B184AD /* SessionCallbackRemovalScenario.m in Sources */,
 				01F47CE3254B1B3100B184AD /* MetadataRedactionRegexScenario.swift in Sources */,
@@ -761,7 +761,7 @@
 				01F47CED254B1B3100B184AD /* ResumedSessionScenario.swift in Sources */,
 				01F47CE8254B1B3100B184AD /* AppAndDeviceAttributesScenario.swift in Sources */,
 				01F47D1A254B1B3100B184AD /* ThreadScenarios.m in Sources */,
-				01F47CE2254B1B3100B184AD /* SwiftCrash.swift in Sources */,
+				01F47CE2254B1B3100B184AD /* SwiftCrashScenario.swift in Sources */,
 				01F47CE9254B1B3100B184AD /* SIGTRAPScenario.m in Sources */,
 				01F47CC8254B1B3100B184AD /* AutoSessionScenario.m in Sources */,
 				01E0DB0625E8E95700A740ED /* AppDurationScenario.swift in Sources */,

--- a/features/fixtures/shared/scenarios/AppAndDeviceAttributesScenario.swift
+++ b/features/fixtures/shared/scenarios/AppAndDeviceAttributesScenario.swift
@@ -30,32 +30,32 @@ class AppAndDeviceAttributesScenario: Scenario {
 /**
  * Override default values in config
  */
-class AppAndDeviceAttributesScenarioConfigOverride: Scenario {
+class AppAndDeviceAttributesConfigOverrideScenario: Scenario {
 
     override func startBugsnag() {
         self.config.autoTrackSessions = false
-        
+
         self.config.appType = "iLeet"
         self.config.bundleVersion = "12345"
         self.config.context = "myContext"
         self.config.releaseStage = "secondStage"
-        
+
         super.startBugsnag()
     }
 
     override func run() {
-        let error = NSError(domain: "AppAndDeviceAttributesScenarioConfigOverride", code: 100, userInfo: nil)
+        let error = NSError(domain: "AppAndDeviceAttributesConfigOverrideScenario", code: 100, userInfo: nil)
         Bugsnag.notifyError(error)
     }
 }
 
 // MARK: -
 
-class AppAndDeviceAttributesScenarioCallbackOverride: Scenario {
+class AppAndDeviceAttributesCallbackOverrideScenario: Scenario {
 
     override func startBugsnag() {
         self.config.autoTrackSessions = false
-        
+
         self.config.addOnSendError { (event) -> Bool in
             event.app.type = "newAppType"
             event.app.releaseStage = "thirdStage"
@@ -63,15 +63,15 @@ class AppAndDeviceAttributesScenarioCallbackOverride: Scenario {
             event.app.bundleVersion = "42"
             event.device.manufacturer = "Nokia"
             event.device.modelNumber = "0898"
-            
+
             return true
         }
-        
+
         super.startBugsnag()
     }
 
     override func run() {
-        let error = NSError(domain: "AppAndDeviceAttributesScenarioCallbackOverride", code: 100, userInfo: nil)
+        let error = NSError(domain: "AppAndDeviceAttributesCallbackOverrideScenario", code: 100, userInfo: nil)
         Bugsnag.notifyError(error)
     }
 }
@@ -81,7 +81,7 @@ class AppAndDeviceAttributesScenarioCallbackOverride: Scenario {
 /**
  * Call startWithApiKey
  */
-class AppAndDeviceAttributesScenarioStartWithApiKey: Scenario {
+class AppAndDeviceAttributesStartWithApiKeyScenario: Scenario {
 
     override func startBugsnag() {
         Bugsnag.start(withApiKey: "12312312312312312312312312312312")
@@ -90,7 +90,7 @@ class AppAndDeviceAttributesScenarioStartWithApiKey: Scenario {
     }
 
     override func run() {
-        let error = NSError(domain: "AppAndDeviceAttributesScenarioStartWithApiKey", code: 100, userInfo: nil)
+        let error = NSError(domain: "AppAndDeviceAttributesStartWithApiKeyScenario", code: 100, userInfo: nil)
         Bugsnag.notifyError(error)
     }
 }
@@ -98,13 +98,13 @@ class AppAndDeviceAttributesScenarioStartWithApiKey: Scenario {
 // MARK: -
 
 class AppAndDeviceAttributesInfiniteLaunchDurationScenario: Scenario {
-    
+
     override func startBugsnag() {
         config.autoTrackSessions = false
         config.launchDurationMillis = 0
         super.startBugsnag()
     }
-    
+
     override func run() {
         after(.seconds(6)) {
             Bugsnag.notify(NSException(name: .genericException, reason: "isLaunching should be true if `launchDurationMillis` is 0"))
@@ -115,12 +115,12 @@ class AppAndDeviceAttributesInfiniteLaunchDurationScenario: Scenario {
 // MARK: -
 
 class AppAndDeviceAttributesUnhandledExceptionDuringLaunchScenario: Scenario {
-    
+
     override func startBugsnag() {
         config.autoTrackSessions = false
         super.startBugsnag()
     }
-    
+
     override func run() {
         NSException(name: .genericException, reason: "isLaunching should be true").raise()
     }
@@ -129,12 +129,12 @@ class AppAndDeviceAttributesUnhandledExceptionDuringLaunchScenario: Scenario {
 // MARK: -
 
 class AppAndDeviceAttributesUnhandledExceptionAfterLaunchScenario: Scenario {
-    
+
     override func startBugsnag() {
         config.autoTrackSessions = false
         super.startBugsnag()
     }
-    
+
     override func run() {
         Bugsnag.markLaunchCompleted()
         NSException(name: .genericException, reason: "isLaunching should be false after `Bugsnag.markLaunchCompleted()`").raise()

--- a/features/fixtures/shared/scenarios/ModifyBreadcrumbInNotifyScenario.swift
+++ b/features/fixtures/shared/scenarios/ModifyBreadcrumbInNotifyScenario.swift
@@ -1,6 +1,6 @@
 import Foundation
 
-class ModifyBreadcrumbInNotify: Scenario {
+class ModifyBreadcrumbInNotifyScenario: Scenario {
 
     override func startBugsnag() {
         self.config.autoTrackSessions = false;

--- a/features/fixtures/shared/scenarios/ReleaseStageScenarios.swift
+++ b/features/fixtures/shared/scenarios/ReleaseStageScenarios.swift
@@ -2,7 +2,7 @@ import Foundation
 
 class MagicError : NSError {}
 
-class HandledErrorValidReleaseStage : Scenario {
+class HandledErrorValidReleaseStageScenario : Scenario {
 
     override func startBugsnag() {
         self.config.autoTrackSessions = false;
@@ -18,7 +18,7 @@ class HandledErrorValidReleaseStage : Scenario {
     }
 }
 
-class UnhandledErrorValidReleaseStage : Scenario {
+class UnhandledErrorValidReleaseStageScenario : Scenario {
 
     override func startBugsnag() {
         self.config.autoTrackSessions = false;
@@ -32,7 +32,7 @@ class UnhandledErrorValidReleaseStage : Scenario {
     }
 }
 
-class UnhandledErrorChangeValidReleaseStage : Scenario {
+class UnhandledErrorChangeValidReleaseStageScenario : Scenario {
 
     override func startBugsnag() {
         self.config.autoTrackSessions = false;
@@ -52,7 +52,7 @@ class UnhandledErrorChangeValidReleaseStage : Scenario {
     }
 }
 
-class UnhandledErrorChangeInvalidReleaseStage : Scenario {
+class UnhandledErrorChangeInvalidReleaseStageScenario : Scenario {
 
     override func startBugsnag() {
         self.config.autoTrackSessions = false;
@@ -72,7 +72,7 @@ class UnhandledErrorChangeInvalidReleaseStage : Scenario {
     }
 }
 
-class HandledErrorInvalidReleaseStage : Scenario {
+class HandledErrorInvalidReleaseStageScenario : Scenario {
 
     override func startBugsnag() {
         self.config.autoTrackSessions = false;
@@ -88,7 +88,7 @@ class HandledErrorInvalidReleaseStage : Scenario {
     }
 }
 
-class UnhandledErrorInvalidReleaseStage : Scenario {
+class UnhandledErrorInvalidReleaseStageScenario : Scenario {
 
     override func startBugsnag() {
         self.config.autoTrackSessions = false;

--- a/features/fixtures/shared/scenarios/Scenario.m
+++ b/features/fixtures/shared/scenarios/Scenario.m
@@ -32,7 +32,9 @@ static char ksLogPath[PATH_MAX];
 
 + (Scenario *)createScenarioNamed:(NSString *)className
                        withConfig:(BugsnagConfiguration *)config {
-    Class clz = NSClassFromString(className);
+
+    NSString *fullClassName = [NSString stringWithFormat:@"%@Scenario", className];
+    Class clz = NSClassFromString(fullClassName);
 
 #if TARGET_OS_IPHONE
     NSString *swiftPrefix = @"iOSTestApp.";
@@ -48,7 +50,7 @@ static char ksLogPath[PATH_MAX];
             if ([name hasPrefix:swiftPrefix]) {
                 name = [name substringFromIndex:swiftPrefix.length];
             }
-            if ([name caseInsensitiveCompare:className] == NSOrderedSame) {
+            if ([name caseInsensitiveCompare:fullClassName] == NSOrderedSame) {
                 clz = classes[i];
                 break;
             }
@@ -57,12 +59,12 @@ static char ksLogPath[PATH_MAX];
     }
 
     if (!clz) {
-        [NSException raise:NSInvalidArgumentException format:@"Failed to find scenario class named %@", className];
+        [NSException raise:NSInvalidArgumentException format:@"Failed to find scenario class named %@", fullClassName];
     }
 
     id obj = [clz alloc];
 
-    NSAssert([obj isKindOfClass:[Scenario class]], @"Class '%@' is not a subclass of Scenario", className);
+    NSAssert([obj isKindOfClass:[Scenario class]], @"Class '%@' is not a subclass of Scenario", fullClassName);
 
     theScenario = obj;
 

--- a/features/fixtures/shared/scenarios/SwiftAssertionScenario.swift
+++ b/features/fixtures/shared/scenarios/SwiftAssertionScenario.swift
@@ -1,6 +1,6 @@
 import Foundation
 
-class SwiftAssertion: Scenario {
+class SwiftAssertionScenario: Scenario {
     override func startBugsnag() {
       self.config.autoTrackSessions = false;
       super.startBugsnag()

--- a/features/fixtures/shared/scenarios/SwiftCrashScenario.swift
+++ b/features/fixtures/shared/scenarios/SwiftCrashScenario.swift
@@ -29,7 +29,7 @@ import Foundation
 /**
  * Trigger a crash from inside a Swift method.
  */
-class SwiftCrash: Scenario {
+class SwiftCrashScenario: Scenario {
     override func startBugsnag() {
       self.config.autoTrackSessions = false;
       super.startBugsnag()

--- a/features/release_stage_errors.feature
+++ b/features/release_stage_errors.feature
@@ -4,13 +4,13 @@ Feature: Discarding reports based on release stage
     Given I clear all persistent data
 
   Scenario: Unhandled error ignored when release stage is not present in enabledReleaseStages
-    When I run "UnhandledErrorInvalidReleaseStage" and relaunch the app
-    And I configure Bugsnag for "UnhandledErrorInvalidReleaseStage"
+    When I run "UnhandledErrorInvalidReleaseStageScenario" and relaunch the app
+    And I configure Bugsnag for "UnhandledErrorInvalidReleaseStageScenario"
     Then I should receive no requests
 
   Scenario: Unhandled error captured when release stage is present in enabledReleaseStages
-    When I run "UnhandledErrorValidReleaseStage" and relaunch the app
-    And I configure Bugsnag for "UnhandledErrorValidReleaseStage"
+    When I run "UnhandledErrorValidReleaseStageScenario" and relaunch the app
+    And I configure Bugsnag for "UnhandledErrorValidReleaseStageScenario"
     And I wait to receive an error
     Then the error is valid for the error reporting API
     And the exception "errorClass" equals "SIGABRT"
@@ -24,13 +24,13 @@ Feature: Discarding reports based on release stage
   if the app is used as a test harness or if the build can receive code updates,
   such as JavaScript execution contexts.
 
-    When I run "UnhandledErrorChangeInvalidReleaseStage" and relaunch the app
-    And I configure Bugsnag for "UnhandledErrorChangeInvalidReleaseStage"
+    When I run "UnhandledErrorChangeInvalidReleaseStageScenario" and relaunch the app
+    And I configure Bugsnag for "UnhandledErrorChangeInvalidReleaseStageScenario"
     Then I should receive no requests
 
   Scenario: Crash when release stage is changed to be present in enabledReleaseStages before the event
-    When I run "UnhandledErrorChangeValidReleaseStage" and relaunch the app
-    And I configure Bugsnag for "UnhandledErrorChangeValidReleaseStage"
+    When I run "UnhandledErrorChangeValidReleaseStageScenario" and relaunch the app
+    And I configure Bugsnag for "UnhandledErrorChangeValidReleaseStageScenario"
     And I wait to receive an error
     Then the error is valid for the error reporting API
     And the exception "errorClass" equals "SIGABRT"
@@ -38,11 +38,11 @@ Feature: Discarding reports based on release stage
     And the event "app.releaseStage" equals "prod"
 
   Scenario: Handled error when release stage is not present in enabledReleaseStages
-    When I run "HandledErrorInvalidReleaseStage"
+    When I run "HandledErrorInvalidReleaseStageScenario"
     Then I should receive no requests
 
   Scenario: Handled error when release stage is present in enabledReleaseStages
-    When I run "HandledErrorValidReleaseStage"
+    When I run "HandledErrorValidReleaseStageScenario"
     And I wait to receive an error
     Then the error is valid for the error reporting API
     And the exception "errorClass" equals the platform-dependent string:

--- a/features/steps/cocoa_steps.rb
+++ b/features/steps/cocoa_steps.rb
@@ -1,6 +1,13 @@
+def short_scenario_name(scenario)
+  unless scenario.end_with? 'Scenario'
+    raise 'All scenario names must end with "Scenario".  There are removed by the test harness and re-added uniformly by the test fixture.'
+  end
+  scenario.delete_suffix 'Scenario'
+end
+
 When('I run {string}') do |event_type|
   steps %(
-    When I send the keys "#{event_type}" to the element "scenario_name"
+    When I send the keys "#{short_scenario_name event_type}" to the element "scenario_name"
     And I click the element "run_scenario"
   )
 end
@@ -50,7 +57,7 @@ end
 
 When('I configure Bugsnag for {string}') do |event_type|
   steps %(
-    When I send the keys "#{event_type}" to the element "scenario_name"
+    When I send the keys "#{short_scenario_name event_type}" to the element "scenario_name"
     And I click the element "start_bugsnag"
   )
 end


### PR DESCRIPTION
## Goal

Save time in e2e test runs by reducing the number of characters that need to be sent to the `scenario_name` field.

## Design

All scenario class/file names have first been made to consistently end in "Scenario".  The suffix is stripped by the relevant Cucumber steps and re-added by the test fixture.  This saves approx 2 seconds on each entry, adding up to over 8 minutes over the whole run.

## Testing

Covered by a `[quick ci]` run, which exercises the entire test suite on both iOS and macOS.