### PR TITLE
[PLAT-7722] Include free disk space in crash reports

### DIFF
--- a/Bugsnag/KSCrash/Source/KSCrash/Recording/BSG_KSCrashReport.c
+++ b/Bugsnag/KSCrash/Source/KSCrash/Recording/BSG_KSCrashReport.c
@@ -622,7 +622,9 @@ void bsg_kscrw_i_writeTraceInfo(const BSG_KSCrash_Context *crashContext,
 
 bool bsg_kscrw_i_exceedsBufferLen(const size_t length);
 
-void bsg_kscrashreport_writeKSCrashFields(BSG_KSCrash_Context *crashContext, BSG_KSCrashReportWriter *writer);
+void bsg_kscrashreport_writeKSCrashFields(BSG_KSCrash_Context *crashContext,
+                                          BSG_KSCrashReportWriter *writer,
+                                          const char *const path);
 
 /** Write the contents of a memory location.
  * Also writes meta information about the data.
@@ -1164,6 +1166,21 @@ void bsg_kscrw_i_writeMemoryInfo(const BSG_KSCrashReportWriter *const writer,
     writer->endContainer(writer);
 }
 
+void bsg_kscrw_i_writeDiskInfo(const BSG_KSCrashReportWriter *const writer,
+                               const char *const key,
+                               const char *const path) {
+    uint64_t freeDisk, size;
+    if (!bsg_ksfuStatfs(path, &freeDisk, &size)) {
+        return;
+    }
+    writer->beginObject(writer, key);
+    {
+        bsg_kscrw_i_addUIntegerElement(writer, BSG_KSCrashField_Free, freeDisk);
+        bsg_kscrw_i_addUIntegerElement(writer, BSG_KSCrashField_Size, size);
+    }
+    writer->endContainer(writer);
+}
+
 /** Write information about the error leading to the crash to the report.
  *
  * @param writer The writer.
@@ -1547,7 +1564,7 @@ void bsg_kscrashreport_writeStandardReport(
                 writer, BSG_KSCrashField_Report, BSG_KSCrashReportType_Standard,
                 crashContext->config.crashID, crashContext->config.processName);
 
-        bsg_kscrashreport_writeKSCrashFields(crashContext, writer);
+        bsg_kscrashreport_writeKSCrashFields(crashContext, writer, path);
 
         if (crashContext->config.onCrashNotify != NULL) {
             // NOTE: The deny list for BSG_KSCrashField_UserAtCrash children in BugsnagEvent.m
@@ -1566,7 +1583,10 @@ void bsg_kscrashreport_writeStandardReport(
     close(fd);
 }
 
-void bsg_kscrashreport_writeKSCrashFields(BSG_KSCrash_Context *crashContext, BSG_KSCrashReportWriter *writer) {
+void bsg_kscrashreport_writeKSCrashFields(BSG_KSCrash_Context *crashContext,
+                                          BSG_KSCrashReportWriter *writer,
+                                          const char *const path) {
+
     bsg_kscrw_i_writeProcessState(writer, BSG_KSCrashField_ProcessState);
 
     if (crashContext->config.systemInfoJSON != NULL) {
@@ -1579,6 +1599,7 @@ void bsg_kscrashreport_writeKSCrashFields(BSG_KSCrash_Context *crashContext, BSG
         bsg_kscrw_i_writeMemoryInfo(writer, BSG_KSCrashField_Memory);
         bsg_kscrw_i_writeAppStats(writer, BSG_KSCrashField_AppStats,
                 &crashContext->state);
+        bsg_kscrw_i_writeDiskInfo(writer, BSG_KSCrashField_Disk, path);
     }
     writer->endContainer(writer);
 

--- a/Bugsnag/KSCrash/Source/KSCrash/Recording/BSG_KSCrashReportFields.h
+++ b/Bugsnag/KSCrash/Source/KSCrash/Recording/BSG_KSCrashReportFields.h
@@ -114,6 +114,7 @@
 #pragma mark - Memory -
 
 #define BSG_KSCrashField_Free "free"
+#define BSG_KSCrashField_Size "size"
 #define BSG_KSCrashField_Usable "usable"
 
 #pragma mark - Error -
@@ -170,6 +171,7 @@
 #pragma mark Standard
 #define BSG_KSCrashField_AppStats "application_stats"
 #define BSG_KSCrashField_BinaryImages "binary_images"
+#define BSG_KSCrashField_Disk "disk"
 #define BSG_KSCrashField_SystemAtCrash "system_atcrash"
 #define BSG_KSCrashField_System "system"
 #define BSG_KSCrashField_Memory "memory"

--- a/Bugsnag/KSCrash/Source/KSCrash/Recording/BSG_KSSystemInfo.h
+++ b/Bugsnag/KSCrash/Source/KSCrash/Recording/BSG_KSSystemInfo.h
@@ -34,6 +34,7 @@
 #define BSG_KSSystemField_BundleVersion "CFBundleVersion"
 #define BSG_KSSystemField_CPUArch "cpu_arch"
 #define BSG_KSSystemField_DeviceAppHash "device_app_hash"
+#define BSG_KSSystemField_Disk "disk"
 #define BSG_KSSystemField_Jailbroken "jailbroken"
 #define BSG_KSSystemField_Machine "machine"
 #define BSG_KSSystemField_Memory "memory"

--- a/Bugsnag/KSCrash/Source/KSCrash/Recording/BSG_KSSystemInfo.m
+++ b/Bugsnag/KSCrash/Source/KSCrash/Recording/BSG_KSSystemInfo.m
@@ -29,6 +29,7 @@
 #import "BSG_KSSystemInfo.h"
 #import "BSG_KSSystemInfoC.h"
 #import "BSG_KSMachHeaders.h"
+#import "BSG_KSFileUtils.h"
 #import "BSG_KSJSONCodecObjC.h"
 #import "BSG_KSMach.h"
 #import "BSG_KSSysCtl.h"
@@ -431,6 +432,19 @@ static NSDictionary * bsg_systemversion() {
         @BSG_KSCrashField_Usable: @(bsg_ksmachusableMemory()),
         @BSG_KSSystemField_Size: [self int64Sysctl:@"hw.memsize"]
     };
+
+    NSString *dir = NSSearchPathForDirectoriesInDomains(
+        NSCachesDirectory, NSUserDomainMask, YES).firstObject;
+    const char *path = dir.fileSystemRepresentation;
+    if (path) {
+        uint64_t dfree, size;
+        if (bsg_ksfuStatfs(path, &dfree, &size)) {
+            sysInfo[@BSG_KSSystemField_Disk] = @{
+                @ BSG_KSCrashField_Free: @(dfree),
+                @ BSG_KSCrashField_Size: @(size)
+            };
+        }
+    }
 
     NSDictionary *statsInfo = [[BSG_KSCrash sharedInstance] captureAppStats];
     sysInfo[@BSG_KSCrashField_AppStats] = statsInfo;

--- a/Bugsnag/KSCrash/Source/KSCrash/Recording/Tools/BSG_KSFileUtils.c
+++ b/Bugsnag/KSCrash/Source/KSCrash/Recording/Tools/BSG_KSFileUtils.c
@@ -31,6 +31,7 @@
 
 #include <errno.h>
 #include <string.h>
+#include <sys/mount.h>
 #include <unistd.h>
 
 const char *bsg_ksfulastPathEntry(const char *const path) {
@@ -79,5 +80,15 @@ bool bsg_ksfuwriteBytesToFD(const int fd, const char *const bytes,
       }
     }
 
+    return true;
+}
+
+bool bsg_ksfuStatfs(const char *path, uint64_t *free, uint64_t *total) {
+    struct statfs st;
+    if (statfs(path, &st) != 0) {
+        return false;
+    }
+    *free = st.f_bsize * st.f_bavail;
+    *total = st.f_bsize * st.f_blocks;
     return true;
 }

--- a/Bugsnag/KSCrash/Source/KSCrash/Recording/Tools/BSG_KSFileUtils.h
+++ b/Bugsnag/KSCrash/Source/KSCrash/Recording/Tools/BSG_KSFileUtils.h
@@ -64,6 +64,18 @@ bool bsg_ksfuwriteBytesToFD(const int fd, const char *bytes, ssize_t length);
  */
 bool bsg_ksfuflushWriteBuffer(const int fd);
 
+/**
+ * Get file system statistics.
+ *
+ * @param path  The path name of any file or directory within the file system.
+ * @param free  A pointer to where the number of free bytes availalable to a
+ *              non-superuser (corresponding to NSFileSystemFreeSize) should be
+ *              written.
+ * @param total A pointer to where the total number of bytes in the file system
+ *              should be written.
+ */
+bool bsg_ksfuStatfs(const char *path, uint64_t *free, uint64_t *total);
+
 #ifdef __cplusplus
 }
 #endif

--- a/Bugsnag/Payload/BugsnagDeviceWithState+Private.h
+++ b/Bugsnag/Payload/BugsnagDeviceWithState+Private.h
@@ -26,8 +26,6 @@ NS_ASSUME_NONNULL_BEGIN
 
 @end
 
-NSNumber *BSGDeviceFreeSpace(NSSearchPathDirectory directory);
-
 NSMutableDictionary *BSGParseDeviceMetadata(NSDictionary *event);
 
 NS_ASSUME_NONNULL_END

--- a/Bugsnag/Payload/BugsnagDeviceWithState.m
+++ b/Bugsnag/Payload/BugsnagDeviceWithState.m
@@ -35,26 +35,6 @@ NSMutableDictionary *BSGParseDeviceMetadata(NSDictionary *event) {
     return device;
 }
 
-/**
- * Calculates the amount of free disk space on the device in bytes, for a given directory.
- * @param directory the directory whose disk space should be queried
- * @return free space in the number of bytes, or nil if this information could not be found
- */
-NSNumber *BSGDeviceFreeSpace(NSSearchPathDirectory directory) {
-    NSFileManager *fileManager = [NSFileManager defaultManager];
-    NSArray *searchPaths = NSSearchPathForDirectoriesInDomains(directory, NSUserDomainMask, true);
-    NSString *path = [searchPaths lastObject];
-
-    NSError *error;
-    NSDictionary *fileSystemAttrs =
-            [fileManager attributesOfFileSystemForPath:path error:&error];
-
-    if (!fileSystemAttrs) {
-        bsg_log_warn(@"Failed to read free disk space: %@", error);
-    }
-    return fileSystemAttrs[NSFileSystemFreeSize];
-}
-
 @implementation BugsnagDeviceWithState
 
 + (BugsnagDeviceWithState *) deviceFromJson:(NSDictionary *)json {
@@ -89,7 +69,7 @@ NSNumber *BSGDeviceFreeSpace(NSSearchPathDirectory directory) {
     [self populateFields:device dictionary:event];
     device.orientation = [event valueForKeyPath:@"user.state.deviceState.orientation"];
     device.freeMemory = [event valueForKeyPath:@"system." BSG_KSSystemField_Memory "." BSG_KSCrashField_Free];
-    device.freeDisk = BSGDeviceFreeSpace(NSCachesDirectory);
+    device.freeDisk = [event valueForKeyPath:@"system." BSG_KSSystemField_Disk "." BSG_KSCrashField_Free];
 
     NSString *val = [event valueForKeyPath:@"report.timestamp"];
 

--- a/Tests/BugsnagTests/BugsnagDeviceTest.m
+++ b/Tests/BugsnagTests/BugsnagDeviceTest.m
@@ -33,6 +33,9 @@
                             @"usable": @15065522176,
                             @"free": @742920192
                     },
+                    @"disk": @{
+                        @"free": @1234567
+                    },
                     @"device_app_hash": @"123"
             },
             @"report": @{
@@ -157,18 +160,6 @@
     formatter.dateFormat = @"yyyy'-'MM'-'dd'T'HH':'mm':'ssZZZ";
     formatter.timeZone = [NSTimeZone timeZoneForSecondsFromGMT:0];
     XCTAssertEqualObjects([formatter dateFromString:@"2014-12-02T01:56:13Z"], device.time);
-}
-
-- (void)testDeviceFreeSpaceShouldBeLargeNumber {
-    NSNumber *freeBytes = BSGDeviceFreeSpace(NSCachesDirectory);
-    XCTAssertNotNil(freeBytes, @"expect a valid number for successful call to retrieve free space");
-    XCTAssertGreaterThan([freeBytes integerValue], 1000, @"expect at least 1k of free space on test device");
-}
-
-- (void)testDeviceFreeSpaceShouldBeNilWhenFailsToRetrieveIt {
-    NSSearchPathDirectory notAccessibleDirectory = NSAdminApplicationDirectory;
-    NSNumber *freeBytes = BSGDeviceFreeSpace(notAccessibleDirectory);
-    XCTAssertNil(freeBytes, @"expect nil when fails to retrieve free space for the directory");
 }
 
 - (void)testDeviceRuntimeInfoAppended {


### PR DESCRIPTION
## Goal

Make `device.freeDisk` accurate for crashes.

Currently crash errors report the disk space available at the time of sending.

## Changeset

* Adds low-level function to retrieve and calculate the equivalent of `NSFileSystemFreeSize`.
* Adds disk usage stats to `BSG_KSSystemInfo` - this gets used for handled errors.
* Adds disk usage stats to crash reports.

#### Async safety

This PR adds a call to `fstat()` in the crash handler.

This function is not documented as being async-safe but should be by virtue of being [implemented as a syscall](https://github.com/apple-oss-distributions/xnu/blob/main/bsd/vfs/vfs_syscalls.c#L3031-L3078).


## Testing

Manually verified that the calculated free space matches `NSFileSystemFreeSize`.

E2E tests verify that `freeDisk` is present in all types of error.