### PR TITLE
Relaunch crashed app once Appium says it is not running

### DIFF
--- a/features/app_and_device_attributes.feature
+++ b/features/app_and_device_attributes.feature
@@ -115,13 +115,13 @@ Feature: App and Device attributes present
     And the event "app.isLaunching" is true
 
   Scenario: isLaunching is true for unhandled exception during launch
-    When I run "AppAndDeviceAttributesUnhandledExceptionDuringLaunchScenario" and relaunch the app
+    When I run "AppAndDeviceAttributesUnhandledExceptionDuringLaunchScenario" and relaunch the crashed app
     And I configure Bugsnag for "AppAndDeviceAttributesUnhandledExceptionDuringLaunchScenario"
     And I wait to receive an error
     And the event "app.isLaunching" is true
 
   Scenario: isLaunching is false for unhandled exception after launch
-    When I run "AppAndDeviceAttributesUnhandledExceptionAfterLaunchScenario" and relaunch the app
+    When I run "AppAndDeviceAttributesUnhandledExceptionAfterLaunchScenario" and relaunch the crashed app
     And I configure Bugsnag for "AppAndDeviceAttributesUnhandledExceptionAfterLaunchScenario"
     And I wait to receive an error
     And the event "app.isLaunching" is false

--- a/features/app_hangs.feature
+++ b/features/app_hangs.feature
@@ -156,9 +156,7 @@ Feature: App hangs
     And the exception "message" equals "The app's main thread failed to respond to an event within 2000 milliseconds"
 
   Scenario: App hangs that occur during app termination should be non-fatal
-    Given I run "AppHangInTerminationScenario"
-    And the app is not running
-    And I relaunch the app
+    Given I run "AppHangInTerminationScenario" and relaunch the crashed app
     And I configure Bugsnag for "AppHangInTerminationScenario"
     Then I wait to receive an error
     And the event "severity" equals "warning"

--- a/features/auto_detect_errors.feature
+++ b/features/auto_detect_errors.feature
@@ -13,7 +13,7 @@ Feature: autoDetectErrors flag controls whether errors are captured automaticall
         And the event "unhandled" is false
         And I discard the oldest error
         And I relaunch the app
-        When I run "AutoDetectFalseNSExceptionScenario" and relaunch the app
+        When I run "AutoDetectFalseNSExceptionScenario" and relaunch the crashed app
         And I configure Bugsnag for "AutoDetectFalseHandledScenario"
         Then I should receive no requests
 
@@ -25,6 +25,6 @@ Feature: autoDetectErrors flag controls whether errors are captured automaticall
         And the event "unhandled" is false
         And I discard the oldest error
         And I relaunch the app
-        When I run "AutoDetectFalseAbortScenario" and relaunch the app
+        When I run "AutoDetectFalseAbortScenario" and relaunch the crashed app
         And I configure Bugsnag for "AutoDetectFalseHandledScenario"
         Then I should receive no requests

--- a/features/auto_notify.feature
+++ b/features/auto_notify.feature
@@ -11,7 +11,7 @@ Feature: autoNotify flag allows disabling error detection after Bugsnag is initi
         And the event "unhandled" is false
         And I discard the oldest error
         And I relaunch the app
-        When I run "AutoNotifyFalseNSExceptionScenario" and relaunch the app
+        When I run "AutoNotifyFalseNSExceptionScenario" and relaunch the crashed app
         And I configure Bugsnag for "AutoNotifyFalseHandledScenario"
         Then I should receive no requests
 
@@ -23,7 +23,7 @@ Feature: autoNotify flag allows disabling error detection after Bugsnag is initi
         And the event "unhandled" is false
         And I discard the oldest error
         And I relaunch the app
-        When I run "AutoNotifyFalseAbortScenario" and relaunch the app
+        When I run "AutoNotifyFalseAbortScenario" and relaunch the crashed app
         And I configure Bugsnag for "AutoNotifyFalseHandledScenario"
         Then I should receive no requests
 
@@ -35,7 +35,7 @@ Feature: autoNotify flag allows disabling error detection after Bugsnag is initi
         And the event "unhandled" is false
         And I discard the oldest error
         And I relaunch the app
-        When I run "AutoNotifyReenabledScenario" and relaunch the app
+        When I run "AutoNotifyReenabledScenario" and relaunch the crashed app
         And I configure Bugsnag for "AutoNotifyReenabledScenario"
         And I wait to receive an error
         Then the error is valid for the error reporting API

--- a/features/barebone_tests.feature
+++ b/features/barebone_tests.feature
@@ -108,7 +108,7 @@ Feature: Barebone tests
     And the stacktrace is valid for the event
 
   Scenario: Barebone test: unhandled error
-    When I run "BareboneTestUnhandledErrorScenario" and relaunch the app
+    When I run "BareboneTestUnhandledErrorScenario" and relaunch the crashed app
     And I set the app to "report" mode
     And I configure Bugsnag for "BareboneTestUnhandledErrorScenario"
     And I wait to receive an error

--- a/features/breadcrumbs.feature
+++ b/features/breadcrumbs.feature
@@ -25,7 +25,7 @@ Feature: Attaching a series of notable events leading up to errors
     Then the event has a "state" breadcrumb named "Bugsnag loaded"
 
   Scenario: An app lauches and subsequently crashes
-    When I run "BuiltinTrapScenario" and relaunch the app
+    When I run "BuiltinTrapScenario" and relaunch the crashed app
     And I configure Bugsnag for "BuiltinTrapScenario"
     And I wait to receive an error
     Then the event has a "state" breadcrumb named "Bugsnag loaded"

--- a/features/context.feature
+++ b/features/context.feature
@@ -16,7 +16,7 @@ Feature: The context can be automatically and manually set on errors
     And the event "context" is null
 
   Scenario: Automatic context from a C error
-    When I run "AbortScenario" and relaunch the app
+    When I run "AbortScenario" and relaunch the crashed app
     And I configure Bugsnag for "AbortScenario"
     And I wait to receive an error
     Then the error is valid for the error reporting API

--- a/features/crashprobe.feature
+++ b/features/crashprobe.feature
@@ -66,9 +66,7 @@ Feature: Reporting crash events
     And the "method" of stack frame 0 equals "-[ReadOnlyPageScenario run]"
 
   Scenario: Stack overflow
-    When I run "StackOverflowScenario"
-    And the app is not running
-    And I relaunch the app
+    When I run "StackOverflowScenario" and relaunch the crashed app
     And I configure Bugsnag for "StackOverflowScenario"
     And I wait to receive an error
     Then the error is valid for the error reporting API

--- a/features/crashprobe.feature
+++ b/features/crashprobe.feature
@@ -142,7 +142,13 @@ Feature: Reporting crash events
     And the "method" of stack frame 0 equals "-[NullPointerScenario run]"
 
   Scenario: Trigger a crash with libsystem_pthread's _pthread_list_lock held
-    When I run "AsyncSafeThreadScenario" and relaunch the crashed app
+    When I run "AsyncSafeThreadScenario"
+
+    # Sleep and relaunch here instead of checking the app state as this specific
+    # crash seems to inhibit Appium's ability to check the app state on iOS 10
+    And I wait for 3 seconds
+    And I relaunch the app
+
     And I configure Bugsnag for "AsyncSafeThreadScenario"
     And I wait to receive an error
     Then the error is valid for the error reporting API

--- a/features/crashprobe.feature
+++ b/features/crashprobe.feature
@@ -4,7 +4,7 @@ Feature: Reporting crash events
     Given I clear all persistent data
 
   Scenario: Executing privileged instruction
-    When I run "PrivilegedInstructionScenario" and relaunch the app
+    When I run "PrivilegedInstructionScenario" and relaunch the crashed app
     And I configure Bugsnag for "PrivilegedInstructionScenario"
     And I wait to receive an error
     Then the error is valid for the error reporting API
@@ -15,7 +15,7 @@ Feature: Reporting crash events
     And the "method" of stack frame 0 equals "-[PrivilegedInstructionScenario run]"
 
   Scenario: Calling __builtin_trap()
-    When I run "BuiltinTrapScenario" and relaunch the app
+    When I run "BuiltinTrapScenario" and relaunch the crashed app
     And I configure Bugsnag for "BuiltinTrapScenario"
     And I wait to receive an error
     Then the error is valid for the error reporting API
@@ -26,7 +26,7 @@ Feature: Reporting crash events
     And the "method" of stack frame 0 equals "-[BuiltinTrapScenario run]"
 
   Scenario: Calling non-existent method
-    When I run "NonExistentMethodScenario" and relaunch the app
+    When I run "NonExistentMethodScenario" and relaunch the crashed app
     And I configure Bugsnag for "NonExistentMethodScenario"
     And I wait to receive an error
     Then the error is valid for the error reporting API
@@ -49,7 +49,7 @@ Feature: Reporting crash events
     And the "method" of stack frame 5 equals "-[NonExistentMethodScenario run]"
 
   Scenario: Trigger a crash after overwriting the link register
-    When I run "OverwriteLinkRegisterScenario" and relaunch the app
+    When I run "OverwriteLinkRegisterScenario" and relaunch the crashed app
     And I configure Bugsnag for "OverwriteLinkRegisterScenario"
     And I wait to receive an error
     Then the error is valid for the error reporting API
@@ -58,7 +58,7 @@ Feature: Reporting crash events
     And the "method" of stack frame 0 equals "-[OverwriteLinkRegisterScenario run]"
 
   Scenario: Attempt to write into a read-only page
-    When I run "ReadOnlyPageScenario" and relaunch the app
+    When I run "ReadOnlyPageScenario" and relaunch the crashed app
     And I configure Bugsnag for "ReadOnlyPageScenario"
     And I wait to receive an error
     Then the error is valid for the error reporting API
@@ -86,7 +86,7 @@ Feature: Reporting crash events
     And the "method" of stack frame 9 equals "-[StackOverflowScenario run]"
 
   Scenario: Crash inside objc_msgSend()
-    When I run "ObjCMsgSendScenario" and relaunch the app
+    When I run "ObjCMsgSendScenario" and relaunch the crashed app
     And I configure Bugsnag for "ObjCMsgSendScenario"
     And I wait to receive an error
     Then the error is valid for the error reporting API
@@ -97,7 +97,7 @@ Feature: Reporting crash events
     And the "method" of stack frame 0 equals "objc_msgSend"
 
   Scenario: Attempt to execute an instruction undefined on the current architecture
-    When I run "UndefinedInstructionScenario" and relaunch the app
+    When I run "UndefinedInstructionScenario" and relaunch the crashed app
     And I configure Bugsnag for "UndefinedInstructionScenario"
     And I wait to receive an error
     Then the error is valid for the error reporting API
@@ -105,7 +105,7 @@ Feature: Reporting crash events
     And the "method" of stack frame 0 equals "-[UndefinedInstructionScenario run]"
 
   Scenario: Send a message to an object whose memory has already been freed
-    When I run "ReleasedObjectScenario" and relaunch the app
+    When I run "ReleasedObjectScenario" and relaunch the crashed app
     And I configure Bugsnag for "ReleasedObjectScenario"
     And I wait to receive an error
     Then the error is valid for the error reporting API
@@ -117,7 +117,7 @@ Feature: Reporting crash events
       | Intel | -[ReleasedObjectScenario run]                  |
 
   Scenario: Crash within Swift code
-    When I run "SwiftCrashScenario" and relaunch the app
+    When I run "SwiftCrashScenario" and relaunch the crashed app
     And I configure Bugsnag for "SwiftCrashScenario"
     And I wait to receive an error
     Then the error is valid for the error reporting API
@@ -126,7 +126,7 @@ Feature: Reporting crash events
     And the event "metaData.error.crashInfo" matches "Fatal error: Unexpectedly found nil while unwrapping an Optional value"
 
   Scenario: Assertion failure in Swift code
-    When I run "SwiftAssertionScenario" and relaunch the app
+    When I run "SwiftAssertionScenario" and relaunch the crashed app
     And I configure Bugsnag for "SwiftAssertionScenario"
     And I wait to receive an error
     Then the error is valid for the error reporting API
@@ -135,7 +135,7 @@ Feature: Reporting crash events
     And the event "metaData.error.crashInfo" matches "Fatal error: several unfortunate things just happened"
 
   Scenario: Dereference a null pointer
-    When I run "NullPointerScenario" and relaunch the app
+    When I run "NullPointerScenario" and relaunch the crashed app
     And I configure Bugsnag for "NullPointerScenario"
     And I wait to receive an error
     Then the error is valid for the error reporting API
@@ -144,7 +144,7 @@ Feature: Reporting crash events
     And the "method" of stack frame 0 equals "-[NullPointerScenario run]"
 
   Scenario: Trigger a crash with libsystem_pthread's _pthread_list_lock held
-    When I run "AsyncSafeThreadScenario" and relaunch the app
+    When I run "AsyncSafeThreadScenario" and relaunch the crashed app
     And I configure Bugsnag for "AsyncSafeThreadScenario"
     And I wait to receive an error
     Then the error is valid for the error reporting API
@@ -156,13 +156,13 @@ Feature: Reporting crash events
       | -[AsyncSafeThreadScenario run] |
 
   Scenario: Trigger a crash with simulated malloc() lock held
-    When I run "AsyncSafeMallocScenario" and relaunch the app
+    When I run "AsyncSafeMallocScenario" and relaunch the crashed app
     And I configure Bugsnag for "AsyncSafeMallocScenario"
     And I wait to receive an error
     And the exception "errorClass" equals "SIGABRT"
 
   Scenario: Read a garbage pointer
-    When I run "ReadGarbagePointerScenario" and relaunch the app
+    When I run "ReadGarbagePointerScenario" and relaunch the crashed app
     And I configure Bugsnag for "ReadGarbagePointerScenario"
     And I wait to receive an error
     Then the error is valid for the error reporting API
@@ -171,7 +171,7 @@ Feature: Reporting crash events
     And the "method" of stack frame 0 equals "-[ReadGarbagePointerScenario run]"
 
   Scenario: Access a non-object as an object
-    When I run "AccessNonObjectScenario" and relaunch the app
+    When I run "AccessNonObjectScenario" and relaunch the crashed app
     And I configure Bugsnag for "AccessNonObjectScenario"
     And I wait to receive an error
     Then the error is valid for the error reporting API
@@ -180,7 +180,7 @@ Feature: Reporting crash events
     And the "method" of stack frame 0 equals "objc_msgSend"
 
   Scenario: Misuse of libdispatch
-    When I run "DispatchCrashScenario" and relaunch the app
+    When I run "DispatchCrashScenario" and relaunch the crashed app
     And I configure Bugsnag for "DispatchCrashScenario"
     And I wait to receive an error
     Then the error is valid for the error reporting API

--- a/features/delivery.feature
+++ b/features/delivery.feature
@@ -23,7 +23,7 @@ Feature: Delivery of errors
     Then I should receive no requests
 
   Scenario: Bugsnag.start() should block for 2 seconds after a launch crash
-    When I run "SendLaunchCrashesSynchronouslyScenario" and relaunch the app
+    When I run "SendLaunchCrashesSynchronouslyScenario" and relaunch the crashed app
     And I set the response delay for the next request to 5000 milliseconds
     And I set the app to "report" mode
     And I run "SendLaunchCrashesSynchronouslyScenario"
@@ -32,7 +32,7 @@ Feature: Delivery of errors
     And the event "metaData.bugsnag.startDuration" is between 2.0 and 2.5
 
   Scenario: Bugsnag.start() should not block if sendLaunchCrashesSynchronously is false
-    When I run "SendLaunchCrashesSynchronouslyFalseScenario" and relaunch the app
+    When I run "SendLaunchCrashesSynchronouslyFalseScenario" and relaunch the crashed app
     And I set the response delay for the next request to 5000 milliseconds
     And I set the app to "report" mode
     And I run "SendLaunchCrashesSynchronouslyFalseScenario"
@@ -41,7 +41,7 @@ Feature: Delivery of errors
     And the event "metaData.bugsnag.startDuration" is between 0.0 and 0.5
 
   Scenario: Bugsnag.start() should not block for non-launch crashes
-    When I run "SendLaunchCrashesSynchronouslyLaunchCompletedScenario" and relaunch the app
+    When I run "SendLaunchCrashesSynchronouslyLaunchCompletedScenario" and relaunch the crashed app
     And I set the response delay for the next request to 5000 milliseconds
     And I set the app to "report" mode
     And I run "SendLaunchCrashesSynchronouslyLaunchCompletedScenario"

--- a/features/discard_classes.feature
+++ b/features/discard_classes.feature
@@ -9,13 +9,13 @@ Feature: Configuration discardClasses option
     And the exception "errorClass" equals "NotDiscarded"
 
   Scenario: Discard unhandled exception
-    When I run "DiscardClassesUnhandledExceptionScenario" and relaunch the app
+    When I run "DiscardClassesUnhandledExceptionScenario" and relaunch the crashed app
     And I configure Bugsnag for "DiscardClassesUnhandledExceptionScenario"
     And I wait to receive an error
     And the exception "errorClass" equals "NotDiscarded"
 
   Scenario: Discard unhandled crash
-    When I run "DiscardClassesUnhandledCrashScenario" and relaunch the app
+    When I run "DiscardClassesUnhandledCrashScenario" and relaunch the crashed app
     And I configure Bugsnag for "DiscardClassesUnhandledCrashScenario"
     And I wait to receive an error
     And the exception "errorClass" equals "NotDiscarded"

--- a/features/enabled_error_types.feature
+++ b/features/enabled_error_types.feature
@@ -5,14 +5,14 @@ Feature: Enabled error types
 
   Scenario: All Crash reporting is disabled
     # enabledErrorTypes = None, Generate a manual notification, crash
-    When I run "DisableAllExceptManualExceptionsAndCrashScenario" and relaunch the app
+    When I run "DisableAllExceptManualExceptionsAndCrashScenario" and relaunch the crashed app
     And I configure Bugsnag for "DisableAllExceptManualExceptionsAndCrashScenario"
     And I wait to receive an error
     Then the error is valid for the error reporting API
     And the event "unhandled" is false
 
   Scenario: NSException Crash Reporting is disabled
-    When I run "DisableNSExceptionScenario" and relaunch the app
+    When I run "DisableNSExceptionScenario" and relaunch the crashed app
     And I configure Bugsnag for "DisableNSExceptionScenario"
     And I wait to receive an error
     Then the error is valid for the error reporting API
@@ -21,21 +21,21 @@ Feature: Enabled error types
     And the event "unhandled" is true
 
   Scenario: CPP Crash Reporting is disabled
-    When I run "EnabledErrorTypesCxxScenario" and relaunch the app
+    When I run "EnabledErrorTypesCxxScenario" and relaunch the crashed app
     And I configure Bugsnag for "EnabledErrorTypesCxxScenario"
     And I wait to receive an error
     Then the error is valid for the error reporting API
     And the event "unhandled" is false
 
   Scenario: Mach Crash Reporting is disabled
-    When I run "DisableMachExceptionScenario" and relaunch the app
+    When I run "DisableMachExceptionScenario" and relaunch the crashed app
     And I configure Bugsnag for "DisableMachExceptionScenario"
     And I wait to receive an error
     Then the error is valid for the error reporting API
     And the event "unhandled" is false
 
   Scenario: Signals Crash Reporting is disabled
-    When I run "DisableSignalsExceptionScenario" and relaunch the app
+    When I run "DisableSignalsExceptionScenario" and relaunch the crashed app
     And I configure Bugsnag for "DisableSignalsExceptionScenario"
     And I wait to receive an error
     Then the error is valid for the error reporting API

--- a/features/event_callbacks.feature
+++ b/features/event_callbacks.feature
@@ -54,7 +54,7 @@ Feature: Callbacks can access and modify event information
     And the event "unhandled" is false
 
   Scenario: An OnSend callback can overwrite information for an unhandled error
-    When I run "SwiftAssertionScenario" and relaunch the app
+    When I run "SwiftAssertionScenario" and relaunch the crashed app
     And I configure Bugsnag for "OnSendOverwriteScenario"
     And I wait to receive an error
     Then the error is valid for the error reporting API
@@ -68,7 +68,7 @@ Feature: Callbacks can access and modify event information
     And the event "user.name" equals "customName"
 
   Scenario: Information set in OnCrashHandler is added to the final report
-    When I run "OnCrashHandlerScenario" and relaunch the app
+    When I run "OnCrashHandlerScenario" and relaunch the crashed app
     And I configure Bugsnag for "OnSendOverwriteScenario"
     And I wait to receive an error
     Then the error is valid for the error reporting API

--- a/features/internal_error_reporting.feature
+++ b/features/internal_error_reporting.feature
@@ -4,7 +4,7 @@ Feature: Internal error reporting
     Given I clear all persistent data
 
   Scenario: An internal error report is sent for invalid KSCrashReport files
-    When I run "InvalidCrashReportScenario" and relaunch the app
+    When I run "InvalidCrashReportScenario" and relaunch the crashed app
     And I configure Bugsnag for "InvalidCrashReportScenario"
     And I wait to receive an error
     And the error "Bugsnag-Api-Key" header is null

--- a/features/last_run_info.feature
+++ b/features/last_run_info.feature
@@ -4,7 +4,7 @@ Feature: Launch detection
     Given I clear all persistent data
 
   Scenario: LastRunInfo consecutiveLaunchCrashes increments when isLaunching is true
-    When I run "LastRunInfoConsecutiveLaunchCrashesScenario" and relaunch the app
+    When I run "LastRunInfoConsecutiveLaunchCrashesScenario" and relaunch the crashed app
     And I configure Bugsnag for "LastRunInfoConsecutiveLaunchCrashesScenario"
     And I wait to receive an error
     And the event "metaData.lastRunInfo.consecutiveLaunchCrashes" equals 1

--- a/features/plugin_interface.feature
+++ b/features/plugin_interface.feature
@@ -9,7 +9,7 @@ Feature: Add custom behavior through a plugin interface
     Given I clear all persistent data
 
   Scenario: Changing payload notifier description
-    When I run "CustomPluginNotifierDescriptionScenario" and relaunch the app
+    When I run "CustomPluginNotifierDescriptionScenario" and relaunch the crashed app
     And I configure Bugsnag for "CustomPluginNotifierDescriptionScenario"
     And I wait to receive an error
     Then the error payload field "notifier.name" equals "Foo Handler Library"

--- a/features/release_stage_errors.feature
+++ b/features/release_stage_errors.feature
@@ -4,12 +4,12 @@ Feature: Discarding reports based on release stage
     Given I clear all persistent data
 
   Scenario: Unhandled error ignored when release stage is not present in enabledReleaseStages
-    When I run "UnhandledErrorInvalidReleaseStageScenario" and relaunch the app
+    When I run "UnhandledErrorInvalidReleaseStageScenario" and relaunch the crashed app
     And I configure Bugsnag for "UnhandledErrorInvalidReleaseStageScenario"
     Then I should receive no requests
 
   Scenario: Unhandled error captured when release stage is present in enabledReleaseStages
-    When I run "UnhandledErrorValidReleaseStageScenario" and relaunch the app
+    When I run "UnhandledErrorValidReleaseStageScenario" and relaunch the crashed app
     And I configure Bugsnag for "UnhandledErrorValidReleaseStageScenario"
     And I wait to receive an error
     Then the error is valid for the error reporting API
@@ -24,12 +24,12 @@ Feature: Discarding reports based on release stage
   if the app is used as a test harness or if the build can receive code updates,
   such as JavaScript execution contexts.
 
-    When I run "UnhandledErrorChangeInvalidReleaseStageScenario" and relaunch the app
+    When I run "UnhandledErrorChangeInvalidReleaseStageScenario" and relaunch the crashed app
     And I configure Bugsnag for "UnhandledErrorChangeInvalidReleaseStageScenario"
     Then I should receive no requests
 
   Scenario: Crash when release stage is changed to be present in enabledReleaseStages before the event
-    When I run "UnhandledErrorChangeValidReleaseStageScenario" and relaunch the app
+    When I run "UnhandledErrorChangeValidReleaseStageScenario" and relaunch the crashed app
     And I configure Bugsnag for "UnhandledErrorChangeValidReleaseStageScenario"
     And I wait to receive an error
     Then the error is valid for the error reporting API

--- a/features/runtime_versions.feature
+++ b/features/runtime_versions.feature
@@ -18,7 +18,7 @@ Feature: Runtime versions are included in all requests
     And the session payload field "device.runtimeVersions.clangVersion" is not null
 
   Scenario: Runtime versions included in C layer ThrownErrorScenario
-    And I run "CxxExceptionScenario" and relaunch the app
+    And I run "CxxExceptionScenario" and relaunch the crashed app
     And I configure Bugsnag for "CxxExceptionScenario"
     And I wait to receive an error
     Then the error is valid for the error reporting API

--- a/features/steps/app_steps.rb
+++ b/features/steps/app_steps.rb
@@ -15,8 +15,8 @@ end
 
 When("I relaunch the app after a crash") do
   # This step should only be used when the app has crashed, but the notifier needs a little
-  # time to write the crash report before being forced to reopen.  From trials, 2s was not enough.
-  sleep(5)
+  # time to write the crash report before being forced to reopen.
+  step 'the app is not running'
   case Maze::Helper.get_current_platform
   when 'macos'
     Maze.driver.get(Maze.driver.capabilities['app'])

--- a/features/steps/app_steps.rb
+++ b/features/steps/app_steps.rb
@@ -14,8 +14,7 @@ When('I relaunch the app') do
 end
 
 When("I relaunch the app after a crash") do
-  # This step should only be used when the app has crashed, but the notifier needs a little
-  # time to write the crash report before being forced to reopen.
+  # Wait for the app to stop running before relaunching
   step 'the app is not running'
   case Maze::Helper.get_current_platform
   when 'macos'

--- a/features/steps/cocoa_steps.rb
+++ b/features/steps/cocoa_steps.rb
@@ -12,7 +12,7 @@ When('I run {string}') do |event_type|
   )
 end
 
-When("I run {string} and relaunch the app") do |event_type|
+When("I run {string} and relaunch the crashed app") do |event_type|
   begin
     step("I run \"#{event_type}\"")
   rescue StandardError

--- a/features/threads.feature
+++ b/features/threads.feature
@@ -15,7 +15,7 @@ Feature: Threads
     And the thread information is valid for the event
 
   Scenario: Threads are captured for unhandled errors by default
-    When I run "UnhandledErrorThreadSendAlwaysScenario" and relaunch the app
+    When I run "UnhandledErrorThreadSendAlwaysScenario" and relaunch the crashed app
     And I configure Bugsnag for "UnhandledErrorThreadSendAlwaysScenario"
     And I wait to receive an error
     Then the error is valid for the error reporting API
@@ -36,7 +36,7 @@ Feature: Threads
     And the error payload field "events.0.threads" is an array with 0 elements
 
   Scenario: Threads are not captured for unhandled errors when sendThreads is set to never
-    When I run "UnhandledErrorThreadSendNeverScenario" and relaunch the app
+    When I run "UnhandledErrorThreadSendNeverScenario" and relaunch the crashed app
     And I configure Bugsnag for "UnhandledErrorThreadSendNeverScenario"
     And I wait to receive an error
     Then the error is valid for the error reporting API

--- a/features/unhandled_cpp_exception.feature
+++ b/features/unhandled_cpp_exception.feature
@@ -4,7 +4,7 @@ Feature: Thrown C++ exceptions are captured by Bugsnag
     Given I clear all persistent data
 
   Scenario: Throwing a C++ exception
-    When I run "CxxExceptionScenario" and relaunch the app
+    When I run "CxxExceptionScenario" and relaunch the crashed app
     And I configure Bugsnag for "CxxExceptionScenario"
     And I wait to receive an error
     Then the error is valid for the error reporting API
@@ -16,7 +16,7 @@ Feature: Thrown C++ exceptions are captured by Bugsnag
     And the event "severityReason.type" equals "unhandledException"
 
   Scenario: Throwing a C++ exception with unhandled override
-    When I run "CxxExceptionOverrideScenario" and relaunch the app
+    When I run "CxxExceptionOverrideScenario" and relaunch the crashed app
     And I configure Bugsnag for "CxxExceptionOverrideScenario"
     And I wait to receive an error
     Then the error is valid for the error reporting API

--- a/features/unhandled_mach_exception.feature
+++ b/features/unhandled_mach_exception.feature
@@ -4,7 +4,7 @@ Feature: Bugsnag captures an unhandled mach exception
     Given I clear all persistent data
 
   Scenario: Trigger a mach exception
-    When I run "UnhandledMachExceptionScenario" and relaunch the app
+    When I run "UnhandledMachExceptionScenario" and relaunch the crashed app
     And I configure Bugsnag for "UnhandledMachExceptionScenario"
     And I wait to receive an error
     Then the error is valid for the error reporting API
@@ -26,7 +26,7 @@ Feature: Bugsnag captures an unhandled mach exception
     And the event "severityReason.type" equals "unhandledException"
 
   Scenario: Trigger a mach exception with unhandled override
-    When I run "UnhandledMachExceptionOverrideScenario" and relaunch the app
+    When I run "UnhandledMachExceptionOverrideScenario" and relaunch the crashed app
     And I configure Bugsnag for "UnhandledMachExceptionOverrideScenario"
     And I wait to receive an error
     Then the error is valid for the error reporting API

--- a/features/unhandled_nsexception.feature
+++ b/features/unhandled_nsexception.feature
@@ -4,7 +4,7 @@ Feature: Uncaught NSExceptions are captured by Bugsnag
     Given I clear all persistent data
 
   Scenario: Throw a NSException
-    When I run "ObjCExceptionScenario" and relaunch the app
+    When I run "ObjCExceptionScenario" and relaunch the crashed app
     And I configure Bugsnag for "ObjCExceptionScenario"
     And I wait to receive an error
     Then the error is valid for the error reporting API
@@ -21,7 +21,7 @@ Feature: Uncaught NSExceptions are captured by Bugsnag
     And the event "severityReason.type" equals "unhandledException"
 
   Scenario: Throw a NSException with unhandled override
-    When I run "ObjCExceptionOverrideScenario" and relaunch the app
+    When I run "ObjCExceptionOverrideScenario" and relaunch the crashed app
     And I configure Bugsnag for "ObjCExceptionOverrideScenario"
     And I wait to receive an error
     Then the error is valid for the error reporting API

--- a/features/unhandled_signal.feature
+++ b/features/unhandled_signal.feature
@@ -4,7 +4,7 @@ Feature: Signals are captured as error reports in Bugsnag
     Given I clear all persistent data
 
   Scenario: Triggering SIGABRT
-    When I run "AbortScenario" and relaunch the app
+    When I run "AbortScenario" and relaunch the crashed app
     And I configure Bugsnag for "AbortScenario"
     And I wait to receive an error
     Then the error is valid for the error reporting API
@@ -31,7 +31,7 @@ Feature: Signals are captured as error reports in Bugsnag
     And the event "severityReason.attributes.signalType" equals "SIGABRT"
 
   Scenario: Triggering SIGABRT with unhandled override
-    When I run "AbortOverrideScenario" and relaunch the app
+    When I run "AbortOverrideScenario" and relaunch the crashed app
     And I configure Bugsnag for "AbortOverrideScenario"
     And I wait to receive an error
     Then the error is valid for the error reporting API
@@ -45,7 +45,7 @@ Feature: Signals are captured as error reports in Bugsnag
     And the event "severityReason.attributes.signalType" equals "SIGABRT"
 
   Scenario: Triggering SIGPIPE
-    When I run "SIGPIPEScenario" and relaunch the app
+    When I run "SIGPIPEScenario" and relaunch the crashed app
     And I configure Bugsnag for "SIGPIPEScenario"
     And I wait to receive an error
     Then the error is valid for the error reporting API
@@ -57,7 +57,7 @@ Feature: Signals are captured as error reports in Bugsnag
     And the event "severityReason.attributes.signalType" equals "SIGPIPE"
 
   Scenario: Triggering SIGBUS
-    When I run "SIGBUSScenario" and relaunch the app
+    When I run "SIGBUSScenario" and relaunch the crashed app
     And I configure Bugsnag for "SIGBUSScenario"
     And I wait to receive an error
     Then the error is valid for the error reporting API
@@ -69,7 +69,7 @@ Feature: Signals are captured as error reports in Bugsnag
     And the event "severityReason.attributes.signalType" equals "SIGBUS"
 
   Scenario: Triggering SIGFPE
-    When I run "SIGFPEScenario" and relaunch the app
+    When I run "SIGFPEScenario" and relaunch the crashed app
     And I configure Bugsnag for "SIGFPEScenario"
     And I wait to receive an error
     Then the error is valid for the error reporting API
@@ -81,7 +81,7 @@ Feature: Signals are captured as error reports in Bugsnag
     And the event "severityReason.attributes.signalType" equals "SIGFPE"
 
   Scenario: Triggering SIGILL
-    When I run "SIGILLScenario" and relaunch the app
+    When I run "SIGILLScenario" and relaunch the crashed app
     And I configure Bugsnag for "SIGILLScenario"
     And I wait to receive an error
     Then the error is valid for the error reporting API
@@ -93,7 +93,7 @@ Feature: Signals are captured as error reports in Bugsnag
     And the event "severityReason.attributes.signalType" equals "SIGILL"
 
   Scenario: Triggering SIGSEGV
-    When I run "SIGSEGVScenario" and relaunch the app
+    When I run "SIGSEGVScenario" and relaunch the crashed app
     And I configure Bugsnag for "SIGSEGVScenario"
     And I wait to receive an error
     Then the error is valid for the error reporting API
@@ -105,7 +105,7 @@ Feature: Signals are captured as error reports in Bugsnag
     And the event "severityReason.attributes.signalType" equals "SIGSEGV"
 
   Scenario: Triggering SIGSYS
-    When I run "SIGSYSScenario" and relaunch the app
+    When I run "SIGSYSScenario" and relaunch the crashed app
     And I configure Bugsnag for "SIGSYSScenario"
     And I wait to receive an error
     Then the error is valid for the error reporting API
@@ -117,7 +117,7 @@ Feature: Signals are captured as error reports in Bugsnag
     And the event "severityReason.attributes.signalType" equals "SIGSYS"
 
   Scenario: Triggering SIGTRAP
-    When I run "SIGTRAPScenario" and relaunch the app
+    When I run "SIGTRAPScenario" and relaunch the crashed app
     And I configure Bugsnag for "SIGTRAPScenario"
     And I wait to receive an error
     Then the error is valid for the error reporting API


### PR DESCRIPTION
## Goal

In e2e tests, reduce the test run time by relaunching the crashed app once Appium says it is not running - rather than waiting a fixed period of time.

## Changeset

Also reworded `I run {string} and relaunch the app` to resolve ambiguity on crashiness.

## Testing

Covered by multiple [full ci] runs in the lead up to the PR.