### PR TITLE
Use AppleScript to accelerate macOS E2E tests

### DIFF
--- a/features/fixtures/macos/macOSTestApp/AppDelegate.m
+++ b/features/fixtures/macos/macOSTestApp/AppDelegate.m
@@ -30,4 +30,17 @@
     return YES;
 }
 
+- (void)application:(NSApplication *)application openURLs:(NSArray<NSURL *> *)urls {
+    NSLog(@"%s %@", __PRETTY_FUNCTION__, urls);
+    for (NSURL *url in urls) {
+        if ([url.scheme isEqualToString:@"macOSTestApp"] &&
+            [url.path isEqualToString:@"/mainWindowController"]) {
+            NSURLComponents *components = [NSURLComponents componentsWithURL:url resolvingAgainstBaseURL:NO];
+            for (NSURLQueryItem *queryItem in components.queryItems) {
+                [self.mainWindowController setValue:queryItem.value forKeyPath:queryItem.name];
+            }
+        }
+    }
+}
+
 @end

--- a/features/fixtures/macos/macOSTestApp/Info.plist
+++ b/features/fixtures/macos/macOSTestApp/Info.plist
@@ -43,6 +43,8 @@
 		<key>NSAllowsArbitraryLoads</key>
 		<true/>
 	</dict>
+	<key>NSAppleScriptEnabled</key>
+	<true/>
 	<key>NSHumanReadableCopyright</key>
 	<string>Copyright © 2020 Bugsnac Inc. All rights reserved.</string>
 	<key>NSMainNibFile</key>

--- a/features/steps/app_steps.rb
+++ b/features/steps/app_steps.rb
@@ -58,12 +58,36 @@ Then('the app is not running') do
   end
 end
 
-When('I set the app to {string} mode') do |mode|
-  steps %(
-    When I send the keys "#{mode}" to the element "scenario_metadata"
-  )
-end
-
 When('I send the app to the background') do
   Maze.driver.background_app(-1)
+end
+
+#
+# Setting scenario and mode
+#
+
+When('I set the app to {string} scenario') do |scenario|
+  case Maze::Helper.get_current_platform
+  when 'macos'
+    mac_set_value('scenarioName', scenario)
+  else
+    steps %(When I send the keys "#{scenario}" to the element "scenario_name")
+  end
+end
+
+When('I set the app to {string} mode') do |mode|
+  case Maze::Helper.get_current_platform
+  when 'macos'
+    mac_set_value('scenarioMetadata', mode)
+  else
+    steps %(When I send the keys "#{mode}" to the element "scenario_metadata")
+  end
+end
+
+def mac_set_value(key, value)
+  # Using find_element to ensure app is ready for input
+  Maze.driver.find_element(:id, 'scenario_name')
+  # Using 'open location' because it is one of the few AppleScript commands that does not require privacy approval
+  location = "macOSTestApp:///mainWindowController?#{key}=#{value}"
+  system("osascript -e 'tell application \"macOSTestApp\" to open location \"#{location}\"'", exception: true)
 end

--- a/features/steps/cocoa_steps.rb
+++ b/features/steps/cocoa_steps.rb
@@ -7,7 +7,7 @@ end
 
 When('I run {string}') do |event_type|
   steps %(
-    When I send the keys "#{short_scenario_name event_type}" to the element "scenario_name"
+    When I set the app to "#{short_scenario_name event_type}" scenario
     And I click the element "run_scenario"
   )
 end
@@ -57,7 +57,7 @@ end
 
 When('I configure Bugsnag for {string}') do |event_type|
   steps %(
-    When I send the keys "#{short_scenario_name event_type}" to the element "scenario_name"
+    When I set the app to "#{short_scenario_name event_type}" scenario
     And I click the element "start_bugsnag"
   )
 end


### PR DESCRIPTION
## Goal

Make macOS E2E tests run faster by avoiding the slow (and unreliable) text entry step (which uses simulated individual key presses.)

## Changeset

Uses the AppleScript `open location` command to pass scenario name and mode to the fixture. This command is used instead of a more formal script interface to avoid additional privacy approval being required. See https://scriptingosx.com/2020/09/avoiding-applescript-security-and-privacy-requests/ for further reading.

## Testing

Verified locally and on CI

## Measured performance improvement

| | [before](https://buildkite.com/bugsnag/bugsnag-cocoa/builds/4321) | [after](https://buildkite.com/bugsnag/bugsnag-cocoa/builds/4327) |
|--|--|--|
| macOS 11 | 19m59.750s | 12m40.816s |
| macOS 10.15 | 20m12.897s | 12m50.076s |
| macOS 10.14 | 21m3.566s | 14m1.527s |
| macOS 10.13 | 24m54.190s | 19m13.043s |
