### PR TITLE
Use backgrounding steps from Maze Runner

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -7,7 +7,7 @@ gem 'xcpretty'
 
 # A reference to Maze Runner is only needed for running tests locally and if committed it must be
 # portable for CI, e.g. a specific release.  However, leaving it commented out would mean quicker CI.
-gem 'bugsnag-maze-runner', git: 'https://github.com/bugsnag/maze-runner', tag: 'v6.6.2'
+gem 'bugsnag-maze-runner', git: 'https://github.com/bugsnag/maze-runner', tag: 'v6.7.0'
 
 # Use a specific branch
 #gem 'bugsnag-maze-runner', git: 'https://github.com/bugsnag/maze-runner', branch: 'master'

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -1,9 +1,9 @@
 GIT
   remote: https://github.com/bugsnag/maze-runner
-  revision: 9efc4f0c876f050d34e0bef54be2599598076818
-  tag: v6.6.2
+  revision: ad4225e8bcfb9765049c8abc7ae8833177249d70
+  tag: v6.7.0
   specs:
-    bugsnag-maze-runner (6.6.2)
+    bugsnag-maze-runner (6.7.0)
       appium_lib (~> 11.2.0)
       bugsnag (~> 6.24)
       cucumber (~> 7.1)

--- a/features/app_hangs.feature
+++ b/features/app_hangs.feature
@@ -134,7 +134,7 @@ Feature: App hangs
   @skip_macos
   Scenario: Fatal app hangs should be reported if the app hangs before going to the background
     When I run "AppHangFatalOnlyScenario"
-    And I background the app for 3 seconds
+    And I send the app to the background for 3 seconds
     And I relaunch the app
     And I configure Bugsnag for "AppHangFatalOnlyScenario"
     And I wait to receive an error
@@ -143,7 +143,7 @@ Feature: App hangs
   @skip_macos
   Scenario: Fatal app hangs should not be reported if they occur once the app is in the background
     When I run "AppHangDidEnterBackgroundScenario"
-    And I background the app for 3 seconds
+    And I send the app to the background for 3 seconds
     And I relaunch the app
     And I configure Bugsnag for "AppHangDidEnterBackgroundScenario"
     Then I should receive no errors
@@ -151,7 +151,7 @@ Feature: App hangs
   @skip_macos
   Scenario: App hangs should be reported if the app hangs after resuming from the background
     When I run "AppHangDidBecomeActiveScenario"
-    And I background the app for 3 seconds
+    And I send the app to the background for 3 seconds
     And I wait to receive an error
     And the exception "message" equals "The app's main thread failed to respond to an event within 2000 milliseconds"
 

--- a/features/breadcrumbs.feature
+++ b/features/breadcrumbs.feature
@@ -44,7 +44,7 @@ Feature: Attaching a series of notable events leading up to errors
   @skip_macos
   Scenario: State breadcrumbs
     When I configure Bugsnag for "HandledErrorScenario"
-    And I background the app for 2 seconds
+    And I send the app to the background for 2 seconds
     And I click the element "run_scenario"
     And I wait to receive an error
     Then the event has a "state" breadcrumb named "Bugsnag loaded"

--- a/features/steps/app_steps.rb
+++ b/features/steps/app_steps.rb
@@ -1,7 +1,3 @@
-When('I background the app for {int} seconds') do |duration|
-  Maze.driver.background_app(duration)
-end
-
 When('I relaunch the app') do
   case Maze::Helper.get_current_platform
   when 'macos'
@@ -56,10 +52,6 @@ Then('the app is not running') do
       raise "Don't know how to query app state on this platform"
     end
   end
-end
-
-When('I send the app to the background') do
-  Maze.driver.background_app(-1)
 end
 
 #


### PR DESCRIPTION
## Goal

Rationalise the Cucumber steps that background the app, to use those now available in Maze Runner.

## Testing

Covered by a full test run on any iOS version, as provided by a `[quick ci'`.