### PR TITLE
[PLAT-6719] Make OnSendError changes non-persistent

### DIFF
--- a/features/event_callbacks.feature
+++ b/features/event_callbacks.feature
@@ -116,3 +116,13 @@ Feature: Callbacks can access and modify event information
     And the event "metaData.callbacks.beforeCrash" is true
     And the event "metaData.callbacks.afterCrash" is null
     And the event "metaData.callbacks.secondCallback" is true
+
+  Scenario: Changes made in OnSendError should not be persisted
+    Given I set the HTTP status code for the next request to 500
+    And I run "OnSendErrorPersistenceScenario"
+    And I wait to receive an error
+    And I clear the error queue
+    And I relaunch the app
+    And I configure Bugsnag for "OnSendErrorPersistenceScenario"
+    And I wait to receive an error
+    Then the event "metaData.unexpected.message" is null

--- a/features/fixtures/ios/iOSTestApp.xcodeproj/project.pbxproj
+++ b/features/fixtures/ios/iOSTestApp.xcodeproj/project.pbxproj
@@ -20,6 +20,7 @@
 		0104085F258CA0A100933C60 /* DispatchCrashScenario.swift in Sources */ = {isa = PBXBuildFile; fileRef = 0104085E258CA0A100933C60 /* DispatchCrashScenario.swift */; };
 		0104B47E275A7B3C003EBDF0 /* RecrashScenarios.mm in Sources */ = {isa = PBXBuildFile; fileRef = 0104B47D275A7B3C003EBDF0 /* RecrashScenarios.mm */; };
 		0163BFA72583B3CF008DC28B /* DiscardClassesScenarios.swift in Sources */ = {isa = PBXBuildFile; fileRef = 0163BFA62583B3CF008DC28B /* DiscardClassesScenarios.swift */; };
+		017B4134276B8D9B0054C91D /* OnSendErrorPersistenceScenario.m in Sources */ = {isa = PBXBuildFile; fileRef = 017B4133276B8D9B0054C91D /* OnSendErrorPersistenceScenario.m */; };
 		01847DD626453D4E00ADA4C7 /* InvalidCrashReportScenario.m in Sources */ = {isa = PBXBuildFile; fileRef = 01847DD526453D4E00ADA4C7 /* InvalidCrashReportScenario.m */; };
 		01AF6A53258A112F00FFC803 /* BareboneTestScenarios.swift in Sources */ = {isa = PBXBuildFile; fileRef = 01AF6A52258A112F00FFC803 /* BareboneTestScenarios.swift */; };
 		01B6BB7525D5748800FC4DE6 /* LastRunInfoScenarios.swift in Sources */ = {isa = PBXBuildFile; fileRef = 01B6BB7425D5748800FC4DE6 /* LastRunInfoScenarios.swift */; };
@@ -183,6 +184,7 @@
 		0104085E258CA0A100933C60 /* DispatchCrashScenario.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = DispatchCrashScenario.swift; sourceTree = "<group>"; };
 		0104B47D275A7B3C003EBDF0 /* RecrashScenarios.mm */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.objcpp; path = RecrashScenarios.mm; sourceTree = "<group>"; };
 		0163BFA62583B3CF008DC28B /* DiscardClassesScenarios.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = DiscardClassesScenarios.swift; sourceTree = "<group>"; };
+		017B4133276B8D9B0054C91D /* OnSendErrorPersistenceScenario.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; path = OnSendErrorPersistenceScenario.m; sourceTree = "<group>"; };
 		01847DD526453D4E00ADA4C7 /* InvalidCrashReportScenario.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; path = InvalidCrashReportScenario.m; sourceTree = "<group>"; };
 		01AF6A52258A112F00FFC803 /* BareboneTestScenarios.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = BareboneTestScenarios.swift; sourceTree = "<group>"; };
 		01B6BB7425D5748800FC4DE6 /* LastRunInfoScenarios.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = LastRunInfoScenarios.swift; sourceTree = "<group>"; };
@@ -602,6 +604,7 @@
 				01DE903726CE99B800455213 /* CriticalThermalStateScenario.swift */,
 				0163BFA62583B3CF008DC28B /* DiscardClassesScenarios.swift */,
 				01847DD526453D4E00ADA4C7 /* InvalidCrashReportScenario.m */,
+				017B4133276B8D9B0054C91D /* OnSendErrorPersistenceScenario.m */,
 				01E5EAD025B713990066EA8A /* OOMScenario.h */,
 				01E5EAD125B713990066EA8A /* OOMScenario.m */,
 				0104B47D275A7B3C003EBDF0 /* RecrashScenarios.mm */,
@@ -949,6 +952,7 @@
 				E7FDB6C6264D5AD800BCF881 /* AutoNotifyFalseAbortScenario.swift in Sources */,
 				E7A324EA247E9DA5008B0052 /* BreadcrumbCallbackOverrideScenario.swift in Sources */,
 				F42955DB6D08642528917FAB /* CxxExceptionScenario.mm in Sources */,
+				017B4134276B8D9B0054C91D /* OnSendErrorPersistenceScenario.m in Sources */,
 				8A3B5F2B240807EE00CE4A3A /* ModifyBreadcrumbInNotifyScenario.swift in Sources */,
 				CBB787912578FC0C0071BDE4 /* MarkUnhandledHandledScenario.m in Sources */,
 				8A32DB8222424E3000EDD92F /* NSExceptionShiftScenario.m in Sources */,

--- a/features/fixtures/macos/macOSTestApp.xcodeproj/project.pbxproj
+++ b/features/fixtures/macos/macOSTestApp.xcodeproj/project.pbxproj
@@ -10,6 +10,7 @@
 		01018BAB25E417EC000312C6 /* AsyncSafeMallocScenario.m in Sources */ = {isa = PBXBuildFile; fileRef = 01018BAA25E417EC000312C6 /* AsyncSafeMallocScenario.m */; };
 		011B7A4C26CD52080071C3EB /* ThermalStateBreadcrumbScenario.swift in Sources */ = {isa = PBXBuildFile; fileRef = 011B7A4B26CD52080071C3EB /* ThermalStateBreadcrumbScenario.swift */; };
 		0123189C275921590007EFD7 /* RecrashScenarios.mm in Sources */ = {isa = PBXBuildFile; fileRef = 0123189B275921590007EFD7 /* RecrashScenarios.mm */; };
+		015AE23A276B88300044B1AE /* OnSendErrorPersistenceScenario.m in Sources */ = {isa = PBXBuildFile; fileRef = 015AE239276B88300044B1AE /* OnSendErrorPersistenceScenario.m */; };
 		0163BF9B2583AF2A008DC28B /* DiscardClassesScenarios.swift in Sources */ = {isa = PBXBuildFile; fileRef = 0163BF9A2583AF2A008DC28B /* DiscardClassesScenarios.swift */; };
 		0176C0AE254AE81B0066E0F3 /* main.m in Sources */ = {isa = PBXBuildFile; fileRef = 0176C0AD254AE81B0066E0F3 /* main.m */; };
 		0176C0B1254AE81B0066E0F3 /* AppDelegate.m in Sources */ = {isa = PBXBuildFile; fileRef = 0176C0B0254AE81B0066E0F3 /* AppDelegate.m */; };
@@ -166,6 +167,7 @@
 		011B7A4B26CD52080071C3EB /* ThermalStateBreadcrumbScenario.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ThermalStateBreadcrumbScenario.swift; sourceTree = "<group>"; };
 		0123189B275921590007EFD7 /* RecrashScenarios.mm */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.objcpp; path = RecrashScenarios.mm; sourceTree = "<group>"; };
 		01452360254AFEA700D436AA /* macOSTestApp-Bridging-Header.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; path = "macOSTestApp-Bridging-Header.h"; sourceTree = "<group>"; };
+		015AE239276B88300044B1AE /* OnSendErrorPersistenceScenario.m */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.objc; path = OnSendErrorPersistenceScenario.m; sourceTree = "<group>"; };
 		0163BF9A2583AF2A008DC28B /* DiscardClassesScenarios.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = DiscardClassesScenarios.swift; sourceTree = "<group>"; };
 		0176C0A8254AE81B0066E0F3 /* macOSTestApp.app */ = {isa = PBXFileReference; explicitFileType = wrapper.application; includeInIndex = 0; path = macOSTestApp.app; sourceTree = BUILT_PRODUCTS_DIR; };
 		0176C0AC254AE81B0066E0F3 /* Info.plist */ = {isa = PBXFileReference; lastKnownFileType = text.plist.xml; path = Info.plist; sourceTree = "<group>"; usesTabs = 1; };
@@ -378,7 +380,6 @@
 		01452234254AFCD600D436AA /* scenarios */ = {
 			isa = PBXGroup;
 			children = (
-				AAFEF9EB26EB536D00980A10 /* NetworkBreadcrumbsScenario.swift */,
 				01F47C91254B1B2F00B184AD /* AbortScenario.h */,
 				01F47C54254B1B2E00B184AD /* AbortScenario.m */,
 				01F47C4A254B1B2D00B184AD /* AccessNonObjectScenario.h */,
@@ -465,6 +466,7 @@
 				01F47C58254B1B2E00B184AD /* MetadataRedactionRegexScenario.swift */,
 				01F47C78254B1B2F00B184AD /* ModifyBreadcrumbInNotifyScenario.swift */,
 				01F47C87254B1B2F00B184AD /* ModifyBreadcrumbScenario.swift */,
+				AAFEF9EB26EB536D00980A10 /* NetworkBreadcrumbsScenario.swift */,
 				01F47CA0254B1B3000B184AD /* NewSessionScenario.swift */,
 				01F47C24254B1B2C00B184AD /* NonExistentMethodScenario.h */,
 				01F47C4B254B1B2D00B184AD /* NonExistentMethodScenario.m */,
@@ -486,6 +488,7 @@
 				01F47C69254B1B2E00B184AD /* OnSendCallbackRemovalScenario.h */,
 				01F47C9B254B1B2F00B184AD /* OnSendCallbackRemovalScenario.m */,
 				01F47C76254B1B2E00B184AD /* OnSendErrorCallbackCrashScenario.swift */,
+				015AE239276B88300044B1AE /* OnSendErrorPersistenceScenario.m */,
 				01F47C6C254B1B2E00B184AD /* OnSendOverwriteScenario.swift */,
 				01F47C41254B1B2D00B184AD /* OOMAutoDetectErrorsScenario.swift */,
 				01F47C9D254B1B3000B184AD /* OOMEnabledErrorTypesScenario.swift */,
@@ -806,6 +809,7 @@
 				01F47CE4254B1B3100B184AD /* AutoDetectFalseNSExceptionScenario.swift in Sources */,
 				01F47D0F254B1B3100B184AD /* OOMWillTerminateScenario.m in Sources */,
 				01F47CFB254B1B3100B184AD /* ReleaseStageScenarios.swift in Sources */,
+				015AE23A276B88300044B1AE /* OnSendErrorPersistenceScenario.m in Sources */,
 				01F47D17254B1B3100B184AD /* ReleaseStageSessionScenario.swift in Sources */,
 				01F47CD2254B1B3100B184AD /* Scenario.m in Sources */,
 				017FBFB8254B09C300809042 /* MainWindowController.m in Sources */,

--- a/features/fixtures/shared/scenarios/OnSendErrorPersistenceScenario.m
+++ b/features/fixtures/shared/scenarios/OnSendErrorPersistenceScenario.m
@@ -1,0 +1,47 @@
+//
+//  OnSendErrorPersistenceScenario.m
+//  macOSTestApp
+//
+//  Created by Nick Dowell on 16/12/2021.
+//  Copyright © 2021 Bugsnag Inc. All rights reserved.
+//
+
+#import "Scenario.h"
+
+NSString * const HasNotifiedKey = @"OnSendErrorPersistenceScenario.hasNotified";
+
+@interface OnSendErrorPersistenceScenario : Scenario
+@property BOOL hasNotified;
+@end
+
+@implementation OnSendErrorPersistenceScenario
+
+- (void)startBugsnag {
+    self.config.autoTrackSessions = NO;
+    
+    if (!self.hasNotified) {
+        [self.config addOnSendErrorBlock:^BOOL(BugsnagEvent *event) {
+            [event addMetadata:@"Hello" withKey:@"message" toSection:@"unexpected"];
+            return YES;
+        }];
+    }
+    
+    [super startBugsnag];
+}
+
+- (void)run {
+    if (!self.hasNotified) {
+        [Bugsnag notifyError:[NSError errorWithDomain:@"NotAnError" code:0 userInfo:nil]];
+        self.hasNotified = YES;
+    }
+}
+
+- (BOOL)hasNotified {
+    return [NSUserDefaults.standardUserDefaults boolForKey:HasNotifiedKey];
+}
+
+- (void)setHasNotified:(BOOL)hasNotified {
+    [NSUserDefaults.standardUserDefaults setBool:hasNotified forKey:HasNotifiedKey];
+}
+
+@end


### PR DESCRIPTION
## Goal

Stop changes made by `OnSendError` blocks from being persisted for retries, to align the behaviour with that for crashes.

## Changeset

`BSGEventUploadOperation` now serializes the event prior to invoking the `OnSendError` blocks and persists this version to disk if the delivery fails.

Note: this increases peak memory usage for apps that have `OnSendError` blocks.

## Testing

Added E2E scenario to verify that changes are not persisted in retries.