### PR TITLE
[PLAT-6816] Detect hangs during launch of scene based apps

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,8 @@ Changelog
 
 ### Bug fixes
 
+* Detect hangs during launch of UIScene based apps.
+  [#1263](https://github.com/bugsnag/bugsnag-cocoa/pull/1263)
 * Fix some potential deadlocks that could occur if a crash handler crashes.
   [#1252](https://github.com/bugsnag/bugsnag-cocoa/pull/1252)
 

--- a/features/fixtures/shared/scenarios/AppHangScenarios.swift
+++ b/features/fixtures/shared/scenarios/AppHangScenarios.swift
@@ -70,7 +70,10 @@ class AppHangFatalOnlyScenario: Scenario {
     
     override func run() {
         NSLog("Hanging indefinitely...")
-        while true {}
+        // Use asyncAfter to allow the Appium click event to be handled
+        DispatchQueue.main.asyncAfter(deadline: .now() + 0.1) {
+            while true {}
+        }
     }
 }
 
@@ -84,7 +87,10 @@ class AppHangFatalDisabledScenario: Scenario {
     
     override func run() {
         NSLog("Hanging indefinitely...")
-        while true {}
+        // Use asyncAfter to allow the Appium click event to be handled
+        DispatchQueue.main.asyncAfter(deadline: .now() + 0.1) {
+            while true {}
+        }
     }
 }
 


### PR DESCRIPTION
## Goal

Detect hangs during launch of scene based apps.

UIScene-based apps are launched with a background UIApplicationState - the state changes to foreground when the first scene is created.

## Changeset

Enables detection of hangs between `Bugsnag.start()` and the first turn of the run loop regardless of the reported application state.

This means that hangs during the launch of background sessions will also be detected - no way to determine between foreground and background launches was found for scene based apps.

Once the run loop has run we expect the app state to be accurate.

## Testing

Tested locally using a sample app.