### PR TITLE
[PLAT-7694] Try to at least get the function address if the top of the stack is missing

### DIFF
--- a/Bugsnag/KSCrash/Source/KSCrash/Recording/Tools/BSG_KSMachHeaders.h
+++ b/Bugsnag/KSCrash/Source/KSCrash/Recording/Tools/BSG_KSMachHeaders.h
@@ -89,6 +89,10 @@ void bsg_mach_headers_remove_image(const struct mach_header *mh, intptr_t slide)
 */
 BSG_Mach_Header_Info *bsg_mach_headers_image_at_address(const uintptr_t address);
 
+/**
+ * Check if an address is roughly within range of the executable images.
+ */
+bool bsg_is_address_in_instruction_range(uintptr_t address);
 
 /** Find a loaded binary image with the specified name.
  *


### PR DESCRIPTION
## Goal

In certain rare cases, the top of the stack can be lost when making a call to a bad function pointer (such as in the example app). Depending on the optimization and stripping flags, you'll only get the parent function of the function that made the bad function call (because the top of the stack will be that bad pointer).

This PR looks in other registers on 64-bit systems that contain the address of the beginning of the function that made the bad call. Then at least one can see the function it was called from, even if not the exact line.

## Design

Check if the first stack entry is valid, and if not, look in the secondary register (`r11` on x86-64, `x17` on arm64) for something that's within the main image. This isn't perfect, but chances are much higher that a rogue pointer will get called in the main app rather than a library, and we don't want to send people on a wild goose chase. If it's not in the main image, it doesn't get used and the behaviour is as before (the original pointer gets used, and rejected by the backend).

## Changeset

Keep track of the low and high addresses of the image list, and then on crash check the top of the stack with that range. If it's out of range, start looking in the secondary registers.

**Note** This only works on 64-bit systems. 32-bit systems behave as they did before.

## Testing

Tested manually with the example app. I couldn't get it to repro in the mazerunner app, probably due to optimization settings.
