### PR TITLE
Use Maze.check abstraction

### DIFF
--- a/.buildkite/pipeline.full.yml
+++ b/.buildkite/pipeline.full.yml
@@ -16,7 +16,8 @@ steps:
     plugins:
       artifacts#v1.3.0:
         download: ["features/fixtures/ios/output/iOSTestApp.ipa"]
-      docker-compose#v3.3.0:
+      docker-compose#v3.7.0:
+        pull: cocoa-maze-runner
         run: cocoa-maze-runner
         command:
           - "--app=/app/build/iOSTestApp.ipa"
@@ -42,7 +43,8 @@ steps:
     plugins:
       artifacts#v1.3.0:
         download: ["features/fixtures/ios/output/iOSTestApp.ipa"]
-      docker-compose#v3.3.0:
+      docker-compose#v3.7.0:
+        pull: cocoa-maze-runner
         run: cocoa-maze-runner
         command:
           - "--app=/app/build/iOSTestApp.ipa"
@@ -69,7 +71,8 @@ steps:
       artifacts#v1.3.0:
         download: "features/fixtures/ios/output/ipa_url.txt"
         upload: "maze_output/failed/**/*"
-      docker-compose#v3.3.0:
+      docker-compose#v3.7.0:
+        pull: cocoa-maze-runner
         run: cocoa-maze-runner
         command:
           - "--app=@build/ipa_url.txt"
@@ -97,7 +100,8 @@ steps:
       artifacts#v1.3.0:
         download: "features/fixtures/ios/output/ipa_url.txt"
         upload: "maze_output/failed/**/*"
-      docker-compose#v3.3.0:
+      docker-compose#v3.7.0:
+        pull: cocoa-maze-runner
         run: cocoa-maze-runner
         command:
           - "--app=@build/ipa_url.txt"
@@ -125,7 +129,8 @@ steps:
       artifacts#v1.3.0:
         download: "features/fixtures/ios/output/ipa_url.txt"
         upload: "maze_output/failed/**/*"
-      docker-compose#v3.3.0:
+      docker-compose#v3.7.0:
+        pull: cocoa-maze-runner
         run: cocoa-maze-runner
         command:
           - "--app=@build/ipa_url.txt"
@@ -153,7 +158,8 @@ steps:
       artifacts#v1.3.0:
         download: "features/fixtures/ios/output/ipa_url.txt"
         upload: "maze_output/failed/**/*"
-      docker-compose#v3.3.0:
+      docker-compose#v3.7.0:
+        pull: cocoa-maze-runner
         run: cocoa-maze-runner
         command:
           - "--app=@build/ipa_url.txt"
@@ -183,7 +189,8 @@ steps:
       artifacts#v1.3.0:
         download: "features/fixtures/ios/output/ipa_url.txt"
         upload: "maze_output/failed/**/*"
-      docker-compose#v3.3.0:
+      docker-compose#v3.7.0:
+        pull: cocoa-maze-runner
         run: cocoa-maze-runner
         command:
           - "--app=@build/ipa_url.txt"
@@ -213,7 +220,8 @@ steps:
       artifacts#v1.3.0:
         download: "features/fixtures/ios/output/ipa_url.txt"
         upload: "maze_output/failed/**/*"
-      docker-compose#v3.3.0:
+      docker-compose#v3.7.0:
+        pull: cocoa-maze-runner
         run: cocoa-maze-runner
         command:
           - "--app=@build/ipa_url.txt"

--- a/.buildkite/pipeline.quick.yml
+++ b/.buildkite/pipeline.quick.yml
@@ -144,7 +144,8 @@ steps:
       artifacts#v1.3.0:
         download: "features/fixtures/ios/output/ipa_url.txt"
         upload: "maze_output/failed/**/*"
-      docker-compose#v3.3.0:
+      docker-compose#v3.7.0:
+        pull: cocoa-maze-runner
         run: cocoa-maze-runner
         command:
           - "--app=@build/ipa_url.txt"
@@ -172,7 +173,8 @@ steps:
       artifacts#v1.3.0:
         download: "features/fixtures/ios/output/ipa_url.txt"
         upload: "maze_output/failed/**/*"
-      docker-compose#v3.3.0:
+      docker-compose#v3.7.0:
+        pull: cocoa-maze-runner
         run: cocoa-maze-runner
         command:
           - "--app=@build/ipa_url.txt"
@@ -200,7 +202,8 @@ steps:
       artifacts#v1.3.0:
         download: "features/fixtures/ios/output/ipa_url.txt"
         upload: "maze_output/failed/**/*"
-      docker-compose#v3.3.0:
+      docker-compose#v3.7.0:
+        pull: cocoa-maze-runner
         run: cocoa-maze-runner
         command:
           - "--app=@build/ipa_url.txt"
@@ -228,7 +231,8 @@ steps:
       artifacts#v1.3.0:
         download: "features/fixtures/ios/output/ipa_url.txt"
         upload: "maze_output/failed/**/*"
-      docker-compose#v3.3.0:
+      docker-compose#v3.7.0:
+        pull: cocoa-maze-runner
         run: cocoa-maze-runner
         command:
           - "--app=@build/ipa_url.txt"

--- a/.buildkite/pipeline.yml
+++ b/.buildkite/pipeline.yml
@@ -136,7 +136,8 @@ steps:
       artifacts#v1.3.0:
         download: "features/fixtures/ios/output/ipa_url.txt"
         upload: "maze_output/failed/**/*"
-      docker-compose#v3.3.0:
+      docker-compose#v3.7.0:
+        pull: cocoa-maze-runner
         run: cocoa-maze-runner
         command:
           - "features/barebone_tests.feature"
@@ -163,7 +164,8 @@ steps:
       artifacts#v1.3.0:
         download: "features/fixtures/ios/output/ipa_url.txt"
         upload: "maze_output/failed/**/*"
-      docker-compose#v3.3.0:
+      docker-compose#v3.7.0:
+        pull: cocoa-maze-runner
         run: cocoa-maze-runner
         command:
           - "features/barebone_tests.feature"

--- a/Gemfile
+++ b/Gemfile
@@ -7,7 +7,7 @@ gem 'xcpretty'
 
 # A reference to Maze Runner is only needed for running tests locally and if committed it must be
 # portable for CI, e.g. a specific release.  However, leaving it commented out would mean quicker CI.
-gem 'bugsnag-maze-runner', git: 'https://github.com/bugsnag/maze-runner', tag: 'v6.7.0'
+gem 'bugsnag-maze-runner', git: 'https://github.com/bugsnag/maze-runner', tag: 'v6.8.0'
 
 # Use a specific branch
 #gem 'bugsnag-maze-runner', git: 'https://github.com/bugsnag/maze-runner', branch: 'master'

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -206,7 +206,7 @@ GEM
     nokogiri (1.12.5)
       mini_portile2 (~> 2.6.1)
       racc (~> 1.4)
-    nokogiri (1.12.5-arm64-darwin)
+    nokogiri (1.12.5-x86_64-darwin)
       racc (~> 1.4)
     octokit (4.21.0)
       faraday (>= 0.9)

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -1,21 +1,20 @@
 GIT
   remote: https://github.com/bugsnag/maze-runner
-  revision: ad4225e8bcfb9765049c8abc7ae8833177249d70
-  tag: v6.7.0
+  revision: fe12189f83aad154f54221ee0fcd41b483d3c0d1
+  tag: v6.8.0
   specs:
-    bugsnag-maze-runner (6.7.0)
+    bugsnag-maze-runner (6.8.0)
       appium_lib (~> 11.2.0)
       bugsnag (~> 6.24)
       cucumber (~> 7.1)
       cucumber-expressions (~> 6.0.0)
       curb (~> 0.9.6)
-      minitest (~> 5.0)
       optimist (~> 3.0.1)
       os (~> 1.0.0)
       rake (~> 12.3.3)
       rubyzip (~> 2.3.2)
       selenium-webdriver (~> 3.11)
-      test-unit (~> 3.3.0)
+      test-unit (~> 3.5.2)
       webrick (~> 1.7.0)
 
 GEM
@@ -207,7 +206,7 @@ GEM
     nokogiri (1.12.5)
       mini_portile2 (~> 2.6.1)
       racc (~> 1.4)
-    nokogiri (1.12.5-x86_64-darwin)
+    nokogiri (1.12.5-arm64-darwin)
       racc (~> 1.4)
     octokit (4.21.0)
       faraday (>= 0.9)
@@ -239,7 +238,7 @@ GEM
       ffi (~> 1.1)
     terminal-table (3.0.2)
       unicode-display_width (>= 1.1.1, < 3)
-    test-unit (3.3.9)
+    test-unit (3.5.3)
       power_assert
     tomlrb (1.3.0)
     typhoeus (1.4.0)

--- a/features/steps/cocoa_steps.rb
+++ b/features/steps/cocoa_steps.rb
@@ -1,6 +1,7 @@
 def short_scenario_name(scenario)
   unless scenario.end_with? 'Scenario'
-    raise 'All scenario names must end with "Scenario".  There are removed by the test harness and re-added uniformly by the test fixture.'
+    raise 'All scenario names must end with "Scenario".  ' \
+          'There are removed by the test harness and re-added uniformly by the test fixture.'
   end
   scenario.delete_suffix 'Scenario'
 end
@@ -80,17 +81,17 @@ def request_matches_row(body, row)
 end
 
 Then('the error payload field {string} is equal for error {int} and error {int}') do |key, index_a, index_b|
-  assert_true(request_fields_are_equal(key, index_a, index_b))
+  Maze.check.true(request_fields_are_equal(key, index_a, index_b))
 end
 
 Then('the error payload field {string} is not equal for error {int} and error {int}') do |key, index_a, index_b|
-  assert_false(request_fields_are_equal(key, index_a, index_b))
+  Maze.check.false(request_fields_are_equal(key, index_a, index_b))
 end
 
 def request_fields_are_equal(key, index_a, index_b)
   requests = Maze::Server.errors.remaining
-  assert_true(requests.length > index_a, "Not enough requests received to access index #{index_a}")
-  assert_true(requests.length > index_b, "Not enough requests received to access index #{index_b}")
+  Maze.check.true(requests.length > index_a, "Not enough requests received to access index #{index_a}")
+  Maze.check.true(requests.length > index_b, "Not enough requests received to access index #{index_b}")
   request_a = requests[index_a][:body]
   request_b = requests[index_b][:body]
   val_a = Maze::Helper.read_key_path(request_a, key)
@@ -117,7 +118,8 @@ def check_device_model(field, list)
   expected_model = Maze.config.capabilities['device']
   valid_models = internal_names[expected_model]
   device_model = Maze::Helper.read_key_path(list.current[:body], field)
-  assert_true(valid_models != nil ? valid_models.include?(device_model) : true, "The field #{device_model} did not match any of the list of expected fields")
+  Maze.check.true(valid_models != nil ? valid_models.include?(device_model) : true,
+                  "The field #{device_model} did not match any of the list of expected fields")
 end
 
 Then('the error payload field {string} matches the test device model') do |field|
@@ -142,10 +144,10 @@ end
 Then('the stacktrace is valid for the event') do
   stacktrace = Maze::Helper.read_key_path(Maze::Server.errors.current[:body], 'events.0.exceptions.0.stacktrace')
   # values that are required for symbolication to work
-  keys = ['frameAddress', 'machoFile', 'machoLoadAddress', 'machoUUID', 'machoVMAddress']
+  keys = %w[frameAddress machoFile machoLoadAddress machoUUID machoVMAddress]
   stacktrace.each_with_index do |frame, i|
     keys.each do |key|
-      assert_not_nil(frame[key], "Stack frame #{i} is missing #{key}")
+      Maze.check.not_nil(frame[key], "Stack frame #{i} is missing #{key}")
     end
   end
 end
@@ -154,19 +156,19 @@ Then('the thread information is valid for the event') do
   # verify that thread/stacktrace information was captured at all
   thread_traces = Maze::Helper.read_key_path(Maze::Server.errors.current[:body], 'events.0.threads')
   stack_traces = Maze::Helper.read_key_path(Maze::Server.errors.current[:body], 'events.0.exceptions.0.stacktrace')
-  assert_not_nil(thread_traces, 'No thread trace recorded')
-  assert_not_nil(stack_traces, 'No thread trace recorded')
-  assert_true(stack_traces.count() > 0, 'Expected stacktrace collected to be > 0')
-  assert_true(thread_traces.count() > 0, 'Expected number of threads collected to be > 0')
+  Maze.check.not_nil(thread_traces, 'No thread trace recorded')
+  Maze.check.not_nil(stack_traces, 'No thread trace recorded')
+  Maze.check.true(stack_traces.count() > 0, 'Expected stacktrace collected to be > 0')
+  Maze.check.true(thread_traces.count() > 0, 'Expected number of threads collected to be > 0')
 
   # verify threads are recorded and contain plausible information (id, type, stacktrace)
   thread_traces.each do |thread|
-    assert_not_nil(thread['id'], "Thread ID missing for #{thread}")
-    assert_equal('cocoa', thread['type'], "Thread type does not equal 'cocoa' for #{thread}")
+    Maze.check.not_nil(thread['id'], "Thread ID missing for #{thread}")
+    Maze.check.equal('cocoa', thread['type'], "Thread type does not equal 'cocoa' for #{thread}")
     stacktrace = thread['stacktrace']
-    assert_not_nil(stacktrace, "Stacktrace is null for #{thread}")
+    Maze.check.not_nil(stacktrace, "Stacktrace is null for #{thread}")
     stack_traces.each do |frame|
-      assert_not_nil(frame['method'], "Method is null for frame #{frame}")
+      Maze.check.not_nil(frame['method'], "Method is null for frame #{frame}")
     end
   end
 
@@ -179,12 +181,16 @@ Then('the thread information is valid for the event') do
       err_thread_trace = thread['stacktrace']
     end
   end
-  assert_equal(1, err_thread_count, "Expected errorReportingThread to be reported once for threads #{thread_traces}")
+  Maze.check.equal(1,
+                   err_thread_count,
+                   "Expected errorReportingThread to be reported once for threads #{thread_traces}")
 
   # verify the errorReportingThread stacktrace matches the exception stacktrace
   stack_traces.each_with_index do |frame, index|
     thread_frame = err_thread_trace[index]
-    assert_equal(frame, thread_frame, "Thread and stacktrace differ at #{index}. Stack=#{frame}, thread=#{thread_frame}")
+    Maze.check.equal(frame,
+                     thread_frame,
+                     "Thread and stacktrace differ at #{index}. Stack=#{frame}, thread=#{thread_frame}")
   end
 end
 
@@ -240,7 +246,7 @@ end
 
 Then('the exception {string} equals one of:') do |keypath, possible_values|
   value = Maze::Helper.read_key_path(Maze::Server.errors.current[:body], "events.0.exceptions.0.#{keypath}")
-  assert_includes(possible_values.raw.flatten, value)
+  Maze.check.includes(possible_values.raw.flatten, value)
 end
 
 Then('the error is an OOM event') do

--- a/features/steps/cocoa_steps.rb
+++ b/features/steps/cocoa_steps.rb
@@ -1,7 +1,8 @@
 def short_scenario_name(scenario)
+  # A "Scenario" suffix is removed by the test harness and re-added uniformly by
+  # the test fixture. This reduces the time that Appium spends entering text.
   unless scenario.end_with? 'Scenario'
-    raise 'All scenario names must end with "Scenario".  ' \
-          'There are removed by the test harness and re-added uniformly by the test fixture.'
+    raise 'All scenario names must end with "Scenario".'
   end
   scenario.delete_suffix 'Scenario'
 end

--- a/features/steps/negative_comparison_steps.rb
+++ b/features/steps/negative_comparison_steps.rb
@@ -1,7 +1,8 @@
 Then("the error payload field {string} does not equal {string}") do |field_path, string_value|
   payload_value = Maze::Helper.read_key_path(Maze::Server.errors.current[:body], field_path)
   result = Maze::Compare.value(payload_value, string_value)
-  assert_false(result.equal?, "Value: #{string_value} equals payload element at: #{field_path}")
+  Maze.check.false(result.equal?,
+                   "Value: #{string_value} equals payload element at: #{field_path}")
 end
 
 Then("the session {string} does not equal {string}") do |field_path, string_value|

--- a/features/steps/reusable_steps.rb
+++ b/features/steps/reusable_steps.rb
@@ -2,65 +2,67 @@
 
 Then('the event {string} equals one of:') do |field, possible_values|
   value = Maze::Helper.read_key_path(Maze::Server.errors.current[:body], "events.0.#{field}")
-  assert_includes(possible_values.raw.flatten, value)
+  Maze.check.includes(possible_values.raw.flatten, value)
 end
 
 Then('the event {string} is within {int} seconds of the current timestamp') do |field, threshold_secs|
   value = Maze::Helper.read_key_path(Maze::Server.errors.current[:body], "events.0.#{field}")
-  assert_not_nil(value, 'Expected a timestamp')
+  Maze.check.not_nil(value, 'Expected a timestamp')
   now_secs = Time.now.to_i
   then_secs = Time.parse(value).to_i
   delta = now_secs - then_secs
-  assert_true(delta.abs < threshold_secs, "Expected current timestamp, but received #{value}")
+  Maze.check.true(delta.abs < threshold_secs, "Expected current timestamp, but received #{value}")
 end
 
 Then('the event {string} is between {float} and {float}') do |field, lower, upper|
   value = Maze::Helper.read_key_path(Maze::Server.errors.current[:body], "events.0.#{field}")
-  assert_not_nil(value, 'Expected a value')
-  assert_true(lower <= value && value <= upper, "Expected a value between #{lower} and #{upper}, but received #{value}")
+  Maze.check.not_nil(value, 'Expected a value')
+  Maze.check.true(lower <= value && value <= upper,
+                  "Expected a value between #{lower} and #{upper}, but received #{value}")
 end
 
 Then('the event {string} is between {int} and {int}') do |field, lower, upper|
   value = Maze::Helper.read_key_path(Maze::Server.errors.current[:body], "events.0.#{field}")
-  assert_not_nil(value, 'Expected a value')
-  assert_true(lower <= value && value <= upper, "Expected a value between #{lower} and #{upper}, but received #{value}")
+  Maze.check.not_nil(value, 'Expected a value')
+  Maze.check.true(lower <= value && value <= upper,
+                  "Expected a value between #{lower} and #{upper}, but received #{value}")
 end
 
 Then('the event {string} is less than the event {string}') do |field1, field2|
   value1 = Maze::Helper.read_key_path(Maze::Server.errors.current[:body], "events.0.#{field1}")
-  assert_not_nil(value1, 'Expected a value')
+  Maze.check.not_nil(value1, 'Expected a value')
   value2 = Maze::Helper.read_key_path(Maze::Server.errors.current[:body], "events.0.#{field2}")
-  assert_not_nil(value2, 'Expected a value')
-  assert_true(value1 < value2, "Expected value to be less than #{value2}, but received #{value1}")
+  Maze.check.not_nil(value2, 'Expected a value')
+  Maze.check.true(value1 < value2, "Expected value to be less than #{value2}, but received #{value1}")
 end
 
 Then('the event breadcrumbs contain {string} with type {string}') do |string, type|
   crumbs = Maze::Helper.read_key_path(find_request(0)[:body], 'events.0.breadcrumbs')
-  assert_not_equal(0, crumbs.length, 'There are no breadcrumbs on this event')
+  Maze.check.not_equal(0, crumbs.length, 'There are no breadcrumbs on this event')
   match = crumbs.detect do |crumb|
     crumb['name'] == string && crumb['type'] == type
   end
-  assert_not_nil(match, 'No crumb matches the provided message and type')
+  Maze.check.not_nil(match, 'No crumb matches the provided message and type')
 end
 
 Then('the event breadcrumbs contain {string}') do |string|
   crumbs = Maze::Helper.read_key_path(Maze::Server.errors.current[:body], 'events.0.breadcrumbs')
-  assert_not_equal(0, crumbs.length, 'There are no breadcrumbs on this event')
+  Maze.check.not_equal(0, crumbs.length, 'There are no breadcrumbs on this event')
   match = crumbs.detect do |crumb|
     crumb['name'] == string
   end
-  assert_not_nil(match, 'No crumb matches the provided message')
+  Maze.check.not_nil(match, 'No crumb matches the provided message')
 end
 
 Then('the stack trace is an array with {int} stack frames') do |expected_length|
   stack_trace = Maze::Helper.read_key_path(Maze::Server.errors.current[:body], 'events.0.exceptions.0.stacktrace')
-  assert_equal(expected_length, stack_trace.length)
+  Maze.check.equal(expected_length, stack_trace.length)
 end
 
 Then('the {string} of stack frame {int} equals one of:') do |key, num, possible_values|
   field = "events.0.exceptions.0.stacktrace.#{num}.#{key}"
   value = Maze::Helper.read_key_path(Maze::Server.errors.current[:body], field)
-  assert_includes(possible_values.raw.flatten, value)
+  Maze.check.includes(possible_values.raw.flatten, value)
 end
 
 Then('the stacktrace contains methods:') do |table|
@@ -68,5 +70,5 @@ Then('the stacktrace contains methods:') do |table|
   expected = table.raw.flatten
   actual = stack_trace.map { |s| s['method'] }
   contains = actual.each_cons(expected.length).to_a.include? expected
-  assert_true(contains, "Stacktrace methods #{actual} did not contain #{expected}")
+  Maze.check.true(contains, "Stacktrace methods #{actual} did not contain #{expected}")
 end


### PR DESCRIPTION
## Goal

Use the `Maze.check` abstraction added to Maze Runner for the checking of values in tests.

## Design

This avoids potential issues from using functions in the global namespace and allows the use of forthcoming features of Maze Runner such as deferred checking.

## Changeset

Also includes a tweak to the pipeline steps to ensure that the latest Maze Runner docker image is always used.

## Testing

Covered by a full CI run.