### PR TITLE
Ensure bundle install works with system Ruby on Intel macs

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -1,9 +1,9 @@
 source 'https://rubygems.org'
 
-# gem 'cocoapods'
-# gem 'danger'
-# gem 'jazzy'
-# gem 'xcpretty'
+gem 'cocoapods'
+gem 'danger'
+gem 'jazzy'
+gem 'xcpretty'
 
 # A reference to Maze Runner is only needed for running tests locally and if committed it must be
 # portable for CI, e.g. a specific release.  However, leaving it commented out would mean quicker CI.

--- a/Gemfile
+++ b/Gemfile
@@ -1,9 +1,9 @@
 source 'https://rubygems.org'
 
-gem 'cocoapods'
-gem 'danger'
-gem 'jazzy'
-gem 'xcpretty'
+# gem 'cocoapods'
+# gem 'danger'
+# gem 'jazzy'
+# gem 'xcpretty'
 
 # A reference to Maze Runner is only needed for running tests locally and if committed it must be
 # portable for CI, e.g. a specific release.  However, leaving it commented out would mean quicker CI.

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -20,8 +20,9 @@ GIT
 GEM
   remote: https://rubygems.org/
   specs:
-    CFPropertyList (3.0.3)
-    activesupport (6.1.4.1)
+    CFPropertyList (3.0.5)
+      rexml
+    activesupport (6.1.4.4)
       concurrent-ruby (~> 1.0, >= 1.0.2)
       i18n (>= 1.6, < 2)
       minitest (>= 5.1)
@@ -123,7 +124,7 @@ GEM
       cucumber-cucumber-expressions (~> 14.0, >= 14.0.0)
       cucumber-messages (~> 17.1, >= 17.1.1)
     curb (0.9.11)
-    danger (8.3.1)
+    danger (8.4.2)
       claide (~> 1.0)
       claide-plugins (>= 0.9.2)
       colored2 (~> 3.1)
@@ -138,7 +139,7 @@ GEM
       terminal-table (>= 1, < 4)
     diff-lcs (1.4.4)
     escape (0.0.4)
-    ethon (0.14.0)
+    ethon (0.15.0)
       ffi (>= 1.15.0)
     eventmachine (1.2.7)
     faraday (1.8.0)
@@ -169,12 +170,12 @@ GEM
     fourflusher (2.3.1)
     fuzzy_match (2.0.4)
     gh_inspector (1.1.3)
-    git (1.9.1)
+    git (1.10.0)
       rchardet (~> 1.8)
     httpclient (2.8.3)
-    i18n (1.8.10)
+    i18n (1.8.11)
       concurrent-ruby (~> 1.0)
-    jazzy (0.14.0)
+    jazzy (0.14.1)
       cocoapods (~> 1.5)
       mustache (~> 1.1)
       open4 (~> 1.3)
@@ -184,7 +185,7 @@ GEM
       sassc (~> 2.1)
       sqlite3 (~> 1.3)
       xcinvoke (~> 0.3.0)
-    json (2.5.1)
+    json (2.6.1)
     kramdown (2.3.1)
       rexml
     kramdown-parser-gfm (1.1.0)
@@ -194,7 +195,7 @@ GEM
       mime-types-data (~> 3.2015)
     mime-types-data (3.2021.1115)
     mini_portile2 (2.6.1)
-    minitest (5.14.4)
+    minitest (5.15.0)
     molinillo (0.8.0)
     multi_test (0.1.2)
     multipart-post (2.1.1)
@@ -205,8 +206,6 @@ GEM
     no_proxy_fix (0.1.2)
     nokogiri (1.12.5)
       mini_portile2 (~> 2.6.1)
-      racc (~> 1.4)
-    nokogiri (1.12.5-x86_64-darwin)
       racc (~> 1.4)
     octokit (4.21.0)
       faraday (>= 0.9)
@@ -261,11 +260,10 @@ GEM
       rexml (~> 3.2.4)
     xcpretty (0.3.0)
       rouge (~> 2.0.7)
-    zeitwerk (2.4.2)
+    zeitwerk (2.5.1)
 
 PLATFORMS
   ruby
-  universal-darwin-20
 
 DEPENDENCIES
   bugsnag-maze-runner!
@@ -275,4 +273,4 @@ DEPENDENCIES
   xcpretty
 
 BUNDLED WITH
-   2.2.20
+   2.3.0


### PR DESCRIPTION
## Goal

Ensure `bundle install` and `bundle exec` work on both ARM and Intel Macs with the default system Ruby.

## Testing

Tested locally and by CI.