### PR TITLE
[PLAT-7781] Add KSCrashReport writing performance test

### DIFF
--- a/Bugsnag.xcodeproj/project.pbxproj
+++ b/Bugsnag.xcodeproj/project.pbxproj
@@ -676,6 +676,9 @@
 		01A617802733CFEC00024A0B /* main.m in Sources */ = {isa = PBXBuildFile; fileRef = 01A6177F2733CFEC00024A0B /* main.m */; };
 		01A617852733D15C00024A0B /* Bugsnag.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = 00AD1C7224869B0E00A27979 /* Bugsnag.framework */; };
 		01A617862733D15C00024A0B /* Bugsnag.framework in Embed Frameworks */ = {isa = PBXBuildFile; fileRef = 00AD1C7224869B0E00A27979 /* Bugsnag.framework */; settings = {ATTRIBUTES = (CodeSignOnCopy, RemoveHeadersOnCopy, ); }; };
+		01ABD8792786DF9A009A5CA2 /* BSG_KSCrashReportTests.m in Sources */ = {isa = PBXBuildFile; fileRef = 01ABD8782786DF9A009A5CA2 /* BSG_KSCrashReportTests.m */; };
+		01ABD87A2786DF9A009A5CA2 /* BSG_KSCrashReportTests.m in Sources */ = {isa = PBXBuildFile; fileRef = 01ABD8782786DF9A009A5CA2 /* BSG_KSCrashReportTests.m */; };
+		01ABD87B2786DF9A009A5CA2 /* BSG_KSCrashReportTests.m in Sources */ = {isa = PBXBuildFile; fileRef = 01ABD8782786DF9A009A5CA2 /* BSG_KSCrashReportTests.m */; };
 		01B14C56251CE55F00118748 /* report-react-native-promise-rejection.json in Resources */ = {isa = PBXBuildFile; fileRef = 01B14C55251CE55F00118748 /* report-react-native-promise-rejection.json */; };
 		01B14C57251CE55F00118748 /* report-react-native-promise-rejection.json in Resources */ = {isa = PBXBuildFile; fileRef = 01B14C55251CE55F00118748 /* report-react-native-promise-rejection.json */; };
 		01B14C58251CE55F00118748 /* report-react-native-promise-rejection.json in Resources */ = {isa = PBXBuildFile; fileRef = 01B14C55251CE55F00118748 /* report-react-native-promise-rejection.json */; };
@@ -1358,6 +1361,7 @@
 		01A6177E2733CFEC00024A0B /* Info.plist */ = {isa = PBXFileReference; lastKnownFileType = text.plist.xml; path = Info.plist; sourceTree = "<group>"; };
 		01A6177F2733CFEC00024A0B /* main.m */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.objc; path = main.m; sourceTree = "<group>"; };
 		01A617842733D15C00024A0B /* BugsnagNetworkRequestPlugin.framework */ = {isa = PBXFileReference; explicitFileType = wrapper.framework; path = BugsnagNetworkRequestPlugin.framework; sourceTree = BUILT_PRODUCTS_DIR; };
+		01ABD8782786DF9A009A5CA2 /* BSG_KSCrashReportTests.m */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.objc; path = BSG_KSCrashReportTests.m; sourceTree = "<group>"; };
 		01B14C55251CE55F00118748 /* report-react-native-promise-rejection.json */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = text.json; path = "report-react-native-promise-rejection.json"; sourceTree = "<group>"; };
 		01B79DA7267CC4A000C8CC5E /* BSGUtils.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; path = BSGUtils.h; sourceTree = "<group>"; };
 		01B79DA8267CC4A000C8CC5E /* BSGUtils.m */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.objc; path = BSGUtils.m; sourceTree = "<group>"; };
@@ -1515,11 +1519,13 @@
 		008966D32486D43700DC48C2 /* KSCrashTests */ = {
 			isa = PBXGroup;
 			children = (
+				01ABD8782786DF9A009A5CA2 /* BSG_KSCrashReportTests.m */,
 				008966D82486D43700DC48C2 /* BSG_KSMachHeadersTests.m */,
 				008966EA2486D43700DC48C2 /* BSG_KSMachTests.m */,
 				008966D62486D43700DC48C2 /* FileBasedTestCase.h */,
 				008966E42486D43700DC48C2 /* FileBasedTestCase.m */,
 				008966E92486D43700DC48C2 /* KSCrashIdentifierTests.m */,
+				CB156240270707740097334C /* KSCrashNames_Test.m */,
 				01C17AE62542ED7F00C102C9 /* KSCrashReportWriterTests.m */,
 				008966DD2486D43700DC48C2 /* KSCrashSentry_NSException_Tests.m */,
 				008966E72486D43700DC48C2 /* KSCrashSentry_Signal_Tests.m */,
@@ -1536,7 +1542,6 @@
 				008966D92486D43700DC48C2 /* RFC3339DateTool_Tests.m */,
 				008966E22486D43700DC48C2 /* XCTestCase+KSCrash.h */,
 				008966D72486D43700DC48C2 /* XCTestCase+KSCrash.m */,
-				CB156240270707740097334C /* KSCrashNames_Test.m */,
 			);
 			path = KSCrashTests;
 			sourceTree = "<group>";
@@ -2766,6 +2771,7 @@
 				008967A82486D43700DC48C2 /* KSCrashIdentifierTests.m in Sources */,
 				008967572486D43700DC48C2 /* BugsnagClientMirrorTest.m in Sources */,
 				0089677B2486D43700DC48C2 /* RFC3339DateTool_Tests.m in Sources */,
+				01ABD8792786DF9A009A5CA2 /* BSG_KSCrashReportTests.m in Sources */,
 				0089676F2486D43700DC48C2 /* NSError+SimpleConstructor_Tests.m in Sources */,
 				01DE903C26CEAF9E00455213 /* BSGUtilsTests.m in Sources */,
 				008966F42486D43700DC48C2 /* BugsnagThreadTests.m in Sources */,
@@ -2942,6 +2948,7 @@
 				01847DAD26441A5E00ADA4C7 /* BSGInternalErrorReporterTests.m in Sources */,
 				0089672B2486D43700DC48C2 /* BugsnagStacktraceTest.m in Sources */,
 				008966F22486D43700DC48C2 /* BugsnagMetadataRedactionTest.m in Sources */,
+				01ABD87A2786DF9A009A5CA2 /* BSG_KSCrashReportTests.m in Sources */,
 				CBDD6D0725AC3EFF00A2E12B /* BSGStorageMigratorTests.m in Sources */,
 				008967372486D43700DC48C2 /* BugsnagMetadataTests.m in Sources */,
 				008967822486D43700DC48C2 /* KSSystemInfo_Tests.m in Sources */,
@@ -3112,6 +3119,7 @@
 				008967382486D43700DC48C2 /* BugsnagMetadataTests.m in Sources */,
 				008967832486D43700DC48C2 /* KSSystemInfo_Tests.m in Sources */,
 				008967622486D43700DC48C2 /* BugsnagBreadcrumbsTest.m in Sources */,
+				01ABD87B2786DF9A009A5CA2 /* BSG_KSCrashReportTests.m in Sources */,
 				008967022486D43700DC48C2 /* BugsnagEventPersistLoadTest.m in Sources */,
 				008967712486D43700DC48C2 /* NSError+SimpleConstructor_Tests.m in Sources */,
 				0089671D2486D43700DC48C2 /* BugsnagSessionTest.m in Sources */,

--- a/Bugsnag.xcodeproj/xcshareddata/xcbaselines/00AD1C7A24869B0E00A27979.xcbaseline/B9A70F85-2A05-489B-A5BA-1129C478B0A1.plist
+++ b/Bugsnag.xcodeproj/xcshareddata/xcbaselines/00AD1C7A24869B0E00A27979.xcbaseline/B9A70F85-2A05-489B-A5BA-1129C478B0A1.plist
@@ -4,14 +4,14 @@
 <dict>
 	<key>classNames</key>
 	<dict>
-		<key>BugsnagBreadcrumbsTest</key>
+		<key>BSG_KSCrashReportTests</key>
 		<dict>
-			<key>testPerformance</key>
+			<key>testWriteStandardReportPerformance</key>
 			<dict>
 				<key>com.apple.XCTPerformanceMetric_WallClockTime</key>
 				<dict>
 					<key>baselineAverage</key>
-					<real>0.048800</real>
+					<real>0.102000</real>
 					<key>baselineIntegrationDisplayName</key>
 					<string>Local Baseline</string>
 				</dict>

--- a/Bugsnag.xcodeproj/xcshareddata/xcbaselines/00AD1C7A24869B0E00A27979.xcbaseline/D90C8D39-16DA-4CCB-8283-66F4A3B10BA2.plist
+++ b/Bugsnag.xcodeproj/xcshareddata/xcbaselines/00AD1C7A24869B0E00A27979.xcbaseline/D90C8D39-16DA-4CCB-8283-66F4A3B10BA2.plist
@@ -4,14 +4,14 @@
 <dict>
 	<key>classNames</key>
 	<dict>
-		<key>BugsnagBreadcrumbsTest</key>
+		<key>BSG_KSCrashReportTests</key>
 		<dict>
-			<key>testPerformance</key>
+			<key>testWriteStandardReportPerformance</key>
 			<dict>
 				<key>com.apple.XCTPerformanceMetric_WallClockTime</key>
 				<dict>
 					<key>baselineAverage</key>
-					<real>0.048800</real>
+					<real>0.650000</real>
 					<key>baselineIntegrationDisplayName</key>
 					<string>Local Baseline</string>
 				</dict>

--- a/Bugsnag.xcodeproj/xcshareddata/xcbaselines/00AD1C7A24869B0E00A27979.xcbaseline/Info.plist
+++ b/Bugsnag.xcodeproj/xcshareddata/xcbaselines/00AD1C7A24869B0E00A27979.xcbaseline/Info.plist
@@ -35,6 +35,30 @@
 				<string>com.apple.platform.iphonesimulator</string>
 			</dict>
 		</dict>
+		<key>B9A70F85-2A05-489B-A5BA-1129C478B0A1</key>
+		<dict>
+			<key>targetArchitecture</key>
+			<string>arm64</string>
+			<key>targetDevice</key>
+			<dict>
+				<key>modelCode</key>
+				<string>iPhone12,8</string>
+				<key>platformIdentifier</key>
+				<string>com.apple.platform.iphoneos</string>
+			</dict>
+		</dict>
+		<key>D90C8D39-16DA-4CCB-8283-66F4A3B10BA2</key>
+		<dict>
+			<key>targetArchitecture</key>
+			<string>arm64</string>
+			<key>targetDevice</key>
+			<dict>
+				<key>modelCode</key>
+				<string>iPhone6,2</string>
+				<key>platformIdentifier</key>
+				<string>com.apple.platform.iphoneos</string>
+			</dict>
+		</dict>
 	</dict>
 </dict>
 </plist>

--- a/Bugsnag.xcodeproj/xcshareddata/xcbaselines/00AD1CB424869C1200A27979.xcbaseline/7E1A1286-DD8C-4E45-9E88-4335CD976176.plist
+++ b/Bugsnag.xcodeproj/xcshareddata/xcbaselines/00AD1CB424869C1200A27979.xcbaseline/7E1A1286-DD8C-4E45-9E88-4335CD976176.plist
@@ -4,6 +4,19 @@
 <dict>
 	<key>classNames</key>
 	<dict>
+		<key>BSG_KSCrashReportTests</key>
+		<dict>
+			<key>testWriteStandardReportPerformance</key>
+			<dict>
+				<key>com.apple.XCTPerformanceMetric_WallClockTime</key>
+				<dict>
+					<key>baselineAverage</key>
+					<real>0.135000</real>
+					<key>baselineIntegrationDisplayName</key>
+					<string>Local Baseline</string>
+				</dict>
+			</dict>
+		</dict>
 		<key>BugsnagBreadcrumbsTest</key>
 		<dict>
 			<key>testPerformance</key>
@@ -11,7 +24,7 @@
 				<key>com.apple.XCTPerformanceMetric_WallClockTime</key>
 				<dict>
 					<key>baselineAverage</key>
-					<real>0.00675</real>
+					<real>0.006750</real>
 					<key>baselineIntegrationDisplayName</key>
 					<string>Local Baseline</string>
 				</dict>

--- a/Tests/KSCrashTests/BSG_KSCrashReportTests.m
+++ b/Tests/KSCrashTests/BSG_KSCrashReportTests.m
@@ -1,0 +1,72 @@
+//
+//  BSG_KSCrashReportTests.m
+//  Bugsnag
+//
+//  Created by Nick Dowell on 06/01/2022.
+//  Copyright © 2022 Bugsnag Inc. All rights reserved.
+//
+
+#import <XCTest/XCTest.h>
+
+#import "BSG_KSCrashC.h"
+#import "BSG_KSCrashReport.h"
+#import "BSG_KSCrashSentry_Private.h"
+#import "BSG_KSMach.h"
+
+@interface BSG_KSCrashReportTests : XCTestCase
+
+@end
+
+@implementation BSG_KSCrashReportTests
+
+- (void)testWriteStandardReportPerformance {
+    NSString *directory = NSTemporaryDirectory();
+    NSString *crashReportFilePath = [directory stringByAppendingPathComponent:@"crash_report"];
+    NSString *recrashReportFilePath = [directory stringByAppendingPathComponent:@"recrash_report"];
+    NSString *stateFilePath = [directory stringByAppendingPathComponent:@"kscrash_state"];
+    NSString *crashID = [[NSUUID UUID] UUIDString];
+    
+    bsg_kscrash_init();
+    bsg_kscrash_setHandlingCrashTypes(BSG_KSCrashTypeNSException);
+    bsg_kscrash_install([crashReportFilePath fileSystemRepresentation],
+                        [recrashReportFilePath fileSystemRepresentation],
+                        [stateFilePath fileSystemRepresentation],
+                        [crashID UTF8String]);
+    
+    // Make a fake stack trace with addresses from a library (Foundation) that will generate a non-trivial symbolication workload.
+    
+    const int numFrames = 500;
+    uintptr_t stackTrace[numFrames];
+    for (int i = 0; i < numFrames; i++) {
+        stackTrace[i] = NSLog;
+        assert(stackTrace[i] != 0);
+    }
+    
+    BSG_KSCrash_Context *context = crashContext();
+    context->crash.crashType = BSG_KSCrashTypeNSException;
+    context->crash.offendingThread = bsg_ksmachthread_self();
+    context->crash.registersAreValid = false;
+    context->crash.NSException.name = "BSG_KSCrashReportTests";
+    context->crash.crashReason = "testWriteStandardReportPerformance";
+    context->crash.stackTrace = stackTrace;
+    context->crash.stackTraceLength = numFrames;
+    context->crash.threadTracingEnabled = true;
+    
+    [self measureMetrics:[[self class] defaultPerformanceMetrics] automaticallyStartMeasuring:NO forBlock:^{
+        const char *reportPath = [crashReportFilePath fileSystemRepresentation];
+        
+        [self startMeasuring]; {
+            bsg_kscrashsentry_suspendThreads();
+            bsg_kscrashreport_writeStandardReport(context, reportPath);
+            bsg_kscrashsentry_resumeThreads();
+        }
+        [self stopMeasuring];
+        
+        [[NSFileManager defaultManager] removeItemAtPath:crashReportFilePath error:nil];
+    }];
+    
+    [[NSFileManager defaultManager] removeItemAtPath:recrashReportFilePath error:nil];
+    [[NSFileManager defaultManager] removeItemAtPath:stateFilePath error:nil];
+}
+
+@end


### PR DESCRIPTION
## Goal

Measure the performance of writing crash reports.

## Changeset

Adds a performance test using XCTest's built-in performance measuring capabilities.

This simulates the writing of an NSException crash with deterministic contents, however performance depends on the number of functions & symbols in the Foundation library which can change between OS releases.

## Testing

Tested locally, added baselines for MacBook Pro, iPhone 5s and iPhone SE (2020) to allow tracking improvements or regressions.