### PR TITLE
[PLAT-7756] Omit unused binary_images in KSCrashReports

### DIFF
--- a/Bugsnag.xcodeproj/xcshareddata/xcbaselines/00AD1C7A24869B0E00A27979.xcbaseline/B9A70F85-2A05-489B-A5BA-1129C478B0A1.plist
+++ b/Bugsnag.xcodeproj/xcshareddata/xcbaselines/00AD1C7A24869B0E00A27979.xcbaseline/B9A70F85-2A05-489B-A5BA-1129C478B0A1.plist
@@ -11,7 +11,7 @@
 				<key>com.apple.XCTPerformanceMetric_WallClockTime</key>
 				<dict>
 					<key>baselineAverage</key>
-					<real>0.102000</real>
+					<real>0.065700</real>
 					<key>baselineIntegrationDisplayName</key>
 					<string>Local Baseline</string>
 				</dict>

--- a/Bugsnag.xcodeproj/xcshareddata/xcbaselines/00AD1C7A24869B0E00A27979.xcbaseline/D90C8D39-16DA-4CCB-8283-66F4A3B10BA2.plist
+++ b/Bugsnag.xcodeproj/xcshareddata/xcbaselines/00AD1C7A24869B0E00A27979.xcbaseline/D90C8D39-16DA-4CCB-8283-66F4A3B10BA2.plist
@@ -11,7 +11,7 @@
 				<key>com.apple.XCTPerformanceMetric_WallClockTime</key>
 				<dict>
 					<key>baselineAverage</key>
-					<real>0.650000</real>
+					<real>0.468000</real>
 					<key>baselineIntegrationDisplayName</key>
 					<string>Local Baseline</string>
 				</dict>

--- a/Bugsnag.xcodeproj/xcshareddata/xcbaselines/00AD1CB424869C1200A27979.xcbaseline/7E1A1286-DD8C-4E45-9E88-4335CD976176.plist
+++ b/Bugsnag.xcodeproj/xcshareddata/xcbaselines/00AD1CB424869C1200A27979.xcbaseline/7E1A1286-DD8C-4E45-9E88-4335CD976176.plist
@@ -11,7 +11,7 @@
 				<key>com.apple.XCTPerformanceMetric_WallClockTime</key>
 				<dict>
 					<key>baselineAverage</key>
-					<real>0.135000</real>
+					<real>0.091900</real>
 					<key>baselineIntegrationDisplayName</key>
 					<string>Local Baseline</string>
 				</dict>

--- a/Bugsnag/KSCrash/Source/KSCrash/Recording/Tools/BSG_KSMachHeaders.h
+++ b/Bugsnag/KSCrash/Source/KSCrash/Recording/Tools/BSG_KSMachHeaders.h
@@ -25,7 +25,7 @@ typedef struct bsg_mach_image {
 
     /// The mach_header or mach_header_64
     ///
-    /// This is also the memory address where the image has been loaded by dyld, including slide.
+    /// This is also the memory address where the __TEXT segment has been loaded by dyld, including slide.
     const struct mach_header *header;
 
     /// The vmaddr specified for the __TEXT segment
@@ -47,6 +47,9 @@ typedef struct bsg_mach_image {
 
     /// True if the image has been unloaded and should be ignored
     bool unloaded;
+    
+    /// True if the image is referenced by the current crash report.
+    bool inCrashReport;
 
     /// The next image in the linked list
     struct bsg_mach_image *next;

--- a/Bugsnag/KSCrash/Source/KSCrash/Recording/Tools/BSG_Symbolicate.h
+++ b/Bugsnag/KSCrash/Source/KSCrash/Recording/Tools/BSG_Symbolicate.h
@@ -15,7 +15,7 @@ extern "C" {
 #include <stdint.h>
 
 struct bsg_symbolicate_result {
-    const struct bsg_mach_image *image;
+    struct bsg_mach_image *image;
     uintptr_t function_address;
     const char *function_name;
 };

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,11 @@
 Changelog
 =========
 
+## TBD
+
+* Improve crash report writing performance and size on disk.
+  [#1273](https://github.com/bugsnag/bugsnag-cocoa/pull/1273)
+
 ## 6.15.2 (2022-01-05)
 
 ### Bug fixes

--- a/Tests/KSCrashTests/BSG_KSCrashReportTests.m
+++ b/Tests/KSCrashTests/BSG_KSCrashReportTests.m
@@ -13,11 +13,60 @@
 #import "BSG_KSCrashSentry_Private.h"
 #import "BSG_KSMach.h"
 
+#import <execinfo.h>
+
 @interface BSG_KSCrashReportTests : XCTestCase
 
 @end
 
 @implementation BSG_KSCrashReportTests
+
+- (void)testBinaryImages {
+    NSString *directory = NSTemporaryDirectory();
+    NSString *crashReportFilePath = [directory stringByAppendingPathComponent:@"crash_report"];
+    NSString *recrashReportFilePath = [directory stringByAppendingPathComponent:@"recrash_report"];
+    NSString *stateFilePath = [directory stringByAppendingPathComponent:@"kscrash_state"];
+    NSString *crashID = [[NSUUID UUID] UUIDString];
+    
+    bsg_kscrash_init();
+    bsg_kscrash_setHandlingCrashTypes(BSG_KSCrashTypeNSException);
+    bsg_kscrash_install([crashReportFilePath fileSystemRepresentation],
+                        [recrashReportFilePath fileSystemRepresentation],
+                        [stateFilePath fileSystemRepresentation],
+                        [crashID UTF8String]);
+    
+    uintptr_t stackTrace[500];
+    
+    BSG_KSCrash_Context *context = crashContext();
+    context->crash.crashType = BSG_KSCrashTypeNSException;
+    context->crash.offendingThread = bsg_ksmachthread_self();
+    context->crash.registersAreValid = false;
+    context->crash.NSException.name = "BSG_KSCrashReportTests";
+    context->crash.crashReason = "testBinaryImages";
+    context->crash.stackTrace = stackTrace;
+    context->crash.stackTraceLength = backtrace((void **)stackTrace, sizeof(stackTrace) / sizeof(*stackTrace));
+    context->crash.threadTracingEnabled = false;
+    
+    const char *reportPath = [crashReportFilePath fileSystemRepresentation];
+    bsg_kscrashsentry_suspendThreads();
+    bsg_kscrashreport_writeStandardReport(context, reportPath);
+    bsg_kscrashsentry_resumeThreads();
+    
+    NSDictionary *report = [NSJSONSerialization JSONObjectWithData:[NSData dataWithContentsOfFile:crashReportFilePath] options:0 error:nil];
+    
+    NSArray *binaryImages = [report valueForKeyPath:@"binary_images"];
+    XCTAssert([binaryImages isKindOfClass:[NSArray class]]);
+    NSSet *binaryImageAddrs = [NSSet setWithArray:[binaryImages valueForKeyPath:@"image_addr"]];
+    
+    NSMutableSet *backtraceImageAddrs = [NSMutableSet setWithArray:[report valueForKeyPath:@"crash.threads.@distinctUnionOfArrays.backtrace.contents.object_addr"]];
+    [backtraceImageAddrs removeObject:[NSNull null]];
+    
+    XCTAssertEqualObjects(binaryImageAddrs, backtraceImageAddrs);
+    
+    [[NSFileManager defaultManager] removeItemAtPath:crashReportFilePath error:nil];
+    [[NSFileManager defaultManager] removeItemAtPath:recrashReportFilePath error:nil];
+    [[NSFileManager defaultManager] removeItemAtPath:stateFilePath error:nil];
+}
 
 - (void)testWriteStandardReportPerformance {
     NSString *directory = NSTemporaryDirectory();


### PR DESCRIPTION
## Goal

Improve performance and storage requirements of writing a crash report.

## Changeset

* Adds a boolean flag to `struct bsg_mach_image` which is used to track which images are referenced by the crash's stack traces.
* Only includes referenced image in `binary_images`.

## Testing

Shows a ~30% speedup in `testWriteStandardReportPerformance`.

Added a unit test case to verify that only the expected binary images are included.

Existing E2E tests ensure that required image info is included - missing images would result in no `machoFile` etc. in the Bugsnag payload, which is [checked for in our tests](https://github.com/bugsnag/bugsnag-cocoa/blob/master/features/steps/cocoa_steps.rb#L145-L154).