### PR TITLE
Fix missing user.id in session-less OOMs

### DIFF
--- a/Bugsnag/Client/BugsnagClient.m
+++ b/Bugsnag/Client/BugsnagClient.m
@@ -211,11 +211,11 @@ __attribute__((annotate("oclint:suppress[too many methods]")))
         _state = [[BugsnagMetadata alloc] initWithDictionary:@{
             BSGKeyApp: @{BSGKeyIsLaunching: @YES},
             BSGKeyClient: BSGDictionaryWithKeyAndObject(BSGKeyContext, _configuration.context),
-            BSGKeyUser: [configuration.user toJson]
+            BSGKeyUser: [_configuration.user toJson] ?: @{}
         }];
         
-        _notifier = configuration.notifier ?: [[BugsnagNotifier alloc] init];
-        self.systemState = [[BugsnagSystemState alloc] initWithConfiguration:configuration];
+        _notifier = _configuration.notifier ?: [[BugsnagNotifier alloc] init];
+        self.systemState = [[BugsnagSystemState alloc] initWithConfiguration:_configuration];
 
         BSGFileLocations *fileLocations = [BSGFileLocations current];
         
@@ -238,7 +238,7 @@ __attribute__((annotate("oclint:suppress[too many methods]")))
         _eventUploader = [[BSGEventUploader alloc] initWithConfiguration:_configuration notifier:_notifier];
         bsg_g_bugsnag_data.onCrash = (void (*)(const BSG_KSCrashReportWriter *))self.configuration.onCrashHandler;
 
-        _notificationBreadcrumbs = [[BSGNotificationBreadcrumbs alloc] initWithConfiguration:configuration breadcrumbSink:self];
+        _notificationBreadcrumbs = [[BSGNotificationBreadcrumbs alloc] initWithConfiguration:_configuration breadcrumbSink:self];
 
         self.sessionTracker = [[BugsnagSessionTracker alloc] initWithConfig:self.configuration
                                                                      client:self
@@ -248,10 +248,10 @@ __attribute__((annotate("oclint:suppress[too many methods]")))
 
         self.breadcrumbs = [[BugsnagBreadcrumbs alloc] initWithConfiguration:self.configuration];
 
-        [BSGJSONSerialization writeJSONObject:configuration.dictionaryRepresentation toFile:_configMetadataFile options:0 error:nil];
+        [BSGJSONSerialization writeJSONObject:_configuration.dictionaryRepresentation toFile:_configMetadataFile options:0 error:nil];
         
         // Start with a copy of the configuration metadata
-        self.metadata = [[configuration metadata] deepCopy];
+        self.metadata = [[_configuration metadata] deepCopy];
         // add metadata about app/device
         NSDictionary *systemInfo = [BSG_KSSystemInfo systemInfo];
         [self.metadata addMetadata:BSGParseAppMetadata(@{@"system": systemInfo}) toSection:BSGKeyApp];
@@ -1263,11 +1263,14 @@ __attribute__((annotate("oclint:suppress[too many methods]")))
     BugsnagSession *session = sessionDict ? [[BugsnagSession alloc] initWithDictionary:sessionDict] : nil;
     session.unhandledCount += 1;
 
+    NSDictionary *userDict = self.stateMetadataFromLastLaunch[BSGKeyUser];
+    BugsnagUser *user = session.user ?: [[BugsnagUser alloc] initWithDictionary:userDict];
+
     BugsnagEvent *event =
     [[BugsnagEvent alloc] initWithApp:app
                                device:device
                          handledState:handledState
-                                 user:session.user ?: [[BugsnagUser alloc] init]
+                                 user:user
                              metadata:metadata
                           breadcrumbs:[self.breadcrumbs cachedBreadcrumbs] ?: @[]
                                errors:@[error]

--- a/Bugsnag/Payload/BugsnagUser+Private.h
+++ b/Bugsnag/Payload/BugsnagUser+Private.h
@@ -12,7 +12,7 @@ NS_ASSUME_NONNULL_BEGIN
 
 @interface BugsnagUser ()
 
-- (instancetype)initWithDictionary:(NSDictionary *)dict;
+- (instancetype)initWithDictionary:(nullable NSDictionary *)dict;
 
 - (instancetype)initWithUserId:(nullable NSString *)userId name:(nullable NSString *)name emailAddress:(nullable NSString *)emailAddress;
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,11 @@ Changelog
 
 ## TBD
 
+### Bug fixes
+
+* Fix missing user.id in OOM events with no active session.
+  [#1274](https://github.com/bugsnag/bugsnag-cocoa/pull/1274)
+
 * Improve crash report writing performance and size on disk.
   [#1273](https://github.com/bugsnag/bugsnag-cocoa/pull/1273)
 

--- a/features/fixtures/ios/iOSTestApp.xcodeproj/project.pbxproj
+++ b/features/fixtures/ios/iOSTestApp.xcodeproj/project.pbxproj
@@ -30,6 +30,7 @@
 		01E0DB0B25E8EBD100A740ED /* AppDurationScenario.swift in Sources */ = {isa = PBXBuildFile; fileRef = 01E0DB0A25E8EBD100A740ED /* AppDurationScenario.swift */; };
 		01E356C026CD5B6A00BE3F64 /* ThermalStateBreadcrumbScenario.swift in Sources */ = {isa = PBXBuildFile; fileRef = 01E356BF26CD5B6A00BE3F64 /* ThermalStateBreadcrumbScenario.swift */; };
 		01E5EAD225B713990066EA8A /* OOMScenario.m in Sources */ = {isa = PBXBuildFile; fileRef = 01E5EAD125B713990066EA8A /* OOMScenario.m */; };
+		01EE7F57278C680C00A59DC6 /* OOMSessionlessScenario.m in Sources */ = {isa = PBXBuildFile; fileRef = 01EE7F56278C680C00A59DC6 /* OOMSessionlessScenario.m */; };
 		01F1474425F282E600C2DC65 /* AppHangScenarios.swift in Sources */ = {isa = PBXBuildFile; fileRef = 01F1474325F282E600C2DC65 /* AppHangScenarios.swift */; };
 		01FA9EC426D63BB20059FF4A /* AppHangInTerminationScenario.swift in Sources */ = {isa = PBXBuildFile; fileRef = 01FA9EC326D63BB20059FF4A /* AppHangInTerminationScenario.swift */; };
 		6526A0D4248A83350002E2C9 /* LoadConfigFromFileAutoScenario.swift in Sources */ = {isa = PBXBuildFile; fileRef = 6526A0D3248A83350002E2C9 /* LoadConfigFromFileAutoScenario.swift */; };
@@ -190,6 +191,7 @@
 		01E356BF26CD5B6A00BE3F64 /* ThermalStateBreadcrumbScenario.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = ThermalStateBreadcrumbScenario.swift; sourceTree = "<group>"; };
 		01E5EAD025B713990066EA8A /* OOMScenario.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; path = OOMScenario.h; sourceTree = "<group>"; };
 		01E5EAD125B713990066EA8A /* OOMScenario.m */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.objc; path = OOMScenario.m; sourceTree = "<group>"; };
+		01EE7F56278C680C00A59DC6 /* OOMSessionlessScenario.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; path = OOMSessionlessScenario.m; sourceTree = "<group>"; };
 		01F1474325F282E600C2DC65 /* AppHangScenarios.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = AppHangScenarios.swift; sourceTree = "<group>"; };
 		01FA9EC326D63BB20059FF4A /* AppHangInTerminationScenario.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AppHangInTerminationScenario.swift; sourceTree = "<group>"; };
 		6526A0D3248A83350002E2C9 /* LoadConfigFromFileAutoScenario.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = LoadConfigFromFileAutoScenario.swift; sourceTree = "<group>"; };
@@ -597,6 +599,7 @@
 				017B4133276B8D9B0054C91D /* OnSendErrorPersistenceScenario.m */,
 				01E5EAD025B713990066EA8A /* OOMScenario.h */,
 				01E5EAD125B713990066EA8A /* OOMScenario.m */,
+				01EE7F56278C680C00A59DC6 /* OOMSessionlessScenario.m */,
 				0104B47D275A7B3C003EBDF0 /* RecrashScenarios.mm */,
 				8AB1081823301FE600672818 /* ReleaseStageScenarios.swift */,
 				F4295ABA693D273D52AA9F6B /* Scenario.h */,
@@ -973,6 +976,7 @@
 				E7A324DA247E70C4008B0052 /* SessionCallbackCrashScenario.swift in Sources */,
 				01F1474425F282E600C2DC65 /* AppHangScenarios.swift in Sources */,
 				0104B47E275A7B3C003EBDF0 /* RecrashScenarios.mm in Sources */,
+				01EE7F57278C680C00A59DC6 /* OOMSessionlessScenario.m in Sources */,
 				E7A324E3247E7C17008B0052 /* SessionCallbackRemovalScenario.m in Sources */,
 				AAFEF9EA26EB533800980A10 /* NetworkBreadcrumbsScenario.swift in Sources */,
 				E7767F15221C223C0006648C /* NewSessionScenario.swift in Sources */,

--- a/features/fixtures/shared/scenarios/OOMSessionlessScenario.m
+++ b/features/fixtures/shared/scenarios/OOMSessionlessScenario.m
@@ -1,0 +1,28 @@
+//
+//  OOMSessionlessScenario.m
+//  iOSTestApp
+//
+//  Created by Nick Dowell on 10/01/2022.
+//  Copyright © 2022 Bugsnag. All rights reserved.
+//
+
+#import "Scenario.h"
+
+@interface OOMSessionlessScenario : Scenario
+
+@end
+
+@implementation OOMSessionlessScenario
+
+- (void)startBugsnag {
+    self.config.autoTrackSessions = NO;
+    self.config.enabledErrorTypes.ooms = YES;
+    [super startBugsnag];
+}
+
+- (void)run {
+    // Fake an OOM
+    kill(getpid(), SIGKILL);
+}
+
+@end

--- a/features/out_of_memory.feature
+++ b/features/out_of_memory.feature
@@ -95,3 +95,10 @@ Feature: Out of memory errors
     Then the error is valid for the error reporting API
     And the event "unhandled" is false
     And the exception "message" equals "OOMEnabledErrorTypesScenario"
+
+  Scenario: Out of memory errors with no session contain a user id
+    Given I run "OOMSessionlessScenario" and relaunch the crashed app
+    And I configure Bugsnag for "OOMSessionlessScenario"
+    And I wait to receive an error
+    Then the error is an OOM event
+    And the event "user.id" is not null


### PR DESCRIPTION
## Goal

Make OOM events include user information even if there was no active session.

## Changeset

* Ensures the correct configuration object (that includes the auto-generated user id) is serialised to disk at start-up
* Uses the serialized user info for OOM events if there is no `session.user`

## Testing

Added an E2E scenario that triggered the problem and verified the fix.