### PR TITLE
Fix flake in features/out_of_memory.feature:99

### DIFF
--- a/features/fixtures/shared/scenarios/OOMSessionlessScenario.m
+++ b/features/fixtures/shared/scenarios/OOMSessionlessScenario.m
@@ -21,8 +21,11 @@
 }
 
 - (void)run {
-    // Fake an OOM
-    kill(getpid(), SIGKILL);
+    // Allow time for state metadata to be flushed to disk
+    dispatch_after(dispatch_time(DISPATCH_TIME_NOW, 1 * NSEC_PER_SEC), dispatch_get_main_queue(), ^{
+        // Fake an OOM
+        kill(getpid(), SIGKILL);
+    });
 }
 
 @end


### PR DESCRIPTION
## Goal

Fix a test flake in `features/out_of_memory.feature:99` that was noticed on iOS 10.

## Changeset

Introduces a delay to allow data to be written to disk before killing the process.

## Testing

Verified fix on CI - https://buildkite.com/bugsnag/bugsnag-cocoa/builds/4610#eaac1202-2b78-4e8f-a16f-825c17a34434/207-217