### PR TITLE
Fix test fixture build warnings

### DIFF
--- a/features/fixtures/macos/macOSTestApp.xcodeproj/project.pbxproj
+++ b/features/fixtures/macos/macOSTestApp.xcodeproj/project.pbxproj
@@ -132,10 +132,10 @@
 		01F47D30254B1B3100B184AD /* AutoContextNSExceptionScenario.swift in Sources */ = {isa = PBXBuildFile; fileRef = 01F47CBF254B1B3000B184AD /* AutoContextNSExceptionScenario.swift */; };
 		01F47D31254B1B3100B184AD /* OverwriteLinkRegisterScenario.m in Sources */ = {isa = PBXBuildFile; fileRef = 01F47CC0254B1B3000B184AD /* OverwriteLinkRegisterScenario.m */; };
 		01F47D32254B1B3100B184AD /* ResumeSessionOOMScenario.m in Sources */ = {isa = PBXBuildFile; fileRef = 01F47CC1254B1B3000B184AD /* ResumeSessionOOMScenario.m */; };
+		01F7365A278D90440000113C /* NetworkBreadcrumbsScenario.swift in Sources */ = {isa = PBXBuildFile; fileRef = 01F73659278D90440000113C /* NetworkBreadcrumbsScenario.swift */; };
 		01FA9EC626D64FFF0059FF4A /* AppHangInTerminationScenario.swift in Sources */ = {isa = PBXBuildFile; fileRef = 01FA9EC526D64FFF0059FF4A /* AppHangInTerminationScenario.swift */; };
 		AA6ACD1A2773E098006464C4 /* UserFromConfigScenario.swift in Sources */ = {isa = PBXBuildFile; fileRef = AA6ACD192773E098006464C4 /* UserFromConfigScenario.swift */; };
 		AA6ACD1E2773E39C006464C4 /* UserInfoScenario.swift in Sources */ = {isa = PBXBuildFile; fileRef = AA6ACD1D2773E39C006464C4 /* UserInfoScenario.swift */; };
-		AAFEF9EC26EB536D00980A10 /* NetworkBreadcrumbsScenario.swift in Sources */ = {isa = PBXBuildFile; fileRef = AAFEF9EB26EB536D00980A10 /* NetworkBreadcrumbsScenario.swift */; };
 		CBB7878E2578FB3F0071BDE4 /* MarkUnhandledHandledScenario.m in Sources */ = {isa = PBXBuildFile; fileRef = CBB7878C2578FB3F0071BDE4 /* MarkUnhandledHandledScenario.m */; };
 		E780377D264D703500430C11 /* AutoNotifyReenabledScenario.swift in Sources */ = {isa = PBXBuildFile; fileRef = E7803779264D703500430C11 /* AutoNotifyReenabledScenario.swift */; };
 		E780377E264D703500430C11 /* AutoNotifyFalseHandledScenario.swift in Sources */ = {isa = PBXBuildFile; fileRef = E780377A264D703500430C11 /* AutoNotifyFalseHandledScenario.swift */; };
@@ -340,12 +340,12 @@
 		01F47CC1254B1B3000B184AD /* ResumeSessionOOMScenario.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; path = ResumeSessionOOMScenario.m; sourceTree = "<group>"; };
 		01F47CC2254B1B3000B184AD /* SIGBUSScenario.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = SIGBUSScenario.h; sourceTree = "<group>"; };
 		01F47CC3254B1B3100B184AD /* SIGFPEScenario.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = SIGFPEScenario.h; sourceTree = "<group>"; };
+		01F73659278D90440000113C /* NetworkBreadcrumbsScenario.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = NetworkBreadcrumbsScenario.swift; sourceTree = "<group>"; };
 		01FA9EC526D64FFF0059FF4A /* AppHangInTerminationScenario.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = AppHangInTerminationScenario.swift; sourceTree = "<group>"; };
 		2C49722B331FF4B0DC477462 /* Pods-macOSTestApp.release.xcconfig */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.xcconfig; name = "Pods-macOSTestApp.release.xcconfig"; path = "Target Support Files/Pods-macOSTestApp/Pods-macOSTestApp.release.xcconfig"; sourceTree = "<group>"; };
 		5C65BFC9838298CFA8A35072 /* Pods_macOSTestApp.framework */ = {isa = PBXFileReference; explicitFileType = wrapper.framework; includeInIndex = 0; path = Pods_macOSTestApp.framework; sourceTree = BUILT_PRODUCTS_DIR; };
 		AA6ACD192773E098006464C4 /* UserFromConfigScenario.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = UserFromConfigScenario.swift; sourceTree = "<group>"; };
 		AA6ACD1D2773E39C006464C4 /* UserInfoScenario.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = UserInfoScenario.swift; sourceTree = "<group>"; };
-		AAFEF9EB26EB536D00980A10 /* NetworkBreadcrumbsScenario.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = NetworkBreadcrumbsScenario.swift; sourceTree = "<group>"; };
 		CBB7878C2578FB3F0071BDE4 /* MarkUnhandledHandledScenario.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; path = MarkUnhandledHandledScenario.m; sourceTree = "<group>"; };
 		CBB7878D2578FB3F0071BDE4 /* MarkUnhandledHandledScenario.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = MarkUnhandledHandledScenario.h; sourceTree = "<group>"; };
 		E32FA33AF8114150BBC3AEF4 /* Pods-macOSTestApp.debug.xcconfig */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.xcconfig; name = "Pods-macOSTestApp.debug.xcconfig"; path = "Target Support Files/Pods-macOSTestApp/Pods-macOSTestApp.debug.xcconfig"; sourceTree = "<group>"; };
@@ -370,9 +370,6 @@
 		01452234254AFCD600D436AA /* scenarios */ = {
 			isa = PBXGroup;
 			children = (
-				AA6ACD1D2773E39C006464C4 /* UserInfoScenario.swift */,
-				AA6ACD192773E098006464C4 /* UserFromConfigScenario.swift */,
-				AAFEF9EB26EB536D00980A10 /* NetworkBreadcrumbsScenario.swift */,
 				01F47C91254B1B2F00B184AD /* AbortScenario.h */,
 				01F47C54254B1B2E00B184AD /* AbortScenario.m */,
 				01F47C4A254B1B2D00B184AD /* AccessNonObjectScenario.h */,
@@ -459,7 +456,7 @@
 				01F47C58254B1B2E00B184AD /* MetadataRedactionRegexScenario.swift */,
 				01F47C78254B1B2F00B184AD /* ModifyBreadcrumbInNotifyScenario.swift */,
 				01F47C87254B1B2F00B184AD /* ModifyBreadcrumbScenario.swift */,
-				AAFEF9EB26EB536D00980A10 /* NetworkBreadcrumbsScenario.swift */,
+				01F73659278D90440000113C /* NetworkBreadcrumbsScenario.swift */,
 				01F47CA0254B1B3000B184AD /* NewSessionScenario.swift */,
 				01F47C24254B1B2C00B184AD /* NonExistentMethodScenario.h */,
 				01F47C4B254B1B2D00B184AD /* NonExistentMethodScenario.m */,
@@ -549,6 +546,8 @@
 				01F47C4C254B1B2D00B184AD /* UnhandledMachExceptionScenario.m */,
 				01F47C93254B1B2F00B184AD /* UserEventOverrideScenario.swift */,
 				01F47CA3254B1B3000B184AD /* UserFromClientScenario.swift */,
+				AA6ACD192773E098006464C4 /* UserFromConfigScenario.swift */,
+				AA6ACD1D2773E39C006464C4 /* UserInfoScenario.swift */,
 				01F47C65254B1B2E00B184AD /* UserPersistenceScenarios.h */,
 				01F47C9C254B1B3000B184AD /* UserPersistenceScenarios.m */,
 				01F47CB0254B1B3000B184AD /* UserSessionOverrideScenario.swift */,
@@ -731,6 +730,7 @@
 			files = (
 				01F47CD9254B1B3100B184AD /* SessionCallbackDiscardScenario.swift in Sources */,
 				01F47CD0254B1B3100B184AD /* StackOverflowScenario.m in Sources */,
+				01F7365A278D90440000113C /* NetworkBreadcrumbsScenario.swift in Sources */,
 				01F47CCA254B1B3100B184AD /* ManualSessionScenario.m in Sources */,
 				01F47D31254B1B3100B184AD /* OverwriteLinkRegisterScenario.m in Sources */,
 				01F47D08254B1B3100B184AD /* AutoSessionCustomVersionScenario.m in Sources */,
@@ -824,7 +824,6 @@
 				01F47CFF254B1B3100B184AD /* EnabledErrorTypesCxxScenario.mm in Sources */,
 				01F47CD5254B1B3100B184AD /* OOMAutoDetectErrorsScenario.swift in Sources */,
 				0176C0AE254AE81B0066E0F3 /* main.m in Sources */,
-				AAFEF9EC26EB536D00980A10 /* NetworkBreadcrumbsScenario.swift in Sources */,
 				01F47CDB254B1B3100B184AD /* UnhandledMachExceptionScenario.m in Sources */,
 				01F47D12254B1B3100B184AD /* OnSendCallbackRemovalScenario.m in Sources */,
 				01F47D24254B1B3100B184AD /* UserSessionOverrideScenario.swift in Sources */,

--- a/features/fixtures/shared/scenarios/BreadcrumbCallbackRemovalScenario.m
+++ b/features/fixtures/shared/scenarios/BreadcrumbCallbackRemovalScenario.m
@@ -25,8 +25,8 @@
         breadcrumb.message = @"Feliz Navidad";
         return true;
     };
-    [self.config addOnBreadcrumbBlock:block];
-    [self.config removeOnBreadcrumbBlock:block];
+    BugsnagOnBreadcrumbRef onBreadcrumb = [self.config addOnBreadcrumbBlock:block];
+    [self.config removeOnBreadcrumb:onBreadcrumb];
 
     [super startBugsnag];
 }

--- a/features/fixtures/shared/scenarios/OnSendCallbackRemovalScenario.m
+++ b/features/fixtures/shared/scenarios/OnSendCallbackRemovalScenario.m
@@ -21,11 +21,11 @@
     self.config.autoTrackSessions = false;
     [self.config addOnSendErrorBlock:block];
 
-    [self.config addOnSendErrorBlock:^BOOL(BugsnagEvent * _Nonnull event) {
+    BugsnagOnSendErrorRef onError = [self.config addOnSendErrorBlock:^BOOL(BugsnagEvent * _Nonnull event) {
         [event addMetadata:@"adding metadata" withKey:@"config2" toSection:@"callbacks"];
         return true;
     }];
-    [self.config removeOnSendErrorBlock:block];
+    [self.config removeOnSendError:onError];
     [super startBugsnag];
 }
 

--- a/features/fixtures/shared/scenarios/SessionCallbackRemovalScenario.m
+++ b/features/fixtures/shared/scenarios/SessionCallbackRemovalScenario.m
@@ -27,8 +27,8 @@
         session.device.id = nil;
         return true;
     };
-    [self.config addOnSessionBlock:block];
-    [self.config removeOnSessionBlock:block];
+    BugsnagOnSessionRef onSession = [self.config addOnSessionBlock:block];
+    [self.config removeOnSession:onSession];
     [super startBugsnag];
 }
 

--- a/features/scripts/export_ios_app.sh
+++ b/features/scripts/export_ios_app.sh
@@ -9,6 +9,7 @@ echo "--- iOSTestApp: xcodebuild archive"
 xcrun xcodebuild \
   -scheme iOSTestApp \
   -workspace iOSTestApp.xcworkspace \
+  -destination generic/platform=iOS \
   -configuration Debug \
   -archivePath archive/iosTestApp.xcarchive \
   -allowProvisioningUpdates \
@@ -21,6 +22,7 @@ echo "--- iOSTestApp: xcodebuild -exportArchive"
 xcrun xcodebuild \
   -exportArchive \
   -archivePath archive/iosTestApp.xcarchive \
+  -destination generic/platform=iOS \
   -exportPath output/ \
   -quiet \
   -exportOptionsPlist exportOptions.plist

--- a/features/scripts/export_mac_app.sh
+++ b/features/scripts/export_mac_app.sh
@@ -13,6 +13,7 @@ echo "--- macOSTestApp: xcodebuild archive"
 xcrun xcodebuild \
   -workspace macOSTestApp.xcworkspace \
   -scheme macOSTestApp \
+  -destination generic/platform=macOS \
   -configuration Debug \
   -archivePath archive/macOSTestApp.xcarchive \
   -quiet \
@@ -26,6 +27,7 @@ xcrun xcodebuild \
   -exportPath output/ \
   -exportOptionsPlist exportOptions.plist \
   -archivePath archive/macOSTestApp.xcarchive \
+  -destination generic/platform=macOS \
   -quiet
 
 cd output


### PR DESCRIPTION
## Goal

Fix build warnings when building test fixtures.

## Changeset

* Stops using deprecated Bugsnag APIs
* Fixes `warning:  The file reference for "NetworkBreadcrumbsScenario.swift" is a member of multiple groups ("scenarios" and "scenarios"); this indicates a malformed project`
* Specifies build destinations to fix `WARNING: Using the first of multiple matching destinations`

## Testing

Verified locally and on CI