### PR TITLE
Remove section that described multiple xcodeproj files

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -67,12 +67,6 @@ Here’s a bit about our process designing and building the Bugsnag libraries:
 
 For an overview of source code organisation, see [ORGANIZATION.md](ORGANIZATION.md).
 
-## Building
-
-Each OS version of `Bugsnag` has an Xcode project in a directory named for the
-OS. For example, to build and run `Bugsnag` for iOS, open
-`iOS/Bugsnag.xcodeproj`.
-
 ## Testing
 
 Run the unit tests for the `Bugsnag` library from Xcode or by running `make


### PR DESCRIPTION
## Goal

Update docs to remove reference to multiple project files, since they no longer exist.

## Design

Now there is a single xcodeproj file it doesn't seem necessary to have the section at all as it's self-evident.  Disagreements welcome.
