### PR TITLE
Use Maze Runner command endpoint

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -7,7 +7,7 @@ gem 'xcpretty'
 
 # A reference to Maze Runner is only needed for running tests locally and if committed it must be
 # portable for CI, e.g. a specific release.  However, leaving it commented out would mean quicker CI.
-gem 'bugsnag-maze-runner', git: 'https://github.com/bugsnag/maze-runner', tag: 'v6.8.0'
+gem 'bugsnag-maze-runner', git: 'https://github.com/bugsnag/maze-runner', tag: 'v6.9.0'
 
 # Use a specific branch
 #gem 'bugsnag-maze-runner', git: 'https://github.com/bugsnag/maze-runner', branch: 'master'

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -1,9 +1,9 @@
 GIT
   remote: https://github.com/bugsnag/maze-runner
-  revision: fe12189f83aad154f54221ee0fcd41b483d3c0d1
-  tag: v6.8.0
+  revision: 4979ecccf0b3f21fa4f9cb439191081993ae5704
+  tag: v6.9.0
   specs:
-    bugsnag-maze-runner (6.8.0)
+    bugsnag-maze-runner (6.9.0)
       appium_lib (~> 11.2.0)
       bugsnag (~> 6.24)
       cucumber (~> 7.1)
@@ -119,10 +119,9 @@ GEM
       cucumber-messages (~> 17.1, >= 17.1.0)
     cucumber-messages (17.1.1)
     cucumber-tag-expressions (4.1.0)
-    cucumber-wire (6.2.0)
+    cucumber-wire (6.2.1)
       cucumber-core (~> 10.1, >= 10.1.0)
       cucumber-cucumber-expressions (~> 14.0, >= 14.0.0)
-      cucumber-messages (~> 17.1, >= 17.1.1)
     curb (0.9.11)
     danger (8.4.2)
       claide (~> 1.0)
@@ -137,7 +136,7 @@ GEM
       no_proxy_fix
       octokit (~> 4.7)
       terminal-table (>= 1, < 4)
-    diff-lcs (1.4.4)
+    diff-lcs (1.5.0)
     escape (0.0.4)
     ethon (0.15.0)
       ffi (>= 1.15.0)
@@ -193,8 +192,8 @@ GEM
     liferaft (0.0.6)
     mime-types (3.4.1)
       mime-types-data (~> 3.2015)
-    mime-types-data (3.2021.1115)
-    mini_portile2 (2.6.1)
+    mime-types-data (3.2022.0105)
+    mini_portile2 (2.7.1)
     minitest (5.15.0)
     molinillo (0.8.0)
     multi_test (0.1.2)
@@ -204,8 +203,8 @@ GEM
     nap (1.1.0)
     netrc (0.11.0)
     no_proxy_fix (0.1.2)
-    nokogiri (1.12.5)
-      mini_portile2 (~> 2.6.1)
+    nokogiri (1.13.0)
+      mini_portile2 (~> 2.7.0)
       racc (~> 1.4)
     octokit (4.21.0)
       faraday (>= 0.9)

--- a/features/fixtures/ios/iOSTestApp.xcodeproj/project.pbxproj
+++ b/features/fixtures/ios/iOSTestApp.xcodeproj/project.pbxproj
@@ -23,7 +23,7 @@
 		017B4134276B8D9B0054C91D /* OnSendErrorPersistenceScenario.m in Sources */ = {isa = PBXBuildFile; fileRef = 017B4133276B8D9B0054C91D /* OnSendErrorPersistenceScenario.m */; };
 		01847DD626453D4E00ADA4C7 /* InvalidCrashReportScenario.m in Sources */ = {isa = PBXBuildFile; fileRef = 01847DD526453D4E00ADA4C7 /* InvalidCrashReportScenario.m */; };
 		01AF6A53258A112F00FFC803 /* BareboneTestScenarios.swift in Sources */ = {isa = PBXBuildFile; fileRef = 01AF6A52258A112F00FFC803 /* BareboneTestScenarios.swift */; };
-		01B6BB7525D5748800FC4DE6 /* LastRunInfoScenarios.swift in Sources */ = {isa = PBXBuildFile; fileRef = 01B6BB7425D5748800FC4DE6 /* LastRunInfoScenarios.swift */; };
+		01B6BB7525D5748800FC4DE6 /* LastRunInfoScenario.swift in Sources */ = {isa = PBXBuildFile; fileRef = 01B6BB7425D5748800FC4DE6 /* LastRunInfoScenario.swift */; };
 		01B6BBB625DA82B800FC4DE6 /* SendLaunchCrashesSynchronouslyScenario.swift in Sources */ = {isa = PBXBuildFile; fileRef = 01B6BBB525DA82B700FC4DE6 /* SendLaunchCrashesSynchronouslyScenario.swift */; };
 		01CD103926690463007FA5F0 /* libBugsnagStatic.a in Frameworks */ = {isa = PBXBuildFile; fileRef = 01CD103826690463007FA5F0 /* libBugsnagStatic.a */; };
 		01DE903826CE99B800455213 /* CriticalThermalStateScenario.swift in Sources */ = {isa = PBXBuildFile; fileRef = 01DE903726CE99B800455213 /* CriticalThermalStateScenario.swift */; };
@@ -183,7 +183,7 @@
 		017B4133276B8D9B0054C91D /* OnSendErrorPersistenceScenario.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; path = OnSendErrorPersistenceScenario.m; sourceTree = "<group>"; };
 		01847DD526453D4E00ADA4C7 /* InvalidCrashReportScenario.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; path = InvalidCrashReportScenario.m; sourceTree = "<group>"; };
 		01AF6A52258A112F00FFC803 /* BareboneTestScenarios.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = BareboneTestScenarios.swift; sourceTree = "<group>"; };
-		01B6BB7425D5748800FC4DE6 /* LastRunInfoScenarios.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = LastRunInfoScenarios.swift; sourceTree = "<group>"; };
+		01B6BB7425D5748800FC4DE6 /* LastRunInfoScenario.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = LastRunInfoScenario.swift; sourceTree = "<group>"; };
 		01B6BBB525DA82B700FC4DE6 /* SendLaunchCrashesSynchronouslyScenario.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = SendLaunchCrashesSynchronouslyScenario.swift; sourceTree = "<group>"; };
 		01CD103826690463007FA5F0 /* libBugsnagStatic.a */ = {isa = PBXFileReference; explicitFileType = archive.ar; path = libBugsnagStatic.a; sourceTree = BUILT_PRODUCTS_DIR; };
 		01DE903726CE99B800455213 /* CriticalThermalStateScenario.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = CriticalThermalStateScenario.swift; sourceTree = "<group>"; };
@@ -604,7 +604,7 @@
 				8AB1081823301FE600672818 /* ReleaseStageScenarios.swift */,
 				F4295ABA693D273D52AA9F6B /* Scenario.h */,
 				F42954E8B66F3FB7F5333CF7 /* Scenario.m */,
-				01B6BB7425D5748800FC4DE6 /* LastRunInfoScenarios.swift */,
+				01B6BB7425D5748800FC4DE6 /* LastRunInfoScenario.swift */,
 				CBB7878F2578FC0C0071BDE4 /* MarkUnhandledHandledScenario.h */,
 				CBB787902578FC0C0071BDE4 /* MarkUnhandledHandledScenario.m */,
 				01B6BBB525DA82B700FC4DE6 /* SendLaunchCrashesSynchronouslyScenario.swift */,
@@ -881,7 +881,7 @@
 				01018BA025E40ADD000312C6 /* AsyncSafeMallocScenario.m in Sources */,
 				8A98400320FD11BF0023ECD1 /* AutoSessionCustomVersionScenario.m in Sources */,
 				8A3B5F292407F66700CE4A3A /* ModifyBreadcrumbScenario.swift in Sources */,
-				01B6BB7525D5748800FC4DE6 /* LastRunInfoScenarios.swift in Sources */,
+				01B6BB7525D5748800FC4DE6 /* LastRunInfoScenario.swift in Sources */,
 				E75040A2247801A8005D33BD /* AutoDetectFalseNSExceptionScenario.swift in Sources */,
 				E700EE7E247D7A61008CFFB6 /* SIGSYSScenario.m in Sources */,
 				E75040A42478052D005D33BD /* AutoDetectFalseAbortScenario.swift in Sources */,

--- a/features/fixtures/ios/iOSTestApp/Base.lproj/Main.storyboard
+++ b/features/fixtures/ios/iOSTestApp/Base.lproj/Main.storyboard
@@ -1,14 +1,14 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<document type="com.apple.InterfaceBuilder3.CocoaTouch.Storyboard.XIB" version="3.0" toolsVersion="19455" targetRuntime="iOS.CocoaTouch" propertyAccessControl="none" useAutolayout="YES" useTraitCollections="YES" useSafeAreas="YES" colorMatched="YES" initialViewController="BYZ-38-t0r">
+<document type="com.apple.InterfaceBuilder3.CocoaTouch.Storyboard.XIB" version="3.0" toolsVersion="19529" targetRuntime="iOS.CocoaTouch" propertyAccessControl="none" useAutolayout="YES" useTraitCollections="YES" useSafeAreas="YES" colorMatched="YES" initialViewController="GWo-9T-4ru">
     <device id="retina6_1" orientation="portrait" appearance="light"/>
     <dependencies>
         <deployment identifier="iOS"/>
-        <plugIn identifier="com.apple.InterfaceBuilder.IBCocoaTouchPlugin" version="19454"/>
+        <plugIn identifier="com.apple.InterfaceBuilder.IBCocoaTouchPlugin" version="19519"/>
         <capability name="Safe area layout guides" minToolsVersion="9.0"/>
         <capability name="documents saved in the Xcode 8 format" minToolsVersion="8.0"/>
     </dependencies>
     <scenes>
-        <!--View Controller-->
+        <!--Bugsnag iOS Test Fixture-->
         <scene sceneID="tne-QT-ifu">
             <objects>
                 <viewController id="BYZ-38-t0r" customClass="ViewController" customModule="iOSTestApp" customModuleProvider="target" sceneMemberID="viewController">
@@ -16,91 +16,86 @@
                         <rect key="frame" x="0.0" y="0.0" width="414" height="896"/>
                         <autoresizingMask key="autoresizingMask" flexibleMaxX="YES" flexibleMaxY="YES"/>
                         <subviews>
-                            <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="251" text="Bugsnag Cocoa - Test application" textAlignment="center" lineBreakMode="tailTruncation" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" translatesAutoresizingMaskIntoConstraints="NO" id="RWZ-At-akB">
-                                <rect key="frame" x="20" y="94" width="374" height="21"/>
-                                <accessibility key="accessibilityConfiguration" identifier="CloseKeyboardItem"/>
-                                <fontDescription key="fontDescription" type="system" pointSize="17"/>
-                                <nil key="textColor"/>
-                                <nil key="highlightedColor"/>
-                            </label>
-                            <textField opaque="NO" contentMode="scaleToFill" contentHorizontalAlignment="left" contentVerticalAlignment="center" borderStyle="roundedRect" placeholder="Scenario Name" textAlignment="center" minimumFontSize="17" translatesAutoresizingMaskIntoConstraints="NO" id="5Cz-db-j7f">
-                                <rect key="frame" x="20" y="135" width="374" height="34"/>
-                                <accessibility key="accessibilityConfiguration" identifier="scenario_name"/>
-                                <fontDescription key="fontDescription" type="system" pointSize="14"/>
-                                <textInputTraits key="textInputTraits"/>
-                            </textField>
-                            <textField opaque="NO" contentMode="scaleToFill" contentHorizontalAlignment="left" contentVerticalAlignment="center" borderStyle="roundedRect" placeholder="Scenario Metadata" textAlignment="center" minimumFontSize="17" translatesAutoresizingMaskIntoConstraints="NO" id="IN4-CK-eEf">
-                                <rect key="frame" x="20" y="189" width="374" height="34"/>
-                                <accessibility key="accessibilityConfiguration" identifier="scenario_metadata"/>
-                                <fontDescription key="fontDescription" type="system" pointSize="14"/>
-                                <textInputTraits key="textInputTraits"/>
-                            </textField>
-                            <button opaque="NO" contentMode="scaleToFill" contentHorizontalAlignment="center" contentVerticalAlignment="center" buttonType="system" lineBreakMode="middleTruncation" translatesAutoresizingMaskIntoConstraints="NO" id="Oym-db-43x">
-                                <rect key="frame" x="20" y="243" width="374" height="30"/>
-                                <accessibility key="accessibilityConfiguration" identifier="run_scenario"/>
-                                <state key="normal" title="Start Scenario"/>
-                                <connections>
-                                    <action selector="runTestScenario" destination="BYZ-38-t0r" eventType="primaryActionTriggered" id="tlB-VZ-ZdP"/>
-                                </connections>
-                            </button>
-                            <button opaque="NO" contentMode="scaleToFill" contentHorizontalAlignment="center" contentVerticalAlignment="center" buttonType="system" lineBreakMode="middleTruncation" translatesAutoresizingMaskIntoConstraints="NO" id="2z0-6z-4u6">
-                                <rect key="frame" x="20" y="293" width="374" height="30"/>
-                                <accessibility key="accessibilityConfiguration" identifier="start_bugsnag"/>
-                                <state key="normal" title="Start Bugsnag"/>
-                                <connections>
-                                    <action selector="startBugsnag" destination="BYZ-38-t0r" eventType="primaryActionTriggered" id="Wv1-OW-OOt"/>
-                                </connections>
-                            </button>
-                            <button opaque="NO" contentMode="scaleToFill" contentHorizontalAlignment="center" contentVerticalAlignment="center" buttonType="system" lineBreakMode="middleTruncation" translatesAutoresizingMaskIntoConstraints="NO" id="zEv-jB-Vej">
-                                <rect key="frame" x="20" y="343" width="374" height="30"/>
-                                <accessibility key="accessibilityConfiguration" identifier="clear_persistent_data"/>
-                                <state key="normal" title="Clear Persistent Data"/>
-                                <connections>
-                                    <action selector="clearPersistentData:" destination="BYZ-38-t0r" eventType="touchUpInside" id="ZcO-Ew-Mhu"/>
-                                </connections>
-                            </button>
-                            <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="251" text="Manual Testing" textAlignment="center" lineBreakMode="tailTruncation" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" translatesAutoresizingMaskIntoConstraints="NO" id="X9q-4y-UF2">
-                                <rect key="frame" x="20" y="423" width="374" height="21"/>
-                                <accessibility key="accessibilityConfiguration" identifier="close_keyboard"/>
-                                <fontDescription key="fontDescription" type="system" pointSize="17"/>
-                                <nil key="textColor"/>
-                                <nil key="highlightedColor"/>
-                            </label>
-                            <textField opaque="NO" contentMode="scaleToFill" contentHorizontalAlignment="left" contentVerticalAlignment="center" borderStyle="roundedRect" placeholder="API key" textAlignment="center" minimumFontSize="17" translatesAutoresizingMaskIntoConstraints="NO" id="KtB-q4-GVd">
-                                <rect key="frame" x="20" y="464" width="374" height="34"/>
-                                <fontDescription key="fontDescription" type="system" pointSize="14"/>
-                                <textInputTraits key="textInputTraits"/>
-                            </textField>
+                            <stackView opaque="NO" contentMode="scaleToFill" axis="vertical" spacing="16" translatesAutoresizingMaskIntoConstraints="NO" id="uYd-Z0-HWq">
+                                <rect key="frame" x="20" y="108" width="374" height="391"/>
+                                <subviews>
+                                    <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="251" text="Manual Testing" textAlignment="center" lineBreakMode="tailTruncation" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" translatesAutoresizingMaskIntoConstraints="NO" id="X9q-4y-UF2">
+                                        <rect key="frame" x="0.0" y="0.0" width="374" height="20.5"/>
+                                        <accessibility key="accessibilityConfiguration" identifier="close_keyboard"/>
+                                        <fontDescription key="fontDescription" type="system" pointSize="17"/>
+                                        <nil key="textColor"/>
+                                        <nil key="highlightedColor"/>
+                                    </label>
+                                    <textField opaque="NO" contentMode="scaleToFill" contentHorizontalAlignment="left" contentVerticalAlignment="center" borderStyle="roundedRect" placeholder="Scenario Name" textAlignment="center" minimumFontSize="17" translatesAutoresizingMaskIntoConstraints="NO" id="5Cz-db-j7f">
+                                        <rect key="frame" x="0.0" y="36.5" width="374" height="34"/>
+                                        <accessibility key="accessibilityConfiguration" identifier="scenario_name"/>
+                                        <fontDescription key="fontDescription" type="system" pointSize="14"/>
+                                        <textInputTraits key="textInputTraits"/>
+                                    </textField>
+                                    <textField opaque="NO" contentMode="scaleToFill" contentHorizontalAlignment="left" contentVerticalAlignment="center" borderStyle="roundedRect" placeholder="Scenario Metadata" textAlignment="center" minimumFontSize="17" translatesAutoresizingMaskIntoConstraints="NO" id="IN4-CK-eEf">
+                                        <rect key="frame" x="0.0" y="86.5" width="374" height="34"/>
+                                        <accessibility key="accessibilityConfiguration" identifier="scenario_metadata"/>
+                                        <fontDescription key="fontDescription" type="system" pointSize="14"/>
+                                        <textInputTraits key="textInputTraits"/>
+                                    </textField>
+                                    <textField opaque="NO" contentMode="scaleToFill" contentHorizontalAlignment="left" contentVerticalAlignment="center" borderStyle="roundedRect" placeholder="API key" textAlignment="center" minimumFontSize="17" translatesAutoresizingMaskIntoConstraints="NO" id="KtB-q4-GVd">
+                                        <rect key="frame" x="0.0" y="136.5" width="374" height="34"/>
+                                        <fontDescription key="fontDescription" type="system" pointSize="14"/>
+                                        <textInputTraits key="textInputTraits"/>
+                                    </textField>
+                                    <button opaque="NO" contentMode="scaleToFill" contentHorizontalAlignment="center" contentVerticalAlignment="center" buttonType="system" lineBreakMode="middleTruncation" translatesAutoresizingMaskIntoConstraints="NO" id="Oym-db-43x">
+                                        <rect key="frame" x="0.0" y="186.5" width="374" height="30"/>
+                                        <accessibility key="accessibilityConfiguration" identifier="run_scenario"/>
+                                        <state key="normal" title="Start Scenario"/>
+                                        <connections>
+                                            <action selector="runTestScenario" destination="BYZ-38-t0r" eventType="primaryActionTriggered" id="tlB-VZ-ZdP"/>
+                                        </connections>
+                                    </button>
+                                    <button opaque="NO" contentMode="scaleToFill" contentHorizontalAlignment="center" contentVerticalAlignment="center" buttonType="system" lineBreakMode="middleTruncation" translatesAutoresizingMaskIntoConstraints="NO" id="2z0-6z-4u6">
+                                        <rect key="frame" x="0.0" y="232.5" width="374" height="30"/>
+                                        <accessibility key="accessibilityConfiguration" identifier="start_bugsnag"/>
+                                        <state key="normal" title="Start Bugsnag"/>
+                                        <connections>
+                                            <action selector="startBugsnag" destination="BYZ-38-t0r" eventType="primaryActionTriggered" id="Wv1-OW-OOt"/>
+                                        </connections>
+                                    </button>
+                                    <button opaque="NO" contentMode="scaleToFill" contentHorizontalAlignment="center" contentVerticalAlignment="center" buttonType="system" lineBreakMode="middleTruncation" translatesAutoresizingMaskIntoConstraints="NO" id="zEv-jB-Vej">
+                                        <rect key="frame" x="0.0" y="278.5" width="374" height="30"/>
+                                        <accessibility key="accessibilityConfiguration" identifier="clear_persistent_data"/>
+                                        <state key="normal" title="Clear Persistent Data"/>
+                                        <connections>
+                                            <action selector="clearPersistentData:" destination="BYZ-38-t0r" eventType="touchUpInside" id="ZcO-Ew-Mhu"/>
+                                        </connections>
+                                    </button>
+                                    <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="251" text="Maze Runner Testing" textAlignment="center" lineBreakMode="tailTruncation" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" translatesAutoresizingMaskIntoConstraints="NO" id="pz1-DD-cDN">
+                                        <rect key="frame" x="0.0" y="324.5" width="374" height="20.5"/>
+                                        <accessibility key="accessibilityConfiguration" identifier="close_keyboard"/>
+                                        <fontDescription key="fontDescription" type="system" pointSize="17"/>
+                                        <nil key="textColor"/>
+                                        <nil key="highlightedColor"/>
+                                    </label>
+                                    <button opaque="NO" contentMode="scaleToFill" contentHorizontalAlignment="center" contentVerticalAlignment="center" buttonType="system" lineBreakMode="middleTruncation" translatesAutoresizingMaskIntoConstraints="NO" id="6o0-hw-DJm">
+                                        <rect key="frame" x="0.0" y="361" width="374" height="30"/>
+                                        <accessibility key="accessibilityConfiguration" identifier="execute_command"/>
+                                        <fontDescription key="fontDescription" type="system" pointSize="15"/>
+                                        <inset key="imageEdgeInsets" minX="0.0" minY="0.0" maxX="2.2250738585072014e-308" maxY="0.0"/>
+                                        <state key="normal" title="Execute Maze Runner command"/>
+                                        <connections>
+                                            <action selector="executeCommand:" destination="BYZ-38-t0r" eventType="touchUpInside" id="gNG-iW-jOE"/>
+                                        </connections>
+                                    </button>
+                                </subviews>
+                            </stackView>
                         </subviews>
                         <viewLayoutGuide key="safeArea" id="41A-zo-0gw"/>
                         <color key="backgroundColor" white="1" alpha="1" colorSpace="custom" customColorSpace="genericGamma22GrayColorSpace"/>
                         <constraints>
-                            <constraint firstItem="41A-zo-0gw" firstAttribute="trailing" secondItem="KtB-q4-GVd" secondAttribute="trailing" constant="20" id="0xf-jy-64A"/>
-                            <constraint firstItem="RWZ-At-akB" firstAttribute="leading" secondItem="41A-zo-0gw" secondAttribute="leading" constant="20" id="1Aj-gR-NNx"/>
-                            <constraint firstItem="zEv-jB-Vej" firstAttribute="leading" secondItem="41A-zo-0gw" secondAttribute="leading" constant="20" id="4QA-rB-Dgc"/>
-                            <constraint firstItem="X9q-4y-UF2" firstAttribute="top" secondItem="zEv-jB-Vej" secondAttribute="bottom" constant="50" id="CM6-Im-X6f"/>
-                            <constraint firstItem="KtB-q4-GVd" firstAttribute="top" secondItem="X9q-4y-UF2" secondAttribute="bottom" constant="20" id="Cka-pj-BLD"/>
-                            <constraint firstItem="41A-zo-0gw" firstAttribute="trailing" secondItem="X9q-4y-UF2" secondAttribute="trailing" constant="20" id="D35-qc-4Ta"/>
-                            <constraint firstItem="41A-zo-0gw" firstAttribute="trailing" secondItem="2z0-6z-4u6" secondAttribute="trailing" constant="20" id="Kv4-xj-g7n"/>
-                            <constraint firstItem="KtB-q4-GVd" firstAttribute="leading" secondItem="41A-zo-0gw" secondAttribute="leading" constant="20" id="MNf-5J-i3s"/>
-                            <constraint firstItem="Oym-db-43x" firstAttribute="leading" secondItem="41A-zo-0gw" secondAttribute="leading" constant="20" id="MaA-V0-mCP"/>
-                            <constraint firstItem="41A-zo-0gw" firstAttribute="trailing" secondItem="5Cz-db-j7f" secondAttribute="trailing" constant="20" id="PBS-th-0dO"/>
-                            <constraint firstItem="41A-zo-0gw" firstAttribute="trailing" secondItem="RWZ-At-akB" secondAttribute="trailing" constant="20" id="Pg7-Cu-ugU"/>
-                            <constraint firstItem="X9q-4y-UF2" firstAttribute="leading" secondItem="41A-zo-0gw" secondAttribute="leading" constant="20" id="UWN-Vj-aeK"/>
-                            <constraint firstItem="Oym-db-43x" firstAttribute="top" secondItem="IN4-CK-eEf" secondAttribute="bottom" constant="20" id="VPw-nk-IzA"/>
-                            <constraint firstItem="5Cz-db-j7f" firstAttribute="top" secondItem="RWZ-At-akB" secondAttribute="bottom" constant="20" id="XET-Kr-TUe"/>
-                            <constraint firstItem="2z0-6z-4u6" firstAttribute="top" secondItem="Oym-db-43x" secondAttribute="bottom" constant="20" id="XrK-3j-sF7"/>
-                            <constraint firstItem="41A-zo-0gw" firstAttribute="trailing" secondItem="IN4-CK-eEf" secondAttribute="trailing" constant="20" id="aqn-8G-GNT"/>
-                            <constraint firstItem="41A-zo-0gw" firstAttribute="trailing" secondItem="Oym-db-43x" secondAttribute="trailing" constant="20" id="d1z-vb-lp7"/>
-                            <constraint firstItem="41A-zo-0gw" firstAttribute="trailing" secondItem="zEv-jB-Vej" secondAttribute="trailing" constant="20" id="f2f-mR-ig0"/>
-                            <constraint firstItem="2z0-6z-4u6" firstAttribute="leading" secondItem="41A-zo-0gw" secondAttribute="leading" constant="20" id="kCa-bn-oMx"/>
-                            <constraint firstItem="IN4-CK-eEf" firstAttribute="top" secondItem="5Cz-db-j7f" secondAttribute="bottom" constant="20" id="ldb-Ut-xXp"/>
-                            <constraint firstItem="5Cz-db-j7f" firstAttribute="leading" secondItem="41A-zo-0gw" secondAttribute="leading" constant="20" id="r5d-oU-m3j"/>
-                            <constraint firstItem="zEv-jB-Vej" firstAttribute="top" secondItem="2z0-6z-4u6" secondAttribute="bottom" constant="20" id="tpf-WN-h2e"/>
-                            <constraint firstItem="IN4-CK-eEf" firstAttribute="leading" secondItem="41A-zo-0gw" secondAttribute="leading" constant="20" id="wJi-PV-dqy"/>
-                            <constraint firstItem="RWZ-At-akB" firstAttribute="top" secondItem="41A-zo-0gw" secondAttribute="top" constant="50" id="zbP-F5-B9p"/>
+                            <constraint firstItem="uYd-Z0-HWq" firstAttribute="leading" secondItem="41A-zo-0gw" secondAttribute="leading" constant="20" id="2P3-re-Gxp"/>
+                            <constraint firstItem="uYd-Z0-HWq" firstAttribute="top" secondItem="41A-zo-0gw" secondAttribute="top" constant="20" id="btD-jh-hvc"/>
+                            <constraint firstItem="41A-zo-0gw" firstAttribute="trailing" secondItem="uYd-Z0-HWq" secondAttribute="trailing" constant="20" id="hlz-y4-zcx"/>
                         </constraints>
                     </view>
+                    <navigationItem key="navigationItem" title="Bugsnag iOS Test Fixture" id="2rr-a0-5ni"/>
                     <connections>
                         <outlet property="apiKeyField" destination="KtB-q4-GVd" id="B66-s4-9bV"/>
                         <outlet property="scenarioMetaDataField" destination="IN4-CK-eEf" id="d0Y-Er-lUg"/>
@@ -108,6 +103,24 @@
                     </connections>
                 </viewController>
                 <placeholder placeholderIdentifier="IBFirstResponder" id="dkx-z0-nzr" sceneMemberID="firstResponder"/>
+            </objects>
+            <point key="canvasLocation" x="1042.0289855072465" y="137.94642857142856"/>
+        </scene>
+        <!--Navigation Controller-->
+        <scene sceneID="ebu-7R-3vm">
+            <objects>
+                <navigationController automaticallyAdjustsScrollViewInsets="NO" id="GWo-9T-4ru" sceneMemberID="viewController">
+                    <toolbarItems/>
+                    <navigationBar key="navigationBar" contentMode="scaleToFill" id="JCn-5i-ITb">
+                        <rect key="frame" x="0.0" y="44" width="414" height="44"/>
+                        <autoresizingMask key="autoresizingMask"/>
+                    </navigationBar>
+                    <nil name="viewControllers"/>
+                    <connections>
+                        <segue destination="BYZ-38-t0r" kind="relationship" relationship="rootViewController" id="brw-z0-jSh"/>
+                    </connections>
+                </navigationController>
+                <placeholder placeholderIdentifier="IBFirstResponder" id="ps2-Mg-S4K" userLabel="First Responder" customClass="UIResponder" sceneMemberID="firstResponder"/>
             </objects>
             <point key="canvasLocation" x="131.8840579710145" y="137.94642857142856"/>
         </scene>

--- a/features/fixtures/macos/macOSTestApp.xcodeproj/project.pbxproj
+++ b/features/fixtures/macos/macOSTestApp.xcodeproj/project.pbxproj
@@ -21,7 +21,7 @@
 		01847DCD26443DF000ADA4C7 /* InvalidCrashReportScenario.m in Sources */ = {isa = PBXBuildFile; fileRef = 01847DCC26443DF000ADA4C7 /* InvalidCrashReportScenario.m */; };
 		01AF6A50258A00DE00FFC803 /* BareboneTestScenarios.swift in Sources */ = {isa = PBXBuildFile; fileRef = 01AF6A4F258A00DE00FFC803 /* BareboneTestScenarios.swift */; };
 		01AF6A84258BB38A00FFC803 /* DispatchCrashScenario.swift in Sources */ = {isa = PBXBuildFile; fileRef = 01AF6A83258BB38A00FFC803 /* DispatchCrashScenario.swift */; };
-		01B6BB7225D56CBF00FC4DE6 /* LastRunInfoScenarios.swift in Sources */ = {isa = PBXBuildFile; fileRef = 01B6BB7125D56CBF00FC4DE6 /* LastRunInfoScenarios.swift */; };
+		01B6BB7225D56CBF00FC4DE6 /* LastRunInfoScenario.swift in Sources */ = {isa = PBXBuildFile; fileRef = 01B6BB7125D56CBF00FC4DE6 /* LastRunInfoScenario.swift */; };
 		01B6BBA225DA774C00FC4DE6 /* SendLaunchCrashesSynchronouslyScenario.swift in Sources */ = {isa = PBXBuildFile; fileRef = 01B6BBA125DA774C00FC4DE6 /* SendLaunchCrashesSynchronouslyScenario.swift */; };
 		01DE903A26CEAD1200455213 /* CriticalThermalStateScenario.swift in Sources */ = {isa = PBXBuildFile; fileRef = 01DE903926CEAD1200455213 /* CriticalThermalStateScenario.swift */; };
 		01E0DB0625E8E95700A740ED /* AppDurationScenario.swift in Sources */ = {isa = PBXBuildFile; fileRef = 01E0DB0425E8E90500A740ED /* AppDurationScenario.swift */; };
@@ -177,7 +177,7 @@
 		01847DCC26443DF000ADA4C7 /* InvalidCrashReportScenario.m */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.objc; path = InvalidCrashReportScenario.m; sourceTree = "<group>"; };
 		01AF6A4F258A00DE00FFC803 /* BareboneTestScenarios.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = BareboneTestScenarios.swift; sourceTree = "<group>"; };
 		01AF6A83258BB38A00FFC803 /* DispatchCrashScenario.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = DispatchCrashScenario.swift; sourceTree = "<group>"; };
-		01B6BB7125D56CBF00FC4DE6 /* LastRunInfoScenarios.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = LastRunInfoScenarios.swift; sourceTree = "<group>"; };
+		01B6BB7125D56CBF00FC4DE6 /* LastRunInfoScenario.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = LastRunInfoScenario.swift; sourceTree = "<group>"; };
 		01B6BBA125DA774C00FC4DE6 /* SendLaunchCrashesSynchronouslyScenario.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SendLaunchCrashesSynchronouslyScenario.swift; sourceTree = "<group>"; };
 		01DE903926CEAD1200455213 /* CriticalThermalStateScenario.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = CriticalThermalStateScenario.swift; sourceTree = "<group>"; };
 		01E0DB0425E8E90500A740ED /* AppDurationScenario.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AppDurationScenario.swift; sourceTree = "<group>"; };
@@ -436,7 +436,7 @@
 				01F47C28254B1B2C00B184AD /* HandledExceptionScenario.swift */,
 				01F47C55254B1B2E00B184AD /* HandledInternalNotifyScenario.swift */,
 				01847DCC26443DF000ADA4C7 /* InvalidCrashReportScenario.m */,
-				01B6BB7125D56CBF00FC4DE6 /* LastRunInfoScenarios.swift */,
+				01B6BB7125D56CBF00FC4DE6 /* LastRunInfoScenario.swift */,
 				01F47C23254B1B2C00B184AD /* LoadConfigFromFileAutoScenario.swift */,
 				01F47C94254B1B2F00B184AD /* LoadConfigFromFileScenario.swift */,
 				01F47C3B254B1B2D00B184AD /* ManualContextClientScenario.swift */,
@@ -853,7 +853,7 @@
 				01F47CF4254B1B3100B184AD /* OOMSessionScenario.swift in Sources */,
 				01F47D21254B1B3100B184AD /* SIGFPEScenario.m in Sources */,
 				01F47CEB254B1B3100B184AD /* AutoSessionHandledEventsScenario.m in Sources */,
-				01B6BB7225D56CBF00FC4DE6 /* LastRunInfoScenarios.swift in Sources */,
+				01B6BB7225D56CBF00FC4DE6 /* LastRunInfoScenario.swift in Sources */,
 				01F47CF7254B1B3100B184AD /* OnSendErrorCallbackCrashScenario.swift in Sources */,
 				01F47CDF254B1B3100B184AD /* AbortScenario.m in Sources */,
 				01F47CD1254B1B3100B184AD /* ManualContextClientScenario.swift in Sources */,

--- a/features/fixtures/macos/macOSTestApp/MainWindowController.xib
+++ b/features/fixtures/macos/macOSTestApp/MainWindowController.xib
@@ -1,8 +1,8 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<document type="com.apple.InterfaceBuilder3.Cocoa.XIB" version="3.0" toolsVersion="17156" targetRuntime="MacOSX.Cocoa" propertyAccessControl="none" useAutolayout="YES" customObjectInstantitationMethod="direct">
+<document type="com.apple.InterfaceBuilder3.Cocoa.XIB" version="3.0" toolsVersion="19529" targetRuntime="MacOSX.Cocoa" propertyAccessControl="none" useAutolayout="YES" customObjectInstantitationMethod="direct">
     <dependencies>
         <deployment identifier="macosx"/>
-        <plugIn identifier="com.apple.InterfaceBuilder.CocoaPlugin" version="17156"/>
+        <plugIn identifier="com.apple.InterfaceBuilder.CocoaPlugin" version="19529"/>
         <capability name="documents saved in the Xcode 8 format" minToolsVersion="8.0"/>
     </dependencies>
     <objects>
@@ -15,14 +15,14 @@
         <customObject id="-3" userLabel="Application" customClass="NSObject"/>
         <window title="Bugsnag Cocoa Test Application" allowsToolTipsWhenApplicationIsInactive="NO" autorecalculatesKeyViewLoop="NO" releasedWhenClosed="NO" animationBehavior="default" id="F0z-JX-Cv5">
             <windowStyleMask key="styleMask" titled="YES" closable="YES" miniaturizable="YES"/>
-            <rect key="contentRect" x="196" y="240" width="480" height="329"/>
-            <rect key="screenRect" x="0.0" y="0.0" width="2560" height="1417"/>
+            <rect key="contentRect" x="196" y="240" width="480" height="369"/>
+            <rect key="screenRect" x="0.0" y="0.0" width="3008" height="1667"/>
             <view key="contentView" id="se5-gp-TjO">
-                <rect key="frame" x="0.0" y="0.0" width="480" height="329"/>
+                <rect key="frame" x="0.0" y="0.0" width="480" height="369"/>
                 <autoresizingMask key="autoresizingMask"/>
                 <subviews>
                     <textField horizontalHuggingPriority="251" verticalHuggingPriority="750" fixedFrame="YES" translatesAutoresizingMaskIntoConstraints="NO" id="YtQ-2w-wwj">
-                        <rect key="frame" x="69" y="290" width="100" height="16"/>
+                        <rect key="frame" x="69" y="330" width="100" height="16"/>
                         <autoresizingMask key="autoresizingMask" flexibleMaxX="YES" flexibleMinY="YES"/>
                         <textFieldCell key="cell" lineBreakMode="clipping" title="Scenario Name:" id="bhR-CE-qTE">
                             <font key="font" metaFont="system"/>
@@ -31,7 +31,7 @@
                         </textFieldCell>
                     </textField>
                     <textField verticalHuggingPriority="750" fixedFrame="YES" translatesAutoresizingMaskIntoConstraints="NO" id="zYv-i6-NpB">
-                        <rect key="frame" x="175" y="288" width="257" height="21"/>
+                        <rect key="frame" x="175" y="328" width="257" height="21"/>
                         <autoresizingMask key="autoresizingMask" flexibleMaxX="YES" flexibleMinY="YES"/>
                         <textFieldCell key="cell" scrollable="YES" lineBreakMode="clipping" selectable="YES" editable="YES" sendsActionOnEndEditing="YES" borderStyle="bezel" drawsBackground="YES" id="niv-ff-aKE">
                             <font key="font" usesAppearanceFont="YES"/>
@@ -48,7 +48,7 @@
                         </connections>
                     </textField>
                     <textField horizontalHuggingPriority="251" verticalHuggingPriority="750" fixedFrame="YES" translatesAutoresizingMaskIntoConstraints="NO" id="Dw5-UD-NBK">
-                        <rect key="frame" x="47" y="259" width="122" height="16"/>
+                        <rect key="frame" x="47" y="299" width="122" height="16"/>
                         <autoresizingMask key="autoresizingMask" flexibleMaxX="YES" flexibleMinY="YES"/>
                         <textFieldCell key="cell" lineBreakMode="clipping" title="Scenario Metadata:" id="kfW-lJ-3gA">
                             <font key="font" metaFont="system"/>
@@ -57,7 +57,7 @@
                         </textFieldCell>
                     </textField>
                     <textField verticalHuggingPriority="750" fixedFrame="YES" translatesAutoresizingMaskIntoConstraints="NO" id="8eg-RQ-oht">
-                        <rect key="frame" x="175" y="257" width="257" height="21"/>
+                        <rect key="frame" x="175" y="297" width="257" height="21"/>
                         <autoresizingMask key="autoresizingMask" flexibleMaxX="YES" flexibleMinY="YES"/>
                         <textFieldCell key="cell" scrollable="YES" lineBreakMode="clipping" selectable="YES" editable="YES" sendsActionOnEndEditing="YES" borderStyle="bezel" drawsBackground="YES" id="LHj-bu-yqp">
                             <font key="font" usesAppearanceFont="YES"/>
@@ -77,7 +77,7 @@
                         </connections>
                     </textField>
                     <button verticalHuggingPriority="750" fixedFrame="YES" translatesAutoresizingMaskIntoConstraints="NO" id="Aze-pw-z8u">
-                        <rect key="frame" x="169" y="221" width="120" height="32"/>
+                        <rect key="frame" x="169" y="261" width="120" height="32"/>
                         <autoresizingMask key="autoresizingMask" flexibleMaxX="YES" flexibleMinY="YES"/>
                         <buttonCell key="cell" type="push" title="Run Scenario" bezelStyle="rounded" alignment="center" borderStyle="border" imageScaling="proportionallyDown" inset="2" id="QUb-9T-qCW">
                             <behavior key="behavior" pushIn="YES" lightByBackground="YES" lightByGray="YES"/>
@@ -89,7 +89,7 @@
                         </connections>
                     </button>
                     <button verticalHuggingPriority="750" fixedFrame="YES" translatesAutoresizingMaskIntoConstraints="NO" id="jzc-Xc-Oqv">
-                        <rect key="frame" x="169" y="188" width="158" height="32"/>
+                        <rect key="frame" x="169" y="228" width="158" height="32"/>
                         <autoresizingMask key="autoresizingMask" flexibleMaxX="YES" flexibleMinY="YES"/>
                         <buttonCell key="cell" type="push" title="Start Bugsnag Only" bezelStyle="rounded" alignment="center" borderStyle="border" imageScaling="proportionallyDown" inset="2" id="NLZ-0g-gQp">
                             <behavior key="behavior" pushIn="YES" lightByBackground="YES" lightByGray="YES"/>
@@ -101,7 +101,7 @@
                         </connections>
                     </button>
                     <button verticalHuggingPriority="750" fixedFrame="YES" translatesAutoresizingMaskIntoConstraints="NO" id="el9-Nk-w6y">
-                        <rect key="frame" x="169" y="155" width="168" height="32"/>
+                        <rect key="frame" x="169" y="195" width="168" height="32"/>
                         <autoresizingMask key="autoresizingMask" flexibleMaxX="YES" flexibleMinY="YES"/>
                         <buttonCell key="cell" type="push" title="Clear Persistent Data" bezelStyle="rounded" alignment="center" borderStyle="border" imageScaling="proportionallyDown" inset="2" id="89m-tR-b1f">
                             <behavior key="behavior" pushIn="YES" lightByBackground="YES" lightByGray="YES"/>
@@ -113,7 +113,7 @@
                         </connections>
                     </button>
                     <textField horizontalHuggingPriority="251" verticalHuggingPriority="750" fixedFrame="YES" translatesAutoresizingMaskIntoConstraints="NO" id="xt3-4X-B4F">
-                        <rect key="frame" x="69" y="123" width="102" height="16"/>
+                        <rect key="frame" x="69" y="163" width="102" height="16"/>
                         <autoresizingMask key="autoresizingMask" flexibleMaxX="YES" flexibleMinY="YES"/>
                         <textFieldCell key="cell" lineBreakMode="clipping" title="Notify Endpoint:" id="Isp-xX-Sb0">
                             <font key="font" metaFont="system"/>
@@ -122,7 +122,7 @@
                         </textFieldCell>
                     </textField>
                     <textField verticalHuggingPriority="750" fixedFrame="YES" translatesAutoresizingMaskIntoConstraints="NO" id="auF-0E-wZk">
-                        <rect key="frame" x="175" y="121" width="257" height="21"/>
+                        <rect key="frame" x="175" y="161" width="257" height="21"/>
                         <autoresizingMask key="autoresizingMask" flexibleMaxX="YES" flexibleMinY="YES"/>
                         <textFieldCell key="cell" scrollable="YES" lineBreakMode="clipping" selectable="YES" editable="YES" sendsActionOnEndEditing="YES" borderStyle="bezel" drawsBackground="YES" id="bRA-Zt-fW2">
                             <font key="font" usesAppearanceFont="YES"/>
@@ -139,7 +139,7 @@
                         </connections>
                     </textField>
                     <textField horizontalHuggingPriority="251" verticalHuggingPriority="750" fixedFrame="YES" translatesAutoresizingMaskIntoConstraints="NO" id="omZ-sy-IPy">
-                        <rect key="frame" x="51" y="92" width="120" height="16"/>
+                        <rect key="frame" x="51" y="132" width="120" height="16"/>
                         <autoresizingMask key="autoresizingMask" flexibleMaxX="YES" flexibleMinY="YES"/>
                         <textFieldCell key="cell" lineBreakMode="clipping" title="Sessions Endpoint:" id="EAX-un-bTu">
                             <font key="font" metaFont="system"/>
@@ -148,7 +148,7 @@
                         </textFieldCell>
                     </textField>
                     <textField verticalHuggingPriority="750" fixedFrame="YES" translatesAutoresizingMaskIntoConstraints="NO" id="pWu-Fr-ZcD">
-                        <rect key="frame" x="175" y="90" width="257" height="21"/>
+                        <rect key="frame" x="175" y="130" width="257" height="21"/>
                         <autoresizingMask key="autoresizingMask" flexibleMaxX="YES" flexibleMinY="YES"/>
                         <textFieldCell key="cell" scrollable="YES" lineBreakMode="clipping" selectable="YES" editable="YES" sendsActionOnEndEditing="YES" borderStyle="bezel" drawsBackground="YES" id="hWd-UL-WOO">
                             <font key="font" usesAppearanceFont="YES"/>
@@ -165,7 +165,7 @@
                         </connections>
                     </textField>
                     <button verticalHuggingPriority="750" fixedFrame="YES" translatesAutoresizingMaskIntoConstraints="NO" id="U4G-36-4aS">
-                        <rect key="frame" x="169" y="54" width="198" height="32"/>
+                        <rect key="frame" x="169" y="94" width="198" height="32"/>
                         <autoresizingMask key="autoresizingMask" flexibleMaxX="YES" flexibleMinY="YES"/>
                         <buttonCell key="cell" type="push" title="Use Dashboard Endpoints" bezelStyle="rounded" alignment="center" borderStyle="border" imageScaling="proportionallyDown" inset="2" id="YPa-4A-oyh">
                             <behavior key="behavior" pushIn="YES" lightByBackground="YES" lightByGray="YES"/>
@@ -177,7 +177,7 @@
                         </connections>
                     </button>
                     <textField horizontalHuggingPriority="251" verticalHuggingPriority="750" fixedFrame="YES" translatesAutoresizingMaskIntoConstraints="NO" id="eut-nR-vlr">
-                        <rect key="frame" x="115" y="22" width="54" height="16"/>
+                        <rect key="frame" x="115" y="62" width="54" height="16"/>
                         <autoresizingMask key="autoresizingMask" flexibleMaxX="YES" flexibleMinY="YES"/>
                         <textFieldCell key="cell" lineBreakMode="clipping" title="API Key:" id="Jdz-KB-kWi">
                             <font key="font" metaFont="system"/>
@@ -186,7 +186,7 @@
                         </textFieldCell>
                     </textField>
                     <textField verticalHuggingPriority="750" fixedFrame="YES" translatesAutoresizingMaskIntoConstraints="NO" id="Trq-YW-JdV">
-                        <rect key="frame" x="175" y="20" width="257" height="21"/>
+                        <rect key="frame" x="175" y="60" width="257" height="21"/>
                         <autoresizingMask key="autoresizingMask" flexibleMaxX="YES" flexibleMinY="YES"/>
                         <textFieldCell key="cell" scrollable="YES" lineBreakMode="clipping" selectable="YES" editable="YES" sendsActionOnEndEditing="YES" borderStyle="bezel" drawsBackground="YES" id="Pih-D3-4n2">
                             <font key="font" usesAppearanceFont="YES"/>
@@ -202,12 +202,24 @@
                             </binding>
                         </connections>
                     </textField>
+                    <button verticalHuggingPriority="750" fixedFrame="YES" translatesAutoresizingMaskIntoConstraints="NO" id="wJy-a4-86k">
+                        <rect key="frame" x="168" y="13" width="231" height="32"/>
+                        <autoresizingMask key="autoresizingMask" flexibleMaxX="YES" flexibleMinY="YES"/>
+                        <buttonCell key="cell" type="push" title="Execute Maze Runner Command" bezelStyle="rounded" alignment="center" borderStyle="border" imageScaling="proportionallyDown" inset="2" id="Abb-Xc-dpP">
+                            <behavior key="behavior" pushIn="YES" lightByBackground="YES" lightByGray="YES"/>
+                            <font key="font" metaFont="system"/>
+                        </buttonCell>
+                        <accessibility identifier="execute_command"/>
+                        <connections>
+                            <action selector="executeMazeRunnerCommand:" target="-2" id="Ht4-TP-l8c"/>
+                        </connections>
+                    </button>
                 </subviews>
             </view>
             <connections>
                 <outlet property="delegate" destination="-2" id="0bl-1N-AYu"/>
             </connections>
-            <point key="canvasLocation" x="56" y="-275.5"/>
+            <point key="canvasLocation" x="56" y="-255.5"/>
         </window>
         <userDefaultsController representsSharedInstance="YES" id="hoh-Hm-7ag"/>
     </objects>

--- a/features/fixtures/shared/scenarios/LastRunInfoScenario.swift
+++ b/features/fixtures/shared/scenarios/LastRunInfoScenario.swift
@@ -1,12 +1,12 @@
 //
-//  LastRunInfoScenarios.swift
+//  LastRunInfoScenario.swift
 //  macOSTestApp
 //
 //  Created by Nick Dowell on 11/02/2021.
 //  Copyright © 2021 Bugsnag Inc. All rights reserved.
 //
 
-class LastRunInfoConsecutiveLaunchCrashesScenario: Scenario {
+class LastRunInfoScenario: Scenario {
     
     override func startBugsnag() {
         config.launchDurationMillis = 0

--- a/features/fixtures/shared/scenarios/Scenario.h
+++ b/features/fixtures/shared/scenarios/Scenario.h
@@ -19,14 +19,11 @@ void markErrorHandledCallback(const BSG_KSCrashReportWriter *writer);
 
 @property (strong, nonatomic, nonnull) BugsnagConfiguration *config;
 
-+ (Scenario *)createScenarioNamed:(NSString *)className withConfig:(BugsnagConfiguration *)config;
++ (Scenario *)createScenarioNamed:(NSString *)className withConfig:(nullable BugsnagConfiguration *)config;
 
-- (instancetype)initWithConfig:(BugsnagConfiguration *)config;
+@property (class, readonly, nullable) Scenario *currentScenario;
 
-/**
- * Blocks the calling thread until network connectivity to the notify endpoint has been verified.
- */
-- (void)waitForNetworkConnectivity;
+- (instancetype)initWithConfig:(nullable BugsnagConfiguration *)config;
 
 /**
  * Executes the test case
@@ -42,6 +39,8 @@ void markErrorHandledCallback(const BSG_KSCrashReportWriter *writer);
 - (void)performBlockAndWaitForEventDelivery:(dispatch_block_t)block NS_SWIFT_NAME(performBlockAndWaitForEventDelivery(_:));
 
 + (void)clearPersistentData;
+
++ (void)executeMazeRunnerCommand:(void (^)(NSString *action, NSString *scenarioName, NSString *scenarioMode))preHandler;
 
 @end
 

--- a/features/last_run_info.feature
+++ b/features/last_run_info.feature
@@ -4,8 +4,8 @@ Feature: Launch detection
     Given I clear all persistent data
 
   Scenario: LastRunInfo consecutiveLaunchCrashes increments when isLaunching is true
-    When I run "LastRunInfoConsecutiveLaunchCrashesScenario" and relaunch the crashed app
-    And I configure Bugsnag for "LastRunInfoConsecutiveLaunchCrashesScenario"
+    When I run "LastRunInfoScenario" and relaunch the crashed app
+    And I configure Bugsnag for "LastRunInfoScenario"
     And I wait to receive an error
     And the event "metaData.lastRunInfo.consecutiveLaunchCrashes" equals 1
     And the event "metaData.lastRunInfo.crashed" is true
@@ -13,19 +13,19 @@ Feature: Launch detection
     And I discard the oldest error
 
     And I run the configured scenario and relaunch the crashed app
-    And I configure Bugsnag for "LastRunInfoConsecutiveLaunchCrashesScenario"
+    And I configure Bugsnag for "LastRunInfoScenario"
     And I wait to receive an error
     And the event "metaData.lastRunInfo.consecutiveLaunchCrashes" equals 2
     And I discard the oldest error
 
     And I run the configured scenario and relaunch the crashed app
-    And I configure Bugsnag for "LastRunInfoConsecutiveLaunchCrashesScenario"
+    And I configure Bugsnag for "LastRunInfoScenario"
     And I wait to receive an error
     And the event "metaData.lastRunInfo.consecutiveLaunchCrashes" equals 3
     And I discard the oldest error
 
     And I run the configured scenario and relaunch the crashed app
-    And I configure Bugsnag for "LastRunInfoConsecutiveLaunchCrashesScenario"
+    And I configure Bugsnag for "LastRunInfoScenario"
     And I wait to receive an error
     And the event "metaData.lastRunInfo.consecutiveLaunchCrashes" equals 0
     And the event "metaData.lastRunInfo.crashed" is true

--- a/features/steps/app_steps.rb
+++ b/features/steps/app_steps.rb
@@ -55,31 +55,9 @@ Then('the app is not running') do
 end
 
 #
-# Setting scenario and mode
+# Setting scenario mode
 #
 
-When('I set the app to {string} scenario') do |scenario|
-  case Maze::Helper.get_current_platform
-  when 'macos'
-    mac_set_value('scenarioName', scenario)
-  else
-    steps %(When I send the keys "#{scenario}" to the element "scenario_name")
-  end
-end
-
 When('I set the app to {string} mode') do |mode|
-  case Maze::Helper.get_current_platform
-  when 'macos'
-    mac_set_value('scenarioMetadata', mode)
-  else
-    steps %(When I send the keys "#{mode}" to the element "scenario_metadata")
-  end
-end
-
-def mac_set_value(key, value)
-  # Using find_element to ensure app is ready for input
-  Maze.driver.find_element(:id, 'scenario_name')
-  # Using 'open location' because it is one of the few AppleScript commands that does not require privacy approval
-  location = "macOSTestApp:///mainWindowController?#{key}=#{value}"
-  system("osascript -e 'tell application \"macOSTestApp\" to open location \"#{location}\"'", exception: true)
+  $scenario_mode = mode
 end


### PR DESCRIPTION
## Goal

Speed up E2E tests.

## Design

Command payloads, that include the scenario name and action to take, are queued up by the test framework and read by the fixture using `GET /command`.

This is much faster than sending scenario names as text, which Appium enters character by character.

* https://github.com/bugsnag/maze-runner/pull/332

## Changeset

* iOS and macOS fixtures now have an execute_command button that fetches and executes a command.
* The scenario name is shown on the UI to provide some visual feedback before performing the action.
* More logic has been moved to Scenario.m where it can be shared between iOS and macOS fixtures.

## Testing

Ran full E2E suite locally and [on CI](https://buildkite.com/bugsnag/bugsnag-cocoa/builds/4653).