### PR TITLE
Fix setting custom notifier info

### DIFF
--- a/Bugsnag/Configuration/BugsnagConfiguration.m
+++ b/Bugsnag/Configuration/BugsnagConfiguration.m
@@ -97,6 +97,7 @@ static NSUserDefaults *userDefaults;
     [copy setMaxPersistedEvents:self.maxPersistedEvents];
     [copy setMaxPersistedSessions:self.maxPersistedSessions];
     [copy setMaxBreadcrumbs:self.maxBreadcrumbs];
+    [copy setNotifier:self.notifier];
     [copy setFeatureFlagStore:self.featureFlagStore];
     [copy setMetadata:self.metadata];
     [copy setEndpoints:self.endpoints];

--- a/Tests/BugsnagTests/BugsnagConfigurationTests.m
+++ b/Tests/BugsnagTests/BugsnagConfigurationTests.m
@@ -10,6 +10,7 @@
 #import "BugsnagCrashSentry.h"
 #import "BugsnagEndpointConfiguration.h"
 #import "BugsnagErrorTypes.h"
+#import "BugsnagNotifier.h"
 #import "BugsnagSessionTracker.h"
 #import "BugsnagTestConstants.h"
 
@@ -855,6 +856,10 @@ NSString * const kBugsnagUserUserId = @"BugsnagUserUserId";
     [config setAutoDetectErrors:YES];
     [config setContext:@"context1"];
     [config setAppType:@"The most amazing app, a brilliant app, the app to end all apps"];
+    [config setNotifier:[[BugsnagNotifier alloc] initWithName:@"Example"
+                                                      version:@"0.0.0"
+                                                          url:@"https://example.com"
+                                                 dependencies:@[[[BugsnagNotifier alloc] init]]]];
     [config setPersistUser:YES];
     [config setSendThreads:BSGThreadSendPolicyUnhandledOnly];
     BugsnagOnSendErrorBlock onSendBlock1 = ^BOOL(BugsnagEvent * _Nonnull event) { return true; };
@@ -901,6 +906,10 @@ NSString * const kBugsnagUserUserId = @"BugsnagUserUserId";
     XCTAssertEqual(config.onSendBlocks[0], clone.onSendBlocks[0]);
     [clone setOnSendBlocks:[@[ onSendBlock2 ] mutableCopy]];
     XCTAssertNotEqual(config.onSendBlocks[0], clone.onSendBlocks[0]);
+    
+    XCTAssertEqualObjects(clone.notifier.name, config.notifier.name);
+    XCTAssertEqualObjects(clone.notifier.version, config.notifier.version);
+    XCTAssertEqualObjects(clone.notifier.url, config.notifier.url);
 }
 
 - (void)testMetadataMutability {


### PR DESCRIPTION
## Goal

Fix setting custom notifier info as required by the React Native, Unity and Unreal Engine notifiers.

This bug is a regression introduced in v6.16.0 by https://github.com/bugsnag/bugsnag-cocoa/commit/ab774f369482b121a9aef3b89b3cf45373bbfd87#diff-9e40e69405013ebceec8e93a7bb9f77586d4fbecc564622b874b364e0b772d29R217

## Changeset

* BugsnagConfiguration's copy implementation now copies the notifier payload.

## Testing

* Added a unit test case that identified the issue and verified the fix.