### PR TITLE
Add missing imports when not using clang modules

### DIFF
--- a/Bugsnag/KSCrash/Source/KSCrash/Recording/BSG_KSCrashNames.c
+++ b/Bugsnag/KSCrash/Source/KSCrash/Recording/BSG_KSCrashNames.c
@@ -8,6 +8,7 @@
 
 #include "BSG_KSCrashNames.h"
 #include <mach/thread_info.h>
+#include <stdio.h>
 
 static const char* thread_state_names[] = {
     // Defined in mach/thread_info.h

--- a/Bugsnag/KSCrash/Source/KSCrash/Recording/Tools/BSG_KSFileUtils.h
+++ b/Bugsnag/KSCrash/Source/KSCrash/Recording/Tools/BSG_KSFileUtils.h
@@ -35,6 +35,7 @@ extern "C" {
 #endif
 
 #include <stdbool.h>
+#include <stdint.h>
 #include <sys/types.h>
 
 /** Get the last entry in a file path. Assumes UNIX style separators.


### PR DESCRIPTION
If `CLANG_ENABLE_MODULES=NO` these imports are missing leading to
compiler errors.