### PR TITLE
[PLAT-7848] Improve handling of concurrent crashes

### DIFF
--- a/Bugsnag/KSCrash/Source/KSCrash/Recording/Sentry/BSG_KSCrashSentry.c
+++ b/Bugsnag/KSCrash/Source/KSCrash/Recording/Sentry/BSG_KSCrashSentry.c
@@ -36,6 +36,8 @@
 #include "BSG_KSLogger.h"
 #include "BSG_KSMach.h"
 
+#include <stdatomic.h>
+
 // ============================================================================
 #pragma mark - Globals -
 // ============================================================================
@@ -211,7 +213,50 @@ void bsg_kscrashsentry_clearContext(BSG_KSCrash_SentryContext *context) {
     memcpy(context->reservedThreads, reservedThreads, sizeof(reservedThreads));
 }
 
-void bsg_kscrashsentry_beginHandlingCrash(BSG_KSCrash_SentryContext *context) {
-    bsg_kscrashsentry_clearContext(context);
-    context->handlingCrash = true;
+// Set to true once _endHandlingCrash() has been called and it is safe to resume
+// any secondary crashed threads.
+static atomic_bool bsg_g_didHandleCrash;
+
+bool bsg_kscrashsentry_beginHandlingCrash(const thread_t offender) {
+    static _Atomic(thread_t) firstOffender;
+    static thread_t firstHandlingThread;
+
+    thread_t expected = 0;
+    if (atomic_compare_exchange_strong(&firstOffender, &expected, offender)) {
+        firstHandlingThread = bsg_ksmachthread_self();
+        BSG_KSLOG_DEBUG("Handling app crash in thread 0x%x", offender);
+        bsg_kscrashsentry_clearContext(bsg_g_context);
+        bsg_g_context->handlingCrash = true;
+        bsg_g_context->offendingThread = offender;
+        return true;
+    }
+
+    if (offender == firstHandlingThread) {
+        BSG_KSLOG_INFO("Detected crash in the crash reporter. "
+                       "Restoring original handlers.");
+        bsg_kscrashsentry_uninstall(BSG_KSCrashTypeAsyncSafe);
+
+        // Reset the context to write a recrash report.
+        bsg_kscrashsentry_clearContext(bsg_g_context);
+        bsg_g_context->crashedDuringCrashHandling = true;
+        bsg_g_context->handlingCrash = true;
+        bsg_g_context->offendingThread = offender;
+        return true;
+    }
+
+    BSG_KSLOG_DEBUG("Ignoring secondary app crash in thread 0x%x", offender);
+    // Block this thread to prevent the crash handling thread from being
+    // interrupted while writing the crash report. If we allowed the default
+    // handler to be triggered for this thread, the process would be killed
+    // before the crash report can be written. The process will be killed by the
+    // default handler once the handling thread has finished and threads resume.
+    while (!atomic_load(&bsg_g_didHandleCrash)) {
+        usleep(USEC_PER_SEC / 10);
+    }
+    return false;
+}
+
+void bsg_kscrashsentry_endHandlingCrash(void) {
+    BSG_KSLOG_DEBUG("Noting completion of crash handling");
+    atomic_store(&bsg_g_didHandleCrash, true);
 }

--- a/Bugsnag/KSCrash/Source/KSCrash/Recording/Sentry/BSG_KSCrashSentry_MachException.c
+++ b/Bugsnag/KSCrash/Source/KSCrash/Recording/Sentry/BSG_KSCrashSentry_MachException.c
@@ -238,12 +238,8 @@ void *ksmachexc_i_handleExceptions(void *const userData) {
 
     BSG_KSLOG_DEBUG("Trapped mach exception code 0x%llx, subcode 0x%llx",
                     exceptionMessage.code[0], exceptionMessage.code[1]);
-    if (bsg_g_installed) {
-        bool wasHandlingCrash = bsg_g_context->handlingCrash;
-        bsg_kscrashsentry_beginHandlingCrash(bsg_g_context);
-
-        BSG_KSLOG_DEBUG(
-            "Exception handler is installed. Continuing exception handling.");
+    if (bsg_g_installed &&
+        bsg_kscrashsentry_beginHandlingCrash(exceptionMessage.thread.name)) {
 
         BSG_KSLOG_DEBUG("Suspending all threads");
         bsg_kscrashsentry_suspendThreads();
@@ -264,15 +260,6 @@ void *ksmachexc_i_handleExceptions(void *const userData) {
             bsg_ksmachexc_i_restoreExceptionPorts();
         }
 
-        if (wasHandlingCrash) {
-            BSG_KSLOG_INFO("Detected crash in the crash reporter. Restoring "
-                           "original handlers.");
-            // The crash reporter itself crashed. Make a note of this and
-            // uninstall all handlers so that we don't get stuck in a loop.
-            bsg_g_context->crashedDuringCrashHandling = true;
-            bsg_kscrashsentry_uninstall(BSG_KSCrashTypeAsyncSafe);
-        }
-
         // Fill out crash information
         BSG_KSLOG_DEBUG("Fetching machine state.");
         BSG_STRUCT_MCONTEXT_L machineContext;
@@ -289,7 +276,6 @@ void *ksmachexc_i_handleExceptions(void *const userData) {
 
         BSG_KSLOG_DEBUG("Filling out context.");
         bsg_g_context->crashType = BSG_KSCrashTypeMachException;
-        bsg_g_context->offendingThread = exceptionMessage.thread.name;
         bsg_g_context->registersAreValid = true;
         bsg_g_context->mach.type = exceptionMessage.exception;
         bsg_g_context->mach.code = exceptionMessage.code[0] & (int64_t)MACH_ERROR_CODE_MASK;
@@ -302,6 +288,7 @@ void *ksmachexc_i_handleExceptions(void *const userData) {
             "Crash handling complete. Restoring original handlers.");
         bsg_kscrashsentry_uninstall(BSG_KSCrashTypeAsyncSafe);
         bsg_kscrashsentry_resumeThreads();
+        bsg_kscrashsentry_endHandlingCrash();
     }
 
     BSG_KSLOG_DEBUG("Replying to mach exception message.");

--- a/Bugsnag/KSCrash/Source/KSCrash/Recording/Sentry/BSG_KSCrashSentry_Private.h
+++ b/Bugsnag/KSCrash/Source/KSCrash/Recording/Sentry/BSG_KSCrashSentry_Private.h
@@ -47,9 +47,30 @@ void bsg_kscrashsentry_suspendThreads(void);
  */
 void bsg_kscrashsentry_resumeThreads(void);
 
-/** Prepare the context for handling a new crash.
+/**
+ * Prepares the context for handling a crash.
+ *
+ * Only a single crash report can be written per process lifetime, with the
+ * exception of a crash in a crash handling thread for which a "recrash" report
+ * can be written.
+ *
+ * True is returned if this crash should be processed. The caller should fill in
+ * the context's crash details and call bsg_g_context->onCrash(). The caller
+ * must call endHandlingCrash() once processing is complete. The process is
+ * then expected to die once the default crash handler executes.
+ *
+ * False is returned if a crash has already been handled, to prevent
+ * interrupting its processing and / or overwriting the existing crash report.
+ * In this case the call to beginHandlingCrash() blocks until the crash handling
+ * thread calls endHandlingCrash().
  */
-void bsg_kscrashsentry_beginHandlingCrash(BSG_KSCrash_SentryContext *context);
+bool bsg_kscrashsentry_beginHandlingCrash(const thread_t offender);
+
+/**
+ * Sentries must call this to unblock any sencondary crashed threads that are
+ * waiting in beginHandlingCrash().
+ */
+void bsg_kscrashsentry_endHandlingCrash(void);
 
 /** Clear a crash sentry context.
  */

--- a/Bugsnag/KSCrash/Source/KSCrash/Recording/Sentry/BSG_KSCrashSentry_Signal.c
+++ b/Bugsnag/KSCrash/Source/KSCrash/Recording/Sentry/BSG_KSCrashSentry_Signal.c
@@ -101,26 +101,14 @@ static struct sigaction *get_previous_sigaction(int sigNum) {
 void bsg_kssighndl_i_handleSignal(int sigNum, siginfo_t *signalInfo,
                                   void *userContext) {
     BSG_KSLOG_DEBUG("Trapped signal %d", sigNum);
-    if (bsg_g_enabled) {
-        bool wasHandlingCrash = bsg_g_context->handlingCrash;
-        bsg_kscrashsentry_beginHandlingCrash(bsg_g_context);
-
-        BSG_KSLOG_DEBUG(
-            "Signal handler is installed. Continuing signal handling.");
+    if (bsg_g_enabled &&
+        bsg_kscrashsentry_beginHandlingCrash(bsg_ksmachthread_self())) {
 
         BSG_KSLOG_DEBUG("Suspending all threads.");
         bsg_kscrashsentry_suspendThreads();
 
-        if (wasHandlingCrash) {
-            BSG_KSLOG_INFO("Detected crash in the crash reporter. Restoring "
-                           "original handlers.");
-            bsg_g_context->crashedDuringCrashHandling = true;
-            bsg_kscrashsentry_uninstall(BSG_KSCrashTypeAsyncSafe);
-        }
-
         BSG_KSLOG_DEBUG("Filling out context.");
         bsg_g_context->crashType = BSG_KSCrashTypeSignal;
-        bsg_g_context->offendingThread = bsg_ksmachthread_self();
         bsg_g_context->registersAreValid = true;
         bsg_g_context->faultAddress = (uintptr_t)signalInfo->si_addr;
         bsg_g_context->signal.userContext = userContext;
@@ -133,6 +121,7 @@ void bsg_kssighndl_i_handleSignal(int sigNum, siginfo_t *signalInfo,
             "Crash handling complete. Restoring original handlers.");
         bsg_kscrashsentry_uninstall(BSG_KSCrashTypeAsyncSafe);
         bsg_kscrashsentry_resumeThreads();
+        bsg_kscrashsentry_endHandlingCrash();
     }
 
     BSG_KSLOG_DEBUG(

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,11 @@
 Changelog
 =========
 
+## TBD
+
+* Improve reliability of crash reporting when multiple crashes occur concurrently.
+  [#1286](https://github.com/bugsnag/bugsnag-cocoa/pull/1286)
+
 ## 6.16.1 (2022-01-19)
 
 ### Bug fixes

--- a/features/crashprobe.feature
+++ b/features/crashprobe.feature
@@ -193,3 +193,10 @@ Feature: Reporting crash events
       | Intel | EXC_BAD_INSTRUCTION |
     And the exception "message" starts with "BUG IN CLIENT OF LIBDISPATCH: dispatch_"
     And the event "metaData.error.crashInfo" starts with "BUG IN CLIENT OF LIBDISPATCH: dispatch_"
+
+  Scenario: Concurrent crashes should result in a single valid crash report
+    Given I run "ConcurrentCrashesScenario" and relaunch the crashed app
+    And I configure Bugsnag for "ConcurrentCrashesScenario"
+    And I wait to receive an error
+    Then the error is valid for the error reporting API
+    And the event "unhandled" is true

--- a/features/fixtures/ios/iOSTestApp.xcodeproj/project.pbxproj
+++ b/features/fixtures/ios/iOSTestApp.xcodeproj/project.pbxproj
@@ -26,6 +26,7 @@
 		01B6BB7525D5748800FC4DE6 /* LastRunInfoScenario.swift in Sources */ = {isa = PBXBuildFile; fileRef = 01B6BB7425D5748800FC4DE6 /* LastRunInfoScenario.swift */; };
 		01B6BBB625DA82B800FC4DE6 /* SendLaunchCrashesSynchronouslyScenario.swift in Sources */ = {isa = PBXBuildFile; fileRef = 01B6BBB525DA82B700FC4DE6 /* SendLaunchCrashesSynchronouslyScenario.swift */; };
 		01CD103926690463007FA5F0 /* libBugsnagStatic.a in Frameworks */ = {isa = PBXBuildFile; fileRef = 01CD103826690463007FA5F0 /* libBugsnagStatic.a */; };
+		01DCB82B27985D690048640A /* ConcurrentCrashesScenario.mm in Sources */ = {isa = PBXBuildFile; fileRef = 01DCB82A27985D2C0048640A /* ConcurrentCrashesScenario.mm */; };
 		01DE903826CE99B800455213 /* CriticalThermalStateScenario.swift in Sources */ = {isa = PBXBuildFile; fileRef = 01DE903726CE99B800455213 /* CriticalThermalStateScenario.swift */; };
 		01DF442C2798044E00C31104 /* SystemConfiguration.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = 01DF442B2798044E00C31104 /* SystemConfiguration.framework */; };
 		01E0DB0B25E8EBD100A740ED /* AppDurationScenario.swift in Sources */ = {isa = PBXBuildFile; fileRef = 01E0DB0A25E8EBD100A740ED /* AppDurationScenario.swift */; };
@@ -187,6 +188,7 @@
 		01B6BB7425D5748800FC4DE6 /* LastRunInfoScenario.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = LastRunInfoScenario.swift; sourceTree = "<group>"; };
 		01B6BBB525DA82B700FC4DE6 /* SendLaunchCrashesSynchronouslyScenario.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = SendLaunchCrashesSynchronouslyScenario.swift; sourceTree = "<group>"; };
 		01CD103826690463007FA5F0 /* libBugsnagStatic.a */ = {isa = PBXFileReference; explicitFileType = archive.ar; path = libBugsnagStatic.a; sourceTree = BUILT_PRODUCTS_DIR; };
+		01DCB82A27985D2C0048640A /* ConcurrentCrashesScenario.mm */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.cpp.objcpp; path = ConcurrentCrashesScenario.mm; sourceTree = "<group>"; };
 		01DE903726CE99B800455213 /* CriticalThermalStateScenario.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = CriticalThermalStateScenario.swift; sourceTree = "<group>"; };
 		01DF442B2798044E00C31104 /* SystemConfiguration.framework */ = {isa = PBXFileReference; lastKnownFileType = wrapper.framework; name = SystemConfiguration.framework; path = System/Library/Frameworks/SystemConfiguration.framework; sourceTree = SDKROOT; };
 		01E0DB0A25E8EBD100A740ED /* AppDurationScenario.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = AppDurationScenario.swift; sourceTree = "<group>"; };
@@ -597,6 +599,7 @@
 				01FA9EC326D63BB20059FF4A /* AppHangInTerminationScenario.swift */,
 				01F1474325F282E600C2DC65 /* AppHangScenarios.swift */,
 				01AF6A52258A112F00FFC803 /* BareboneTestScenarios.swift */,
+				01DCB82A27985D2C0048640A /* ConcurrentCrashesScenario.mm */,
 				01DE903726CE99B800455213 /* CriticalThermalStateScenario.swift */,
 				0163BFA62583B3CF008DC28B /* DiscardClassesScenarios.swift */,
 				01847DD526453D4E00ADA4C7 /* InvalidCrashReportScenario.m */,
@@ -996,6 +999,7 @@
 				A1117E592535B29800014FDA /* OOMEnabledErrorTypesScenario.swift in Sources */,
 				F4295397AD31C1C1E64144F5 /* NonExistentMethodScenario.m in Sources */,
 				E700EE53247D31EA008CFFB6 /* OnErrorOverwriteScenario.swift in Sources */,
+				01DCB82B27985D690048640A /* ConcurrentCrashesScenario.mm in Sources */,
 				8AEFC79920F9132C00A78779 /* AutoSessionHandledEventsScenario.m in Sources */,
 				E7A324ED247E9DB3008B0052 /* BreadcrumbCallbackRemovalScenario.m in Sources */,
 				0037410F2473CF2300BE41AA /* AppAndDeviceAttributesScenario.swift in Sources */,

--- a/features/fixtures/macos/macOSTestApp.xcodeproj/project.pbxproj
+++ b/features/fixtures/macos/macOSTestApp.xcodeproj/project.pbxproj
@@ -23,6 +23,7 @@
 		01AF6A84258BB38A00FFC803 /* DispatchCrashScenario.swift in Sources */ = {isa = PBXBuildFile; fileRef = 01AF6A83258BB38A00FFC803 /* DispatchCrashScenario.swift */; };
 		01B6BB7225D56CBF00FC4DE6 /* LastRunInfoScenario.swift in Sources */ = {isa = PBXBuildFile; fileRef = 01B6BB7125D56CBF00FC4DE6 /* LastRunInfoScenario.swift */; };
 		01B6BBA225DA774C00FC4DE6 /* SendLaunchCrashesSynchronouslyScenario.swift in Sources */ = {isa = PBXBuildFile; fileRef = 01B6BBA125DA774C00FC4DE6 /* SendLaunchCrashesSynchronouslyScenario.swift */; };
+		01DCB82D279868160048640A /* ConcurrentCrashesScenario.mm in Sources */ = {isa = PBXBuildFile; fileRef = 01DCB82C279868160048640A /* ConcurrentCrashesScenario.mm */; };
 		01DE903A26CEAD1200455213 /* CriticalThermalStateScenario.swift in Sources */ = {isa = PBXBuildFile; fileRef = 01DE903926CEAD1200455213 /* CriticalThermalStateScenario.swift */; };
 		01E0DB0625E8E95700A740ED /* AppDurationScenario.swift in Sources */ = {isa = PBXBuildFile; fileRef = 01E0DB0425E8E90500A740ED /* AppDurationScenario.swift */; };
 		01ECBCF425A7522000FC0678 /* OnErrorOverwriteUnhandledFalseScenario.swift in Sources */ = {isa = PBXBuildFile; fileRef = 01ECBCF225A7522000FC0678 /* OnErrorOverwriteUnhandledFalseScenario.swift */; };
@@ -179,6 +180,7 @@
 		01AF6A83258BB38A00FFC803 /* DispatchCrashScenario.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = DispatchCrashScenario.swift; sourceTree = "<group>"; };
 		01B6BB7125D56CBF00FC4DE6 /* LastRunInfoScenario.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = LastRunInfoScenario.swift; sourceTree = "<group>"; };
 		01B6BBA125DA774C00FC4DE6 /* SendLaunchCrashesSynchronouslyScenario.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SendLaunchCrashesSynchronouslyScenario.swift; sourceTree = "<group>"; };
+		01DCB82C279868160048640A /* ConcurrentCrashesScenario.mm */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.objcpp; path = ConcurrentCrashesScenario.mm; sourceTree = "<group>"; };
 		01DE903926CEAD1200455213 /* CriticalThermalStateScenario.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = CriticalThermalStateScenario.swift; sourceTree = "<group>"; };
 		01E0DB0425E8E90500A740ED /* AppDurationScenario.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AppDurationScenario.swift; sourceTree = "<group>"; };
 		01ECBCF225A7522000FC0678 /* OnErrorOverwriteUnhandledFalseScenario.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = OnErrorOverwriteUnhandledFalseScenario.swift; sourceTree = "<group>"; };
@@ -415,6 +417,7 @@
 				01F47CAC254B1B3000B184AD /* BugsnagHooks.h */,
 				01F47CB5254B1B3000B184AD /* BuiltinTrapScenario.h */,
 				01F47C2B254B1B2D00B184AD /* BuiltinTrapScenario.m */,
+				01DCB82C279868160048640A /* ConcurrentCrashesScenario.mm */,
 				01DE903926CEAD1200455213 /* CriticalThermalStateScenario.swift */,
 				01F47C77254B1B2E00B184AD /* CustomPluginNotifierDescriptionScenario.h */,
 				01F47C85254B1B2F00B184AD /* CustomPluginNotifierDescriptionScenario.m */,
@@ -847,6 +850,7 @@
 				01F47CD4254B1B3100B184AD /* AsyncSafeThreadScenario.m in Sources */,
 				01ECBCF525A7522000FC0678 /* OnErrorOverwriteUnhandledTrueScenario.swift in Sources */,
 				E7803780264D703500430C11 /* AutoNotifyFalseAbortScenario.swift in Sources */,
+				01DCB82D279868160048640A /* ConcurrentCrashesScenario.mm in Sources */,
 				0123189C275921590007EFD7 /* RecrashScenarios.mm in Sources */,
 				01F47CDE254B1B3100B184AD /* ReleasedObjectScenario.m in Sources */,
 				01F47D16254B1B3100B184AD /* NewSessionScenario.swift in Sources */,

--- a/features/fixtures/shared/scenarios/ConcurrentCrashesScenario.mm
+++ b/features/fixtures/shared/scenarios/ConcurrentCrashesScenario.mm
@@ -1,0 +1,67 @@
+//
+//  ConcurrentCrashesScenario.mm
+//  iOSTestApp
+//
+//  Created by Nick Dowell on 19/01/2022.
+//  Copyright © 2022 Bugsnag. All rights reserved.
+//
+
+#import "Scenario.h"
+
+#import <pthread.h>
+#import <stdexcept>
+
+@interface ConcurrentCrashesScenario : Scenario
+
+@end
+
+@implementation ConcurrentCrashesScenario
+
+- (void)startBugsnag {
+    self.config.autoTrackSessions = NO;
+    [super startBugsnag];
+}
+
+static volatile bool ready;
+
+static void * ConcurrentCrashesThread(void *ptr) {
+    NSException *nsexception;
+    @try {
+        [(id)[NSNull null] objectForKey:@""];
+    } @catch (NSException *exception) {
+        nsexception = exception;
+    }
+    
+    while (!ready);
+    
+    switch (rand() % 4) {
+        case 0: // Signal
+            abort();
+            break;
+            
+        case 1: // Mach exception
+            __builtin_trap();
+            break;
+            
+        case 2: // C++ exception
+            throw std::runtime_error("Something went wrong");
+            break;
+            
+        case 3: // NSException
+            @throw nsexception;
+            break;
+    }
+    return NULL;
+}
+
+- (void)run {
+    srand((unsigned int)time(NULL));
+    for (int i = 0; i < 4; i++) {
+        pthread_t thread;
+        pthread_create(&thread, NULL, ConcurrentCrashesThread, NULL);
+    }
+    sleep(1);
+    ready = true;
+}
+
+@end


### PR DESCRIPTION
## Goal

Successfully report crashes in the event that multiple threads crash at the same time.

In the current release, a secondary crash that occurs while the first crash handling thread is still working (and presumably has not yet suspended other threads) will be incorrectly identified as a "crash in the crash reporter" and trigger an internal error report (via a recrash report.)

There are also other race conditions that could cause corruption of the crash reporting process.

## Changeset

Crash reporting is now explicitly one-shot (in practical terms it already was - a single crash report path is configured per process lifetime) so that only a single crash report will attempt to be written.

A recrash report is now only written for a secondary crash which occured in the original crash reporting thread.

Both of these checks are performed in `bsg_kscrashsentry_beginHandlingCrash()` which now takes the offending (crashed) thread as its argument. An atomic compare-exchange operation is used to ensure only a single thread can win the race to be reported.

Crashes in secondary threads are prevented from immediately killing the process by waiting in `bsg_kscrashsentry_beginHandlingCrash()` until the crash handling has finished.

## Testing

An E2E scenario that reliably reproduced the problem has been added, and the fix verified [in](https://buildkite.com/bugsnag/bugsnag-cocoa/builds/4722) [multiple](https://buildkite.com/bugsnag/bugsnag-cocoa/builds/4723) [runs](https://buildkite.com/bugsnag/bugsnag-cocoa/builds/4729). Attempts to include checks of the stackframe contents failed because C++ exception stacktraces are not currently recorded when Bugsnag is linked dynamically, which it is for the Mac fixture.

Existing test for recrash reports have also been run successfully.