### PR TITLE
Improve concurrent KSLogging

### DIFF
--- a/Tests/KSCrashTests/KSLogger_Tests.m
+++ b/Tests/KSCrashTests/KSLogger_Tests.m
@@ -109,4 +109,75 @@
     XCTAssertEqualObjects(result, expected, @"");
 }
 
+- (void)testTruncatedLogEntries
+{
+    NSString *logFileName = [self.tempDir stringByAppendingPathComponent:@"log.txt"];
+    bsg_kslog_setLogFilename([logFileName UTF8String], true);
+    
+    const char *loremIpsum =
+    "Lorem ipsum dolor sit amet, consectetur adipiscing elit. Nunc bibendum auctor lo"
+    "rem sit amet facilisis. In dictum convallis varius. Nam ut convallis quam, non u"
+    "llamcorper neque. Donec vitae imperdiet sapien. In semper convallis nunc nec lao"
+    "reet. Praesent lorem neque, sodales at elementum id, luctus et eros. Maecenas te"
+    "llus libero, mattis at augue sed, viverra dignissim nibh.\n\nNullam ac mi dictum"
+    ", vestibulum velit sed, egestas neque. Nulla mattis eget risus sed hendrerit. Do"
+    "nec a mi augue. Morbi vel orci magna. Duis hendrerit gravida nisl eget sodales. "
+    "Aenean dignissim lorem dui, at finibus neque sodales nec. Vivamus quis purus lor"
+    "em. Morbi lacinia porttitor mauris interdum elementum. Ut vestibulum diam a tell"
+    "us pharetra, vitae iaculis erat semper. Aenean consectetur orci turpis, non male"
+    "suada tortor congue ac. Duis ac elit in libero scelerisque venenatis quis quis d"
+    "ui. Pellentesque sed fringilla nulla, ac eleifend lorem.\n\nNulla in ipsum conva"
+    "llis, congue ipsum sed, consequat felis. Nullam ut libero congue, posuere nisl a"
+    ", suscipit arcu. Maecenas tincidunt mauris vel tortor tincidunt imperdiet. Nulla"
+    "m id urna finibus, condimentum quam ut, consectetur urna. Nunc maximus varius la"
+    "cus et fermentum. Pellentesque massa nunc, dignissim et dui id, tempus interdum "
+    "tellus. Mauris condimentum eleifend leo in auctor. Nunc molestie sed leo in dign"
+    "issim. Suspendisse mattis vestibulum sollicitudin. Proin tristique ipsum nec mol"
+    "lis finibus. Etiam tristique est id neque accumsan, ac orci aliquam.\n";
+    
+    const int line = __LINE__;
+    BSG_KSLOG_ALWAYS("%s", loremIpsum);
+    BSG_KSLOG_ALWAYS("Testing");
+    BSG_KSLOGBASIC_ALWAYS("%s", loremIpsum);
+    BSG_KSLOGBASIC_ALWAYS("Testing");
+
+    bsg_kslog_setLogFilename(NULL, true);
+    
+    NSError *error = nil;
+    NSString *contents = [NSString stringWithContentsOfFile:logFileName encoding:NSUTF8StringEncoding error:&error];
+    XCTAssertNotNil(contents, @"%@", error);
+    
+    NSString *expected = [NSString stringWithFormat:@""
+                          // Generated with `sed 's/$/\\n/' | tr -d '\n' | fold | sed 's/$/"/' | sed 's/^/"/'`
+                          "FORCE: KSLogger_Tests.m:%d: -[KSLogger_Tests testTruncatedLogEntries](): Lorem "
+                          "ipsum dolor sit amet, consectetur adipiscing elit. Nunc bibendum auctor lorem si"
+                          "t amet facilisis. In dictum convallis varius. Nam ut convallis quam, non ullamco"
+                          "rper neque. Donec vitae imperdiet sapien. In semper convallis nunc nec laoreet. "
+                          "Praesent lorem neque, sodales at elementum id, luctus et eros. Maecenas tellus l"
+                          "ibero, mattis at augue sed, viverra dignissim nibh.\n\nNullam ac mi dictum, vest"
+                          "ibulum velit sed, egestas neque. Nulla mattis eget risus sed hendrerit. Donec a "
+                          "mi augue. Morbi vel orci magna. Duis hendrerit gravida nisl eget sodales. Aenean"
+                          " dignissim lorem dui, at finibus neque sodales nec. Vivamus quis purus lorem. Mo"
+                          "rbi lacinia porttitor mauris interdum elementum. Ut vestibulum diam a tellus pha"
+                          "retra, vitae iaculis erat semper. Aenean consectetur orci turpis, non malesuada "
+                          "tortor congue ac. Duis ac elit in libero scelerisque venenatis quis quis dui. Pe"
+                          "llentesque sed fringilla nulla, ac eleifend lorem.\n\nNulla in ipsu\nFORCE: KSLo"
+                          "gger_Tests.m:%d: -[KSLogger_Tests testTruncatedLogEntries](): Testing\nLorem ip"
+                          "sum dolor sit amet, consectetur adipiscing elit. Nunc bibendum auctor lorem sit "
+                          "amet facilisis. In dictum convallis varius. Nam ut convallis quam, non ullamcorp"
+                          "er neque. Donec vitae imperdiet sapien. In semper convallis nunc nec laoreet. Pr"
+                          "aesent lorem neque, sodales at elementum id, luctus et eros. Maecenas tellus lib"
+                          "ero, mattis at augue sed, viverra dignissim nibh.\n\nNullam ac mi dictum, vestib"
+                          "ulum velit sed, egestas neque. Nulla mattis eget risus sed hendrerit. Donec a mi"
+                          " augue. Morbi vel orci magna. Duis hendrerit gravida nisl eget sodales. Aenean d"
+                          "ignissim lorem dui, at finibus neque sodales nec. Vivamus quis purus lorem. Morb"
+                          "i lacinia porttitor mauris interdum elementum. Ut vestibulum diam a tellus phare"
+                          "tra, vitae iaculis erat semper. Aenean consectetur orci turpis, non malesuada to"
+                          "rtor congue ac. Duis ac elit in libero scelerisque venenatis quis quis dui. Pell"
+                          "entesque sed fringilla nulla, ac eleifend lorem.\n\nNulla in ipsum convallis, co"
+                          "ngue ipsum sed, consequat felis. Nullam ut libero congue, p\nTesting\n",
+                          line + 1, line + 2];
+    XCTAssertEqualObjects(contents, expected);
+}
+
 @end


### PR DESCRIPTION
The KSCrash logs were invaluable in investigating and debugging the improvements to concurrent crash handling.

However, the logs were often confusing to read due to overlapping writes from different threads.

These changes improve log readability by ensuring each log message is written with a single call to `write()`, thereby reducing the chances for overlaps.

To fully ensure log file consistency would require some form of locking, this was avoided to avoid altering behaviour of code when logging is enabled.