### PR TITLE
[PLAT-7976] Fix excessive memory usage under stress test

### DIFF
--- a/.buildkite/pipeline.yml
+++ b/.buildkite/pipeline.yml
@@ -255,10 +255,10 @@ steps:
         --app=macOSTestApp
         --order=random
 
-  - label: 'macOS 11 stress test'
+  - label: 'macOS 12 stress test'
     timeout_in_minutes: 3
     agents:
-      queue: opensource-mac-cocoa-11
+      queue: opensource-arm-mac-cocoa-12
     env:
       STRESS_TEST: "true"
     commands:

--- a/Bugsnag/BugsnagSystemState.m
+++ b/Bugsnag/BugsnagSystemState.m
@@ -29,6 +29,8 @@
 #import "BugsnagSessionTracker.h"
 #import "BugsnagSystemState.h"
 
+#import <stdatomic.h>
+
 static NSString * const ConsecutiveLaunchCrashesKey = @"consecutiveLaunchCrashes";
 static NSString * const InternalKey = @"internal";
 
@@ -160,7 +162,6 @@ static NSDictionary *copyDictionary(NSDictionary *launchState) {
 
 @interface BugsnagSystemState ()
 
-@property(readonly,nonatomic) NSMutableDictionary *currentLaunchStateRW;
 @property(readwrite,atomic) NSDictionary *currentLaunchState;
 @property(readwrite,nonatomic) NSDictionary *lastLaunchState;
 @property(readonly,nonatomic) NSString *persistenceFilePath;
@@ -175,13 +176,12 @@ static NSDictionary *copyDictionary(NSDictionary *launchState) {
         _kvStore = [BugsnagKVStore new];
         _persistenceFilePath = [BSGFileLocations current].systemState;
         _lastLaunchState = loadPreviousState(_kvStore, _persistenceFilePath);
-        _currentLaunchStateRW = initCurrentState(_kvStore, config);
-        _currentLaunchState = [_currentLaunchStateRW copy];
+        _currentLaunchState = initCurrentState(_kvStore, config);
         _consecutiveLaunchCrashes = [_lastLaunchState[InternalKey][ConsecutiveLaunchCrashesKey] unsignedIntegerValue];
         if (@available(iOS 11.0, tvOS 11.0, *)) {
             [self setThermalState:NSProcessInfo.processInfo.thermalState];
         }
-        [self syncState:_currentLaunchState];
+        [self sync];
 
         __weak __typeof__(self) weakSelf = self;
         NSNotificationCenter *center = [NSNotificationCenter defaultCenter];
@@ -287,20 +287,31 @@ static NSDictionary *copyDictionary(NSDictionary *launchState) {
 }
 
 - (void)mutateLaunchState:(nonnull void (^)(NSMutableDictionary *state))block {
-    NSDictionary *state = nil;
+    static _Atomic(BOOL) writePending;
     @synchronized (self) {
-        block(self.currentLaunchStateRW);
+        NSMutableDictionary *mutableState = [NSMutableDictionary dictionary];
+        for (NSString *section in self.currentLaunchState) {
+            mutableState[section] = [self.currentLaunchState[section] mutableCopy];
+        }
+        block(mutableState);
         // User-facing state should never mutate from under them.
-        self.currentLaunchState = copyDictionary(self.currentLaunchStateRW);
-        state = self.currentLaunchState;
+        self.currentLaunchState = copyDictionary(mutableState);
+        
+        BOOL expected = NO;
+        if (!atomic_compare_exchange_strong(&writePending, &expected, YES)) {
+            // _writePending was YES -- avoid an unnecesary dispatch_async()
+            return;
+        }
     }
     // Run on a BG thread so we don't monopolize the notification queue.
     dispatch_async(BSGGetFileSystemQueue(), ^(void){
-        [self syncState:state];
+        atomic_store(&writePending, NO);
+        [self sync];
     });
 }
 
-- (void)syncState:(NSDictionary *)state {
+- (void)sync {
+    NSDictionary *state = self.currentLaunchState;
     NSAssert([BSGJSONSerialization isValidJSONObject:state], @"BugsnagSystemState cannot be converted to JSON data");
     NSError *error = nil;
     if (![BSGJSONSerialization writeJSONObject:state toFile:self.persistenceFilePath options:0 error:&error]) {

--- a/features/fixtures/macos-stress-test/BugsnagStressTest/main.m
+++ b/features/fixtures/macos-stress-test/BugsnagStressTest/main.m
@@ -13,7 +13,7 @@
 
 static NSString * const kNotifyEndpoint = @"http://localhost:9339/notify";
 
-static const int kNumberOfIterations = 5000;
+static const int kNumberOfIterations = 15000;
 
 static const NSInteger kMaxConcurrentNotifies = 8;
 


### PR DESCRIPTION
## Goal

Fix [stress test](https://github.com/bugsnag/bugsnag-cocoa/blob/master/features/fixtures/macos-stress-test/BugsnagStressTest/main.m) failure encountered on ARM Macs due to excessive memory usage.

The stress test calls `notify()` repeatedly on several concurrent threads as quickly as possible.

`git bisect` revealed that [adopting async I/O for breadcrumbs and system state](https://github.com/bugsnag/bugsnag-cocoa/commit/bf9719a1170f7542ed09e09570b47603ab6b210e) introduced this problem - unfortunately it was not causing a failure on CI due to too few iterations (5000 calls to notify) to reach the 45MB memory limit.

The issue was tracked down to contention of the file writing dispatch queue causing the numbers of pending blocks to grow faster than the queue can be serviced. Each block was retaining the payload to be written, leading to significant memory usage.

`BugsnagSystemState` is a bottleneck because it writes out its state each time the current session's `handledCount` or `unhandledCount` are incremented, and contends with breadcrumb writing for the dispatch queue.

## Changeset

`BugsnagSystemState` now avoids queueing up multiple I/O blocks.

Rather than writing each intermediary version of the state, only the latest version is written.

A `static` variable was used because our compiler warning settings mean direct ivar access (required for the `atomic_` APIs) result in errors. Since `BugsnagSystemState` is only instantiated once, this is not a problem.

## Testing

Verified by running the stress test locally and observing memory usage in Xcode. Now typically remains below 40MB whereas it was previously growing continually.