### PR TITLE
Ignore non-fatal SIGPIPEs

### DIFF
--- a/Bugsnag/KSCrash/Source/KSCrash/Recording/Sentry/BSG_KSCrashSentry_Signal.c
+++ b/Bugsnag/KSCrash/Source/KSCrash/Recording/Sentry/BSG_KSCrashSentry_Signal.c
@@ -212,6 +212,11 @@ bool bsg_kscrashsentry_installSignalHandler(
             }
             goto failed;
         }
+        if (fatalSignals[i] == SIGPIPE &&
+            bsg_g_previousSignalHandlers[i].sa_handler == SIG_IGN) {
+            BSG_KSLOG_DEBUG("Removing handler for signal %d", fatalSignals[i]);
+            sigaction(fatalSignals[i], &bsg_g_previousSignalHandlers[i], NULL);
+        }
     }
     BSG_KSLOG_DEBUG("Signal handlers installed.");
     return true;

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,11 @@
 Changelog
 =========
 
+## TBD
+
+* Stop reporting `SIGPIPE` errors in apps that set `SIG_IGN`.
+  [#1295](https://github.com/bugsnag/bugsnag-cocoa/pull/1295)
+
 ## 6.16.2 (2022-01-26)
 
 * Improve reliability of crash reporting when multiple crashes occur concurrently.

--- a/features/fixtures/ios/iOSTestApp.xcodeproj/project.pbxproj
+++ b/features/fixtures/ios/iOSTestApp.xcodeproj/project.pbxproj
@@ -33,6 +33,7 @@
 		01E356C026CD5B6A00BE3F64 /* ThermalStateBreadcrumbScenario.swift in Sources */ = {isa = PBXBuildFile; fileRef = 01E356BF26CD5B6A00BE3F64 /* ThermalStateBreadcrumbScenario.swift */; };
 		01E5EAD225B713990066EA8A /* OOMScenario.m in Sources */ = {isa = PBXBuildFile; fileRef = 01E5EAD125B713990066EA8A /* OOMScenario.m */; };
 		01EE7F57278C680C00A59DC6 /* OOMSessionlessScenario.m in Sources */ = {isa = PBXBuildFile; fileRef = 01EE7F56278C680C00A59DC6 /* OOMSessionlessScenario.m */; };
+		01F115C927BAAF2D00892B1E /* SIGPIPEIgnoredScenario.m in Sources */ = {isa = PBXBuildFile; fileRef = 01F115C827BAAF2D00892B1E /* SIGPIPEIgnoredScenario.m */; };
 		01F1474425F282E600C2DC65 /* AppHangScenarios.swift in Sources */ = {isa = PBXBuildFile; fileRef = 01F1474325F282E600C2DC65 /* AppHangScenarios.swift */; };
 		01FA9EC426D63BB20059FF4A /* AppHangInTerminationScenario.swift in Sources */ = {isa = PBXBuildFile; fileRef = 01FA9EC326D63BB20059FF4A /* AppHangInTerminationScenario.swift */; };
 		6526A0D4248A83350002E2C9 /* LoadConfigFromFileAutoScenario.swift in Sources */ = {isa = PBXBuildFile; fileRef = 6526A0D3248A83350002E2C9 /* LoadConfigFromFileAutoScenario.swift */; };
@@ -196,6 +197,7 @@
 		01E5EAD025B713990066EA8A /* OOMScenario.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; path = OOMScenario.h; sourceTree = "<group>"; };
 		01E5EAD125B713990066EA8A /* OOMScenario.m */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.objc; path = OOMScenario.m; sourceTree = "<group>"; };
 		01EE7F56278C680C00A59DC6 /* OOMSessionlessScenario.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; path = OOMSessionlessScenario.m; sourceTree = "<group>"; };
+		01F115C827BAAF2D00892B1E /* SIGPIPEIgnoredScenario.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; path = SIGPIPEIgnoredScenario.m; sourceTree = "<group>"; };
 		01F1474325F282E600C2DC65 /* AppHangScenarios.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = AppHangScenarios.swift; sourceTree = "<group>"; };
 		01FA9EC326D63BB20059FF4A /* AppHangInTerminationScenario.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AppHangInTerminationScenario.swift; sourceTree = "<group>"; };
 		6526A0D3248A83350002E2C9 /* LoadConfigFromFileAutoScenario.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = LoadConfigFromFileAutoScenario.swift; sourceTree = "<group>"; };
@@ -611,6 +613,7 @@
 				8AB1081823301FE600672818 /* ReleaseStageScenarios.swift */,
 				F4295ABA693D273D52AA9F6B /* Scenario.h */,
 				F42954E8B66F3FB7F5333CF7 /* Scenario.m */,
+				01F115C827BAAF2D00892B1E /* SIGPIPEIgnoredScenario.m */,
 				01B6BB7425D5748800FC4DE6 /* LastRunInfoScenario.swift */,
 				CBB7878F2578FC0C0071BDE4 /* MarkUnhandledHandledScenario.h */,
 				CBB787902578FC0C0071BDE4 /* MarkUnhandledHandledScenario.m */,
@@ -882,6 +885,7 @@
 			files = (
 				E700EE7B247D7A1F008CFFB6 /* SIGSEGVScenario.m in Sources */,
 				E75040A02478019D005D33BD /* AutoDetectFalseHandledScenario.swift in Sources */,
+				01F115C927BAAF2D00892B1E /* SIGPIPEIgnoredScenario.m in Sources */,
 				8AB8866620404DD30003E444 /* ViewController.swift in Sources */,
 				8AB8866420404DD30003E444 /* AppDelegate.swift in Sources */,
 				00507A64242BFE5600EF1B87 /* EnabledBreadcrumbTypesIsNilScenario.swift in Sources */,

--- a/features/fixtures/macos/macOSTestApp.xcodeproj/project.pbxproj
+++ b/features/fixtures/macos/macOSTestApp.xcodeproj/project.pbxproj
@@ -28,6 +28,7 @@
 		01E0DB0625E8E95700A740ED /* AppDurationScenario.swift in Sources */ = {isa = PBXBuildFile; fileRef = 01E0DB0425E8E90500A740ED /* AppDurationScenario.swift */; };
 		01ECBCF425A7522000FC0678 /* OnErrorOverwriteUnhandledFalseScenario.swift in Sources */ = {isa = PBXBuildFile; fileRef = 01ECBCF225A7522000FC0678 /* OnErrorOverwriteUnhandledFalseScenario.swift */; };
 		01ECBCF525A7522000FC0678 /* OnErrorOverwriteUnhandledTrueScenario.swift in Sources */ = {isa = PBXBuildFile; fileRef = 01ECBCF325A7522000FC0678 /* OnErrorOverwriteUnhandledTrueScenario.swift */; };
+		01F115C727BAA67B00892B1E /* SIGPIPEIgnoredScenario.m in Sources */ = {isa = PBXBuildFile; fileRef = 01F115C627BAA67B00892B1E /* SIGPIPEIgnoredScenario.m */; };
 		01F1473A25F2817100C2DC65 /* AppHangScenarios.swift in Sources */ = {isa = PBXBuildFile; fileRef = 01F1473925F2817100C2DC65 /* AppHangScenarios.swift */; };
 		01F47CC4254B1B3100B184AD /* OriginalErrorNSExceptionScenario.swift in Sources */ = {isa = PBXBuildFile; fileRef = 01F47C21254B1B2C00B184AD /* OriginalErrorNSExceptionScenario.swift */; };
 		01F47CC5254B1B3100B184AD /* LoadConfigFromFileAutoScenario.swift in Sources */ = {isa = PBXBuildFile; fileRef = 01F47C23254B1B2C00B184AD /* LoadConfigFromFileAutoScenario.swift */; };
@@ -185,6 +186,7 @@
 		01E0DB0425E8E90500A740ED /* AppDurationScenario.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AppDurationScenario.swift; sourceTree = "<group>"; };
 		01ECBCF225A7522000FC0678 /* OnErrorOverwriteUnhandledFalseScenario.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = OnErrorOverwriteUnhandledFalseScenario.swift; sourceTree = "<group>"; };
 		01ECBCF325A7522000FC0678 /* OnErrorOverwriteUnhandledTrueScenario.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = OnErrorOverwriteUnhandledTrueScenario.swift; sourceTree = "<group>"; };
+		01F115C627BAA67B00892B1E /* SIGPIPEIgnoredScenario.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; path = SIGPIPEIgnoredScenario.m; sourceTree = "<group>"; };
 		01F1473925F2817100C2DC65 /* AppHangScenarios.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AppHangScenarios.swift; sourceTree = "<group>"; };
 		01F47C21254B1B2C00B184AD /* OriginalErrorNSExceptionScenario.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = OriginalErrorNSExceptionScenario.swift; sourceTree = "<group>"; };
 		01F47C22254B1B2C00B184AD /* ThreadScenarios.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = ThreadScenarios.h; sourceTree = "<group>"; };
@@ -524,6 +526,7 @@
 				01F47CAD254B1B3000B184AD /* SIGFPEScenario.m */,
 				01F47C3E254B1B2D00B184AD /* SIGILLScenario.h */,
 				01F47C42254B1B2D00B184AD /* SIGILLScenario.m */,
+				01F115C627BAA67B00892B1E /* SIGPIPEIgnoredScenario.m */,
 				01F47C6A254B1B2E00B184AD /* SIGPIPEScenario.h */,
 				01F47CA9254B1B3000B184AD /* SIGPIPEScenario.m */,
 				01F47C50254B1B2D00B184AD /* SIGSEGVScenario.h */,
@@ -733,6 +736,7 @@
 			files = (
 				01F47CD9254B1B3100B184AD /* SessionCallbackDiscardScenario.swift in Sources */,
 				01F47CD0254B1B3100B184AD /* StackOverflowScenario.m in Sources */,
+				01F115C727BAA67B00892B1E /* SIGPIPEIgnoredScenario.m in Sources */,
 				01F7365A278D90440000113C /* NetworkBreadcrumbsScenario.swift in Sources */,
 				01F47CCA254B1B3100B184AD /* ManualSessionScenario.m in Sources */,
 				01F47D31254B1B3100B184AD /* OverwriteLinkRegisterScenario.m in Sources */,

--- a/features/fixtures/shared/scenarios/SIGPIPEIgnoredScenario.m
+++ b/features/fixtures/shared/scenarios/SIGPIPEIgnoredScenario.m
@@ -1,0 +1,31 @@
+//
+//  SIGPIPEIgnoredScenario.m
+//  iOSTestApp
+//
+//  Created by Nick Dowell on 14/02/2022.
+//  Copyright © 2022 Bugsnag. All rights reserved.
+//
+
+#import "Scenario.h"
+
+@interface SIGPIPEIgnoredScenario : Scenario
+
+@end
+
+@implementation SIGPIPEIgnoredScenario
+
+- (void)startBugsnag {
+    sigignore(SIGPIPE);
+    self.config.autoTrackSessions = NO;
+    [super startBugsnag];
+}
+
+- (void)run {
+    int pipefds[2];
+    pipe(pipefds);
+    close(pipefds[0]);
+    write(pipefds[1], "hello\n", 6);
+    [Bugsnag startSession];
+}
+
+@end

--- a/features/fixtures/shared/scenarios/SIGPIPEScenario.m
+++ b/features/fixtures/shared/scenarios/SIGPIPEScenario.m
@@ -16,7 +16,10 @@
 }
 
 - (void)run {
-    raise(SIGPIPE);
+    int pipefds[2];
+    pipe(pipefds);
+    close(pipefds[0]);
+    write(pipefds[1], "hello\n", 6);
 }
 
 @end

--- a/features/unhandled_signal.feature
+++ b/features/unhandled_signal.feature
@@ -56,6 +56,13 @@ Feature: Signals are captured as error reports in Bugsnag
     And the event "severityReason.type" equals "signal"
     And the event "severityReason.attributes.signalType" equals "SIGPIPE"
 
+  Scenario: No error should be reported if SIGPIPE is ignored
+    Given I run "SIGPIPEIgnoredScenario"
+    And I wait to receive a session
+    And I relaunch the app
+    And I configure Bugsnag for "SIGPIPEIgnoredScenario"
+    Then I should receive no errors
+
   Scenario: Triggering SIGBUS
     When I run "SIGBUSScenario" and relaunch the crashed app
     And I configure Bugsnag for "SIGBUSScenario"


### PR DESCRIPTION
## Goal

Stop reporting false `SIGPIPE` unhandled errors when ignored with `SIG_IGN`.

If an app uses `sigignore(SIGPIPE)` or `signal(SIGPIPE, SIG_IGN)` then when a `SIGPIPE` is raised, the process will not be terminated.

Bugsnag's hander assumes that the signal will be fatal and writes a crash report.

## Changeset

Removes Bugsnag's signal handler for `SIGPIPE` if the previously configured handler was `SIG_IGN`.

## Testing

Adds an E2E scenario that was able to reproduce the problem and verify the fix.

Updates SIGPIPEScenario to use a more realistic method to trigger a SIGPIPE.