### PR TITLE
[PLAT-8000] Use DISPATCH_SOURCE_TYPE_MEMORYPRESSURE

### DIFF
--- a/Bugsnag/Helpers/BugsnagKeys.h
+++ b/Bugsnag/Helpers/BugsnagKeys.h
@@ -53,6 +53,7 @@ extern NSString *const BSGKeyIsLR;
 extern NSString *const BSGKeyIsPC;
 extern NSString *const BSGKeyLabel;
 extern NSString *const BSGKeyLogLevel;
+extern NSString *const BSGKeyLowMemoryWarning;
 extern NSString *const BSGKeyMach;
 extern NSString *const BSGKeyMachoFile;
 extern NSString *const BSGKeyMachoLoadAddr;

--- a/Bugsnag/Helpers/BugsnagKeys.m
+++ b/Bugsnag/Helpers/BugsnagKeys.m
@@ -52,6 +52,7 @@ NSString *const BSGKeyIsLR = @"isLR";
 NSString *const BSGKeyIsPC = @"isPC";
 NSString *const BSGKeyLabel = @"label";
 NSString *const BSGKeyLogLevel = @"logLevel";
+NSString *const BSGKeyLowMemoryWarning = @"lowMemoryWarning";
 NSString *const BSGKeyMach = @"mach";
 NSString *const BSGKeyMachoFile = @"machoFile";
 NSString *const BSGKeyMachoLoadAddr = @"machoLoadAddress";

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,9 @@ Changelog
 
 ## TBD
 
+* Improve accuracy of `metaData.device.lowMemoryWarning`.
+  [#1296](https://github.com/bugsnag/bugsnag-cocoa/pull/1296)
+
 * Stop reporting `SIGPIPE` errors in apps that set `SIG_IGN`.
   [#1295](https://github.com/bugsnag/bugsnag-cocoa/pull/1295)
 

--- a/Tests/BugsnagTests/BugsnagClientMirrorTest.m
+++ b/Tests/BugsnagTests/BugsnagClientMirrorTest.m
@@ -41,7 +41,6 @@
             @"appLaunchTimerFired: v24@0:8@16",
             @"appendNSErrorInfo:block:event: B40@0:8@16@?24@32",
             @"appendNSErrorInfo:block:event: c40@0:8@16@?24@32",
-            @"applicationDidReceiveMemoryWarning: v24@0:8@16",
             @"applicationWillTerminate: v24@0:8@16",
             @"autoNotify B16@0:8",
             @"autoNotify c16@0:8",


### PR DESCRIPTION
## Goal

Improve the accuracy of `metaData.device.lowMemoryWarning` to make it more likely that OOMs will contain this metadata.

## Changeset

Creates a `DISPATCH_SOURCE_TYPE_MEMORYPRESSURE` source to receive memory pressure notifications.

This allows Bugsnag to be informed of memory pressure before `UIApplication` is able to send its `UIApplicationDidReceiveMemoryWarningNotification`.

`lowMemoryWarning` is now removed if memory pressure recovers.

## Testing

Tested locally using example app, adding some log statements to show that `DISPATCH_MEMORYPRESSURE` notifictions arrive before the UIKit equivalents:

```
2022-02-16 14:50:25.192359+0000 objective-c-ios[841:80634] 1991 / 2958 MB (67%)
2022-02-16 14:50:25.195755+0000 objective-c-ios[841:80634] 1992 / 2958 MB (67%)
2022-02-16 14:50:25.199362+0000 objective-c-ios[841:80690] DISPATCH_MEMORYPRESSURE_CRITICAL
2022-02-16 14:50:25.199363+0000 objective-c-ios[841:80634] 1993 / 2958 MB (67%)
2022-02-16 14:50:25.200735+0000 objective-c-ios[841:80634] -[ViewController didReceiveMemoryWarning]
```

Presence of the metadata is verified in E2E tests [here](https://github.com/bugsnag/bugsnag-cocoa/blob/nickdowell/low-memory-warning/features/barebone_tests.feature#L252).