### PR TITLE
Don't check session data contents if they are nil

### DIFF
--- a/Bugsnag/BugsnagSystemState.m
+++ b/Bugsnag/BugsnagSystemState.m
@@ -243,11 +243,7 @@ static NSDictionary *copyDictionary(NSDictionary *launchState) {
 }
 
 - (void)sessionUpdateNotification:(NSNotification *)notification {
-    if (notification.object == nil) {
-        // No data to update
-        return;
-    }
-    if (![BSGJSONSerialization isValidJSONObject:notification.object]) {
+    if (notification.object && ![BSGJSONSerialization isValidJSONObject:notification.object]) {
         bsg_log_err("Invalid session payload in notification");
         return;
     }

--- a/Bugsnag/BugsnagSystemState.m
+++ b/Bugsnag/BugsnagSystemState.m
@@ -243,6 +243,10 @@ static NSDictionary *copyDictionary(NSDictionary *launchState) {
 }
 
 - (void)sessionUpdateNotification:(NSNotification *)notification {
+    if (notification.object == nil) {
+        // No data to update
+        return;
+    }
     if (![BSGJSONSerialization isValidJSONObject:notification.object]) {
         bsg_log_err("Invalid session payload in notification");
         return;


### PR DESCRIPTION
## Goal

When a session is resumed, we send an update notification with a nil object to indicate that there's no new session info to update:

        [center addObserver:self selector:@selector(sessionUpdateNotification:) name:BSGSessionUpdateNotification object:nil];

In our update handler, it fails the JSON check so the data doesn't get updated (as we want), but it also prints out an ominous error message:

    if (![BSGJSONSerialization isValidJSONObject:notification.object]) {
        bsg_log_err("Invalid session payload in notification");
        return;
    }

This PR does an explicit nil check so that it doesn't print an error message on session resume.

## Testing

Reran e2e tests
