### PR TITLE
Fix flake in testMetadataStorageBuffer

### DIFF
--- a/Tests/BugsnagTests/BugsnagMetadataTests.m
+++ b/Tests/BugsnagTests/BugsnagMetadataTests.m
@@ -411,6 +411,11 @@
         }];
     }
     
+    // Wait for threads to start
+    for (int i = 0; i < threadCount; i++) {
+        while (!threads[i]) {}
+    }
+    
     char *scratch = malloc(1024 * 1024);
     
     for (int i = 0; i < 10000; i++) {


### PR DESCRIPTION
## Goal

Fix flake in `-[BugsnagMetadataTests testMetadataStorageBuffer]`

## Changeset

Waits for the `threads` array to be populated before starting the main test loop, to ensure that a valid `thread_t` will be passed to `thread_suspend()` and the buffer won't be modified while being copied.

## Testing

Reproduced the flake and verified the fix on an M1 Mac mini. Issue was not reproducible on Intel.