### PR TITLE
[PLAT-8019] Prevent reporting of hangs during background launches

### DIFF
--- a/.buildkite/pipeline.yml
+++ b/.buildkite/pipeline.yml
@@ -141,6 +141,7 @@ steps:
         run: cocoa-maze-runner
         command:
           - "features/barebone_tests.feature"
+          - "features/app_hangs.feature"
           - "--app=@build/ipa_url.txt"
           - "--farm=bs"
           - "--device=IOS_15"
@@ -169,6 +170,7 @@ steps:
         run: cocoa-maze-runner
         command:
           - "features/barebone_tests.feature"
+          - "features/app_hangs.feature"
           - "--app=@build/ipa_url.txt"
           - "--farm=bs"
           - "--device=IOS_10"
@@ -200,6 +202,7 @@ steps:
       - bundle install
       - bundle exec maze-runner
         features/barebone_tests.feature
+        features/app_hangs.feature
         --farm=local
         --os=macos
         --os-version=10.13
@@ -224,6 +227,7 @@ steps:
       - bundle install
       - bundle exec maze-runner
         features/barebone_tests.feature
+        features/app_hangs.feature
         --farm=local
         --os=macos
         --os-version=10.15
@@ -249,6 +253,7 @@ steps:
       - bundle install
       - bundle exec maze-runner
         features/barebone_tests.feature
+        features/app_hangs.feature
         --farm=local
         --os=macos
         --os-version=12

--- a/Bugsnag/BugsnagSystemState.h
+++ b/Bugsnag/BugsnagSystemState.h
@@ -16,7 +16,6 @@
 #define SYSTEMSTATE_KEY_DEVICE @"device"
 
 #define SYSTEMSTATE_APP_WAS_TERMINATED @"wasTerminated"
-#define SYSTEMSTATE_APP_IS_ACTIVE @"isActive"
 #define SYSTEMSTATE_APP_IS_IN_FOREGROUND @"inForeground"
 #define SYSTEMSTATE_APP_IS_LAUNCHING BSGKeyIsLaunching
 #define SYSTEMSTATE_APP_VERSION @"version"

--- a/Bugsnag/Client/BugsnagClient.m
+++ b/Bugsnag/Client/BugsnagClient.m
@@ -219,7 +219,6 @@ __attribute__((annotate("oclint:suppress[too many methods]")))
         }];
         
         _notifier = _configuration.notifier ?: [[BugsnagNotifier alloc] init];
-        self.systemState = [[BugsnagSystemState alloc] initWithConfiguration:_configuration];
 
         BSGFileLocations *fileLocations = [BSGFileLocations current];
         
@@ -284,6 +283,7 @@ __attribute__((annotate("oclint:suppress[too many methods]")))
 - (void)start {
     [self.configuration validate];
     [self.crashSentry install:self.configuration onCrash:&BSSerializeDataCrashHandler];
+    self.systemState = [[BugsnagSystemState alloc] initWithConfiguration:self.configuration];
     [self computeDidCrashLastLaunch];
     [self.breadcrumbs removeAllBreadcrumbs];
     [self setupConnectivityListener];

--- a/Bugsnag/Helpers/BSGAppHangDetector.m
+++ b/Bugsnag/Helpers/BSGAppHangDetector.m
@@ -22,7 +22,6 @@
 @interface BSGAppHangDetector ()
 
 @property (weak, nonatomic) id<BSGAppHangDetectorDelegate> delegate;
-@property (nonatomic) BOOL runLoopIsRunning;
 @property (nonatomic) BOOL recordAllThreads;
 @property (nonatomic) CFRunLoopObserverRef observer;
 @property (atomic) dispatch_time_t processingDeadline;
@@ -82,7 +81,6 @@
                 // Each iteration indicates a separate unit of work so the hang detection should be reset accordingly.
                 dispatch_semaphore_signal(self.processingFinished);
             }
-            self.runLoopIsRunning = YES;
             self.processingDeadline = dispatch_time(DISPATCH_TIME_NOW, (int64_t)(threshold * NSEC_PER_SEC));
             dispatch_semaphore_signal(self.processingStarted);
             isProcessing = YES;
@@ -148,9 +146,7 @@
         }
 #endif
         
-        // Ignore background state if the runloop has not yet ticked so that hangs in `didFinishLaunching` in UIScene-based
-        // apps are detected. UIScene-based apps always start in UIApplicationStateBackground, unlike those without scenes.
-        if (shouldReportAppHang && !bsg_kscrashstate_currentState()->applicationIsInForeground && self.runLoopIsRunning) {
+        if (shouldReportAppHang && !bsg_kscrashstate_currentState()->applicationIsInForeground) {
             bsg_log_debug(@"Ignoring app hang because app is in the background");
             shouldReportAppHang = NO;
         }

--- a/Bugsnag/KSCrash/Source/KSCrash/Recording/BSG_KSSystemInfo.h
+++ b/Bugsnag/KSCrash/Source/KSCrash/Recording/BSG_KSSystemInfo.h
@@ -89,14 +89,4 @@
  */
 + (NSString *)deviceAndAppHash;
 
-#if TARGET_OS_IOS || TARGET_OS_TV
-+ (UIApplicationState)currentAppState;
-
-/**
- * YES if the app is currently shown in the foreground
- */
-+ (BOOL)isInForeground:(UIApplicationState)state;
-
-#endif
-
 @end

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,13 @@
 Changelog
 =========
 
+## TBD
+
+### Bug fixes
+
+* Fix accuracy of `app.inForeground` and prevent reporting of hangs during background launches.
+  [#1307](https://github.com/bugsnag/bugsnag-cocoa/pull/1307)
+
 ## 6.16.3 (2022-02-23)
 
 ### Bug fixes

--- a/Tests/BugsnagTests/TestSupport.m
+++ b/Tests/BugsnagTests/TestSupport.m
@@ -8,6 +8,8 @@
 
 #import "TestSupport.h"
 
+#import "BSG_KSCrashC.h"
+#import "BSG_KSCrashState.h"
 #import "BSGFileLocations.h"
 #import "BSGUtils.h"
 #import "Bugsnag+Private.h"
@@ -24,7 +26,14 @@
             [NSException raise:NSInternalInconsistencyException format:@"Could not delete %@", dir];
         }
     });
+    
     [Bugsnag purge];
+    
+    // bsg_kscrash_install() will refuse to install itself twice, so reinit kscrashstate to avoid leaking state between tests
+    NSString *path = [BSGFileLocations current].state;
+    NSString *dir = [path stringByDeletingLastPathComponent];
+    [NSFileManager.defaultManager createDirectoryAtPath:dir withIntermediateDirectories:YES attributes:nil error:nil];
+    bsg_kscrashstate_init(path.fileSystemRepresentation, &crashContext()->state);
 }
 
 @end

--- a/Tests/KSCrashTests/KSSystemInfo_Tests.m
+++ b/Tests/KSCrashTests/KSSystemInfo_Tests.m
@@ -29,10 +29,6 @@
 #import "BSG_KSSystemInfo.h"
 #import "BSG_KSSystemInfoC.h"
 
-#if TARGET_OS_TV
-#import "UIApplicationStub.h"
-#endif
-
 
 @interface KSSystemInfo_Tests : XCTestCase @end
 
@@ -60,27 +56,5 @@
         free(processName);
     }
 }
-
-#if TARGET_OS_TV || TARGET_OS_IOS
-- (void)testCurrentAppState {
-#if TARGET_OS_TV
-    [self setUpUIApplicationStub];
-#endif
-    XCTAssertEqual(UIApplicationStateActive, [BSG_KSSystemInfo currentAppState]);
-}
-
-- (void)testInactiveIsInForeground {
-    XCTAssertTrue([BSG_KSSystemInfo isInForeground:UIApplicationStateInactive]);
-}
-
-- (void)testActiveIsInForeground {
-    XCTAssertTrue([BSG_KSSystemInfo isInForeground:UIApplicationStateActive]);
-
-}
-
-- (void)testBackgroundIsNotInForeground {
-    XCTAssertFalse([BSG_KSSystemInfo isInForeground:UIApplicationStateBackground]);
-}
-#endif
 
 @end


### PR DESCRIPTION
## Goal

Prevent reporting of hangs during background launches.

## Design

Problem: `-[UIApplication applicationState]` always returns `UIApplicationStateBackground` during the launch of `UIScene` based apps, which means if we rely only on this to detect foreground app launches then we would not report fatal app hangs in `didFinishLaunching`.

The workaround in #1263 went too far because a hang detected during prewarming or other background launch could be reported as a fatal if iOS subsequently terminated the (backgrounded) apps without warning to reclaim resources (which is quite likely.)

iOS sets a process's `TASK_CATEGORY_POLICY` to different values depending on the type of launch, in order to control its priority for resources such as CPU and disk. Querying this using the `task_policy_get()` API lets us query the category and infer the launch type.

<details><summary>TASK_CATEGORY_POLICY definition</summary>

```
/*
 * TASK_CATEGORY_POLICY:
 *
 * This provides information to the kernel about the role
 * of the task in the system.
 *
 * Parameters:
 *
 * role: Enumerated as follows:
 *
 * TASK_UNSPECIFIED is the default, since the role is not
 * inherited from the parent.
 *
 * TASK_FOREGROUND_APPLICATION should be assigned when the
 * task is a normal UI application in the foreground from
 * the HI point of view.
 * **N.B. There may be more than one of these at a given time.
 *
 * TASK_BACKGROUND_APPLICATION should be assigned when the
 * task is a normal UI application in the background from
 * the HI point of view.
 *
 * TASK_CONTROL_APPLICATION should be assigned to the unique
 * UI application which implements the pop-up application dialog.
 * There can only be one task at a time with this designation,
 * which is assigned FCFS.
 *
 * TASK_GRAPHICS_SERVER should be assigned to the graphics
 * management (window) server.  There can only be one task at
 * a time with this designation, which is assigned FCFS.
 */
```
</details>

Testing on various iOS versions has confirmed that `TASK_FOREGROUND_APPLICATION` is a reliable indicator that the process is a foreground app.

Note that this is not a suitable replacement for querying `UIApplicationState` at arbitraty times because the system does not update a task's policy immediately upon state transitions.

## Changeset

Moves all application foreground state logic into `BSG_KSCrashState` and uses the task's category policy to detect foreground state at initialisation on iOS.

Removes the "runloop not yet ticked" workaround from `BSGAppHangDetector`, since that was allowing too many background hangs to be reported as fatal.

Removes `isActive` from `BugsnagSystemState` since the removal of `[BSG_KSSystemInfo currentAppState]` makes it awkward to capture this data, and it is not actually necessary for the OOM logic - if `isActive` is true, so is `isInForeground`.

`BugsnagSystemState` is now initialised later, since it requires `BSG_KSCrashState` to be ready.

## Testing

Manually tested launching in foreground, for a background fetch, and prewarming (by rebooting the device.)

All app hang E2E scenarios have passed on CI - https://buildkite.com/bugsnag/bugsnag-cocoa/builds/5050
