### PR TITLE
Tidy up BSG_KSCrashState

### DIFF
--- a/Bugsnag/KSCrash/Source/KSCrash/Recording/BSG_KSCrash.m
+++ b/Bugsnag/KSCrash/Source/KSCrash/Recording/BSG_KSCrash.m
@@ -174,10 +174,6 @@
                 selector:@selector(applicationWillEnterForeground)
                     name:UIApplicationWillEnterForegroundNotification
                   object:nil];
-    [nCenter addObserver:self
-                selector:@selector(applicationWillTerminate)
-                    name:UIApplicationWillTerminateNotification
-                  object:nil];
 #elif TARGET_OS_OSX
     // MacOS "active" serves the same purpose as "foreground" in iOS
     [nCenter addObserver:self
@@ -187,10 +183,6 @@
     [nCenter addObserver:self
                 selector:@selector(applicationWillEnterForeground)
                     name:NSApplicationDidBecomeActiveNotification
-                  object:nil];
-    [nCenter addObserver:self
-                selector:@selector(applicationWillTerminate)
-                    name:NSApplicationWillTerminateNotification
                   object:nil];
 #endif
 
@@ -216,16 +208,9 @@
         return bsg_kscrashstate_currentState()->NAME;                          \
     }
 
-BSG_SYNTHESIZE_CRASH_STATE_PROPERTY(NSTimeInterval,
-                                    foregroundDurationSinceLastCrash)
-BSG_SYNTHESIZE_CRASH_STATE_PROPERTY(NSTimeInterval,
-                                    backgroundDurationSinceLastCrash)
-BSG_SYNTHESIZE_CRASH_STATE_PROPERTY(int, launchesSinceLastCrash)
-BSG_SYNTHESIZE_CRASH_STATE_PROPERTY(int, sessionsSinceLastCrash)
 BSG_SYNTHESIZE_CRASH_STATE_PROPERTY(NSTimeInterval, foregroundDurationSinceLaunch)
 BSG_SYNTHESIZE_CRASH_STATE_PROPERTY(NSTimeInterval,
                                     backgroundDurationSinceLaunch)
-BSG_SYNTHESIZE_CRASH_STATE_PROPERTY(int, sessionsSinceLaunch)
 BSG_SYNTHESIZE_CRASH_STATE_PROPERTY(BOOL, crashedLastLaunch)
 
 - (BOOL)redirectConsoleLogsToFile:(NSString *)fullPath
@@ -255,10 +240,6 @@ BSG_SYNTHESIZE_CRASH_STATE_PROPERTY(BOOL, crashedLastLaunch)
 
 - (void)applicationWillEnterForeground {
     bsg_kscrashstate_notifyAppInForeground(true);
-}
-
-- (void)applicationWillTerminate {
-    bsg_kscrashstate_notifyAppTerminate();
 }
 
 @end

--- a/Bugsnag/KSCrash/Source/KSCrash/Recording/BSG_KSCrashAdvanced.h
+++ b/Bugsnag/KSCrash/Source/KSCrash/Recording/BSG_KSCrashAdvanced.h
@@ -33,29 +33,12 @@
 
 #pragma mark - Information -
 
-/** Total active time elapsed since the last crash. */
-@property(nonatomic, readonly, assign)
-    NSTimeInterval foregroundDurationSinceLastCrash;
-
-/** Total time backgrounded elapsed since the last crash. */
-@property(nonatomic, readonly, assign)
-    NSTimeInterval backgroundDurationSinceLastCrash;
-
-/** Number of app launches since the last crash. */
-@property(nonatomic, readonly, assign) int launchesSinceLastCrash;
-
-/** Number of sessions (launch, resume from suspend) since last crash. */
-@property(nonatomic, readonly, assign) int sessionsSinceLastCrash;
-
 /** Total active time elapsed since launch. */
 @property(nonatomic, readonly, assign) NSTimeInterval foregroundDurationSinceLaunch;
 
 /** Total time backgrounded elapsed since launch. */
 @property(nonatomic, readonly, assign)
     NSTimeInterval backgroundDurationSinceLaunch;
-
-/** Number of sessions (launch, resume from suspend) since app launch. */
-@property(nonatomic, readonly, assign) int sessionsSinceLaunch;
 
 /** If true, the application crashed on the previous launch. */
 @property(nonatomic, readonly, assign) BOOL crashedLastLaunch;

--- a/Bugsnag/KSCrash/Source/KSCrash/Recording/BSG_KSCrashC.c
+++ b/Bugsnag/KSCrash/Source/KSCrash/Recording/BSG_KSCrashC.c
@@ -154,9 +154,6 @@ void bsg_kscrash_reinstall(const char *const crashReportFilePath,
     if (!bsg_kscrashstate_init(bsg_g_stateFilePath, &context->state)) {
         BSG_KSLOG_ERROR("Failed to initialize persistent crash state");
     }
-    uint64_t timeNow = mach_absolute_time();
-    context->state.appLaunchTime = timeNow;
-    context->state.lastUpdateDurationsTime = timeNow;
 }
 
 BSG_KSCrashType bsg_kscrash_setHandlingCrashTypes(BSG_KSCrashType crashTypes) {

--- a/Bugsnag/KSCrash/Source/KSCrash/Recording/BSG_KSCrashReport.c
+++ b/Bugsnag/KSCrash/Source/KSCrash/Recording/BSG_KSCrashReport.c
@@ -1347,20 +1347,6 @@ void bsg_kscrw_i_writeAppStats(const BSG_KSCrashReportWriter *const writer,
     {
         writer->addBooleanElement(writer, BSG_KSCrashField_AppInFG,
                                   state->applicationIsInForeground);
-
-        writer->addIntegerElement(writer, BSG_KSCrashField_LaunchesSinceCrash,
-                                  state->launchesSinceLastCrash);
-        writer->addIntegerElement(writer, BSG_KSCrashField_SessionsSinceCrash,
-                                  state->sessionsSinceLastCrash);
-        writer->addFloatingPointElement(writer,
-                                        BSG_KSCrashField_ActiveTimeSinceCrash,
-                                        state->foregroundDurationSinceLastCrash);
-        writer->addFloatingPointElement(
-            writer, BSG_KSCrashField_BGTimeSinceCrash,
-            state->backgroundDurationSinceLastCrash);
-
-        writer->addIntegerElement(writer, BSG_KSCrashField_SessionsSinceLaunch,
-                                  state->sessionsSinceLaunch);
         writer->addFloatingPointElement(writer,
                                         BSG_KSCrashField_ActiveTimeSinceLaunch,
                                         state->foregroundDurationSinceLaunch);

--- a/Bugsnag/KSCrash/Source/KSCrash/Recording/BSG_KSCrashReportFields.h
+++ b/Bugsnag/KSCrash/Source/KSCrash/Recording/BSG_KSCrashReportFields.h
@@ -145,14 +145,9 @@
 
 #pragma mark - App Stats -
 
-#define BSG_KSCrashField_ActiveTimeSinceCrash "active_time_since_last_crash"
 #define BSG_KSCrashField_ActiveTimeSinceLaunch "active_time_since_launch"
 #define BSG_KSCrashField_AppInFG "application_in_foreground"
-#define BSG_KSCrashField_BGTimeSinceCrash "background_time_since_last_crash"
 #define BSG_KSCrashField_BGTimeSinceLaunch "background_time_since_launch"
-#define BSG_KSCrashField_LaunchesSinceCrash "launches_since_last_crash"
-#define BSG_KSCrashField_SessionsSinceCrash "sessions_since_last_crash"
-#define BSG_KSCrashField_SessionsSinceLaunch "sessions_since_launch"
 
 #pragma mark - Report -
 

--- a/Bugsnag/KSCrash/Source/KSCrash/Recording/BSG_KSCrashState.h
+++ b/Bugsnag/KSCrash/Source/KSCrash/Recording/BSG_KSCrashState.h
@@ -43,26 +43,11 @@ typedef struct {
 
     // Saved data
 
-    /** Total time elapsed in the foreground since the last crash. */
-    double foregroundDurationSinceLastCrash;
-
-    /** Total time backgrounded elapsed since the last crash. */
-    double backgroundDurationSinceLastCrash;
-
-    /** Number of app launches since the last crash. */
-    int launchesSinceLastCrash;
-
-    /** Number of sessions (launch, resume from suspend) since last crash. */
-    int sessionsSinceLastCrash;
-
     /** Total time elapsed in the foreground since launch. */
     double foregroundDurationSinceLaunch;
 
     /** Total time backgrounded elapsed since launch. */
     double backgroundDurationSinceLaunch;
-
-    /** Number of sessions (launch, resume from suspend) since app launch. */
-    int sessionsSinceLaunch;
 
     /** If true, the application crashed on the previous launch. */
     bool crashedLastLaunch;
@@ -100,10 +85,6 @@ bool bsg_kscrashstate_init(const char *stateFilePath, BSG_KSCrash_State *state);
  *                 it is in the background.
  */
 void bsg_kscrashstate_notifyAppInForeground(bool isInForeground);
-
-/** Notify the crash reporter that the application is terminating.
- */
-void bsg_kscrashstate_notifyAppTerminate(void);
 
 /** Notify the crash reporter that the application has crashed.
  */

--- a/Bugsnag/KSCrash/Source/KSCrash/Recording/BSG_KSCrashState.h
+++ b/Bugsnag/KSCrash/Source/KSCrash/Recording/BSG_KSCrashState.h
@@ -37,7 +37,6 @@ extern "C" {
 
 #include <stdbool.h>
 #include <stdint.h>
-#include "BSG_KSCrashType.h"
 
 typedef struct {
 

--- a/Bugsnag/KSCrash/Source/KSCrash/Recording/BSG_KSCrashState.m
+++ b/Bugsnag/KSCrash/Source/KSCrash/Recording/BSG_KSCrashState.m
@@ -182,11 +182,11 @@ bool bsg_kscrashstate_init(const char *const stateFilePath,
     bsg_g_stateFilePath = stateFilePath;
     bsg_g_state = state;
 
+    uint64_t timeNow = mach_absolute_time();
+    memset(state, 0, sizeof(*state));
     bsg_kscrashstate_i_loadState(state, stateFilePath);
-
-    state->foregroundDurationSinceLaunch = 0;
-    state->backgroundDurationSinceLaunch = 0;
-    state->crashedThisLaunch = false;
+    state->appLaunchTime = timeNow;
+    state->lastUpdateDurationsTime = timeNow;
 
     // On iOS/tvOS, the app may have launched in the background due to a fetch
     // event or notification (or prewarming on iOS 15+)

--- a/Tests/KSCrashTests/KSCrashState_Tests.m
+++ b/Tests/KSCrashTests/KSCrashState_Tests.m
@@ -62,15 +62,10 @@
 
     XCTAssertTrue(context.applicationIsInForeground, @"");
 
-    XCTAssertEqual(context.foregroundDurationSinceLastCrash, 0.0, @"");
-    XCTAssertEqual(context.backgroundDurationSinceLastCrash, 0.0, @"");
-    XCTAssertEqual(context.launchesSinceLastCrash, 1, @"");
-    XCTAssertEqual(context.sessionsSinceLastCrash, 1, @"");
     XCTAssertEqual(context.appLaunchTime, 0, @"");
 
     XCTAssertEqual(context.foregroundDurationSinceLaunch, 0.0, @"");
     XCTAssertEqual(context.backgroundDurationSinceLaunch, 0.0, @"");
-    XCTAssertEqual(context.sessionsSinceLaunch, 1, @"");
 
     XCTAssertFalse(context.crashedThisLaunch, @"");
     XCTAssertFalse(context.crashedLastLaunch, @"");
@@ -81,15 +76,10 @@
 
     XCTAssertTrue(context.applicationIsInForeground, @"");
 
-    XCTAssertEqual(context.foregroundDurationSinceLastCrash, 0.0, @"");
-    XCTAssertEqual(context.backgroundDurationSinceLastCrash, 0.0, @"");
-    XCTAssertEqual(context.launchesSinceLastCrash, 2, @"");
-    XCTAssertEqual(context.sessionsSinceLastCrash, 2, @"");
     XCTAssertEqual(context.appLaunchTime, 0, @"");
 
     XCTAssertEqual(context.foregroundDurationSinceLaunch, 0.0, @"");
     XCTAssertEqual(context.backgroundDurationSinceLaunch, 0.0, @"");
-    XCTAssertEqual(context.sessionsSinceLaunch, 1, @"");
 
     XCTAssertFalse(context.crashedThisLaunch, @"");
     XCTAssertFalse(context.crashedLastLaunch, @"");
@@ -112,21 +102,10 @@
                  checkpoint0.applicationIsInForeground, @"");
     XCTAssertTrue(checkpointC.appLaunchTime == checkpoint0.appLaunchTime, @"");
 
-    XCTAssertGreaterThan(checkpointC.foregroundDurationSinceLastCrash,
-                         checkpoint0.foregroundDurationSinceLastCrash);
-    XCTAssertTrue(checkpointC.backgroundDurationSinceLastCrash ==
-                 checkpoint0.backgroundDurationSinceLastCrash, @"");
-    XCTAssertTrue(checkpointC.launchesSinceLastCrash ==
-                 checkpoint0.launchesSinceLastCrash, @"");
-    XCTAssertTrue(checkpointC.sessionsSinceLastCrash ==
-                 checkpoint0.sessionsSinceLastCrash, @"");
-
     XCTAssertGreaterThan(checkpointC.foregroundDurationSinceLaunch,
                          checkpoint0.foregroundDurationSinceLaunch);
     XCTAssertTrue(checkpointC.backgroundDurationSinceLaunch ==
                  checkpoint0.backgroundDurationSinceLaunch, @"");
-    XCTAssertTrue(checkpointC.sessionsSinceLaunch ==
-                 checkpoint0.sessionsSinceLaunch, @"");
 
     XCTAssertTrue(checkpointC.crashedThisLaunch, @"");
     XCTAssertFalse(checkpointC.crashedLastLaunch, @"");
@@ -137,14 +116,8 @@
 
     XCTAssertTrue(context.applicationIsInForeground, @"");
 
-    XCTAssertEqual(context.foregroundDurationSinceLastCrash, 0.0, @"");
-    XCTAssertEqual(context.backgroundDurationSinceLastCrash, 0.0, @"");
-    XCTAssertEqual(context.launchesSinceLastCrash, 1, @"");
-    XCTAssertEqual(context.sessionsSinceLastCrash, 1, @"");
-
     XCTAssertEqual(context.foregroundDurationSinceLaunch, 0.0, @"");
     XCTAssertEqual(context.backgroundDurationSinceLaunch, 0.0, @"");
-    XCTAssertEqual(context.sessionsSinceLaunch, 1, @"");
 
     XCTAssertFalse(context.crashedThisLaunch, @"");
     XCTAssertTrue(context.crashedLastLaunch, @"");
@@ -182,15 +155,8 @@
     XCTAssertTrue(checkpointR.applicationIsInForeground, @"");
     XCTAssertEqual(checkpointR.appLaunchTime, 0, @"");
 
-    // We don't save after going inactive, so this will still be 0.
-    XCTAssertEqual(checkpointR.foregroundDurationSinceLastCrash, 0.0, @"");
-    XCTAssertEqual(checkpointR.backgroundDurationSinceLastCrash, 0.0, @"");
-    XCTAssertEqual(checkpointR.launchesSinceLastCrash, 2, @"");
-    XCTAssertEqual(checkpointR.sessionsSinceLastCrash, 2, @"");
-
     XCTAssertEqual(checkpointR.foregroundDurationSinceLaunch, 0.0, @"");
     XCTAssertEqual(checkpointR.backgroundDurationSinceLaunch, 0.0, @"");
-    XCTAssertEqual(checkpointR.sessionsSinceLaunch, 1, @"");
 
     XCTAssertFalse(checkpointR.crashedThisLaunch, @"");
     XCTAssertFalse(checkpointR.crashedLastLaunch, @"");
@@ -215,21 +181,10 @@
     XCTAssertFalse(checkpoint1.applicationIsInForeground, @"");
     XCTAssertTrue(checkpoint0.appLaunchTime == checkpoint1.appLaunchTime, @"");
 
-    XCTAssertGreaterThan(checkpoint1.foregroundDurationSinceLastCrash,
-                         checkpoint0.foregroundDurationSinceLastCrash);
-    XCTAssertTrue(checkpoint1.backgroundDurationSinceLastCrash ==
-                 checkpoint0.backgroundDurationSinceLastCrash, @"");
-    XCTAssertTrue(checkpoint1.launchesSinceLastCrash ==
-                 checkpoint0.launchesSinceLastCrash, @"");
-    XCTAssertTrue(checkpoint1.sessionsSinceLastCrash ==
-                 checkpoint0.sessionsSinceLastCrash, @"");
-
     XCTAssertGreaterThan(checkpoint1.foregroundDurationSinceLaunch,
                          checkpoint0.foregroundDurationSinceLaunch);
     XCTAssertTrue(checkpoint1.backgroundDurationSinceLaunch ==
                  checkpoint0.backgroundDurationSinceLaunch, @"");
-    XCTAssertTrue(checkpoint1.sessionsSinceLaunch ==
-                 checkpoint0.sessionsSinceLaunch, @"");
 
     XCTAssertFalse(checkpoint1.crashedThisLaunch, @"");
     XCTAssertFalse(checkpoint1.crashedLastLaunch, @"");
@@ -242,14 +197,8 @@
 
     XCTAssertTrue(checkpointR.applicationIsInForeground, @"");
 
-    XCTAssertTrue(checkpointR.foregroundDurationSinceLastCrash > 0, @"");
-    XCTAssertEqual(checkpointR.backgroundDurationSinceLastCrash, 0.0, @"");
-    XCTAssertEqual(checkpointR.launchesSinceLastCrash, 2, @"");
-    XCTAssertEqual(checkpointR.sessionsSinceLastCrash, 2, @"");
-
     XCTAssertEqual(checkpointR.foregroundDurationSinceLaunch, 0.0, @"");
     XCTAssertEqual(checkpointR.backgroundDurationSinceLaunch, 0.0, @"");
-    XCTAssertEqual(checkpointR.sessionsSinceLaunch, 1, @"");
 
     XCTAssertFalse(checkpointR.crashedThisLaunch, @"");
     XCTAssertFalse(checkpointR.crashedLastLaunch, @"");
@@ -267,9 +216,7 @@
     bsg_kscrashstate_notifyAppInForeground(false);
     BSG_KSCrash_State checkpoint0 = context;
     usleep(1);
-    bsg_kscrashstate_notifyAppTerminate();
 
-    usleep(1);
     memset(&context, 0, sizeof(context));
     bsg_kscrashstate_init([stateFile cStringUsingEncoding:NSUTF8StringEncoding],
                       &context);
@@ -278,14 +225,8 @@
     XCTAssertTrue(checkpointR.applicationIsInForeground, @"");
     XCTAssertEqual(checkpointR.appLaunchTime, 0, @"");
 
-    XCTAssertTrue(checkpointR.backgroundDurationSinceLastCrash >
-                 checkpoint0.backgroundDurationSinceLastCrash, @"");
-    XCTAssertEqual(checkpointR.launchesSinceLastCrash, 2, @"");
-    XCTAssertEqual(checkpointR.sessionsSinceLastCrash, 2, @"");
-
     XCTAssertEqual(checkpointR.foregroundDurationSinceLaunch, 0.0, @"");
     XCTAssertEqual(checkpointR.backgroundDurationSinceLaunch, 0.0, @"");
-    XCTAssertEqual(checkpointR.sessionsSinceLaunch, 1, @"");
 
     XCTAssertFalse(checkpointR.crashedThisLaunch, @"");
     XCTAssertFalse(checkpointR.crashedLastLaunch, @"");
@@ -311,21 +252,10 @@
                  checkpoint0.applicationIsInForeground, @"");
     XCTAssertTrue(checkpointC.appLaunchTime == checkpoint0.appLaunchTime, @"");
 
-    XCTAssertTrue(checkpointC.foregroundDurationSinceLastCrash ==
-                 checkpoint0.foregroundDurationSinceLastCrash, @"");
-    XCTAssertTrue(checkpointC.backgroundDurationSinceLastCrash >
-                 checkpoint0.backgroundDurationSinceLastCrash, @"");
-    XCTAssertTrue(checkpointC.launchesSinceLastCrash ==
-                 checkpoint0.launchesSinceLastCrash, @"");
-    XCTAssertTrue(checkpointC.sessionsSinceLastCrash ==
-                 checkpoint0.sessionsSinceLastCrash, @"");
-
     XCTAssertTrue(checkpointC.foregroundDurationSinceLaunch ==
                  checkpoint0.foregroundDurationSinceLaunch, @"");
     XCTAssertTrue(checkpointC.backgroundDurationSinceLaunch >
                  checkpoint0.backgroundDurationSinceLaunch, @"");
-    XCTAssertTrue(checkpointC.sessionsSinceLaunch ==
-                 checkpoint0.sessionsSinceLaunch, @"");
 
     XCTAssertTrue(checkpointC.crashedThisLaunch, @"");
     XCTAssertFalse(checkpointC.crashedLastLaunch, @"");
@@ -336,14 +266,8 @@
 
     XCTAssertTrue(context.applicationIsInForeground, @"");
 
-    XCTAssertEqual(context.foregroundDurationSinceLastCrash, 0.0, @"");
-    XCTAssertEqual(context.backgroundDurationSinceLastCrash, 0.0, @"");
-    XCTAssertEqual(context.launchesSinceLastCrash, 1, @"");
-    XCTAssertEqual(context.sessionsSinceLastCrash, 1, @"");
-
     XCTAssertEqual(context.foregroundDurationSinceLaunch, 0.0, @"");
     XCTAssertEqual(context.backgroundDurationSinceLaunch, 0.0, @"");
-    XCTAssertEqual(context.sessionsSinceLaunch, 1, @"");
 
     XCTAssertFalse(context.crashedThisLaunch, @"");
     XCTAssertTrue(context.crashedLastLaunch, @"");
@@ -383,21 +307,10 @@
     XCTAssertTrue(checkpoint1.applicationIsInForeground, @"");
     XCTAssertTrue(checkpoint1.appLaunchTime == checkpoint0.appLaunchTime, @"");
 
-    XCTAssertTrue(checkpoint1.foregroundDurationSinceLastCrash ==
-                 checkpoint0.foregroundDurationSinceLastCrash, @"");
-    XCTAssertTrue(checkpoint1.backgroundDurationSinceLastCrash >
-                 checkpoint0.backgroundDurationSinceLastCrash, @"");
-    XCTAssertTrue(checkpoint1.launchesSinceLastCrash ==
-                 checkpoint0.launchesSinceLastCrash, @"");
-    XCTAssertTrue(checkpoint1.sessionsSinceLastCrash ==
-                 checkpoint0.sessionsSinceLastCrash + 1, @"");
-
     XCTAssertTrue(checkpoint1.foregroundDurationSinceLaunch ==
                  checkpoint0.foregroundDurationSinceLaunch, @"");
     XCTAssertTrue(checkpoint1.backgroundDurationSinceLaunch >
                  checkpoint0.backgroundDurationSinceLaunch, @"");
-    XCTAssertTrue(checkpoint1.sessionsSinceLaunch ==
-                 checkpoint0.sessionsSinceLaunch + 1, @"");
 
     XCTAssertFalse(checkpoint1.crashedThisLaunch, @"");
     XCTAssertFalse(checkpoint1.crashedLastLaunch, @"");
@@ -410,15 +323,8 @@
 
     XCTAssertTrue(checkpointR.applicationIsInForeground, @"");
 
-    XCTAssertTrue(checkpointR.foregroundDurationSinceLastCrash > 0, @"");
-    // We don't save after going to FG, so this will still be 0.
-    XCTAssertEqual(checkpointR.backgroundDurationSinceLastCrash, 0.0, @"");
-    XCTAssertEqual(checkpointR.launchesSinceLastCrash, 2, @"");
-    XCTAssertEqual(checkpointR.sessionsSinceLastCrash, 2, @"");
-
     XCTAssertEqual(checkpointR.foregroundDurationSinceLaunch, 0.0, @"");
     XCTAssertEqual(checkpointR.backgroundDurationSinceLaunch, 0.0, @"");
-    XCTAssertEqual(checkpointR.sessionsSinceLaunch, 1, @"");
 
     XCTAssertFalse(checkpointR.crashedThisLaunch, @"");
     XCTAssertFalse(checkpointR.crashedLastLaunch, @"");
@@ -445,21 +351,10 @@
                  checkpoint0.applicationIsInForeground, @"");
     XCTAssertTrue(checkpointC.appLaunchTime == checkpoint0.appLaunchTime, @"");
 
-    XCTAssertGreaterThan(checkpointC.foregroundDurationSinceLastCrash,
-                         checkpoint0.foregroundDurationSinceLastCrash);
-    XCTAssertTrue(checkpointC.backgroundDurationSinceLastCrash ==
-                 checkpoint0.backgroundDurationSinceLastCrash, @"");
-    XCTAssertTrue(checkpointC.launchesSinceLastCrash ==
-                 checkpoint0.launchesSinceLastCrash, @"");
-    XCTAssertTrue(checkpointC.sessionsSinceLastCrash ==
-                 checkpoint0.sessionsSinceLastCrash, @"");
-
     XCTAssertGreaterThan(checkpointC.foregroundDurationSinceLaunch,
                          checkpoint0.foregroundDurationSinceLaunch);
     XCTAssertTrue(checkpointC.backgroundDurationSinceLaunch ==
                  checkpoint0.backgroundDurationSinceLaunch, @"");
-    XCTAssertTrue(checkpointC.sessionsSinceLaunch ==
-                 checkpoint0.sessionsSinceLaunch, @"");
 
     XCTAssertTrue(checkpointC.crashedThisLaunch, @"");
     XCTAssertFalse(checkpointC.crashedLastLaunch, @"");
@@ -470,14 +365,8 @@
 
     XCTAssertTrue(context.applicationIsInForeground, @"");
 
-    XCTAssertEqual(context.foregroundDurationSinceLastCrash, 0.0, @"");
-    XCTAssertEqual(context.backgroundDurationSinceLastCrash, 0.0, @"");
-    XCTAssertEqual(context.launchesSinceLastCrash, 1, @"");
-    XCTAssertEqual(context.sessionsSinceLastCrash, 1, @"");
-
     XCTAssertEqual(context.foregroundDurationSinceLaunch, 0.0, @"");
     XCTAssertEqual(context.backgroundDurationSinceLaunch, 0.0, @"");
-    XCTAssertEqual(context.sessionsSinceLaunch, 1, @"");
 
     XCTAssertFalse(context.crashedThisLaunch, @"");
     XCTAssertTrue(context.crashedLastLaunch, @"");

--- a/Tests/KSCrashTests/KSCrashState_Tests.m
+++ b/Tests/KSCrashTests/KSCrashState_Tests.m
@@ -62,7 +62,7 @@
 
     XCTAssertTrue(context.applicationIsInForeground, @"");
 
-    XCTAssertEqual(context.appLaunchTime, 0, @"");
+    XCTAssertNotEqual(context.appLaunchTime, 0);
 
     XCTAssertEqual(context.foregroundDurationSinceLaunch, 0.0, @"");
     XCTAssertEqual(context.backgroundDurationSinceLaunch, 0.0, @"");
@@ -76,7 +76,7 @@
 
     XCTAssertTrue(context.applicationIsInForeground, @"");
 
-    XCTAssertEqual(context.appLaunchTime, 0, @"");
+    XCTAssertNotEqual(context.appLaunchTime, 0);
 
     XCTAssertEqual(context.foregroundDurationSinceLaunch, 0.0, @"");
     XCTAssertEqual(context.backgroundDurationSinceLaunch, 0.0, @"");
@@ -153,7 +153,7 @@
     BSG_KSCrash_State checkpointR = context;
 
     XCTAssertTrue(checkpointR.applicationIsInForeground, @"");
-    XCTAssertEqual(checkpointR.appLaunchTime, 0, @"");
+    XCTAssertNotEqual(context.appLaunchTime, 0);
 
     XCTAssertEqual(checkpointR.foregroundDurationSinceLaunch, 0.0, @"");
     XCTAssertEqual(checkpointR.backgroundDurationSinceLaunch, 0.0, @"");
@@ -223,7 +223,7 @@
     BSG_KSCrash_State checkpointR = context;
 
     XCTAssertTrue(checkpointR.applicationIsInForeground, @"");
-    XCTAssertEqual(checkpointR.appLaunchTime, 0, @"");
+    XCTAssertNotEqual(context.appLaunchTime, 0);
 
     XCTAssertEqual(checkpointR.foregroundDurationSinceLaunch, 0.0, @"");
     XCTAssertEqual(checkpointR.backgroundDurationSinceLaunch, 0.0, @"");

--- a/Tests/KSCrashTests/KSCrashState_Tests.m
+++ b/Tests/KSCrashTests/KSCrashState_Tests.m
@@ -273,19 +273,6 @@
     XCTAssertTrue(context.crashedLastLaunch, @"");
 }
 
-- (void) testAppLaunchTime
-{
-    BSG_KSCrash_State context = {0};
-    NSString* stateFile = [self.tempPath stringByAppendingPathComponent:@"state.json"];
-    NSData *data = [NSJSONSerialization dataWithJSONObject:@{@"appLaunchTime": @34234235534534 } options:0 error:nil];
-    [data writeToFile:stateFile atomically:YES];
-
-    bsg_kscrashstate_init([stateFile cStringUsingEncoding:NSUTF8StringEncoding],
-                          &context);
-    usleep(1);
-    XCTAssertEqual(34234235534534, context.appLaunchTime);
-}
-
 - (void)testBGFGRelaunch
 {
     BSG_KSCrash_State context = {0};


### PR DESCRIPTION
## Goal

Remove unused code and data to make code more understandable and reduce binary size.

## Changeset

Removes unused fields from KSCrash_State / KSCrashReport:
- foregroundDurationSinceLastCrash (active_time_since_last_crash)
- backgroundDurationSinceLastCrash (background_time_since_last_crash)
- launchesSinceLastCrash (launches_since_last_crash)
- sessionsSinceLastCrash (sessions_since_last_crash)
- sessionsSinceLaunch (sessions_since_launch)

Removes unused JSON parsing code and switches to BSGJSONSerialization for loading previous state.

Moves initialisation of appLaunchTime and lastUpdateDurationsTime to bsg_kscrashstate_init().

## Testing

Amended unit tests and ran E2E scenarios.