### PR TITLE
[PLAT-5601] Fix crash in CPPExceptionTerminate when handling null exception

### DIFF
--- a/features/fixtures/ios/iOSTestApp.xcodeproj/project.pbxproj
+++ b/features/fixtures/ios/iOSTestApp.xcodeproj/project.pbxproj
@@ -37,6 +37,8 @@
 		01F1474425F282E600C2DC65 /* AppHangScenarios.swift in Sources */ = {isa = PBXBuildFile; fileRef = 01F1474325F282E600C2DC65 /* AppHangScenarios.swift */; };
 		01FA9EC426D63BB20059FF4A /* AppHangInTerminationScenario.swift in Sources */ = {isa = PBXBuildFile; fileRef = 01FA9EC326D63BB20059FF4A /* AppHangInTerminationScenario.swift */; };
 		6526A0D4248A83350002E2C9 /* LoadConfigFromFileAutoScenario.swift in Sources */ = {isa = PBXBuildFile; fileRef = 6526A0D3248A83350002E2C9 /* LoadConfigFromFileAutoScenario.swift */; };
+		8A096DF627C7E56C00DB6ECC /* CxxUnexpectedScenario.mm in Sources */ = {isa = PBXBuildFile; fileRef = 8A096DF527C7E56C00DB6ECC /* CxxUnexpectedScenario.mm */; };
+		8A096DFC27C7E77600DB6ECC /* CxxBareThrowScenario.mm in Sources */ = {isa = PBXBuildFile; fileRef = 8A096DFB27C7E77600DB6ECC /* CxxBareThrowScenario.mm */; };
 		8A14F0F62282D4AE00337B05 /* (null) in Sources */ = {isa = PBXBuildFile; };
 		8A32DB8222424E3000EDD92F /* NSExceptionShiftScenario.m in Sources */ = {isa = PBXBuildFile; fileRef = 8A32DB8122424E3000EDD92F /* NSExceptionShiftScenario.m */; };
 		8A38C5D124094D7B00BC4463 /* DiscardedBreadcrumbTypeScenario.swift in Sources */ = {isa = PBXBuildFile; fileRef = 8A38C5D024094D7B00BC4463 /* DiscardedBreadcrumbTypeScenario.swift */; };
@@ -201,6 +203,8 @@
 		01F1474325F282E600C2DC65 /* AppHangScenarios.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = AppHangScenarios.swift; sourceTree = "<group>"; };
 		01FA9EC326D63BB20059FF4A /* AppHangInTerminationScenario.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AppHangInTerminationScenario.swift; sourceTree = "<group>"; };
 		6526A0D3248A83350002E2C9 /* LoadConfigFromFileAutoScenario.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = LoadConfigFromFileAutoScenario.swift; sourceTree = "<group>"; };
+		8A096DF527C7E56C00DB6ECC /* CxxUnexpectedScenario.mm */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.cpp.objcpp; path = CxxUnexpectedScenario.mm; sourceTree = "<group>"; };
+		8A096DFB27C7E77600DB6ECC /* CxxBareThrowScenario.mm */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.objcpp; path = CxxBareThrowScenario.mm; sourceTree = "<group>"; };
 		8A32DB8022424E3000EDD92F /* NSExceptionShiftScenario.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = NSExceptionShiftScenario.h; sourceTree = "<group>"; };
 		8A32DB8122424E3000EDD92F /* NSExceptionShiftScenario.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; path = NSExceptionShiftScenario.m; sourceTree = "<group>"; };
 		8A38C5D024094D7B00BC4463 /* DiscardedBreadcrumbTypeScenario.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = DiscardedBreadcrumbTypeScenario.swift; sourceTree = "<group>"; };
@@ -603,6 +607,8 @@
 				01AF6A52258A112F00FFC803 /* BareboneTestScenarios.swift */,
 				01DCB82A27985D2C0048640A /* ConcurrentCrashesScenario.mm */,
 				01DE903726CE99B800455213 /* CriticalThermalStateScenario.swift */,
+				8A096DFB27C7E77600DB6ECC /* CxxBareThrowScenario.mm */,
+				8A096DF527C7E56C00DB6ECC /* CxxUnexpectedScenario.mm */,
 				0163BFA62583B3CF008DC28B /* DiscardClassesScenarios.swift */,
 				01847DD526453D4E00ADA4C7 /* InvalidCrashReportScenario.m */,
 				017B4133276B8D9B0054C91D /* OnSendErrorPersistenceScenario.m */,
@@ -917,6 +923,7 @@
 				8AEEBBD020FC9E1D00C60763 /* AutoSessionMixedEventsScenario.m in Sources */,
 				E7FDB6C8264D607F00BCF881 /* AutoNotifyReenabledScenario.swift in Sources */,
 				E753F24624927409001FB671 /* NotifyCallbackCrashScenario.swift in Sources */,
+				8A096DFC27C7E77600DB6ECC /* CxxBareThrowScenario.mm in Sources */,
 				AA6ACD1C2773E0B3006464C4 /* UserFromConfigScenario.swift in Sources */,
 				8AF8FCAC22BD1E5400A967CA /* UnhandledInternalNotifyScenario.swift in Sources */,
 				6526A0D4248A83350002E2C9 /* LoadConfigFromFileAutoScenario.swift in Sources */,
@@ -969,6 +976,7 @@
 				F429538D8941382EC2C857CE /* AsyncSafeThreadScenario.m in Sources */,
 				F42955869D33EE0E510B9651 /* ReadGarbagePointerScenario.m in Sources */,
 				01FA9EC426D63BB20059FF4A /* AppHangInTerminationScenario.swift in Sources */,
+				8A096DF627C7E56C00DB6ECC /* CxxUnexpectedScenario.mm in Sources */,
 				8AEFC73420F8D1BB00A78779 /* ManualSessionWithUserScenario.m in Sources */,
 				E753F25424937A83001FB671 /* ThreadScenarios.m in Sources */,
 				F4295B56219D228FAA99BC14 /* ObjCExceptionScenario.m in Sources */,

--- a/features/fixtures/macos/macOSTestApp.xcodeproj/project.pbxproj
+++ b/features/fixtures/macos/macOSTestApp.xcodeproj/project.pbxproj
@@ -136,6 +136,8 @@
 		01F47D32254B1B3100B184AD /* ResumeSessionOOMScenario.m in Sources */ = {isa = PBXBuildFile; fileRef = 01F47CC1254B1B3000B184AD /* ResumeSessionOOMScenario.m */; };
 		01F7365A278D90440000113C /* NetworkBreadcrumbsScenario.swift in Sources */ = {isa = PBXBuildFile; fileRef = 01F73659278D90440000113C /* NetworkBreadcrumbsScenario.swift */; };
 		01FA9EC626D64FFF0059FF4A /* AppHangInTerminationScenario.swift in Sources */ = {isa = PBXBuildFile; fileRef = 01FA9EC526D64FFF0059FF4A /* AppHangInTerminationScenario.swift */; };
+		8A096DF827C7E63A00DB6ECC /* CxxUnexpectedScenario.mm in Sources */ = {isa = PBXBuildFile; fileRef = 8A096DF727C7E63A00DB6ECC /* CxxUnexpectedScenario.mm */; };
+		8A096DFA27C7E6D800DB6ECC /* CxxBareThrowScenario.mm in Sources */ = {isa = PBXBuildFile; fileRef = 8A096DF927C7E6D800DB6ECC /* CxxBareThrowScenario.mm */; };
 		AA6ACD1A2773E098006464C4 /* UserFromConfigScenario.swift in Sources */ = {isa = PBXBuildFile; fileRef = AA6ACD192773E098006464C4 /* UserFromConfigScenario.swift */; };
 		AA6ACD1E2773E39C006464C4 /* UserInfoScenario.swift in Sources */ = {isa = PBXBuildFile; fileRef = AA6ACD1D2773E39C006464C4 /* UserInfoScenario.swift */; };
 		CBB7878E2578FB3F0071BDE4 /* MarkUnhandledHandledScenario.m in Sources */ = {isa = PBXBuildFile; fileRef = CBB7878C2578FB3F0071BDE4 /* MarkUnhandledHandledScenario.m */; };
@@ -348,6 +350,8 @@
 		01FA9EC526D64FFF0059FF4A /* AppHangInTerminationScenario.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = AppHangInTerminationScenario.swift; sourceTree = "<group>"; };
 		2C49722B331FF4B0DC477462 /* Pods-macOSTestApp.release.xcconfig */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.xcconfig; name = "Pods-macOSTestApp.release.xcconfig"; path = "Target Support Files/Pods-macOSTestApp/Pods-macOSTestApp.release.xcconfig"; sourceTree = "<group>"; };
 		5C65BFC9838298CFA8A35072 /* Pods_macOSTestApp.framework */ = {isa = PBXFileReference; explicitFileType = wrapper.framework; includeInIndex = 0; path = Pods_macOSTestApp.framework; sourceTree = BUILT_PRODUCTS_DIR; };
+		8A096DF727C7E63A00DB6ECC /* CxxUnexpectedScenario.mm */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.objcpp; path = CxxUnexpectedScenario.mm; sourceTree = "<group>"; };
+		8A096DF927C7E6D800DB6ECC /* CxxBareThrowScenario.mm */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.cpp.objcpp; path = CxxBareThrowScenario.mm; sourceTree = "<group>"; };
 		AA6ACD192773E098006464C4 /* UserFromConfigScenario.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = UserFromConfigScenario.swift; sourceTree = "<group>"; };
 		AA6ACD1D2773E39C006464C4 /* UserInfoScenario.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = UserInfoScenario.swift; sourceTree = "<group>"; };
 		CBB7878C2578FB3F0071BDE4 /* MarkUnhandledHandledScenario.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; path = MarkUnhandledHandledScenario.m; sourceTree = "<group>"; };
@@ -423,8 +427,10 @@
 				01DE903926CEAD1200455213 /* CriticalThermalStateScenario.swift */,
 				01F47C77254B1B2E00B184AD /* CustomPluginNotifierDescriptionScenario.h */,
 				01F47C85254B1B2F00B184AD /* CustomPluginNotifierDescriptionScenario.m */,
+				8A096DF927C7E6D800DB6ECC /* CxxBareThrowScenario.mm */,
 				01F47C26254B1B2C00B184AD /* CxxExceptionScenario.h */,
 				01F47C8F254B1B2F00B184AD /* CxxExceptionScenario.mm */,
+				8A096DF727C7E63A00DB6ECC /* CxxUnexpectedScenario.mm */,
 				01F47C43254B1B2D00B184AD /* DisabledSessionTrackingScenario.h */,
 				01F47C88254B1B2F00B184AD /* DisabledSessionTrackingScenario.m */,
 				0163BF9A2583AF2A008DC28B /* DiscardClassesScenarios.swift */,
@@ -803,6 +809,7 @@
 				015AE23A276B88300044B1AE /* OnSendErrorPersistenceScenario.m in Sources */,
 				01F47D17254B1B3100B184AD /* ReleaseStageSessionScenario.swift in Sources */,
 				01F47CD2254B1B3100B184AD /* Scenario.m in Sources */,
+				8A096DFA27C7E6D800DB6ECC /* CxxBareThrowScenario.mm in Sources */,
 				017FBFB8254B09C300809042 /* MainWindowController.m in Sources */,
 				01F47CF0254B1B3100B184AD /* OnSendOverwriteScenario.swift in Sources */,
 				01F47D1B254B1B3100B184AD /* SIGSEGVScenario.m in Sources */,
@@ -816,6 +823,7 @@
 				01F47D30254B1B3100B184AD /* AutoContextNSExceptionScenario.swift in Sources */,
 				01F47CE1254B1B3100B184AD /* ManualSessionWithUserScenario.m in Sources */,
 				01FA9EC626D64FFF0059FF4A /* AppHangInTerminationScenario.swift in Sources */,
+				8A096DF827C7E63A00DB6ECC /* CxxUnexpectedScenario.mm in Sources */,
 				01F47D01254B1B3100B184AD /* SessionCallbackOrderScenario.swift in Sources */,
 				01AF6A84258BB38A00FFC803 /* DispatchCrashScenario.swift in Sources */,
 				01F47D0A254B1B3100B184AD /* CxxExceptionScenario.mm in Sources */,

--- a/features/fixtures/shared/scenarios/CxxBareThrowScenario.mm
+++ b/features/fixtures/shared/scenarios/CxxBareThrowScenario.mm
@@ -1,0 +1,25 @@
+//
+//  CxxBareThrowScenario.mm
+//  macOSTestApp
+//
+//  Created by Delisa Fuller on 2/24/22.
+//  Copyright © 2022 Bugsnag Inc. All rights reserved.
+//
+
+#import "Scenario.h"
+#import <stdexcept>
+
+@interface CxxBareThrowScenario : Scenario
+@end
+
+@implementation CxxBareThrowScenario
+
+- (void)run {
+    try {
+        throw;
+    } catch (...) {
+        // hmm!
+    }
+}
+
+@end

--- a/features/fixtures/shared/scenarios/CxxUnexpectedScenario.mm
+++ b/features/fixtures/shared/scenarios/CxxUnexpectedScenario.mm
@@ -1,0 +1,21 @@
+//
+//  CxxUnexpectedScenario.mm
+//  iOSTestApp
+//
+//  Created by Delisa Fuller on 2/24/22.
+//  Copyright © 2022 Bugsnag. All rights reserved.
+//
+
+#import "Scenario.h"
+#import <stdexcept>
+
+@interface CxxUnexpectedScenario : Scenario
+@end
+
+@implementation CxxUnexpectedScenario
+
+- (void)run {
+    std::unexpected();
+}
+
+@end

--- a/features/unhandled_cpp_exception.feature
+++ b/features/unhandled_cpp_exception.feature
@@ -30,12 +30,18 @@ Feature: Thrown C++ exceptions are captured by Bugsnag
 
   Scenario: Throwing without an exception
     When I run "CxxBareThrowScenario" and relaunch the crashed app
+    And I configure Bugsnag for "CxxBareThrowScenario"
     And I wait to receive an error
     Then the error is valid for the error reporting API
-    And the "method" of stack frame 0 equals "-[CxxBareThrowScenario run]"
+    And the exception "errorClass" equals "std::terminate"
+    And the exception "message" equals "throw may have been called without an exception"
+    And the "method" of stack frame 2 equals "-[CxxBareThrowScenario run]"
 
   Scenario: Causing an unexpected event
     When I run "CxxUnexpectedScenario" and relaunch the crashed app
+    And I configure Bugsnag for "CxxUnexpectedScenario"
     And I wait to receive an error
     Then the error is valid for the error reporting API
-    And the "method" of stack frame 0 equals "-[CxxUnexpectedScenario run]"
+    And the exception "errorClass" equals "std::terminate"
+    And the exception "message" equals "throw may have been called without an exception"
+    And the "method" of stack frame 4 equals "-[CxxUnexpectedScenario run]"

--- a/features/unhandled_cpp_exception.feature
+++ b/features/unhandled_cpp_exception.feature
@@ -27,3 +27,15 @@ Feature: Thrown C++ exceptions are captured by Bugsnag
     And the event "unhandled" is false
     And the event "severityReason.unhandledOverridden" is true
     And the event "severityReason.type" equals "unhandledException"
+
+  Scenario: Throwing without an exception
+    When I run "CxxBareThrowScenario" and relaunch the crashed app
+    And I wait to receive an error
+    Then the error is valid for the error reporting API
+    And the "method" of stack frame 0 equals "-[CxxBareThrowScenario run]"
+
+  Scenario: Causing an unexpected event
+    When I run "CxxUnexpectedScenario" and relaunch the crashed app
+    And I wait to receive an error
+    Then the error is valid for the error reporting API
+    And the "method" of stack frame 0 equals "-[CxxUnexpectedScenario run]"


### PR DESCRIPTION
## Goal

Fixes a crash in Bugsnag's std::terminate_handler (`CPPExceptionTerminate()`) if `throw` is called without an exception or `std::unexpected()` is called, that manifests itself as:

```
EXC_BAD_ACCESS: Stack overflow in ...

CPPExceptionTerminate
std::__terminate
std::terminate
CPPExceptionTerminate
std::__terminate
std::terminate
CPPExceptionTerminate
std::__terminate
std::terminate
(etc.)
```

## Changeset

Skips the "rethrow" logic and gets the current backtrace if there is no current exception.

```
errorClass: "std::terminate"
message: "throw may have been called without an exception"
```

## Testing

Amended E2E scenarios and verified fix on iOS and macOS.

Props to @kattrali for finding the repro case and identifying the solution! 🎉 