### PR TITLE
Upload maze runner files for failed scenarios

### DIFF
--- a/.buildkite/pipeline.full.yml
+++ b/.buildkite/pipeline.full.yml
@@ -14,8 +14,9 @@ steps:
     agents:
       queue: opensource
     plugins:
-      artifacts#v1.3.0:
+      artifacts#v1.5.0:
         download: ["features/fixtures/ios/output/iOSTestApp.ipa"]
+        upload: "maze_output/failed/**/*"
       docker-compose#v3.7.0:
         pull: cocoa-maze-runner
         run: cocoa-maze-runner
@@ -41,8 +42,9 @@ steps:
     agents:
       queue: opensource
     plugins:
-      artifacts#v1.3.0:
+      artifacts#v1.5.0:
         download: ["features/fixtures/ios/output/iOSTestApp.ipa"]
+        upload: "maze_output/failed/**/*"
       docker-compose#v3.7.0:
         pull: cocoa-maze-runner
         run: cocoa-maze-runner
@@ -68,7 +70,7 @@ steps:
     agents:
       queue: opensource
     plugins:
-      artifacts#v1.3.0:
+      artifacts#v1.5.0:
         download: "features/fixtures/ios/output/ipa_url.txt"
         upload: "maze_output/failed/**/*"
       docker-compose#v3.7.0:
@@ -97,7 +99,7 @@ steps:
     agents:
       queue: opensource
     plugins:
-      artifacts#v1.3.0:
+      artifacts#v1.5.0:
         download: "features/fixtures/ios/output/ipa_url.txt"
         upload: "maze_output/failed/**/*"
       docker-compose#v3.7.0:
@@ -126,7 +128,7 @@ steps:
     agents:
       queue: opensource
     plugins:
-      artifacts#v1.3.0:
+      artifacts#v1.5.0:
         download: "features/fixtures/ios/output/ipa_url.txt"
         upload: "maze_output/failed/**/*"
       docker-compose#v3.7.0:
@@ -155,7 +157,7 @@ steps:
     agents:
       queue: opensource
     plugins:
-      artifacts#v1.3.0:
+      artifacts#v1.5.0:
         download: "features/fixtures/ios/output/ipa_url.txt"
         upload: "maze_output/failed/**/*"
       docker-compose#v3.7.0:
@@ -186,7 +188,7 @@ steps:
     agents:
       queue: opensource
     plugins:
-      artifacts#v1.3.0:
+      artifacts#v1.5.0:
         download: "features/fixtures/ios/output/ipa_url.txt"
         upload: "maze_output/failed/**/*"
       docker-compose#v3.7.0:
@@ -217,7 +219,7 @@ steps:
     agents:
       queue: opensource
     plugins:
-      artifacts#v1.3.0:
+      artifacts#v1.5.0:
         download: "features/fixtures/ios/output/ipa_url.txt"
         upload: "maze_output/failed/**/*"
       docker-compose#v3.7.0:
@@ -246,7 +248,7 @@ steps:
     agents:
       queue: opensource-mac-cocoa-11
     plugins:
-      artifacts#v1.3.0:
+      artifacts#v1.5.0:
         download: ["features/fixtures/macos/output/macOSTestApp.zip"]
         upload: ["macOSTestApp.log", "appium_server.log", "maze_output/failed/**/*"]
     commands:
@@ -266,7 +268,7 @@ steps:
     agents:
       queue: opensource-arm-mac-cocoa-12
     plugins:
-      artifacts#v1.3.0:
+      artifacts#v1.5.0:
         download: "features/fixtures/macos/output/macOSTestApp.zip"
         upload:
           - "macOSTestApp.log"
@@ -289,7 +291,7 @@ steps:
     agents:
       queue: opensource-mac-cocoa-10.13
     plugins:
-      artifacts#v1.3.0:
+      artifacts#v1.5.0:
         download: ["features/fixtures/macos/output/macOSTestApp.zip"]
         upload: ["macOSTestApp.log", "appium_server.log", "maze_output/failed/**/*"]
     commands:
@@ -309,7 +311,7 @@ steps:
     agents:
       queue: opensource-mac-cocoa-10.14
     plugins:
-      artifacts#v1.3.0:
+      artifacts#v1.5.0:
         download: ["features/fixtures/macos/output/macOSTestApp.zip"]
         upload: ["macOSTestApp.log", "appium_server.log", "maze_output/failed/**/*"]
     commands:

--- a/.buildkite/pipeline.quick.yml
+++ b/.buildkite/pipeline.quick.yml
@@ -121,7 +121,7 @@ steps:
     agents:
       queue: opensource-mac-cocoa-10.15
     plugins:
-      artifacts#v1.3.0:
+      artifacts#v1.5.0:
         download: ["features/fixtures/macos/output/macOSTestApp.zip"]
         upload: ["macOSTestApp.log", "appium_server.log", "maze_output/failed/**/*"]
     commands:
@@ -141,7 +141,7 @@ steps:
     agents:
       queue: opensource
     plugins:
-      artifacts#v1.3.0:
+      artifacts#v1.5.0:
         download: "features/fixtures/ios/output/ipa_url.txt"
         upload: "maze_output/failed/**/*"
       docker-compose#v3.7.0:
@@ -170,7 +170,7 @@ steps:
     agents:
       queue: opensource
     plugins:
-      artifacts#v1.3.0:
+      artifacts#v1.5.0:
         download: "features/fixtures/ios/output/ipa_url.txt"
         upload: "maze_output/failed/**/*"
       docker-compose#v3.7.0:
@@ -199,7 +199,7 @@ steps:
     agents:
       queue: opensource
     plugins:
-      artifacts#v1.3.0:
+      artifacts#v1.5.0:
         download: "features/fixtures/ios/output/ipa_url.txt"
         upload: "maze_output/failed/**/*"
       docker-compose#v3.7.0:
@@ -228,7 +228,7 @@ steps:
     agents:
       queue: opensource
     plugins:
-      artifacts#v1.3.0:
+      artifacts#v1.5.0:
         download: "features/fixtures/ios/output/ipa_url.txt"
         upload: "maze_output/failed/**/*"
       docker-compose#v3.7.0:

--- a/.buildkite/pipeline.yml
+++ b/.buildkite/pipeline.yml
@@ -48,7 +48,7 @@ steps:
     commands:
       - ./scripts/build-carthage.sh
     plugins:
-      artifacts#v1.3.0:
+      artifacts#v1.5.0:
         upload: "features/fixtures/carthage/carthage-*.log"
 
   ##############################################################################
@@ -133,7 +133,7 @@ steps:
     agents:
       queue: opensource
     plugins:
-      artifacts#v1.3.0:
+      artifacts#v1.5.0:
         download: "features/fixtures/ios/output/ipa_url.txt"
         upload: "maze_output/failed/**/*"
       docker-compose#v3.7.0:
@@ -161,7 +161,7 @@ steps:
     agents:
       queue: opensource
     plugins:
-      artifacts#v1.3.0:
+      artifacts#v1.5.0:
         download: "features/fixtures/ios/output/ipa_url.txt"
         upload: "maze_output/failed/**/*"
       docker-compose#v3.7.0:
@@ -190,7 +190,7 @@ steps:
     agents:
       queue: opensource-mac-cocoa-10.13
     plugins:
-      artifacts#v1.3.0:
+      artifacts#v1.5.0:
         download: "features/fixtures/macos/output/macOSTestApp.zip"
         upload:
           - "macOSTestApp.log"
@@ -214,7 +214,7 @@ steps:
     agents:
       queue: opensource-mac-cocoa-10.15
     plugins:
-      artifacts#v1.3.0:
+      artifacts#v1.5.0:
         download: "features/fixtures/macos/output/macOSTestApp.zip"
         upload:
           - "macOSTestApp.log"
@@ -238,7 +238,7 @@ steps:
     agents:
       queue: opensource-arm-mac-cocoa-12
     plugins:
-      artifacts#v1.3.0:
+      artifacts#v1.5.0:
         download: "features/fixtures/macos/output/macOSTestApp.zip"
         upload:
           - "macOSTestApp.log"


### PR DESCRIPTION
## Goal

Upload maze runner files for failed scenarios.

## Changeset

I've also bumped the Buildkite artifacts plugin (no immediate benefit, but good to try and follow the latest).

## Testing

Covered by CI.