### PR TITLE
macOS Appium removal tweaks

### DIFF
--- a/features/steps/app_steps.rb
+++ b/features/steps/app_steps.rb
@@ -172,5 +172,7 @@ def run_macos_app
     'features/fixtures/macos/output/macOSTestApp.app/Contents/MacOS/macOSTestApp',
     [:err, :out] => ['macOSTestApp.log', File::APPEND|File::CREAT|File::RDWR]
   )
-  sleep(0.2)
+  # Ideally we would wait until we know the scenario's run method has been executed.
+  # We need to sleep to prevent tests calling Then('the app is not running') before the fixture has started.
+  sleep 1
 end

--- a/features/steps/app_steps.rb
+++ b/features/steps/app_steps.rb
@@ -170,8 +170,7 @@ def run_macos_app
   $fixture_pid = Process.spawn(
     Maze::Runner.environment,
     'features/fixtures/macos/output/macOSTestApp.app/Contents/MacOS/macOSTestApp',
-    [:err, :out] => 'macOSTestApp.log'
+    [:err, :out] => ['macOSTestApp.log', File::APPEND|File::CREAT|File::RDWR]
   )
   sleep(0.2)
 end
-

--- a/features/support/env.rb
+++ b/features/support/env.rb
@@ -62,16 +62,13 @@ Maze.hooks.after do |scenario|
 
   if Maze.config.os == 'macos'
     FileUtils.mv('/tmp/kscrash.log', path)
+    FileUtils.mv('macOSTestApp.log', path)
+    Process.kill('KILL', $fixture_pid) if $fixture_pid
+    $fixture_pid = nil
   else
     data = Maze.driver.pull_file '@com.bugsnag.iOSTestApp/Documents/kscrash.log'
     File.open(File.join(path, 'kscrash.log'), 'wb') { |file| file << data }
   end
 rescue
   # pull_file can fail on BrowserStack iOS 10 with "Error: Command 'umount' not found"
-end
-
-if Maze.config.os.eql?('macos')
-  Maze.hooks.after do |_scenario|
-    Process.kill('KILL', $fixture_pid) if $fixture_pid
-  end
 end


### PR DESCRIPTION
* Stops fixture's log being truncated when relaunched in a scenario.
* Captures fixture's log in maze_output.
* Increases and documents launch delay.
