### PR TITLE
[PLAT-8137] Fix flake in thermal_state.feature:45

### DIFF
--- a/features/thermal_state.feature
+++ b/features/thermal_state.feature
@@ -39,6 +39,7 @@ Feature: Thermal State
     And I wait to receive a session
     And I discard the oldest session
     And I send the app to the background
+    And I wait for 1 seconds
     And I relaunch the app
     And I configure Bugsnag for "CriticalThermalStateScenario"
     And I wait to receive a session


### PR DESCRIPTION
## Goal

Fix flake in `thermal_state.feature:45`

Supersedes #1318

App was being killed too soon after being sent to the background, sometimes before `UIApplicationDidEnterBackgroundNotification` was received or handled by the app.

## Changeset

Adds a 1 second delay before relaunching test fixture.

## Testing

Full CI run - https://buildkite.com/bugsnag/bugsnag-cocoa/builds/5124