### PR TITLE
Add unit testing on iOS/tvOS 15

### DIFF
--- a/.buildkite/pipeline.full.yml
+++ b/.buildkite/pipeline.full.yml
@@ -250,7 +250,7 @@ steps:
     plugins:
       artifacts#v1.5.0:
         download: ["features/fixtures/macos/output/macOSTestApp.zip"]
-        upload: ["macOSTestApp.log", "appium_server.log", "maze_output/failed/**/*"]
+        upload: ["macOSTestApp.log", "maze_output/failed/**/*"]
     commands:
       - bundle install
       - bundle exec maze-runner
@@ -271,7 +271,6 @@ steps:
         download: "features/fixtures/macos/output/macOSTestApp.zip"
         upload:
           - "macOSTestApp.log"
-          - "appium_server.log"
           - "maze_output/failed/**/*"
     commands:
       - bundle config set --local path 'vendor/bundle'
@@ -291,7 +290,7 @@ steps:
     plugins:
       artifacts#v1.5.0:
         download: ["features/fixtures/macos/output/macOSTestApp.zip"]
-        upload: ["macOSTestApp.log", "appium_server.log", "maze_output/failed/**/*"]
+        upload: ["macOSTestApp.log", "maze_output/failed/**/*"]
     commands:
       - bundle install
       - bundle exec maze-runner
@@ -310,7 +309,7 @@ steps:
     plugins:
       artifacts#v1.5.0:
         download: ["features/fixtures/macos/output/macOSTestApp.zip"]
-        upload: ["macOSTestApp.log", "appium_server.log", "maze_output/failed/**/*"]
+        upload: ["macOSTestApp.log", "maze_output/failed/**/*"]
     commands:
       - bundle install
       - bundle exec maze-runner

--- a/.buildkite/pipeline.full.yml
+++ b/.buildkite/pipeline.full.yml
@@ -30,6 +30,7 @@ steps:
           - "--order=random"
     concurrency: 9
     concurrency_group: browserstack-app
+    concurrency_method: eager
     retry:
       automatic:
         - exit_status: -1  # Agent was lost
@@ -58,6 +59,7 @@ steps:
           - "--order=random"
     concurrency: 9
     concurrency_group: browserstack-app
+    concurrency_method: eager
     retry:
       automatic:
         - exit_status: -1  # Agent was lost

--- a/.buildkite/pipeline.quick.yml
+++ b/.buildkite/pipeline.quick.yml
@@ -123,7 +123,7 @@ steps:
     plugins:
       artifacts#v1.5.0:
         download: ["features/fixtures/macos/output/macOSTestApp.zip"]
-        upload: ["macOSTestApp.log", "appium_server.log", "maze_output/failed/**/*"]
+        upload: ["macOSTestApp.log", "maze_output/failed/**/*"]
     commands:
       - bundle install
       - bundle exec maze-runner

--- a/.buildkite/pipeline.quick.yml
+++ b/.buildkite/pipeline.quick.yml
@@ -25,25 +25,12 @@ steps:
     artifact_paths:
       - logs/*
 
-  - label: iOS 13 unit tests
+  - label: iOS 14 unit tests
     timeout_in_minutes: 10
     agents:
       queue: opensource-arm-mac-cocoa-12
-    concurrency: 3
-    concurrency_group: cocoa-unit-tests
     commands:
-      - ./scripts/run-unit-tests.sh PLATFORM=iOS OS=13.7
-    artifact_paths:
-      - logs/*
-
-  - label: iOS 12 unit tests
-    timeout_in_minutes: 10
-    agents:
-      queue: opensource-arm-mac-cocoa-12
-    concurrency: 3
-    concurrency_group: cocoa-unit-tests
-    commands:
-      - ./scripts/run-unit-tests.sh PLATFORM=iOS OS=12.4
+      - ./scripts/run-unit-tests.sh PLATFORM=iOS OS=14.5
     artifact_paths:
       - logs/*
 
@@ -51,8 +38,6 @@ steps:
     timeout_in_minutes: 10
     agents:
       queue: opensource-mac-cocoa-11
-    concurrency: 3
-    concurrency_group: cocoa-unit-tests
     commands:
       - ./scripts/run-unit-tests.sh PLATFORM=iOS OS=11.4
     artifact_paths:
@@ -67,25 +52,12 @@ steps:
     artifact_paths:
       - logs/*
 
-  - label: tvOS 13 unit tests
+  - label: tvOS 14 unit tests
     timeout_in_minutes: 10
     agents:
       queue: opensource-arm-mac-cocoa-12
-    concurrency: 3
-    concurrency_group: cocoa-unit-tests
     commands:
-      - ./scripts/run-unit-tests.sh PLATFORM=tvOS OS=13.4
-    artifact_paths:
-      - logs/*
-
-  - label: tvOS 12 unit tests
-    timeout_in_minutes: 10
-    agents:
-      queue: opensource-arm-mac-cocoa-12
-    concurrency: 3
-    concurrency_group: cocoa-unit-tests
-    commands:
-      - ./scripts/run-unit-tests.sh PLATFORM=tvOS OS=12.4
+      - ./scripts/run-unit-tests.sh PLATFORM=tvOS OS=14.5
     artifact_paths:
       - logs/*
 
@@ -93,8 +65,6 @@ steps:
     timeout_in_minutes: 10
     agents:
       queue: opensource-mac-cocoa-11
-    concurrency: 3
-    concurrency_group: cocoa-unit-tests
     commands:
       - ./scripts/run-unit-tests.sh PLATFORM=tvOS OS=11.4
     artifact_paths:

--- a/.buildkite/pipeline.yml
+++ b/.buildkite/pipeline.yml
@@ -33,8 +33,6 @@ steps:
     timeout_in_minutes: 10
     agents:
       queue: opensource-arm-mac-cocoa-12
-    concurrency: 3
-    concurrency_group: cocoa-unit-tests
     commands:
       - make build_swift
       - make build_ios_static
@@ -43,8 +41,6 @@ steps:
     timeout_in_minutes: 15
     agents:
       queue: opensource-arm-mac-cocoa-12
-    concurrency: 3
-    concurrency_group: cocoa-unit-tests
     commands:
       - ./scripts/build-carthage.sh
     plugins:
@@ -69,8 +65,6 @@ steps:
     timeout_in_minutes: 10
     agents:
       queue: opensource-mac-cocoa-10.15
-    concurrency: 3
-    concurrency_group: cocoa-unit-tests
     commands:
       - ./scripts/run-unit-tests.sh PLATFORM=macOS
     artifact_paths:
@@ -85,12 +79,12 @@ steps:
     artifact_paths:
       - logs/*
 
-  - label: iOS 14 unit tests
+  - label: iOS 15 unit tests
     timeout_in_minutes: 10
     agents:
       queue: opensource-arm-mac-cocoa-12
     commands:
-      - ./scripts/run-unit-tests.sh PLATFORM=iOS OS=14.5
+      - ./scripts/run-unit-tests.sh PLATFORM=iOS OS=15.0
     artifact_paths:
       - logs/*
 
@@ -103,12 +97,12 @@ steps:
     artifact_paths:
       - logs/*
 
-  - label: tvOS 14 unit tests
+  - label: tvOS 15 unit tests
     timeout_in_minutes: 10
     agents:
       queue: opensource-arm-mac-cocoa-12
     commands:
-      - ./scripts/run-unit-tests.sh PLATFORM=tvOS OS=14.5
+      - ./scripts/run-unit-tests.sh PLATFORM=tvOS OS=15.0
     artifact_paths:
       - logs/*
 

--- a/.buildkite/pipeline.yml
+++ b/.buildkite/pipeline.yml
@@ -194,7 +194,6 @@ steps:
         download: "features/fixtures/macos/output/macOSTestApp.zip"
         upload:
           - "macOSTestApp.log"
-          - "appium_server.log"
           - "maze_output/failed/**/*"
     commands:
       - bundle install
@@ -217,7 +216,6 @@ steps:
         download: "features/fixtures/macos/output/macOSTestApp.zip"
         upload:
           - "macOSTestApp.log"
-          - "appium_server.log"
           - "maze_output/failed/**/*"
     commands:
       - bundle install
@@ -240,7 +238,6 @@ steps:
         download: "features/fixtures/macos/output/macOSTestApp.zip"
         upload:
           - "macOSTestApp.log"
-          - "appium_server.log"
           - "maze_output/failed/**/*"
     commands:
       - bundle config set --local path 'vendor/bundle'


### PR DESCRIPTION
## Goal

Adds unit tests on iOS/tvOS 15.

## Changeset

- The existing tests for iOS/tvOS 14 are moved to the "quick" build level an 12/13 dropped entirely due to flakes running on Rosetta and limited value overall.
- Clears away some remnants of Appium use
- Removes the concurrency group used to control the number of unit tests running.  We have more servers and they run so quickly it's not needed.

## Testing

Covered by a full CI run.