### PR TITLE
Use /command endpoint on macOS

### DIFF
--- a/features/fixtures/macos/macOSTestApp/AppDelegate.m
+++ b/features/fixtures/macos/macOSTestApp/AppDelegate.m
@@ -13,7 +13,7 @@
 
 @interface AppDelegate ()
 
-@property NSWindowController *mainWindowController;
+@property MainWindowController *mainWindowController;
 
 @end
 
@@ -21,27 +21,29 @@
 
 @implementation AppDelegate
 
+- (BOOL)launchedByMazeRunner {
+    return [[[NSProcessInfo processInfo] environment] objectForKey:@"MAZE_RUNNER"] != nil;
+}
+
 - (void)applicationDidFinishLaunching:(NSNotification *)notification {
     self.mainWindowController = [[MainWindowController alloc] initWithWindowNibName:@"MainWindowController"];
     [self.mainWindowController showWindow:self];
-    [NSApp activateIgnoringOtherApps:YES];
+    
+    if ([self launchedByMazeRunner]) {
+        [NSApp activateIgnoringOtherApps:YES];
+    }
+}
+
+- (void)applicationDidBecomeActive:(NSNotification *)notification {
+    static BOOL once;
+    if (!once && [self launchedByMazeRunner]) {
+        once = YES;
+        [self.mainWindowController executeMazeRunnerCommand:self];
+    }
 }
 
 - (BOOL)applicationShouldTerminateAfterLastWindowClosed:(NSApplication *)sender {
     return YES;
-}
-
-- (void)application:(NSApplication *)application openURLs:(NSArray<NSURL *> *)urls {
-    NSLog(@"%s %@", __PRETTY_FUNCTION__, urls);
-    for (NSURL *url in urls) {
-        if ([url.scheme isEqualToString:@"macOSTestApp"] &&
-            [url.path isEqualToString:@"/mainWindowController"]) {
-            NSURLComponents *components = [NSURLComponents componentsWithURL:url resolvingAgainstBaseURL:NO];
-            for (NSURLQueryItem *queryItem in components.queryItems) {
-                [self.mainWindowController setValue:queryItem.value forKeyPath:queryItem.name];
-            }
-        }
-    }
 }
 
 @end

--- a/features/fixtures/macos/macOSTestApp/MainWindowController.h
+++ b/features/fixtures/macos/macOSTestApp/MainWindowController.h
@@ -12,6 +12,8 @@ NS_ASSUME_NONNULL_BEGIN
 
 @interface MainWindowController : NSWindowController
 
+- (IBAction)executeMazeRunnerCommand:(id)sender;
+
 @end
 
 NS_ASSUME_NONNULL_END

--- a/features/fixtures/macos/macOSTestApp/MainWindowController.m
+++ b/features/fixtures/macos/macOSTestApp/MainWindowController.m
@@ -24,8 +24,6 @@ static void BSLog(NSString *format, ...) NS_FORMAT_FUNCTION(1,2) NS_NO_TAIL_CALL
 @property (copy) NSString *scenarioName;
 @property (copy) NSString *sessionEndpoint;
 
-@property Boolean automatedMode;
-
 @end
 
 #pragma mark -
@@ -38,14 +36,6 @@ static void BSLog(NSString *format, ...) NS_FORMAT_FUNCTION(1,2) NS_NO_TAIL_CALL
     self.apiKey = @"12312312312312312312312312312312";
     self.notifyEndpoint = @"http://localhost:9339/notify";
     self.sessionEndpoint = @"http://localhost:9339/sessions";
-    self.automatedMode = true;
-    
-    if (self.automatedMode) {
-        dispatch_async(dispatch_get_main_queue(), ^{
-            [self performSelector:@selector(startUsingEnvironment) withObject:nil afterDelay:0.1];
-        });
-
-    }
 }
 
 - (BugsnagConfiguration *)configuration {
@@ -106,24 +96,6 @@ static void BSLog(NSString *format, ...) NS_FORMAT_FUNCTION(1,2) NS_NO_TAIL_CALL
         self.scenarioName = scenarioName;
         self.scenarioMetadata = eventMode;
     }];
-}
-
-- (void) startUsingEnvironment {
-    BSLog(@"Running in Automated mode using environment variables");
-    NSDictionary *environment = [[NSProcessInfo processInfo] environment];
-    self.scenarioName = [environment objectForKey:@"BUGSNAG_SCENARIO_NAME"];
-    self.scenarioMetadata = [environment objectForKey:@"BUGSNAG_SCENARIO_METADATA"];
-    NSString *clearData = (NSString *)[environment objectForKey:@"BUGSNAG_CLEAR_DATA"];
-    if ([clearData isEqualToString:@"true"]) {
-        [self clearPersistentData:nil];
-    }
-    NSString *action = (NSString *)[environment objectForKey:@"BUGSNAG_SCENARIO_ACTION"];
-    BSLog(@"Received action: %@ for scenario: %@ and metadata: %@", action, self.scenarioName, self.scenarioMetadata);
-    if ([action isEqualToString:@"run_scenario"]) {
-        [self runScenario:nil];
-    } else if ([action isEqualToString:@"start_bugsnag"]) {
-        [self startBugsnag:nil];
-    }
 }
 
 @end

--- a/features/fixtures/macos/macOSTestApp/main.m
+++ b/features/fixtures/macos/macOSTestApp/main.m
@@ -8,8 +8,6 @@
 
 #import <Cocoa/Cocoa.h>
 
-extern void _LSUnregisterURL(CFURLRef url);
-
 void NotificationCallback(CFNotificationCenterRef center, void *observer, CFNotificationName cfName, const void *object, CFDictionaryRef userInfo) {
     NSString *name = (__bridge NSString *)cfName;
     // Ignore high-frequency notifications
@@ -34,29 +32,6 @@ int main(int argc, const char * argv[]) {
         // Stop NSApplication swallowing NSExceptions thrown on the main thread.
         @"NSApplicationCrashOnExceptions": @YES,
     }];
-    
-    if ([NSProcessInfo.processInfo.arguments containsObject:@"-register"]) {
-        NSLog(@"Registering with Launch Services and exiting...");
-        
-        NSURL *appURL = NSBundle.mainBundle.bundleURL;
-        NSString *bundleId = NSBundle.mainBundle.bundleIdentifier;
-        for (NSURL *url in CFBridgingRelease(LSCopyApplicationURLsForBundleIdentifier((__bridge CFStringRef)bundleId, NULL))) {
-            if (![url isEqual:appURL]) {
-                NSLog(@"LSUnregisterURL %@", url.path);
-                _LSUnregisterURL((__bridge CFURLRef)url);
-            }
-        }
-        
-        NSLog(@"LSRegisterURL %@", appURL.path);
-        OSStatus status = LSRegisterURL((__bridge CFURLRef)appURL, true);
-        if (status != noErr) {
-            NSLog(@"LSRegisterURL failed: %d", status);
-        }
-        
-        return 0;
-    }
-    
-    NSLog(@"bundlePath = %@", NSBundle.mainBundle.bundlePath);
     
     // Log (almost) all notifications to aid in diagnosing Appium test flakes
     CFNotificationCenterAddObserver(CFNotificationCenterGetLocalCenter(),

--- a/features/fixtures/macos/macOSTestApp/main.m
+++ b/features/fixtures/macos/macOSTestApp/main.m
@@ -8,20 +8,6 @@
 
 #import <Cocoa/Cocoa.h>
 
-void NotificationCallback(CFNotificationCenterRef center, void *observer, CFNotificationName cfName, const void *object, CFDictionaryRef userInfo) {
-    NSString *name = (__bridge NSString *)cfName;
-    // Ignore high-frequency notifications
-    if (name == NSMenuDidAddItemNotification ||
-        name == NSMenuDidChangeItemNotification ||
-        name == NSViewDidUpdateTrackingAreasNotification ||
-        name == NSViewFrameDidChangeNotification ||
-        [name hasSuffix:@"UpdateNotification"] ||
-        false) {
-        return;
-    }
-    NSLog(@"%@", name);
-}
-
 int main(int argc, const char * argv[]) {
     [[NSUserDefaults standardUserDefaults] registerDefaults:@{
         // Disable state restoration to prevent the following dialog being shown after crashes
@@ -32,11 +18,6 @@ int main(int argc, const char * argv[]) {
         // Stop NSApplication swallowing NSExceptions thrown on the main thread.
         @"NSApplicationCrashOnExceptions": @YES,
     }];
-    
-    // Log (almost) all notifications to aid in diagnosing Appium test flakes
-    CFNotificationCenterAddObserver(CFNotificationCenterGetLocalCenter(),
-                                    NULL, NotificationCallback, NULL, NULL,
-                                    CFNotificationSuspensionBehaviorDeliverImmediately);
     
     return NSApplicationMain(argc, argv);
 }

--- a/features/fixtures/shared/scenarios/Scenario.m
+++ b/features/fixtures/shared/scenarios/Scenario.m
@@ -30,6 +30,32 @@ static char ksLogPath[PATH_MAX];
     dispatch_block_t _onEventDelivery;
 }
 
++ (void)load {
+    [[NSNotificationCenter defaultCenter] addObserverForName:nil object:nil queue:nil usingBlock:^(NSNotification *notification) {
+        for (NSString *prefix in @[@"NSAutomaticFocusRingChanged",
+                                   @"NSBundleDidLoadNotification",
+                                   @"NSMenu",
+                                   @"NSTextStorage",
+                                   @"NSTextView",
+                                   @"NSThreadWillExitNotification",
+                                   @"NSUndoManagerCheckpointNotification",
+                                   @"NSViewDidUpdateTrackingAreasNotification",
+                                   @"NSViewFrameDidChangeNotification",
+                                   @"UIScreenBrightnessDidChangeNotification",
+                                   @"_"]) {
+            if ([notification.name hasPrefix:prefix]) {
+                return;
+            }
+        }
+#if TARGET_OS_OSX
+        if ([notification.name hasSuffix:@"UpdateNotification"]) {
+            return;
+        }
+#endif
+        NSLog(@"%@", notification.name);
+    }];
+}
+
 + (Scenario *)createScenarioNamed:(NSString *)className withConfig:(BugsnagConfiguration *)config {
     Class class = NSClassFromString(className) ?:
     NSClassFromString([@"iOSTestApp." stringByAppendingString:className]) ?:

--- a/features/fixtures/shared/scenarios/Scenario.m
+++ b/features/fixtures/shared/scenarios/Scenario.m
@@ -123,7 +123,7 @@ static NSURLSessionUploadTask * uploadTaskWithRequest_fromData_completionHandler
 }
 
 + (void)clearPersistentData {
-    NSLog(@"Clear persistent data");
+    NSLog(@"%s", __PRETTY_FUNCTION__);
     [NSUserDefaults.standardUserDefaults removePersistentDomainForName:NSBundle.mainBundle.bundleIdentifier];
     NSString *cachesDir = NSSearchPathForDirectoriesInDomains(NSCachesDirectory, NSUserDomainMask, YES).firstObject;
     NSArray<NSString *> *entries = @[
@@ -155,6 +155,7 @@ static NSURLSessionUploadTask * uploadTaskWithRequest_fromData_completionHandler
 }
 
 + (void)executeMazeRunnerCommand:(void (^)(NSString *action, NSString *scenarioName, NSString *scenarioMode))preHandler {
+    NSLog(@"%s", __PRETTY_FUNCTION__);
     NSURLSession *session = [NSURLSession sessionWithConfiguration:[NSURLSessionConfiguration ephemeralSessionConfiguration]];
     
     NSURLRequest *request = [NSURLRequest requestWithURL:[NSURL URLWithString:@"http://bs-local.com:9339/command"]];
@@ -175,6 +176,10 @@ static NSURLSessionUploadTask * uploadTaskWithRequest_fromData_completionHandler
         NSString *eventMode = [command objectForKey:@"scenario_mode"];
         if ([eventMode isKindOfClass:[NSNull class]]) {
             eventMode = nil;
+        }
+
+        if ([[command objectForKey:@"reset_data"] isEqual:@YES]) {
+            [self clearPersistentData];
         }
 
         dispatch_async(dispatch_get_main_queue(), ^{

--- a/features/steps/app_steps.rb
+++ b/features/steps/app_steps.rb
@@ -146,6 +146,6 @@ def run_macos_app
   $fixture_pid = Process.spawn(
     { 'MAZE_RUNNER' => 'TRUE' },
     'features/fixtures/macos/output/macOSTestApp.app/Contents/MacOS/macOSTestApp',
-    [:err, :out] => ['macOSTestApp.log', File::APPEND|File::CREAT|File::RDWR]
+    %i[err out] => ['macOSTestApp.log', File::APPEND | File::CREAT | File::RDWR]
   )
 end

--- a/features/steps/app_steps.rb
+++ b/features/steps/app_steps.rb
@@ -31,17 +31,7 @@ def run_and_relaunch
 end
 
 When('I clear all persistent data') do
-  platform = Maze::Helper.get_current_platform
-  case platform
-  when 'ios'
-    steps %(
-      When I click the element "clear_persistent_data"
-    )
-  when 'macos'
-    $reset_data = true
-  else
-    raise "Unknown platform: #{platform}"
-  end
+  $reset_data = true
 end
 
 When('I configure Bugsnag for {string}') do |scenario_name|
@@ -116,29 +106,15 @@ end
 
 def execute_command(action, scenario_name)
   platform = Maze::Helper.get_current_platform
-  command = { action: action, scenario_name: scenario_name, scenario_mode: $scenario_mode }
-  case platform
-  when 'ios'
-    Maze::Server.commands.add command
-    trigger_app_command
-    $scenario_mode = nil
-    $reset_data = false
-    # Ensure fixture has read the command
-    count = 100
-    sleep 0.1 until Maze::Server.commands.remaining.empty? || (count -= 1) < 1
-    raise 'Test fixture did not GET /command' unless Maze::Server.commands.remaining.empty?
-  when 'macos'
-    Maze::Runner.environment['BUGSNAG_SCENARIO_ACTION'] = action.to_s
-    Maze::Runner.environment['BUGSNAG_SCENARIO_NAME'] = scenario_name.to_s
-    Maze::Runner.environment['BUGSNAG_SCENARIO_METADATA'] = $scenario_mode.to_s
-    Maze::Runner.environment['BUGSNAG_CLEAR_DATA'] = $reset_data ? 'true' : 'false'
-    $last_scenario = command
-    $scenario_mode = nil
-    run_macos_app
-    $reset_data = false
-  else
-    raise "Unknown platform: #{platform}"
-  end
+  command = { action: action, scenario_name: scenario_name, scenario_mode: $scenario_mode, reset_data: $reset_data }
+  Maze::Server.commands.add command
+  trigger_app_command
+  $scenario_mode = nil
+  $reset_data = false
+  # Ensure fixture has read the command
+  count = 100
+  sleep 0.1 until Maze::Server.commands.remaining.empty? || (count -= 1) < 1
+  raise 'Test fixture did not GET /command' unless Maze::Server.commands.remaining.empty?
 end
 
 def trigger_app_command
@@ -168,11 +144,8 @@ end
 def run_macos_app
   Process.kill('KILL', $fixture_pid) if $fixture_pid
   $fixture_pid = Process.spawn(
-    Maze::Runner.environment,
+    { 'MAZE_RUNNER' => 'TRUE' },
     'features/fixtures/macos/output/macOSTestApp.app/Contents/MacOS/macOSTestApp',
     [:err, :out] => ['macOSTestApp.log', File::APPEND|File::CREAT|File::RDWR]
   )
-  # Ideally we would wait until we know the scenario's run method has been executed.
-  # We need to sleep to prevent tests calling Then('the app is not running') before the fixture has started.
-  sleep 1
 end


### PR DESCRIPTION
## Goal

Use Maze Runner's `/command` endpoint on macOS for consistency with iOS.

## Changeset

Uses the `/command` endpoint to run tests in the macOS fixture, which removes the need to `sleep` after spawning the fixture.

Removes now-unused alternative mechanisms for automation.

Consolidates logging of notifications for consistency between fixtures.

Fixes some Rubocop warnings.

## Testing

Full E2E run on macOS - https://buildkite.com/bugsnag/bugsnag-cocoa/builds/5134#a73d53d2-c677-4f37-b792-8c218f0bf59f