### PR TITLE
docs: add Unreal for version bumps after release

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -159,6 +159,6 @@ Run the integration tests - see [TESTING.md](TESTING.md#end-to-end-tests).
 * Plan to make releases to downstream libraries once adoption of the main
   library has begun, if appropriate (generally for bug fixes).  These include:
   * [bugsnag-js](https://github.com/bugsnag/bugsnag-js) - see [JS Contributing Guide](https://github.com/bugsnag/bugsnag-js/blob/next/packages/react-native/CONTRIBUTING.md#ios)
-  * [bugsnag-cocos2dx](https://github.com/bugsnag/bugsnag-cocos2dx)
   * [bugsnag-unity](https://github.com/bugsnag/bugsnag-unity)
-
+  * [bugsnag-unreal](https://github.com/bugsnag/bugsnag-unreal)
+  * [bugsnag-cocos2dx](https://github.com/bugsnag/bugsnag-cocos2dx) - critical fixes only


### PR DESCRIPTION
## Goal

We now need to push new notifier versions to the Unreal notifier. Updated the Contributing doc to note this.