### PR TITLE
[PLAT-8219] Fix crash when using BugsnagNetworkRequestPlugin alongside New Relic

### DIFF
--- a/BugsnagNetworkRequestPlugin/BugsnagNetworkRequestPlugin/BSGURLSessionTracingProxy.m
+++ b/BugsnagNetworkRequestPlugin/BugsnagNetworkRequestPlugin/BSGURLSessionTracingProxy.m
@@ -36,19 +36,8 @@
     return [self.delegate respondsToSelector:aSelector];
 }
 
-- (NSMethodSignature *)methodSignatureForSelector:(SEL)aSelector {
-    // Note: We allow a race condition on self.tracingDelegate.canTrace because the
-    //       caller has already determined that we respond to selector, and it would
-    //       break things to stop "supporting" it now. We'll catch this edge case in
-    //       forwardInvocation, and again in the call to tracingDelegate.
-    if (sel_isEqual(aSelector, METRICS_SELECTOR)) {
-        return [(NSObject *)self.tracingDelegate methodSignatureForSelector:aSelector];
-    }
-    return [(NSObject *)self.delegate methodSignatureForSelector:aSelector];
-}
-
-- (void)forwardInvocation:(NSInvocation *)invocation {
-    [invocation invokeWithTarget:self.delegate];
+- (id)forwardingTargetForSelector:(__unused SEL)aSelector {
+    return self.delegate;
 }
 
 - (void)URLSession:(NSURLSession *)session task:(NSURLSessionTask *)task didFinishCollectingMetrics:(NSURLSessionTaskMetrics *)metrics

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,13 @@
 Changelog
 =========
 
+## TBD
+
+### Bug fixes
+
+* Fix `-[NSProxy doesNotRecognizeSelector:]` crash when using `BugsnagNetworkRequestPlugin` in projects that use the New Relic SDK.
+  [#1324](https://github.com/bugsnag/bugsnag-cocoa/pull/1324)
+
 ## 6.16.4 (2022-03-02)
 
 ### Bug fixes


### PR DESCRIPTION
## Goal

Fix a crash that occurs when `BugsnagNetworkRequestPlugin` is linked into a project that uses the New Relic.

<details><summary>Sample crash:</summary>

```
2022-03-25 12:00:40.842579+0000 NetApp[27482:2012467] *** Terminating app due to uncaught exception 'NSInvalidArgumentException', reason: '*** -[NSProxy doesNotRecognizeSelector:URLSession:downloadTask:didWriteData:totalBytesWritten:totalBytesExpectedToWrite:] called!'
*** First throw call stack:
(
	0   CoreFoundation                      0x00007fff203feba4 __exceptionPreprocess + 242
	1   libobjc.A.dylib                     0x00007fff201a1be7 objc_exception_throw + 48
	2   Foundation                          0x00007fff208184c2 +[NSProxy instanceMethodSignatureForSelector:] + 0
	3   CoreFoundation                      0x00007fff204030ac ___forwarding___ + 1433
	4   CoreFoundation                      0x00007fff204051d8 _CF_forwarding_prep_0 + 120
	5   CFNetwork                           0x00007fff23e164e5 _CFHostIsDomainTopLevelForCertificatePolicy + 29799
	6   Foundation                          0x00007fff207e24bb __NSBLOCKOPERATION_IS_CALLING_OUT_TO_A_BLOCK__ + 7
	7   Foundation                          0x00007fff207e23b3 -[NSBlockOperation main] + 98
	8   Foundation                          0x00007fff207e53c3 __NSOPERATION_IS_INVOKING_MAIN__ + 17
	9   Foundation                          0x00007fff207e1600 -[NSOperation start] + 785
	10  Foundation                          0x00007fff207e5d17 __NSOPERATIONQUEUE_IS_STARTING_AN_OPERATION__ + 17
	11  Foundation                          0x00007fff207e585c __NSOQSchedule_f + 182
	12  libdispatch.dylib                   0x00000001068bfa76 _dispatch_block_async_invoke2 + 83
	13  libdispatch.dylib                   0x00000001068b0a2c _dispatch_client_callout + 8
	14  libdispatch.dylib                   0x00000001068b73a6 _dispatch_lane_serial_drain + 845
	15  libdispatch.dylib                   0x00000001068b80f2 _dispatch_lane_invoke + 490
	16  libdispatch.dylib                   0x00000001068b71c7 _dispatch_lane_serial_drain + 366
	17  libdispatch.dylib                   0x00000001068b80bc _dispatch_lane_invoke + 436
	18  libdispatch.dylib                   0x00000001068c4472 _dispatch_workloop_worker_thread + 900
	19  libsystem_pthread.dylib             0x00007fff6da2845d _pthread_wqthread + 314
	20  libsystem_pthread.dylib             0x00007fff6da2742f start_wqthread + 15
)
```
</details>

## Changeset

Uses the lighter-weight [forwardingTargetForSelector:](https://developer.apple.com/documentation/objectivec/nsobject/1418855-forwardingtargetforselector?language=objc) mechanism instead of implementing [methodSignatureForSelector:](https://developer.apple.com/documentation/objectivec/nsobject/1571960-methodsignatureforselector?language=objc) and [forwardInvocation:](https://developer.apple.com/documentation/objectivec/nsobject/1571955-forwardinvocation?language=objc).

It's not entirely clear _why_ this fixes the crash, but it does in the example app used, and is also faster 🚀

New Relic's session delegate implements `forwardingTargetForSelector:` rather than `forwardInvocation:` and the crash presumably arose because of the mismatch.

## Testing

Reproduced the crash by creating an example app that uses BugsnagNetworkRequestPlugin, New Relic, and initiates a download task using [Moya](https://github.com/Moya/Moya).