### PR TITLE
Simplify EXC_BAD_ACCESS examples

### DIFF
--- a/examples/objective-c-ios/objective-c-ios/ViewController.m
+++ b/examples/objective-c-ios/objective-c-ios/ViewController.m
@@ -66,12 +66,10 @@
 }
 
 /**
- This method causes a low-level exception from the operating system to terminate the app.  Upon reopening the app this signal should be notified to your Bugsnag dashboard.
+ This method causes an EXC_BAD_ACCESS Mach exception from the operating system to terminate the app.  Upon reopening the app this exception should be notified to your Bugsnag dashboard.
  */
 - (IBAction)generateMachException:(id)sender {
-    // This should result in an EXC_BAD_ACCESS mach exception with code = KERN_INVALID_ADDRESS and subcode = 0xDEADBEEF
-    void (* ptr)(void) = (void *)0xDEADBEEF;
-    ptr();
+    *(int *)0xdeadbeef = 0;
 }
 
 /**

--- a/examples/swift-ios/swift-ios/AnObjCClass.mm
+++ b/examples/swift-ios/swift-ios/AnObjCClass.mm
@@ -55,9 +55,7 @@
 }
 
 - (void)accessInvalidMemoryAddress {
-    // This should result in an EXC_BAD_ACCESS mach exception with code = KERN_INVALID_ADDRESS and subcode = 0xDEADBEEF
-    void (* ptr)(void) = (void (*)(void))0xDEADBEEF;
-    ptr();
+    *(int *)0xdeadbeef = 0;
 }
 
 - (void)throwCxxException {

--- a/examples/swiftui/Shared/AnObjCClass.mm
+++ b/examples/swiftui/Shared/AnObjCClass.mm
@@ -55,9 +55,7 @@
 }
 
 - (void)accessInvalidMemoryAddress {
-    // This should result in an EXC_BAD_ACCESS mach exception with code = KERN_INVALID_ADDRESS and subcode = 0xDEADBEEF
-    void (* ptr)(void) = (void (*)(void))0xDEADBEEF;
-    ptr();
+    *(int *)0xdeadbeef = 0;
 }
 
 - (void)throwCxxException {


### PR DESCRIPTION
## Goal

Generate a better stack trace for the Mach exception / bad memory access example.

## Changeset

Implements this example using a simple memory access instead of jumping to a bad function pointer.

## Testing

Verified manually that stack traces for this example now contains the offending function.