### PR TITLE
[PLAT-8291] Fix flake in features/delivery.feature:6

### DIFF
--- a/features/delivery.feature
+++ b/features/delivery.feature
@@ -7,6 +7,8 @@ Feature: Delivery of errors
     When I set the HTTP status code for the next request to 500
     And I run "HandledExceptionScenario"
     And I wait to receive an error
+    # Wait for fixture to receive the response and save the payload
+    And I wait for 2 seconds
     And I relaunch the app
     And I clear the error queue
     And I configure Bugsnag for "HandledExceptionScenario"


### PR DESCRIPTION
## Goal

Fix flake in `features/delivery.feature:6`

This test scenario would occasionally fail due to the fixture being killed before the payload had been saved for retry.

## Changeset

Waits 2 seconds after sending the HTTP 500 response before relaunching the fixture.

## Testing

Reproduced the failure locally (using a Cucumber "Scenario Outline" to run repeatedly - [example](https://github.com/bugsnag/bugsnag-cocoa/commit/696282fb0ffd9f7c98d32546f7656e46fbf5f6bb#diff-d99ed834631071f576f922e61f1498b5266779e2d50041e5b4f98774bb3d5d54R6)) and verify the fix.