### PR TITLE
[PLAT-8292] Fix duplication of app and device data in session payloads

### DIFF
--- a/Bugsnag/Delivery/BSGSessionUploader.m
+++ b/Bugsnag/Delivery/BSGSessionUploader.m
@@ -20,6 +20,7 @@
 #import "BugsnagSession+Private.h"
 #import "BugsnagSession.h"
 #import "BugsnagSessionFileStore.h"
+#import "BugsnagUser+Private.h"
 
 
 @interface BSGSessionUploader ()
@@ -84,6 +85,9 @@
     }];
 }
 
+//
+// https://bugsnagsessiontrackingapi.docs.apiary.io/#reference/0/session/report-a-session-starting
+//
 - (void)sendSession:(BugsnagSession *)session completionHandler:(nonnull void (^)(BugsnagApiClientDeliveryStatus status))completionHandler {
     NSString *apiKey = [self.config.apiKey copy];
     if (!apiKey) {
@@ -109,7 +113,11 @@
         BSGKeyApp: [session.app toDict] ?: [NSNull null],
         BSGKeyDevice: [session.device toDictionary] ?: [NSNull null],
         BSGKeyNotifier: [self.notifier toDict] ?: [NSNull null],
-        BSGKeySessions: BSGArrayWithObject([session toJson])
+        BSGKeySessions: @[@{
+            BSGKeyId: session.id,
+            BSGKeyStartedAt: [BSG_RFC3339DateTool stringFromDate:session.startedAt] ?: [NSNull null],
+            BSGKeyUser: [session.user toJson] ?: @{}
+        }]
     };
     
     [self.apiClient sendJSONPayload:payload headers:headers toURL:url completionHandler:^(BugsnagApiClientDeliveryStatus status, NSError *error) {

--- a/Bugsnag/Helpers/BSGKeys.h
+++ b/Bugsnag/Helpers/BSGKeys.h
@@ -94,6 +94,7 @@ static BSGKey const BSGKeySeverity                  = @"severity";
 static BSGKey const BSGKeySeverityReason            = @"severityReason";
 static BSGKey const BSGKeySignal                    = @"signal";
 static BSGKey const BSGKeyStacktrace                = @"stacktrace";
+static BSGKey const BSGKeyStartedAt                 = @"startedAt";
 static BSGKey const BSGKeySymbolAddr                = @"symbolAddress";
 static BSGKey const BSGKeySymbolAddress             = @"symbol_addr";
 static BSGKey const BSGKeySymbolName                = @"symbol_name";

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,13 @@
 Changelog
 =========
 
+## TBD
+
+### Bug fixes
+
+* Fix duplication of `app` and `device` data in session payloads.
+  [#1332](https://github.com/bugsnag/bugsnag-cocoa/pull/1332)
+
 ## 6.16.6 (2022-04-06)
 
 ### Changes

--- a/features/steps/cocoa_steps.rb
+++ b/features/steps/cocoa_steps.rb
@@ -109,6 +109,13 @@ Then('the error is valid for the error reporting API ignoring breadcrumb timesta
   else
     raise "Unknown platform: #{platform}"
   end
+  payload = Maze::Server.errors.current[:body]
+  payload['events'].each do |event|
+    session = event['session']
+    # verify that the session contains the expected keys
+    Maze.check.equal(session.keys.sort, %w[events id startedAt]) unless session.nil?
+    Maze.check.equal(session['events'].keys.sort, %w[handled unhandled]) unless session.nil?
+  end
 end
 
 Then('the session is valid for the session reporting API') do
@@ -124,6 +131,13 @@ Then('the session is valid for the session reporting API') do
     )
   else
     raise "Unknown platform: #{platform}"
+  end
+  payload = Maze::Server.sessions.current[:body]
+  # verify that the payload contains the expected keys
+  Maze.check.equal(payload.keys.sort, %w[app device notifier sessions])
+  # verify that each session contains the expected keys
+  payload['sessions'].each do |session|
+    Maze.check.equal(session.keys.sort, %w[id startedAt user])
   end
 end
 


### PR DESCRIPTION
## Goal

Stop `app` and `device` from being included inside the `session` JSON object in addition to being in the top-level payload sent to `sessions.bugsnag.com`.

## Changeset

Constructs the payload using a dictionary literal instead of `-[BugsnagSession toJson]` (which builds a payload suitable for when a session needs to be saved to disk.)

Prior to #1246 `-[BugsnagSession toDictionary]` was used - but that is also unsuitable for use here since it adds the unwanted `"handledCount"` and `"unhandledCount"` fields.

`BugsnagSession` has multiple serialization methods and it's not obvious where each should be used. A follow-up PR will refactor this to reduce the chance of similar bugs being introduced in the future.

## Testing

Altered the E2E steps to very session payload keys for event and session payloads.