### PR TITLE
[PLAT-8290] Fix underreporting of device.totalMemory

### DIFF
--- a/Bugsnag/BugsnagSystemState.m
+++ b/Bugsnag/BugsnagSystemState.m
@@ -142,7 +142,7 @@ static NSMutableDictionary* initCurrentState(BugsnagKVStore *kvstore, BugsnagCon
 #else
     device[@"simulator"] = @NO;
 #endif
-    device[@"totalMemory"] = systemInfo[@BSG_KSSystemField_Memory][@"usable"];
+    device[@"totalMemory"] = systemInfo[@ BSG_KSSystemField_Memory][@ BSG_KSSystemField_Size];
 
     NSMutableDictionary *state = [NSMutableDictionary new];
     state[BSGKeyApp] = app;

--- a/Bugsnag/KSCrash/Source/KSCrash/Recording/BSG_KSCrashReport.c
+++ b/Bugsnag/KSCrash/Source/KSCrash/Recording/BSG_KSCrashReport.c
@@ -1159,8 +1159,6 @@ void bsg_kscrw_i_writeMemoryInfo(const BSG_KSCrashReportWriter *const writer,
                                  const char *const key) {
     writer->beginObject(writer, key);
     {
-        writer->addUIntegerElement(writer, BSG_KSCrashField_Usable,
-                                   bsg_ksmachusableMemory());
         writer->addUIntegerElement(writer, BSG_KSCrashField_Free,
                                    bsg_ksmachfreeMemory());
     }

--- a/Bugsnag/KSCrash/Source/KSCrash/Recording/BSG_KSCrashReportFields.h
+++ b/Bugsnag/KSCrash/Source/KSCrash/Recording/BSG_KSCrashReportFields.h
@@ -115,7 +115,6 @@
 
 #define BSG_KSCrashField_Free "free"
 #define BSG_KSCrashField_Size "size"
-#define BSG_KSCrashField_Usable "usable"
 
 #pragma mark - Error -
 

--- a/Bugsnag/KSCrash/Source/KSCrash/Recording/BSG_KSSystemInfo.m
+++ b/Bugsnag/KSCrash/Source/KSCrash/Recording/BSG_KSSystemInfo.m
@@ -429,7 +429,6 @@ static NSDictionary * bsg_systemversion() {
     sysInfo[@BSG_KSSystemField_TimeZone] = [[NSTimeZone localTimeZone] abbreviation];
     sysInfo[@BSG_KSSystemField_Memory] = @{
         @BSG_KSCrashField_Free: @(bsg_ksmachfreeMemory()),
-        @BSG_KSCrashField_Usable: @(bsg_ksmachusableMemory()),
         @BSG_KSSystemField_Size: [self int64Sysctl:@"hw.memsize"]
     };
 

--- a/Bugsnag/KSCrash/Source/KSCrash/Recording/Tools/BSG_KSMach.c
+++ b/Bugsnag/KSCrash/Source/KSCrash/Recording/Tools/BSG_KSMach.c
@@ -94,17 +94,6 @@ uint64_t bsg_ksmachfreeMemory(void) {
     return 0;
 }
 
-uint64_t bsg_ksmachusableMemory(void) {
-    vm_statistics_data_t vmStats;
-    vm_size_t pageSize;
-    if (bsg_ksmachi_VMStats(&vmStats, &pageSize)) {
-        return ((uint64_t)pageSize) *
-               (vmStats.active_count + vmStats.inactive_count +
-                vmStats.wire_count + vmStats.free_count);
-    }
-    return 0;
-}
-
 const char *bsg_ksmachcurrentCPUArch(void) {
     const NXArchInfo *archInfo = NXGetLocalArchInfo();
     return archInfo == NULL ? NULL : archInfo->name;

--- a/Bugsnag/KSCrash/Source/KSCrash/Recording/Tools/BSG_KSMach.h
+++ b/Bugsnag/KSCrash/Source/KSCrash/Recording/Tools/BSG_KSMach.h
@@ -61,12 +61,6 @@ void bsg_ksmach_init(void);
  */
 uint64_t bsg_ksmachfreeMemory(void);
 
-/** Get the total memory that is currently usable.
- *
- * @return total usable memory.
- */
-uint64_t bsg_ksmachusableMemory(void);
-
 /** Get the current CPU architecture.
  *
  * @return The current architecture.

--- a/Bugsnag/Payload/BugsnagDevice.m
+++ b/Bugsnag/Payload/BugsnagDevice.m
@@ -49,7 +49,7 @@
     device.modelNumber = system[@BSG_KSSystemField_Model];
     device.osName = system[@BSG_KSSystemField_SystemName];
     device.osVersion = system[@BSG_KSSystemField_SystemVersion];
-    device.totalMemory = system[@BSG_KSSystemField_Memory][@BSG_KSCrashField_Usable];
+    device.totalMemory = system[@ BSG_KSSystemField_Memory][@ BSG_KSCrashField_Size];
 
     NSMutableDictionary *runtimeVersions = [NSMutableDictionary new];
     runtimeVersions[@"osBuild"] = system[@BSG_KSSystemField_OSVersion];

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,9 @@ Changelog
 
 ### Bug fixes
 
+* Fix underreporting of `device.totalMemory`, which now matches `NSProcessInfo.physicalMemory`.
+  [#1335](https://github.com/bugsnag/bugsnag-cocoa/pull/1335)
+
 * Skip unnecessary file reading at startup when no unexpected app termination is detected.
   [#1334](https://github.com/bugsnag/bugsnag-cocoa/pull/1334)
 

--- a/Tests/BugsnagTests/BugsnagDeviceTest.m
+++ b/Tests/BugsnagTests/BugsnagDeviceTest.m
@@ -30,7 +30,7 @@
                     @"clang_version": @"10.0.0 (clang-1000.11.45.5)",
                     @"jailbroken": @YES,
                     @"memory": @{
-                            @"usable": @15065522176,
+                            @"size": @15065522176,
                             @"free": @742920192
                     },
                     @"disk": @{

--- a/Tests/BugsnagTests/BugsnagSessionTest.m
+++ b/Tests/BugsnagTests/BugsnagSessionTest.m
@@ -68,7 +68,7 @@
                     @"clang_version": @"10.0.0 (clang-1000.11.45.5)",
                     @"jailbroken": @YES,
                     @"memory": @{
-                            @"usable": @15065522176,
+                            @"size": @15065522176,
                             @"free": @742920192
                     },
                     @"device_app_hash": @"123"

--- a/Tests/KSCrashTests/BSG_KSMachTests.m
+++ b/Tests/KSCrashTests/BSG_KSMachTests.m
@@ -109,12 +109,6 @@ void * executeBlock(void *ptr)
     XCTAssertTrue(freeMem > 0, @"");
 }
 
-- (void) testUsableMemory
-{
-    uint64_t usableMem = bsg_ksmachusableMemory();
-    XCTAssertTrue(usableMem > 0, @"");
-}
-
 - (void) testSuspendThreads
 {
 #if TARGET_CPU_X86_64 && defined(XCTSkipIf)


### PR DESCRIPTION
## Goal

Fix automated test that were intermittently failing (rarely) because `totalMemory < freeMemory`.

## Changeset

Sets `device.totalMemory` from `sysctlbyname("hw.memsize", ...)` (via `BSG_KSSystemInfo`) which matches [NSProcessInfo.physicalMemory](https://developer.apple.com/documentation/foundation/nsprocessinfo/1408211-physicalmemory).

Removed the now unused calculation of "usable" memory.

## Testing

E2E tests verify that `device.totalMemory` is present and less than `device.freeMemory`