### PR TITLE
Fix flake in features/event_callbacks.feature:120

### DIFF
--- a/features/event_callbacks.feature
+++ b/features/event_callbacks.feature
@@ -122,6 +122,8 @@ Feature: Callbacks can access and modify event information
     And I run "OnSendErrorPersistenceScenario"
     And I wait to receive an error
     And I clear the error queue
+    # Wait for fixture to receive the response and save the payload
+    And I wait for 2 seconds
     And I relaunch the app
     And I configure Bugsnag for "OnSendErrorPersistenceScenario"
     And I wait to receive an error


### PR DESCRIPTION
## Goal

Fix a flake that can occur in `features/event_callbacks.feature:120` if app is killed before Bugsnag persists the payload it should retry.

## Changeset

Adds a wait before relaunching app, just like #1331 

## Testing

Verified locally.