### PR TITLE
[PLAT-8359] Add BSGRunContext

### DIFF
--- a/Bugsnag.xcodeproj/project.pbxproj
+++ b/Bugsnag.xcodeproj/project.pbxproj
@@ -627,6 +627,13 @@
 		01468F5625876DC1002B0519 /* BSGNotificationBreadcrumbs.m in Sources */ = {isa = PBXBuildFile; fileRef = 01468F5125876DC1002B0519 /* BSGNotificationBreadcrumbs.m */; };
 		01468F5725876DC1002B0519 /* BSGNotificationBreadcrumbs.m in Sources */ = {isa = PBXBuildFile; fileRef = 01468F5125876DC1002B0519 /* BSGNotificationBreadcrumbs.m */; };
 		01468F5825876DC1002B0519 /* BSGNotificationBreadcrumbs.m in Sources */ = {isa = PBXBuildFile; fileRef = 01468F5125876DC1002B0519 /* BSGNotificationBreadcrumbs.m */; };
+		0154E20228070AEA009044E4 /* BSGRunContext.h in Headers */ = {isa = PBXBuildFile; fileRef = 0154E20028070AEA009044E4 /* BSGRunContext.h */; };
+		0154E20328070AEA009044E4 /* BSGRunContext.h in Headers */ = {isa = PBXBuildFile; fileRef = 0154E20028070AEA009044E4 /* BSGRunContext.h */; };
+		0154E20428070AEA009044E4 /* BSGRunContext.h in Headers */ = {isa = PBXBuildFile; fileRef = 0154E20028070AEA009044E4 /* BSGRunContext.h */; };
+		0154E20528070AEA009044E4 /* BSGRunContext.m in Sources */ = {isa = PBXBuildFile; fileRef = 0154E20128070AEA009044E4 /* BSGRunContext.m */; };
+		0154E20628070AEA009044E4 /* BSGRunContext.m in Sources */ = {isa = PBXBuildFile; fileRef = 0154E20128070AEA009044E4 /* BSGRunContext.m */; };
+		0154E20728070AEA009044E4 /* BSGRunContext.m in Sources */ = {isa = PBXBuildFile; fileRef = 0154E20128070AEA009044E4 /* BSGRunContext.m */; };
+		0154E20828070AEA009044E4 /* BSGRunContext.m in Sources */ = {isa = PBXBuildFile; fileRef = 0154E20128070AEA009044E4 /* BSGRunContext.m */; };
 		015F528425C15BB7000D1915 /* MRCCanary.m in Sources */ = {isa = PBXBuildFile; fileRef = 015F528325C15BB7000D1915 /* MRCCanary.m */; settings = {COMPILER_FLAGS = "-fno-objc-arc"; }; };
 		015F528525C15BB7000D1915 /* MRCCanary.m in Sources */ = {isa = PBXBuildFile; fileRef = 015F528325C15BB7000D1915 /* MRCCanary.m */; settings = {COMPILER_FLAGS = "-fno-objc-arc"; }; };
 		015F528625C15BB7000D1915 /* MRCCanary.m in Sources */ = {isa = PBXBuildFile; fileRef = 015F528325C15BB7000D1915 /* MRCCanary.m */; settings = {COMPILER_FLAGS = "-fno-objc-arc"; }; };
@@ -1328,6 +1335,8 @@
 		0140D24725765F8F00FD0306 /* BSGUIKit.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; path = BSGUIKit.h; sourceTree = "<group>"; };
 		01468F5025876DC1002B0519 /* BSGNotificationBreadcrumbs.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = BSGNotificationBreadcrumbs.h; sourceTree = "<group>"; };
 		01468F5125876DC1002B0519 /* BSGNotificationBreadcrumbs.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; path = BSGNotificationBreadcrumbs.m; sourceTree = "<group>"; };
+		0154E20028070AEA009044E4 /* BSGRunContext.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; path = BSGRunContext.h; sourceTree = "<group>"; };
+		0154E20128070AEA009044E4 /* BSGRunContext.m */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.objc; path = BSGRunContext.m; sourceTree = "<group>"; };
 		015F528325C15BB7000D1915 /* MRCCanary.m */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.objc; path = MRCCanary.m; sourceTree = "<group>"; };
 		0163BF5825823D8D008DC28B /* BSGNotificationBreadcrumbsTests.m */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.objc; path = BSGNotificationBreadcrumbsTests.m; sourceTree = "<group>"; };
 		016875C4258D003200DFFF69 /* NSUserDefaultsStub.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; path = NSUserDefaultsStub.h; sourceTree = "<group>"; };
@@ -1889,6 +1898,8 @@
 				CBCF77A125010648004AF22A /* BSGJSONSerialization.h */,
 				CBCF77A225010648004AF22A /* BSGJSONSerialization.m */,
 				008968152486DA5600DC48C2 /* BSGKeys.h */,
+				0154E20028070AEA009044E4 /* BSGRunContext.h */,
+				0154E20128070AEA009044E4 /* BSGRunContext.m */,
 				008968112486DA5600DC48C2 /* BSGSerialization.h */,
 				008968162486DA5600DC48C2 /* BSGSerialization.m */,
 				0140D24725765F8F00FD0306 /* BSGUIKit.h */,
@@ -2095,6 +2106,7 @@
 				008969DE2486DAD100DC48C2 /* BSG_KSCrashC.h in Headers */,
 				0089699F2486DAD100DC48C2 /* BSG_KSJSONCodecObjC.h in Headers */,
 				0089697E2486DAD100DC48C2 /* BSG_KSArchSpecific.h in Headers */,
+				0154E20228070AEA009044E4 /* BSGRunContext.h in Headers */,
 				008969BA2486DAD100DC48C2 /* BSG_KSJSONCodec.h in Headers */,
 				008969E72486DAD100DC48C2 /* BSG_KSSystemInfoC.h in Headers */,
 				CBAA6ABB250BA70E00713376 /* BugsnagKVStore.h in Headers */,
@@ -2199,6 +2211,7 @@
 				008969DF2486DAD100DC48C2 /* BSG_KSCrashC.h in Headers */,
 				008969A02486DAD100DC48C2 /* BSG_KSJSONCodecObjC.h in Headers */,
 				0089697F2486DAD100DC48C2 /* BSG_KSArchSpecific.h in Headers */,
+				0154E20328070AEA009044E4 /* BSGRunContext.h in Headers */,
 				008969BB2486DAD100DC48C2 /* BSG_KSJSONCodec.h in Headers */,
 				008969E82486DAD100DC48C2 /* BSG_KSSystemInfoC.h in Headers */,
 				CBAA6ABC250BA70E00713376 /* BugsnagKVStore.h in Headers */,
@@ -2303,6 +2316,7 @@
 				008969E02486DAD100DC48C2 /* BSG_KSCrashC.h in Headers */,
 				008969A12486DAD100DC48C2 /* BSG_KSJSONCodecObjC.h in Headers */,
 				008969802486DAD100DC48C2 /* BSG_KSArchSpecific.h in Headers */,
+				0154E20428070AEA009044E4 /* BSGRunContext.h in Headers */,
 				008969BC2486DAD100DC48C2 /* BSG_KSJSONCodec.h in Headers */,
 				008969E92486DAD100DC48C2 /* BSG_KSSystemInfoC.h in Headers */,
 				CBAA6ABD250BA70F00713376 /* BugsnagKVStore.h in Headers */,
@@ -2651,6 +2665,7 @@
 			buildActionMask = 2147483647;
 			files = (
 				CBAA6AB5250BA01D00713376 /* BugsnagKVStore.c in Sources */,
+				0154E20528070AEA009044E4 /* BSGRunContext.m in Sources */,
 				008969992486DAD100DC48C2 /* BSG_KSMach_Arm64.c in Sources */,
 				008967E82486DA2D00DC48C2 /* BugsnagErrorTypes.m in Sources */,
 				0126F7AE25DD5118008483C2 /* BSGEventUploadFileOperation.m in Sources */,
@@ -2895,6 +2910,7 @@
 				008969AF2486DAD100DC48C2 /* NSError+BSG_SimpleConstructor.m in Sources */,
 				008968CC2486DA9600DC48C2 /* BugsnagThread.m in Sources */,
 				0126F78F25DD508C008483C2 /* BSGEventUploadOperation.m in Sources */,
+				0154E20628070AEA009044E4 /* BSGRunContext.m in Sources */,
 				008968032486DA4500DC48C2 /* BSGConnectivity.m in Sources */,
 				CBE9062E25A34DAB0045B965 /* BSGStorageMigratorV0V1.m in Sources */,
 				010FF28825ED2A8D00E4F2B0 /* BSGAppHangDetector.m in Sources */,
@@ -2998,6 +3014,7 @@
 			buildActionMask = 2147483647;
 			files = (
 				CBAA6AB7250BA01D00713376 /* BugsnagKVStore.c in Sources */,
+				0154E20728070AEA009044E4 /* BSGRunContext.m in Sources */,
 				0089699B2486DAD100DC48C2 /* BSG_KSMach_Arm64.c in Sources */,
 				008967EA2486DA2D00DC48C2 /* BugsnagErrorTypes.m in Sources */,
 				008968742486DA9500DC48C2 /* BugsnagDevice.m in Sources */,
@@ -3171,6 +3188,7 @@
 			buildActionMask = 2147483647;
 			files = (
 				CBAA6AB8250BA01D00713376 /* BugsnagKVStore.c in Sources */,
+				0154E20828070AEA009044E4 /* BSGRunContext.m in Sources */,
 				CB33CD042703438400C76656 /* BSG_KSCrashNames.c in Sources */,
 				E7462909248907E500F92D67 /* BSG_KSMach_x86_32.c in Sources */,
 				E746290B248907E500F92D67 /* BSG_KSMach_Arm.c in Sources */,

--- a/Bugsnag/Client/BugsnagClient.m
+++ b/Bugsnag/Client/BugsnagClient.m
@@ -35,6 +35,7 @@
 #import "BSGJSONSerialization.h"
 #import "BSGKeys.h"
 #import "BSGNotificationBreadcrumbs.h"
+#import "BSGRunContext.h"
 #import "BSGSerialization.h"
 #import "BSGUtils.h"
 #import "BSG_KSCrash.h"
@@ -262,6 +263,8 @@ __attribute__((annotate("oclint:suppress[too many methods]")))
     __weak typeof(self) weakSelf = self;
 
     [self.configuration validate];
+
+    BSGRunContextInit(BSGFileLocations.current.runContext.fileSystemRepresentation);
     BSGCrashSentryInstall(self.configuration, BSSerializeDataCrashHandler);
     self.systemState = [[BugsnagSystemState alloc] initWithConfiguration:self.configuration];
 

--- a/Bugsnag/Helpers/BSGRunContext.h
+++ b/Bugsnag/Helpers/BSGRunContext.h
@@ -5,6 +5,13 @@
 //  Copyright © 2022 Bugsnag Inc. All rights reserved.
 //
 
+//
+// The struct version should be incremented prior to a release if changes have
+// been made to BSGRunContext.
+//
+// During development this is not strictly necessary since last run's data will
+// not be loaded if the struct's size has changed.
+//
 #define BSGRUNCONTEXT_VERSION 1
 
 struct BSGRunContext {

--- a/Bugsnag/Helpers/BSGRunContext.h
+++ b/Bugsnag/Helpers/BSGRunContext.h
@@ -1,0 +1,24 @@
+//
+//  BSGRunContext.h
+//  Bugsnag
+//
+//  Copyright © 2022 Bugsnag Inc. All rights reserved.
+//
+
+#define BSGRUNCONTEXT_VERSION 1
+
+struct BSGRunContext {
+    long structVersion;
+};
+
+/// Information about the current run of the app / process.
+///
+/// This structure is mapped to a file so that changes will be persisted by the OS.
+///
+/// Guaranteed to be non-null once BSGRunContextInit() is called.
+extern struct BSGRunContext *_Nonnull bsg_runContext;
+
+/// Information about the last run of the app / process, if it could be loaded.
+extern const struct BSGRunContext *_Nullable bsg_lastRunContext;
+
+void BSGRunContextInit(const char *_Nonnull path);

--- a/Bugsnag/Helpers/BSGRunContext.m
+++ b/Bugsnag/Helpers/BSGRunContext.m
@@ -1,0 +1,78 @@
+//
+//  BSGRunContext.m
+//  Bugsnag
+//
+//  Copyright © 2022 Bugsnag Inc. All rights reserved.
+//
+
+#import "BSGRunContext.h"
+
+#import "BSG_KSLogger.h"
+
+#import <Foundation/Foundation.h>
+#import <sys/mman.h>
+#import <sys/stat.h>
+
+#define SIZEOF_STRUCT sizeof(struct BSGRunContext)
+
+struct BSGRunContext *bsg_runContext;
+
+const struct BSGRunContext *bsg_lastRunContext;
+
+/// Loads the contents of the state file into memory and sets the
+/// `bsg_lastRunContext` pointer if the contents are valid.
+static void BSGRunContextLoadLast(int fd) {
+    struct stat sb;
+    // Only expose previous state if size matches...
+    if (fstat(fd, &sb) == 0 && sb.st_size == SIZEOF_STRUCT) {
+        static struct BSGRunContext context;
+        if (read(fd, &context, SIZEOF_STRUCT) == SIZEOF_STRUCT &&
+            // ...and so does the structVersion
+            context.structVersion == BSGRUNCONTEXT_VERSION) {
+            bsg_lastRunContext = &context;
+        }
+    }
+}
+
+/// Truncates or extends the file to the size of struct BSGRunContext,
+/// maps it into memory, and sets the `bsg_runContext` pointer.
+static void BSGRunContextResizeAndMapFile(int fd) {
+    static struct BSGRunContext fallback;
+    
+    int err = ftruncate(fd, SIZEOF_STRUCT);
+    if (err != 0) {
+        bsg_log_warn(@"ftruncate failed: %d", err);
+        goto fail;
+    }
+    
+    struct BSGRunContext *ptr = mmap(0, SIZEOF_STRUCT, PROT_READ | PROT_WRITE, MAP_FILE | MAP_SHARED, fd, 0);
+    if (ptr == MAP_FAILED) {
+        bsg_log_warn(@"mmap failed");
+        goto fail;
+    }
+    
+    bsg_runContext = ptr;
+    return;
+    
+fail:
+    bsg_runContext = &fallback;
+}
+
+/// Populates `bsg_runContext`
+static void BSGRunContextPopulate() {
+    memset(bsg_runContext, 0, SIZEOF_STRUCT);
+    bsg_runContext->structVersion = BSGRUNCONTEXT_VERSION;
+}
+
+void BSGRunContextInit(const char *path) {
+    int fd = open(path, O_RDWR | O_CREAT, 0600);
+    if (fd < 0) {
+        bsg_log_warn(@"Could not open %s", path);
+    }
+    BSGRunContextLoadLast(fd);
+    BSGRunContextResizeAndMapFile(fd);
+    BSGRunContextPopulate();
+    if (fd > 0) {
+        close(fd);
+    }
+}

--- a/Bugsnag/Helpers/BSGRunContext.m
+++ b/Bugsnag/Helpers/BSGRunContext.m
@@ -40,15 +40,16 @@ static void BSGRunContextResizeAndMapFile(int fd) {
     static struct BSGRunContext fallback;
     
     // Note: ftruncate fills the file with zeros when extending.
-    int err = ftruncate(fd, SIZEOF_STRUCT);
-    if (err != 0) {
-        bsg_log_warn(@"ftruncate failed: %d", err);
+    if (ftruncate(fd, SIZEOF_STRUCT) != 0) {
+        bsg_log_warn(@"ftruncate failed: %d", errno);
         goto fail;
     }
     
-    struct BSGRunContext *ptr = mmap(0, SIZEOF_STRUCT, PROT_READ | PROT_WRITE, MAP_FILE | MAP_SHARED, fd, 0);
+    const int prot = PROT_READ | PROT_WRITE;
+    const int flags = MAP_FILE | MAP_SHARED;
+    void *ptr = mmap(0, SIZEOF_STRUCT, prot, flags, fd, 0);
     if (ptr == MAP_FAILED) {
-        bsg_log_warn(@"mmap failed");
+        bsg_log_warn(@"mmap failed: %d", errno);
         goto fail;
     }
     

--- a/Bugsnag/Helpers/BSGRunContext.m
+++ b/Bugsnag/Helpers/BSGRunContext.m
@@ -39,6 +39,7 @@ static void BSGRunContextLoadLast(int fd) {
 static void BSGRunContextResizeAndMapFile(int fd) {
     static struct BSGRunContext fallback;
     
+    // Note: ftruncate fills the file with zeros when extending.
     int err = ftruncate(fd, SIZEOF_STRUCT);
     if (err != 0) {
         bsg_log_warn(@"ftruncate failed: %d", err);
@@ -51,6 +52,7 @@ static void BSGRunContextResizeAndMapFile(int fd) {
         goto fail;
     }
     
+    memset(ptr, 0, SIZEOF_STRUCT);
     bsg_runContext = ptr;
     return;
     
@@ -60,7 +62,8 @@ fail:
 
 /// Populates `bsg_runContext`
 static void BSGRunContextPopulate() {
-    memset(bsg_runContext, 0, SIZEOF_STRUCT);
+    // Set `structVersion` last so that BSGRunContextLoadLast() will reject data
+    // that is not fully initialised.
     bsg_runContext->structVersion = BSGRUNCONTEXT_VERSION;
 }
 

--- a/Bugsnag/Storage/BSGFileLocations.h
+++ b/Bugsnag/Storage/BSGFileLocations.h
@@ -40,6 +40,11 @@ NS_ASSUME_NONNULL_BEGIN
 @property (readonly, nonatomic) NSString *metadata;
 
 /**
+ * BSGRunContext
+ */
+@property (readonly, nonatomic) NSString *runContext;
+
+/**
  * State info that gets added to the low level crash report.
  */
 @property (readonly, nonatomic) NSString *state;

--- a/Bugsnag/Storage/BSGFileLocations.m
+++ b/Bugsnag/Storage/BSGFileLocations.m
@@ -99,6 +99,7 @@ static NSString *getAndCreateSubdir(NSString *rootPath, NSString *relativePath) 
         _flagHandledCrash = [root stringByAppendingPathComponent:@"bugsnag_handled_crash.txt"];
         _configuration = [root stringByAppendingPathComponent:@"config.json"];
         _metadata = [root stringByAppendingPathComponent:@"metadata.json"];
+        _runContext = [root stringByAppendingPathComponent:@"run_context"];
         _state = [root stringByAppendingPathComponent:@"state.json"];
         _systemState = [root stringByAppendingPathComponent:@"system_state.json"];
     }


### PR DESCRIPTION
## Goal

Establish new memory-mapped storage for changeable app / device / system info.

## Changeset

Adds `struct BSGRunContext` and basic routines to load existing data, set up mapping and initialise global pointers.

Settled on "runcontext" as it is a term not currently used in the codebase. Other rejected names considered include "runinfo", "runstate", "systemstate" and "systeminfo".

## Testing

Tested manually by debugging example app.