### PR TITLE
[PLAT-8361] Move kill detection to BSGRunContext

### DIFF
--- a/Bugsnag/BugsnagSystemState.h
+++ b/Bugsnag/BugsnagSystemState.h
@@ -33,8 +33,6 @@ NS_ASSUME_NONNULL_BEGIN
 
 @property (nonatomic) NSUInteger consecutiveLaunchCrashes;
 
-@property (readonly, nonatomic) BOOL lastLaunchTerminatedUnexpectedly;
-
 /**
  * Purge all stored system state.
  */

--- a/Bugsnag/BugsnagSystemState.m
+++ b/Bugsnag/BugsnagSystemState.m
@@ -203,41 +203,4 @@ static NSDictionary *copyDictionary(NSDictionary *launchState) {
     self.lastLaunchState = loadPreviousState(self.persistenceFilePath);
 }
 
-// MARK: -
-
-- (BOOL)lastLaunchTerminatedUnexpectedly {
-    // App extensions have a different lifecycle and the heuristic used for finding app terminations rooted in fixable code does not apply
-    if ([BSG_KSSystemInfo isRunningInAppExtension]) {
-        return NO;
-    }
-    
-    if (!bsg_lastRunContext) {
-        return NO;
-    }
-    
-    if (bsg_lastRunContext->isTerminating) {
-        return NO; // The app terminated normally
-    }
-    
-    if (bsg_lastRunContext->isDebuggerAttached) {
-        return NO; // The debugger may have killed the app
-    }
-    
-    // If the app was in the background, we cannot determine whether the termination was unexpected
-    if (!bsg_lastRunContext->isForeground) {
-        return NO;
-    }
-    
-    // Ignore unexpected terminations that may have been due to the app being upgraded
-    if (uuid_compare(bsg_lastRunContext->machoUUID, bsg_runContext->machoUUID)) {
-        return NO;
-    }
-    
-    if (bsg_lastRunContext->bootTime != bsg_runContext->bootTime) {
-        return NO; // The app may have been terminated due to the reboot
-    }
-    
-    return YES;
-}
-
 @end

--- a/Bugsnag/Client/BugsnagClient.m
+++ b/Bugsnag/Client/BugsnagClient.m
@@ -427,7 +427,7 @@ __attribute__((annotate("oclint:suppress[too many methods]")))
         bsg_log_info(@"Last run terminated during an app hang.");
         didCrash = YES;
     }
-    else if (self.configuration.autoDetectErrors && self.systemState.lastLaunchTerminatedUnexpectedly) {
+    else if (self.configuration.autoDetectErrors && BSGRunContextWasKilled()) {
         if (BSGRunContextWasCriticalThermalState()) {
             bsg_log_info(@"Last run terminated during a critical thermal state.");
             if (self.configuration.enabledErrorTypes.thermalKills) {

--- a/Bugsnag/Helpers/BSGRunContext.h
+++ b/Bugsnag/Helpers/BSGRunContext.h
@@ -54,6 +54,8 @@ static inline bool BSGRunContextWasCriticalThermalState() {
 }
 #endif
 
+bool BSGRunContextWasKilled(void);
+
 static inline bool BSGRunContextWasLaunching() {
     return bsg_lastRunContext && bsg_lastRunContext->isLaunching;
 }

--- a/Bugsnag/Helpers/BSGRunContext.h
+++ b/Bugsnag/Helpers/BSGRunContext.h
@@ -6,6 +6,8 @@
 //
 
 #include <stdbool.h>
+#include <stdint.h>
+#include <uuid/uuid.h>
 
 //
 // The struct version should be incremented prior to a release if changes have
@@ -23,6 +25,8 @@ struct BSGRunContext {
     bool isForeground;
     bool isTerminating;
     long thermalState;
+    uint64_t bootTime;
+    uuid_t machoUUID;
 };
 
 /// Information about the current run of the app / process.

--- a/Bugsnag/KSCrash/Source/KSCrash/Recording/BSG_KSSystemInfo.h
+++ b/Bugsnag/KSCrash/Source/KSCrash/Recording/BSG_KSSystemInfo.h
@@ -26,7 +26,6 @@
 
 #define BSG_KSSystemField_AppUUID "app_uuid"
 #define BSG_KSSystemField_BinaryArch "binary_arch"
-#define BSG_KSSystemField_BootTime "boot_time"
 #define BSG_KSSystemField_BundleID "CFBundleIdentifier"
 #define BSG_KSSystemField_BundleName "CFBundleName"
 #define BSG_KSSystemField_BundleExecutable "CFBundleExecutable"

--- a/Bugsnag/KSCrash/Source/KSCrash/Recording/BSG_KSSystemInfo.m
+++ b/Bugsnag/KSCrash/Source/KSCrash/Recording/BSG_KSSystemInfo.m
@@ -399,7 +399,6 @@ static NSDictionary * bsg_systemversion() {
 #endif // TARGET_OS_SIMULATOR
 
     sysInfo[@BSG_KSSystemField_OSVersion] = [self osBuildVersion];
-    sysInfo[@BSG_KSSystemField_BootTime] = [self dateSysctl:@"kern.boottime"];
     sysInfo[@BSG_KSSystemField_BundleID] = infoDict[@"CFBundleIdentifier"];
     sysInfo[@BSG_KSSystemField_BundleName] = infoDict[@"CFBundleName"];
     sysInfo[@BSG_KSSystemField_BundleExecutable] = infoDict[@"CFBundleExecutable"];

--- a/Tests/BugsnagTests/BSGOutOfMemoryTests.m
+++ b/Tests/BugsnagTests/BSGOutOfMemoryTests.m
@@ -76,62 +76,58 @@
     const struct BSGRunContext *oldContext = bsg_lastRunContext;
     struct BSGRunContext lastRunContext = *bsg_runContext;
     bsg_lastRunContext = &lastRunContext;
-    
-    BugsnagSystemState *(^ systemState)() = ^{
-        return [[BugsnagSystemState alloc] initWithConfiguration:[[BugsnagConfiguration alloc] initWithApiKey:DUMMY_APIKEY_32CHAR_1]];
-    };
 
     // Debugger active
     
     lastRunContext.isDebuggerAttached = true;
     lastRunContext.isTerminating = true;
     lastRunContext.isForeground = true;
-    XCTAssertFalse(systemState().lastLaunchTerminatedUnexpectedly);
+    XCTAssertFalse(BSGRunContextWasKilled());
 
     lastRunContext.isDebuggerAttached = true;
     lastRunContext.isTerminating = true;
     lastRunContext.isForeground = false;
-    XCTAssertFalse(systemState().lastLaunchTerminatedUnexpectedly);
+    XCTAssertFalse(BSGRunContextWasKilled());
 
     lastRunContext.isDebuggerAttached = true;
     lastRunContext.isTerminating = false;
     lastRunContext.isForeground = true;
-    XCTAssertFalse(systemState().lastLaunchTerminatedUnexpectedly);
+    XCTAssertFalse(BSGRunContextWasKilled());
 
     lastRunContext.isDebuggerAttached = true;
     lastRunContext.isTerminating = false;
     lastRunContext.isForeground = false;
-    XCTAssertFalse(systemState().lastLaunchTerminatedUnexpectedly);
+    XCTAssertFalse(BSGRunContextWasKilled());
 
     // Debugger inactive
 
     lastRunContext.isDebuggerAttached = false;
     lastRunContext.isTerminating = true;
     lastRunContext.isForeground = true;
-    XCTAssertFalse(systemState().lastLaunchTerminatedUnexpectedly);
+    XCTAssertFalse(BSGRunContextWasKilled());
 
     lastRunContext.isDebuggerAttached = false;
     lastRunContext.isTerminating = true;
     lastRunContext.isForeground = false;
-    XCTAssertFalse(systemState().lastLaunchTerminatedUnexpectedly);
+    XCTAssertFalse(BSGRunContextWasKilled());
 
     lastRunContext.isDebuggerAttached = false;
     lastRunContext.isTerminating = false;
     lastRunContext.isForeground = true;
-    XCTAssertTrue(systemState().lastLaunchTerminatedUnexpectedly);
+    XCTAssertTrue(BSGRunContextWasKilled());
     
     uuid_generate(lastRunContext.machoUUID);
-    XCTAssertFalse(systemState().lastLaunchTerminatedUnexpectedly);
+    XCTAssertFalse(BSGRunContextWasKilled());
     uuid_copy(lastRunContext.machoUUID, bsg_runContext->machoUUID);
     
     lastRunContext.bootTime = 0;
-    XCTAssertFalse(systemState().lastLaunchTerminatedUnexpectedly);
+    XCTAssertFalse(BSGRunContextWasKilled());
     lastRunContext.bootTime = bsg_runContext->bootTime;
 
     lastRunContext.isDebuggerAttached = false;
     lastRunContext.isTerminating = false;
     lastRunContext.isForeground = false;
-    XCTAssertFalse(systemState().lastLaunchTerminatedUnexpectedly);
+    XCTAssertFalse(BSGRunContextWasKilled());
     
     bsg_lastRunContext = oldContext;
 }

--- a/Tests/BugsnagTests/BugsnagClientTests.m
+++ b/Tests/BugsnagTests/BugsnagClientTests.m
@@ -321,31 +321,4 @@ NSString *BSGFormatSeverity(BSGSeverity severity);
     return dict;
 }
 
-#if TARGET_OS_IOS || TARGET_OS_TV
-
-static BOOL testOnCrashHandlerNotCalledForOOM_didCallOnCrashHandler;
-
-static void testOnCrashHandlerNotCalledForOOM_onCrashHandler(const BSG_KSCrashReportWriter *writer) {
-    testOnCrashHandlerNotCalledForOOM_didCallOnCrashHandler = YES;
-}
-
-static BOOL testOnCrashHandlerNotCalledForOOM_lastLaunchTerminatedUnexpectedly(id self, SEL _cmd) {
-    return YES;
-}
-
-- (void)testOnCrashHandlerNotCalledForOOM {
-    BugsnagConfiguration *configuration = [[BugsnagConfiguration alloc] initWithApiKey:DUMMY_APIKEY_32CHAR_1];
-    configuration.onCrashHandler = testOnCrashHandlerNotCalledForOOM_onCrashHandler;
-    BugsnagClient *client = [[BugsnagClient alloc] initWithConfiguration:configuration];
-    Method method = class_getInstanceMethod([BugsnagSystemState class], @selector(lastLaunchTerminatedUnexpectedly));
-    NSParameterAssert(method != NULL);
-    void *originalImplementation = method_setImplementation(method, (void *)testOnCrashHandlerNotCalledForOOM_lastLaunchTerminatedUnexpectedly);
-    [client start];
-    method_setImplementation(method, originalImplementation);
-    XCTAssertFalse(testOnCrashHandlerNotCalledForOOM_didCallOnCrashHandler, @"onCrashHandler should not be called for OOMs");
-    XCTAssertTrue(client.lastRunInfo.crashed);
-}
-
-#endif
-
 @end

--- a/Tests/BugsnagTests/TestSupport.m
+++ b/Tests/BugsnagTests/TestSupport.m
@@ -11,6 +11,7 @@
 #import "BSG_KSCrashC.h"
 #import "BSG_KSCrashState.h"
 #import "BSGFileLocations.h"
+#import "BSGRunContext.h"
 #import "BSGUtils.h"
 #import "Bugsnag+Private.h"
 
@@ -29,11 +30,7 @@
     
     [Bugsnag purge];
     
-    // bsg_kscrash_install() will refuse to install itself twice, so reinit kscrashstate to avoid leaking state between tests
-    NSString *path = [BSGFileLocations current].state;
-    NSString *dir = [path stringByDeletingLastPathComponent];
-    [NSFileManager.defaultManager createDirectoryAtPath:dir withIntermediateDirectories:YES attributes:nil error:nil];
-    bsg_kscrashstate_init(path.fileSystemRepresentation, &crashContext()->state);
+    bsg_lastRunContext = NULL;
 }
 
 @end

--- a/features/fixtures/shared/scenarios/OOMScenario.m
+++ b/features/fixtures/shared/scenarios/OOMScenario.m
@@ -20,9 +20,14 @@
 
 @implementation OOMScenario
 
+void onCrashHandler(const BSG_KSCrashReportWriter *writer) {
+    assert(!!"onCrashHandler should not be called for OOMs");
+}
+
 - (void)startBugsnag {
     self.config.autoTrackSessions = YES;
     self.config.enabledErrorTypes.ooms = YES;
+    self.config.onCrashHandler = onCrashHandler;
     self.config.launchDurationMillis = 0; // Ensure isLaunching will be true for the OOM, no matter how long it takes to occur.
     self.config.appType = @"vanilla";
     self.config.appVersion = @"3.2.1";


### PR DESCRIPTION
## Goal

Move remaining data for detection of unexpected terminations (OOMs and Thermal Kills) to `BSGRunContext`.

## Changeset

Stores bootTime and the apps's Mach-O UUID in `BSGRunContext`.

Mach-O UUID is now compared instead of app version & bundle version to determine whether the app has been upgraded.

Moves logic from `-[BugsnagSystemState lastLaunchTerminatedUnexpectedly]` to `BSGRunContextWasKilled()` since it is tied to `BSGRunContext`.

## Testing

Amended existing tests to work with `BSGRunContext`