### PR TITLE
[PLAT-8362] Store session info in BSGRunContext

### DIFF
--- a/Bugsnag/BugsnagSessionTracker.h
+++ b/Bugsnag/BugsnagSessionTracker.h
@@ -13,18 +13,15 @@
 
 NS_ASSUME_NONNULL_BEGIN
 
-typedef void (^SessionTrackerCallback)(BugsnagSession *_Nullable session);
-
 @interface BugsnagSessionTracker : NSObject
 
 /**
  Create a new session tracker
 
  @param config The Bugsnag configuration to use
- @param callback A callback invoked each time a new session is started
  @return A new session tracker
  */
-- (instancetype)initWithConfig:(BugsnagConfiguration *)config client:(nullable BugsnagClient *)client callback:(SessionTrackerCallback)callback;
+- (instancetype)initWithConfig:(BugsnagConfiguration *)config client:(nullable BugsnagClient *)client;
 
 - (void)startWithNotificationCenter:(NSNotificationCenter *)notificationCenter isInForeground:(BOOL)isInForeground;
 

--- a/Bugsnag/BugsnagSessionTracker.m
+++ b/Bugsnag/BugsnagSessionTracker.m
@@ -34,23 +34,16 @@ static NSTimeInterval const BSGNewSessionBackgroundDuration = 30;
 @property (weak, nonatomic) BugsnagClient *client;
 @property (strong, nonatomic) BSGSessionUploader *sessionUploader;
 @property (strong, nonatomic) NSDate *backgroundStartTime;
-
-/**
- * Called when a session is altered
- */
-@property (nonatomic, strong, readonly) SessionTrackerCallback callback;
-
 @property (nonatomic) NSMutableDictionary *extraRuntimeInfo;
 @end
 
 @implementation BugsnagSessionTracker
 
-- (instancetype)initWithConfig:(BugsnagConfiguration *)config client:(BugsnagClient *)client callback:(SessionTrackerCallback)callback {
+- (instancetype)initWithConfig:(BugsnagConfiguration *)config client:(BugsnagClient *)client {
     if ((self = [super init])) {
         _config = config;
         _client = client;
         _sessionUploader = [[BSGSessionUploader alloc] initWithConfig:config notifier:client.notifier];
-        _callback = callback;
         _extraRuntimeInfo = [NSMutableDictionary new];
     }
     return self;
@@ -118,7 +111,7 @@ static NSTimeInterval const BSGNewSessionBackgroundDuration = 30;
 - (void)pauseSession {
     self.currentSession.stopped = YES;
 
-    self.callback(nil);
+    BSGSessionUpdateRunContext(nil);
 }
 
 - (BOOL)resumeSession {
@@ -130,7 +123,7 @@ static NSTimeInterval const BSGNewSessionBackgroundDuration = 30;
     } else {
         BOOL stopped = session.isStopped;
         session.stopped = NO;
-        self.callback(session);
+        BSGSessionUpdateRunContext(session);
         return stopped;
     }
 }
@@ -185,7 +178,7 @@ static NSTimeInterval const BSGNewSessionBackgroundDuration = 30;
 
     self.currentSession = newSession;
 
-    self.callback(newSession);
+    BSGSessionUpdateRunContext(newSession);
 
     [self.sessionUploader uploadSession:newSession];
 }
@@ -213,7 +206,7 @@ static NSTimeInterval const BSGNewSessionBackgroundDuration = 30;
         self.currentSession.handledCount = handledCount;
         self.currentSession.unhandledCount = unhandledCount;
     }
-    self.callback(self.currentSession);
+    BSGSessionUpdateRunContext(self.currentSession);
 }
 
 #pragma mark - Handling events
@@ -243,7 +236,7 @@ static NSTimeInterval const BSGNewSessionBackgroundDuration = 30;
         } else {
             session.handledCount++;
         }
-        self.callback(session);
+        BSGSessionUpdateRunContext(session);
     }
 }
 

--- a/Bugsnag/BugsnagSystemState.h
+++ b/Bugsnag/BugsnagSystemState.h
@@ -12,8 +12,6 @@
 
 #import "BSGKeys.h"
 
-@class BugsnagSession;
-
 #define SYSTEMSTATE_KEY_APP @"app"
 #define SYSTEMSTATE_KEY_DEVICE @"device"
 
@@ -37,8 +35,6 @@ NS_ASSUME_NONNULL_BEGIN
  * Purge all stored system state.
  */
 - (void)purge;
-
-- (void)setSession:(nullable BugsnagSession *)session;
 
 @end
 

--- a/Bugsnag/BugsnagSystemState.m
+++ b/Bugsnag/BugsnagSystemState.m
@@ -23,7 +23,6 @@
 #import "BSG_KSCrashState.h"
 #import "BSG_KSSystemInfo.h"
 #import "BugsnagLogger.h"
-#import "BugsnagSession+Private.h"
 
 #import <stdatomic.h>
 
@@ -131,12 +130,6 @@ static NSDictionary *copyDictionary(NSDictionary *launchState) {
         [self sync];
     }
     return self;
-}
-
-- (void)setSession:(nullable BugsnagSession *)session {
-    [self mutateLaunchState:^(NSMutableDictionary *state) {
-        state[BSGKeySession] = session ? BSGSessionToEventJson((BugsnagSession *_Nonnull)session) : nil;
-    }];
 }
 
 - (void)setCodeBundleID:(NSString*)codeBundleID {

--- a/Bugsnag/Helpers/BSGRunContext.h
+++ b/Bugsnag/Helpers/BSGRunContext.h
@@ -27,6 +27,10 @@ struct BSGRunContext {
     long thermalState;
     uint64_t bootTime;
     uuid_t machoUUID;
+    uuid_string_t sessionId;
+    double sessionStartTime;
+    unsigned long handledCount;
+    unsigned long unhandledCount;
 };
 
 /// Information about the current run of the app / process.

--- a/Bugsnag/Payload/BugsnagEvent.m
+++ b/Bugsnag/Payload/BugsnagEvent.m
@@ -294,8 +294,6 @@ NSDictionary *BSGParseCustomException(NSDictionary *report,
         depth = 0;
     }
 
-    BugsnagSession *session = BSGSessionFromDictionary(event[BSGKeyUser]);
-
     // generate threads/error info
     NSArray *binaryImages = event[@"binary_images"];
     NSArray *threadDict = [event valueForKeyPath:@"crash.threads"];
@@ -352,6 +350,9 @@ NSDictionary *BSGParseCustomException(NSDictionary *report,
                                     [configDict isKindOfClass:[NSDictionary class]] ? configDict : @{}];
 
     BugsnagAppWithState *app = [BugsnagAppWithState appWithDictionary:event config:config codeBundleId:self.codeBundleId];
+
+    BugsnagSession *session = BSGSessionFromCrashReport(event, app, device, user);
+
     BugsnagEvent *obj = [self initWithApp:app
                                    device:device
                              handledState:handledState

--- a/Bugsnag/Payload/BugsnagSession+Private.h
+++ b/Bugsnag/Payload/BugsnagSession+Private.h
@@ -8,6 +8,10 @@
 
 #import <Bugsnag/BugsnagSession.h>
 
+#import "BSG_KSCrashReportWriter.h"
+
+#define BSG_PRIVATE __attribute__((visibility("hidden")))
+
 NS_ASSUME_NONNULL_BEGIN
 
 @class BugsnagUser;
@@ -47,5 +51,17 @@ NSDictionary * BSGSessionToEventJson(BugsnagSession *session);
 
 /// Parses a session dictionary from an event's JSON representation.
 BugsnagSession *_Nullable BSGSessionFromEventJson(NSDictionary *_Nullable json, BugsnagApp *app, BugsnagDevice *device, BugsnagUser *user);
+
+/// Saves the session info into bsg_runContext.
+BSG_PRIVATE void BSGSessionUpdateRunContext(BugsnagSession *_Nullable session);
+
+/// Returns session information from bsg_lastRunContext.
+BSG_PRIVATE BugsnagSession *_Nullable BSGSessionFromLastRunContext(BugsnagApp *app, BugsnagDevice *device, BugsnagUser *user);
+
+/// Saves current session information (from bsg_runContext) into a crash report.
+BSG_PRIVATE void BSGSessionWriteCrashReport(const BSG_KSCrashReportWriter *writer);
+
+/// Returns session information from a crash report previously written to by BSGSessionWriteCrashReport or BSSerializeDataCrashHandler.
+BSG_PRIVATE BugsnagSession *_Nullable BSGSessionFromCrashReport(NSDictionary *report, BugsnagApp *app, BugsnagDevice *device, BugsnagUser *user);
 
 NS_ASSUME_NONNULL_END

--- a/Bugsnag/Payload/BugsnagSession.m
+++ b/Bugsnag/Payload/BugsnagSession.m
@@ -9,6 +9,7 @@
 #import "BugsnagSession+Private.h"
 
 #import "BSGKeys.h"
+#import "BSGRunContext.h"
 #import "BSG_RFC3339DateTool.h"
 #import "BugsnagApp+Private.h"
 #import "BugsnagDevice+Private.h"
@@ -51,7 +52,7 @@
 
 @end
 
-#pragma mark -
+#pragma mark - Serialization
 
 NSDictionary * BSGSessionToDictionary(BugsnagSession *session) {
     return @{
@@ -101,5 +102,59 @@ BugsnagSession * BSGSessionFromEventJson(NSDictionary *_Nullable json, BugsnagAp
     NSDictionary *events = json[BSGKeyEvents];
     session.handledCount = [events[BSGKeyHandled] unsignedIntegerValue];
     session.unhandledCount = [events[BSGKeyUnhandled] unsignedIntegerValue];
+    return session;
+}
+
+void BSGSessionUpdateRunContext(BugsnagSession *_Nullable session) {
+    if (session) {
+        [session.id getCString:bsg_runContext->sessionId maxLength:sizeof(bsg_runContext->sessionId) encoding:NSUTF8StringEncoding];
+        bsg_runContext->sessionStartTime = session.startedAt.timeIntervalSinceReferenceDate;
+        bsg_runContext->handledCount = session.handledCount;
+        bsg_runContext->unhandledCount = session.unhandledCount;
+    } else {
+        bzero(bsg_runContext->sessionId, sizeof(bsg_runContext->sessionId));
+        bsg_runContext->sessionStartTime = 0;
+    }
+}
+
+BugsnagSession * BSGSessionFromLastRunContext(BugsnagApp *app, BugsnagDevice *device, BugsnagUser *user) {
+    if (bsg_lastRunContext && bsg_lastRunContext->sessionId[0] && bsg_lastRunContext->sessionStartTime > 0) {
+        NSString *sessionId = @(bsg_lastRunContext->sessionId);
+        NSDate *startedAt = [NSDate dateWithTimeIntervalSinceReferenceDate:bsg_lastRunContext->sessionStartTime];
+        BugsnagSession *session = [[BugsnagSession alloc] initWithId:sessionId startedAt:startedAt user:user app:app device:device];
+        session.handledCount = bsg_lastRunContext->handledCount;
+        session.unhandledCount = bsg_lastRunContext->unhandledCount;
+        return session;
+    } else {
+        return nil;
+    }
+}
+
+void BSGSessionWriteCrashReport(const BSG_KSCrashReportWriter *writer) {
+    if (bsg_runContext->sessionId[0] && bsg_runContext->sessionStartTime > 0) {
+        writer->addStringElement(writer, "id", bsg_runContext->sessionId);
+        writer->addFloatingPointElement(writer, "startedAt", bsg_runContext->sessionStartTime);
+        writer->addUIntegerElement(writer, "handledCount", bsg_runContext->handledCount);
+        writer->addUIntegerElement(writer, "unhandledCount", bsg_runContext->unhandledCount + 1);
+    }
+}
+
+BugsnagSession * BSGSessionFromCrashReport(NSDictionary *report, BugsnagApp *app, BugsnagDevice *device, BugsnagUser *user) {
+    NSDictionary *json = report[BSGKeyUser];
+    NSString *sessionId = json[BSGKeyId];
+    id startedAt = json[BSGKeyStartedAt];
+    NSDate *date = nil;
+    if ([startedAt isKindOfClass:[NSNumber class]]) {
+        date = [NSDate dateWithTimeIntervalSinceReferenceDate:[startedAt doubleValue]];
+    } else if ([startedAt isKindOfClass:[NSString class]]) {
+        // BSSerializeDataCrashHandler used to store the date as a string
+        date = [BSG_RFC3339DateTool dateFromString:startedAt];
+    }
+    if (!sessionId || !date) {
+        return nil;
+    }
+    BugsnagSession *session = [[BugsnagSession alloc] initWithId:sessionId startedAt:date user:user app:app device:device];
+    session.handledCount = [json[BSGKeyHandledCount] unsignedLongValue];
+    session.unhandledCount = [json[BSGKeyUnhandledCount] unsignedLongValue];
     return session;
 }

--- a/Tests/BugsnagTests/BugsnagConfigurationTests.m
+++ b/Tests/BugsnagTests/BugsnagConfigurationTests.m
@@ -63,7 +63,7 @@
     config.endpoints = [[BugsnagEndpointConfiguration alloc] initWithNotify:@"http://notify.example.com"
                                                                    sessions:@""];
     BugsnagSessionTracker *sessionTracker
-    = [[BugsnagSessionTracker alloc] initWithConfig:config client:nil callback:^(BugsnagSession *session) {}];
+    = [[BugsnagSessionTracker alloc] initWithConfig:config client:nil];
 
     XCTAssertNil(sessionTracker.runningSession);
     [sessionTracker startNewSession];
@@ -75,7 +75,7 @@
     config.endpoints = [[BugsnagEndpointConfiguration alloc] initWithNotify:@"http://notify.example.com"
                                                                    sessions:@"f"];
     BugsnagSessionTracker *sessionTracker
-    = [[BugsnagSessionTracker alloc] initWithConfig:config client:nil callback:^(BugsnagSession *session) {}];
+    = [[BugsnagSessionTracker alloc] initWithConfig:config client:nil];
 
     XCTAssertNil(sessionTracker.runningSession);
     [sessionTracker startNewSession];

--- a/Tests/BugsnagTests/BugsnagSessionTrackerStopTest.m
+++ b/Tests/BugsnagTests/BugsnagSessionTrackerStopTest.m
@@ -23,7 +23,7 @@
     [super setUp];
     self.configuration = [[BugsnagConfiguration alloc] initWithApiKey:DUMMY_APIKEY_32CHAR_1];
     self.configuration.autoTrackSessions = NO;
-    self.tracker = [[BugsnagSessionTracker alloc] initWithConfig:self.configuration client:nil callback:^(BugsnagSession *session) {}];
+    self.tracker = [[BugsnagSessionTracker alloc] initWithConfig:self.configuration client:nil];
 }
 
 /**

--- a/Tests/BugsnagTests/BugsnagSessionTrackerTest.m
+++ b/Tests/BugsnagTests/BugsnagSessionTrackerTest.m
@@ -26,7 +26,7 @@
     [super setUp];
     self.configuration = [[BugsnagConfiguration alloc] initWithApiKey:DUMMY_APIKEY_32CHAR_1];
     [self.configuration deletePersistedUserData];
-    self.sessionTracker = [[BugsnagSessionTracker alloc] initWithConfig:self.configuration client:nil callback:^(BugsnagSession *session) {}];
+    self.sessionTracker = [[BugsnagSessionTracker alloc] initWithConfig:self.configuration client:nil];
 }
 
 - (void)testStartNewSession {
@@ -123,7 +123,7 @@
     [self.configuration addOnSessionBlock:^BOOL(BugsnagSession *sessionPayload) {
         return NO;
     }];
-    self.sessionTracker = [[BugsnagSessionTracker alloc] initWithConfig:self.configuration client:nil callback:^(BugsnagSession *session) {}];
+    self.sessionTracker = [[BugsnagSessionTracker alloc] initWithConfig:self.configuration client:nil];
     [self.sessionTracker startNewSession];
     XCTAssertNil(self.sessionTracker.currentSession);
 }
@@ -136,7 +136,7 @@
         [expectation fulfill];
         return YES;
     }];
-    self.sessionTracker = [[BugsnagSessionTracker alloc] initWithConfig:self.configuration client:nil callback:^(BugsnagSession *session) {}];
+    self.sessionTracker = [[BugsnagSessionTracker alloc] initWithConfig:self.configuration client:nil];
     [self.sessionTracker startNewSession];
     [self waitForExpectations:@[expectation] timeout:2];
     XCTAssertNotNil(self.sessionTracker.currentSession);

--- a/features/barebone_tests.feature
+++ b/features/barebone_tests.feature
@@ -63,6 +63,10 @@ Feature: Barebone tests
     And the event "metaData.user.group" equals "users"
     And the event "metaData.user.id" is null
     And the event "metaData.user.name" is null
+    And the event "session.id" is not null
+    And the event "session.startedAt" is not null
+    And the event "session.events.handled" equals 0
+    And the event "session.events.unhandled" equals 1
     And the event "severity" equals "warning"
     And the event "severityReason.type" equals "handledException"
     And the event "severityReason.unhandledOverridden" is true
@@ -157,6 +161,10 @@ Feature: Barebone tests
     And the event "metaData.user.group" equals "users"
     And the event "metaData.user.id" is null
     And the event "metaData.user.name" is null
+    And the event "session.id" is not null
+    And the event "session.startedAt" is not null
+    And the event "session.events.handled" equals 0
+    And the event "session.events.unhandled" equals 1
     And the event "severity" equals "error"
     And the event "severityReason.type" equals "unhandledException"
     And the event "severityReason.unhandledOverridden" is null

--- a/features/fixtures/shared/scenarios/BareboneTestScenarios.swift
+++ b/features/fixtures/shared/scenarios/BareboneTestScenarios.swift
@@ -109,7 +109,6 @@ class BareboneTestUnhandledErrorScenario: Scenario {
     private var payload: Payload!
     
     override func startBugsnag() {
-        config.autoTrackSessions = false
         if eventMode == "report" {
             // The version of the app at report time.
             config.appVersion = "23.4"


### PR DESCRIPTION
## Goal

Reduce the overhead of persisting session information needed to build OOM and Thermal Kill payloads.

## Changeset

Moves (C-level) session info storage into `BSGRunContext` and removes session info from `BugsnagSystemState`.

Logic to convert sessions objects to and from BSGRunContext has been moved to `BugsnagSession.m` to make it easy to compare reading and writing code.

## Testing

Passed full E2E run, which includes scenarios that verify presence of session data in OOM and crash payloads.