### PR TITLE
[PLAT-8371] Create Swift Package Manager compatible tags

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -144,7 +144,9 @@ ifneq ($(shell git diff origin/master..master),)
 	$(error you have unpushed commits on the master branch)
 endif
 	@git tag v$(PRESET_VERSION)
-	@git push origin v$(PRESET_VERSION)
+	# Swift Package Manager prefers tags to be unprefixed package versions
+	@git tag $(PRESET_VERSION)
+	@git push origin v$(PRESET_VERSION) $(PRESET_VERSION)
 	@git checkout next
 	@git rebase origin/next
 	@git merge master


### PR DESCRIPTION
## Goal

Fix issue where Xcode's package selection would not suggest up-to-date versions of Bugsnag
* https://github.com/bugsnag/bugsnag-cocoa/issues/1336

SPM expects to find tags that are package version numbers without any prefix:

> To create a version tag, tag the last commit with the package version. A _package version_ is a three period-separated integer. An example is 1.0.0.

* https://developer.apple.com/documentation/xcode/publishing_a_swift_package_with_xcode

## Changeset

Pushes an unprefixed version tag upon release, while keeping the `v$(PRESET_VERSION)` tag for consistency with our historical tags & other repos.

## Testing

Manually pushed an unprefixed `6.16.7` tag and verified that Xcode suggests that version when adding Bugsnag to a project.