### PR TITLE
Minor improvements

### DIFF
--- a/Bugsnag/BugsnagSystemState.m
+++ b/Bugsnag/BugsnagSystemState.m
@@ -18,7 +18,6 @@
 
 #import "BSGFileLocations.h"
 #import "BSGJSONSerialization.h"
-#import "BSGRunContext.h"
 #import "BSGUtils.h"
 #import "BSG_KSCrashState.h"
 #import "BSG_KSSystemInfo.h"
@@ -30,20 +29,12 @@ static NSString * const ConsecutiveLaunchCrashesKey = @"consecutiveLaunchCrashes
 static NSString * const InternalKey = @"internal";
 
 static NSDictionary * loadPreviousState(NSString *jsonPath) {
-    if (!bsg_lastRunContext) {
-        return @{};
-    }
-
     NSError *error = nil;
     NSMutableDictionary *state = [BSGJSONSerialization JSONObjectWithContentsOfFile:jsonPath options:NSJSONReadingMutableContainers error:&error];
     if(![state isKindOfClass:[NSMutableDictionary class]]) {
         bsg_log_err(@"Could not load system_state.json: %@", error);
         return @{};
     }
-
-    NSMutableDictionary *app = state[SYSTEMSTATE_KEY_APP];
-    app[@"inForeground"]    = @(bsg_lastRunContext->isForeground);
-    app[BSGKeyIsLaunching]  = @(bsg_lastRunContext->isLaunching);
 
     return state;
 }

--- a/Bugsnag/Client/BugsnagClient+Private.h
+++ b/Bugsnag/Client/BugsnagClient+Private.h
@@ -74,7 +74,6 @@ typedef void (^ BSGClientObserver)(BSGClientObserverEvent event, _Nullable id va
 /// {
 ///     "app": {
 ///         "codeBundleId": "com.example.app",
-///         "isLaunching": true
 ///     },
 ///     "client": {
 ///         "context": "MyViewController",

--- a/Bugsnag/KSCrash/Source/KSCrash/Recording/BSG_KSCrashState.m
+++ b/Bugsnag/KSCrash/Source/KSCrash/Recording/BSG_KSCrashState.m
@@ -193,7 +193,6 @@ bool bsg_kscrashstate_init(const char *const stateFilePath,
 
 void bsg_kscrashstate_notifyAppInForeground(const bool isInForeground) {
     BSG_KSCrash_State *const state = bsg_g_state;
-    const char *const stateFilePath = bsg_g_stateFilePath;
 
     if (state->applicationIsInForeground == isInForeground) {
         return;
@@ -206,7 +205,6 @@ void bsg_kscrashstate_notifyAppInForeground(const bool isInForeground) {
         state->backgroundDurationSinceLaunch += duration;
     } else {
         state->foregroundDurationSinceLaunch += duration;
-        bsg_kscrashstate_i_saveState(state, stateFilePath);
     }
     state->lastUpdateDurationsTime = timeNow;
 }

--- a/Bugsnag/Payload/BugsnagAppWithState.m
+++ b/Bugsnag/Payload/BugsnagAppWithState.m
@@ -64,7 +64,7 @@
     app.durationInForeground = activeTimeSinceLaunch;
     app.duration = @([activeTimeSinceLaunch longValue] + [backgroundTimeSinceLaunch longValue]);
     app.inForeground = [stats[@BSG_KSCrashField_AppInFG] boolValue];
-    app.isLaunching = [[event valueForKeyPath:@"user.state.app.isLaunching"] boolValue];
+    app.isLaunching = [[event valueForKeyPath:@"user.isLaunching"] boolValue];
     [BugsnagApp populateFields:app dictionary:event config:config codeBundleId:codeBundleId];
     return app;
 }


### PR DESCRIPTION
## Goal

Remove unnecessary code & duplication of state.

## Changeset

Removes `inForeground` and `isLaunching` from `BugsnagSystemState`. `-generateEventForLastLaunchWithError:` now gets these directly from `bsg_lastRunContext`.

Removes `isLaunching` from `BugsnagClient.state`. `bsg_runContext->isLaunching` is now used when populating handled errors and crash reports.

Stops `BSG_CrashState` writing a file when foreground state changes (the file no longer contains this info.)

## Testing

Verified with E2E tests.