### PR TITLE
Add Danger rule for BSGRUNCONTEXT_VERSION

### DIFF
--- a/Dangerfile
+++ b/Dangerfile
@@ -33,4 +33,11 @@ if defined?(github) && github.branch_for_base == 'master' && !github.branch_for_
   failure 'Only release PRs should target the master branch'
 end
 
+begin
+  diff = git.diff_for_file Dir['Bugsnag/**/BSGRunContext.h'][0]
+  if diff && diff.patch !~ /BSGRUNCONTEXT_VERSION/
+    warn 'This PR modifies `BSGRunContext.h` but does not change `BSGRUNCONTEXT_VERSION`'
+  end
+end
+
 framework_size


### PR DESCRIPTION
## Goal

Help prevent forgetting to increment `BSGRUNCONTEXT_VERSION`.

Failing to increment this between releases if changes to the structure have been made could lead to unpredictable behaviour in the notifier.

## Changeset

Adds a Danger rule that adds a warning to PRs that modify `BSGRunContext.h` without changing `BSGRUNCONTEXT_VERSION`.

## Testing

Verified locally using Danger's dry run functionality.

```
$ danger dry_run --base=e03fb32265edaf8091817cc8c364fdfbbaa5bcae --head=a7cacd5407ea085fb1ecd69b4a857eb6693fc030
Results:

Warnings:
- [ ] This PR modifies `BSGRunContext.h` but does not change `BSGRUNCONTEXT_VERSION`
```