### PR TITLE
[PLAT-8410] Add `device.time` to OOM and Thermal Kill events

### DIFF
--- a/Bugsnag.xcodeproj/project.pbxproj
+++ b/Bugsnag.xcodeproj/project.pbxproj
@@ -1339,6 +1339,7 @@
 		019480D32625F3EB00E833ED /* BSGAppKitTests.m */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.objc; path = BSGAppKitTests.m; sourceTree = "<group>"; };
 		0195FC3B256BC81400DE6646 /* BugsnagEvent+Private.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; path = "BugsnagEvent+Private.h"; sourceTree = "<group>"; };
 		0198762E2567D5AB000A7AF3 /* BugsnagStackframe+Private.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; path = "BugsnagStackframe+Private.h"; sourceTree = "<group>"; };
+		019D165A2822B791009B35C9 /* BSGDefines.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; path = BSGDefines.h; sourceTree = "<group>"; };
 		01A2C540271EB9B300A27B23 /* BSG_Symbolicate.c */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.c; path = BSG_Symbolicate.c; sourceTree = "<group>"; };
 		01A2C541271EB9B300A27B23 /* BSG_Symbolicate.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = BSG_Symbolicate.h; sourceTree = "<group>"; };
 		01A6176B2733CFEA00024A0B /* TestHost-iOS.app */ = {isa = PBXFileReference; explicitFileType = wrapper.application; includeInIndex = 0; path = "TestHost-iOS.app"; sourceTree = BUILT_PRODUCTS_DIR; };
@@ -1868,6 +1869,7 @@
 				010FF28225ED2A8D00E4F2B0 /* BSGAppHangDetector.h */,
 				010FF28325ED2A8D00E4F2B0 /* BSGAppHangDetector.m */,
 				019480C42625EE9800E833ED /* BSGAppKit.h */,
+				019D165A2822B791009B35C9 /* BSGDefines.h */,
 				0109939A273D13D800128BBE /* BSGFeatureFlagStore.h */,
 				0109939B273D13D800128BBE /* BSGFeatureFlagStore.m */,
 				01847D942644140F00ADA4C7 /* BSGInternalErrorReporter.h */,

--- a/Bugsnag/Client/BugsnagClient.m
+++ b/Bugsnag/Client/BugsnagClient.m
@@ -298,6 +298,7 @@ __attribute__((annotate("oclint:suppress[too many methods]")))
     bsg_log_debug(@"App has finished launching");
     [self.appLaunchTimer invalidate];
     bsg_runContext->isLaunching = NO;
+    BSGRunContextUpdateTimestamp();
 }
 
 - (void)sendLaunchCrashSynchronously {
@@ -756,6 +757,7 @@ __attribute__((annotate("oclint:suppress[too many methods]")))
 
 - (void)addBreadcrumbWithBlock:(void (^)(BugsnagBreadcrumb *))block {
     [self.breadcrumbs addBreadcrumbWithBlock:block];
+    BSGRunContextUpdateTimestamp();
 }
 
 /**
@@ -1121,6 +1123,9 @@ __attribute__((annotate("oclint:suppress[too many methods]")))
 #if TARGET_OS_IOS
     device.orientation = BSGStringFromDeviceOrientation(bsg_lastRunContext->lastKnownOrientation);
 #endif
+    if (bsg_lastRunContext->timestamp > 0) {
+        device.time = [NSDate dateWithTimeIntervalSinceReferenceDate:bsg_lastRunContext->timestamp];
+    }
 
     NSDictionary *metadataDict = [BSGJSONSerialization JSONObjectWithContentsOfFile:BSGFileLocations.current.metadata options:0 error:nil];
     BugsnagMetadata *metadata = [[BugsnagMetadata alloc] initWithDictionary:metadataDict ?: @{}];

--- a/Bugsnag/Helpers/BSGDefines.h
+++ b/Bugsnag/Helpers/BSGDefines.h
@@ -1,0 +1,13 @@
+//
+//  BSGDefines.h
+//  Bugsnag
+//
+//  Copyright © 2022 Bugsnag Inc. All rights reserved.
+//
+
+#ifndef BSGDefines_h
+#define BSGDefines_h
+
+#define BSG_PRIVATE __attribute__((visibility("hidden")))
+
+#endif /* BSGDefines_h */

--- a/Bugsnag/Helpers/BSGRunContext.h
+++ b/Bugsnag/Helpers/BSGRunContext.h
@@ -10,6 +10,8 @@
 #include <stdint.h>
 #include <uuid/uuid.h>
 
+#include "BSGDefines.h"
+
 //
 // The struct version should be incremented prior to a release if changes have
 // been made to BSGRunContext.
@@ -38,6 +40,7 @@ struct BSGRunContext {
     long lastKnownOrientation;
     dispatch_source_memorypressure_flags_t memoryPressure;
 #endif
+    double timestamp;
 };
 
 /// Information about the current run of the app / process.
@@ -53,6 +56,10 @@ extern const struct BSGRunContext *_Nullable bsg_lastRunContext;
 #pragma mark -
 
 void BSGRunContextInit(const char *_Nonnull path);
+
+#pragma mark -
+
+BSG_PRIVATE void BSGRunContextUpdateTimestamp(void);
 
 #pragma mark -
 

--- a/Bugsnag/Payload/BugsnagSession+Private.h
+++ b/Bugsnag/Payload/BugsnagSession+Private.h
@@ -8,9 +8,8 @@
 
 #import <Bugsnag/BugsnagSession.h>
 
+#import "BSGDefines.h"
 #import "BSG_KSCrashReportWriter.h"
-
-#define BSG_PRIVATE __attribute__((visibility("hidden")))
 
 NS_ASSUME_NONNULL_BEGIN
 

--- a/Bugsnag/Payload/BugsnagSession.m
+++ b/Bugsnag/Payload/BugsnagSession.m
@@ -115,6 +115,7 @@ void BSGSessionUpdateRunContext(BugsnagSession *_Nullable session) {
         bzero(bsg_runContext->sessionId, sizeof(bsg_runContext->sessionId));
         bsg_runContext->sessionStartTime = 0;
     }
+    BSGRunContextUpdateTimestamp();
 }
 
 BugsnagSession * BSGSessionFromLastRunContext(BugsnagApp *app, BugsnagDevice *device, BugsnagUser *user) {

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,13 @@
 Changelog
 =========
 
+## TBD
+
+### Enhancements
+
+* Add `device.time` to OOM and Thermal Kill events.
+  [#1355](https://github.com/bugsnag/bugsnag-cocoa/pull/1355)
+
 ## 6.16.8 (2022-05-04)
 
 ### Changes

--- a/features/barebone_tests.feature
+++ b/features/barebone_tests.feature
@@ -243,7 +243,7 @@ Feature: Barebone tests
     And the event "device.osVersion" matches "\d+\.\d+"
     And the event "device.runtimeVersions.clangVersion" is not null
     And the event "device.runtimeVersions.osBuild" is not null
-    And the event "device.time" is null
+    And the event "device.time" is a timestamp
     And the event "device.totalMemory" is not null
     And the event "metaData.app.name" equals "iOSTestApp"
     And the event "metaData.custom.bar" equals "foo"

--- a/features/out_of_memory.feature
+++ b/features/out_of_memory.feature
@@ -48,6 +48,7 @@ Feature: Out of memory errors
     And the event "device.manufacturer" equals "Apple"
     And the event "device.orientation" matches "(face(down|up)|landscape(left|right)|portrait(upsidedown)?)"
     And the event "device.runtimeVersions" is not null
+    And the event "device.time" is a timestamp
     And the event "device.totalMemory" is not null
     And the event "metaData.custom.bar" equals "foo"
     And the event "session.id" is not null

--- a/features/thermal_state.feature
+++ b/features/thermal_state.feature
@@ -25,6 +25,7 @@ Feature: Thermal State
     And the exception "message" equals "The app was terminated by the operating system due to a critical thermal state"
     And the event "metaData.device.thermalState" matches "critical"
     And the event has a critical thermal state breadcrumb
+    And the event "device.time" is a timestamp
     And the event "session.events.handled" equals 0
     And the event "session.events.unhandled" equals 1
     And the event "severity" equals "error"


### PR DESCRIPTION
## Goal

Provide a timestamp for OOM and Thermal Kill events so that the dashboard renders breadcrumbs with sensible relative timestamps.

## Changeset

Adds a `timestamp` field to `BSGRunContext` which is updated from a timer and in response to certain events (so that `device.time >= breadcrumbs.last.timestamp`)

Sets `device.time` for OOM and TK events based on the last run's context.

Uses `CFAbsoluteTimeGetCurrent()` as the source of timing information, which provides a wall-clock time equivalent to `[NSDate date].timeIntervalSinceReferenceDate`.

## Performance

`CFAbsoluteTime()` is very fast on recent OS versions (~70 nanoseconds on iPhone 5s with iOS 12) where it does not need to call into the kernel.

On iPad 3 running iOS 9 it takes ~1400 nanoseconds (1.4 µs) which while much slower is still reasonable for the frequency at which this code calls it. For comparison, a single character `write()` to stdout takes ~8 µs.

Considered using `mach_approximate_time()` which is _much_ faster (~45 nanoseconds on iPad 3) but since it would be difficult (perhaps impossible?) to convert to the required wall-clock time and only old devices / OSes would benefit, the extra complexity does not feel justified.

## Testing

Amends OOM barebone E2E scenario to verify presence of `device.time`.

Manually verified outcome on dashboard using example app.