### PR TITLE
[PLAT-8411] Add `device.freeMemory` to OOM and Thermal Kill events

### DIFF
--- a/.buildkite/pipeline.full.yml
+++ b/.buildkite/pipeline.full.yml
@@ -338,6 +338,8 @@ steps:
       - xcodebuild -allowProvisioningUpdates -workspace objective-c-ios.xcworkspace -scheme objective-c-ios -configuration Release -destination generic/platform=iOS -derivedDataPath DerivedData -quiet build GCC_TREAT_WARNINGS_AS_ERRORS=YES
       - echo "+++ Build Debug iOS Simulator"
       - xcodebuild -allowProvisioningUpdates -workspace objective-c-ios.xcworkspace -scheme objective-c-ios -configuration Debug -destination generic/platform=iOS\ Simulator -derivedDataPath DerivedData -quiet build GCC_TREAT_WARNINGS_AS_ERRORS=YES
+      - echo "+++ Build Debug Mac Catalyst"
+      - xcodebuild -allowProvisioningUpdates -workspace objective-c-ios.xcworkspace -scheme objective-c-ios -configuration Debug -destination generic/platform=macOS -derivedDataPath DerivedData -quiet build
 
   - label: 'examples/objective-c-osx'
     timeout_in_minutes: 30

--- a/Bugsnag/Client/BugsnagClient.m
+++ b/Bugsnag/Client/BugsnagClient.m
@@ -1126,6 +1126,9 @@ __attribute__((annotate("oclint:suppress[too many methods]")))
     if (bsg_lastRunContext->timestamp > 0) {
         device.time = [NSDate dateWithTimeIntervalSinceReferenceDate:bsg_lastRunContext->timestamp];
     }
+    if (bsg_lastRunContext->availableMemory) {
+        device.freeMemory = @(bsg_lastRunContext->availableMemory);
+    }
 
     NSDictionary *metadataDict = [BSGJSONSerialization JSONObjectWithContentsOfFile:BSGFileLocations.current.metadata options:0 error:nil];
     BugsnagMetadata *metadata = [[BugsnagMetadata alloc] initWithDictionary:metadataDict ?: @{}];

--- a/Bugsnag/Helpers/BSGRunContext.h
+++ b/Bugsnag/Helpers/BSGRunContext.h
@@ -41,6 +41,7 @@ struct BSGRunContext {
     dispatch_source_memorypressure_flags_t memoryPressure;
 #endif
     double timestamp;
+    size_t availableMemory;
 };
 
 /// Information about the current run of the app / process.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,9 @@ Changelog
 
 ### Enhancements
 
+* Add `device.freeMemory` to OOM and Thermal Kill events on iOS 13 and later.
+  [#1357](https://github.com/bugsnag/bugsnag-cocoa/pull/1357)
+
 * Add `device.time` to OOM and Thermal Kill events.
   [#1355](https://github.com/bugsnag/bugsnag-cocoa/pull/1355)
 

--- a/features/barebone_tests.feature
+++ b/features/barebone_tests.feature
@@ -236,6 +236,7 @@ Feature: Barebone tests
     And the event "device.modelNumber" equals the platform-dependent string:
       | ios   | @not_null |
       | macos | @null     |
+    And on iOS 13 and later, the event "device.freeMemory" is an integer
     And the event "device.osName" equals the platform-dependent string:
       | ios   | iOS    |
       | macos | Mac OS |
@@ -244,7 +245,7 @@ Feature: Barebone tests
     And the event "device.runtimeVersions.clangVersion" is not null
     And the event "device.runtimeVersions.osBuild" is not null
     And the event "device.time" is a timestamp
-    And the event "device.totalMemory" is not null
+    And the event "device.totalMemory" is an integer
     And the event "metaData.app.name" equals "iOSTestApp"
     And the event "metaData.custom.bar" equals "foo"
     And the event "metaData.device.batteryLevel" is a number
@@ -278,7 +279,5 @@ Feature: Barebone tests
     And the error payload field "events.0.app.duration" is null
     And the error payload field "events.0.app.durationInForeground" is null
     And the error payload field "events.0.device.freeDisk" is null
-    And the error payload field "events.0.device.freeMemory" is null
     And the error payload field "events.0.device.model" matches the test device model
-    And the error payload field "events.0.device.totalMemory" is an integer
     And the error payload field "events.0.threads" is an array with 0 elements

--- a/features/out_of_memory.feature
+++ b/features/out_of_memory.feature
@@ -45,11 +45,12 @@ Feature: Out of memory errors
     And the event "app.bundleVersion" is not null
     And the event "app.dsymUUIDs" is not null
     And the event "app.version" is not null
+    And on iOS 13 and later, the event "device.freeMemory" is an integer
     And the event "device.manufacturer" equals "Apple"
     And the event "device.orientation" matches "(face(down|up)|landscape(left|right)|portrait(upsidedown)?)"
     And the event "device.runtimeVersions" is not null
     And the event "device.time" is a timestamp
-    And the event "device.totalMemory" is not null
+    And the event "device.totalMemory" is an integer
     And the event "metaData.custom.bar" equals "foo"
     And the event "session.id" is not null
     And the event "session.startedAt" is not null

--- a/features/steps/reusable_steps.rb
+++ b/features/steps/reusable_steps.rb
@@ -1,7 +1,13 @@
+# frozen_string_literal: true
+
 # A collection of steps that could be added to Maze Runner
 
 Then(/^on (iOS|macOS), (.+)/) do |platform, step_text|
   step(step_text) if platform.downcase == Maze::Helper.get_current_platform
+end
+
+Then(/^on (iOS|macOS) (\d+) and later, (.+)/) do |platform, version, step_text|
+  step(step_text) if platform.downcase == Maze::Helper.get_current_platform && Maze.config.os_version >= version
 end
 
 Then('the event {string} equals one of:') do |field, possible_values|
@@ -17,6 +23,11 @@ end
 Then('the event {string} is a number') do |field|
   value = Maze::Helper.read_key_path(Maze::Server.errors.current[:body], "events.0.#{field}")
   Maze.check.kind_of Numeric, value
+end
+
+Then('the event {string} is an integer') do |field|
+  value = Maze::Helper.read_key_path(Maze::Server.errors.current[:body], "events.0.#{field}")
+  Maze.check.kind_of Integer, value
 end
 
 Then('the event {string} is within {int} seconds of the current timestamp') do |field, threshold_secs|


### PR DESCRIPTION
## Goal

Provide recent memory statistics to improve confidence in OOM errors.

## Changeset

Adds an `availableMemory` field to `BSGRunContext` and updates this in the timer callback (twice per second) and in response to a memory pressure notification.

Only on iOS/tvOS 13 and later where `os_proc_available_memory()` is available.

ℹ️ Does not update `BSGRUNCONTEXT_VERSION` since no release yet contains BSGRunContext.

## Performance

`os_proc_available_memory()` is much faster than calling `host_statistics()` or `task_info()`... ~150 vs ~700 nanoseconds on an iPhone SE (2020).

## Testing

Amends E2E scenarios to verify presence of `device.freeMemory`