### PR TITLE
Improve macOS E2E reliability and logging output

### DIFF
--- a/features/fixtures/macos/macOSTestApp/main.m
+++ b/features/fixtures/macos/macOSTestApp/main.m
@@ -9,6 +9,12 @@
 #import <Cocoa/Cocoa.h>
 
 int main(int argc, const char * argv[]) {
+    NSString *tmpdir = [[[NSProcessInfo processInfo] environment] objectForKey:@"TMPDIR"];
+    [[NSFileManager defaultManager] removeItemAtPath:
+     // Avoids a crash observed in -[NSPersistentUICrashHandler inspectCrashDataWithModification:handler:]
+     // that seems to occur if "$TMPDIR/com.bugsnag.macOSTestApp.savedState" is corrupted
+     [tmpdir stringByAppendingPathComponent:@"com.bugsnag.macOSTestApp.savedState"] error:nil];
+    
     [[NSUserDefaults standardUserDefaults] registerDefaults:@{
         // Disable state restoration to prevent the following dialog being shown after crashes
         // "The last time you opened macOSTestApp, it unexpectedly quit while reopening windows.

--- a/features/steps/app_steps.rb
+++ b/features/steps/app_steps.rb
@@ -142,7 +142,10 @@ def wait_for_true
 end
 
 def run_macos_app
-  Process.kill('KILL', $fixture_pid) if $fixture_pid
+  if $fixture_pid
+    Process.kill 'KILL', $fixture_pid
+    Process.waitpid $fixture_pid
+  end
   $fixture_pid = Process.spawn(
     { 'MAZE_RUNNER' => 'TRUE' },
     'features/fixtures/macos/output/macOSTestApp.app/Contents/MacOS/macOSTestApp',

--- a/features/support/env.rb
+++ b/features/support/env.rb
@@ -56,11 +56,11 @@ Maze.hooks.before do |_scenario|
   if Maze.config.os == 'ios' && Maze.config.farm == :local
     begin
       $logger_pid = Process.spawn(
-        'idevicesyslog', '-u', Maze.config.device_id, '-p', 'iOSTestApp',
-        out: File.open('device.log', 'w')
+        'idevicesyslog', '-u', Maze.config.device_id, '-m', 'iOSTestApp',
+        %i[err out] => File.open('device.log', 'w')
       )
     rescue Errno::ENOENT
-      # Use of idevicesyslog is optional
+      p 'Install libimobiledevice to capture iOS device logs'
     end
   end
 end
@@ -75,28 +75,32 @@ Maze.hooks.after do |scenario|
   FileUtils.makedirs(path)
 
   if Maze.config.os == 'macos'
-    FileUtils.mv('/tmp/kscrash.log', path)
-    Process.kill('KILL', $fixture_pid) if $fixture_pid
-    $fixture_pid = nil
-    Process.wait(
-      Process.spawn(
-        '/usr/bin/log', 'show', '--predicate', 'process == "macOSTestApp"',
-        '--style', 'syslog', '--start', $started_at.strftime('%Y-%m-%d %H:%M:%S%z'),
+    if $fixture_pid # will be nil if scenario was skipped
+      Process.kill 'KILL', $fixture_pid
+      Process.waitpid $fixture_pid
+      $fixture_pid = nil
+      sleep 1 # prevent log bleed between scenarios due to second precision of --start
+      log = Process.spawn(
+        '/usr/bin/log', 'show', '--style', 'syslog', '--predicate',
+        'eventMessage contains "macOSTestApp" OR process == "macOSTestApp"',
+        '--start', $started_at.strftime('%Y-%m-%d %H:%M:%S%z'),
         out: File.open(File.join(path, 'device.log'), 'w')
       )
-    )
-  else
-    if Maze.config.farm == :local
-      if $logger_pid
-        Process.kill('TERM', $logger_pid)
-        Process.waitpid($logger_pid)
-        $logger_pid = nil
-      end
-      FileUtils.mv('device.log', path)
+      Process.wait log
+      FileUtils.mv '/tmp/kscrash.log', path
     end
-    data = Maze.driver.pull_file '@com.bugsnag.iOSTestApp/Documents/kscrash.log'
-    File.open(File.join(path, 'kscrash.log'), 'wb') { |file| file << data }
+  else
+    if $logger_pid
+      Process.kill 'TERM', $logger_pid
+      Process.waitpid $logger_pid
+      $logger_pid = nil
+      FileUtils.mv 'device.log', path
+    end
+    begin
+      data = Maze.driver.pull_file '@com.bugsnag.iOSTestApp/Documents/kscrash.log'
+      File.open(File.join(path, 'kscrash.log'), 'wb') { |file| file << data }
+    rescue StandardError
+      p "Maze.driver.pull_file failed: #{$ERROR_INFO}"
+    end
   end
-rescue StandardError
-  # pull_file can fail on BrowserStack iOS 10 with "Error: Command 'umount' not found"
 end


### PR DESCRIPTION
## Goal

Address some macOS E2E test flakes.

## Changeset

Removes `$TMPDIR/com.bugsnag.macOSTestApp.savedState` before starting AppKit.

The following crash was observed on the failing machines when launching the test fixture, and it could be that the saved state was corrupt (maybe partly written data when the fixture crashed?) Manually removing the file solved the crash.

```
Thread 8 Crashed:: Dispatch queue: com.apple.root.background-qos
0   com.apple.CoreFoundation      	0x00007fff3984e595 CFDataReplaceBytes.cold.5 + 14
1   com.apple.CoreFoundation      	0x00007fff396dd658 CFDataReplaceBytes + 323
2   com.apple.AppKit              	0x00007fff3699bd4e -[NSPersistentUICrashHandler inspectCrashDataWithModification:handler:] + 143
3   com.apple.AppKit              	0x00007fff36b2fce9 __82-[NSPersistentUIRestorer tearDownStateRestorationApparatusAndResumeWindowOrdering]_block_invoke + 47
4   com.apple.AppKit              	0x00007fff37473f38 ___NSPersistentUIDispatchQueueAsync_block_invoke + 28
5   libdispatch.dylib             	0x00007fff7377f6c4 _dispatch_call_block_and_release + 12
6   libdispatch.dylib             	0x00007fff73780658 _dispatch_client_callout + 8
7   libdispatch.dylib             	0x00007fff7378eaa8 _dispatch_root_queue_drain + 663
8   libdispatch.dylib             	0x00007fff7378f097 _dispatch_worker_thread2 + 92
9   libsystem_pthread.dylib       	0x00007fff739da9f7 _pthread_wqthread + 220
10  libsystem_pthread.dylib       	0x00007fff739d9b77 start_wqthread + 15
```

Avoids trying to capture macOS logs if the fixture was not run - i.e. for skipped scenarios.

Ensures [Process#waitpid](https://ruby-doc.org/core-3.1.2/Process.html#method-c-waitpid) is called to avoid zombie processes 🧟

Restricts scope of `rescue` blocks to avoid hiding unexpected exceptions.

Captures slightly richer device logs by also including messages that contain the fixture name from other processes.

## Testing

Ran tests on a [separate branch](https://buildkite.com/bugsnag/bugsnag-cocoa/builds?branch=nickdowell%2Fe2e-flakes) to identify problem and verify fix.