### PR TITLE
Replace BSGJSONSerialization class with functions

### DIFF
--- a/Bugsnag/Breadcrumbs/BugsnagBreadcrumbs.m
+++ b/Bugsnag/Breadcrumbs/BugsnagBreadcrumbs.m
@@ -67,14 +67,13 @@ static struct bsg_breadcrumb_list_item *g_breadcrumbs_head;
         for (struct bsg_breadcrumb_list_item *item = g_breadcrumbs_head; item != NULL; item = item->next) {
             NSError *error = nil;
             NSData *data = [NSData dataWithBytesNoCopy:item->jsonData length:strlen(item->jsonData) freeWhenDone:NO];
-            id JSONObject = [BSGJSONSerialization JSONObjectWithData:data options:0 error:&error];
+            NSDictionary *JSONObject = BSGJSONDictionaryFromData(data, 0, &error);
             if (!JSONObject) {
                 bsg_log_err(@"Unable to parse breadcrumb: %@", error);
                 continue;
             }
-            BugsnagBreadcrumb *breadcrumb = nil;
-            if (![JSONObject isKindOfClass:[NSDictionary class]] ||
-                !(breadcrumb = [BugsnagBreadcrumb breadcrumbFromDict:JSONObject])) {
+            BugsnagBreadcrumb *breadcrumb = [BugsnagBreadcrumb breadcrumbFromDict:JSONObject];
+            if (!breadcrumb) {
                 bsg_log_err(@"Unexpected breadcrumb payload in buffer");
                 continue;
             }
@@ -214,13 +213,8 @@ static struct bsg_breadcrumb_list_item *g_breadcrumbs_head;
 #pragma mark - File storage
 
 - (NSData *)dataForBreadcrumb:(BugsnagBreadcrumb *)breadcrumb {
-    id JSONObject = [breadcrumb objectValue];
-    if (![BSGJSONSerialization isValidJSONObject:JSONObject]) {
-        bsg_log_err(@"Unable to serialize breadcrumb: Not a valid JSON object");
-        return nil;
-    }
     NSError *error = nil;
-    NSData *data = [BSGJSONSerialization dataWithJSONObject:JSONObject options:0 error:&error];
+    NSData *data = BSGJSONDataFromDictionary([breadcrumb objectValue], &error);
     if (!data) {
         bsg_log_err(@"Unable to serialize breadcrumb: %@", error);
     }
@@ -265,14 +259,13 @@ static struct bsg_breadcrumb_list_item *g_breadcrumbs_head;
             }
             continue;
         }
-        id JSONObject = [BSGJSONSerialization JSONObjectWithData:data options:0 error:&error];
+        NSDictionary *JSONObject = BSGJSONDictionaryFromData(data, 0, &error);
         if (!JSONObject) {
             bsg_log_err(@"Unable to parse breadcrumb: %@", error);
             continue;
         }
-        BugsnagBreadcrumb *breadcrumb;
-        if (![JSONObject isKindOfClass:[NSDictionary class]] ||
-            !(breadcrumb = [BugsnagBreadcrumb breadcrumbFromDict:JSONObject])) {
+        BugsnagBreadcrumb *breadcrumb = [BugsnagBreadcrumb breadcrumbFromDict:JSONObject];
+        if (!breadcrumb) {
             bsg_log_err(@"Unexpected breadcrumb payload in file %@", file);
             continue;
         }

--- a/Bugsnag/Breadcrumbs/BugsnagBreadcrumbs.m
+++ b/Bugsnag/Breadcrumbs/BugsnagBreadcrumbs.m
@@ -213,9 +213,10 @@ static struct bsg_breadcrumb_list_item *g_breadcrumbs_head;
 #pragma mark - File storage
 
 - (NSData *)dataForBreadcrumb:(BugsnagBreadcrumb *)breadcrumb {
+    NSData *data = nil;
     NSError *error = nil;
-    NSData *data = BSGJSONDataFromDictionary([breadcrumb objectValue], &error);
-    if (!data) {
+    NSDictionary *json = [breadcrumb objectValue];
+    if (!json || !(data = BSGJSONDataFromDictionary(json, &error))) {
         bsg_log_err(@"Unable to serialize breadcrumb: %@", error);
     }
     return data;

--- a/Bugsnag/BugsnagSystemState.m
+++ b/Bugsnag/BugsnagSystemState.m
@@ -174,7 +174,7 @@ static NSDictionary *copyDictionary(NSDictionary *launchState) {
 - (void)sync {
     NSDictionary *state = self.currentLaunchState;
     NSError *error = nil;
-    if (!BSGJSONWriteDictionaryToFile(state, self.persistenceFilePath, &error)) {
+    if (!BSGJSONWriteToFileAtomically(state, self.persistenceFilePath, &error)) {
         bsg_log_err(@"System state cannot be written as JSON: %@", error);
     }
 }

--- a/Bugsnag/BugsnagSystemState.m
+++ b/Bugsnag/BugsnagSystemState.m
@@ -30,7 +30,7 @@ static NSString * const InternalKey = @"internal";
 
 static NSDictionary * loadPreviousState(NSString *jsonPath) {
     NSError *error = nil;
-    NSMutableDictionary *state = [BSGJSONSerialization JSONObjectWithContentsOfFile:jsonPath options:NSJSONReadingMutableContainers error:&error];
+    NSMutableDictionary *state = (NSMutableDictionary *)BSGJSONDictionaryFromFile(jsonPath, NSJSONReadingMutableContainers, &error);
     if(![state isKindOfClass:[NSMutableDictionary class]]) {
         if (!(error.domain == NSCocoaErrorDomain && error.code == NSFileReadNoSuchFileError)) {
             bsg_log_err(@"Could not load system_state.json: %@", error);
@@ -173,9 +173,9 @@ static NSDictionary *copyDictionary(NSDictionary *launchState) {
 
 - (void)sync {
     NSDictionary *state = self.currentLaunchState;
-    NSAssert([BSGJSONSerialization isValidJSONObject:state], @"BugsnagSystemState cannot be converted to JSON data");
+    NSAssert(BSGJSONDictionaryIsValid(state), @"BugsnagSystemState cannot be converted to JSON data");
     NSError *error = nil;
-    if (![BSGJSONSerialization writeJSONObject:state toFile:self.persistenceFilePath options:0 error:&error]) {
+    if (!BSGJSONWriteDictionaryToFile(state, self.persistenceFilePath, &error)) {
         bsg_log_err(@"System state cannot be written as JSON: %@", error);
     }
 }

--- a/Bugsnag/BugsnagSystemState.m
+++ b/Bugsnag/BugsnagSystemState.m
@@ -173,7 +173,6 @@ static NSDictionary *copyDictionary(NSDictionary *launchState) {
 
 - (void)sync {
     NSDictionary *state = self.currentLaunchState;
-    NSAssert(BSGJSONDictionaryIsValid(state), @"BugsnagSystemState cannot be converted to JSON data");
     NSError *error = nil;
     if (!BSGJSONWriteDictionaryToFile(state, self.persistenceFilePath, &error)) {
         bsg_log_err(@"System state cannot be written as JSON: %@", error);

--- a/Bugsnag/Client/BugsnagClient.m
+++ b/Bugsnag/Client/BugsnagClient.m
@@ -227,7 +227,7 @@ __attribute__((annotate("oclint:suppress[too many methods]")))
     [self computeDidCrashLastLaunch];
 
     // These files can only be overwritten once the previous contents have been read; see -generateEventForLastLaunchWithError:
-    BSGJSONWriteDictionaryToFile(self.configuration.dictionaryRepresentation, BSGFileLocations.current.configuration, nil);
+    BSGJSONWriteToFileAtomically(self.configuration.dictionaryRepresentation, BSGFileLocations.current.configuration, nil);
     [self.metadata setStorageBuffer:&bsg_g_bugsnag_data.metadataJSON file:BSGFileLocations.current.metadata];
     [self.state setStorageBuffer:&bsg_g_bugsnag_data.stateJSON file:BSGFileLocations.current.state];
     [self.breadcrumbs removeAllBreadcrumbs];
@@ -1023,7 +1023,7 @@ __attribute__((annotate("oclint:suppress[too many methods]")))
     
     NSError *writeError = nil;
     NSDictionary *json = [self.appHangEvent toJsonWithRedactedKeys:self.configuration.redactedKeys];
-    if (!BSGJSONWriteDictionaryToFile(json, BSGFileLocations.current.appHangEvent, &writeError)) {
+    if (!BSGJSONWriteToFileAtomically(json, BSGFileLocations.current.appHangEvent, &writeError)) {
         bsg_log_err(@"Could not write app_hang.json: %@", writeError);
     }
 }

--- a/Bugsnag/Delivery/BSGEventUploadFileOperation.m
+++ b/Bugsnag/Delivery/BSGEventUploadFileOperation.m
@@ -25,8 +25,8 @@
 }
 
 - (BugsnagEvent *)loadEventAndReturnError:(NSError * __autoreleasing *)errorPtr {
-    id json = [BSGJSONSerialization JSONObjectWithContentsOfFile:self.file options:0 error:errorPtr];
-    if (![json isKindOfClass:[NSDictionary class]]) {
+    NSDictionary *json = BSGJSONDictionaryFromFile(self.file, 0, errorPtr);
+    if (!json) {
         return nil;
     }
     return [[BugsnagEvent alloc] initWithJson:json];

--- a/Bugsnag/Delivery/BSGEventUploadKSCrashReportOperation.m
+++ b/Bugsnag/Delivery/BSGEventUploadKSCrashReportOperation.m
@@ -57,7 +57,7 @@ static void ReportInternalError(NSString *errorClass, NSString *message, NSDicti
         return nil;
     }
     
-    id json = [BSGJSONSerialization JSONObjectWithData:data options:0 error:&error];
+    NSDictionary *json = BSGJSONDictionaryFromData(data, 0, &error);
     if (!json) {
         NSMutableDictionary *diagnostics = [NSMutableDictionary dictionary];
         diagnostics[@"data"] = [data base64EncodedStringWithOptions:0];
@@ -97,11 +97,6 @@ static void ReportInternalError(NSString *errorClass, NSString *message, NSDicti
 // Methods below were copied from BSG_KSCrashReportStore.m
 
 - (NSMutableDictionary *)fixupCrashReport:(NSDictionary *)report {
-    if (![report isKindOfClass:[NSDictionary class]]) {
-        bsg_log_err(@"Report should be a dictionary, not %@", [report class]);
-        return nil;
-    }
-
     NSMutableDictionary *mutableReport = [report mutableCopy];
     NSMutableDictionary *mutableInfo =
             [report[@BSG_KSCrashField_Report] mutableCopy];

--- a/Bugsnag/Delivery/BSGEventUploader.m
+++ b/Bugsnag/Delivery/BSGEventUploader.m
@@ -254,7 +254,7 @@ static NSString * const RecrashReportPrefix = @"RecrashReport-";
     dispatch_sync(BSGGetFileSystemQueue(), ^{
         NSString *file = [[self.eventsDirectory stringByAppendingPathComponent:[NSUUID UUID].UUIDString] stringByAppendingPathExtension:@"json"];
         NSError *error = nil;
-        if (!BSGJSONWriteDictionaryToFile(eventPayload, file, &error)) {
+        if (!BSGJSONWriteToFileAtomically(eventPayload, file, &error)) {
             bsg_log_err(@"Error encountered while saving event payload for retry: %@", error);
             return;
         }

--- a/Bugsnag/Delivery/BSGEventUploader.m
+++ b/Bugsnag/Delivery/BSGEventUploader.m
@@ -147,8 +147,8 @@ static NSString * const RecrashReportPrefix = @"RecrashReport-";
         
         NSString *path = [directory stringByAppendingPathComponent:filename];
         if (!didReportRecrash) {
-            id recrashReport = [BSGJSONSerialization JSONObjectWithContentsOfFile:path options:0 error:&error];
-            if ([recrashReport isKindOfClass:[NSDictionary class]]) {
+            NSDictionary *recrashReport = BSGJSONDictionaryFromFile(path, 0, &error);
+            if (recrashReport) {
                 bsg_log_debug(@"Reporting %@", filename);
                 [BSGInternalErrorReporter.sharedInstance reportRecrash:recrashReport];
                 didReportRecrash = YES;
@@ -162,7 +162,7 @@ static NSString * const RecrashReportPrefix = @"RecrashReport-";
         // Delete the report to prevent reporting a "JSON parsing error"
         NSString *crashReportFilename = [filename stringByReplacingOccurrencesOfString:RecrashReportPrefix withString:CrashReportPrefix];
         NSString *crashReportPath = [directory stringByAppendingPathComponent:crashReportFilename];
-        if (![BSGJSONSerialization JSONObjectWithContentsOfFile:crashReportPath options:0 error:nil]) {
+        if (!BSGJSONDictionaryFromFile(crashReportPath, 0, nil)) {
             bsg_log_info(@"Deleting unparsable %@", crashReportFilename);
             if (![fileManager removeItemAtPath:crashReportPath error:&error]) {
                 bsg_log_err(@"%@", error);
@@ -254,7 +254,7 @@ static NSString * const RecrashReportPrefix = @"RecrashReport-";
     dispatch_sync(BSGGetFileSystemQueue(), ^{
         NSString *file = [[self.eventsDirectory stringByAppendingPathComponent:[NSUUID UUID].UUIDString] stringByAppendingPathExtension:@"json"];
         NSError *error = nil;
-        if (![BSGJSONSerialization writeJSONObject:eventPayload toFile:file options:0 error:&error]) {
+        if (!BSGJSONWriteDictionaryToFile(eventPayload, file, &error)) {
             bsg_log_err(@"Error encountered while saving event payload for retry: %@", error);
             return;
         }

--- a/Bugsnag/Delivery/BSGSessionUploader.m
+++ b/Bugsnag/Delivery/BSGSessionUploader.m
@@ -71,7 +71,7 @@ static NSArray * SortedFiles(NSFileManager *fileManager, NSMutableDictionary<NSS
                       stringByAppendingPathExtension:@"json"];
     
     NSError *error;
-    if ([BSGJSONSerialization writeJSONObject:json toFile:file options:0 error:&error]) {
+    if (BSGJSONWriteDictionaryToFile(json, file, &error)) {
         bsg_log_debug(@"Stored session %@", session.id);
         [self pruneFiles];
     } else {
@@ -92,7 +92,7 @@ static NSArray * SortedFiles(NSFileManager *fileManager, NSMutableDictionary<NSS
             continue;
         }
         
-        NSDictionary *json = [BSGJSONSerialization JSONObjectWithContentsOfFile:file options:0 error:nil];
+        NSDictionary *json = BSGJSONDictionaryFromFile(file, 0, nil);
         BugsnagSession *session = BSGSessionFromDictionary(json);
         if (!session) {
             bsg_log_debug(@"Deleting invalid session %@",

--- a/Bugsnag/Delivery/BSGSessionUploader.m
+++ b/Bugsnag/Delivery/BSGSessionUploader.m
@@ -71,7 +71,7 @@ static NSArray * SortedFiles(NSFileManager *fileManager, NSMutableDictionary<NSS
                       stringByAppendingPathExtension:@"json"];
     
     NSError *error;
-    if (BSGJSONWriteDictionaryToFile(json, file, &error)) {
+    if (BSGJSONWriteToFileAtomically(json, file, &error)) {
         bsg_log_debug(@"Stored session %@", session.id);
         [self pruneFiles];
     } else {

--- a/Bugsnag/Delivery/BugsnagApiClient.m
+++ b/Bugsnag/Delivery/BugsnagApiClient.m
@@ -50,14 +50,8 @@ typedef NS_ENUM(NSInteger, HTTPStatusCode) {
                   toURL:(NSURL *)url
       completionHandler:(void (^)(BugsnagApiClientDeliveryStatus status, NSError * _Nullable error))completionHandler {
     
-    if (![BSGJSONSerialization isValidJSONObject:payload]) {
-        bsg_log_err(@"Error: Invalid JSON payload passed to %s", __PRETTY_FUNCTION__);
-        completionHandler(BugsnagApiClientDeliveryStatusUndeliverable, nil);
-        return;
-    }
-    
     NSError *error = nil;
-    NSData *data = [BSGJSONSerialization dataWithJSONObject:payload options:0 error:&error];
+    NSData *data = BSGJSONDataFromDictionary(payload, &error);
     if (!data) {
         bsg_log_err(@"Error: Could not encode JSON payload passed to %s", __PRETTY_FUNCTION__);
         completionHandler(BugsnagApiClientDeliveryStatusUndeliverable, error);

--- a/Bugsnag/Helpers/BSGJSONSerialization.h
+++ b/Bugsnag/Helpers/BSGJSONSerialization.h
@@ -17,13 +17,13 @@ NS_ASSUME_NONNULL_BEGIN
  * This wrapper catches all exceptions and forces everything to be returned as an error.
  */
 
-BOOL BSGJSONDictionaryIsValid(NSDictionary *_Nullable dictionary);
+BOOL BSGJSONDictionaryIsValid(NSDictionary *dictionary, NSError **error);
 
-NSData *_Nullable BSGJSONDataFromDictionary(NSDictionary *_Nullable dictionary, NSError **error);
+NSData *_Nullable BSGJSONDataFromDictionary(NSDictionary *dictionary, NSError **error);
 
 NSDictionary *_Nullable BSGJSONDictionaryFromData(NSData *data, NSJSONReadingOptions options, NSError **error);
 
-BOOL BSGJSONWriteDictionaryToFile(NSDictionary *_Nullable dictionary, NSString *file, NSError **error);
+BOOL BSGJSONWriteDictionaryToFile(NSDictionary *dictionary, NSString *file, NSError **error);
 
 NSDictionary *_Nullable BSGJSONDictionaryFromFile(NSString *file, NSJSONReadingOptions options, NSError **error);
 

--- a/Bugsnag/Helpers/BSGJSONSerialization.h
+++ b/Bugsnag/Helpers/BSGJSONSerialization.h
@@ -16,38 +16,15 @@ NS_ASSUME_NONNULL_BEGIN
  * with no specification as to which mechanism will trigger for what kinds of errors.
  * This wrapper catches all exceptions and forces everything to be returned as an error.
  */
-@interface BSGJSONSerialization : NSObject
 
-/* Returns YES if the given object can be converted to JSON data, NO otherwise. The object must have the following properties:
-    - Top level object is an NSArray or NSDictionary
-    - All objects are NSString, NSNumber, NSArray, NSDictionary, or NSNull
-    - All dictionary keys are NSStrings
-    - NSNumbers are not NaN or infinity
- Other rules may apply. Calling this method or attempting a conversion are the definitive ways to tell if a given object can be converted to JSON data.
- */
-+ (BOOL)isValidJSONObject:(nullable id)obj;
+BOOL BSGJSONDictionaryIsValid(NSDictionary *_Nullable dictionary);
 
-/* Generate JSON data from a Foundation object. If the object will not produce valid JSON then an error will be returned. Setting the NSJSONWritingPrettyPrinted option will generate JSON with whitespace designed to make the output more readable. If that option is not set, the most compact possible JSON will be generated. If an error occurs, the error parameter will be set and the return value will be nil. The resulting data is a encoded in UTF-8.
- */
-+ (nullable NSData *)dataWithJSONObject:(id)obj options:(NSJSONWritingOptions)opt error:(NSError **)error;
+NSData *_Nullable BSGJSONDataFromDictionary(NSDictionary *_Nullable dictionary, NSError **error);
 
-/* Create a Foundation object from JSON data. Set the NSJSONReadingAllowFragments option if the parser should allow top-level objects that are not an NSArray or NSDictionary. Setting the NSJSONReadingMutableContainers option will make the parser generate mutable NSArrays and NSDictionaries. Setting the NSJSONReadingMutableLeaves option will make the parser generate mutable NSString objects. If an error occurs during the parse, then the error parameter will be set and the result will be nil.
-   The data must be in one of the 5 supported encodings listed in the JSON specification: UTF-8, UTF-16LE, UTF-16BE, UTF-32LE, UTF-32BE. The data may or may not have a BOM. The most efficient encoding to use for parsing is UTF-8, so if you have a choice in encoding the data passed to this method, use UTF-8.
- */
-+ (nullable id)JSONObjectWithData:(NSData *)data options:(NSJSONReadingOptions)opt error:(NSError **)error;
+NSDictionary *_Nullable BSGJSONDictionaryFromData(NSData *data, NSJSONReadingOptions options, NSError **error);
 
-/* Write JSON data into a stream. The stream should be opened and configured. The return value is the number of bytes written to the stream, or 0 on error. All other behavior of this method is the same as the dataWithJSONObject:options:error: method.
- */
-+ (NSInteger)writeJSONObject:(id)obj toStream:(NSOutputStream *)stream options:(NSJSONWritingOptions)opt error:(NSError **)error;
+BOOL BSGJSONWriteDictionaryToFile(NSDictionary *_Nullable dictionary, NSString *file, NSError **error);
 
-/* Create a JSON object from JSON data stream. The stream should be opened and configured. All other behavior of this method is the same as the JSONObjectWithData:options:error: method.
- */
-+ (nullable id)JSONObjectWithStream:(NSInputStream *)stream options:(NSJSONReadingOptions)opt error:(NSError **)error;
-
-+ (BOOL)writeJSONObject:(id)JSONObject toFile:(NSString *)file options:(NSJSONWritingOptions)options error:(NSError **)errorPtr;
-
-+ (nullable id)JSONObjectWithContentsOfFile:(NSString *)file options:(NSJSONReadingOptions)options error:(NSError **)errorPtr;
-
-@end
+NSDictionary *_Nullable BSGJSONDictionaryFromFile(NSString *file, NSJSONReadingOptions options, NSError **error);
 
 NS_ASSUME_NONNULL_END

--- a/Bugsnag/Helpers/BSGJSONSerialization.h
+++ b/Bugsnag/Helpers/BSGJSONSerialization.h
@@ -23,7 +23,7 @@ NSData *_Nullable BSGJSONDataFromDictionary(NSDictionary *dictionary, NSError **
 
 NSDictionary *_Nullable BSGJSONDictionaryFromData(NSData *data, NSJSONReadingOptions options, NSError **error);
 
-BOOL BSGJSONWriteDictionaryToFile(NSDictionary *dictionary, NSString *file, NSError **error);
+BOOL BSGJSONWriteToFileAtomically(NSDictionary *dictionary, NSString *file, NSError **error);
 
 NSDictionary *_Nullable BSGJSONDictionaryFromFile(NSString *file, NSJSONReadingOptions options, NSError **error);
 

--- a/Bugsnag/Helpers/BSGJSONSerialization.m
+++ b/Bugsnag/Helpers/BSGJSONSerialization.m
@@ -61,7 +61,7 @@ NSDictionary *_Nullable BSGJSONDictionaryFromData(NSData *data, NSJSONReadingOpt
     return nil;
 }
 
-BOOL BSGJSONWriteDictionaryToFile(NSDictionary *JSONObject, NSString *file, NSError **errorPtr) {
+BOOL BSGJSONWriteToFileAtomically(NSDictionary *JSONObject, NSString *file, NSError **errorPtr) {
     NSData *data = BSGJSONDataFromDictionary(JSONObject, errorPtr);
     return [data writeToFile:file options:NSDataWritingAtomic error:errorPtr];
 }

--- a/Bugsnag/Helpers/BugsnagCollections.m
+++ b/Bugsnag/Helpers/BugsnagCollections.m
@@ -85,7 +85,7 @@ NSDictionary * BSGJSONDictionary(NSDictionary *dictionary) {
     if (!dictionary) {
         return nil;
     }
-    if (BSGJSONDictionaryIsValid(dictionary)) {
+    if (BSGJSONDictionaryIsValid(dictionary, nil)) {
         return dictionary;
     }
     NSMutableDictionary *json = [NSMutableDictionary dictionary];
@@ -94,7 +94,7 @@ NSDictionary * BSGJSONDictionary(NSDictionary *dictionary) {
             continue;
         }
         const id value = dictionary[key];
-        if (BSGJSONDictionaryIsValid(@{key: value})) {
+        if (BSGJSONDictionaryIsValid(@{key: value}, nil)) {
             json[key] = value;
         } else if ([value isKindOfClass:[NSDictionary class]]) {
             json[key] = BSGJSONDictionary(value);

--- a/Bugsnag/Helpers/BugsnagCollections.m
+++ b/Bugsnag/Helpers/BugsnagCollections.m
@@ -85,7 +85,7 @@ NSDictionary * BSGJSONDictionary(NSDictionary *dictionary) {
     if (!dictionary) {
         return nil;
     }
-    if ([BSGJSONSerialization isValidJSONObject:dictionary]) {
+    if (BSGJSONDictionaryIsValid(dictionary)) {
         return dictionary;
     }
     NSMutableDictionary *json = [NSMutableDictionary dictionary];
@@ -94,7 +94,7 @@ NSDictionary * BSGJSONDictionary(NSDictionary *dictionary) {
             continue;
         }
         const id value = dictionary[key];
-        if ([BSGJSONSerialization isValidJSONObject:@{key: value}]) {
+        if (BSGJSONDictionaryIsValid(@{key: value})) {
             json[key] = value;
         } else if ([value isKindOfClass:[NSDictionary class]]) {
             json[key] = BSGJSONDictionary(value);

--- a/Bugsnag/KSCrash/Source/KSCrash/Recording/BSG_KSCrashState.m
+++ b/Bugsnag/KSCrash/Source/KSCrash/Recording/BSG_KSCrashState.m
@@ -102,10 +102,8 @@ bool bsg_kscrashstate_i_loadState(BSG_KSCrash_State *const context,
         return false;
     }
     NSError *error;
-    NSDictionary *dict = [BSGJSONSerialization
-                          JSONObjectWithContentsOfFile:file
-                          options:0 error:&error];
-    if (![dict isKindOfClass:[NSDictionary class]]) {
+    NSDictionary *dict = BSGJSONDictionaryFromFile(file, 0, &error);
+    if (!dict) {
         if (!(error.domain == NSCocoaErrorDomain &&
               error.code == NSFileReadNoSuchFileError)) {
             bsg_log_err(@"%s: Could not load file: %@", path, error);

--- a/Bugsnag/Metadata/BugsnagMetadata.m
+++ b/Bugsnag/Metadata/BugsnagMetadata.m
@@ -240,7 +240,7 @@
 
 - (void)serialize {
     NSError *error = nil;
-    NSData *data = [BSGJSONSerialization dataWithJSONObject:[self toDictionary] options:0 error:&error];
+    NSData *data = BSGJSONDataFromDictionary([self dictionary], &error);
     if (!data) {
         bsg_log_err(@"%s: %@", __FUNCTION__, error);
         return;

--- a/Bugsnag/Payload/BugsnagSession.m
+++ b/Bugsnag/Payload/BugsnagSession.m
@@ -67,9 +67,6 @@ NSDictionary * BSGSessionToDictionary(BugsnagSession *session) {
 }
 
 BugsnagSession *_Nullable BSGSessionFromDictionary(NSDictionary *json) {
-    if (![json isKindOfClass:[NSDictionary class]]) {
-        return nil;
-    }
     NSString *sessionId = json[BSGKeyId];
     NSDate *startedAt = [BSG_RFC3339DateTool dateFromString:json[BSGKeyStartedAt]];
     if (!sessionId || !startedAt) {

--- a/Tests/BugsnagTests/BSGJSONSerializationTests.m
+++ b/Tests/BugsnagTests/BSGJSONSerializationTests.m
@@ -37,14 +37,14 @@
     
     NSString *file = [NSTemporaryDirectory() stringByAppendingPathComponent:@(__PRETTY_FUNCTION__)];
     
-    XCTAssertTrue(BSGJSONWriteDictionaryToFile(validJSON, file, nil));
+    XCTAssertTrue(BSGJSONWriteToFileAtomically(validJSON, file, nil));
 
     XCTAssertEqualObjects(BSGJSONDictionaryFromFile(file, 0, nil), @{@"foo": @"bar"});
     
     [[NSFileManager defaultManager] removeItemAtPath:file error:nil];
     
     NSError *error = nil;
-    XCTAssertFalse(BSGJSONWriteDictionaryToFile(invalidJSON, file, &error));
+    XCTAssertFalse(BSGJSONWriteToFileAtomically(invalidJSON, file, &error));
     XCTAssertNotNil(error);
     
     error = nil;
@@ -54,7 +54,7 @@
     NSString *unwritablePath = @"/System/Library/foobar";
     
     error = nil;
-    XCTAssertFalse(BSGJSONWriteDictionaryToFile(validJSON, unwritablePath, &error));
+    XCTAssertFalse(BSGJSONWriteToFileAtomically(validJSON, unwritablePath, &error));
     XCTAssertNotNil(error);
     
     error = nil;

--- a/Tests/BugsnagTests/BSGJSONSerializationTests.m
+++ b/Tests/BugsnagTests/BSGJSONSerializationTests.m
@@ -20,26 +20,12 @@
     NSData* badJSONData = [@"{123=\"test\"}" dataUsingEncoding:NSUTF8StringEncoding];
     id result;
     NSError* error;
-    result = [BSGJSONSerialization dataWithJSONObject:badDict options:0 error:&error];
+    result = BSGJSONDataFromDictionary(badDict, &error);
     XCTAssertNotNil(error);
     XCTAssertNil(result);
     error = nil;
     
-    result = [BSGJSONSerialization JSONObjectWithData:badJSONData options:0 error:&error];
-    XCTAssertNotNil(error);
-    XCTAssertNil(result);
-    error = nil;
-
-    NSOutputStream* outstream = [NSOutputStream outputStreamToMemory];
-    [outstream open];
-    [BSGJSONSerialization writeJSONObject:badDict toStream:outstream options:0 error:&error];
-    XCTAssertNotNil(error);
-    error = nil;
-    
-    NSInputStream* instream = [NSInputStream inputStreamWithData:badJSONData];
-    [instream open];
-
-    result = [BSGJSONSerialization JSONObjectWithStream:instream options:0 error:&error];
+    result = BSGJSONDictionaryFromData(badJSONData, 0, &error);
     XCTAssertNotNil(error);
     XCTAssertNil(result);
     error = nil;
@@ -51,28 +37,28 @@
     
     NSString *file = [NSTemporaryDirectory() stringByAppendingPathComponent:@(__PRETTY_FUNCTION__)];
     
-    XCTAssertTrue([BSGJSONSerialization writeJSONObject:validJSON toFile:file options:0 error:nil]);
+    XCTAssertTrue(BSGJSONWriteDictionaryToFile(validJSON, file, nil));
 
-    XCTAssertEqualObjects([BSGJSONSerialization JSONObjectWithContentsOfFile:file options:0 error:nil], @{@"foo": @"bar"});
+    XCTAssertEqualObjects(BSGJSONDictionaryFromFile(file, 0, nil), @{@"foo": @"bar"});
     
     [[NSFileManager defaultManager] removeItemAtPath:file error:nil];
     
     NSError *error = nil;
-    XCTAssertFalse([BSGJSONSerialization writeJSONObject:invalidJSON toFile:file options:0 error:&error]);
+    XCTAssertFalse(BSGJSONWriteDictionaryToFile(invalidJSON, file, &error));
     XCTAssertNotNil(error);
     
     error = nil;
-    XCTAssertNil([BSGJSONSerialization JSONObjectWithContentsOfFile:file options:0 error:&error]);
+    XCTAssertNil(BSGJSONDictionaryFromFile(file, 0, &error));
     XCTAssertNotNil(error);
 
     NSString *unwritablePath = @"/System/Library/foobar";
     
     error = nil;
-    XCTAssertFalse([BSGJSONSerialization writeJSONObject:validJSON toFile:unwritablePath options:0 error:&error]);
+    XCTAssertFalse(BSGJSONWriteDictionaryToFile(validJSON, unwritablePath, &error));
     XCTAssertNotNil(error);
     
     error = nil;
-    XCTAssertNil([BSGJSONSerialization JSONObjectWithContentsOfFile:unwritablePath options:0 error:&error]);
+    XCTAssertNil(BSGJSONDictionaryFromFile(file, 0, &error));
     XCTAssertNotNil(error);
 }
 
@@ -80,7 +66,7 @@
     NSError *error = nil;
 #pragma clang diagnostic push
 #pragma clang diagnostic ignored "-Wnonnull"
-    XCTAssertNil([BSGJSONSerialization JSONObjectWithData:nil options:0 error:&error]);
+    XCTAssertNil(BSGJSONDictionaryFromData(nil, 0, &error));
 #pragma clang diagnostic pop
     XCTAssertNotNil(error);
     id underlyingError = error.userInfo[NSUnderlyingErrorKey];


### PR DESCRIPTION
## Goal

Simplify JSON (de)serialization code and reduce binary size.

## Changeset

Replaces the `BSGJSONSerialization` class and static methods with equivalent functions.

Deserializes JSON to `NSDictionary` to reduce the number of `[object isKindOfClass:[NSDictinoary class]]` checks throughout the codebase.

Removes unused `NSStream` based methods.

## Testing

Passes all unit and E2E tests.