### PR TITLE
Prune oldest instead of newest persisted sessions

### DIFF
--- a/Bugsnag/Delivery/BSGSessionUploader.m
+++ b/Bugsnag/Delivery/BSGSessionUploader.m
@@ -124,8 +124,11 @@ static NSArray * SortedFiles(NSFileManager *fileManager, NSMutableDictionary<NSS
     NSMutableArray *sortedFiles = [SortedFiles(fileManager, NULL) mutableCopy];
     
     while (sortedFiles.count > self.config.maxPersistedSessions) {
-        [fileManager removeItemAtPath:(id _Nonnull)sortedFiles.lastObject error:nil];
-        [sortedFiles removeLastObject];
+        NSString *file = sortedFiles[0];
+        bsg_log_debug(@"Deleting %@ to comply with maxPersistedSessions",
+                      file.lastPathComponent.stringByDeletingPathExtension);
+        [fileManager removeItemAtPath:file error:nil];
+        [sortedFiles removeObject:file];
     }
 }
 

--- a/features/delivery.feature
+++ b/features/delivery.feature
@@ -73,3 +73,19 @@ Feature: Delivery of errors
     Then the session "user.id" equals "new"
     And I discard the oldest session
     And I should receive no requests
+
+  Scenario: The oldest sessions should be deleted to comply with maxPersistedSessions
+    Given I set the HTTP status code to 500
+    And I run "MaxPersistedSessionsScenario"
+    And I wait to receive 2 sessions
+    And the session "user.id" equals "1"
+    And I discard the oldest session
+    And the session "user.id" equals "2"
+    And I discard the oldest session
+    When I set the HTTP status code to 200
+    And I relaunch the app
+    And I configure Bugsnag for "MaxPersistedSessionsScenario"
+    And I wait to receive 2 sessions
+    Then the session "user.id" equals "3"
+    And I discard the oldest session
+    And the session "user.id" equals "2"

--- a/features/fixtures/ios/iOSTestApp.xcodeproj/project.pbxproj
+++ b/features/fixtures/ios/iOSTestApp.xcodeproj/project.pbxproj
@@ -19,6 +19,7 @@
 		01018BA025E40ADD000312C6 /* AsyncSafeMallocScenario.m in Sources */ = {isa = PBXBuildFile; fileRef = 01018B9F25E40ADD000312C6 /* AsyncSafeMallocScenario.m */; };
 		0104085F258CA0A100933C60 /* DispatchCrashScenario.swift in Sources */ = {isa = PBXBuildFile; fileRef = 0104085E258CA0A100933C60 /* DispatchCrashScenario.swift */; };
 		0104B47E275A7B3C003EBDF0 /* RecrashScenarios.mm in Sources */ = {isa = PBXBuildFile; fileRef = 0104B47D275A7B3C003EBDF0 /* RecrashScenarios.mm */; };
+		01221E55282E5538008095C3 /* MaxPersistedSessionsScenario.m in Sources */ = {isa = PBXBuildFile; fileRef = 01221E54282E5538008095C3 /* MaxPersistedSessionsScenario.m */; };
 		0163BFA72583B3CF008DC28B /* DiscardClassesScenarios.swift in Sources */ = {isa = PBXBuildFile; fileRef = 0163BFA62583B3CF008DC28B /* DiscardClassesScenarios.swift */; };
 		017B4134276B8D9B0054C91D /* OnSendErrorPersistenceScenario.m in Sources */ = {isa = PBXBuildFile; fileRef = 017B4133276B8D9B0054C91D /* OnSendErrorPersistenceScenario.m */; };
 		01847DD626453D4E00ADA4C7 /* InvalidCrashReportScenario.m in Sources */ = {isa = PBXBuildFile; fileRef = 01847DD526453D4E00ADA4C7 /* InvalidCrashReportScenario.m */; };
@@ -181,6 +182,7 @@
 		01018B9F25E40ADD000312C6 /* AsyncSafeMallocScenario.m */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.objc; path = AsyncSafeMallocScenario.m; sourceTree = "<group>"; };
 		0104085E258CA0A100933C60 /* DispatchCrashScenario.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = DispatchCrashScenario.swift; sourceTree = "<group>"; };
 		0104B47D275A7B3C003EBDF0 /* RecrashScenarios.mm */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.objcpp; path = RecrashScenarios.mm; sourceTree = "<group>"; };
+		01221E54282E5538008095C3 /* MaxPersistedSessionsScenario.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; path = MaxPersistedSessionsScenario.m; sourceTree = "<group>"; };
 		0163BFA62583B3CF008DC28B /* DiscardClassesScenarios.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = DiscardClassesScenarios.swift; sourceTree = "<group>"; };
 		017B4133276B8D9B0054C91D /* OnSendErrorPersistenceScenario.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; path = OnSendErrorPersistenceScenario.m; sourceTree = "<group>"; };
 		01847DD526453D4E00ADA4C7 /* InvalidCrashReportScenario.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; path = InvalidCrashReportScenario.m; sourceTree = "<group>"; };
@@ -593,6 +595,7 @@
 				8A096DF527C7E56C00DB6ECC /* CxxUnexpectedScenario.mm */,
 				0163BFA62583B3CF008DC28B /* DiscardClassesScenarios.swift */,
 				01847DD526453D4E00ADA4C7 /* InvalidCrashReportScenario.m */,
+				01221E54282E5538008095C3 /* MaxPersistedSessionsScenario.m */,
 				01AFCFCA282CE9F700D48D45 /* OldSessionScenario.m */,
 				017B4133276B8D9B0054C91D /* OnSendErrorPersistenceScenario.m */,
 				01E5EAD025B713990066EA8A /* OOMScenario.h */,
@@ -872,6 +875,7 @@
 			isa = PBXSourcesBuildPhase;
 			buildActionMask = 2147483647;
 			files = (
+				01221E55282E5538008095C3 /* MaxPersistedSessionsScenario.m in Sources */,
 				E700EE7B247D7A1F008CFFB6 /* SIGSEGVScenario.m in Sources */,
 				E75040A02478019D005D33BD /* AutoDetectFalseHandledScenario.swift in Sources */,
 				01F115C927BAAF2D00892B1E /* SIGPIPEIgnoredScenario.m in Sources */,

--- a/features/fixtures/macos/macOSTestApp.xcodeproj/project.pbxproj
+++ b/features/fixtures/macos/macOSTestApp.xcodeproj/project.pbxproj
@@ -135,6 +135,7 @@
 		01F47D30254B1B3100B184AD /* AutoContextNSExceptionScenario.swift in Sources */ = {isa = PBXBuildFile; fileRef = 01F47CBF254B1B3000B184AD /* AutoContextNSExceptionScenario.swift */; };
 		01F47D31254B1B3100B184AD /* OverwriteLinkRegisterScenario.m in Sources */ = {isa = PBXBuildFile; fileRef = 01F47CC0254B1B3000B184AD /* OverwriteLinkRegisterScenario.m */; };
 		01F47D32254B1B3100B184AD /* ResumeSessionOOMScenario.m in Sources */ = {isa = PBXBuildFile; fileRef = 01F47CC1254B1B3000B184AD /* ResumeSessionOOMScenario.m */; };
+		01F54384282E50FE00684474 /* MaxPersistedSessionsScenario.m in Sources */ = {isa = PBXBuildFile; fileRef = 01F54383282E50FE00684474 /* MaxPersistedSessionsScenario.m */; };
 		01F7365A278D90440000113C /* NetworkBreadcrumbsScenario.swift in Sources */ = {isa = PBXBuildFile; fileRef = 01F73659278D90440000113C /* NetworkBreadcrumbsScenario.swift */; };
 		01FA9EC626D64FFF0059FF4A /* AppHangInTerminationScenario.swift in Sources */ = {isa = PBXBuildFile; fileRef = 01FA9EC526D64FFF0059FF4A /* AppHangInTerminationScenario.swift */; };
 		8A096DF827C7E63A00DB6ECC /* CxxUnexpectedScenario.mm in Sources */ = {isa = PBXBuildFile; fileRef = 8A096DF727C7E63A00DB6ECC /* CxxUnexpectedScenario.mm */; };
@@ -344,6 +345,7 @@
 		01F47CC1254B1B3000B184AD /* ResumeSessionOOMScenario.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; path = ResumeSessionOOMScenario.m; sourceTree = "<group>"; };
 		01F47CC2254B1B3000B184AD /* SIGBUSScenario.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = SIGBUSScenario.h; sourceTree = "<group>"; };
 		01F47CC3254B1B3100B184AD /* SIGFPEScenario.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = SIGFPEScenario.h; sourceTree = "<group>"; };
+		01F54383282E50FE00684474 /* MaxPersistedSessionsScenario.m */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.objc; path = MaxPersistedSessionsScenario.m; sourceTree = "<group>"; };
 		01F73659278D90440000113C /* NetworkBreadcrumbsScenario.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = NetworkBreadcrumbsScenario.swift; sourceTree = "<group>"; };
 		01FA9EC526D64FFF0059FF4A /* AppHangInTerminationScenario.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = AppHangInTerminationScenario.swift; sourceTree = "<group>"; };
 		2C49722B331FF4B0DC477462 /* Pods-macOSTestApp.release.xcconfig */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.xcconfig; name = "Pods-macOSTestApp.release.xcconfig"; path = "Target Support Files/Pods-macOSTestApp/Pods-macOSTestApp.release.xcconfig"; sourceTree = "<group>"; };
@@ -451,6 +453,7 @@
 				01F47C6E254B1B2E00B184AD /* ManyConcurrentNotifyScenario.m */,
 				CBB7878D2578FB3F0071BDE4 /* MarkUnhandledHandledScenario.h */,
 				CBB7878C2578FB3F0071BDE4 /* MarkUnhandledHandledScenario.m */,
+				01F54383282E50FE00684474 /* MaxPersistedSessionsScenario.m */,
 				01F47CBD254B1B3000B184AD /* MetadataMergeScenario.swift */,
 				01F47C29254B1B2C00B184AD /* MetadataRedactionDefaultScenario.swift */,
 				01F47C80254B1B2F00B184AD /* MetadataRedactionNestedScenario.swift */,
@@ -731,6 +734,7 @@
 			isa = PBXSourcesBuildPhase;
 			buildActionMask = 2147483647;
 			files = (
+				01F54384282E50FE00684474 /* MaxPersistedSessionsScenario.m in Sources */,
 				01F47CD9254B1B3100B184AD /* SessionCallbackDiscardScenario.swift in Sources */,
 				01F47CD0254B1B3100B184AD /* StackOverflowScenario.m in Sources */,
 				01F115C727BAA67B00892B1E /* SIGPIPEIgnoredScenario.m in Sources */,

--- a/features/fixtures/shared/scenarios/MaxPersistedSessionsScenario.m
+++ b/features/fixtures/shared/scenarios/MaxPersistedSessionsScenario.m
@@ -1,0 +1,38 @@
+//
+//  MaxPersistedSessionsScenario.m
+//  macOSTestApp
+//
+//  Created by Nick Dowell on 13/05/2022.
+//  Copyright © 2022 Bugsnag Inc. All rights reserved.
+//
+
+#import "Scenario.h"
+
+@interface MaxPersistedSessionsScenario : Scenario
+@end
+
+@implementation MaxPersistedSessionsScenario
+
+- (void)startBugsnag {
+    self.config.autoTrackSessions = NO;
+    self.config.maxPersistedSessions = 1;
+
+    [super startBugsnag];
+
+    [Bugsnag setUser:[self nextUserId] withEmail:nil andName:nil];
+    [Bugsnag startSession];
+}
+
+- (void)run {
+    [Bugsnag setUser:[self nextUserId] withEmail:nil andName:nil];
+    [Bugsnag startSession];
+}
+
+- (NSString *)nextUserId {
+    NSString *key = @"sessionCounter";
+    NSInteger sessionCounter = [NSUserDefaults.standardUserDefaults integerForKey:key] + 1;
+    [NSUserDefaults.standardUserDefaults setInteger:sessionCounter forKey:key];
+    return [NSString stringWithFormat:@"%ld", sessionCounter];
+}
+
+@end


### PR DESCRIPTION
## Goal

Fix a bug introduced by #1362 

## Changeset

Delete the first (oldest) entry from `sortedFiles` when pruning old persisted session.

## Testing

The automated tests don't currently verify this behaviour...