### PR TITLE
Explicitly kill and relaunch the test fixture

### DIFF
--- a/TESTING.md
+++ b/TESTING.md
@@ -84,10 +84,10 @@ Build the test iOS fixture:
 
 1. Run Maze Runner as follows, adjusting for your specific device:
     ```shell script
-    bundle exec maze-runner --app=features/fixtures/ios/output/iOSTestApp.ipa \
+    bundle exec maze-runner --farm=local                                      \
+                            --app=features/fixtures/ios/output/iOSTestApp.ipa \
                             --udid=<udid>                                     \
                             --os=ios                                          \
-                            --os-version=14                                   \
                             features/app_and_device_attributes.feature
     ```
    `<udid>` is the device Identifier found under Devices and Simulators in Xcode.

--- a/features/app_hangs.feature
+++ b/features/app_hangs.feature
@@ -104,14 +104,14 @@ Feature: App hangs
   Scenario: Fatal app hangs should be reported if appHangThresholdMillis = BugsnagAppHangThresholdFatalOnly
     When I run "AppHangFatalOnlyScenario"
     And I wait for 3 seconds
-    And I relaunch the app
+    And I kill and relaunch the app
     And I set the HTTP status code to 500
     And I configure Bugsnag for "AppHangFatalOnlyScenario"
     And I wait to receive an error
     And I clear the error queue
     # Wait for fixture to receive the response and save the payload
     And I wait for 2 seconds
-    And I relaunch the app
+    And I kill and relaunch the app
     And I set the HTTP status code to 200
     And I configure Bugsnag for "AppHangFatalOnlyScenario"
     And I wait to receive an error
@@ -133,7 +133,7 @@ Feature: App hangs
   Scenario: Fatal app hangs should not be reported if enabledErrorTypes.appHangs = false
     When I run "AppHangFatalDisabledScenario"
     And I wait for 3 seconds
-    And I relaunch the app
+    And I kill and relaunch the app
     And I configure Bugsnag for "AppHangFatalDisabledScenario"
     Then I should receive no errors
 
@@ -141,7 +141,7 @@ Feature: App hangs
   Scenario: Fatal app hangs should be reported if the app hangs before going to the background
     When I run "AppHangFatalOnlyScenario"
     And I send the app to the background for 3 seconds
-    And I relaunch the app
+    And I kill and relaunch the app
     And I configure Bugsnag for "AppHangFatalOnlyScenario"
     And I wait to receive an error
     And the exception "message" equals "The app was terminated while unresponsive"
@@ -150,7 +150,7 @@ Feature: App hangs
   Scenario: Fatal app hangs should not be reported if they occur once the app is in the background
     When I run "AppHangDidEnterBackgroundScenario"
     And I send the app to the background for 3 seconds
-    And I relaunch the app
+    And I kill and relaunch the app
     And I configure Bugsnag for "AppHangDidEnterBackgroundScenario"
     Then I should receive no errors
 

--- a/features/auto_detect_errors.feature
+++ b/features/auto_detect_errors.feature
@@ -12,7 +12,7 @@ Feature: autoDetectErrors flag controls whether errors are captured automaticall
         And the error payload field "events" is an array with 1 elements
         And the event "unhandled" is false
         And I discard the oldest error
-        And I relaunch the app
+        And I kill and relaunch the app
         When I run "AutoDetectFalseNSExceptionScenario" and relaunch the crashed app
         And I configure Bugsnag for "AutoDetectFalseHandledScenario"
         Then I should receive no requests
@@ -24,7 +24,7 @@ Feature: autoDetectErrors flag controls whether errors are captured automaticall
         And the error payload field "events" is an array with 1 elements
         And the event "unhandled" is false
         And I discard the oldest error
-        And I relaunch the app
+        And I kill and relaunch the app
         When I run "AutoDetectFalseAbortScenario" and relaunch the crashed app
         And I configure Bugsnag for "AutoDetectFalseHandledScenario"
         Then I should receive no requests

--- a/features/barebone_tests.feature
+++ b/features/barebone_tests.feature
@@ -206,7 +206,7 @@ Feature: Barebone tests
     # immediately after an app has stopped running
     And I wait for 2 seconds
 
-    And I relaunch the app
+    And I kill and relaunch the app
     And I configure Bugsnag for "OOMScenario"
     And I wait to receive a session
 

--- a/features/crashprobe.feature
+++ b/features/crashprobe.feature
@@ -147,7 +147,7 @@ Feature: Reporting crash events
     # Sleep and relaunch here instead of checking the app state as this specific
     # crash seems to inhibit Appium's ability to check the app state on iOS 10
     And I wait for 3 seconds
-    And I relaunch the app
+    And I kill and relaunch the app
 
     And I configure Bugsnag for "AsyncSafeThreadScenario"
     And I wait to receive an error

--- a/features/delivery.feature
+++ b/features/delivery.feature
@@ -8,7 +8,7 @@ Feature: Delivery of errors
     And I run "HandledExceptionScenario"
     And I wait to receive an error
     And I wait for the fixture to process the response
-    And I relaunch the app
+    And I kill and relaunch the app
     And I clear the error queue
     And I configure Bugsnag for "HandledExceptionScenario"
     And I wait to receive an error
@@ -18,7 +18,7 @@ Feature: Delivery of errors
     When I set the HTTP status code for the next request to 400
     And I run "HandledExceptionScenario"
     And I wait to receive an error
-    And I relaunch the app
+    And I kill and relaunch the app
     And I clear the error queue
     And I configure Bugsnag for "HandledExceptionScenario"
     Then I should receive no requests
@@ -55,7 +55,7 @@ Feature: Delivery of errors
     And I run "AutoSessionScenario"
     And I wait to receive a session
     And I wait for the fixture to process the response
-    And I relaunch the app
+    And I kill and relaunch the app
     When I run "AutoSessionScenario"
     Then I wait to receive 3 sessions
 
@@ -66,7 +66,7 @@ Feature: Delivery of errors
     And I wait to receive a session
     And I wait for the fixture to process the response
     And I discard the oldest session
-    And I relaunch the app
+    And I kill and relaunch the app
     When I set the app to "new" mode
     And I run "OldSessionScenario"
     And I wait to receive a session

--- a/features/event_callbacks.feature
+++ b/features/event_callbacks.feature
@@ -124,7 +124,7 @@ Feature: Callbacks can access and modify event information
     And I clear the error queue
     # Wait for fixture to receive the response and save the payload
     And I wait for 2 seconds
-    And I relaunch the app
+    And I kill and relaunch the app
     And I configure Bugsnag for "OnSendErrorPersistenceScenario"
     And I wait to receive an error
     Then the event "metaData.unexpected.message" is null

--- a/features/out_of_memory.feature
+++ b/features/out_of_memory.feature
@@ -2,7 +2,7 @@
 Feature: Out of memory errors
 
 # Due to the combination of BrowserStack's behaviour when resetting the app and the way that our OOM detection works,
-# the I relaunch the app steps are currently sufficient to trigger the OOM mechanism. However, these tests may not
+# the I kill and relaunch the app steps are currently sufficient to trigger the OOM mechanism. However, these tests may not
 # behave in the same way on local devices, device farms other that BrowserStack, or if we change that OOM detection works.
 
   Background:
@@ -21,7 +21,7 @@ Feature: Out of memory errors
     And the event has a "manual" breadcrumb named "OOMLoadScenarioBreadcrumb"
     And I discard the oldest error
 
-    When I relaunch the app
+    When I kill and relaunch the app
     And I configure Bugsnag for "OOMLoadScenario"
 
     And I wait to receive a session
@@ -76,7 +76,7 @@ Feature: Out of memory errors
     And the exception "message" equals "OOMAutoDetectErrorsScenario"
     And I discard the oldest error
 
-    And I relaunch the app
+    And I kill and relaunch the app
     And I run "OOMAutoDetectErrorsScenario"
     And I wait to receive an error
     Then the error is valid for the error reporting API
@@ -91,7 +91,7 @@ Feature: Out of memory errors
     And the exception "message" equals "OOMEnabledErrorTypesScenario"
     And I discard the oldest error
 
-    And I relaunch the app
+    And I kill and relaunch the app
     And I run "OOMEnabledErrorTypesScenario"
     And I wait to receive an error
     Then the error is valid for the error reporting API

--- a/features/release_stage_sessions.feature
+++ b/features/release_stage_sessions.feature
@@ -8,7 +8,7 @@ Feature: Discarding sessions based on release stage
     And I wait to receive a session
     And the session is valid for the session reporting API
 
-    And I relaunch the app
+    And I kill and relaunch the app
     And I configure Bugsnag for "DisabledReleaseStageAutoSessionScenario"
     Then I should receive no errors
 
@@ -17,6 +17,6 @@ Feature: Discarding sessions based on release stage
     And I wait to receive a session
     And the session is valid for the session reporting API
 
-    And I relaunch the app
+    And I kill and relaunch the app
     And I configure Bugsnag for "DisabledReleaseStageManualSessionScenario"
     Then I should receive no errors

--- a/features/session_tracking.feature
+++ b/features/session_tracking.feature
@@ -107,7 +107,7 @@ Feature: Session Tracking
   Scenario: Encountering an unhandled event during a session
     When I run "AutoSessionUnhandledScenario"
     And I wait for 4 seconds
-    And I relaunch the app
+    And I kill and relaunch the app
     And I set the app to "noevent" mode
     And I configure Bugsnag for "AutoSessionUnhandledScenario"
     And I wait to receive a session
@@ -127,7 +127,7 @@ Feature: Session Tracking
   Scenario: Encountering handled and unhandled events during a session
     When I run "AutoSessionMixedEventsScenario"
     And I wait for 5 seconds
-    And I relaunch the app
+    And I kill and relaunch the app
     And I configure Bugsnag for "AutoSessionMixedEventsScenario"
     And I wait to receive 2 sessions
     Then the session is valid for the session reporting API

--- a/features/steps/app_steps.rb
+++ b/features/steps/app_steps.rb
@@ -26,7 +26,7 @@ def run_and_relaunch
   steps %(
     Given I click the element "run_scenario"
     And the app is not running
-    Then I relaunch the app
+    Then I kill and relaunch the app
   )
 end
 
@@ -38,11 +38,12 @@ When('I configure Bugsnag for {string}') do |scenario_name|
   execute_command :start_bugsnag, scenario_name
 end
 
-When('I relaunch the app') do
+When('I kill and relaunch the app') do
   case Maze::Helper.get_current_platform
   when 'macos'
     # Pass
   else
+    Maze.driver.close_app
     Maze.driver.launch_app
   end
 end

--- a/features/thermal_state.feature
+++ b/features/thermal_state.feature
@@ -41,7 +41,7 @@ Feature: Thermal State
     And I discard the oldest session
     And I send the app to the background
     And I wait for 1 seconds
-    And I relaunch the app
+    And I kill and relaunch the app
     And I configure Bugsnag for "CriticalThermalStateScenario"
     And I wait to receive a session
     Then I should receive no errors

--- a/features/unhandled_signal.feature
+++ b/features/unhandled_signal.feature
@@ -59,7 +59,7 @@ Feature: Signals are captured as error reports in Bugsnag
   Scenario: No error should be reported if SIGPIPE is ignored
     Given I run "SIGPIPEIgnoredScenario"
     And I wait to receive a session
-    And I relaunch the app
+    And I kill and relaunch the app
     And I configure Bugsnag for "SIGPIPEIgnoredScenario"
     Then I should receive no errors
 

--- a/features/user_persistence.feature
+++ b/features/user_persistence.feature
@@ -8,7 +8,7 @@ Feature: Persisting User Information
 
     # User is set and comes through
     And I wait to receive a session
-    And I relaunch the app
+    And I kill and relaunch the app
     Then the session is valid for the session reporting API
     And the session "user.id" equals "foo"
     And the session "user.email" equals "baz@grok.com"
@@ -19,7 +19,7 @@ Feature: Persisting User Information
     Then I run "UserPersistenceNoUserScenario"
     And I wait to receive a session
     And I wait to receive an error
-    And I relaunch the app
+    And I kill and relaunch the app
 
     # Session - User persisted
     Then the session is valid for the session reporting API
@@ -39,7 +39,7 @@ Scenario: User Info is persisted from client across app runs
     # Session is captured before the user can be set on the Client
     And I wait to receive a session
     And I wait for 1 second
-    And I relaunch the app
+    And I kill and relaunch the app
 
     Then the session is valid for the session reporting API
     And the session "user.id" is not null
@@ -51,7 +51,7 @@ Scenario: User Info is persisted from client across app runs
     Then I run "UserPersistenceNoUserScenario"
     And I wait to receive a session
     And I wait to receive an error
-    And I relaunch the app
+    And I kill and relaunch the app
 
     # Session - User persisted
     Then the session is valid for the session reporting API
@@ -72,7 +72,7 @@ Scenario: User Info is persisted from client across app runs
     # User is set and comes through
     And I wait to receive a session
     And I wait to receive an error
-    And I relaunch the app
+    And I kill and relaunch the app
 
     # First Session
     Then the session is valid for the session reporting API


### PR DESCRIPTION
## Goal

Explicitly kill and relaunch the app during test scenarios, naming the Cucumber step accordingly.

## Testing

Covered by a full CI run.  I've also checked that test scenarios work on local devices (including the app hang scenarios, which have not worked locally in the past).