### PR TITLE
Fix test flakes

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -5,7 +5,7 @@ gem 'jazzy'
 
 # A reference to Maze Runner is only needed for running tests locally and if committed it must be
 # portable for CI, e.g. a specific release.  However, leaving it commented out would mean quicker CI.
-gem 'bugsnag-maze-runner', git: 'https://github.com/bugsnag/maze-runner', tag: 'v6.15.0'
+gem 'bugsnag-maze-runner', git: 'https://github.com/bugsnag/maze-runner', tag: 'v6.16.0'
 
 # Use a specific branch
 #gem 'bugsnag-maze-runner', git: 'https://github.com/bugsnag/maze-runner', branch: 'master'

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -1,9 +1,9 @@
 GIT
   remote: https://github.com/bugsnag/maze-runner
-  revision: d71ba8a1b770e86800b4e9f6782a63fef019a989
-  tag: v6.15.0
+  revision: 7af6c9b23048cae8b475770911827d8101a201f4
+  tag: v6.16.0
   specs:
-    bugsnag-maze-runner (6.15.0)
+    bugsnag-maze-runner (6.16.0)
       appium_lib (~> 11.2.0)
       bugsnag (~> 6.24)
       cucumber (~> 7.1)

--- a/features/delivery.feature
+++ b/features/delivery.feature
@@ -83,7 +83,7 @@ Feature: Delivery of errors
     And the session "user.id" equals "2"
     And I discard the oldest session
     When I set the HTTP status code to 200
-    And I relaunch the app
+    And I kill and relaunch the app
     And I configure Bugsnag for "MaxPersistedSessionsScenario"
     And I wait to receive 2 sessions
     Then the session "user.id" equals "3"

--- a/features/fixtures/shared/scenarios/MaxPersistedSessionsScenario.m
+++ b/features/fixtures/shared/scenarios/MaxPersistedSessionsScenario.m
@@ -19,11 +19,17 @@
 
     [super startBugsnag];
 
-    [Bugsnag setUser:[self nextUserId] withEmail:nil andName:nil];
-    [Bugsnag startSession];
+    [self performBlockAndWaitForSessionDelivery:^{
+        [Bugsnag setUser:[self nextUserId] withEmail:nil andName:nil];
+        [Bugsnag startSession];
+    }];
 }
 
 - (void)run {
+    // Filesystem timestamps have a resolution of 1 second, so wait to ensure
+    // that the first persisted session will have an older file creation date.
+    [NSThread sleepForTimeInterval:1];
+
     [Bugsnag setUser:[self nextUserId] withEmail:nil andName:nil];
     [Bugsnag startSession];
 }

--- a/features/fixtures/shared/scenarios/Scenario.h
+++ b/features/fixtures/shared/scenarios/Scenario.h
@@ -38,6 +38,8 @@ void markErrorHandledCallback(const BSG_KSCrashReportWriter *writer);
 
 - (void)performBlockAndWaitForEventDelivery:(dispatch_block_t)block NS_SWIFT_NAME(performBlockAndWaitForEventDelivery(_:));
 
+- (void)performBlockAndWaitForSessionDelivery:(dispatch_block_t)block NS_SWIFT_NAME(performBlockAndWaitForSessionDelivery(_:));
+
 + (void)clearPersistentData;
 
 + (void)executeMazeRunnerCommand:(void (^)(NSString *action, NSString *scenarioName, NSString *scenarioMode))preHandler;

--- a/features/last_run_info.feature
+++ b/features/last_run_info.feature
@@ -2,6 +2,7 @@ Feature: Launch detection
 
   Background:
     Given I clear all persistent data
+    And I ignore invalid sessions
 
   Scenario: LastRunInfo consecutiveLaunchCrashes increments when isLaunching is true
     When I run "LastRunInfoScenario" and relaunch the crashed app

--- a/features/steps/reusable_steps.rb
+++ b/features/steps/reusable_steps.rb
@@ -2,6 +2,10 @@
 
 # A collection of steps that could be added to Maze Runner
 
+When('I ignore invalid {word}') do |type|
+  Maze.config.captured_invalid_requests.delete(type.to_sym)
+end
+
 Then(/^on (iOS|macOS), (.+)/) do |platform, step_text|
   step(step_text) if platform.downcase == Maze::Helper.get_current_platform
 end

--- a/features/support/env.rb
+++ b/features/support/env.rb
@@ -52,7 +52,11 @@ Before('@stress_test') do |_scenario|
 end
 
 Maze.hooks.before do |_scenario|
+  # Reset to defaults in case previous scenario changed them
+  Maze.config.captured_invalid_requests = Set[:errors, :sessions, :builds, :uploads, :sourcemaps]
+
   $started_at = Time.now
+
   if Maze.config.os == 'ios' && Maze.config.farm == :local
     begin
       $logger_pid = Process.spawn(


### PR DESCRIPTION
## Changeset

Fixes a number of E2E flakes;

* `CriticalThermalStateScenario` could flake due to a real `ProcessInfo.thermalStateDidChangeNotification` being received after the mock one sent by the scenario. `ProcessInfo.thermalState` is now swizzled to ensure it always returns the `.critical` needed for this test.
* `CriticalThermalStateScenario` could also flake if the fixture crashed while a session payload was in transit. The scenario now waits.
* `LastRunInfoScenario` could flake due to crashing while a session payload is in transit. Maze runner is now configured to ignore these for this test.
* `MaxPersistedSessionsScenario` could flake if the session HTTP requests were not completed in the expected order. The scenario now waits for delivery of the first session before continuing.
* `MaxPersistedSessionsScenario` could also flake if the two persisted session files have the same date due to the filesystem only having second precision - which one gets deleted would be unpredictable. The scenario now has a delay to ensure the second session will be stored later.

## Testing

Ran the affected scenarios on CI to verify - [link](https://buildkite.com/bugsnag/bugsnag-cocoa/builds/5502).

Ran the full E2E suite several times - [link](https://buildkite.com/bugsnag/bugsnag-cocoa/builds?branch=nickdowell%2Ffix-flakes)