### PR TITLE
[PLAT-8413] Delete oversized or stale persisted errors

### DIFF
--- a/Bugsnag/Delivery/BSGEventUploadObjectOperation.m
+++ b/Bugsnag/Delivery/BSGEventUploadObjectOperation.m
@@ -25,8 +25,13 @@
     return self.event;
 }
 
-- (BOOL)shouldStoreEventPayloadForRetry {
-    return YES;
+- (void)prepareForRetry:(NSDictionary *)payload HTTPBodySize:(NSUInteger)HTTPBodySize {
+    if (HTTPBodySize > MaxPersistedSize) {
+        bsg_log_debug(@"Not persisting %@ because HTTP body size (%lu bytes) exceeds MaxPersistedSize",
+                      self.name, (unsigned long)HTTPBodySize);
+        return;
+    }
+    [self.delegate storeEventPayload:payload];
 }
 
 - (NSString *)name {

--- a/Bugsnag/Delivery/BSGEventUploadOperation.h
+++ b/Bugsnag/Delivery/BSGEventUploadOperation.h
@@ -16,6 +16,12 @@
 
 NS_ASSUME_NONNULL_BEGIN
 
+/// Persisted events older than this should be deleted upon failure.
+static const NSTimeInterval MaxPersistedAge = 60 * 24 * 60 * 60;
+
+/// Event payloads larger than this should not be persisted.
+static const NSUInteger MaxPersistedSize = 1000000;
+
 @protocol BSGEventUploadOperationDelegate;
 
 /**
@@ -36,13 +42,11 @@ NS_ASSUME_NONNULL_BEGIN
 /// Must be implemented by all subclasses.
 - (nullable BugsnagEvent *)loadEventAndReturnError:(NSError **)errorPtr;
 
-/// Called if the event should not be sent or failed to upload in a non-retrable way.
-///
 /// To be implemented by subclasses that load their data from a file.
 - (void)deleteEvent;
 
-/// Whether the payload should be stored so that it can be retried later.
-@property (readonly, nonatomic) BOOL shouldStoreEventPayloadForRetry;
+/// Must be implemented by all subclasses.
+- (void)prepareForRetry:(NSDictionary *)payload HTTPBodySize:(NSUInteger)HTTPBodySize;
 
 @end
 

--- a/Bugsnag/Delivery/BSGEventUploadOperation.m
+++ b/Bugsnag/Delivery/BSGEventUploadOperation.m
@@ -129,6 +129,7 @@ typedef NS_ENUM(NSUInteger, BSGEventUploadOperationState) {
         return;
     }
     
+    __block NSData *HTTPBody =
     [delegate.apiClient sendJSONPayload:requestPayload headers:requestHeaders toURL:notifyURL
                       completionHandler:^(BugsnagApiClientDeliveryStatus status, __attribute__((unused)) NSError *deliveryError) {
         
@@ -139,10 +140,8 @@ typedef NS_ENUM(NSUInteger, BSGEventUploadOperationState) {
                 break;
                 
             case BugsnagApiClientDeliveryStatusFailed:
-                bsg_log_debug(@"Upload failed; will retry event %@", self.name);
-                if (self.shouldStoreEventPayloadForRetry) {
-                    [delegate storeEventPayload:originalPayload ?: eventPayload];
-                }
+                bsg_log_debug(@"Upload failed retryably for event %@", self.name);
+                [self prepareForRetry:originalPayload ?: eventPayload HTTPBodySize:HTTPBody.length];
                 break;
                 
             case BugsnagApiClientDeliveryStatusUndeliverable:
@@ -161,6 +160,11 @@ typedef NS_ENUM(NSUInteger, BSGEventUploadOperationState) {
     // Must be implemented by all subclasses
     [self doesNotRecognizeSelector:_cmd];
     return nil;
+}
+
+- (void)prepareForRetry:(__unused NSDictionary *)payload HTTPBodySize:(__unused NSUInteger)HTTPBodySize {
+    // Must be implemented by all subclasses
+    [self doesNotRecognizeSelector:_cmd];
 }
 
 - (void)deleteEvent {

--- a/Bugsnag/Delivery/BugsnagApiClient.h
+++ b/Bugsnag/Delivery/BugsnagApiClient.h
@@ -28,10 +28,10 @@ typedef NS_ENUM(NSInteger, BugsnagApiClientDeliveryStatus) {
 
 - (instancetype)initWithSession:(nullable NSURLSession *)session;
 
-- (void)sendJSONPayload:(NSDictionary *)payload
-                headers:(NSDictionary<BugsnagHTTPHeaderName, NSString *> *)headers
-                  toURL:(NSURL *)url
-      completionHandler:(void (^)(BugsnagApiClientDeliveryStatus status, NSError * _Nullable error))completionHandler;
+- (nullable NSData *)sendJSONPayload:(NSDictionary *)payload
+                             headers:(NSDictionary<BugsnagHTTPHeaderName, NSString *> *)headers
+                               toURL:(NSURL *)url
+                   completionHandler:(void (^)(BugsnagApiClientDeliveryStatus status, NSError *_Nullable error))completionHandler;
 
 + (NSString *)SHA1HashStringWithData:(NSData *)data;
 

--- a/Bugsnag/Delivery/BugsnagApiClient.m
+++ b/Bugsnag/Delivery/BugsnagApiClient.m
@@ -45,17 +45,17 @@ typedef NS_ENUM(NSInteger, HTTPStatusCode) {
 
 #pragma mark - Delivery
 
-- (void)sendJSONPayload:(NSDictionary *)payload
-                headers:(NSDictionary<BugsnagHTTPHeaderName, NSString *> *)headers
-                  toURL:(NSURL *)url
-      completionHandler:(void (^)(BugsnagApiClientDeliveryStatus status, NSError * _Nullable error))completionHandler {
+- (NSData *)sendJSONPayload:(NSDictionary *)payload
+                    headers:(NSDictionary<BugsnagHTTPHeaderName, NSString *> *)headers
+                      toURL:(NSURL *)url
+          completionHandler:(void (^)(BugsnagApiClientDeliveryStatus status, NSError *_Nullable error))completionHandler {
     
     NSError *error = nil;
     NSData *data = BSGJSONDataFromDictionary(payload, &error);
     if (!data) {
         bsg_log_err(@"Error: Could not encode JSON payload passed to %s", __PRETTY_FUNCTION__);
         completionHandler(BugsnagApiClientDeliveryStatusUndeliverable, error);
-        return;
+        return nil;
     }
     
     NSMutableDictionary<BugsnagHTTPHeaderName, NSString *> *mutableHeaders = [headers mutableCopy];
@@ -102,6 +102,7 @@ typedef NS_ENUM(NSInteger, HTTPStatusCode) {
         
         completionHandler(BugsnagApiClientDeliveryStatusFailed, connectionError);
     }] resume];
+    return data;
 }
 
 - (NSMutableURLRequest *)prepareRequest:(NSURL *)url

--- a/features/delivery.feature
+++ b/features/delivery.feature
@@ -23,6 +23,58 @@ Feature: Delivery of errors
     And I configure Bugsnag for "HandledExceptionScenario"
     Then I should receive no requests
 
+  Scenario: Delivery is not retried for oversized handled payloads
+    Given I set the HTTP status code to 500
+    When I run "OversizedHandledErrorScenario"
+    And I wait to receive an error
+    And I wait for the fixture to process the response
+    # The error should not have been persited
+    And I kill and relaunch the app
+    And I clear the error queue
+    And I configure Bugsnag for "OversizedHandledErrorScenario"
+    Then I should receive no requests
+
+  Scenario: Delivery is not retried for old handled payloads
+    Given I set the HTTP status code to 500
+    When I run "OldHandledErrorScenario"
+    And I wait to receive an error
+    And I wait for the fixture to process the response
+    # The error should now have been persisted
+    And I kill and relaunch the app
+    And I clear the error queue
+    And I configure Bugsnag for "OldHandledErrorScenario"
+    And I wait to receive an error
+    And I wait for the fixture to process the response
+    # The error should now have been deleted 
+    And I kill and relaunch the app
+    And I clear the error queue
+    And I configure Bugsnag for "OldHandledErrorScenario"
+    Then I should receive no requests
+
+  Scenario: Delivery is not retried for oversized crash payloads
+    Given I set the HTTP status code to 500
+    When I run "OversizedCrashReportScenario" and relaunch the crashed app
+    And I configure Bugsnag for "OversizedCrashReportScenario"
+    And I wait to receive an error
+    And I wait for the fixture to process the response
+    # The crash report should now have been deleted
+    And I kill and relaunch the app
+    And I clear the error queue
+    And I configure Bugsnag for "OversizedCrashReportScenario"
+    Then I should receive no requests
+
+  Scenario: Delivery is not retried for old crash payloads
+    Given I set the HTTP status code to 500
+    When I run "OldCrashReportScenario" and relaunch the crashed app
+    And I configure Bugsnag for "OldCrashReportScenario"
+    And I wait to receive an error
+    And I wait for the fixture to process the response
+    # The crash report should now have been deleted
+    And I kill and relaunch the app
+    And I clear the error queue
+    And I configure Bugsnag for "OldCrashReportScenario"
+    Then I should receive no requests
+
   Scenario: Bugsnag.start() should block for 2 seconds after a launch crash
     When I run "SendLaunchCrashesSynchronouslyScenario" and relaunch the crashed app
     And I set the response delay for the next request to 5000 milliseconds

--- a/features/fixtures/ios/iOSTestApp.xcodeproj/project.pbxproj
+++ b/features/fixtures/ios/iOSTestApp.xcodeproj/project.pbxproj
@@ -37,6 +37,10 @@
 		01EE7F57278C680C00A59DC6 /* OOMSessionlessScenario.m in Sources */ = {isa = PBXBuildFile; fileRef = 01EE7F56278C680C00A59DC6 /* OOMSessionlessScenario.m */; };
 		01F115C927BAAF2D00892B1E /* SIGPIPEIgnoredScenario.m in Sources */ = {isa = PBXBuildFile; fileRef = 01F115C827BAAF2D00892B1E /* SIGPIPEIgnoredScenario.m */; };
 		01F1474425F282E600C2DC65 /* AppHangScenarios.swift in Sources */ = {isa = PBXBuildFile; fileRef = 01F1474325F282E600C2DC65 /* AppHangScenarios.swift */; };
+		01F6B75A2832756300B75C5D /* OldCrashReportScenario.swift in Sources */ = {isa = PBXBuildFile; fileRef = 01F6B7582832756300B75C5D /* OldCrashReportScenario.swift */; };
+		01F6B75B2832756300B75C5D /* OldHandledErrorScenario.swift in Sources */ = {isa = PBXBuildFile; fileRef = 01F6B7592832756300B75C5D /* OldHandledErrorScenario.swift */; };
+		01F6B75E2832757F00B75C5D /* OversizedCrashReportScenario.swift in Sources */ = {isa = PBXBuildFile; fileRef = 01F6B75C2832757F00B75C5D /* OversizedCrashReportScenario.swift */; };
+		01F6B75F2832757F00B75C5D /* OversizedHandledErrorScenario.swift in Sources */ = {isa = PBXBuildFile; fileRef = 01F6B75D2832757F00B75C5D /* OversizedHandledErrorScenario.swift */; };
 		01FA9EC426D63BB20059FF4A /* AppHangInTerminationScenario.swift in Sources */ = {isa = PBXBuildFile; fileRef = 01FA9EC326D63BB20059FF4A /* AppHangInTerminationScenario.swift */; };
 		6526A0D4248A83350002E2C9 /* LoadConfigFromFileAutoScenario.swift in Sources */ = {isa = PBXBuildFile; fileRef = 6526A0D3248A83350002E2C9 /* LoadConfigFromFileAutoScenario.swift */; };
 		8A096DF627C7E56C00DB6ECC /* CxxUnexpectedScenario.mm in Sources */ = {isa = PBXBuildFile; fileRef = 8A096DF527C7E56C00DB6ECC /* CxxUnexpectedScenario.mm */; };
@@ -201,6 +205,10 @@
 		01EE7F56278C680C00A59DC6 /* OOMSessionlessScenario.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; path = OOMSessionlessScenario.m; sourceTree = "<group>"; };
 		01F115C827BAAF2D00892B1E /* SIGPIPEIgnoredScenario.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; path = SIGPIPEIgnoredScenario.m; sourceTree = "<group>"; };
 		01F1474325F282E600C2DC65 /* AppHangScenarios.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = AppHangScenarios.swift; sourceTree = "<group>"; };
+		01F6B7582832756300B75C5D /* OldCrashReportScenario.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = OldCrashReportScenario.swift; sourceTree = "<group>"; };
+		01F6B7592832756300B75C5D /* OldHandledErrorScenario.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = OldHandledErrorScenario.swift; sourceTree = "<group>"; };
+		01F6B75C2832757F00B75C5D /* OversizedCrashReportScenario.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = OversizedCrashReportScenario.swift; sourceTree = "<group>"; };
+		01F6B75D2832757F00B75C5D /* OversizedHandledErrorScenario.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = OversizedHandledErrorScenario.swift; sourceTree = "<group>"; };
 		01FA9EC326D63BB20059FF4A /* AppHangInTerminationScenario.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AppHangInTerminationScenario.swift; sourceTree = "<group>"; };
 		6526A0D3248A83350002E2C9 /* LoadConfigFromFileAutoScenario.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = LoadConfigFromFileAutoScenario.swift; sourceTree = "<group>"; };
 		8A096DF527C7E56C00DB6ECC /* CxxUnexpectedScenario.mm */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.cpp.objcpp; path = CxxUnexpectedScenario.mm; sourceTree = "<group>"; };
@@ -596,11 +604,15 @@
 				0163BFA62583B3CF008DC28B /* DiscardClassesScenarios.swift */,
 				01847DD526453D4E00ADA4C7 /* InvalidCrashReportScenario.m */,
 				01221E54282E5538008095C3 /* MaxPersistedSessionsScenario.m */,
+				01F6B7582832756300B75C5D /* OldCrashReportScenario.swift */,
+				01F6B7592832756300B75C5D /* OldHandledErrorScenario.swift */,
 				01AFCFCA282CE9F700D48D45 /* OldSessionScenario.m */,
 				017B4133276B8D9B0054C91D /* OnSendErrorPersistenceScenario.m */,
 				01E5EAD025B713990066EA8A /* OOMScenario.h */,
 				01E5EAD125B713990066EA8A /* OOMScenario.m */,
 				01EE7F56278C680C00A59DC6 /* OOMSessionlessScenario.m */,
+				01F6B75C2832757F00B75C5D /* OversizedCrashReportScenario.swift */,
+				01F6B75D2832757F00B75C5D /* OversizedHandledErrorScenario.swift */,
 				0104B47D275A7B3C003EBDF0 /* RecrashScenarios.mm */,
 				8AB1081823301FE600672818 /* ReleaseStageScenarios.swift */,
 				F4295ABA693D273D52AA9F6B /* Scenario.h */,
@@ -907,6 +919,7 @@
 				E75040B22478214F005D33BD /* MetadataRedactionNestedScenario.swift in Sources */,
 				E700EE65247D6C08008CFFB6 /* OnSendCallbackRemovalScenario.m in Sources */,
 				8A38C5D124094D7B00BC4463 /* DiscardedBreadcrumbTypeScenario.swift in Sources */,
+				01F6B75F2832757F00B75C5D /* OversizedHandledErrorScenario.swift in Sources */,
 				8AEEBBD020FC9E1D00C60763 /* AutoSessionMixedEventsScenario.m in Sources */,
 				E753F24624927409001FB671 /* NotifyCallbackCrashScenario.swift in Sources */,
 				8A096DFC27C7E77600DB6ECC /* CxxBareThrowScenario.mm in Sources */,
@@ -926,6 +939,7 @@
 				CBE1C9242574F532004B8B5B /* OnErrorOverwriteUnhandledFalseScenario.swift in Sources */,
 				A1117E5B2536036400014FDA /* OOMSessionScenario.swift in Sources */,
 				8AF8FCAE22BD23BA00A967CA /* HandledInternalNotifyScenario.swift in Sources */,
+				01F6B75B2832756300B75C5D /* OldHandledErrorScenario.swift in Sources */,
 				CBE1C9252574F532004B8B5B /* OnErrorOverwriteUnhandledTrueScenario.swift in Sources */,
 				8A42FD35225DEE04007AE561 /* SessionOOMScenario.m in Sources */,
 				AA6ACD202773E3F0006464C4 /* UserInfoScenario.swift in Sources */,
@@ -935,6 +949,7 @@
 				01B6BBB625DA82B800FC4DE6 /* SendLaunchCrashesSynchronouslyScenario.swift in Sources */,
 				F4295836C8AF75547C675E8D /* ReleasedObjectScenario.m in Sources */,
 				01E5EAD225B713990066EA8A /* OOMScenario.m in Sources */,
+				01F6B75E2832757F00B75C5D /* OversizedCrashReportScenario.swift in Sources */,
 				8A530CCC22FDDBF000F0C108 /* ManyConcurrentNotifyScenario.m in Sources */,
 				F42958881D3F34A76CADE4EC /* SwiftCrashScenario.swift in Sources */,
 				E7A324EA247E9DA5008B0052 /* BreadcrumbCallbackOverrideScenario.swift in Sources */,
@@ -966,6 +981,7 @@
 				F4295B56219D228FAA99BC14 /* ObjCExceptionScenario.m in Sources */,
 				F4295218A62E41518DC3C057 /* AccessNonObjectScenario.m in Sources */,
 				E7A324E0247E70F9008B0052 /* SessionCallbackDiscardScenario.swift in Sources */,
+				01F6B75A2832756300B75C5D /* OldCrashReportScenario.swift in Sources */,
 				8A72A0382396574F00328051 /* CustomPluginNotifierDescriptionScenario.m in Sources */,
 				E700EE72247D79FF008CFFB6 /* SIGBUSScenario.m in Sources */,
 				E7767F11221C21D90006648C /* StoppedSessionScenario.swift in Sources */,

--- a/features/fixtures/macos/macOSTestApp.xcodeproj/project.pbxproj
+++ b/features/fixtures/macos/macOSTestApp.xcodeproj/project.pbxproj
@@ -136,6 +136,10 @@
 		01F47D31254B1B3100B184AD /* OverwriteLinkRegisterScenario.m in Sources */ = {isa = PBXBuildFile; fileRef = 01F47CC0254B1B3000B184AD /* OverwriteLinkRegisterScenario.m */; };
 		01F47D32254B1B3100B184AD /* ResumeSessionOOMScenario.m in Sources */ = {isa = PBXBuildFile; fileRef = 01F47CC1254B1B3000B184AD /* ResumeSessionOOMScenario.m */; };
 		01F54384282E50FE00684474 /* MaxPersistedSessionsScenario.m in Sources */ = {isa = PBXBuildFile; fileRef = 01F54383282E50FE00684474 /* MaxPersistedSessionsScenario.m */; };
+		01F6B74C2832381300B75C5D /* OldCrashReportScenario.swift in Sources */ = {isa = PBXBuildFile; fileRef = 01F6B7482832381300B75C5D /* OldCrashReportScenario.swift */; };
+		01F6B74D2832381300B75C5D /* OversizedHandledErrorScenario.swift in Sources */ = {isa = PBXBuildFile; fileRef = 01F6B7492832381300B75C5D /* OversizedHandledErrorScenario.swift */; };
+		01F6B74E2832381300B75C5D /* OldHandledErrorScenario.swift in Sources */ = {isa = PBXBuildFile; fileRef = 01F6B74A2832381300B75C5D /* OldHandledErrorScenario.swift */; };
+		01F6B74F2832381300B75C5D /* OversizedCrashReportScenario.swift in Sources */ = {isa = PBXBuildFile; fileRef = 01F6B74B2832381300B75C5D /* OversizedCrashReportScenario.swift */; };
 		01F7365A278D90440000113C /* NetworkBreadcrumbsScenario.swift in Sources */ = {isa = PBXBuildFile; fileRef = 01F73659278D90440000113C /* NetworkBreadcrumbsScenario.swift */; };
 		01FA9EC626D64FFF0059FF4A /* AppHangInTerminationScenario.swift in Sources */ = {isa = PBXBuildFile; fileRef = 01FA9EC526D64FFF0059FF4A /* AppHangInTerminationScenario.swift */; };
 		8A096DF827C7E63A00DB6ECC /* CxxUnexpectedScenario.mm in Sources */ = {isa = PBXBuildFile; fileRef = 8A096DF727C7E63A00DB6ECC /* CxxUnexpectedScenario.mm */; };
@@ -346,6 +350,10 @@
 		01F47CC2254B1B3000B184AD /* SIGBUSScenario.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = SIGBUSScenario.h; sourceTree = "<group>"; };
 		01F47CC3254B1B3100B184AD /* SIGFPEScenario.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = SIGFPEScenario.h; sourceTree = "<group>"; };
 		01F54383282E50FE00684474 /* MaxPersistedSessionsScenario.m */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.objc; path = MaxPersistedSessionsScenario.m; sourceTree = "<group>"; };
+		01F6B7482832381300B75C5D /* OldCrashReportScenario.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = OldCrashReportScenario.swift; sourceTree = "<group>"; };
+		01F6B7492832381300B75C5D /* OversizedHandledErrorScenario.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = OversizedHandledErrorScenario.swift; sourceTree = "<group>"; };
+		01F6B74A2832381300B75C5D /* OldHandledErrorScenario.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = OldHandledErrorScenario.swift; sourceTree = "<group>"; };
+		01F6B74B2832381300B75C5D /* OversizedCrashReportScenario.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = OversizedCrashReportScenario.swift; sourceTree = "<group>"; };
 		01F73659278D90440000113C /* NetworkBreadcrumbsScenario.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = NetworkBreadcrumbsScenario.swift; sourceTree = "<group>"; };
 		01FA9EC526D64FFF0059FF4A /* AppHangInTerminationScenario.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = AppHangInTerminationScenario.swift; sourceTree = "<group>"; };
 		2C49722B331FF4B0DC477462 /* Pods-macOSTestApp.release.xcconfig */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.xcconfig; name = "Pods-macOSTestApp.release.xcconfig"; path = "Target Support Files/Pods-macOSTestApp/Pods-macOSTestApp.release.xcconfig"; sourceTree = "<group>"; };
@@ -473,6 +481,8 @@
 				01F47C36254B1B2D00B184AD /* ObjCExceptionScenario.m */,
 				01F47C4D254B1B2D00B184AD /* ObjCMsgSendScenario.h */,
 				01F47CAB254B1B3000B184AD /* ObjCMsgSendScenario.m */,
+				01F6B7482832381300B75C5D /* OldCrashReportScenario.swift */,
+				01F6B74A2832381300B75C5D /* OldHandledErrorScenario.swift */,
 				01AFCFC6282C058D00D48D45 /* OldSessionScenario.m */,
 				01F47C9F254B1B3000B184AD /* OnCrashHandlerScenario.h */,
 				01F47C7F254B1B2F00B184AD /* OnCrashHandlerScenario.m */,
@@ -493,6 +503,8 @@
 				01F47C97254B1B2F00B184AD /* OOMWillTerminateScenario.m */,
 				01F47C86254B1B2F00B184AD /* OriginalErrorNSErrorScenario.swift */,
 				01F47C21254B1B2C00B184AD /* OriginalErrorNSExceptionScenario.swift */,
+				01F6B74B2832381300B75C5D /* OversizedCrashReportScenario.swift */,
+				01F6B7492832381300B75C5D /* OversizedHandledErrorScenario.swift */,
 				01F47C25254B1B2C00B184AD /* OverwriteLinkRegisterScenario.h */,
 				01F47CC0254B1B3000B184AD /* OverwriteLinkRegisterScenario.m */,
 				01F47C31254B1B2D00B184AD /* PrivilegedInstructionScenario.h */,
@@ -734,6 +746,7 @@
 			isa = PBXSourcesBuildPhase;
 			buildActionMask = 2147483647;
 			files = (
+				01F6B74F2832381300B75C5D /* OversizedCrashReportScenario.swift in Sources */,
 				01F54384282E50FE00684474 /* MaxPersistedSessionsScenario.m in Sources */,
 				01F47CD9254B1B3100B184AD /* SessionCallbackDiscardScenario.swift in Sources */,
 				01F47CD0254B1B3100B184AD /* StackOverflowScenario.m in Sources */,
@@ -763,6 +776,7 @@
 				01F47CC8254B1B3100B184AD /* AutoSessionScenario.m in Sources */,
 				01E0DB0625E8E95700A740ED /* AppDurationScenario.swift in Sources */,
 				01847DCD26443DF000ADA4C7 /* InvalidCrashReportScenario.m in Sources */,
+				01F6B74E2832381300B75C5D /* OldHandledErrorScenario.swift in Sources */,
 				01F47D2D254B1B3100B184AD /* OnErrorOverwriteScenario.swift in Sources */,
 				01F47CC7254B1B3100B184AD /* MetadataRedactionDefaultScenario.swift in Sources */,
 				01F47CEC254B1B3100B184AD /* SessionCallbackCrashScenario.swift in Sources */,
@@ -825,10 +839,12 @@
 				01F47D28254B1B3100B184AD /* ReadGarbagePointerScenario.m in Sources */,
 				01F47D2B254B1B3100B184AD /* AutoSessionUnhandledScenario.m in Sources */,
 				01F47D2E254B1B3100B184AD /* OOMLoadScenario.swift in Sources */,
+				01F6B74C2832381300B75C5D /* OldCrashReportScenario.swift in Sources */,
 				01F47CE5254B1B3100B184AD /* AccessNonObjectScenario.m in Sources */,
 				01F47D10254B1B3100B184AD /* AutoSessionWithUserScenario.m in Sources */,
 				01F47CFC254B1B3100B184AD /* SessionCallbackOverrideScenario.swift in Sources */,
 				01F47D00254B1B3100B184AD /* ManualContextOnErrorScenario.swift in Sources */,
+				01F6B74D2832381300B75C5D /* OversizedHandledErrorScenario.swift in Sources */,
 				01F47D22254B1B3100B184AD /* BreadcrumbCallbackRemovalScenario.m in Sources */,
 				01F47CFF254B1B3100B184AD /* EnabledErrorTypesCxxScenario.mm in Sources */,
 				01F47CD5254B1B3100B184AD /* OOMAutoDetectErrorsScenario.swift in Sources */,

--- a/features/fixtures/shared/scenarios/OldCrashReportScenario.swift
+++ b/features/fixtures/shared/scenarios/OldCrashReportScenario.swift
@@ -1,0 +1,33 @@
+class OldCrashReportScenario: Scenario {
+    
+    override func startBugsnag() {
+        modifyEventCreationDate()
+        config.autoTrackSessions = false
+        config.enabledErrorTypes.ooms = false
+        super.startBugsnag()
+    }
+    
+    override func run() {
+        fatalError("This is a test")
+    }
+    
+    func modifyEventCreationDate() {
+        let dir = [NSSearchPathForDirectoriesInDomains(.applicationSupportDirectory, .userDomainMask, true)[0],
+                   "com.bugsnag.Bugsnag",
+                   Bundle.main.bundleIdentifier!,
+                   "v1",
+                   "KSCrashReports"].joined(separator: "/")
+        
+        let creationDate = Calendar(identifier: .gregorian).date(byAdding: .day, value: -61, to: Date())!
+        
+        do {
+            for name in try FileManager.default.contentsOfDirectory(atPath: dir) {
+                let file = (dir as NSString).appendingPathComponent(name)
+                try FileManager.default.setAttributes([.creationDate: creationDate], ofItemAtPath: file)
+                NSLog("OldCrashReportScenario: Updated creation date of \((file as NSString).lastPathComponent) to \(creationDate)")
+            }
+        } catch {
+            NSLog("\(error)")
+        }
+    }
+}

--- a/features/fixtures/shared/scenarios/OldHandledErrorScenario.swift
+++ b/features/fixtures/shared/scenarios/OldHandledErrorScenario.swift
@@ -1,0 +1,33 @@
+class OldHandledErrorScenario: Scenario {
+    
+    override func startBugsnag() {
+        modifyEventCreationDate()
+        config.autoTrackSessions = false
+        config.enabledErrorTypes.ooms = false
+        super.startBugsnag()
+    }
+    
+    override func run() {
+        Bugsnag.notifyError(NSError(domain: "", code: 0, userInfo: nil))
+    }
+    
+    func modifyEventCreationDate() {
+        let dir = [NSSearchPathForDirectoriesInDomains(.applicationSupportDirectory, .userDomainMask, true)[0],
+                   "com.bugsnag.Bugsnag",
+                   Bundle.main.bundleIdentifier!,
+                   "v1",
+                   "events"].joined(separator: "/")
+        
+        let creationDate = Calendar(identifier: .gregorian).date(byAdding: .day, value: -61, to: Date())!
+        
+        do {
+            for name in try FileManager.default.contentsOfDirectory(atPath: dir) {
+                let file = (dir as NSString).appendingPathComponent(name)
+                try FileManager.default.setAttributes([.creationDate: creationDate], ofItemAtPath: file)
+                NSLog("OldCrashReportScenario: Updated creation date of \((file as NSString).lastPathComponent) to \(creationDate)")
+            }
+        } catch {
+            NSLog("\(error)")
+        }
+    }
+}

--- a/features/fixtures/shared/scenarios/OversizedCrashReportScenario.swift
+++ b/features/fixtures/shared/scenarios/OversizedCrashReportScenario.swift
@@ -1,0 +1,20 @@
+class OversizedCrashReportScenario: Scenario {
+    
+    override func startBugsnag() {
+        config.autoTrackSessions = false
+        config.enabledErrorTypes.ooms = false
+        config.addOnSendError {
+            var data = Data(count: 1024 * 1024)
+            _ = data.withUnsafeMutableBytes {
+                SecRandomCopyBytes(kSecRandomDefault, $0.count, $0.baseAddress!)
+            }
+            $0.addMetadata(data.base64EncodedString(), key: "random", section: "test")
+            return true
+        }
+        super.startBugsnag()
+    }
+    
+    override func run() {
+        fatalError("This is a test")
+    }
+}

--- a/features/fixtures/shared/scenarios/OversizedHandledErrorScenario.swift
+++ b/features/fixtures/shared/scenarios/OversizedHandledErrorScenario.swift
@@ -1,0 +1,20 @@
+class OversizedHandledErrorScenario: Scenario {
+    
+    override func startBugsnag() {
+        config.autoTrackSessions = false
+        config.enabledErrorTypes.ooms = false
+        config.addOnSendError {
+            var data = Data(count: 1024 * 1024)
+            _ = data.withUnsafeMutableBytes {
+                SecRandomCopyBytes(kSecRandomDefault, $0.count, $0.baseAddress!)
+            }
+            $0.addMetadata(data.base64EncodedString(), key: "random", section: "test")
+            return true
+        }
+        super.startBugsnag()
+    }
+    
+    override func run() {
+        Bugsnag.notifyError(NSError(domain: "", code: 0, userInfo: nil))
+    }
+}


### PR DESCRIPTION
## Goal

Prevent error event sending from being retried indefinitely in the event of HTTP or connection errors, by discarding them once more than 60 days old or if too large.

## Changeset

`BSGEventUploadFileOperation` deletes and `BSGEventUploadObjectOperation` skips persistence if sending fails and
* the file was created over 60 days ago or
* the HTTP body size is greater than 1MB

`BugsnagApiClient` now returns the HTTP body so that its size can be checked without re-encoding. Note that the size of an event on disk may be very different from the size of the HTTP body if `OnSendError` callbacks make any major changes.

## Testing

Adds E2E scenarios to verify that oversized and stale payloads are not retried.