### PR TITLE
Add watchOS target for BugsnagNetworkRequestPlugin

### DIFF
--- a/Bugsnag.xcodeproj/project.pbxproj
+++ b/Bugsnag.xcodeproj/project.pbxproj
@@ -3969,6 +3969,7 @@
 				TVOS_DEPLOYMENT_TARGET = 9.2;
 				VERSIONING_SYSTEM = "apple-generic";
 				VERSION_INFO_PREFIX = "";
+				WATCHOS_DEPLOYMENT_TARGET = 2.0;
 			};
 			name = Debug;
 		};
@@ -4010,6 +4011,7 @@
 				VALIDATE_PRODUCT = YES;
 				VERSIONING_SYSTEM = "apple-generic";
 				VERSION_INFO_PREFIX = "";
+				WATCHOS_DEPLOYMENT_TARGET = 2.0;
 			};
 			name = Release;
 		};
@@ -4376,7 +4378,6 @@
 				SKIP_INSTALL = YES;
 				SWIFT_EMIT_LOC_STRINGS = YES;
 				TARGETED_DEVICE_FAMILY = 4;
-				WATCHOS_DEPLOYMENT_TARGET = 8.3;
 			};
 			name = Debug;
 		};
@@ -4435,7 +4436,6 @@
 				SKIP_INSTALL = YES;
 				SWIFT_EMIT_LOC_STRINGS = YES;
 				TARGETED_DEVICE_FAMILY = 4;
-				WATCHOS_DEPLOYMENT_TARGET = 8.3;
 			};
 			name = Release;
 		};
@@ -4483,7 +4483,6 @@
 				SWIFT_OBJC_BRIDGING_HEADER = "Tests/BugsnagTests/Tests-Bridging-Header.h";
 				SWIFT_VERSION = 4.2;
 				TARGETED_DEVICE_FAMILY = 4;
-				WATCHOS_DEPLOYMENT_TARGET = 8.3;
 			};
 			name = Debug;
 		};
@@ -4531,7 +4530,6 @@
 				SWIFT_OBJC_BRIDGING_HEADER = "Tests/BugsnagTests/Tests-Bridging-Header.h";
 				SWIFT_VERSION = 4.2;
 				TARGETED_DEVICE_FAMILY = 4;
-				WATCHOS_DEPLOYMENT_TARGET = 8.3;
 			};
 			name = Release;
 		};

--- a/Bugsnag/Breadcrumbs/BSGNotificationBreadcrumbs.m
+++ b/Bugsnag/Breadcrumbs/BSGNotificationBreadcrumbs.m
@@ -237,7 +237,7 @@
                                       object:nil];
 #endif
         
-        if (@available(iOS 11.0, tvOS 11.0, *)) {
+        if (@available(iOS 11.0, tvOS 11.0, watchOS 4.0, *)) {
             [self.notificationCenter addObserver:self
                                         selector:@selector(thermalStateDidChange:)
                                             name:NSProcessInfoThermalStateDidChangeNotification

--- a/Bugsnag/Client/BugsnagClient.m
+++ b/Bugsnag/Client/BugsnagClient.m
@@ -697,7 +697,7 @@ __attribute__((annotate("oclint:suppress[too many methods]")))
         deviceMetadata[BSGKeyCharging] = bsg_runContext->batteryState >= UIDeviceBatteryStateCharging ? @YES : @NO;
     }
 #endif
-    if (@available(iOS 11.0, tvOS 11.0, *)) {
+    if (@available(iOS 11.0, tvOS 11.0, watchOS 4.0, *)) {
         deviceMetadata[BSGKeyThermalState] = BSGStringFromThermalState(bsg_runContext->thermalState);
     }
     [event.metadata addMetadata:deviceMetadata toSection:BSGKeyDevice];
@@ -1157,7 +1157,7 @@ __attribute__((annotate("oclint:suppress[too many methods]")))
     // Don't set to @NO because server may interpret any non-nil value as meaning true
     deviceMetadata[BSGKeyLowMemoryWarning] = BSGRunContextWasMemoryWarning() ? @YES : nil;
 #endif
-    if (@available(iOS 11.0, tvOS 11.0, *)) {
+    if (@available(iOS 11.0, tvOS 11.0, watchOS 4.0, *)) {
         deviceMetadata[BSGKeyThermalState] = BSGStringFromThermalState(bsg_lastRunContext->thermalState);
     }
     [metadata addMetadata:deviceMetadata toSection:BSGKeyDevice];

--- a/Bugsnag/Helpers/BSGRunContext.m
+++ b/Bugsnag/Helpers/BSGRunContext.m
@@ -45,7 +45,7 @@ static void InitRunContext() {
     // event or notification (or prewarming on iOS 15+)
     bsg_runContext->isForeground = GetIsForeground();
     
-    if (@available(iOS 11.0, tvOS 11.0, *)) {
+    if (@available(iOS 11.0, tvOS 11.0, watchOS 4.0, *)) {
         bsg_runContext->thermalState = NSProcessInfo.processInfo.thermalState;
     }
     
@@ -137,7 +137,11 @@ static bool GetIsForeground() {
 #endif
 
 #if TARGET_OS_WATCH
-    return [WKExtension sharedExtension].applicationState != WKApplicationStateBackground;
+    if (@available(watchOS 3.0, *)) {
+        return [WKExtension sharedExtension].applicationState != WKApplicationStateBackground;
+    } else {
+        return false;
+    }
 #endif
 }
 
@@ -257,7 +261,7 @@ static void AddObservers() {
     OBSERVE(NSApplicationWillTerminateNotification, NoteAppWillTerminate);
 #endif
     
-    if (@available(iOS 11.0, tvOS 11.0, *)) {
+    if (@available(iOS 11.0, tvOS 11.0, watchOS 4.0, *)) {
         OBSERVE(NSProcessInfoThermalStateDidChangeNotification, NoteThermalState);
     }
     

--- a/Bugsnag/Payload/BugsnagEvent.m
+++ b/Bugsnag/Payload/BugsnagEvent.m
@@ -288,7 +288,7 @@ NSDictionary *BSGParseCustomException(NSDictionary *report,
     deviceMetadata[BSGKeyBatteryLevel] = [event valueForKeyPath:@"user.batteryLevel"];
     deviceMetadata[BSGKeyCharging] = [event valueForKeyPath:@"user.charging"];
 #endif
-    if (@available(iOS 11.0, tvOS 11.0, *)) {
+    if (@available(iOS 11.0, tvOS 11.0, watchOS 4.0, *)) {
         NSNumber *thermalState = [event valueForKeyPath:@"user.thermalState"];
         if ([thermalState isKindOfClass:[NSNumber class]]) {
             deviceMetadata[BSGKeyThermalState] = BSGStringFromThermalState(thermalState.longValue);

--- a/BugsnagNetworkRequestPlugin/BugsnagNetworkRequestPlugin.xcodeproj/project.pbxproj
+++ b/BugsnagNetworkRequestPlugin/BugsnagNetworkRequestPlugin.xcodeproj/project.pbxproj
@@ -26,6 +26,16 @@
 		CB2430E126F1DABE00CB5EC4 /* BSGURLSessionTracingProxy.m in Sources */ = {isa = PBXBuildFile; fileRef = CB487F0026E8D0B0004F6B87 /* BSGURLSessionTracingProxy.m */; };
 		CB2430E226F1DABE00CB5EC4 /* NSURLSession+Tracing.m in Sources */ = {isa = PBXBuildFile; fileRef = CB487F0526E8D0B1004F6B87 /* NSURLSession+Tracing.m */; };
 		CB2430E326F1DAC500CB5EC4 /* BugsnagNetworkRequestPlugin.m in Sources */ = {isa = PBXBuildFile; fileRef = CB487ABE26D7B295004F6B87 /* BugsnagNetworkRequestPlugin.m */; };
+		CB3B7F942832709000CAD67A /* BugsnagNetworkRequestPlugin.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = CB3B7F8C2832709000CAD67A /* BugsnagNetworkRequestPlugin.framework */; };
+		CB3B7FA1283270E500CAD67A /* BugsnagNetworkRequestPlugin.m in Sources */ = {isa = PBXBuildFile; fileRef = CB487ABE26D7B295004F6B87 /* BugsnagNetworkRequestPlugin.m */; };
+		CB3B7FA2283270E900CAD67A /* BSGURLSessionTracingDelegate.m in Sources */ = {isa = PBXBuildFile; fileRef = CB487F0226E8D0B0004F6B87 /* BSGURLSessionTracingDelegate.m */; };
+		CB3B7FA3283270EC00CAD67A /* BSGURLSessionTracingProxy.m in Sources */ = {isa = PBXBuildFile; fileRef = CB487F0026E8D0B0004F6B87 /* BSGURLSessionTracingProxy.m */; };
+		CB3B7FA4283270EF00CAD67A /* NSURLSession+Tracing.m in Sources */ = {isa = PBXBuildFile; fileRef = CB487F0526E8D0B1004F6B87 /* NSURLSession+Tracing.m */; };
+		CB3B7FA5283270FC00CAD67A /* BSGURLSessionTracingDelegateTests.m in Sources */ = {isa = PBXBuildFile; fileRef = 0196AA0F26FB395E008E54FC /* BSGURLSessionTracingDelegateTests.m */; };
+		CB3B7FA62832710000CAD67A /* BSGURLSessionTracingProxyTests.m in Sources */ = {isa = PBXBuildFile; fileRef = 016113852716EFBE002A50D4 /* BSGURLSessionTracingProxyTests.m */; };
+		CB3B7FA72832710300CAD67A /* BugsnagNetworkRequestPluginTests.m in Sources */ = {isa = PBXBuildFile; fileRef = CB487A6726D7B109004F6B87 /* BugsnagNetworkRequestPluginTests.m */; };
+		CB3B7FA82832746000CAD67A /* BugsnagNetworkRequestPlugin.h in Headers */ = {isa = PBXBuildFile; fileRef = CB487C2F26DE3EFB004F6B87 /* BugsnagNetworkRequestPlugin.h */; settings = {ATTRIBUTES = (Public, ); }; };
+		CB3B7FAA2832752600CAD67A /* Bugsnag.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = CB3B7FA92832752600CAD67A /* Bugsnag.framework */; };
 		CB487A6326D7B109004F6B87 /* BugsnagNetworkRequestPlugin.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = CB487A5926D7B109004F6B87 /* BugsnagNetworkRequestPlugin.framework */; };
 		CB487A7526D7B12F004F6B87 /* Bugsnag.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = CB487A7426D7B12F004F6B87 /* Bugsnag.framework */; };
 		CB487A8626D7B144004F6B87 /* BugsnagNetworkRequestPlugin.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = CB487A7D26D7B144004F6B87 /* BugsnagNetworkRequestPlugin.framework */; };
@@ -75,6 +85,13 @@
 			proxyType = 1;
 			remoteGlobalIDString = CB487A5826D7B109004F6B87;
 			remoteInfo = "BugsnagNetworkRequestPlugin-iOS";
+		};
+		CB3B7F952832709000CAD67A /* PBXContainerItemProxy */ = {
+			isa = PBXContainerItemProxy;
+			containerPortal = CB487A5026D7B109004F6B87 /* Project object */;
+			proxyType = 1;
+			remoteGlobalIDString = CB3B7F8B2832709000CAD67A;
+			remoteInfo = "BugsnagNetworkRequestPlugin-watchOS";
 		};
 		CB487A6426D7B109004F6B87 /* PBXContainerItemProxy */ = {
 			isa = PBXContainerItemProxy;
@@ -135,6 +152,9 @@
 		01DC33B42733FC9B005B2BDD /* Info.plist */ = {isa = PBXFileReference; lastKnownFileType = text.plist.xml; path = Info.plist; sourceTree = "<group>"; };
 		01DC33B52733FC9B005B2BDD /* main.m */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.objc; path = main.m; sourceTree = "<group>"; };
 		CB2430D726F1DA8A00CB5EC4 /* libBugsnagNetworkRequestPluginStatic.a */ = {isa = PBXFileReference; explicitFileType = archive.ar; includeInIndex = 0; path = libBugsnagNetworkRequestPluginStatic.a; sourceTree = BUILT_PRODUCTS_DIR; };
+		CB3B7F8C2832709000CAD67A /* BugsnagNetworkRequestPlugin.framework */ = {isa = PBXFileReference; explicitFileType = wrapper.framework; includeInIndex = 0; path = BugsnagNetworkRequestPlugin.framework; sourceTree = BUILT_PRODUCTS_DIR; };
+		CB3B7F932832709000CAD67A /* BugsnagNetworkRequestPlugin-watchOSTests.xctest */ = {isa = PBXFileReference; explicitFileType = wrapper.cfbundle; includeInIndex = 0; path = "BugsnagNetworkRequestPlugin-watchOSTests.xctest"; sourceTree = BUILT_PRODUCTS_DIR; };
+		CB3B7FA92832752600CAD67A /* Bugsnag.framework */ = {isa = PBXFileReference; explicitFileType = wrapper.framework; path = Bugsnag.framework; sourceTree = BUILT_PRODUCTS_DIR; };
 		CB487A5926D7B109004F6B87 /* BugsnagNetworkRequestPlugin.framework */ = {isa = PBXFileReference; explicitFileType = wrapper.framework; includeInIndex = 0; path = BugsnagNetworkRequestPlugin.framework; sourceTree = BUILT_PRODUCTS_DIR; };
 		CB487A5D26D7B109004F6B87 /* Info.plist */ = {isa = PBXFileReference; lastKnownFileType = text.plist.xml; path = Info.plist; sourceTree = "<group>"; };
 		CB487A6226D7B109004F6B87 /* BugsnagNetworkRequestPlugin-iOSTests.xctest */ = {isa = PBXFileReference; explicitFileType = wrapper.cfbundle; includeInIndex = 0; path = "BugsnagNetworkRequestPlugin-iOSTests.xctest"; sourceTree = BUILT_PRODUCTS_DIR; };
@@ -171,6 +191,22 @@
 			isa = PBXFrameworksBuildPhase;
 			buildActionMask = 2147483647;
 			files = (
+			);
+			runOnlyForDeploymentPostprocessing = 0;
+		};
+		CB3B7F892832709000CAD67A /* Frameworks */ = {
+			isa = PBXFrameworksBuildPhase;
+			buildActionMask = 2147483647;
+			files = (
+				CB3B7FAA2832752600CAD67A /* Bugsnag.framework in Frameworks */,
+			);
+			runOnlyForDeploymentPostprocessing = 0;
+		};
+		CB3B7F902832709000CAD67A /* Frameworks */ = {
+			isa = PBXFrameworksBuildPhase;
+			buildActionMask = 2147483647;
+			files = (
+				CB3B7F942832709000CAD67A /* BugsnagNetworkRequestPlugin.framework in Frameworks */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};
@@ -262,6 +298,8 @@
 				CB487A9D26D7B172004F6B87 /* BugsnagNetworkRequestPlugin.framework */,
 				CB487AA526D7B172004F6B87 /* BugsnagNetworkRequestPlugin-tvOSTests.xctest */,
 				01DC33A12733FC9A005B2BDD /* BugsnagNetworkRequestPluginTestHost-iOS.app */,
+				CB3B7F8C2832709000CAD67A /* BugsnagNetworkRequestPlugin.framework */,
+				CB3B7F932832709000CAD67A /* BugsnagNetworkRequestPlugin-watchOSTests.xctest */,
 			);
 			name = Products;
 			sourceTree = "<group>";
@@ -296,6 +334,7 @@
 		CB487A7326D7B12F004F6B87 /* Frameworks */ = {
 			isa = PBXGroup;
 			children = (
+				CB3B7FA92832752600CAD67A /* Bugsnag.framework */,
 				CB487AB426D7B191004F6B87 /* Bugsnag.framework */,
 				CB487A9426D7B166004F6B87 /* Bugsnag.framework */,
 				CB487A7426D7B12F004F6B87 /* Bugsnag.framework */,
@@ -322,6 +361,14 @@
 /* End PBXGroup section */
 
 /* Begin PBXHeadersBuildPhase section */
+		CB3B7F872832709000CAD67A /* Headers */ = {
+			isa = PBXHeadersBuildPhase;
+			buildActionMask = 2147483647;
+			files = (
+				CB3B7FA82832746000CAD67A /* BugsnagNetworkRequestPlugin.h in Headers */,
+			);
+			runOnlyForDeploymentPostprocessing = 0;
+		};
 		CB487A5426D7B109004F6B87 /* Headers */ = {
 			isa = PBXHeadersBuildPhase;
 			buildActionMask = 2147483647;
@@ -393,6 +440,42 @@
 			productName = BugsnagNetworkRequestPluginStatic;
 			productReference = CB2430D726F1DA8A00CB5EC4 /* libBugsnagNetworkRequestPluginStatic.a */;
 			productType = "com.apple.product-type.library.static";
+		};
+		CB3B7F8B2832709000CAD67A /* BugsnagNetworkRequestPlugin-watchOS */ = {
+			isa = PBXNativeTarget;
+			buildConfigurationList = CB3B7F9F2832709000CAD67A /* Build configuration list for PBXNativeTarget "BugsnagNetworkRequestPlugin-watchOS" */;
+			buildPhases = (
+				CB3B7F872832709000CAD67A /* Headers */,
+				CB3B7F882832709000CAD67A /* Sources */,
+				CB3B7F892832709000CAD67A /* Frameworks */,
+				CB3B7F8A2832709000CAD67A /* Resources */,
+			);
+			buildRules = (
+			);
+			dependencies = (
+			);
+			name = "BugsnagNetworkRequestPlugin-watchOS";
+			productName = "BugsnagNetworkRequestPlugin-watchOS";
+			productReference = CB3B7F8C2832709000CAD67A /* BugsnagNetworkRequestPlugin.framework */;
+			productType = "com.apple.product-type.framework";
+		};
+		CB3B7F922832709000CAD67A /* BugsnagNetworkRequestPlugin-watchOSTests */ = {
+			isa = PBXNativeTarget;
+			buildConfigurationList = CB3B7FA02832709000CAD67A /* Build configuration list for PBXNativeTarget "BugsnagNetworkRequestPlugin-watchOSTests" */;
+			buildPhases = (
+				CB3B7F8F2832709000CAD67A /* Sources */,
+				CB3B7F902832709000CAD67A /* Frameworks */,
+				CB3B7F912832709000CAD67A /* Resources */,
+			);
+			buildRules = (
+			);
+			dependencies = (
+				CB3B7F962832709000CAD67A /* PBXTargetDependency */,
+			);
+			name = "BugsnagNetworkRequestPlugin-watchOSTests";
+			productName = "BugsnagNetworkRequestPlugin-watchOSTests";
+			productReference = CB3B7F932832709000CAD67A /* BugsnagNetworkRequestPlugin-watchOSTests.xctest */;
+			productType = "com.apple.product-type.bundle.unit-test";
 		};
 		CB487A5826D7B109004F6B87 /* BugsnagNetworkRequestPlugin-iOS */ = {
 			isa = PBXNativeTarget;
@@ -517,6 +600,12 @@
 					CB2430D626F1DA8A00CB5EC4 = {
 						CreatedOnToolsVersion = 12.5.1;
 					};
+					CB3B7F8B2832709000CAD67A = {
+						CreatedOnToolsVersion = 13.3.1;
+					};
+					CB3B7F922832709000CAD67A = {
+						CreatedOnToolsVersion = 13.3.1;
+					};
 					CB487A5826D7B109004F6B87 = {
 						CreatedOnToolsVersion = 12.5.1;
 					};
@@ -559,6 +648,8 @@
 				CB487A9C26D7B172004F6B87 /* BugsnagNetworkRequestPlugin-tvOS */,
 				CB487AA426D7B172004F6B87 /* BugsnagNetworkRequestPlugin-tvOSTests */,
 				01DC33A02733FC9A005B2BDD /* BugsnagNetworkRequestPluginTestHost-iOS */,
+				CB3B7F8B2832709000CAD67A /* BugsnagNetworkRequestPlugin-watchOS */,
+				CB3B7F922832709000CAD67A /* BugsnagNetworkRequestPlugin-watchOSTests */,
 			);
 		};
 /* End PBXProject section */
@@ -571,6 +662,20 @@
 				01DC33B32733FC9B005B2BDD /* LaunchScreen.storyboard in Resources */,
 				01DC33B02733FC9B005B2BDD /* Assets.xcassets in Resources */,
 				01DC33AE2733FC9A005B2BDD /* Main.storyboard in Resources */,
+			);
+			runOnlyForDeploymentPostprocessing = 0;
+		};
+		CB3B7F8A2832709000CAD67A /* Resources */ = {
+			isa = PBXResourcesBuildPhase;
+			buildActionMask = 2147483647;
+			files = (
+			);
+			runOnlyForDeploymentPostprocessing = 0;
+		};
+		CB3B7F912832709000CAD67A /* Resources */ = {
+			isa = PBXResourcesBuildPhase;
+			buildActionMask = 2147483647;
+			files = (
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};
@@ -636,6 +741,27 @@
 				CB2430E226F1DABE00CB5EC4 /* NSURLSession+Tracing.m in Sources */,
 				CB2430E326F1DAC500CB5EC4 /* BugsnagNetworkRequestPlugin.m in Sources */,
 				CB2430E126F1DABE00CB5EC4 /* BSGURLSessionTracingProxy.m in Sources */,
+			);
+			runOnlyForDeploymentPostprocessing = 0;
+		};
+		CB3B7F882832709000CAD67A /* Sources */ = {
+			isa = PBXSourcesBuildPhase;
+			buildActionMask = 2147483647;
+			files = (
+				CB3B7FA4283270EF00CAD67A /* NSURLSession+Tracing.m in Sources */,
+				CB3B7FA3283270EC00CAD67A /* BSGURLSessionTracingProxy.m in Sources */,
+				CB3B7FA1283270E500CAD67A /* BugsnagNetworkRequestPlugin.m in Sources */,
+				CB3B7FA2283270E900CAD67A /* BSGURLSessionTracingDelegate.m in Sources */,
+			);
+			runOnlyForDeploymentPostprocessing = 0;
+		};
+		CB3B7F8F2832709000CAD67A /* Sources */ = {
+			isa = PBXSourcesBuildPhase;
+			buildActionMask = 2147483647;
+			files = (
+				CB3B7FA72832710300CAD67A /* BugsnagNetworkRequestPluginTests.m in Sources */,
+				CB3B7FA62832710000CAD67A /* BSGURLSessionTracingProxyTests.m in Sources */,
+				CB3B7FA5283270FC00CAD67A /* BSGURLSessionTracingDelegateTests.m in Sources */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};
@@ -714,6 +840,11 @@
 			isa = PBXTargetDependency;
 			target = CB487A5826D7B109004F6B87 /* BugsnagNetworkRequestPlugin-iOS */;
 			targetProxy = 01DC33BE2733FDF0005B2BDD /* PBXContainerItemProxy */;
+		};
+		CB3B7F962832709000CAD67A /* PBXTargetDependency */ = {
+			isa = PBXTargetDependency;
+			target = CB3B7F8B2832709000CAD67A /* BugsnagNetworkRequestPlugin-watchOS */;
+			targetProxy = CB3B7F952832709000CAD67A /* PBXContainerItemProxy */;
 		};
 		CB487A6526D7B109004F6B87 /* PBXTargetDependency */ = {
 			isa = PBXTargetDependency;
@@ -809,6 +940,108 @@
 				PRODUCT_NAME = "$(TARGET_NAME)";
 				SKIP_INSTALL = YES;
 				TARGETED_DEVICE_FAMILY = "1,2";
+			};
+			name = Release;
+		};
+		CB3B7F9B2832709000CAD67A /* Debug */ = {
+			isa = XCBuildConfiguration;
+			buildSettings = {
+				APPLICATION_EXTENSION_API_ONLY = YES;
+				CLANG_CXX_LANGUAGE_STANDARD = "gnu++17";
+				CODE_SIGN_STYLE = Automatic;
+				CURRENT_PROJECT_VERSION = 1;
+				DEFINES_MODULE = YES;
+				DEVELOPMENT_TEAM = 372ZUL2ZB7;
+				DYLIB_COMPATIBILITY_VERSION = 1;
+				DYLIB_CURRENT_VERSION = 1;
+				DYLIB_INSTALL_NAME_BASE = "@rpath";
+				GENERATE_INFOPLIST_FILE = YES;
+				INFOPLIST_KEY_NSHumanReadableCopyright = "";
+				INSTALL_PATH = "$(LOCAL_LIBRARY_DIR)/Frameworks";
+				LD_RUNPATH_SEARCH_PATHS = (
+					"$(inherited)",
+					"@executable_path/Frameworks",
+					"@loader_path/Frameworks",
+				);
+				MARKETING_VERSION = 1.0;
+				PRODUCT_BUNDLE_IDENTIFIER = com.bugsnag.BugsnagNetworkRequestPlugin;
+				PRODUCT_NAME = BugsnagNetworkRequestPlugin;
+				SDKROOT = watchos;
+				SKIP_INSTALL = YES;
+				SWIFT_EMIT_LOC_STRINGS = YES;
+				TARGETED_DEVICE_FAMILY = 4;
+			};
+			name = Debug;
+		};
+		CB3B7F9C2832709000CAD67A /* Release */ = {
+			isa = XCBuildConfiguration;
+			buildSettings = {
+				APPLICATION_EXTENSION_API_ONLY = YES;
+				CLANG_CXX_LANGUAGE_STANDARD = "gnu++17";
+				CODE_SIGN_STYLE = Automatic;
+				CURRENT_PROJECT_VERSION = 1;
+				DEFINES_MODULE = YES;
+				DEVELOPMENT_TEAM = 372ZUL2ZB7;
+				DYLIB_COMPATIBILITY_VERSION = 1;
+				DYLIB_CURRENT_VERSION = 1;
+				DYLIB_INSTALL_NAME_BASE = "@rpath";
+				GENERATE_INFOPLIST_FILE = YES;
+				INFOPLIST_KEY_NSHumanReadableCopyright = "";
+				INSTALL_PATH = "$(LOCAL_LIBRARY_DIR)/Frameworks";
+				LD_RUNPATH_SEARCH_PATHS = (
+					"$(inherited)",
+					"@executable_path/Frameworks",
+					"@loader_path/Frameworks",
+				);
+				MARKETING_VERSION = 1.0;
+				PRODUCT_BUNDLE_IDENTIFIER = com.bugsnag.BugsnagNetworkRequestPlugin;
+				PRODUCT_NAME = BugsnagNetworkRequestPlugin;
+				SDKROOT = watchos;
+				SKIP_INSTALL = YES;
+				SWIFT_EMIT_LOC_STRINGS = YES;
+				TARGETED_DEVICE_FAMILY = 4;
+			};
+			name = Release;
+		};
+		CB3B7F9D2832709000CAD67A /* Debug */ = {
+			isa = XCBuildConfiguration;
+			buildSettings = {
+				CLANG_CXX_LANGUAGE_STANDARD = "gnu++17";
+				CODE_SIGN_STYLE = Automatic;
+				CURRENT_PROJECT_VERSION = 1;
+				DEVELOPMENT_TEAM = 372ZUL2ZB7;
+				GCC_WARN_ABOUT_DEPRECATED_FUNCTIONS = NO;
+				GCC_WARN_PEDANTIC = NO;
+				GCC_WARN_UNUSED_PARAMETER = NO;
+				GENERATE_INFOPLIST_FILE = YES;
+				MARKETING_VERSION = 1.0;
+				PRODUCT_BUNDLE_IDENTIFIER = com.bugsnag.BugsnagNetworkRequestPluginTests;
+				PRODUCT_NAME = "$(TARGET_NAME)";
+				SDKROOT = watchos;
+				SWIFT_EMIT_LOC_STRINGS = NO;
+				TARGETED_DEVICE_FAMILY = 4;
+				WATCHOS_DEPLOYMENT_TARGET = 7.0;
+			};
+			name = Debug;
+		};
+		CB3B7F9E2832709000CAD67A /* Release */ = {
+			isa = XCBuildConfiguration;
+			buildSettings = {
+				CLANG_CXX_LANGUAGE_STANDARD = "gnu++17";
+				CODE_SIGN_STYLE = Automatic;
+				CURRENT_PROJECT_VERSION = 1;
+				DEVELOPMENT_TEAM = 372ZUL2ZB7;
+				GCC_WARN_ABOUT_DEPRECATED_FUNCTIONS = NO;
+				GCC_WARN_PEDANTIC = NO;
+				GCC_WARN_UNUSED_PARAMETER = NO;
+				GENERATE_INFOPLIST_FILE = YES;
+				MARKETING_VERSION = 1.0;
+				PRODUCT_BUNDLE_IDENTIFIER = com.bugsnag.BugsnagNetworkRequestPluginTests;
+				PRODUCT_NAME = "$(TARGET_NAME)";
+				SDKROOT = watchos;
+				SWIFT_EMIT_LOC_STRINGS = NO;
+				TARGETED_DEVICE_FAMILY = 4;
+				WATCHOS_DEPLOYMENT_TARGET = 7.0;
 			};
 			name = Release;
 		};
@@ -908,6 +1141,7 @@
 				TVOS_DEPLOYMENT_TARGET = 9.2;
 				VERSIONING_SYSTEM = "apple-generic";
 				VERSION_INFO_PREFIX = "";
+				WATCHOS_DEPLOYMENT_TARGET = 4.0;
 			};
 			name = Debug;
 		};
@@ -1001,6 +1235,7 @@
 				VALIDATE_PRODUCT = YES;
 				VERSIONING_SYSTEM = "apple-generic";
 				VERSION_INFO_PREFIX = "";
+				WATCHOS_DEPLOYMENT_TARGET = 4.0;
 			};
 			name = Release;
 		};
@@ -1283,6 +1518,24 @@
 			buildConfigurations = (
 				CB2430DD26F1DA8A00CB5EC4 /* Debug */,
 				CB2430DE26F1DA8A00CB5EC4 /* Release */,
+			);
+			defaultConfigurationIsVisible = 0;
+			defaultConfigurationName = Release;
+		};
+		CB3B7F9F2832709000CAD67A /* Build configuration list for PBXNativeTarget "BugsnagNetworkRequestPlugin-watchOS" */ = {
+			isa = XCConfigurationList;
+			buildConfigurations = (
+				CB3B7F9B2832709000CAD67A /* Debug */,
+				CB3B7F9C2832709000CAD67A /* Release */,
+			);
+			defaultConfigurationIsVisible = 0;
+			defaultConfigurationName = Release;
+		};
+		CB3B7FA02832709000CAD67A /* Build configuration list for PBXNativeTarget "BugsnagNetworkRequestPlugin-watchOSTests" */ = {
+			isa = XCConfigurationList;
+			buildConfigurations = (
+				CB3B7F9D2832709000CAD67A /* Debug */,
+				CB3B7F9E2832709000CAD67A /* Release */,
 			);
 			defaultConfigurationIsVisible = 0;
 			defaultConfigurationName = Release;

--- a/BugsnagNetworkRequestPlugin/BugsnagNetworkRequestPluginTests/BugsnagNetworkRequestPluginTests.m
+++ b/BugsnagNetworkRequestPlugin/BugsnagNetworkRequestPluginTests/BugsnagNetworkRequestPluginTests.m
@@ -462,6 +462,8 @@ typedef void (^CompletionHandler)(NSData *data, NSURLResponse *response, NSError
                          params:nil];
         }];
 
+#if !TARGET_OS_WATCH
+        // TODO: Rewrite these to support the much more strict HTTP library in watchOS and later iOS
         [self resetBreadcrumbs];
         [self runMultipartTasksWithURL:urlString
                            method:@"GET"
@@ -476,6 +478,7 @@ typedef void (^CompletionHandler)(NSData *data, NSURLResponse *response, NSError
                             url:urlString
                          params:nil];
         }];
+#endif
 
         [self resetBreadcrumbs];
         [self runDownloadTasksWithURL:urlString
@@ -492,6 +495,8 @@ typedef void (^CompletionHandler)(NSData *data, NSURLResponse *response, NSError
                          params:nil];
         }];
 
+#if !TARGET_OS_WATCH
+        // TODO: Rewrite these to support the much more strict HTTP library in watchOS and later iOS
         [self resetBreadcrumbs];
         [self runUploadTasksWithURL:urlString
                        statusCode:statusCode
@@ -505,11 +510,17 @@ typedef void (^CompletionHandler)(NSData *data, NSURLResponse *response, NSError
                             url:urlString
                          params:nil];
         }];
+#endif
     }
 }
 
 - (void)testTaskMethods {
+#if TARGET_OS_WATCH
+    // TODO: Rewrite these to support the much more strict HTTP library in watchOS and later iOS
+    for (NSString *method in @[@"GET", @"HEAD"]) {
+#else
     for (NSString *method in @[@"GET", @"HEAD", @"POST", @"PUT", @"DELETE", @"CONNECT", @"OPTIONS", @"TRACE", @"PATCH"]) {
+#endif
         [self resetBreadcrumbs];
         [self runDataTasksWithURL:@"https://bugsnag.com/?a=b&c=d"
                            method:method

--- a/Tests/BugsnagTests/BSGNotificationBreadcrumbsTests.m
+++ b/Tests/BugsnagTests/BSGNotificationBreadcrumbsTests.m
@@ -160,7 +160,7 @@
 }
 
 - (void)testNSProcessInfoThermalStateThermalStateNotifications {
-    if (@available(iOS 13.0, tvOS 13.0, *)) {
+    if (@available(iOS 13.0, tvOS 13.0, watchOS 4.0, *)) {
         MockProcessInfo *processInfo = [[MockProcessInfo alloc] init];
         self.notificationObject = processInfo;
         

--- a/Tests/KSCrashTests/BSG_KSCrashReportTests.m
+++ b/Tests/KSCrashTests/BSG_KSCrashReportTests.m
@@ -86,7 +86,7 @@
     const int numFrames = 500;
     uintptr_t stackTrace[numFrames];
     for (int i = 0; i < numFrames; i++) {
-        stackTrace[i] = NSLog;
+        stackTrace[i] = (uintptr_t)NSLog;
         assert(stackTrace[i] != 0);
     }
     

--- a/Tests/KSCrashTests/BSG_KSMachHeadersTests.m
+++ b/Tests/KSCrashTests/BSG_KSMachHeadersTests.m
@@ -89,10 +89,10 @@ const struct segment_command command2 = {
     bsg_mach_headers_add_image(&header2, 0);
     
     BSG_Mach_Header_Info *item;
-    item = bsg_mach_headers_image_at_address(&header1);
+    item = bsg_mach_headers_image_at_address((uintptr_t)&header1);
     XCTAssertEqual(item->imageVmAddr, 111);
     
-    item = bsg_mach_headers_image_at_address(&header2);
+    item = bsg_mach_headers_image_at_address((uintptr_t)&header2);
     XCTAssertEqual(item->imageVmAddr, 222);
 }
 
@@ -117,7 +117,7 @@ const struct segment_command command2 = {
         uintptr_t address = number.unsignedIntegerValue;
         BSG_Mach_Header_Info *image = bsg_mach_headers_image_at_address(address);
         struct dl_info dlinfo = {0};
-        if (dladdr(address, &dlinfo) != 0) {
+        if (dladdr((const void*)address, &dlinfo) != 0) {
             // If dladdr was able to locate the image, so should bsg_mach_headers_image_at_address
             XCTAssertEqual(image->header, dlinfo.dli_fbase);
             XCTAssertEqual(image->imageVmAddr + image->slide, (uint64_t)dlinfo.dli_fbase);

--- a/Tests/KSCrashTests/KSCrashState_Tests.m
+++ b/Tests/KSCrashTests/KSCrashState_Tests.m
@@ -218,7 +218,6 @@
     NSParameterAssert(context.applicationIsInForeground);
     usleep(1);
     bsg_kscrashstate_notifyAppInForeground(false);
-    BSG_KSCrash_State checkpoint0 = context;
     usleep(1);
 
     memset(&context, 0, sizeof(context));


### PR DESCRIPTION
This PR adds a watchOS target for BugsnagNetworkRequestPlugin, and also fixes the minimum watchOS version, as well as a few warning messages that occur from having a 64-bit chip with 32-bit addressing.

## Testing

Updated network unit tests to also run on watchOS
