### PR TITLE
[PLAT-8476] Allow internal error reporting to be disabled

### DIFF
--- a/Bugsnag/Client/BugsnagClient.m
+++ b/Bugsnag/Client/BugsnagClient.m
@@ -211,13 +211,17 @@ __attribute__((annotate("oclint:suppress[too many methods]")))
         NSDictionary *systemInfo = [BSG_KSSystemInfo systemInfo];
         [self.metadata addMetadata:BSGParseAppMetadata(@{@"system": systemInfo}) toSection:BSGKeyApp];
         [self.metadata addMetadata:BSGParseDeviceMetadata(@{@"system": systemInfo}) toSection:BSGKeyDevice];
-
-        BSGInternalErrorReporter.sharedInstance = [[BSGInternalErrorReporter alloc] initWithDataSource:self];
     }
     return self;
 }
 
 - (void)start {
+    if (self.configuration.telemetry & BSGTelemetryInternalErrors) {
+        BSGInternalErrorReporter.sharedInstance = [[BSGInternalErrorReporter alloc] initWithDataSource:self];
+    } else {
+        bsg_log_debug(@"Internal error reporting was disable in config");
+    }
+
     [self.configuration validate];
 
     BSGRunContextInit(BSGFileLocations.current.runContext.fileSystemRepresentation);

--- a/Bugsnag/Configuration/BugsnagConfiguration.m
+++ b/Bugsnag/Configuration/BugsnagConfiguration.m
@@ -114,6 +114,7 @@ static NSUserDefaults *userDefaults;
     [copy setOnBreadcrumbBlocks:self.onBreadcrumbBlocks];
     [copy setOnSendBlocks:self.onSendBlocks];
     [copy setOnSessionBlocks:self.onSessionBlocks];
+    [copy setTelemetry:self.telemetry];
     return copy;
 }
 
@@ -201,6 +202,8 @@ static NSUserDefaults *userDefaults;
             sessionWithConfiguration:[NSURLSessionConfiguration
                                          defaultSessionConfiguration]];
     }
+    
+    _telemetry = BSGTelemetryInternalErrors;
     
     NSString *releaseStage = nil;
     #if DEBUG

--- a/Bugsnag/Helpers/BSGInternalErrorReporter.h
+++ b/Bugsnag/Helpers/BSGInternalErrorReporter.h
@@ -8,6 +8,8 @@
 
 #import <Foundation/Foundation.h>
 
+#import "BSGDefines.h"
+
 @class BugsnagAppWithState;
 @class BugsnagConfiguration;
 @class BugsnagDeviceWithState;
@@ -17,7 +19,7 @@
 NS_ASSUME_NONNULL_BEGIN
 
 /// Returns a concise desription of the error including its domain, code, and debug description or localizedDescription.
-FOUNDATION_EXPORT NSString *BSGErrorDescription(NSError *error);
+BSG_PRIVATE NSString *BSGErrorDescription(NSError *error);
 
 // MARK: -
 
@@ -35,7 +37,7 @@ FOUNDATION_EXPORT NSString *BSGErrorDescription(NSError *error);
 
 @interface BSGInternalErrorReporter : NSObject
 
-@property (class, nonatomic) BSGInternalErrorReporter *sharedInstance;
+@property (class, nullable, nonatomic) BSGInternalErrorReporter *sharedInstance;
 
 /// Runs the block immediately if sharedInstance exists, otherwise runs the block once sharedInstance has been created.
 + (void)performBlock:(void (^)(BSGInternalErrorReporter *))block;

--- a/Bugsnag/include/Bugsnag/BugsnagConfiguration.h
+++ b/Bugsnag/include/Bugsnag/BugsnagConfiguration.h
@@ -68,6 +68,17 @@ typedef NS_ENUM(NSInteger, BSGThreadSendPolicy) {
 };
 
 /**
+ * Types of telemetry that may be sent to Bugsnag for product improvement purposes.
+ */
+typedef NS_OPTIONS(NSUInteger, BSGTelemetryOptions) {
+
+    /**
+     * Errors within the Bugsnag SDK.
+     */
+    BSGTelemetryInternalErrors = (1UL << 0),
+};
+
+/**
  * Setting `BugsnagConfiguration.appHangThresholdMillis` to this value disables the reporting of
  * app hangs that ended before the app was terminated.
  */
@@ -315,10 +326,6 @@ typedef id<NSObject> BugsnagOnSessionRef;
  */
 @property (nonatomic) BOOL persistUser;
 
-// -----------------------------------------------------------------------------
-// MARK: - Methods
-// -----------------------------------------------------------------------------
-
 /**
  * A class defining the types of error that are reported. By default,
  * all properties are true.
@@ -444,6 +451,17 @@ typedef id<NSObject> BugsnagOnSessionRef;
 - (void)removeOnBreadcrumbBlock:(BugsnagOnBreadcrumbBlock)block
     BSG_DEPRECATED_WITH_REPLACEMENT("removeOnBreadcrumb:")
     NS_SWIFT_NAME(removeOnBreadcrumb(block:));
+
+// =============================================================================
+// MARK: - Telemetry
+// =============================================================================
+
+/**
+ * The types of telemetry that may be sent to Bugsnag for product improvement purposes.
+ *
+ * By default all types of telemetry are enabled.
+ */
+@property (nonatomic) BSGTelemetryOptions telemetry;
 
 // =============================================================================
 // MARK: - Plugins

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,13 @@
 Changelog
 =========
 
+## TBD
+
+### Enhancements
+
+* Add `configuration.telemetry` to allow sending of internal errors to be disabled.
+  [#1375](https://github.com/bugsnag/bugsnag-cocoa/pull/1375)
+
 ## 6.17.1 (2022-05-18)
 
 ### Bug fixes

--- a/features/fixtures/shared/scenarios/InvalidCrashReportScenario.m
+++ b/features/fixtures/shared/scenarios/InvalidCrashReportScenario.m
@@ -21,7 +21,9 @@ static void CrashHandler(const BSG_KSCrashReportWriter *writer) {
 - (void)startBugsnag {
     self.config.autoTrackSessions = NO;
     self.config.onCrashHandler = CrashHandler;
-    
+    if ([self.eventMode isEqualToString:@"internalErrorsDisabled"]) {
+        self.config.telemetry &= ~BSGTelemetryInternalErrors;
+    }
     [super startBugsnag];
 }
 

--- a/features/internal_error_reporting.feature
+++ b/features/internal_error_reporting.feature
@@ -20,3 +20,9 @@ Feature: Internal error reporting
     And the event "unhandled" is false
     And the exception "errorClass" equals "JSON parsing error"
     And the exception "message" matches "NSCocoaErrorDomain 3840: No string key for value in object around .+\."
+
+  Scenario: Internal errors are not sent if disabled
+    When I run "InvalidCrashReportScenario" and relaunch the crashed app
+    And I set the app to "internalErrorsDisabled" mode
+    And I configure Bugsnag for "InvalidCrashReportScenario"
+    Then I should receive no requests


### PR DESCRIPTION
## Goal

Allow internal error reporting to be disabled.

## Changeset

Adds `telemetry` property to `BugsnagConfiguration` which contains a single "internal errors" option, enabled by default.

Skips initialization of `BSGInternalErrorReporter` if option is disabled.

## Testing

Adds E2E scenario to verify that internal errors are not sent when option is disabled.