### PR TITLE
Shorten Buildkite queue names

### DIFF
--- a/.buildkite/pipeline.full.yml
+++ b/.buildkite/pipeline.full.yml
@@ -248,7 +248,7 @@ steps:
       - cocoa_fixture
     timeout_in_minutes: 60
     agents:
-      queue: opensource-mac-cocoa-11
+      queue: macos-11
     plugins:
       artifacts#v1.5.0:
         download: ["features/fixtures/macos/output/macOSTestApp.zip"]

--- a/.buildkite/pipeline.full.yml
+++ b/.buildkite/pipeline.full.yml
@@ -267,7 +267,7 @@ steps:
       - cocoa_fixture
     timeout_in_minutes: 60
     agents:
-      queue: opensource-arm-mac-cocoa-12
+      queue: macos-12-arm
     plugins:
       artifacts#v1.5.0:
         download: "features/fixtures/macos/output/macOSTestApp.zip"
@@ -329,7 +329,7 @@ steps:
   - label: 'examples/objective-c-ios'
     timeout_in_minutes: 30
     agents:
-      queue: opensource-arm-mac-cocoa-12
+      queue: macos-12-arm
     commands:
       - cd examples/objective-c-ios
       - echo "--- Pod install"
@@ -344,7 +344,7 @@ steps:
   - label: 'examples/objective-c-osx'
     timeout_in_minutes: 30
     agents:
-      queue: opensource-arm-mac-cocoa-12
+      queue: macos-12-arm
     commands:
       - cd examples/objective-c-osx
       - echo "--- Pod install"
@@ -357,7 +357,7 @@ steps:
   - label: 'examples/swift-ios'
     timeout_in_minutes: 30
     agents:
-      queue: opensource-arm-mac-cocoa-12
+      queue: macos-12-arm
     commands:
       - cd examples/swift-ios
       - echo "--- Pod install"
@@ -370,7 +370,7 @@ steps:
   - label: 'examples/swift-package-manager'
     timeout_in_minutes: 30
     agents:
-      queue: opensource-arm-mac-cocoa-12
+      queue: macos-12-arm
     commands:
       - cd examples/swift-package-manager
       - echo "--- Resolve Swift Package Dependencies"
@@ -384,7 +384,7 @@ steps:
   - label: 'examples/swiftui'
     timeout_in_minutes: 30
     agents:
-      queue: opensource-arm-mac-cocoa-12
+      queue: macos-12-arm
     commands:
       - cd examples/swiftui
       - echo "--- Resolve Swift Package Dependencies"

--- a/.buildkite/pipeline.quick.yml
+++ b/.buildkite/pipeline.quick.yml
@@ -46,7 +46,7 @@ steps:
   - label: iOS 10 unit tests
     timeout_in_minutes: 10
     agents:
-      queue: opensource-mac-cocoa-10.15
+      queue: macos-10.15
     commands:
       - ./scripts/run-unit-tests.sh PLATFORM=iOS OS=10.3.1 DEVICE=iPhone\ 5s
     artifact_paths:
@@ -73,7 +73,7 @@ steps:
   - label: tvOS 10 unit tests
     timeout_in_minutes: 10
     agents:
-      queue: opensource-mac-cocoa-10.15
+      queue: macos-10.15
     commands:
       - ./scripts/run-unit-tests.sh PLATFORM=tvOS OS=10.2
     artifact_paths:
@@ -89,7 +89,7 @@ steps:
       - cocoa_fixture
     timeout_in_minutes: 60
     agents:
-      queue: opensource-mac-cocoa-10.15
+      queue: macos-10.15
     plugins:
       artifacts#v1.5.0:
         download: ["features/fixtures/macos/output/macOSTestApp.zip"]

--- a/.buildkite/pipeline.quick.yml
+++ b/.buildkite/pipeline.quick.yml
@@ -10,7 +10,7 @@ steps:
   - label: macOS 11 unit tests
     timeout_in_minutes: 10
     agents:
-      queue: opensource-mac-cocoa-11
+      queue: macos-11
     commands:
       - ./scripts/run-unit-tests.sh PLATFORM=macOS
     artifact_paths:
@@ -37,7 +37,7 @@ steps:
   - label: iOS 11 unit tests
     timeout_in_minutes: 10
     agents:
-      queue: opensource-mac-cocoa-11
+      queue: macos-11
     commands:
       - ./scripts/run-unit-tests.sh PLATFORM=iOS OS=11.4
     artifact_paths:
@@ -64,7 +64,7 @@ steps:
   - label: tvOS 11 unit tests
     timeout_in_minutes: 10
     agents:
-      queue: opensource-mac-cocoa-11
+      queue: macos-11
     commands:
       - ./scripts/run-unit-tests.sh PLATFORM=tvOS OS=11.4
     artifact_paths:

--- a/.buildkite/pipeline.quick.yml
+++ b/.buildkite/pipeline.quick.yml
@@ -28,7 +28,7 @@ steps:
   - label: iOS 14 unit tests
     timeout_in_minutes: 10
     agents:
-      queue: opensource-arm-mac-cocoa-12
+      queue: macos-12-arm
     commands:
       - ./scripts/run-unit-tests.sh PLATFORM=iOS OS=14.5
     artifact_paths:
@@ -55,7 +55,7 @@ steps:
   - label: tvOS 14 unit tests
     timeout_in_minutes: 10
     agents:
-      queue: opensource-arm-mac-cocoa-12
+      queue: macos-12-arm
     commands:
       - ./scripts/run-unit-tests.sh PLATFORM=tvOS OS=14.5
     artifact_paths:

--- a/.buildkite/pipeline.yml
+++ b/.buildkite/pipeline.yml
@@ -64,7 +64,7 @@ steps:
   - label: macOS 10.15 unit tests
     timeout_in_minutes: 10
     agents:
-      queue: opensource-mac-cocoa-10.15
+      queue: macos-10.15
     commands:
       - ./scripts/run-unit-tests.sh PLATFORM=macOS
     artifact_paths:
@@ -204,7 +204,7 @@ steps:
       - cocoa_fixture
     timeout_in_minutes: 10
     agents:
-      queue: opensource-mac-cocoa-10.15
+      queue: macos-10.15
     plugins:
       artifacts#v1.5.0:
         download: "features/fixtures/macos/output/macOSTestApp.zip"

--- a/.buildkite/pipeline.yml
+++ b/.buildkite/pipeline.yml
@@ -21,7 +21,7 @@ steps:
     key: cocoa_fixture
     timeout_in_minutes: 30
     agents:
-      queue: opensource-arm-mac-cocoa-12
+      queue: macos-12-arm
     artifact_paths:
       - features/fixtures/ios/output/iOSTestApp.ipa
       - features/fixtures/macos/output/macOSTestApp.zip
@@ -32,7 +32,7 @@ steps:
   - label: Static framework and Swift Package Manager builds
     timeout_in_minutes: 10
     agents:
-      queue: opensource-arm-mac-cocoa-12
+      queue: macos-12-arm
     commands:
       - make build_swift
       - make build_ios_static
@@ -40,7 +40,7 @@ steps:
   - label: Carthage
     timeout_in_minutes: 15
     agents:
-      queue: opensource-arm-mac-cocoa-12
+      queue: macos-12-arm
     commands:
       - ./scripts/build-carthage.sh
     plugins:
@@ -55,7 +55,7 @@ steps:
   - label: ARM macOS 12 unit tests
     timeout_in_minutes: 10
     agents:
-      queue: opensource-arm-mac-cocoa-12
+      queue: macos-12-arm
     commands:
       - ./scripts/run-unit-tests.sh PLATFORM=macOS
     artifact_paths:
@@ -82,7 +82,7 @@ steps:
   - label: iOS 15 unit tests
     timeout_in_minutes: 10
     agents:
-      queue: opensource-arm-mac-cocoa-12
+      queue: macos-12-arm
     commands:
       - ./scripts/run-unit-tests.sh PLATFORM=iOS OS=15.0
     artifact_paths:
@@ -100,7 +100,7 @@ steps:
   - label: tvOS 15 unit tests
     timeout_in_minutes: 10
     agents:
-      queue: opensource-arm-mac-cocoa-12
+      queue: macos-12-arm
     commands:
       - ./scripts/run-unit-tests.sh PLATFORM=tvOS OS=15.0
     artifact_paths:
@@ -226,7 +226,7 @@ steps:
       - cocoa_fixture
     timeout_in_minutes: 10
     agents:
-      queue: opensource-arm-mac-cocoa-12
+      queue: macos-12-arm
     plugins:
       artifacts#v1.5.0:
         download: "features/fixtures/macos/output/macOSTestApp.zip"
@@ -246,7 +246,7 @@ steps:
   - label: 'macOS 12 stress test'
     timeout_in_minutes: 3
     agents:
-      queue: opensource-arm-mac-cocoa-12
+      queue: macos-12-arm
     env:
       STRESS_TEST: "true"
     commands:


### PR DESCRIPTION
## Goal

Shorten the Buildkite queue names.

## Design

The buildkite build servers now have shorter names (as well as the longer ones), set up by Ansible.

## Changeset

Shorten queue names - each performed using global find and replace.

## Testing

Covered by a full CI run.