### PR TITLE
[PLAT-8477] Redact internal errors

### DIFF
--- a/Bugsnag/Helpers/BSGInternalErrorReporter.h
+++ b/Bugsnag/Helpers/BSGInternalErrorReporter.h
@@ -19,7 +19,7 @@
 NS_ASSUME_NONNULL_BEGIN
 
 /// Returns a concise desription of the error including its domain, code, and debug description or localizedDescription.
-BSG_PRIVATE NSString *BSGErrorDescription(NSError *error);
+BSG_PRIVATE NSString *_Nullable BSGErrorDescription(NSError *_Nullable error);
 
 // MARK: -
 
@@ -49,14 +49,14 @@ BSG_PRIVATE NSString *BSGErrorDescription(NSError *error);
 /// Reports an error to Bugsnag's internal bugsnag-cocoa project dashboard.
 /// @param errorClass The class of error which occurred. This field is used to group the errors together so should not contain any contextual
 /// information that would prevent correct grouping. This would ordinarily be the Exception name when dealing with an exception.
+/// @param context The context to associate with this event. Errors are grouped by errorClass:context
 /// @param message The error message associated with the error. Usually this will contain some information about this specific instance of the error
 /// and is not used to group the errors.
 /// @param diagnostics JSON compatible information to include in the `BugsnagDiagnostics` metadata section.
-/// @param groupingHash String to override Bugsnag's default event grouping. Events sharing the same grouping hash will be grouped together.
 - (void)reportErrorWithClass:(NSString *)errorClass
+                     context:(nullable NSString *)context
                      message:(nullable NSString *)message
-                 diagnostics:(nullable NSDictionary<NSString *, id> *)diagnostics
-                groupingHash:(nullable NSString *)groupingHash;
+                 diagnostics:(nullable NSDictionary<NSString *, id> *)diagnostics;
 
 - (void)reportException:(NSException *)exception
             diagnostics:(nullable NSDictionary<NSString *, id> *)diagnostics
@@ -67,9 +67,9 @@ BSG_PRIVATE NSString *BSGErrorDescription(NSError *error);
 // Private
 
 - (nullable BugsnagEvent *)eventWithErrorClass:(NSString *)errorClass
+                                       context:(nullable NSString *)context
                                        message:(nullable NSString *)message
-                                   diagnostics:(nullable NSDictionary<NSString *, id> *)diagnostics
-                                  groupingHash:(nullable NSString *)groupingHash;
+                                   diagnostics:(nullable NSDictionary<NSString *, id> *)diagnostics;
 
 - (nullable BugsnagEvent *)eventWithException:(NSException *)exception
                                   diagnostics:(nullable NSDictionary<NSString *, id> *)diagnostics

--- a/Tests/BugsnagTests/BSGEventUploadKSCrashReportOperationTests.m
+++ b/Tests/BugsnagTests/BSGEventUploadKSCrashReportOperationTests.m
@@ -10,19 +10,56 @@
 #import <XCTest/XCTest.h>
 
 #import "BSGEventUploadKSCrashReportOperation.h"
+#import "BSGInternalErrorReporter.h"
 
 @interface BSGEventUploadKSCrashReportOperationTests : XCTestCase
+
+@property NSString *errorClass;
+@property NSString *context;
+@property NSString *message;
+@property NSDictionary *diagnostics;
 
 @end
 
 @implementation BSGEventUploadKSCrashReportOperationTests
 
-- (void)testKSCrashReport1 {
-    NSString *file = [[NSBundle bundleForClass:[self class]] pathForResource:@"KSCrashReport1" ofType:@"json" inDirectory:@"Data"];
+- (void)setUp {
+    [super setUp];
+    
+    BSGInternalErrorReporter.sharedInstance = (id)self;
+}
+
+- (BSGEventUploadKSCrashReportOperation *)operationWithFile:(NSString *)file {
 #pragma clang diagnostic push
 #pragma clang diagnostic ignored "-Wnonnull"
-    BSGEventUploadKSCrashReportOperation *operation = [[BSGEventUploadKSCrashReportOperation alloc] initWithFile:file delegate:nil];
+    return [[BSGEventUploadKSCrashReportOperation alloc] initWithFile:file delegate:nil];
 #pragma clang diagnostic pop
+}
+
+- (NSString *)temporaryFileWithContents:(NSString *)contents {
+    NSString *file = [NSTemporaryDirectory() stringByAppendingPathComponent:[[NSUUID UUID] UUIDString]];
+    [contents writeToFile:file atomically:NO encoding:NSUTF8StringEncoding error:nil];
+    [self addTeardownBlock:^{
+        [NSFileManager.defaultManager removeItemAtPath:file error:nil];
+    }];
+    return file;
+}
+
+- (void)reportErrorWithClass:(NSString *)errorClass
+                     context:(NSString *)context
+                     message:(NSString *)message
+                 diagnostics:(NSDictionary<NSString *, id> *)diagnostics {
+    self.errorClass = errorClass;
+    self.context = context;
+    self.message = message;
+    self.diagnostics = diagnostics;
+}
+
+#pragma mark -
+
+- (void)testKSCrashReport1 {
+    NSString *file = [[NSBundle bundleForClass:[self class]] pathForResource:@"KSCrashReport1" ofType:@"json" inDirectory:@"Data"];
+    BSGEventUploadKSCrashReportOperation *operation = [self operationWithFile:file];
     BugsnagEvent *event = [operation loadEventAndReturnError:nil];
     XCTAssertEqual(event.threads.count, 20);
     XCTAssertEqualObjects([event.breadcrumbs valueForKeyPath:NSStringFromSelector(@selector(message))], @[@"Bugsnag loaded"]);
@@ -37,6 +74,33 @@
     XCTAssertEqualObjects(event.threads.firstObject.stacktrace.firstObject.machoFile, @"/Users/nick/Library/Developer/Xcode/Derived Data/macOSTestApp-ffunpkxyeczwoccascsrmsggolbp/Build/Products/Debug/macOSTestApp.app/Contents/MacOS/macOSTestApp");
     XCTAssertEqualObjects(event.user.id, @"48decb8cf9f410c4c20e6f597070ee60b131a5c4");
     XCTAssertTrue(event.app.inForeground);
+}
+
+- (void)testEmptyFile {
+    NSString *file = [self temporaryFileWithContents:@""];
+    BSGEventUploadKSCrashReportOperation *operation = [self operationWithFile:file];
+    XCTAssertNil([operation loadEventAndReturnError:nil]);
+    XCTAssertEqualObjects(self.errorClass, @"Invalid crash report");
+    XCTAssertEqualObjects(self.context, @"File is empty");
+    XCTAssert([self.message hasPrefix:@"NSCocoaErrorDomain 3840: "]);
+}
+
+- (void)testUnterminatedJSON {
+    NSString *file = [self temporaryFileWithContents:@"{"];
+    BSGEventUploadKSCrashReportOperation *operation = [self operationWithFile:file];
+    XCTAssertNil([operation loadEventAndReturnError:nil]);
+    XCTAssertEqualObjects(self.errorClass, @"Invalid crash report");
+    XCTAssertEqualObjects(self.context, @"Does not end with \"}\"");
+    XCTAssert([self.message hasPrefix:@"NSCocoaErrorDomain 3840: "]);
+}
+
+- (void)testInvalidJSON {
+    NSString *file = [self temporaryFileWithContents:@"{}"];
+    BSGEventUploadKSCrashReportOperation *operation = [self operationWithFile:file];
+    XCTAssertNil([operation loadEventAndReturnError:nil]);
+    XCTAssertEqualObjects(self.errorClass, @"Invalid crash report");
+    XCTAssertEqualObjects(self.context, @"Invalid JSON payload");
+    XCTAssertNil(self.message);
 }
 
 @end

--- a/Tests/BugsnagTests/BSGInternalErrorReporterTests.m
+++ b/Tests/BugsnagTests/BSGInternalErrorReporterTests.m
@@ -37,10 +37,10 @@
     BugsnagConfiguration *configuration = [[BugsnagConfiguration alloc] initWithApiKey:@"0192837465afbecd0192837465afbecd"];
     BSGInternalErrorReporter *reporter = [[BSGInternalErrorReporter alloc] initWithDataSource:self];
     
-    BugsnagEvent *event = [reporter eventWithErrorClass:@"Internal error" message:@"Something went wrong" diagnostics:@{} groupingHash:@"test"];
+    BugsnagEvent *event = [reporter eventWithErrorClass:@"Internal error" context:@"test" message:@"Something went wrong" diagnostics:@{}];
     XCTAssertEqualObjects(event.errors[0].errorClass, @"Internal error");
     XCTAssertEqualObjects(event.errors[0].errorMessage, @"Something went wrong");
-    XCTAssertEqualObjects(event.groupingHash, @"test");
+    XCTAssertEqualObjects(event.context, @"test");
     XCTAssertEqualObjects(event.threads, @[]);
     XCTAssertEqual(event.errors[0].stacktrace.count, 0);
     XCTAssertNil(event.apiKey);

--- a/features/internal_error_reporting.feature
+++ b/features/internal_error_reporting.feature
@@ -12,13 +12,14 @@ Feature: Internal error reporting
     And the error payload field "events.0.exceptions.0.stacktrace" is an array with 0 elements
     And the error payload field "events.0.threads" is an array with 0 elements
     And the event "apiKey" is null
-    And the event "groupingHash" equals "BSGEventUploadKSCrashReportOperation.m: JSON parsing error: NSCocoaErrorDomain 3840: No string key for value in object"
+    And the event "context" equals "JSON parsing error"
     And the event "metaData.BugsnagDiagnostics.apiKey" equals "12312312312312312312312312312312"
-    And the event "metaData.BugsnagDiagnostics.data" is not null
-    And the event "metaData.BugsnagDiagnostics.file" is not null
+    And the event "metaData.BugsnagDiagnostics.data" is null
+    And the event "metaData.BugsnagDiagnostics.keys" is a non-empty array
+    And the event "metaData.BugsnagDiagnostics.fileName" matches ".+\.json$"
     And the event "metaData.BugsnagDiagnostics.modificationInterval" is between 1.0 and 2.0
     And the event "unhandled" is false
-    And the exception "errorClass" equals "JSON parsing error"
+    And the exception "errorClass" equals "Invalid crash report"
     And the exception "message" matches "NSCocoaErrorDomain 3840: No string key for value in object around .+\."
 
   Scenario: Internal errors are not sent if disabled

--- a/features/steps/reusable_steps.rb
+++ b/features/steps/reusable_steps.rb
@@ -24,6 +24,12 @@ Then('the event {string} is a boolean') do |field|
   Maze.check.include [true, false], value
 end
 
+Then('the event {string} is a non-empty array') do |field|
+  value = Maze::Helper.read_key_path(Maze::Server.errors.current[:body], "events.0.#{field}")
+  Maze.check.kind_of Array, value
+  Maze.check.true(value.length.positive?, "the field '#{field}' must be a non-empty array")
+end
+
 Then('the event {string} is a number') do |field|
   value = Maze::Helper.read_key_path(Maze::Server.errors.current[:body], "events.0.#{field}")
   Maze.check.kind_of Numeric, value


### PR DESCRIPTION
## Goal

Use a different device ID, stop including the unparseable JSON payload, and improve grouping of internal errors.

## Changeset

Adds a new function for getting a unique device ID for internal errors that differs from `+[BSG_KSSystemInfo deviceAndAppHash]`.

Removes `BugsnagDiagnostics.data`.

Implements a new mechanism for reporting parsing errors:
* `context` is now used for grouping (in combination with `errorClass`) rather than specifying a `groupingHash`.
* `context` is set to the type of payload error - e.g. empty file, missing `{`, etc.
* `BugsnagDiagnostics.keys` is set to a list of the expected keys that were found in the valid portion of the JSON payload, to give an indication of where the error was.

## Testing

`BSGEventUploadKSCrashReportOperationTests` has been updated to verify internal errors.