### PR TITLE
[PLAT-8492] Fix data races in BSGRunContextUpdateTimestamp and UpdateAvailableMemory

### DIFF
--- a/Bugsnag/Helpers/BSGRunContext.h
+++ b/Bugsnag/Helpers/BSGRunContext.h
@@ -19,7 +19,7 @@
 // During development this is not strictly necessary since last run's data will
 // not be loaded if the struct's size has changed.
 //
-#define BSGRUNCONTEXT_VERSION 1
+#define BSGRUNCONTEXT_VERSION 2
 
 struct BSGRunContext {
     long structVersion;
@@ -40,7 +40,7 @@ struct BSGRunContext {
     long lastKnownOrientation;
     dispatch_source_memorypressure_flags_t memoryPressure;
 #endif
-    double timestamp;
+    double timestamp __attribute__((aligned(8)));
     size_t availableMemory;
 };
 

--- a/Bugsnag/Helpers/BSGRunContext.m
+++ b/Bugsnag/Helpers/BSGRunContext.m
@@ -13,6 +13,7 @@
 #import "BSG_KSSystemInfo.h"
 
 #import <Foundation/Foundation.h>
+#import <stdatomic.h>
 #import <sys/mman.h>
 #import <sys/stat.h>
 #import <sys/sysctl.h>
@@ -28,6 +29,14 @@
 #if TARGET_OS_OSX
 #import "BSGAppKit.h"
 #endif
+
+
+// Fields which may be updated from arbitrary threads simultaneously should be
+// updated using this macro to avoid data races (which are detected by TSan.)
+#define ATOMIC_SET(field, value) do { \
+    typeof(field) newValue_ = (value); \
+    atomic_store((_Atomic(typeof(field)) *)&field, newValue_); \
+} while (0)
 
 
 #pragma mark Forward declarations
@@ -284,7 +293,7 @@ static void AddObservers() {
 #pragma mark - Misc
 
 void BSGRunContextUpdateTimestamp() {
-    bsg_runContext->timestamp = CFAbsoluteTimeGetCurrent();
+    ATOMIC_SET(bsg_runContext->timestamp, CFAbsoluteTimeGetCurrent());
 }
 
 static void UpdateAvailableMemory() {
@@ -292,7 +301,7 @@ static void UpdateAvailableMemory() {
     // to a much more expensive (~5x) system call on earlier releases.
 #if __has_include(<os/proc.h>) && TARGET_OS_IPHONE && !TARGET_OS_MACCATALYST
     if (__builtin_available(iOS 13.0, tvOS 13.0, watchOS 6.0, *)) {
-        bsg_runContext->availableMemory = os_proc_available_memory();
+        ATOMIC_SET(bsg_runContext->availableMemory, os_proc_available_memory());
     }
 #endif
 }

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,9 @@ Changelog
 * Add `configuration.telemetry` to allow sending of internal errors to be disabled.
   [#1375](https://github.com/bugsnag/bugsnag-cocoa/pull/1375)
 
+* Fix data races detected by TSan in `BSGRunContextUpdateTimestamp` and `UpdateAvailableMemory`. 
+  [#1384](https://github.com/bugsnag/bugsnag-cocoa/pull/1384)
+
 ## 6.17.1 (2022-05-18)
 
 ### Bug fixes


### PR DESCRIPTION
## Goal

Fix data races detected by ThreadSanitizer, as reported in
* #1381 

## Changeset

Uses `atomic_store` to prevent data races when writing `timestamp` and `availableMemory`.

Doesn't declare the struct fields as `_Atomic` because atomic access is not needed when reading (i.e. from `bsg_lastRunContext`.)

Forces appropriate alignment of `timestamp` for atomic access.

## Testing

Reproduce and verified using example app with TSan enabled.