### PR TITLE
Allow session tracking on watchos even though it's technically an ext…

### DIFF
--- a/Bugsnag/BugsnagSessionTracker.m
+++ b/Bugsnag/BugsnagSessionTracker.m
@@ -48,6 +48,7 @@ static NSTimeInterval const BSGNewSessionBackgroundDuration = 30;
 }
 
 - (void)startWithNotificationCenter:(NSNotificationCenter *)notificationCenter isInForeground:(BOOL)isInForeground {
+#if !TARGET_OS_WATCH
     if ([BSG_KSSystemInfo isRunningInAppExtension]) {
         // UIApplication lifecycle notifications and UIApplicationState, which the automatic session tracking logic
         // depends on, are not available in app extensions.
@@ -56,6 +57,7 @@ static NSTimeInterval const BSGNewSessionBackgroundDuration = 30;
         }
         return;
     }
+#endif
     
     if (isInForeground) {
         [self startNewSessionIfAutoCaptureEnabled];

--- a/examples/swift-watchos/swift-watchos WatchKit Extension/ExtensionDelegate.swift
+++ b/examples/swift-watchos/swift-watchos WatchKit Extension/ExtensionDelegate.swift
@@ -7,6 +7,7 @@
 
 import WatchKit
 import Bugsnag
+import BugsnagNetworkRequestPlugin
 
 class ExtensionDelegate: NSObject, WKExtensionDelegate {
 
@@ -26,7 +27,6 @@ class ExtensionDelegate: NSObject, WKExtensionDelegate {
         
         // Create config object from the application plist
 //      let config = BugsnagConfiguration.loadConfig()
-        
         // ... or construct an empty object
 //      let config = BugsnagConfiguration("YOUR-API-KEY")
 


### PR DESCRIPTION
## Goal

WatchOS apps are extensions, which caused the compilation to not include session tracking. Session tracking can be done on WatchOS, so compilation now allows it on a watchOS target.

Also added an import for `BugsnagNetworkRequestPlugin` to the watchOS example app so that it can be enabled in a custom config.

## Testing

Manually tested sessions being created and sent.
