### PR TITLE
Never collect threads when they're not supported

### DIFF
--- a/Bugsnag/KSCrash/Source/KSCrash/Recording/BSG_KSCrashC.c
+++ b/Bugsnag/KSCrash/Source/KSCrash/Recording/BSG_KSCrashC.c
@@ -32,6 +32,7 @@
 #include "BSG_KSObjC.h"
 #include "BSG_KSString.h"
 #include "BSG_KSSystemInfoC.h"
+#include "BSGDefines.h"
 
 //#define BSG_KSLogger_LocalLevel TRACE
 #include "BSG_KSLogger.h"
@@ -192,5 +193,9 @@ void bsg_kscrash_setReportWhenDebuggerIsAttached(
 }
 
 void bsg_kscrash_setThreadTracingEnabled(bool threadTracingEnabled) {
+#if BSG_HAVE_MACH_THREADS
     crashContext()->crash.threadTracingEnabled = threadTracingEnabled;
+#else
+    (void)threadTracingEnabled;
+#endif
 }


### PR DESCRIPTION
## Goal

The library is still capturing minimal, but basically useless information about threads when the mach threads interface is not supported. Instead, just omit thread information altogether when they're not supported.

## Testing

Manual testing on simulators and real watch, iphone, mac.
