### PR TITLE
[Plat-8488] Fix false "crash in handler" messaging

### DIFF
--- a/Bugsnag/KSCrash/Source/KSCrash/Recording/Sentry/BSG_KSCrashSentry.c
+++ b/Bugsnag/KSCrash/Source/KSCrash/Recording/Sentry/BSG_KSCrashSentry.c
@@ -229,7 +229,7 @@ bool bsg_kscrashsentry_beginHandlingCrash(const thread_t offender) {
         return true;
     }
 
-    if (offender == firstHandlingThread) {
+    if (bsg_g_context->handlingCrash) {
         BSG_KSLOG_INFO("Detected crash in the crash reporter. "
                        "Restoring original handlers.");
         bsg_kscrashsentry_uninstall(BSG_KSCrashTypeAsyncSafe);
@@ -256,5 +256,6 @@ bool bsg_kscrashsentry_beginHandlingCrash(const thread_t offender) {
 
 void bsg_kscrashsentry_endHandlingCrash(void) {
     BSG_KSLOG_DEBUG("Noting completion of crash handling");
+    bsg_g_context->handlingCrash = false;
     atomic_store(&bsg_g_didHandleCrash, true);
 }


### PR DESCRIPTION
## Goal

Calling `bsg_kscrashsentry_endHandlingCrash` doesn't fully clear the crash handling state, so calling `bsg_kscrashsentry_beginHandlingCrash` a second time afterwards will issue a false alarm about a crash in the crash handler.

This PR ensures that the state is correct after calling `bsg_kscrashsentry_endHandlingCrash`, and explicitly checks that flag in `bsg_kscrashsentry_beginHandlingCrash` rather than relying on a thread ID comparison.

## Testing

Manual verification on all major devices.
