### PR TITLE
Make sure sendThreads config is always 'never' when Mach threads API is unavailable

### DIFF
--- a/Bugsnag/Configuration/BugsnagConfiguration.m
+++ b/Bugsnag/Configuration/BugsnagConfiguration.m
@@ -35,6 +35,7 @@
 #import "BugsnagLogger.h"
 #import "BugsnagMetadata+Private.h"
 #import "BugsnagUser+Private.h"
+#import "BSGDefines.h"
 
 const NSUInteger BugsnagAppHangThresholdFatalOnly = INT_MAX;
 
@@ -185,7 +186,11 @@ static NSUserDefaults *userDefaults;
     _maxPersistedEvents = 32;
     _maxPersistedSessions = 128;
     _autoTrackSessions = YES;
+#if BSG_HAVE_MACH_THREADS
     _sendThreads = BSGThreadSendPolicyAlways;
+#else
+    _sendThreads = BSGThreadSendPolicyNever;
+#endif
     // Default to recording all error types
     _enabledErrorTypes = [BugsnagErrorTypes new];
 
@@ -464,6 +469,12 @@ static NSUserDefaults *userDefaults;
 // -----------------------------------------------------------------------------
 // MARK: - Properties: Getters and Setters
 // -----------------------------------------------------------------------------
+
+- (void)setSendThreads:(BSGThreadSendPolicy)sendThreads {
+#if BSG_HAVE_MACH_THREADS
+    _sendThreads = sendThreads;
+#endif
+}
 
 - (void)setAppHangThresholdMillis:(NSUInteger)appHangThresholdMillis {
     if (appHangThresholdMillis >= 250) {

--- a/Tests/BugsnagTests/BSGConfigurationBuilderTests.m
+++ b/Tests/BugsnagTests/BSGConfigurationBuilderTests.m
@@ -4,6 +4,7 @@
 #import "BSGConfigurationBuilder.h"
 #import "BugsnagConfiguration+Private.h"
 #import "BugsnagTestConstants.h"
+#import <TargetConditionals.h>
 
 @interface BSGConfigurationBuilderTests : XCTestCase
 @end
@@ -60,7 +61,11 @@
     XCTAssertEqual(config.maxBreadcrumbs, 50);
     XCTAssertTrue(config.persistUser);
     XCTAssertEqualObjects(@[@"password"], [config.redactedKeys allObjects]);
+#if TARGET_OS_WATCH
+    XCTAssertEqual(BSGThreadSendPolicyNever, config.sendThreads);
+#else
     XCTAssertEqual(BSGThreadSendPolicyAlways, config.sendThreads);
+#endif
     XCTAssertEqual(BSGEnabledBreadcrumbTypeAll, config.enabledBreadcrumbTypes);
     XCTAssertEqualObjects(@"https://notify.bugsnag.com", config.endpoints.notify);
     XCTAssertEqualObjects(@"https://sessions.bugsnag.com", config.endpoints.sessions);

--- a/Tests/BugsnagTests/BugsnagConfigurationTests.m
+++ b/Tests/BugsnagTests/BugsnagConfigurationTests.m
@@ -13,6 +13,7 @@
 #import "BugsnagNotifier.h"
 #import "BugsnagSessionTracker.h"
 #import "BugsnagTestConstants.h"
+#import <TargetConditionals.h>
 
 // =============================================================================
 // MARK: - Tests
@@ -657,7 +658,11 @@ NSString * const kBugsnagUserUserId = @"BugsnagUserUserId";
     XCTAssertEqualObjects(@"production", config.releaseStage);
 #endif
 
+#if TARGET_OS_WATCH
+    XCTAssertEqual(BSGThreadSendPolicyNever, config.sendThreads);
+#else
     XCTAssertEqual(BSGThreadSendPolicyAlways, config.sendThreads);
+#endif
 }
 
 // =============================================================================
@@ -841,7 +846,11 @@ NSString * const kBugsnagUserUserId = @"BugsnagUserUserId";
 
 - (void)testSendThreadsDefault {
     BugsnagConfiguration *config = [[BugsnagConfiguration alloc] initWithApiKey:DUMMY_APIKEY_32CHAR_1];
+#if TARGET_OS_WATCH
+    XCTAssertEqual(BSGThreadSendPolicyNever, config.sendThreads);
+#else
     XCTAssertEqual(BSGThreadSendPolicyAlways, config.sendThreads);
+#endif
 }
 
 - (void)testNSCopying {

--- a/Tests/BugsnagTests/ConfigurationApiValidationTest.m
+++ b/Tests/BugsnagTests/ConfigurationApiValidationTest.m
@@ -11,6 +11,7 @@
 #import "BugsnagConfiguration+Private.h"
 #import "BugsnagPlugin.h"
 #import "BugsnagTestConstants.h"
+#import <TargetConditionals.h>
 
 @interface FooPlugin: NSObject<BugsnagPlugin>
 @end
@@ -84,11 +85,19 @@
 
 - (void)testValidSendThreads {
     self.config.sendThreads = BSGThreadSendPolicyAlways;
+#if TARGET_OS_WATCH
+    XCTAssertEqual(BSGThreadSendPolicyNever, self.config.sendThreads);
+#else
     XCTAssertEqual(BSGThreadSendPolicyAlways, self.config.sendThreads);
+#endif
     self.config.sendThreads = BSGThreadSendPolicyNever;
     XCTAssertEqual(BSGThreadSendPolicyNever, self.config.sendThreads);
     self.config.sendThreads = BSGThreadSendPolicyUnhandledOnly;
+#if TARGET_OS_WATCH
+    XCTAssertEqual(BSGThreadSendPolicyNever, self.config.sendThreads);
+#else
     XCTAssertEqual(BSGThreadSendPolicyUnhandledOnly, self.config.sendThreads);
+#endif
 }
 
 - (void)testValidAutoDetectErrors {


### PR DESCRIPTION
When the Mach threads API is unavailable, none of the threads information can be useful, so make sure that the `sendThreads` configuration is always set to `never` in this case.

Tested on ios, watchos, macos, tvos
