### PR TITLE
Fix crash when adding BugsnagReactNativePlugin

### DIFF
--- a/Bugsnag/Configuration/BugsnagConfiguration.m
+++ b/Bugsnag/Configuration/BugsnagConfiguration.m
@@ -75,7 +75,7 @@ static NSUserDefaults *userDefaults;
  *
  * @param zone This parameter is ignored. Memory zones are no longer used by Objective-C.
  */
-- (nonnull id)copyWithZone:(nullable __attribute__((unused)) NSZone *)zone {
+- (nonnull id)copyWithZone:(nullable NSZone *)zone {
     BugsnagConfiguration *copy = [[BugsnagConfiguration alloc] initWithApiKey:[self.apiKey copy]];
     // Omit apiKey - it's set explicitly in the line above
     [copy setAppHangThresholdMillis:self.appHangThresholdMillis];
@@ -101,7 +101,7 @@ static NSUserDefaults *userDefaults;
     [copy setEndpoints:self.endpoints];
     [copy setOnCrashHandler:self.onCrashHandler];
     [copy setPersistUser:self.persistUser];
-    [copy setPlugins:[self.plugins copy]];
+    [copy setPlugins:[self.plugins mutableCopyWithZone:zone]];
     [copy setReleaseStage:self.releaseStage];
     copy.session = self.session; // NSURLSession does not declare conformance to NSCopying
     [copy setSendThreads:self.sendThreads];

--- a/Tests/BugsnagTests/BugsnagConfigurationTests.m
+++ b/Tests/BugsnagTests/BugsnagConfigurationTests.m
@@ -859,6 +859,7 @@ NSString * const kBugsnagUserUserId = @"BugsnagUserUserId";
                                                  dependencies:@[[[BugsnagNotifier alloc] init]]]];
     [config setPersistUser:YES];
     [config setSendThreads:BSGThreadSendPolicyUnhandledOnly];
+    [config addPlugin:(id)[NSNull null]];
     BugsnagOnSendErrorBlock onSendBlock1 = ^BOOL(BugsnagEvent * _Nonnull event) { return true; };
     BugsnagOnSendErrorBlock onSendBlock2 = ^BOOL(BugsnagEvent * _Nonnull event) { return true; };
 
@@ -907,6 +908,10 @@ NSString * const kBugsnagUserUserId = @"BugsnagUserUserId";
     XCTAssertEqualObjects(clone.notifier.name, config.notifier.name);
     XCTAssertEqualObjects(clone.notifier.version, config.notifier.version);
     XCTAssertEqualObjects(clone.notifier.url, config.notifier.url);
+
+    // Plugins
+    XCTAssert([clone.plugins containsObject:[NSNull null]]);
+    XCTAssertNoThrow([clone.plugins removeObject:[NSNull null]]);
 }
 
 - (void)testMetadataMutability {


### PR DESCRIPTION
## Goal

Fix crash when starting Bugsnag with `BugsnagReactNativePlugin`.

`BugsnagClient` expects `self.configuration.plugins` to be of type `NSMutableSet` as advertised.

https://github.com/bugsnag/bugsnag-cocoa/blob/96f738f2382e47815cd036c728fcf29c2ca57b52/Bugsnag/Client/BugsnagClient.m#L253-L256

This bug has prevented [updating bugsnag-cocoa in bugsnag-js](https://github.com/bugsnag/bugsnag-js/pull/1745)

## Changeset

Ensure `plugins` is a mutable set when copying a `BugsnagConfiguration`.

## Testing

Amends unit test to replicate problem and verify fix.