### PR TITLE
Ignore the arm64_32 v8 subtype

### DIFF
--- a/Bugsnag/KSCrash/Source/KSCrash/Recording/BSG_KSSystemInfo.m
+++ b/Bugsnag/KSCrash/Source/KSCrash/Recording/BSG_KSSystemInfo.m
@@ -284,12 +284,8 @@ static NSDictionary * bsg_systemversion() {
         }
     }
     case CPU_TYPE_ARM64_32: {
-        switch (subType) {
-            case CPU_SUBTYPE_ARM64_32_V8:
-                return @"arm64_32_v8";
-            default:
-                return @"arm64_32";
-        }
+        // Ignore arm64_32_v8 subtype
+        return @"arm64_32";
     }
     case CPU_TYPE_X86:
         return @"x86";


### PR DESCRIPTION
Bring the arm64_32 reporting in line with arm64 reporting by ignoring the v8 subtype.
