### PR TITLE
Replace BSGConfigurationBuilder with functions

### DIFF
--- a/Bugsnag/Configuration/BSGConfigurationBuilder.h
+++ b/Bugsnag/Configuration/BSGConfigurationBuilder.h
@@ -1,16 +1,3 @@
-#import <Foundation/Foundation.h>
+#import <Bugsnag/BugsnagConfiguration.h>
 
-@class BugsnagConfiguration;
-
-@interface BSGConfigurationBuilder : NSObject
-
-/**
- * Creates a configuration, applying supported options before returning the new
- * config object.
- *
- * @return a new BugsnagConfiguration object or nil if the a valid object could
- * not be created (including a non-empty API key)
- */
-+ (BugsnagConfiguration *_Nonnull)configurationFromOptions:(NSDictionary *_Nonnull)options;
-
-@end
+BugsnagConfiguration * BSGConfigurationWithOptions(NSDictionary *options);

--- a/Bugsnag/Configuration/BSGConfigurationBuilder.m
+++ b/Bugsnag/Configuration/BSGConfigurationBuilder.m
@@ -1,7 +1,6 @@
 #import "BSGConfigurationBuilder.h"
 
 #import "BSGKeys.h"
-#import "BugsnagConfiguration.h"
 #import "BugsnagEndpointConfiguration.h"
 #import "BugsnagLogger.h"
 
@@ -10,9 +9,16 @@ static BOOL BSGValueIsBoolean(id object) {
             && CFGetTypeID((__bridge CFTypeRef)object) == CFBooleanGetTypeID();
 }
 
-@implementation BSGConfigurationBuilder
+static void LoadBoolean     (BugsnagConfiguration *config, NSDictionary *options, NSString *key);
+static void LoadString      (BugsnagConfiguration *config, NSDictionary *options, NSString *key);
+static void LoadNumber      (BugsnagConfiguration *config, NSDictionary *options, NSString *key);
+static void LoadStringSet   (BugsnagConfiguration *config, NSDictionary *options, NSString *key);
+static void LoadEndpoints   (BugsnagConfiguration *config, NSDictionary *options);
+static void LoadSendThreads (BugsnagConfiguration *config, NSDictionary *options);
 
-+ (BugsnagConfiguration *)configurationFromOptions:(NSDictionary *)options {
+#pragma mark -
+
+BugsnagConfiguration * BSGConfigurationWithOptions(NSDictionary *options) {
     NSString *apiKey = options[BSGKeyApiKey];
     if (apiKey != nil && ![apiKey isKindOfClass:[NSString class]]) {
         @throw [NSException exceptionWithName:NSInvalidArgumentException reason:@"Bugsnag apiKey must be a string" userInfo:nil];
@@ -44,57 +50,54 @@ static BOOL BSGValueIsBoolean(id object) {
         bsg_log_warn(@"Unknown dictionary keys passed in configuration options: %@", unknownKeys);
     }
     
-    [self loadString:config options:options key:BSGKeyAppType];
-    [self loadString:config options:options key:BSGKeyAppVersion];
-    [self loadBoolean:config options:options key:BSGKeyAutoDetectErrors];
-    [self loadBoolean:config options:options key:BSGKeyAutoTrackSessions];
-    [self loadString:config options:options key:BSGKeyBundleVersion];
-    [self loadBoolean:config options:options key:BSGKeyPersistUser];
-    [self loadString:config options:options key:BSGKeyReleaseStage];
-
-    [self loadStringArray:config options:options key:BSGKeyEnabledReleaseStages];
-    [self loadStringArray:config options:options key:BSGKeyRedactedKeys];
-    [self loadEndpoints:config options:options];
-
-    [self loadNumber:config options:options key:BSGKeyMaxBreadcrumbs];
-    [self loadNumber:config options:options key:BSGKeyMaxPersistedEvents];
-    [self loadNumber:config options:options key:BSGKeyMaxPersistedSessions];
-    [self loadSendThreads:config options:options];
+    LoadString      (config, options, BSGKeyAppType);
+    LoadString      (config, options, BSGKeyAppVersion);
+    LoadBoolean     (config, options, BSGKeyAutoDetectErrors);
+    LoadBoolean     (config, options, BSGKeyAutoTrackSessions);
+    LoadString      (config, options, BSGKeyBundleVersion);
+    LoadBoolean     (config, options, BSGKeyPersistUser);
+    LoadString      (config, options, BSGKeyReleaseStage);
+    LoadStringSet   (config, options, BSGKeyEnabledReleaseStages);
+    LoadStringSet   (config, options, BSGKeyRedactedKeys);
+    LoadEndpoints   (config, options);
+    LoadNumber      (config, options, BSGKeyMaxBreadcrumbs);
+    LoadNumber      (config, options, BSGKeyMaxPersistedEvents);
+    LoadNumber      (config, options, BSGKeyMaxPersistedSessions);
+    LoadSendThreads (config, options);
     return config;
 }
 
-+ (void)loadBoolean:(BugsnagConfiguration *)config options:(NSDictionary *)options key:(NSString *)key {
+static void LoadBoolean(BugsnagConfiguration *config, NSDictionary *options, NSString *key) {
     if (BSGValueIsBoolean(options[key])) {
         [config setValue:options[key] forKey:key];
     }
 }
 
-+ (void)loadString:(BugsnagConfiguration *)config options:(NSDictionary *)options key:(NSString *)key {
+static void LoadString(BugsnagConfiguration *config, NSDictionary *options, NSString *key) {
     if (options[key] && [options[key] isKindOfClass:[NSString class]]) {
         [config setValue:options[key] forKey:key];
     }
 }
 
-+ (void)loadNumber:(BugsnagConfiguration *)config options:(NSDictionary *)options key:(NSString *)key {
+static void LoadNumber(BugsnagConfiguration *config, NSDictionary *options, NSString *key) {
     if (options[key] && [options[key] isKindOfClass:[NSNumber class]]) {
         [config setValue:options[key] forKey:key];
     }
 }
 
-+ (void)loadStringArray:(BugsnagConfiguration *)config options:(NSDictionary *)options key:(NSString *)key {
+static void LoadStringSet(BugsnagConfiguration *config, NSDictionary *options, NSString *key) {
     if (options[key] && [options[key] isKindOfClass:[NSArray class]]) {
         NSArray *val = options[key];
-
         for (NSString *obj in val) {
             if (![obj isKindOfClass:[NSString class]]) {
                 return;
             }
         }
-        [config setValue:val forKey:key];
+        [config setValue:[NSSet setWithArray:val] forKey:key];
     }
 }
 
-+ (void)loadEndpoints:(BugsnagConfiguration *)config options:(NSDictionary *)options {
+static void LoadEndpoints(BugsnagConfiguration *config, NSDictionary *options) {
     if (options[BSGKeyEndpoints] && [options[BSGKeyEndpoints] isKindOfClass:[NSDictionary class]]) {
         NSDictionary *endpoints = options[BSGKeyEndpoints];
 
@@ -109,7 +112,7 @@ static BOOL BSGValueIsBoolean(id object) {
     }
 }
 
-+ (void)loadSendThreads:(BugsnagConfiguration *)config options:(NSDictionary *)options {
+static void LoadSendThreads(BugsnagConfiguration *config, NSDictionary *options) {
     if (options[BSGKeySendThreads] && [options[BSGKeySendThreads] isKindOfClass:[NSString class]]) {
         NSString *sendThreads = [options[BSGKeySendThreads] lowercaseString];
 
@@ -122,5 +125,3 @@ static BOOL BSGValueIsBoolean(id object) {
         }
     }
 }
-
-@end

--- a/Bugsnag/Configuration/BugsnagConfiguration.m
+++ b/Bugsnag/Configuration/BugsnagConfiguration.m
@@ -59,11 +59,7 @@ static NSUserDefaults *userDefaults;
 
 + (instancetype _Nonnull)loadConfig {
     NSDictionary *options = [[NSBundle mainBundle] infoDictionary][@"bugsnag"];
-    return [BSGConfigurationBuilder configurationFromOptions:options];
-}
-
-+ (instancetype)loadConfigFromOptions:(NSDictionary *)options {
-    return [BSGConfigurationBuilder configurationFromOptions:options];
+    return BSGConfigurationWithOptions(options);
 }
 
 // -----------------------------------------------------------------------------

--- a/Tests/BugsnagTests/BSGConfigurationBuilderTests.m
+++ b/Tests/BugsnagTests/BSGConfigurationBuilderTests.m
@@ -14,41 +14,39 @@
 
 - (void)testDecodeEmptyApiKey {
     BugsnagConfiguration *configuration;
-    XCTAssertNoThrow(configuration = [BSGConfigurationBuilder configurationFromOptions:@{@"apiKey": @""}]);
+    XCTAssertNoThrow(configuration = BSGConfigurationWithOptions(@{@"apiKey": @""}));
     XCTAssertEqualObjects(configuration.apiKey, @"");
     XCTAssertThrows([configuration validate]);
 }
 
 - (void)testDecodeInvalidTypeApiKey {
-    XCTAssertThrows([BSGConfigurationBuilder
-                     configurationFromOptions:@{@"apiKey": @[@"one"]}]);
+    XCTAssertThrows(BSGConfigurationWithOptions(@{@"apiKey": @[@"one"]}));
 }
 
 - (void)testDecodeWithoutApiKey {
     BugsnagConfiguration *configuration;
-    XCTAssertNoThrow(configuration = [BSGConfigurationBuilder configurationFromOptions:@{@"autoDetectErrors": @NO}]);
+    XCTAssertNoThrow(configuration = BSGConfigurationWithOptions(@{@"autoDetectErrors": @NO}));
     XCTAssertNil(configuration.apiKey);
     XCTAssertFalse(configuration.autoDetectErrors);
     XCTAssertThrows([configuration validate]);
 }
 
 - (void)testDecodeUnknownKeys {
-    BugsnagConfiguration *config = [BSGConfigurationBuilder configurationFromOptions:@{
+    BugsnagConfiguration *config = BSGConfigurationWithOptions(@{
             @"giraffes": @3,
             @"apiKey": DUMMY_APIKEY_32CHAR_1
-    }];
+    });
     XCTAssertNotNil(config);
 }
 
 - (void)testDecodeEmptyOptions {
-    XCTAssertNoThrow([BSGConfigurationBuilder configurationFromOptions:@{}]);
+    XCTAssertNoThrow(BSGConfigurationWithOptions(@{}));
 }
 
 // MARK: - config loading
 
 - (void)testDecodeDefaultValues {
-    BugsnagConfiguration *config = [BSGConfigurationBuilder
-            configurationFromOptions:@{@"apiKey": DUMMY_APIKEY_32CHAR_1}];
+    BugsnagConfiguration *config = BSGConfigurationWithOptions(@{@"apiKey": DUMMY_APIKEY_32CHAR_1});
     XCTAssertNotNil(config);
     XCTAssertEqualObjects(DUMMY_APIKEY_32CHAR_1, config.apiKey);
     XCTAssertNotNil(config.appType);
@@ -82,7 +80,7 @@
 
 - (void)testDecodeFullConfig {
     BugsnagConfiguration *config =
-            [BSGConfigurationBuilder configurationFromOptions:@{
+    BSGConfigurationWithOptions(@{
                     @"apiKey": DUMMY_APIKEY_32CHAR_1,
                     @"appType": @"cocoa-custom",
                     @"appVersion": @"5.2.33",
@@ -101,7 +99,7 @@
                     @"redactedKeys": @[@"foo"],
                     @"sendThreads": @"never",
                     @"releaseStage": @"beta1",
-            }];
+            });
     XCTAssertNotNil(config);
     XCTAssertEqualObjects(DUMMY_APIKEY_32CHAR_1, config.apiKey);
     XCTAssertEqualObjects(@"cocoa-custom", config.appType);
@@ -113,14 +111,13 @@
     XCTAssertEqual(19, config.maxPersistedSessions);
     XCTAssertEqual(27, config.maxBreadcrumbs);
     XCTAssertFalse(config.persistUser);
-    XCTAssertEqualObjects(@[@"foo"], config.redactedKeys);
+    XCTAssertEqualObjects(config.redactedKeys, [NSSet setWithObject:@"foo"]);
     XCTAssertEqual(BSGThreadSendPolicyNever, config.sendThreads);
     XCTAssertEqualObjects(@"beta1", config.releaseStage);
     XCTAssertEqualObjects(@"https://reports.example.co", config.endpoints.notify);
     XCTAssertEqualObjects(@"https://sessions.example.co", config.endpoints.sessions);
 
-    NSArray *releaseStages = @[@"beta2", @"prod"];
-    XCTAssertEqualObjects(releaseStages, config.enabledReleaseStages);
+    XCTAssertEqualObjects(config.enabledReleaseStages, ([NSSet setWithObjects:@"beta2", @"prod", nil]));
     XCTAssertTrue(config.enabledErrorTypes.ooms);
 
     XCTAssertTrue(config.enabledErrorTypes.unhandledExceptions);
@@ -134,7 +131,7 @@
 
 - (void)testInvalidConfigOptions {
     BugsnagConfiguration *config =
-            [BSGConfigurationBuilder configurationFromOptions:@{
+    BSGConfigurationWithOptions(@{
                     @"apiKey": DUMMY_APIKEY_32CHAR_1,
                     @"appType": @[],
                     @"appVersion": @99,
@@ -151,86 +148,86 @@
                     @"redactedKeys": @[@77],
                     @"sendThreads": @"nev",
                     @"releaseStage": @YES,
-            }];
+            });
     XCTAssertNotNil(config); // no exception should be thrown when loading
 }
 
 - (void)testDecodeEnabledReleaseStagesInvalidTypes {
-    BugsnagConfiguration *config = [BSGConfigurationBuilder configurationFromOptions:@{
+    BugsnagConfiguration *config = BSGConfigurationWithOptions(@{
             @"enabledReleaseStages": @[@"beta", @"prod", @300],
             @"apiKey": DUMMY_APIKEY_32CHAR_1
-    }];
+    });
     XCTAssertNotNil(config);
     XCTAssertNil(config.enabledReleaseStages);
 
-    config = [BSGConfigurationBuilder configurationFromOptions:@{
+    config = BSGConfigurationWithOptions(@{
             @"enabledReleaseStages": @{@"name": @"foo"},
             @"apiKey": DUMMY_APIKEY_32CHAR_1
-    }];
+    });
     XCTAssertNotNil(config);
     XCTAssertNil(config.enabledReleaseStages);
 
-    config = [BSGConfigurationBuilder configurationFromOptions:@{
+    config = BSGConfigurationWithOptions(@{
             @"enabledReleaseStages": @"fooo",
             @"apiKey": DUMMY_APIKEY_32CHAR_1
-    }];
+    });
     XCTAssertNotNil(config);
     XCTAssertNil(config.enabledReleaseStages);
 }
 
 - (void)testDecodeEndpointsInvalidTypes {
-    BugsnagConfiguration *config = [BSGConfigurationBuilder configurationFromOptions:@{
+    BugsnagConfiguration *config = BSGConfigurationWithOptions(@{
             @"endpoints": @"foo",
             @"apiKey": DUMMY_APIKEY_32CHAR_1
-    }];
+    });
     XCTAssertNotNil(config);
     XCTAssertEqualObjects(@"https://notify.bugsnag.com", config.endpoints.notify);
     XCTAssertEqualObjects(@"https://sessions.bugsnag.com", config.endpoints.sessions);
 
-    config = [BSGConfigurationBuilder configurationFromOptions:@{
+    config = BSGConfigurationWithOptions(@{
             @"endpoints": @[@"http://example.com", @"http://foo.example.com"],
             @"apiKey": DUMMY_APIKEY_32CHAR_1
-    }];
+    });
     XCTAssertNotNil(config);
     XCTAssertEqualObjects(@"https://notify.bugsnag.com", config.endpoints.notify);
     XCTAssertEqualObjects(@"https://sessions.bugsnag.com", config.endpoints.sessions);
 
-    config = [BSGConfigurationBuilder configurationFromOptions:@{
+    config = BSGConfigurationWithOptions(@{
             @"endpoints": @{},
             @"apiKey": DUMMY_APIKEY_32CHAR_1
-    }];
+    });
     XCTAssertNotNil(config);
     XCTAssertEqualObjects(@"https://notify.bugsnag.com", config.endpoints.notify);
     XCTAssertEqualObjects(@"https://sessions.bugsnag.com", config.endpoints.sessions);
 }
 
 - (void)testDecodeEndpointsOnlyNotifySet {
-    BugsnagConfiguration *config = [BSGConfigurationBuilder configurationFromOptions:@{
+    BugsnagConfiguration *config = BSGConfigurationWithOptions(@{
             @"apiKey": DUMMY_APIKEY_32CHAR_1,
             @"endpoints": @{
                     @"notify": @"https://notify.example.com",
             },
-    }];
+    });
     XCTAssertNotNil(config);
     XCTAssertEqualObjects(@"https://notify.example.com", config.endpoints.notify);
     XCTAssertEqualObjects(@"https://sessions.bugsnag.com", config.endpoints.sessions);
 }
 
 - (void)testDecodeEndpointsOnlySessionsSet {
-    BugsnagConfiguration *config = [BSGConfigurationBuilder configurationFromOptions:@{
+    BugsnagConfiguration *config = BSGConfigurationWithOptions(@{
             @"apiKey": DUMMY_APIKEY_32CHAR_1,
             @"endpoints": @{@"sessions": @"https://sessions.example.com"},
-    }];
+    });
     XCTAssertNotNil(config);
     XCTAssertEqualObjects(@"https://notify.bugsnag.com", config.endpoints.notify);
     XCTAssertEqualObjects(@"https://sessions.example.com", config.endpoints.sessions);
 }
 
 - (void)testDecodeReleaseStageInvalidType {
-    BugsnagConfiguration *config = [BSGConfigurationBuilder configurationFromOptions:@{
+    BugsnagConfiguration *config = BSGConfigurationWithOptions(@{
             @"releaseStage": @NO,
             @"apiKey": DUMMY_APIKEY_32CHAR_1
-    }];
+    });
     XCTAssertNotNil(config);
 
 #if DEBUG


### PR DESCRIPTION
## Goal

Reduce binary size.

Fix a bug: `enabledReleaseStages` and `redactedKeys` are declared as `NSSet` but `BSGConfigurationBuilder` would set `NSArray` values when loading from Info.plist options.

## Changeset

Reimplements `BSGConfigurationBuilder` as a set of functions.

Removes unused `+[BugsnagConfiguration loadConfigFromOptions:]` method.

## Testing

Amended unit test case to verify that `enabledReleaseStages` and `redactedKeys` are `NSSet` objects.