### PR TITLE
[PLAT-8530] Fix incorrect `device.time` in 32-bit crash reports

### DIFF
--- a/Bugsnag/KSCrash/Source/KSCrash/Recording/BSG_KSCrashReport.c
+++ b/Bugsnag/KSCrash/Source/KSCrash/Recording/BSG_KSCrashReport.c
@@ -1260,7 +1260,8 @@ void bsg_kscrw_i_writeReportInfo(const BSG_KSCrashReportWriter *const writer,
         struct timeval t;
         if (!gettimeofday(&t, NULL)) {
             writer->addIntegerElement(writer, BSG_KSCrashField_Timestamp_Millis,
-                                      t.tv_sec * 1000 + t.tv_usec / 1000);
+                                      (long long)t.tv_sec * 1000 +
+                                      (long long)t.tv_usec / 1000);
         }
         writer->addStringElement(writer, BSG_KSCrashField_Type, type);
     }

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,8 +8,13 @@ Changelog
 * Add `configuration.telemetry` to allow sending of internal errors to be disabled.
   [#1375](https://github.com/bugsnag/bugsnag-cocoa/pull/1375)
 
+### Bug fixes
+
 * Fix data races detected by TSan in `BSGRunContextUpdateTimestamp` and `UpdateAvailableMemory`. 
   [#1384](https://github.com/bugsnag/bugsnag-cocoa/pull/1384)
+
+* Fix incorrect `device.time` in 32-bit crash reports.
+  [#1399](https://github.com/bugsnag/bugsnag-cocoa/pull/1399)
 
 ## 6.17.1 (2022-05-18)
 


### PR DESCRIPTION
## Goal

Fix invalid timestamps in 32-bit crash reports caused by integer overflow.

Identified when adding E2E support for watchOS - #1398 

`tv_sec * 1000` was overflowing due to `tv_sec` (type: `long`) being 32-bit in `ILP32` environments.

## Changeset

Promotes `tv_sec` and `tv_usec` to `long long` (64 bit) when converting values to milliseconds.

## Testing

Our E2E tests do not have any iOS or macOS 32-bit coverage, and attempts to add support are blocked:
* BrowserStack currently rejects iOS apps that don't include 64-bit support.
A 32-bit-only build is needed for that slice to run on 64-bit devices (the only ones available).
* Building 32-bit code for macOS requires Xcode <= 9, which is not available in our build environment.
https://developer.apple.com/documentation/xcode-release-notes/xcode-10-release-notes#Deprecations
_The macOS 10.14 SDK no longer contains support for compiling 32-bit applications.
If developers need to compile for i386, Xcode 9.4 or earlier is required. (39858111)_

Verified by running `features/barebone_tests.feature:123` on Apple Watch.