### PR TITLE
Restore KSLogging for E2E tests

### DIFF
--- a/features/fixtures/macos/Podfile
+++ b/features/fixtures/macos/Podfile
@@ -9,7 +9,7 @@ post_install do |installer|
   installer.pods_project.targets.each do |target|
     if target.name == "Bugsnag"
       target.build_configurations.each do |config|
-        config.build_settings['GCC_PREPROCESSOR_DEFINITIONS'] ||= ['$(inherited)', 'BSG_LOG_LEVEL=BSG_LOGLEVEL_DEBUG']
+        config.build_settings['GCC_PREPROCESSOR_DEFINITIONS'] ||= ['$(inherited)', 'BSG_LOG_LEVEL=BSG_LOGLEVEL_DEBUG BSG_KSLOG_ENABLED=1']
         config.build_settings['GCC_TREAT_WARNINGS_AS_ERRORS'] = 'YES'
 
         # Include all our build warning settings without needing to duplicate them here

--- a/features/scripts/export_ios_app.sh
+++ b/features/scripts/export_ios_app.sh
@@ -21,7 +21,7 @@ xcrun xcodebuild \
   -quiet \
   archive \
   CLANG_ENABLE_MODULES=NO \
-  GCC_PREPROCESSOR_DEFINITIONS='$(inherited) BSG_LOG_LEVEL=BSG_LOGLEVEL_DEBUG'
+  GCC_PREPROCESSOR_DEFINITIONS='$(inherited) BSG_LOG_LEVEL=BSG_LOGLEVEL_DEBUG BSG_KSLOG_ENABLED=1'
 
 echo "--- iOSTestApp: xcodebuild -exportArchive"
 

--- a/features/support/env.rb
+++ b/features/support/env.rb
@@ -91,6 +91,7 @@ Maze.hooks.after do |scenario|
         out: File.open(File.join(path, 'device.log'), 'w')
       )
       Process.wait log
+      FileUtils.mv '/tmp/kscrash.log', path
     end
   else
     if $logger_pid
@@ -98,6 +99,12 @@ Maze.hooks.after do |scenario|
       Process.waitpid $logger_pid
       $logger_pid = nil
       FileUtils.mv 'device.log', path
+    end
+    begin
+      data = Maze.driver.pull_file '@com.bugsnag.iOSTestApp/Documents/kscrash.log'
+      File.open(File.join(path, 'kscrash.log'), 'wb') { |file| file << data }
+    rescue StandardError
+      p "Maze.driver.pull_file failed: #{$ERROR_INFO}"
     end
   end
 end


### PR DESCRIPTION
## Goal

Re-enable capture of KSCrash-level logs from E2E tests.

See also:
* https://github.com/bugsnag/bugsnag-cocoa/pull/1237

## Changeset

Re-enables KSLogging in E2E tests, reversing some of the changes made in #1397.

Sets `BSG_KSLOG_ENABLED=1` when building iOS and macOS fixtures, and restores the previous support code.

## Testing

Verified locally by running `make e2e_ios_local` and `make e2e_macos`.