### PR TITLE
Declare thermalKills unavailable on watchOS

### DIFF
--- a/Bugsnag/Client/BugsnagClient.m
+++ b/Bugsnag/Client/BugsnagClient.m
@@ -346,6 +346,7 @@ __attribute__((annotate("oclint:suppress[too many methods]")))
         didCrash = YES;
     }
 #endif
+#if !TARGET_OS_WATCH
     else if (self.configuration.autoDetectErrors && BSGRunContextWasKilled()) {
         if (BSGRunContextWasCriticalThermalState()) {
             bsg_log_info(@"Last run terminated during a critical thermal state.");
@@ -362,6 +363,7 @@ __attribute__((annotate("oclint:suppress[too many methods]")))
         }
         didCrash = YES;
     }
+#endif
     
     self.appDidCrashLastLaunch = didCrash;
     

--- a/Bugsnag/Helpers/BSGRunContext.h
+++ b/Bugsnag/Helpers/BSGRunContext.h
@@ -75,7 +75,9 @@ static inline bool BSGRunContextWasCriticalThermalState() {
 }
 #endif
 
+#if !TARGET_OS_WATCH
 bool BSGRunContextWasKilled(void);
+#endif
 
 static inline bool BSGRunContextWasLaunching() {
     return bsg_lastRunContext && bsg_lastRunContext->isLaunching;

--- a/Bugsnag/Helpers/BSGRunContext.m
+++ b/Bugsnag/Helpers/BSGRunContext.m
@@ -313,6 +313,7 @@ static void UpdateAvailableMemory() {
 
 #pragma mark - Kill detection
 
+#if !TARGET_OS_WATCH
 bool BSGRunContextWasKilled() {
     // App extensions have a different lifecycle and the heuristic used for
     // finding app terminations rooted in fixable code does not apply
@@ -349,6 +350,7 @@ bool BSGRunContextWasKilled() {
     
     return YES;
 }
+#endif
 
 
 #pragma mark - File handling & memory mapping

--- a/Bugsnag/include/Bugsnag/BugsnagErrorTypes.h
+++ b/Bugsnag/include/Bugsnag/BugsnagErrorTypes.h
@@ -34,7 +34,7 @@
  *
  * This flag is true by default.
  */
-@property (nonatomic) BOOL thermalKills;
+@property (nonatomic) BOOL thermalKills API_UNAVAILABLE(watchos);
 
 /**
  * Determines whether NSExceptions should be reported to bugsnag.


### PR DESCRIPTION
## Goal

Mark `thermalKills` as unavailable on watchOS.

## Changeset

Adds `API_UNAVAILABLE(watchos)` to `thermalKills` declaration.

Adds `#if !TARGET_OS_WATCH` conditionals around related code.

Considered adding a new `BSG_HAVE_` macro but think that needs further discussion (should it be "have thermal kills detection" or "have kill detection"?), so opted to leave that for a future refactoring.

## Testing

Tested locally by running unit tests.