### PR TITLE
Minor tweaks

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -183,7 +183,7 @@ endif
 	@open 'https://github.com/bugsnag/bugsnag-cocoa/releases/new?title=v$(PRESET_VERSION)&tag=v$(PRESET_VERSION)&body='$$(awk 'start && /^## /{exit;};/^## /{start=1;next};start' CHANGELOG.md | hexdump -v -e '/1 "%02x"' | sed 's/\(..\)/%\1/g')
 	# Workaround for CocoaPods/CocoaPods#8000
 	@EXPANDED_CODE_SIGN_IDENTITY="" EXPANDED_CODE_SIGN_IDENTITY_NAME="" EXPANDED_PROVISIONING_PROFILE="" pod trunk push --allow-warnings Bugsnag.podspec.json
-	@EXPANDED_CODE_SIGN_IDENTITY="" EXPANDED_CODE_SIGN_IDENTITY_NAME="" EXPANDED_PROVISIONING_PROFILE="" pod trunk push --allow-warnings BugsnagNetworkRequestPlugin.podspec.json
+	@EXPANDED_CODE_SIGN_IDENTITY="" EXPANDED_CODE_SIGN_IDENTITY_NAME="" EXPANDED_PROVISIONING_PROFILE="" pod trunk push --allow-warnings --synchronous BugsnagNetworkRequestPlugin.podspec.json
 
 bump: ## Bump the version numbers to $VERSION
 ifeq ($(VERSION),)

--- a/examples/swift-watchos/swift-watchos.xcodeproj/project.pbxproj
+++ b/examples/swift-watchos/swift-watchos.xcodeproj/project.pbxproj
@@ -200,6 +200,7 @@
 				CB3B7FC32833C1EF00CAD67A /* Frameworks */,
 				CB3B7FC42833C1EF00CAD67A /* Resources */,
 				AAA327408B6C42133D8452F6 /* [CP] Embed Pods Frameworks */,
+				01515B1E2850F2E300E498EC /* Upload Bugsnag dSYM */,
 			);
 			buildRules = (
 			);
@@ -280,6 +281,26 @@
 /* End PBXResourcesBuildPhase section */
 
 /* Begin PBXShellScriptBuildPhase section */
+		01515B1E2850F2E300E498EC /* Upload Bugsnag dSYM */ = {
+			isa = PBXShellScriptBuildPhase;
+			buildActionMask = 2147483647;
+			files = (
+			);
+			inputFileListPaths = (
+			);
+			inputPaths = (
+				"${DWARF_DSYM_FOLDER_PATH}/${DWARF_DSYM_FILE_NAME}/Contents/Resources/DWARF/${TARGET_NAME}",
+			);
+			name = "Upload Bugsnag dSYM";
+			outputFileListPaths = (
+			);
+			outputPaths = (
+			);
+			runOnlyForDeploymentPostprocessing = 0;
+			shellPath = /usr/bin/ruby;
+			shellScript = "Dir[\"#{ENV['DWARF_DSYM_FOLDER_PATH']}/*/Contents/Resources/DWARF/*\"].each do |dsym|\n  Process.detach Process.spawn('/usr/bin/curl', '--http1.1',\n    '-F', \"dsym=@#{dsym}\",\n    '-F', \"projectRoot=#{ENV[\"PROJECT_DIR\"]}\",\n    'https://upload.bugsnag.com/',\n    %i[err out] => :close\n  )\nend\n";
+			showEnvVarsInLog = 0;
+		};
 		912FB2F2D4B33747C43FBBD9 /* [CP] Check Pods Manifest.lock */ = {
 			isa = PBXShellScriptBuildPhase;
 			buildActionMask = 2147483647;

--- a/examples/swift-watchos/swift-watchos.xcodeproj/xcshareddata/xcschemes/swift-watchos WatchKit App.xcscheme
+++ b/examples/swift-watchos/swift-watchos.xcodeproj/xcshareddata/xcschemes/swift-watchos WatchKit App.xcscheme
@@ -45,7 +45,7 @@
       </Testables>
    </TestAction>
    <LaunchAction
-      buildConfiguration = "Debug"
+      buildConfiguration = "Release"
       selectedDebuggerIdentifier = ""
       selectedLauncherIdentifier = "Xcode.IDEFoundation.Launcher.PosixSpawn"
       launchStyle = "0"


### PR DESCRIPTION
## Changeset

Adds a dSYM upload phase to the watchOS example project and sets build configuration to Release to facilitate realistic symbolication testing.

Passes the `--synchronous` argument to `pod push` to fix errors when validation depends on the just-pushed Bugsnag pod (i.e. when changing platform support.)

## Testing

Verified by running on local device and checking dashboard events.