### PR TITLE
Ignore invalid sessions in BareboneTestUnhandledErrorScenario

### DIFF
--- a/features/barebone_tests.feature
+++ b/features/barebone_tests.feature
@@ -121,6 +121,7 @@ Feature: Barebone tests
 
   @watchos
   Scenario: Barebone test: unhandled error
+    Given I ignore invalid sessions
     When I run "BareboneTestUnhandledErrorScenario" and relaunch the crashed app
     And I set the app to "report" mode
     And I configure Bugsnag for "BareboneTestUnhandledErrorScenario"


### PR DESCRIPTION
## Goal

Fix flake in `barebone_tests.feature:123` that can occur if crash occurs in the middle of session HTTP request.

## Changeset

Ignores invalid session requests for this scenario.

## Testing

Verified on CI