### PR TITLE
Remove `device.freeMemory` from OOM and Thermal Kill events

### DIFF
--- a/Bugsnag/Client/BugsnagClient.m
+++ b/Bugsnag/Client/BugsnagClient.m
@@ -1159,9 +1159,6 @@ __attribute__((annotate("oclint:suppress[too many methods]")))
     if (bsg_lastRunContext->timestamp > 0) {
         device.time = [NSDate dateWithTimeIntervalSinceReferenceDate:bsg_lastRunContext->timestamp];
     }
-    if (bsg_lastRunContext->availableMemory) {
-        device.freeMemory = @(bsg_lastRunContext->availableMemory);
-    }
 
     NSDictionary *metadataDict = BSGJSONDictionaryFromFile(BSGFileLocations.current.metadata, 0, nil);
     BugsnagMetadata *metadata = [[BugsnagMetadata alloc] initWithDictionary:metadataDict ?: @{}];

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,10 @@ Changelog
 
 ### Bug fixes
 
+* Remove `device.freeMemory` from OOM and Thermal Kill events.
+  This indicated the app's remaining quota rather than the device's free memory, so has been removed to avoid confusion.
+  [#1408](https://github.com/bugsnag/bugsnag-cocoa/pull/1408)
+
 * Fix a crash that could occur in apps that set `com.apple.developer.default-data-protection` to `NSFileProtectionComplete`.
   [#1407](https://github.com/bugsnag/bugsnag-cocoa/pull/1407)
 

--- a/features/barebone_tests.feature
+++ b/features/barebone_tests.feature
@@ -241,7 +241,7 @@ Feature: Barebone tests
     And the event "device.modelNumber" equals the platform-dependent string:
       | ios   | @not_null |
       | macos | @null     |
-    And on iOS 13 and later, the event "device.freeMemory" is an integer
+    And the event "device.freeMemory" is null
     And the event "device.osName" equals the platform-dependent string:
       | ios   | iOS    |
       | macos | Mac OS |

--- a/features/out_of_memory.feature
+++ b/features/out_of_memory.feature
@@ -45,7 +45,7 @@ Feature: Out of memory errors
     And the event "app.bundleVersion" is not null
     And the event "app.dsymUUIDs" is not null
     And the event "app.version" is not null
-    And on iOS 13 and later, the event "device.freeMemory" is an integer
+    And the event "device.freeMemory" is null
     And the event "device.manufacturer" equals "Apple"
     And the event "device.orientation" matches "(face(down|up)|landscape(left|right)|portrait(upsidedown)?)"
     And the event "device.runtimeVersions" is not null


### PR DESCRIPTION
## Goal

Remove `device.freeMemory` from OOMs to avoid potential confusion.

`device.freeMemory` previously contained the amount of remaining memory (as returned by [os_proc_available_memory()](https://developer.apple.com/documentation/os/3191911-os_proc_available_memory)) before the app reaches its limit.

This information may be reintroduced in a future release, but in a different way that distinguishes between app and device (system) memory... Memory pressure and low memory warnings are actually related to the system state rather than app's memory usage, so looking at app usage alone does not give a full picture.

## Changeset

Removes `device.freeMemory` from OOM and Thermal Kill events.

## Testing

Covered by E2E tests.