### PR TITLE
[PLAT-5165] Support tapping rows in `examples/objective-c-ios`

### DIFF
--- a/examples/objective-c-ios/objective-c-ios/ViewController.m
+++ b/examples/objective-c-ios/objective-c-ios/ViewController.m
@@ -30,6 +30,15 @@
     [Bugsnag leaveBreadcrumbWithMessage:@"Received memory warning"];
 }
 
+- (void)tableView:(UITableView *)tableView didSelectRowAtIndexPath:(NSIndexPath *)indexPath {
+    UITableViewCell *cell = [tableView cellForRowAtIndexPath:indexPath];
+    UIButton *button = cell.contentView.subviews.firstObject; 
+    [button sendActionsForControlEvents:UIControlEventTouchUpInside];
+    [tableView deselectRowAtIndexPath:indexPath animated:YES];
+}
+
+#pragma mark -
+
 /**
  This method generates an out-of-memory (OOM) exception.  The method of generating this error can be seen in the `OutOfMemoryController` file.
  


### PR DESCRIPTION
## Goal

Trigger actions in example app when tapping within rows but outside of the text (button).

## Changeset

Implements `-tableView:didSelectRowAtIndexPath:` and triggers contained button to execute examples.

## Testing

Verified manually.