### PR TITLE
Ignore invalid sessions in all crashing scenarios

### DIFF
--- a/features/barebone_tests.feature
+++ b/features/barebone_tests.feature
@@ -121,7 +121,6 @@ Feature: Barebone tests
 
   @watchos
   Scenario: Barebone test: unhandled error
-    Given I ignore invalid sessions
     When I run "BareboneTestUnhandledErrorScenario" and relaunch the crashed app
     And I set the app to "report" mode
     And I configure Bugsnag for "BareboneTestUnhandledErrorScenario"

--- a/features/last_run_info.feature
+++ b/features/last_run_info.feature
@@ -2,7 +2,6 @@ Feature: Launch detection
 
   Background:
     Given I clear all persistent data
-    And I ignore invalid sessions
 
   Scenario: LastRunInfo consecutiveLaunchCrashes increments when isLaunching is true
     When I run "LastRunInfoScenario" and relaunch the crashed app

--- a/features/steps/app_steps.rb
+++ b/features/steps/app_steps.rb
@@ -4,31 +4,9 @@ end
 
 When("I run {string} and relaunch the crashed app") do |event_type|
   steps %(
+    Given I ignore invalid sessions
     Given I run \"#{event_type}\"
     And I relaunch the app after a crash
-  )
-end
-
-When("I run the configured scenario and relaunch the crashed app") do
-  case Maze::Helper.get_current_platform
-  when 'ios'
-    run_and_relaunch
-  when 'macos'
-    $scenario_mode = $last_scenario[:scenario_mode]
-    execute_command($last_scenario[:action], $last_scenario[:scenario_name])
-  when 'watchos'
-    run_watchos_app
-    sleep 10 # we don't have a way to check if the app is still running
-  else
-    raise "Unsupported platform: #{Maze::Helper.get_current_platform}"
-  end
-end
-
-def run_and_relaunch
-  steps %(
-    Given I click the element "run_scenario"
-    And the app is not running
-    Then I kill and relaunch the app
   )
 end
 


### PR DESCRIPTION
## Goal

Reduce flakes caused by invalid session payloads received when fixture crashes.

A few of these flakes had been addressed individually, but more have been observed...

* https://github.com/bugsnag/bugsnag-cocoa/pull/1408
* https://github.com/bugsnag/bugsnag-cocoa/pull/1366/commits/4ba03ae6c4c844f3ac5db124553c78078479eb6c

## Changeset

The `I run {string} and relaunch the crashed app` step now configures Maze Runner to ignore invalid sessions.

Removes the unused step `I run the configured scenario and relaunch the crashed app`

## Testing

Verified on CI