### PR TITLE
[PLAT-8604] Disable `NSFileProtectionComplete` for crash reports

### DIFF
--- a/Bugsnag/BSGCrashSentry.m
+++ b/Bugsnag/BSGCrashSentry.m
@@ -10,6 +10,7 @@
 
 #import "BSGDefines.h"
 #import "BSGFileLocations.h"
+#import "BSGUtils.h"
 #import "BSG_KSCrash.h"
 #import "BSG_KSCrashC.h"
 #import "BSG_KSMach.h"
@@ -37,9 +38,15 @@ void BSGCrashSentryInstall(BugsnagConfiguration *config, BSG_KSReportWriteCallba
         }
     }
 
+    NSString *crashReportsDirectory = BSGFileLocations.current.kscrashReports;
+
+    // NSFileProtectionComplete prevents new crash reports being written when
+    // the device is locked, so must be disabled.
+    BSGDisableNSFileProtectionComplete(crashReportsDirectory);
+
     // In addition to installing crash handlers, -[BSG_KSCrash install:] initializes various
     // subsystems that Bugsnag relies on, so needs to be called even if autoDetectErrors is disabled.
-    if ((![ksCrash install:crashTypes directory:[BSGFileLocations current].kscrashReports] && crashTypes)) {
+    if ((![ksCrash install:crashTypes directory:crashReportsDirectory] && crashTypes)) {
         bsg_log_err(@"Failed to install crash handlers; no exceptions or crashes will be reported");
     }
 }

--- a/Bugsnag/Helpers/BSGRunContext.h
+++ b/Bugsnag/Helpers/BSGRunContext.h
@@ -61,7 +61,7 @@ extern const struct BSGRunContext *_Nullable bsg_lastRunContext;
 
 #pragma mark -
 
-void BSGRunContextInit(const char *_Nonnull path);
+void BSGRunContextInit(NSString *_Nonnull path);
 
 #pragma mark -
 

--- a/Bugsnag/Helpers/BSGUtils.h
+++ b/Bugsnag/Helpers/BSGUtils.h
@@ -8,6 +8,8 @@
 
 #import <Foundation/Foundation.h>
 
+#import "BSGDefines.h"
+
 #if TARGET_OS_IOS
 #import "BSGUIKit.h"
 #endif
@@ -15,6 +17,14 @@
 __BEGIN_DECLS
 
 NS_ASSUME_NONNULL_BEGIN
+
+/// Changes the NSFileProtectionKey attribute of the specified file or directory from NSFileProtectionComplete to NSFileProtectionCompleteUnlessOpen.
+/// Has no effect if the specified file or directory does not have NSFileProtectionComplete.
+///
+/// Files with NSFileProtectionComplete cannot be read from or written to while the device is locked or booting.
+///
+/// Files with NSFileProtectionCompleteUnlessOpen can be created while the device is locked, but once closed, cannot be opened again until the device is unlocked.
+BSG_PRIVATE BOOL BSGDisableNSFileProtectionComplete(NSString *path);
 
 dispatch_queue_t BSGGetFileSystemQueue(void);
 

--- a/Bugsnag/Helpers/BSGUtils.m
+++ b/Bugsnag/Helpers/BSGUtils.m
@@ -8,6 +8,36 @@
 
 #import "BSGUtils.h"
 
+#import "BugsnagLogger.h"
+
+BOOL BSGDisableNSFileProtectionComplete(NSString *path) {
+    // Using NSFileProtection* causes run-time link errors on older versions of macOS.
+    // NSURLFileProtectionKey is unavailable in macOS SDKs prior to 11.0
+#if !TARGET_OS_OSX || defined(__MAC_11_0)
+    if (@available(macOS 11.0, *)) {
+        NSURL *url = [NSURL fileURLWithPath:path];
+        
+        NSURLFileProtectionType protection = nil;
+        [url getResourceValue:&protection forKey:NSURLFileProtectionKey error:nil];
+        
+        if (protection != NSURLFileProtectionComplete) {
+            return YES;
+        }
+        
+        NSError *error = nil;
+        if (![url setResourceValue:NSURLFileProtectionCompleteUnlessOpen
+                            forKey:NSURLFileProtectionKey error:&error]) {
+            bsg_log_warn(@"BSGDisableFileProtection: %@", error);
+            return NO;
+        }
+        bsg_log_debug(@"Set NSFileProtectionCompleteUnlessOpen for %@", path);
+    }
+#else
+    (void)(path);
+#endif
+    return YES;
+}
+
 dispatch_queue_t BSGGetFileSystemQueue(void) {
     static dispatch_once_t onceToken;
     static dispatch_queue_t queue;

--- a/Bugsnag/KSCrash/Source/KSCrash/Recording/BSG_KSCrashState.m
+++ b/Bugsnag/KSCrash/Source/KSCrash/Recording/BSG_KSCrashState.m
@@ -119,6 +119,10 @@ bool bsg_kscrashstate_i_loadState(BSG_KSCrash_State *const context,
  */
 bool bsg_kscrashstate_i_saveState(const BSG_KSCrash_State *const state,
                                   const char *const path) {
+
+    // Opening an existing file fails under NSFileProtectionComplete*
+    unlink(path);
+
     int fd = open(path, O_RDWR | O_CREAT | O_TRUNC, 0644);
     if (fd < 0) {
         bsg_log_err(@"Could not open file %s for writing: %s", path, strerror(errno));

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,9 @@ Changelog
 * Ignore OOMs that occur while the app is inactive, reverting an inadvertent change in v6.16.4.
   [#1416](https://github.com/bugsnag/bugsnag-cocoa/pull/1416)
 
+* Fix reporting of crashes that occur while device is locked in apps using `NSFileProtectionComplete`.
+  [#1415](https://github.com/bugsnag/bugsnag-cocoa/pull/1415)
+
 ## 6.18.1 (2022-06-22)
 
 ### Bug fixes

--- a/Tests/BugsnagTests/BSGOutOfMemoryTests.m
+++ b/Tests/BugsnagTests/BSGOutOfMemoryTests.m
@@ -71,7 +71,7 @@
 
 - (void)testLastLaunchTerminatedUnexpectedly {
     if (!bsg_runContext) {
-        BSGRunContextInit(BSGFileLocations.current.runContext.fileSystemRepresentation);
+        BSGRunContextInit(BSGFileLocations.current.runContext);
     }
     const struct BSGRunContext *oldContext = bsg_lastRunContext;
     struct BSGRunContext lastRunContext = *bsg_runContext;


### PR DESCRIPTION
## Goal

Fix reporting of crashes that occur while data protection is enabled and the device is locked.

Crash reports were failing to be written, with diagnostic logs like the following:

```
[Bugsnag] [ERROR] Could not open file [...]/v1/KSCrashReports/swift-ios-CrashState.json for writing: Operation not permitted
INFO : BSG_KSCrashReport.c:1438: bsg_kscrashreport_writeStandardReport(): Writing crash report to [...]/v1/KSCrashReports/CrashReport-E1EEDC19-B397-48B5-A5E7-E45C9E980CD7.json
ERROR: BSG_KSCrashReport.c:1353: bsg_kscrw_i_openCrashReportFile(): Could not open crash report file [...]/v1/KSCrashReports/CrashReport-E1EEDC19-B397-48B5-A5E7-E45C9E980CD7.json: Operation not permitted
ERROR: BSG_KSCrashReport.c:258: bsg_kscrw_i_addJSONElementFromFile(): Could not open file [...]/v1/config.json: Operation not permitted
```

## Changeset

If the default protection is `NSFileProtectionComplete`, changes the protection for the crash reports directory (and contents) and `run_context` to `NSFileProtectionCompleteUnlessOpen`.

[`NSFileProtectionCompleteUnlessOpen`](https://developer.apple.com/documentation/foundation/nsfileprotectioncompleteunlessopen) allows new files to be created while the device is locked, but once closed, cannot be opened again until the device is unlocked. This allows crash reports to be written while preserving security through data protection.

Stores config JSON in memory to allow inclusion in crash reports without reading from a file which may be inaccessible.

## Testing

Manually verified crash reporting using test app.