### PR TITLE
Ignore OOMs that occur while the app is inactive

### DIFF
--- a/Bugsnag/Helpers/BSGRunContext.h
+++ b/Bugsnag/Helpers/BSGRunContext.h
@@ -19,13 +19,14 @@
 // During development this is not strictly necessary since last run's data will
 // not be loaded if the struct's size has changed.
 //
-#define BSGRUNCONTEXT_VERSION 2
+#define BSGRUNCONTEXT_VERSION 3
 
 struct BSGRunContext {
     long structVersion;
     bool isDebuggerAttached;
     bool isLaunching;
     bool isForeground;
+    bool isActive;
     bool isTerminating;
     long thermalState;
     uint64_t bootTime;
@@ -40,6 +41,8 @@ struct BSGRunContext {
 #endif
 #if TARGET_OS_IOS
     long lastKnownOrientation;
+#endif
+#if BSG_HAVE_OOM_DETECTION
     dispatch_source_memorypressure_flags_t memoryPressure;
 #endif
     double timestamp __attribute__((aligned(8)));

--- a/Bugsnag/Helpers/BSGRunContext.m
+++ b/Bugsnag/Helpers/BSGRunContext.m
@@ -38,7 +38,11 @@
 #pragma mark Forward declarations
 
 static uint64_t GetBootTime(void);
+static bool GetIsActive(void);
 static bool GetIsForeground(void);
+#if TARGET_OS_IOS || TARGET_OS_TV
+static UIApplication * GetUIApplication(void);
+#endif
 static void InstallTimer(void);
 static void UpdateAvailableMemory(void);
 
@@ -66,6 +70,14 @@ static void InitRunContext() {
         uuid_copy(bsg_runContext->machoUUID, image->uuid);
     }
     
+    if ([NSThread isMainThread]) {
+        bsg_runContext->isActive = GetIsActive();
+    } else {
+        dispatch_async(dispatch_get_main_queue(), ^{
+            bsg_runContext->isActive = GetIsActive();
+        });
+    }
+    
     BSGRunContextUpdateTimestamp();
     InstallTimer();
     
@@ -82,6 +94,22 @@ static uint64_t GetBootTime() {
     int ret = sysctl((int[]){CTL_KERN, KERN_BOOTTIME}, 2, &tv, &len, NULL, 0);
     if (ret == -1) return 0;
     return (uint64_t)tv.tv_sec * USEC_PER_SEC + (uint64_t)tv.tv_usec;
+}
+
+static bool GetIsActive() {
+#if TARGET_OS_OSX
+    return GetIsForeground();
+#endif
+
+#if TARGET_OS_IOS || TARGET_OS_TV
+    UIApplication *app = GetUIApplication();
+    return app && app.applicationState == UIApplicationStateActive;
+#endif
+
+#if TARGET_OS_WATCH
+    WKExtension *ext = [WKExtension sharedExtension];
+    return ext && ext.applicationState == WKApplicationStateActive;
+#endif
 }
 
 static bool GetIsForeground() {
@@ -115,17 +143,7 @@ static bool GetIsForeground() {
 #endif
 
 #if TARGET_OS_IOS || TARGET_OS_TV
-    // +sharedApplication is unavailable to app extensions
-    if ([BSG_KSSystemInfo isRunningInAppExtension]) {
-        // Returning "foreground" seems wrong but matches what
-        // +[BSG_KSSystemInfo currentAppState] used to return
-        return true;
-    }
-
-    // Using performSelector: to avoid a compile-time check that
-    // +sharedApplication is not called from app extensions
-    UIApplication *application = [UIAPPLICATION performSelector:
-                                  @selector(sharedApplication)];
+    UIApplication *application = GetUIApplication();
 
     // There will be no UIApplication if UIApplicationMain() has not yet been
     // called - e.g. from a SwiftUI app's init() function or UIKit app's main()
@@ -147,13 +165,24 @@ static bool GetIsForeground() {
 #endif
 
 #if TARGET_OS_WATCH
-    if (@available(watchOS 3.0, *)) {
-        return [WKExtension sharedExtension].applicationState != WKApplicationStateBackground;
-    } else {
-        return false;
-    }
+    WKExtension *ext = [WKExtension sharedExtension];
+    return ext && ext.applicationState != WKApplicationStateBackground;
 #endif
 }
+
+#if TARGET_OS_IOS || TARGET_OS_TV
+
+static UIApplication * GetUIApplication(void) {
+    // +sharedApplication is unavailable to app extensions
+    if ([BSG_KSSystemInfo isRunningInAppExtension]) {
+        return nil;
+    }
+    // Using performSelector: to avoid a compile-time check that
+    // +sharedApplication is not called from app extensions
+    return [UIAPPLICATION performSelector:@selector(sharedApplication)];
+}
+
+#endif
 
 static void InstallTimer() {
     static dispatch_source_t timer;
@@ -177,17 +206,27 @@ static void InstallTimer() {
 
 #pragma mark - Observation
 
-#if TARGET_OS_IOS || TARGET_OS_OSX
+#if TARGET_OS_IOS || TARGET_OS_TV || TARGET_OS_OSX
+
+static void NoteAppActive() {
+    bsg_runContext->isActive = YES;
+    bsg_runContext->isForeground = YES;
+    BSGRunContextUpdateTimestamp();
+}
 
 static void NoteAppBackground() {
+    bsg_runContext->isActive = NO;
     bsg_runContext->isForeground = NO;
     BSGRunContextUpdateTimestamp();
 }
 
-static void NoteAppForeground() {
+#if !TARGET_OS_OSX
+static void NoteAppInactive() {
+    bsg_runContext->isActive = NO;
     bsg_runContext->isForeground = YES;
     BSGRunContextUpdateTimestamp();
 }
+#endif
 
 static void NoteAppWillTerminate() {
     bsg_runContext->isTerminating = YES;
@@ -228,7 +267,7 @@ static void NoteThermalState(__unused CFNotificationCenterRef center,
     BSGRunContextUpdateTimestamp();
 }
 
-#if TARGET_OS_IOS
+#if BSG_HAVE_OOM_DETECTION
 
 static void ObserveMemoryPressure() {
     // DISPATCH_SOURCE_TYPE_MEMORYPRESSURE arrives slightly sooner than
@@ -258,15 +297,16 @@ static void AddObservers() {
     center, NULL, function, (__bridge CFStringRef)name, NULL, \
     CFNotificationSuspensionBehaviorDeliverImmediately)
     
-#if TARGET_OS_IOS
-    OBSERVE(UIApplicationDidBecomeActiveNotification, NoteAppForeground);
+#if TARGET_OS_IOS || TARGET_OS_TV
+    OBSERVE(UIApplicationDidBecomeActiveNotification, NoteAppActive);
     OBSERVE(UIApplicationDidEnterBackgroundNotification, NoteAppBackground);
-    OBSERVE(UIApplicationWillEnterForegroundNotification, NoteAppForeground);
+    OBSERVE(UIApplicationWillEnterForegroundNotification, NoteAppInactive);
+    OBSERVE(UIApplicationWillResignActiveNotification, NoteAppInactive);
     OBSERVE(UIApplicationWillTerminateNotification, NoteAppWillTerminate);
 #endif
     
 #if TARGET_OS_OSX
-    OBSERVE(NSApplicationDidBecomeActiveNotification, NoteAppForeground);
+    OBSERVE(NSApplicationDidBecomeActiveNotification, NoteAppActive);
     OBSERVE(NSApplicationDidResignActiveNotification, NoteAppBackground);
     OBSERVE(NSApplicationWillTerminateNotification, NoteAppWillTerminate);
 #endif
@@ -288,7 +328,9 @@ static void AddObservers() {
     OBSERVE(UIDeviceOrientationDidChangeNotification, NoteOrientation);
     OBSERVE(UIDeviceBatteryLevelDidChangeNotification, NoteBatteryLevel);
     OBSERVE(UIDeviceBatteryStateDidChangeNotification, NoteBatteryState);
+#endif
 
+#if BSG_HAVE_OOM_DETECTION
     ObserveMemoryPressure();
 #endif
 }
@@ -314,6 +356,7 @@ static void UpdateAvailableMemory() {
 #pragma mark - Kill detection
 
 #if !TARGET_OS_WATCH
+
 bool BSGRunContextWasKilled() {
     // App extensions have a different lifecycle and the heuristic used for
     // finding app terminations rooted in fixable code does not apply
@@ -333,12 +376,6 @@ bool BSGRunContextWasKilled() {
         return NO; // The debugger may have killed the app
     }
     
-    // Once the app is in the background we cannot determine between good (user
-    // swiping up to close app) and bad (OS killing the app) terminations.
-    if (!bsg_lastRunContext->isForeground) {
-        return NO;
-    }
-    
     if (bsg_lastRunContext->bootTime != bsg_runContext->bootTime) {
         return NO; // The app may have been terminated due to the reboot
     }
@@ -348,8 +385,22 @@ bool BSGRunContextWasKilled() {
         return NO;
     }
     
+    // Once the app is in the background we cannot determine between good (user
+    // closed from the app switcher) and bad (OS killed the app) terminations.
+    if (!bsg_lastRunContext->isForeground) {
+        bsg_log_debug(@"Ignoring kill that occurred while in background");
+        return NO;
+    }
+    
+    // PLAT-3259: Do not report OOMs from UIApplicationStateInactive.
+    if (!bsg_lastRunContext->isActive) {
+        bsg_log_debug(@"Ignoring kill that occurred while inactive");
+        return NO;
+    }
+    
     return YES;
 }
+
 #endif
 
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,13 @@
 Changelog
 =========
 
+## TBD
+
+### Bug fixes
+
+* Ignore OOMs that occur while the app is inactive, reverting an inadvertent change in v6.16.4.
+  [#1416](https://github.com/bugsnag/bugsnag-cocoa/pull/1416)
+
 ## 6.18.1 (2022-06-22)
 
 ### Bug fixes

--- a/Tests/BugsnagTests/BSGOutOfMemoryTests.m
+++ b/Tests/BugsnagTests/BSGOutOfMemoryTests.m
@@ -82,21 +82,25 @@
     lastRunContext.isDebuggerAttached = true;
     lastRunContext.isTerminating = true;
     lastRunContext.isForeground = true;
+    lastRunContext.isActive = true;
     XCTAssertFalse(BSGRunContextWasKilled());
 
     lastRunContext.isDebuggerAttached = true;
     lastRunContext.isTerminating = true;
     lastRunContext.isForeground = false;
+    lastRunContext.isActive = false;
     XCTAssertFalse(BSGRunContextWasKilled());
 
     lastRunContext.isDebuggerAttached = true;
     lastRunContext.isTerminating = false;
     lastRunContext.isForeground = true;
+    lastRunContext.isActive = true;
     XCTAssertFalse(BSGRunContextWasKilled());
 
     lastRunContext.isDebuggerAttached = true;
     lastRunContext.isTerminating = false;
     lastRunContext.isForeground = false;
+    lastRunContext.isActive = false;
     XCTAssertFalse(BSGRunContextWasKilled());
 
     // Debugger inactive
@@ -104,16 +108,25 @@
     lastRunContext.isDebuggerAttached = false;
     lastRunContext.isTerminating = true;
     lastRunContext.isForeground = true;
+    lastRunContext.isActive = true;
     XCTAssertFalse(BSGRunContextWasKilled());
 
     lastRunContext.isDebuggerAttached = false;
     lastRunContext.isTerminating = true;
     lastRunContext.isForeground = false;
+    lastRunContext.isActive = false;
     XCTAssertFalse(BSGRunContextWasKilled());
 
     lastRunContext.isDebuggerAttached = false;
     lastRunContext.isTerminating = false;
     lastRunContext.isForeground = true;
+    lastRunContext.isActive = false;
+    XCTAssertFalse(BSGRunContextWasKilled());
+
+    lastRunContext.isDebuggerAttached = false;
+    lastRunContext.isTerminating = false;
+    lastRunContext.isForeground = true;
+    lastRunContext.isActive = true;
     XCTAssertTrue(BSGRunContextWasKilled());
     
     uuid_generate(lastRunContext.machoUUID);
@@ -127,6 +140,7 @@
     lastRunContext.isDebuggerAttached = false;
     lastRunContext.isTerminating = false;
     lastRunContext.isForeground = false;
+    lastRunContext.isActive = false;
     XCTAssertFalse(BSGRunContextWasKilled());
     
     bsg_lastRunContext = oldContext;

--- a/features/fixtures/ios/iOSTestApp.xcodeproj/project.pbxproj
+++ b/features/fixtures/ios/iOSTestApp.xcodeproj/project.pbxproj
@@ -64,6 +64,7 @@
 		01AFCFCB282CE9F700D48D45 /* OldSessionScenario.m in Sources */ = {isa = PBXBuildFile; fileRef = 01AFCFCA282CE9F700D48D45 /* OldSessionScenario.m */; };
 		01B6BB7525D5748800FC4DE6 /* LastRunInfoScenario.swift in Sources */ = {isa = PBXBuildFile; fileRef = 01B6BB7425D5748800FC4DE6 /* LastRunInfoScenario.swift */; };
 		01B6BBB625DA82B800FC4DE6 /* SendLaunchCrashesSynchronouslyScenario.swift in Sources */ = {isa = PBXBuildFile; fileRef = 01B6BBB525DA82B700FC4DE6 /* SendLaunchCrashesSynchronouslyScenario.swift */; };
+		01BA54FC28699BC100EC14E0 /* OOMInactiveScenario.swift in Sources */ = {isa = PBXBuildFile; fileRef = 01BA54FB28699BC100EC14E0 /* OOMInactiveScenario.swift */; };
 		01CD103926690463007FA5F0 /* libBugsnagStatic.a in Frameworks */ = {isa = PBXBuildFile; fileRef = 01CD103826690463007FA5F0 /* libBugsnagStatic.a */; };
 		01DCB82B27985D690048640A /* ConcurrentCrashesScenario.mm in Sources */ = {isa = PBXBuildFile; fileRef = 01DCB82A27985D2C0048640A /* ConcurrentCrashesScenario.mm */; };
 		01DE903826CE99B800455213 /* CriticalThermalStateScenario.swift in Sources */ = {isa = PBXBuildFile; fileRef = 01DE903726CE99B800455213 /* CriticalThermalStateScenario.swift */; };
@@ -250,6 +251,7 @@
 		01AFCFCA282CE9F700D48D45 /* OldSessionScenario.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; path = OldSessionScenario.m; sourceTree = "<group>"; };
 		01B6BB7425D5748800FC4DE6 /* LastRunInfoScenario.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = LastRunInfoScenario.swift; sourceTree = "<group>"; };
 		01B6BBB525DA82B700FC4DE6 /* SendLaunchCrashesSynchronouslyScenario.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = SendLaunchCrashesSynchronouslyScenario.swift; sourceTree = "<group>"; };
+		01BA54FB28699BC100EC14E0 /* OOMInactiveScenario.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = OOMInactiveScenario.swift; sourceTree = "<group>"; };
 		01CD103826690463007FA5F0 /* libBugsnagStatic.a */ = {isa = PBXFileReference; explicitFileType = archive.ar; path = libBugsnagStatic.a; sourceTree = BUILT_PRODUCTS_DIR; };
 		01DCB82A27985D2C0048640A /* ConcurrentCrashesScenario.mm */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.cpp.objcpp; path = ConcurrentCrashesScenario.mm; sourceTree = "<group>"; };
 		01DE903726CE99B800455213 /* CriticalThermalStateScenario.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = CriticalThermalStateScenario.swift; sourceTree = "<group>"; };
@@ -560,6 +562,7 @@
 				E700EE54247D3204008CFFB6 /* OnSendOverwriteScenario.swift */,
 				A1117E562535B22300014FDA /* OOMAutoDetectErrorsScenario.swift */,
 				A1117E582535B29800014FDA /* OOMEnabledErrorTypesScenario.swift */,
+				01BA54FB28699BC100EC14E0 /* OOMInactiveScenario.swift */,
 				A1117E542535A59100014FDA /* OOMLoadScenario.swift */,
 				01E5EAD125B713990066EA8A /* OOMScenario.m */,
 				01EE7F56278C680C00A59DC6 /* OOMSessionlessScenario.m */,
@@ -834,6 +837,7 @@
 				E75040B02478214F005D33BD /* MetadataRedactionDefaultScenario.swift in Sources */,
 				010BAB192833CF660003FF36 /* AppAndDeviceAttributesUnhandledExceptionDuringLaunchScenario.swift in Sources */,
 				E700EE6C247D793A008CFFB6 /* SIGPIPEScenario.m in Sources */,
+				01BA54FC28699BC100EC14E0 /* OOMInactiveScenario.swift in Sources */,
 				A1117E552535A59100014FDA /* OOMLoadScenario.swift in Sources */,
 				8A840FBA21AF5C450041DBFA /* SwiftAssertionScenario.swift in Sources */,
 				E753F24824927412001FB671 /* OnSendErrorCallbackCrashScenario.swift in Sources */,

--- a/features/fixtures/shared/scenarios/OOMInactiveScenario.swift
+++ b/features/fixtures/shared/scenarios/OOMInactiveScenario.swift
@@ -1,0 +1,30 @@
+//
+//  OOMInactiveScenario.swift
+//  iOSTestApp
+//
+//  Created by Nick Dowell on 27/06/2022.
+//  Copyright © 2022 Bugsnag. All rights reserved.
+//
+
+#if os(iOS)
+
+import UIKit
+
+class OOMInactiveScenario: Scenario {
+    
+    override func startBugsnag() {
+        config.enabledErrorTypes.ooms = true
+        Bugsnag.start(with: config)
+    }
+    
+    override func run() {
+        // FIXME: Would be better if we could trigger a real transition to UIApplicationStateInactive
+        NotificationCenter.default.post(name: UIApplication.willResignActiveNotification,
+                                        object: UIApplication.shared, userInfo: nil)
+        
+        NSLog("Killing app to fake an OOM")
+        kill(getpid(), SIGKILL)
+    }
+}
+
+#endif

--- a/features/out_of_memory.feature
+++ b/features/out_of_memory.feature
@@ -104,3 +104,8 @@ Feature: Out of memory errors
     And I wait to receive an error
     Then the error is an OOM event
     And the event "user.id" is not null
+
+  Scenario: Out of memory errors are not reported from UIApplicationStateInactive
+    Given I run "OOMInactiveScenario" and relaunch the crashed app
+    And I configure Bugsnag for "OOMInactiveScenario"
+    Then I should receive no errors


### PR DESCRIPTION
## Goal

Ignore OOMs that occur in `UIApplicationStateInactive`, restoring behaviour previously introduced by #394.

Pull request #1307 (in v6.16.4) inadvertently stopped rejecting these OOMs.

## Changeset

Adds `BSGRunContext.inActive`.
Observes `UIApplicationDidBecomeActiveNotification` / `WillResignActiveNotification`.
Checks `isActive` in `BSGRunContextWasKilled()`.

Enables state tracking on tvOS, since OOMs are also reported there.

## Testing

Adds an E2E scenario that simulates an OOM occurring in `UIApplicationStateInactive` and verifies that no error is reported.