### PR TITLE
[PLAT-8614] Prevent reporting of OOMs on simulators

### DIFF
--- a/Bugsnag/Client/BugsnagClient.m
+++ b/Bugsnag/Client/BugsnagClient.m
@@ -345,15 +345,17 @@ __attribute__((annotate("oclint:suppress[too many methods]")))
             if (self.configuration.enabledErrorTypes.thermalKills) {
                 self.eventFromLastLaunch = [self generateThermalKillEvent];
             }
+            didCrash = YES;
+        }
 #if BSG_HAVE_OOM_DETECTION
-        } else {
+        else {
             bsg_log_info(@"Last run terminated unexpectedly; possible Out Of Memory.");
             if (self.configuration.enabledErrorTypes.ooms) {
                 self.eventFromLastLaunch = [self generateOutOfMemoryEvent];
             }
-#endif
+            didCrash = YES;
         }
-        didCrash = YES;
+#endif
     }
 #endif
     
@@ -1164,7 +1166,7 @@ __attribute__((annotate("oclint:suppress[too many methods]")))
         deviceMetadata[BSGKeyCharging] = BSGIsBatteryCharging(bsg_lastRunContext->batteryState) ? @YES : @NO;
     }
 #endif
-#if TARGET_OS_IOS
+#if BSG_HAVE_OOM_DETECTION
     // Don't set to @NO because server may interpret any non-nil value as meaning true
     deviceMetadata[BSGKeyLowMemoryWarning] = BSGRunContextWasMemoryWarning() ? @YES : nil;
 #endif

--- a/Bugsnag/Helpers/BSGDefines.h
+++ b/Bugsnag/Helpers/BSGDefines.h
@@ -17,7 +17,7 @@
 #define BSG_HAVE_BATTERY                      (                 TARGET_OS_IOS                 || TARGET_OS_WATCH)
 #define BSG_HAVE_MACH_EXCEPTIONS              (TARGET_OS_OSX || TARGET_OS_IOS                                   )
 #define BSG_HAVE_MACH_THREADS                 (TARGET_OS_OSX || TARGET_OS_IOS || TARGET_OS_TV                   )
-#define BSG_HAVE_OOM_DETECTION                (                 TARGET_OS_IOS || TARGET_OS_TV                   )
+#define BSG_HAVE_OOM_DETECTION                (                 TARGET_OS_IOS || TARGET_OS_TV                   ) && !TARGET_OS_SIMULATOR
 #define BSG_HAVE_REACHABILITY                 (TARGET_OS_OSX || TARGET_OS_IOS || TARGET_OS_TV                   )
 #define BSG_HAVE_REACHABILITY_WWAN            (                 TARGET_OS_IOS || TARGET_OS_TV                   )
 #define BSG_HAVE_SIGNAL                       (TARGET_OS_OSX || TARGET_OS_IOS || TARGET_OS_TV                   )

--- a/Bugsnag/Helpers/BSGRunContext.h
+++ b/Bugsnag/Helpers/BSGRunContext.h
@@ -86,7 +86,7 @@ static inline bool BSGRunContextWasLaunching() {
     return bsg_lastRunContext && bsg_lastRunContext->isLaunching;
 }
 
-#if TARGET_OS_IOS
+#if BSG_HAVE_OOM_DETECTION
 static inline bool BSGRunContextWasMemoryWarning() {
     return bsg_lastRunContext && bsg_lastRunContext->memoryPressure > DISPATCH_MEMORYPRESSURE_NORMAL;
 }

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,13 @@
 Changelog
 =========
 
+## TBD
+
+### Bug fixes
+
+* Prevent reporting of OOMs on simulators. 
+  [#1421](https://github.com/bugsnag/bugsnag-cocoa/pull/1421)
+
 ## 6.19.0 (2022-06-29)
 
 ### Enhancements


### PR DESCRIPTION
## Goal

Prevent reporting of (false positive) OOMs on simulators.

Apps running in the simulator are not killed by the system in response to memory warnings. OOMs reported from the simulator are therefore most likely to be due to the app being killed by Xcode when running without a debugger attached, and it does not make sense to report these.

## Changeset

`BSG_HAVE_OOM_DETECTION` now evaluates to 0 when building for simulators.

## Testing

Verified using local test app. E2E tests on CI verify that OOM reporting still works on real devices.