### PR TITLE
[PLAT-8639] Add `usage` telemetry

### DIFF
--- a/Bugsnag.xcodeproj/project.pbxproj
+++ b/Bugsnag.xcodeproj/project.pbxproj
@@ -629,6 +629,19 @@
 		016875C6258D003200DFFF69 /* NSUserDefaultsStub.m in Sources */ = {isa = PBXBuildFile; fileRef = 016875C5258D003200DFFF69 /* NSUserDefaultsStub.m */; };
 		016875C7258D003200DFFF69 /* NSUserDefaultsStub.m in Sources */ = {isa = PBXBuildFile; fileRef = 016875C5258D003200DFFF69 /* NSUserDefaultsStub.m */; };
 		016875C8258D003200DFFF69 /* NSUserDefaultsStub.m in Sources */ = {isa = PBXBuildFile; fileRef = 016875C5258D003200DFFF69 /* NSUserDefaultsStub.m */; };
+		017DCF8C2874212F000ECB22 /* BSGTelemetry.h in Headers */ = {isa = PBXBuildFile; fileRef = 017DCF8A2874212F000ECB22 /* BSGTelemetry.h */; };
+		017DCF8D2874212F000ECB22 /* BSGTelemetry.h in Headers */ = {isa = PBXBuildFile; fileRef = 017DCF8A2874212F000ECB22 /* BSGTelemetry.h */; };
+		017DCF8E2874212F000ECB22 /* BSGTelemetry.h in Headers */ = {isa = PBXBuildFile; fileRef = 017DCF8A2874212F000ECB22 /* BSGTelemetry.h */; };
+		017DCF8F2874212F000ECB22 /* BSGTelemetry.h in Headers */ = {isa = PBXBuildFile; fileRef = 017DCF8A2874212F000ECB22 /* BSGTelemetry.h */; };
+		017DCF902874212F000ECB22 /* BSGTelemetry.m in Sources */ = {isa = PBXBuildFile; fileRef = 017DCF8B2874212F000ECB22 /* BSGTelemetry.m */; };
+		017DCF912874212F000ECB22 /* BSGTelemetry.m in Sources */ = {isa = PBXBuildFile; fileRef = 017DCF8B2874212F000ECB22 /* BSGTelemetry.m */; };
+		017DCF922874212F000ECB22 /* BSGTelemetry.m in Sources */ = {isa = PBXBuildFile; fileRef = 017DCF8B2874212F000ECB22 /* BSGTelemetry.m */; };
+		017DCF932874212F000ECB22 /* BSGTelemetry.m in Sources */ = {isa = PBXBuildFile; fileRef = 017DCF8B2874212F000ECB22 /* BSGTelemetry.m */; };
+		017DCF942874212F000ECB22 /* BSGTelemetry.m in Sources */ = {isa = PBXBuildFile; fileRef = 017DCF8B2874212F000ECB22 /* BSGTelemetry.m */; };
+		017DCF9B287422BB000ECB22 /* BSGTelemetryTests.m in Sources */ = {isa = PBXBuildFile; fileRef = 017DCF9A287422BB000ECB22 /* BSGTelemetryTests.m */; };
+		017DCF9C287422BB000ECB22 /* BSGTelemetryTests.m in Sources */ = {isa = PBXBuildFile; fileRef = 017DCF9A287422BB000ECB22 /* BSGTelemetryTests.m */; };
+		017DCF9D287422BB000ECB22 /* BSGTelemetryTests.m in Sources */ = {isa = PBXBuildFile; fileRef = 017DCF9A287422BB000ECB22 /* BSGTelemetryTests.m */; };
+		017DCF9E287422BB000ECB22 /* BSGTelemetryTests.m in Sources */ = {isa = PBXBuildFile; fileRef = 017DCF9A287422BB000ECB22 /* BSGTelemetryTests.m */; };
 		01840B6F25DC26E200F95648 /* BSGEventUploader.h in Headers */ = {isa = PBXBuildFile; fileRef = 01840B6D25DC26E200F95648 /* BSGEventUploader.h */; };
 		01840B7025DC26E200F95648 /* BSGEventUploader.h in Headers */ = {isa = PBXBuildFile; fileRef = 01840B6D25DC26E200F95648 /* BSGEventUploader.h */; };
 		01840B7125DC26E200F95648 /* BSGEventUploader.h in Headers */ = {isa = PBXBuildFile; fileRef = 01840B6D25DC26E200F95648 /* BSGEventUploader.h */; };
@@ -1578,6 +1591,9 @@
 		016875C4258D003200DFFF69 /* NSUserDefaultsStub.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; path = NSUserDefaultsStub.h; sourceTree = "<group>"; };
 		016875C5258D003200DFFF69 /* NSUserDefaultsStub.m */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.objc; path = NSUserDefaultsStub.m; sourceTree = "<group>"; };
 		017824BD262D65A000D18AFA /* Bugsnag.xcconfig */ = {isa = PBXFileReference; lastKnownFileType = text.xcconfig; path = Bugsnag.xcconfig; sourceTree = "<group>"; };
+		017DCF8A2874212F000ECB22 /* BSGTelemetry.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; path = BSGTelemetry.h; sourceTree = "<group>"; };
+		017DCF8B2874212F000ECB22 /* BSGTelemetry.m */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.objc; path = BSGTelemetry.m; sourceTree = "<group>"; };
+		017DCF9A287422BB000ECB22 /* BSGTelemetryTests.m */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.objc; path = BSGTelemetryTests.m; sourceTree = "<group>"; };
 		01840B6D25DC26E200F95648 /* BSGEventUploader.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; path = BSGEventUploader.h; sourceTree = "<group>"; };
 		01840B6E25DC26E200F95648 /* BSGEventUploader.m */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.objc; path = BSGEventUploader.m; sourceTree = "<group>"; };
 		01847D942644140F00ADA4C7 /* BSGInternalErrorReporter.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = BSGInternalErrorReporter.h; sourceTree = "<group>"; };
@@ -2030,6 +2046,7 @@
 				0163BF5825823D8D008DC28B /* BSGNotificationBreadcrumbsTests.m */,
 				008966C82486D43600DC48C2 /* BSGOutOfMemoryTests.m */,
 				CB6419AA25A73E8C00613D25 /* BSGStorageMigratorTests.m */,
+				017DCF9A287422BB000ECB22 /* BSGTelemetryTests.m */,
 				01DE903B26CEAF9E00455213 /* BSGUtilsTests.m */,
 				CB9103632502320A00E9D1E2 /* BugsnagApiClientTest.m */,
 				E701FA9E2490EF4A008D842F /* BugsnagApiValidationTest.m */,
@@ -2169,6 +2186,8 @@
 				0154E20128070AEA009044E4 /* BSGRunContext.m */,
 				008968112486DA5600DC48C2 /* BSGSerialization.h */,
 				008968162486DA5600DC48C2 /* BSGSerialization.m */,
+				017DCF8A2874212F000ECB22 /* BSGTelemetry.h */,
+				017DCF8B2874212F000ECB22 /* BSGTelemetry.m */,
 				0140D24725765F8F00FD0306 /* BSGUIKit.h */,
 				01B79DA7267CC4A000C8CC5E /* BSGUtils.h */,
 				01B79DA8267CC4A000C8CC5E /* BSGUtils.m */,
@@ -2340,6 +2359,7 @@
 				3A700A9A24A63AC60068CD1B /* BSG_KSCrashReportWriter.h in Headers */,
 				3A700A9B24A63AC60068CD1B /* BugsnagErrorTypes.h in Headers */,
 				01847D962644140F00ADA4C7 /* BSGInternalErrorReporter.h in Headers */,
+				017DCF8C2874212F000ECB22 /* BSGTelemetry.h in Headers */,
 				01840B6F25DC26E200F95648 /* BSGEventUploader.h in Headers */,
 				3A700A9C24A63AC60068CD1B /* BugsnagEvent.h in Headers */,
 				CB4C83BE280FFB0500E7E2BD /* BSGDefines.h in Headers */,
@@ -2443,6 +2463,7 @@
 				3A700AAE24A63CFD0068CD1B /* BSG_KSCrashReportWriter.h in Headers */,
 				3A700AAF24A63CFD0068CD1B /* BugsnagErrorTypes.h in Headers */,
 				01847D972644140F00ADA4C7 /* BSGInternalErrorReporter.h in Headers */,
+				017DCF8D2874212F000ECB22 /* BSGTelemetry.h in Headers */,
 				01840B7025DC26E200F95648 /* BSGEventUploader.h in Headers */,
 				3A700AB024A63CFD0068CD1B /* BugsnagEvent.h in Headers */,
 				CB4C83BF280FFB0600E7E2BD /* BSGDefines.h in Headers */,
@@ -2546,6 +2567,7 @@
 				3A700AC224A63D110068CD1B /* BSG_KSCrashReportWriter.h in Headers */,
 				3A700AC324A63D110068CD1B /* BugsnagErrorTypes.h in Headers */,
 				01847D982644140F00ADA4C7 /* BSGInternalErrorReporter.h in Headers */,
+				017DCF8E2874212F000ECB22 /* BSGTelemetry.h in Headers */,
 				01840B7125DC26E200F95648 /* BSGEventUploader.h in Headers */,
 				3A700AC424A63D110068CD1B /* BugsnagEvent.h in Headers */,
 				CB4C83C0280FFB0600E7E2BD /* BSGDefines.h in Headers */,
@@ -2678,6 +2700,7 @@
 				CBBDE96C2800693F0070DCD3 /* BugsnagHandledState.h in Headers */,
 				CBBDE911280068560070DCD3 /* BSGCrashSentry.h in Headers */,
 				CBBDE9922800698F0070DCD3 /* BSG_KSSystemInfo.h in Headers */,
+				017DCF8F2874212F000ECB22 /* BSGTelemetry.h in Headers */,
 				CBBDE91A280068780070DCD3 /* BSGNotificationBreadcrumbs.h in Headers */,
 				CBBDE92B280068AD0070DCD3 /* BugsnagApiClient.h in Headers */,
 				CBBDE98B2800698F0070DCD3 /* BSG_KSCrashNames.h in Headers */,
@@ -3109,6 +3132,7 @@
 				008969B12486DAD100DC48C2 /* BSG_KSMach_x86_64.c in Sources */,
 				0089696C2486DAD000DC48C2 /* BSG_KSJSONCodecObjC.m in Sources */,
 				008969B72486DAD100DC48C2 /* BSG_KSSignalInfo.c in Sources */,
+				017DCF902874212F000ECB22 /* BSGTelemetry.m in Sources */,
 				008968992486DA9600DC48C2 /* BugsnagStackframe.m in Sources */,
 				00896A022486DAD100DC48C2 /* BSG_KSCrashSentry_NSException.m in Sources */,
 				008967D32486DA2D00DC48C2 /* BugsnagEndpointConfiguration.m in Sources */,
@@ -3174,6 +3198,7 @@
 				008967512486D43700DC48C2 /* BSGOutOfMemoryTests.m in Sources */,
 				E701FA9F2490EF4A008D842F /* BugsnagApiValidationTest.m in Sources */,
 				008967902486D43700DC48C2 /* KSJSONCodec_Tests.m in Sources */,
+				017DCF9B287422BB000ECB22 /* BSGTelemetryTests.m in Sources */,
 				008967722486D43700DC48C2 /* KSSysCtl_Tests.m in Sources */,
 				0089676C2486D43700DC48C2 /* BugsnagTestsDummyClass.m in Sources */,
 				008966EB2486D43700DC48C2 /* BugsnagDeviceTest.m in Sources */,
@@ -3283,6 +3308,7 @@
 				0126F7BF25DD512B008483C2 /* BSGEventUploadKSCrashReportOperation.m in Sources */,
 				0089696D2486DAD000DC48C2 /* BSG_KSJSONCodecObjC.m in Sources */,
 				CB3744982845FA9500A3955E /* BSG_KSCrashStringConversion.c in Sources */,
+				017DCF912874212F000ECB22 /* BSGTelemetry.m in Sources */,
 				008969B82486DAD100DC48C2 /* BSG_KSSignalInfo.c in Sources */,
 				0089689A2486DA9600DC48C2 /* BugsnagStackframe.m in Sources */,
 				00896A032486DAD100DC48C2 /* BSG_KSCrashSentry_NSException.m in Sources */,
@@ -3416,6 +3442,7 @@
 				01C17AE82542ED7F00C102C9 /* KSCrashReportWriterTests.m in Sources */,
 				00896A412486DBDD00DC48C2 /* BSGConfigurationBuilderTests.m in Sources */,
 				008967672486D43700DC48C2 /* BugsnagNotifierTest.m in Sources */,
+				017DCF9C287422BB000ECB22 /* BSGTelemetryTests.m in Sources */,
 				0089676D2486D43700DC48C2 /* BugsnagTestsDummyClass.m in Sources */,
 				008967402486D43700DC48C2 /* BugsnagAppTest.m in Sources */,
 				E701FAA82490EF77008D842F /* ClientApiValidationTest.m in Sources */,
@@ -3454,6 +3481,7 @@
 				0126F7C025DD512B008483C2 /* BSGEventUploadKSCrashReportOperation.m in Sources */,
 				0089696E2486DAD000DC48C2 /* BSG_KSJSONCodecObjC.m in Sources */,
 				008969B92486DAD100DC48C2 /* BSG_KSSignalInfo.c in Sources */,
+				017DCF922874212F000ECB22 /* BSGTelemetry.m in Sources */,
 				0089689B2486DA9600DC48C2 /* BugsnagStackframe.m in Sources */,
 				00896A042486DAD100DC48C2 /* BSG_KSCrashSentry_NSException.m in Sources */,
 				008967D52486DA2D00DC48C2 /* BugsnagEndpointConfiguration.m in Sources */,
@@ -3591,6 +3619,7 @@
 				0187D464255BD7B800C503D9 /* BugsnagApiClientTest.m in Sources */,
 				0089676E2486D43700DC48C2 /* BugsnagTestsDummyClass.m in Sources */,
 				008967412486D43700DC48C2 /* BugsnagAppTest.m in Sources */,
+				017DCF9D287422BB000ECB22 /* BSGTelemetryTests.m in Sources */,
 				008967052486D43700DC48C2 /* BugsnagThreadSerializationTest.m in Sources */,
 				008966FF2486D43700DC48C2 /* BugsnagOnBreadcrumbTest.m in Sources */,
 			);
@@ -3605,6 +3634,7 @@
 				E7462909248907E500F92D67 /* BSG_KSMach_x86_32.c in Sources */,
 				E746290B248907E500F92D67 /* BSG_KSMach_Arm.c in Sources */,
 				0126F7B125DD5118008483C2 /* BSGEventUploadFileOperation.m in Sources */,
+				017DCF942874212F000ECB22 /* BSGTelemetry.m in Sources */,
 				E746290C248907E500F92D67 /* BSG_KSJSONCodec.c in Sources */,
 				E746290D248907E500F92D67 /* BSG_KSMach.c in Sources */,
 				010993A2273D13D800128BBE /* BSGFeatureFlagStore.m in Sources */,
@@ -3724,6 +3754,7 @@
 				CBBDE9672800691E0070DCD3 /* BugsnagDevice.m in Sources */,
 				CBBDE9812800698F0070DCD3 /* BSG_KSFile.c in Sources */,
 				018F050B284E49E4004EA50D /* BSG_KSCrashStringConversion.c in Sources */,
+				017DCF932874212F000ECB22 /* BSGTelemetry.m in Sources */,
 				CBBDE977280069670070DCD3 /* BSGFileLocations.m in Sources */,
 				CBBDE90F280068560070DCD3 /* BugsnagFeatureFlag.m in Sources */,
 				CBBDE96F2800693F0070DCD3 /* BugsnagSession.m in Sources */,
@@ -3800,6 +3831,7 @@
 				CB28F0C8282A49F8003AB200 /* BugsnagTestsDummyClass.m in Sources */,
 				CB28F0C9282A4A19003AB200 /* BugsnagApiValidationTest.m in Sources */,
 				CB28F127282A7DB0003AB200 /* ConfigurationApiValidationTest.m in Sources */,
+				017DCF9E287422BB000ECB22 /* BSGTelemetryTests.m in Sources */,
 				CB28F0AC28294D4F003AB200 /* KSString_Tests.m in Sources */,
 				CB28F0B828294DE1003AB200 /* BSGConfigurationBuilderTests.m in Sources */,
 				CB28F0DB282A4BA6003AB200 /* BugsnagMetadataTests.m in Sources */,

--- a/Bugsnag/Breadcrumbs/BugsnagBreadcrumbs.m
+++ b/Bugsnag/Breadcrumbs/BugsnagBreadcrumbs.m
@@ -121,9 +121,7 @@ static struct bsg_breadcrumb_list_item *g_breadcrumbs_head;
     if (!newItem) {
         return;
     }
-    [data enumerateByteRangesUsingBlock:^(const void *bytes, NSRange byteRange, __unused BOOL *stop) {
-        memcpy(newItem->jsonData + byteRange.location, bytes, byteRange.length);
-    }];
+    [data getBytes:newItem->jsonData length:data.length];
     
     @synchronized (self) {
         const unsigned int fileNumber = self.nextFileNumber;

--- a/Bugsnag/Client/BugsnagClient.m
+++ b/Bugsnag/Client/BugsnagClient.m
@@ -40,6 +40,7 @@
 #import "BSGNotificationBreadcrumbs.h"
 #import "BSGRunContext.h"
 #import "BSGSerialization.h"
+#import "BSGTelemetry.h"
 #import "BSGUIKit.h"
 #import "BSGUtils.h"
 #import "BSG_KSCrashC.h"
@@ -77,6 +78,8 @@ static struct {
     // Contains notifier state under "deviceState", and crash-specific
     // information under "crash".
     char *stateJSON;
+    // Usage telemetry, from BSGTelemetryCreateUsage()
+    char *usageJSON;
     // User onCrash handler
     void (*onCrash)(const BSG_KSCrashReportWriter *writer);
 } bsg_g_bugsnag_data;
@@ -119,6 +122,10 @@ void BSSerializeDataCrashHandler(const BSG_KSCrashReportWriter *writer) {
         if (fd > -1) {
             close(fd);
         }
+    }
+
+    if (bsg_g_bugsnag_data.usageJSON) {
+        writer->addJSONElement(writer, "usage", bsg_g_bugsnag_data.usageJSON);
     }
 
     if (bsg_g_bugsnag_data.onCrash) {
@@ -215,6 +222,11 @@ __attribute__((annotate("oclint:suppress[too many methods]")))
     self.systemState = [[BugsnagSystemState alloc] initWithConfiguration:self.configuration];
 
     [self computeDidCrashLastLaunch];
+
+    NSDictionary *usage = BSGTelemetryCreateUsage(self.configuration);
+    if (usage) {
+        bsg_g_bugsnag_data.usageJSON = BSGCStringWithData(BSGJSONDataFromDictionary(usage, NULL));
+    }
 
     // These files can only be overwritten once the previous contents have been read; see -generateEventForLastLaunchWithError:
     NSData *configData = BSGJSONDataFromDictionary(self.configuration.dictionaryRepresentation, NULL);
@@ -731,6 +743,8 @@ __attribute__((annotate("oclint:suppress[too many methods]")))
 
     [self.sessionTracker incrementEventCountUnhandled:event.handledState.unhandled];
     event.session = self.sessionTracker.runningSession;
+
+    event.usage = BSGTelemetryCreateUsage(self.configuration);
 
     if (event.unhandled) {
         // Unhandled Javscript exceptions from React Native result in the app being terminated shortly after the

--- a/Bugsnag/Client/BugsnagClient.m
+++ b/Bugsnag/Client/BugsnagClient.m
@@ -219,9 +219,7 @@ __attribute__((annotate("oclint:suppress[too many methods]")))
     // These files can only be overwritten once the previous contents have been read; see -generateEventForLastLaunchWithError:
     NSData *configData = BSGJSONDataFromDictionary(self.configuration.dictionaryRepresentation, NULL);
     [configData writeToFile:BSGFileLocations.current.configuration options:NSDataWritingAtomic error:nil];
-    if ((bsg_g_bugsnag_data.configJSON = calloc(1, configData.length + 1))) {
-        memcpy(bsg_g_bugsnag_data.configJSON, configData.bytes, configData.length);
-    }
+    bsg_g_bugsnag_data.configJSON = BSGCStringWithData(configData);
     [self.metadata setStorageBuffer:&bsg_g_bugsnag_data.metadataJSON file:BSGFileLocations.current.metadata];
     [self.state setStorageBuffer:&bsg_g_bugsnag_data.stateJSON file:BSGFileLocations.current.state];
     [self.breadcrumbs removeAllBreadcrumbs];

--- a/Bugsnag/Configuration/BugsnagConfiguration.m
+++ b/Bugsnag/Configuration/BugsnagConfiguration.m
@@ -210,7 +210,7 @@ static NSUserDefaults *userDefaults;
                                          defaultSessionConfiguration]];
     }
     
-    _telemetry = BSGTelemetryInternalErrors;
+    _telemetry = BSGTelemetryAll;
     
     NSString *releaseStage = nil;
     #if DEBUG

--- a/Bugsnag/Helpers/BSGKeys.h
+++ b/Bugsnag/Helpers/BSGKeys.h
@@ -108,6 +108,7 @@ static BSGKey const BSGKeyUnhandled                 = @"unhandled";
 static BSGKey const BSGKeyUnhandledCount            = @"unhandledCount";
 static BSGKey const BSGKeyUnhandledOverridden       = @"unhandledOverridden";
 static BSGKey const BSGKeyUrl                       = @"url";
+static BSGKey const BSGKeyUsage                     = @"usage";
 static BSGKey const BSGKeyUser                      = @"user";
 static BSGKey const BSGKeyUuid                      = @"uuid";
 static BSGKey const BSGKeyVariant                   = @"variant";

--- a/Bugsnag/Helpers/BSGTelemetry.h
+++ b/Bugsnag/Helpers/BSGTelemetry.h
@@ -1,0 +1,15 @@
+//
+//  BSGTelemetry.h
+//  Bugsnag
+//
+//  Created by Nick Dowell on 05/07/2022.
+//  Copyright © 2022 Bugsnag Inc. All rights reserved.
+//
+
+#import <Bugsnag/BugsnagConfiguration.h>
+
+NS_ASSUME_NONNULL_BEGIN
+
+NSDictionary *_Nullable BSGTelemetryCreateUsage(BugsnagConfiguration *configuration);
+
+NS_ASSUME_NONNULL_END

--- a/Bugsnag/Helpers/BSGTelemetry.m
+++ b/Bugsnag/Helpers/BSGTelemetry.m
@@ -1,0 +1,117 @@
+//
+//  BSGTelemetry.m
+//  Bugsnag
+//
+//  Created by Nick Dowell on 05/07/2022.
+//  Copyright © 2022 Bugsnag Inc. All rights reserved.
+//
+
+#import "BSGTelemetry.h"
+
+#import "BSGDefines.h"
+#import "BugsnagConfiguration+Private.h"
+#import "BugsnagErrorTypes.h"
+
+static NSNumber *_Nullable BooleanValue(BOOL actual, BOOL defaultValue) {
+    return actual != defaultValue ? (actual ? @YES : @NO) : nil;
+}
+
+static NSNumber *_Nullable IntegerValue(NSUInteger actual, NSUInteger defaultValue) {
+    return actual != defaultValue ? @(actual) : nil;
+}
+
+static NSDictionary * ConfigValue(BugsnagConfiguration *configuration) {
+    NSMutableDictionary *config = [NSMutableDictionary dictionary];
+    
+    BugsnagConfiguration *defaults = [[BugsnagConfiguration alloc] initWithApiKey:nil]; 
+    
+#if BSG_HAVE_APP_HANG_DETECTION
+    config[@"appHangThresholdMillis"] = IntegerValue(configuration.appHangThresholdMillis, defaults.appHangThresholdMillis);
+#endif
+    
+    config[@"autoDetectErrors"] = BooleanValue(configuration.autoDetectErrors, defaults.autoDetectErrors);
+    config[@"autoTrackSessions"] = BooleanValue(configuration.autoTrackSessions, defaults.autoTrackSessions);
+    config[@"discardClassesCount"] = IntegerValue(configuration.discardClasses.count, 0);
+    config[@"launchDurationMillis"] = IntegerValue(configuration.launchDurationMillis, defaults.launchDurationMillis);
+    config[@"maxBreadcrumbs"] = IntegerValue(configuration.maxBreadcrumbs, defaults.maxBreadcrumbs);
+    config[@"maxPersistedEvents"] = IntegerValue(configuration.maxPersistedEvents, defaults.maxPersistedEvents);
+    config[@"maxPersistedSessions"] = IntegerValue(configuration.maxPersistedSessions, defaults.maxPersistedSessions);
+    config[@"persistUser"] = BooleanValue(configuration.persistUser, defaults.persistUser);
+    config[@"pluginCount"] = IntegerValue(configuration.plugins.count, 0);
+    
+    BSGEnabledBreadcrumbType enabledBreadcrumbTypes = configuration.enabledBreadcrumbTypes;
+    if (enabledBreadcrumbTypes != defaults.enabledBreadcrumbTypes) {
+        NSMutableArray *array = [NSMutableArray array];
+        if (enabledBreadcrumbTypes & BSGEnabledBreadcrumbTypeError)         { [array addObject:@"error"]; }
+        if (enabledBreadcrumbTypes & BSGEnabledBreadcrumbTypeLog)           { [array addObject:@"log"]; }
+        if (enabledBreadcrumbTypes & BSGEnabledBreadcrumbTypeNavigation)    { [array addObject:@"navigation"]; }
+        if (enabledBreadcrumbTypes & BSGEnabledBreadcrumbTypeProcess)       { [array addObject:@"process"]; }
+        if (enabledBreadcrumbTypes & BSGEnabledBreadcrumbTypeRequest)       { [array addObject:@"request"]; }
+        if (enabledBreadcrumbTypes & BSGEnabledBreadcrumbTypeState)         { [array addObject:@"state"]; }
+        if (enabledBreadcrumbTypes & BSGEnabledBreadcrumbTypeUser)          { [array addObject:@"user"]; }
+        config[@"enabledBreadcrumbTypes"] = [array componentsJoinedByString:@","];
+    }
+    
+    BugsnagErrorTypes *enabledErrorTypes = configuration.enabledErrorTypes;
+    if (!enabledErrorTypes.cppExceptions ||
+#if !TARGET_OS_WATCH
+        !enabledErrorTypes.appHangs ||
+        !enabledErrorTypes.ooms ||
+        !enabledErrorTypes.thermalKills ||
+        !enabledErrorTypes.signals ||
+        !enabledErrorTypes.machExceptions ||
+#endif
+        !enabledErrorTypes.unhandledExceptions ||
+        !enabledErrorTypes.unhandledRejections) {
+        NSMutableArray *array = [NSMutableArray array];
+#if !TARGET_OS_WATCH
+        if (enabledErrorTypes.appHangs)             { [array addObject:@"appHangs"]; }
+        if (enabledErrorTypes.machExceptions)       { [array addObject:@"machExceptions"]; }
+        if (enabledErrorTypes.ooms)                 { [array addObject:@"ooms"]; }
+        if (enabledErrorTypes.signals)              { [array addObject:@"signals"]; }
+        if (enabledErrorTypes.thermalKills)         { [array addObject:@"thermalKills"]; }
+#endif
+        if (enabledErrorTypes.cppExceptions)        { [array addObject:@"cppExceptions"]; }
+        if (enabledErrorTypes.unhandledExceptions)  { [array addObject:@"unhandledExceptions"]; }
+        if (enabledErrorTypes.unhandledRejections)  { [array addObject:@"unhandledRejections"]; }
+        [array sortedArrayUsingSelector:@selector(compare:)];
+        config[@"enabledErrorTypes"] = [array componentsJoinedByString:@","];
+    }
+    
+#if BSG_HAVE_MACH_THREADS
+    if (configuration.sendThreads != defaults.sendThreads) {
+        switch (configuration.sendThreads) {
+            case BSGThreadSendPolicyAlways:
+                config[@"sendThreads"] = @"always";
+                break;
+            case BSGThreadSendPolicyUnhandledOnly:
+                config[@"sendThreads"] = @"unhandledOnly";
+                break;
+            case BSGThreadSendPolicyNever:
+                config[@"sendThreads"] = @"never";
+                break;
+            default:
+                break;
+        }
+    }
+#endif
+    
+    return config;
+}
+
+NSDictionary * BSGTelemetryCreateUsage(BugsnagConfiguration *configuration) {
+    if (!(configuration.telemetry & BSGTelemetryUsage)) {
+        return nil;
+    }
+    
+    NSMutableDictionary *callbacks = [NSMutableDictionary dictionary];
+    callbacks[@"onBreadcrumb"] = IntegerValue(configuration.onBreadcrumbBlocks.count, 0);
+    callbacks[@"onCrashHandler"] = configuration.onCrashHandler ? @1 : nil;
+    callbacks[@"onSendError"] = IntegerValue(configuration.onSendBlocks.count, 0);
+    callbacks[@"onSession"] = IntegerValue(configuration.onSessionBlocks.count, 0);
+    
+    return @{
+        @"callbacks": callbacks,
+        @"config": ConfigValue(configuration)
+    };
+}

--- a/Bugsnag/Helpers/BSGTelemetry.m
+++ b/Bugsnag/Helpers/BSGTelemetry.m
@@ -9,6 +9,7 @@
 #import "BSGTelemetry.h"
 
 #import "BSGDefines.h"
+#import "BSG_KSMachHeaders.h"
 #import "BugsnagConfiguration+Private.h"
 #import "BugsnagErrorTypes.h"
 
@@ -18,6 +19,10 @@ static NSNumber *_Nullable BooleanValue(BOOL actual, BOOL defaultValue) {
 
 static NSNumber *_Nullable IntegerValue(NSUInteger actual, NSUInteger defaultValue) {
     return actual != defaultValue ? @(actual) : nil;
+}
+
+static BOOL IsStaticallyLinked(void) {
+    return bsg_mach_headers_get_self_image() == bsg_mach_headers_get_main_image();
 }
 
 static NSDictionary * ConfigValue(BugsnagConfiguration *configuration) {
@@ -38,6 +43,7 @@ static NSDictionary * ConfigValue(BugsnagConfiguration *configuration) {
     config[@"maxPersistedSessions"] = IntegerValue(configuration.maxPersistedSessions, defaults.maxPersistedSessions);
     config[@"persistUser"] = BooleanValue(configuration.persistUser, defaults.persistUser);
     config[@"pluginCount"] = IntegerValue(configuration.plugins.count, 0);
+    config[@"staticallyLinked"] = BooleanValue(IsStaticallyLinked(), NO);
     
     BSGEnabledBreadcrumbType enabledBreadcrumbTypes = configuration.enabledBreadcrumbTypes;
     if (enabledBreadcrumbTypes != defaults.enabledBreadcrumbTypes) {

--- a/Bugsnag/Helpers/BSGUtils.h
+++ b/Bugsnag/Helpers/BSGUtils.h
@@ -9,14 +9,14 @@
 #import <Foundation/Foundation.h>
 
 #import "BSGDefines.h"
-
-#if TARGET_OS_IOS
 #import "BSGUIKit.h"
-#endif
 
 __BEGIN_DECLS
 
 NS_ASSUME_NONNULL_BEGIN
+
+/// Returns a heap allocated null-terminated C string with the contents of `data`, or NULL if `data` is nil or empty.
+BSG_PRIVATE char *_Nullable BSGCStringWithData(NSData *_Nullable data);
 
 /// Changes the NSFileProtectionKey attribute of the specified file or directory from NSFileProtectionComplete to NSFileProtectionCompleteUnlessOpen.
 /// Has no effect if the specified file or directory does not have NSFileProtectionComplete.

--- a/Bugsnag/Helpers/BSGUtils.m
+++ b/Bugsnag/Helpers/BSGUtils.m
@@ -10,6 +10,15 @@
 
 #import "BugsnagLogger.h"
 
+char *_Nullable BSGCStringWithData(NSData *_Nullable data) {
+    char *buffer;
+    if (data.length && (buffer = calloc(1, data.length + 1))) {
+        [data getBytes:buffer length:data.length];
+        return buffer;
+    }
+    return NULL;
+}
+
 BOOL BSGDisableNSFileProtectionComplete(NSString *path) {
     // Using NSFileProtection* causes run-time link errors on older versions of macOS.
     // NSURLFileProtectionKey is unavailable in macOS SDKs prior to 11.0

--- a/Bugsnag/Metadata/BugsnagMetadata.m
+++ b/Bugsnag/Metadata/BugsnagMetadata.m
@@ -257,13 +257,10 @@
 // Metadata is stored in memory as a JSON encoded C string so that it is accessible at crash time.
 //
 - (void)writeData:(NSData *)data toBuffer:(char **)buffer {
-    char *newbuffer = calloc(1, data.length + 1);
+    char *newbuffer = BSGCStringWithData(data);
     if (!newbuffer) {
         return;
     }
-    [data enumerateByteRangesUsingBlock:^(const void * _Nonnull bytes, NSRange byteRange, __unused BOOL * _Nonnull stop) {
-        memcpy(newbuffer + byteRange.location, bytes, byteRange.length);
-    }];
     char *oldbuffer = *buffer;
     *buffer = newbuffer;
     free(oldbuffer);

--- a/Bugsnag/Payload/BugsnagEvent+Private.h
+++ b/Bugsnag/Payload/BugsnagEvent+Private.h
@@ -46,6 +46,9 @@ NS_ASSUME_NONNULL_BEGIN
 /// An array of string representations of BSGErrorType describing the types of stackframe / stacktrace in this error.
 @property (readonly, nonatomic) NSArray<NSString *> *stacktraceTypes;
 
+/// Usage telemetry info, from BSGTelemetryCreateUsage()
+@property (readwrite, nullable, nonatomic) NSDictionary *usage;
+
 @property (readwrite, nonnull, nonatomic) BugsnagUser *user;
 
 - (instancetype)initWithApp:(BugsnagAppWithState *)app

--- a/Bugsnag/Payload/BugsnagEvent.m
+++ b/Bugsnag/Payload/BugsnagEvent.m
@@ -208,6 +208,8 @@ NSDictionary *BSGParseCustomException(NSDictionary *report,
             return [BugsnagThread threadFromJson:dict];
         }) ?: @[];
 
+        _usage = BSGDeserializeDict(json[BSGKeyUsage]);
+
         _user = BSGDeserializeObject(json[BSGKeyUser], ^id _Nullable(NSDictionary * _Nonnull dict) {
             return [[BugsnagUser alloc] initWithDictionary:dict];
         }) ?: [[BugsnagUser alloc] init];
@@ -393,6 +395,7 @@ NSDictionary *BSGParseCustomException(NSDictionary *report,
     obj.customException = BSGParseCustomException(event, [errors[0].errorClass copy], [errors[0].errorMessage copy]);
     obj.error = error;
     obj.depth = depth;
+    obj.usage = [event valueForKeyPath:@"user.usage"];
     return obj;
 }
 
@@ -616,6 +619,8 @@ NSDictionary *BSGParseCustomException(NSDictionary *report,
     event[BSGKeyUser] = [self.user toJson];
 
     event[BSGKeySession] = self.session ? BSGSessionToEventJson((BugsnagSession *_Nonnull)self.session) : nil;
+
+    event[BSGKeyUsage] = self.usage;
 
     return event;
 }

--- a/Bugsnag/include/Bugsnag/BugsnagConfiguration.h
+++ b/Bugsnag/include/Bugsnag/BugsnagConfiguration.h
@@ -76,6 +76,16 @@ typedef NS_OPTIONS(NSUInteger, BSGTelemetryOptions) {
      * Errors within the Bugsnag SDK.
      */
     BSGTelemetryInternalErrors = (1UL << 0),
+
+    /**
+     * Information about how Bugsnag has been configured.
+     */
+    BSGTelemetryUsage = (1UL << 1),
+
+    /**
+     * All types of telemetry are enabled by default.
+     */
+    BSGTelemetryAll = (BSGTelemetryInternalErrors | BSGTelemetryUsage)
 };
 
 /**

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,11 @@ Changelog
 
 ## TBD
 
+### Enhancements
+
+* Send usage telemetry to Bugsnag for product improvement purposes. Can be disabled using `configuration.telemetry`.
+  [#1422](https://github.com/bugsnag/bugsnag-cocoa/pull/1422)
+
 ### Bug fixes
 
 * Prevent reporting of OOMs on simulators. 

--- a/Tests/BugsnagTests/BSGTelemetryTests.m
+++ b/Tests/BugsnagTests/BSGTelemetryTests.m
@@ -1,0 +1,110 @@
+//
+//  BSGTelemetryTests.m
+//  Bugsnag
+//
+//  Created by Nick Dowell on 05/07/2022.
+//  Copyright © 2022 Bugsnag Inc. All rights reserved.
+//
+
+#import <XCTest/XCTest.h>
+
+#import <Bugsnag/Bugsnag.h>
+
+#import "BSGTelemetry.h"
+#import "BugsnagTestConstants.h"
+
+@interface BSGTelemetryTests : XCTestCase
+
+@end
+
+@implementation BSGTelemetryTests
+
+static void OnCrashHandler(const BSG_KSCrashReportWriter *writer) {}
+
+- (BugsnagConfiguration *)createConfiguration {
+    return [[BugsnagConfiguration alloc] initWithApiKey:DUMMY_APIKEY_32CHAR_1];
+}
+
+- (void)testEmptyWhenDefault {
+    BugsnagConfiguration *configuration = [self createConfiguration];
+    XCTAssertEqualObjects(BSGTelemetryCreateUsage(configuration), (@{@"callbacks": @{}, @"config": @{}}));
+}
+
+- (void)testCallbacks {
+    BugsnagConfiguration *configuration = [self createConfiguration];
+    [configuration addOnBreadcrumbBlock:^BOOL(BugsnagBreadcrumb * _Nonnull breadcrumb) { return NO; }];
+    [configuration addOnSendErrorBlock:^BOOL(BugsnagEvent * _Nonnull event) { return NO; }];
+    [configuration addOnSessionBlock:^BOOL(BugsnagSession * _Nonnull session) { return NO; }];
+    configuration.onCrashHandler = OnCrashHandler;
+    NSDictionary *expected = @{@"config": @{},
+                               @"callbacks": @{
+                                   @"onBreadcrumb": @1,
+                                   @"onCrashHandler": @1,
+                                   @"onSendError": @1,
+                                   @"onSession": @1,
+                               }};
+    XCTAssertEqualObjects(BSGTelemetryCreateUsage(configuration), expected);
+}
+
+- (void)testConfigValues {
+    BugsnagConfiguration *configuration = [self createConfiguration];
+#if !TARGET_OS_WATCH
+    configuration.appHangThresholdMillis = 250;
+    configuration.sendThreads = BSGThreadSendPolicyUnhandledOnly;
+#endif
+    configuration.autoDetectErrors = NO;
+    configuration.autoTrackSessions = NO;
+    configuration.discardClasses = [NSSet setWithObject:@"SomeErrorClass"];
+    configuration.launchDurationMillis = 1000;
+    configuration.maxBreadcrumbs = 16;
+    configuration.maxPersistedEvents = 4;
+    configuration.maxPersistedSessions = 8;
+    configuration.persistUser = NO;
+    [configuration addPlugin:(id)[NSNull null]];
+    NSDictionary *expected = @{@"callbacks": @{},
+                               @"config": @{
+#if !TARGET_OS_WATCH
+                                   @"appHangThresholdMillis": @250,
+                                   @"sendThreads": @"unhandledOnly",
+#endif
+                                   @"autoDetectErrors": @NO,
+                                   @"autoTrackSessions": @NO,
+                                   @"discardClassesCount": @1,
+                                   @"launchDurationMillis": @1000,
+                                   @"maxBreadcrumbs": @16,
+                                   @"maxPersistedEvents": @4,
+                                   @"maxPersistedSessions": @8,
+                                   @"persistUser": @NO,
+                                   @"pluginCount": @1,
+                               }};
+    XCTAssertEqualObjects(BSGTelemetryCreateUsage(configuration), expected);
+}
+
+- (void)testEnabledBreadcrumbTypes {
+    BugsnagConfiguration *configuration = [self createConfiguration];
+    configuration.enabledBreadcrumbTypes &= ~BSGEnabledBreadcrumbTypeNavigation;
+    XCTAssertEqualObjects(BSGTelemetryCreateUsage(configuration),
+                          (@{@"callbacks": @{}, @"config": @{
+                              @"enabledBreadcrumbTypes": @"error,log,process,request,state,user"}}));
+}
+
+- (void)testEnabledErrorTypes {
+    BugsnagConfiguration *configuration = [self createConfiguration];
+    configuration.enabledErrorTypes.cppExceptions = NO;
+#if TARGET_OS_WATCH
+    NSString *expected = @"unhandledExceptions,unhandledRejections";
+#else
+    NSString *expected = @"appHangs,machExceptions,ooms,signals,thermalKills,unhandledExceptions,unhandledRejections";
+#endif
+    XCTAssertEqualObjects(BSGTelemetryCreateUsage(configuration),
+                          (@{@"callbacks": @{}, @"config": @{
+                              @"enabledErrorTypes": expected}}));
+}
+
+- (void)testNilWhenDisabled {
+    BugsnagConfiguration *configuration = [self createConfiguration];
+    configuration.telemetry &= ~BSGTelemetryUsage;
+    XCTAssertNil(BSGTelemetryCreateUsage(configuration));
+}
+
+@end

--- a/features/barebone_tests.feature
+++ b/features/barebone_tests.feature
@@ -70,6 +70,8 @@ Feature: Barebone tests
     And the event "severityReason.type" equals "handledException"
     And the event "severityReason.unhandledOverridden" is true
     And the event "unhandled" is true
+    And the event "usage.callbacks" is not null
+    And the event "usage.config" is not null
     And the event "user.email" equals "foobar@example.com"
     And the event "user.id" equals "foobar"
     And the event "user.name" equals "Foo Bar"
@@ -176,6 +178,8 @@ Feature: Barebone tests
     And on !watchOS, the event "threads.0.state" is not null
     And on watchOS, the event "threads" is an array with 0 elements
     And the event "unhandled" is true
+    And the event "usage.callbacks" is not null
+    And the event "usage.config" is not null
     And the event "user.email" equals "barfoo@example.com"
     And the event "user.id" equals "barfoo"
     And the event "user.name" equals "Bar Foo"

--- a/features/barebone_tests.feature
+++ b/features/barebone_tests.feature
@@ -72,6 +72,10 @@ Feature: Barebone tests
     And the event "unhandled" is true
     And the event "usage.callbacks" is not null
     And the event "usage.config" is not null
+    And the event "usage.config.staticallyLinked" equals the platform-dependent boolean:
+      | ios     | true  |
+      | macos   | @null |
+      | watchos | @null |
     And the event "user.email" equals "foobar@example.com"
     And the event "user.id" equals "foobar"
     And the event "user.name" equals "Foo Bar"

--- a/features/fixtures/ios/iOSTestApp.xcodeproj/project.pbxproj
+++ b/features/fixtures/ios/iOSTestApp.xcodeproj/project.pbxproj
@@ -59,6 +59,7 @@
 		01221E55282E5538008095C3 /* MaxPersistedSessionsScenario.m in Sources */ = {isa = PBXBuildFile; fileRef = 01221E54282E5538008095C3 /* MaxPersistedSessionsScenario.m */; };
 		0163BFA72583B3CF008DC28B /* DiscardClassesHandledExceptionRegexScenario.swift in Sources */ = {isa = PBXBuildFile; fileRef = 0163BFA62583B3CF008DC28B /* DiscardClassesHandledExceptionRegexScenario.swift */; };
 		017B4134276B8D9B0054C91D /* OnSendErrorPersistenceScenario.m in Sources */ = {isa = PBXBuildFile; fileRef = 017B4133276B8D9B0054C91D /* OnSendErrorPersistenceScenario.m */; };
+		017DCFA028743FB5000ECB22 /* TelemetryUsageDisabledScenario.swift in Sources */ = {isa = PBXBuildFile; fileRef = 017DCF9F28743FB5000ECB22 /* TelemetryUsageDisabledScenario.swift */; };
 		01847DD626453D4E00ADA4C7 /* InvalidCrashReportScenario.m in Sources */ = {isa = PBXBuildFile; fileRef = 01847DD526453D4E00ADA4C7 /* InvalidCrashReportScenario.m */; };
 		01AF6A53258A112F00FFC803 /* BareboneTestHandledScenario.swift in Sources */ = {isa = PBXBuildFile; fileRef = 01AF6A52258A112F00FFC803 /* BareboneTestHandledScenario.swift */; };
 		01AFCFCB282CE9F700D48D45 /* OldSessionScenario.m in Sources */ = {isa = PBXBuildFile; fileRef = 01AFCFCA282CE9F700D48D45 /* OldSessionScenario.m */; };
@@ -246,6 +247,7 @@
 		01221E54282E5538008095C3 /* MaxPersistedSessionsScenario.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; path = MaxPersistedSessionsScenario.m; sourceTree = "<group>"; };
 		0163BFA62583B3CF008DC28B /* DiscardClassesHandledExceptionRegexScenario.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = DiscardClassesHandledExceptionRegexScenario.swift; sourceTree = "<group>"; };
 		017B4133276B8D9B0054C91D /* OnSendErrorPersistenceScenario.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; path = OnSendErrorPersistenceScenario.m; sourceTree = "<group>"; };
+		017DCF9F28743FB5000ECB22 /* TelemetryUsageDisabledScenario.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = TelemetryUsageDisabledScenario.swift; sourceTree = "<group>"; };
 		01847DD526453D4E00ADA4C7 /* InvalidCrashReportScenario.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; path = InvalidCrashReportScenario.m; sourceTree = "<group>"; };
 		01AF6A52258A112F00FFC803 /* BareboneTestHandledScenario.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = BareboneTestHandledScenario.swift; sourceTree = "<group>"; };
 		01AFCFCA282CE9F700D48D45 /* OldSessionScenario.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; path = OldSessionScenario.m; sourceTree = "<group>"; };
@@ -605,6 +607,7 @@
 				8AF6FD76225E3F870056EF9E /* StopSessionOOMScenario.m */,
 				8A840FB921AF5C450041DBFA /* SwiftAssertionScenario.swift */,
 				F4295EEDC00E5ED3C166DBF0 /* SwiftCrashScenario.swift */,
+				017DCF9F28743FB5000ECB22 /* TelemetryUsageDisabledScenario.swift */,
 				01E356BF26CD5B6A00BE3F64 /* ThermalStateBreadcrumbScenario.swift */,
 				F429538D19421F28D8EB0446 /* UndefinedInstructionScenario.m */,
 				010BAB362833D2080003FF36 /* UnhandledErrorChangeInvalidReleaseStageScenario.swift */,
@@ -896,6 +899,7 @@
 				F42958BE5DDACDBF653CA926 /* ManualSessionScenario.m in Sources */,
 				010BAB1D2833CFB00003FF36 /* AppHangDidBecomeActiveScenario.swift in Sources */,
 				01AFCFCB282CE9F700D48D45 /* OldSessionScenario.m in Sources */,
+				017DCFA028743FB5000ECB22 /* TelemetryUsageDisabledScenario.swift in Sources */,
 				E7A324E8247E9D9A008B0052 /* BreadcrumbCallbackOrderScenario.swift in Sources */,
 				F42951BF19D7F35A03273CFB /* AutoSessionScenario.m in Sources */,
 				E700EE4A247D1164008CFFB6 /* UserSessionOverrideScenario.swift in Sources */,

--- a/features/fixtures/macos/macOSTestApp.xcodeproj/project.pbxproj
+++ b/features/fixtures/macos/macOSTestApp.xcodeproj/project.pbxproj
@@ -59,6 +59,7 @@
 		017D9D092833C81100B0AA87 /* UserPersistencePersistUserScenario.m in Sources */ = {isa = PBXBuildFile; fileRef = 017D9CF82833C81100B0AA87 /* UserPersistencePersistUserScenario.m */; };
 		017D9D0A2833C81100B0AA87 /* ObjCExceptionOverrideScenario.m in Sources */ = {isa = PBXBuildFile; fileRef = 017D9CF92833C81100B0AA87 /* ObjCExceptionOverrideScenario.m */; };
 		017D9D0B2833C81100B0AA87 /* CxxExceptionOverrideScenario.mm in Sources */ = {isa = PBXBuildFile; fileRef = 017D9CFB2833C81100B0AA87 /* CxxExceptionOverrideScenario.mm */; };
+		017DCFA228744035000ECB22 /* TelemetryUsageDisabledScenario.swift in Sources */ = {isa = PBXBuildFile; fileRef = 017DCFA128744035000ECB22 /* TelemetryUsageDisabledScenario.swift */; };
 		017FBFB8254B09C300809042 /* MainWindowController.m in Sources */ = {isa = PBXBuildFile; fileRef = 017FBFB6254B09C300809042 /* MainWindowController.m */; };
 		017FBFB9254B09C300809042 /* MainWindowController.xib in Resources */ = {isa = PBXBuildFile; fileRef = 017FBFB7254B09C300809042 /* MainWindowController.xib */; };
 		01847DCD26443DF000ADA4C7 /* InvalidCrashReportScenario.m in Sources */ = {isa = PBXBuildFile; fileRef = 01847DCC26443DF000ADA4C7 /* InvalidCrashReportScenario.m */; };
@@ -256,6 +257,7 @@
 		017D9CF92833C81100B0AA87 /* ObjCExceptionOverrideScenario.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; path = ObjCExceptionOverrideScenario.m; sourceTree = "<group>"; };
 		017D9CFA2833C81100B0AA87 /* spin_malloc.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = spin_malloc.h; sourceTree = "<group>"; };
 		017D9CFB2833C81100B0AA87 /* CxxExceptionOverrideScenario.mm */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.objcpp; path = CxxExceptionOverrideScenario.mm; sourceTree = "<group>"; };
+		017DCFA128744035000ECB22 /* TelemetryUsageDisabledScenario.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = TelemetryUsageDisabledScenario.swift; sourceTree = "<group>"; };
 		017FBFB5254B09C300809042 /* MainWindowController.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; path = MainWindowController.h; sourceTree = "<group>"; };
 		017FBFB6254B09C300809042 /* MainWindowController.m */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.objc; path = MainWindowController.m; sourceTree = "<group>"; };
 		017FBFB7254B09C300809042 /* MainWindowController.xib */ = {isa = PBXFileReference; lastKnownFileType = file.xib; path = MainWindowController.xib; sourceTree = "<group>"; };
@@ -558,6 +560,7 @@
 				01F47C51254B1B2D00B184AD /* StopSessionOOMScenario.m */,
 				01F47CAF254B1B3000B184AD /* SwiftAssertionScenario.swift */,
 				01F47C57254B1B2E00B184AD /* SwiftCrashScenario.swift */,
+				017DCFA128744035000ECB22 /* TelemetryUsageDisabledScenario.swift */,
 				011B7A4B26CD52080071C3EB /* ThermalStateBreadcrumbScenario.swift */,
 				01F47C9E254B1B3000B184AD /* UndefinedInstructionScenario.m */,
 				010BAB462833D34A0003FF36 /* UnhandledErrorChangeInvalidReleaseStageScenario.swift */,
@@ -761,6 +764,7 @@
 				01F47CD9254B1B3100B184AD /* SessionCallbackDiscardScenario.swift in Sources */,
 				01F47CD0254B1B3100B184AD /* StackOverflowScenario.m in Sources */,
 				01F115C727BAA67B00892B1E /* SIGPIPEIgnoredScenario.m in Sources */,
+				017DCFA228744035000ECB22 /* TelemetryUsageDisabledScenario.swift in Sources */,
 				01F7365A278D90440000113C /* NetworkBreadcrumbsScenario.swift in Sources */,
 				01F47CCA254B1B3100B184AD /* ManualSessionScenario.m in Sources */,
 				01F47D31254B1B3100B184AD /* OverwriteLinkRegisterScenario.m in Sources */,

--- a/features/fixtures/shared/scenarios/TelemetryUsageDisabledScenario.swift
+++ b/features/fixtures/shared/scenarios/TelemetryUsageDisabledScenario.swift
@@ -1,0 +1,11 @@
+class TelemetryUsageDisabledScenario: Scenario {
+    
+    override func startBugsnag() {
+        config.telemetry.remove(.usage)
+        super.startBugsnag()
+    }
+    
+    override func run() {
+        Bugsnag.notifyError(NSError(domain: "Test", code: 0))
+    }
+}

--- a/features/telemetry.feature
+++ b/features/telemetry.feature
@@ -1,4 +1,4 @@
-Feature: Internal error reporting
+Feature: Telemetry
 
   Background:
     Given I clear all persistent data
@@ -27,3 +27,8 @@ Feature: Internal error reporting
     And I set the app to "internalErrorsDisabled" mode
     And I configure Bugsnag for "InvalidCrashReportScenario"
     Then I should receive no requests
+
+  Scenario: Usage telemetry is not send if disabled
+    When I run "TelemetryUsageDisabledScenario"
+    And I wait to receive an error
+    Then the event "usage" is null


### PR DESCRIPTION
## Goal

Allow Bugsnag to determine usage of configuration options, to aid product development.

## Changeset

Adds a "usage" telemetry configuration option.

Adds a function to create a usage dictionary based on current configuration - `BSGTelemetryCreateUsage()`.

Includes `"usage"` in handled and crashing errors. OOMs and other kills intentionally out of scope.

## Testing

`BSGTelemetryCreateUsage()` is covered by new unit tests.

E2E tests verify the presence of `"usage"` and that it is omitted when the telemetry option is disabled.