### PR TITLE
[PLAT-6059] Fix empty traces in some edge cases

### DIFF
--- a/Bugsnag/KSCrash/Source/KSCrash/Recording/Tools/BSG_KSBacktrace.c
+++ b/Bugsnag/KSCrash/Source/KSCrash/Recording/Tools/BSG_KSBacktrace.c
@@ -144,13 +144,13 @@ int bsg_ksbt_backtraceThreadState(
     const uintptr_t framePtr = bsg_ksmachframePointer(machineContext);
     if (framePtr == 0 || bsg_ksmachcopyMem((void *)framePtr, &frame,
                                            sizeof(frame)) != KERN_SUCCESS) {
-        return 0;
+        return i;
     }
     for (int j = 1; j < skipEntries; j++) {
         if (frame.previous == 0 ||
             bsg_ksmachcopyMem(frame.previous, &frame, sizeof(frame)) !=
                 KERN_SUCCESS) {
-            return 0;
+            return i;
         }
     }
 


### PR DESCRIPTION
## Goal

The code was incorrectly returning 0 stack trace entries in some error edge cases when it should have been returning the current count. This is a rare edge case, but it may have been contributing to our CI flakes.

## Testing

Reran all tests.
