### PR TITLE
Support E2E code coverage on macOS

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -28,6 +28,7 @@ Podfile.lock
 .swiftpm
 Package.resolved
 /compile_commands.json
+/coverage
 /docs/
 /infer-out
 /oclint.json

--- a/Makefile
+++ b/Makefile
@@ -136,6 +136,12 @@ e2e_ios_local:
 e2e_macos:
 	./features/scripts/export_mac_app.sh
 	bundle exec maze-runner --app=macOSTestApp --os=macOS --os-version=11 $(FEATURES)
+ifeq ($(ENABLE_CODE_COVERAGE), YES)
+	xcrun llvm-profdata merge -sparse *.profraw -o default.profdata
+	rm -rf *.profraw
+	xcrun llvm-cov show -format html -output-dir coverage -instr-profile default.profdata features/fixtures/macos/output/macOSTestApp.app/Contents/Frameworks/Bugsnag.framework/Versions/A/Bugsnag -arch $(shell uname -m)
+	rm default.profdata
+endif
 
 .PHONY: e2e_watchos
 e2e_watchos: features/fixtures/watchos/Podfile.lock features/fixtures/shared/scenarios/watchos_maze_host.h

--- a/TESTING.md
+++ b/TESTING.md
@@ -55,7 +55,7 @@ Build the test iOS fixture:
     ```
 5. To run all features, omit the final argument.
 
-### Running tests on your own device
+### Running tests on your own iOS device
 
 #### Prerequisites
 
@@ -91,6 +91,21 @@ Build the test iOS fixture:
                             features/app_and_device_attributes.feature
     ```
    `<udid>` is the device Identifier found under Devices and Simulators in Xcode.
+
+### Running tests on macOS
+
+1. Use `make e2e_macos` to run tests and use the `FEATURES` environment variable to specify which tests to run:
+    ```shell script
+    make e2e_macos FEATURES='features/barebone_tests.feature features/telemetry.feature'
+    ```
+
+#### Gathering code coverage
+
+1. To create a code coverage report, set `ENABLE_CODE_COVERAGE=YES` like so:
+    ```shell script
+    make e2e_macos ENABLE_CODE_COVERAGE=YES
+    ````
+   Open `coverage/index.html` to view the coverage report.
 
 ### Running tests on Apple Watch
 

--- a/features/scripts/export_mac_app.sh
+++ b/features/scripts/export_mac_app.sh
@@ -1,6 +1,6 @@
 #!/usr/bin/env bash
 
-set -o errexit
+set -euo pipefail
 
 cd features/fixtures/macos
 
@@ -10,15 +10,26 @@ pod install
 
 echo "--- macOSTestApp: xcodebuild archive"
 
-xcrun xcodebuild \
-  -workspace macOSTestApp.xcworkspace \
-  -scheme macOSTestApp \
-  -destination generic/platform=macOS \
-  -configuration Debug \
-  -archivePath archive/macOSTestApp.xcarchive \
-  -quiet \
-  archive \
+BUILD_ARGS=(
+  -workspace macOSTestApp.xcworkspace
+  -scheme macOSTestApp
+  -destination generic/platform=macOS
+  -configuration Debug
+  -archivePath archive/macOSTestApp.xcarchive
+  -quiet
+  archive
   ONLY_ACTIVE_ARCH=NO
+)
+
+if [ "${ENABLE_CODE_COVERAGE:-}" = YES ]; then
+  BUILD_ARGS+=(
+    OTHER_CFLAGS='$(inherited) -fprofile-instr-generate -fcoverage-mapping'
+    OTHER_LDFLAGS='$(inherited) -fprofile-instr-generate'
+    OTHER_SWIFT_FLAGS='$(inherited) -profile-generate -profile-coverage-mapping'
+  )
+fi
+
+xcodebuild "${BUILD_ARGS[@]}"
 
 echo "--- macOSTestApp: xcodebuild -exportArchive"
 
@@ -34,4 +45,4 @@ cd output
 
 echo "--- macOSTestApp: zip"
 
-zip -r macOSTestApp.zip macOSTestApp.app
+zip -qr macOSTestApp.zip macOSTestApp.app

--- a/features/steps/app_steps.rb
+++ b/features/steps/app_steps.rb
@@ -142,9 +142,9 @@ def run_macos_app
     Process.waitpid $fixture_pid
   end
   $fixture_pid = Process.spawn(
-    { 'MAZE_RUNNER' => 'TRUE' },
+    { 'MAZE_RUNNER' => 'TRUE', 'LLVM_PROFILE_FILE' => '%c%p.profraw' },
     'features/fixtures/macos/output/macOSTestApp.app/Contents/MacOS/macOSTestApp',
-    %i[err out] => :close
+    %i[err out] => '/dev/null'
   )
 end
 


### PR DESCRIPTION
## Goal

Enable gathering code coverage reports for E2E testing.

## Design

Code coverage can be enabled by setting the `ENABLE_CODE_COVERAGE` environment variable to `YES`.

**Only for local running**. It doesn't seem suitable to run regular E2E CI tests with coverage enabled due to the additional instrumentation code that the compiler inserts into the binary, which could subtly change behaviour.

Further reading:
* https://clang.llvm.org/docs/SourceBasedCodeCoverage.html
* https://llvm.org/docs/CommandGuide/llvm-cov.html

## Changeset

Modifies `export_mac_app.sh` to build with code coverage when enabled.

Modifies `make e2e_macos` to process coverage data into HTML output when enabled.

Updates `app_steps.rb` to appropriately configure code coverage output via the `LLVM_PROFILE_FILE` environment variable (has no effect when instrumentation is not compiled in). Changes `%i[err out] => :close` to `%i[err out] => '/dev/null'` to fix corruption of the coverage output files.

## Testing

Tested locally and gathered coverage for a one-off [full run on CI](https://buildkite.com/bugsnag/bugsnag-cocoa/builds/5914)