### PR TITLE
[PLAT-8680] ordered feature flags

### DIFF
--- a/Bugsnag/BugsnagFeatureFlag.m
+++ b/Bugsnag/BugsnagFeatureFlag.m
@@ -26,4 +26,24 @@
     return self;
 }
 
+- (BOOL)isEqual:(id)object {
+    if (object == nil) {
+        return NO;
+    }
+
+    if (self == object) {
+        return YES;
+    }
+
+    if (![object isKindOfClass:[BugsnagFeatureFlag class]]) {
+        return NO;
+    }
+
+    BugsnagFeatureFlag *obj = (BugsnagFeatureFlag *)object;
+
+    // Ignore the variant when checking for equality. We only care if the name matches
+    // when checking for duplicates.
+    return [obj.name isEqualToString:self.name];
+}
+
 @end

--- a/Bugsnag/Client/BugsnagClient.m
+++ b/Bugsnag/Client/BugsnagClient.m
@@ -994,8 +994,8 @@ __attribute__((annotate("oclint:suppress[too many methods]")))
         };
         
         @synchronized (self.featureFlagStore) {
-            for (NSString *name in self.featureFlagStore) {
-                observer(BSGClientObserverAddFeatureFlag, [BugsnagFeatureFlag flagWithName:name variant:self.featureFlagStore[name]]);
+            for (BugsnagFeatureFlag *flag in self.featureFlagStore) {
+                observer(BSGClientObserverAddFeatureFlag, flag);
             }
         }
     } else {

--- a/Bugsnag/Helpers/BSGFeatureFlagStore.h
+++ b/Bugsnag/Helpers/BSGFeatureFlagStore.h
@@ -10,7 +10,7 @@
 
 NS_ASSUME_NONNULL_BEGIN
 
-typedef NSMutableDictionary<NSString *, id> BSGFeatureFlagStore;
+typedef NSMutableArray<BugsnagFeatureFlag *> BSGFeatureFlagStore;
 
 void BSGFeatureFlagStoreAddFeatureFlag(BSGFeatureFlagStore *store, NSString *name, NSString *_Nullable variant);
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,9 @@ Changelog
 
 ### Enhancements
 
+* Feature flags are now kept in order of insertion or modification rather than in alphabetical order.
+  [#1429](https://github.com/bugsnag/bugsnag-android/pull/1429)
+
 * Send usage telemetry to Bugsnag for product improvement purposes. Can be disabled using `configuration.telemetry`.
   [#1422](https://github.com/bugsnag/bugsnag-cocoa/pull/1422)
 

--- a/Tests/BugsnagTests/BSGFeatureFlagStoreTests.m
+++ b/Tests/BugsnagTests/BSGFeatureFlagStoreTests.m
@@ -19,27 +19,45 @@
 - (void)test {
     BSGFeatureFlagStore *store = [[BSGFeatureFlagStore alloc] init];
     XCTAssertEqualObjects(BSGFeatureFlagStoreToJSON(store), @[]);
+
+    BSGFeatureFlagStoreAddFeatureFlag(store, @"featureC", @"checked");
+    XCTAssertEqualObjects(BSGFeatureFlagStoreToJSON(store),
+                          (@[@{@"featureFlag": @"featureC", @"variant": @"checked"}]));
     
     BSGFeatureFlagStoreAddFeatureFlag(store, @"featureA", @"enabled");
     XCTAssertEqualObjects(BSGFeatureFlagStoreToJSON(store),
-                          (@[@{@"featureFlag": @"featureA", @"variant": @"enabled"}]));
-    
-    BSGFeatureFlagStoreAddFeatureFlags(store, @[[BugsnagFeatureFlag flagWithName:@"featureA"]]);
-    XCTAssertEqualObjects(BSGFeatureFlagStoreToJSON(store),
-                          @[@{@"featureFlag": @"featureA"}]);
-    
+                          (@[
+                            @{@"featureFlag": @"featureC", @"variant": @"checked"},
+                            @{@"featureFlag": @"featureA", @"variant": @"enabled"}
+                          ]));
+
     BSGFeatureFlagStoreAddFeatureFlag(store, @"featureB", nil);
     XCTAssertEqualObjects(BSGFeatureFlagStoreToJSON(store),
-                          (@[@{@"featureFlag": @"featureA"},
-                             @{@"featureFlag": @"featureB"}]));
-    
+                          (@[
+                            @{@"featureFlag": @"featureC", @"variant": @"checked"},
+                            @{@"featureFlag": @"featureA", @"variant": @"enabled"},
+                            @{@"featureFlag": @"featureB"}
+                          ]));
+
+
+    BSGFeatureFlagStoreAddFeatureFlags(store, @[[BugsnagFeatureFlag flagWithName:@"featureA"]]);
+    XCTAssertEqualObjects(BSGFeatureFlagStoreToJSON(store),
+                          (@[
+                            @{@"featureFlag": @"featureC", @"variant": @"checked"},
+                            @{@"featureFlag": @"featureB"},
+                            @{@"featureFlag": @"featureA"}
+                          ]));
+
     XCTAssertEqualObjects(BSGFeatureFlagStoreFromJSON(BSGFeatureFlagStoreToJSON(store)),
                           store);
     
-    BSGFeatureFlagStoreClear(store, @"featureA");
+    BSGFeatureFlagStoreClear(store, @"featureB");
     XCTAssertEqualObjects(BSGFeatureFlagStoreToJSON(store),
-                          @[@{@"featureFlag": @"featureB"}]);
-    
+                          (@[
+                            @{@"featureFlag": @"featureC", @"variant": @"checked"},
+                            @{@"featureFlag": @"featureA"}
+                          ]));
+
     BSGFeatureFlagStoreClear(store, nil);
     XCTAssertEqualObjects(BSGFeatureFlagStoreToJSON(store), @[]);
 }

--- a/Tests/BugsnagTests/BugsnagClientMirrorTest.m
+++ b/Tests/BugsnagTests/BugsnagClientMirrorTest.m
@@ -63,7 +63,7 @@
             @"eventUploader @16@0:8",
             @"extraRuntimeInfo @16@0:8",
             @"featureFlagStore @16@0:8",
-            @"featureFlagStore ^{NSMutableDictionary=#}16@0:8",
+            @"featureFlagStore ^{NSMutableArray=#}16@0:8",
             @"generateAppWithState: @24@0:8@16",
             @"generateDeviceWithState: @24@0:8@16",
             @"generateEventForLastLaunchWithError:handledState: @32@0:8@16@24",


### PR DESCRIPTION
## Goal

Keep feature flags in the order they were added or modified.

## Design

Change the internal representation from a dictionary to an array.

## Testing

Updated unit tests to verify ordering.
