### PR TITLE
[PLAT-8643] Fix a rare crash in `BugsnagBreadcrumbsWriteCrashReport()`

### DIFF
--- a/Bugsnag/Breadcrumbs/BugsnagBreadcrumbs.m
+++ b/Bugsnag/Breadcrumbs/BugsnagBreadcrumbs.m
@@ -18,6 +18,7 @@
 #import "BugsnagConfiguration+Private.h"
 #import "BugsnagLogger.h"
 
+#import <stdatomic.h>
 
 //
 // Breadcrumbs are stored as a linked list of JSON encoded C strings
@@ -29,7 +30,8 @@ struct bsg_breadcrumb_list_item {
     char jsonData[]; // MUST be null terminated
 };
 
-static struct bsg_breadcrumb_list_item *g_breadcrumbs_head;
+static _Atomic(struct bsg_breadcrumb_list_item *) g_breadcrumbs_head;
+static atomic_bool g_writing_crash_report;
 
 #pragma mark -
 
@@ -64,7 +66,7 @@ static struct bsg_breadcrumb_list_item *g_breadcrumbs_head;
 - (NSArray<BugsnagBreadcrumb *> *)breadcrumbs {
     NSMutableArray<BugsnagBreadcrumb *> *breadcrumbs = [NSMutableArray array];
     @synchronized (self) {
-        for (struct bsg_breadcrumb_list_item *item = g_breadcrumbs_head; item != NULL; item = item->next) {
+        for (struct bsg_breadcrumb_list_item *item = atomic_load(&g_breadcrumbs_head); item != NULL; item = item->next) {
             NSError *error = nil;
             NSData *data = [NSData dataWithBytesNoCopy:item->jsonData length:strlen(item->jsonData) freeWhenDone:NO];
             NSDictionary *JSONObject = BSGJSONDictionaryFromData(data, 0, &error);
@@ -128,20 +130,20 @@ static struct bsg_breadcrumb_list_item *g_breadcrumbs_head;
         const BOOL deleteOld = fileNumber >= self.maxBreadcrumbs;
         self.nextFileNumber = fileNumber + 1;
         
-        if (g_breadcrumbs_head) {
-            struct bsg_breadcrumb_list_item *tail = g_breadcrumbs_head;
+        struct bsg_breadcrumb_list_item *head = atomic_load(&g_breadcrumbs_head);
+        if (head) {
+            struct bsg_breadcrumb_list_item *tail = head;
             while (tail->next) {
                 tail = tail->next;
             }
             tail->next = newItem;
             if (deleteOld) {
-                struct bsg_breadcrumb_list_item *head = g_breadcrumbs_head;
-                g_breadcrumbs_head = head->next;
-                head->next = NULL;
+                atomic_store(&g_breadcrumbs_head, head->next);
+                while (atomic_load(&g_writing_crash_report)) { continue; }
                 free(head);
             }
         } else {
-            g_breadcrumbs_head = newItem;
+            atomic_store(&g_breadcrumbs_head, newItem);
         }
         
         if (!writeToDisk) {
@@ -196,8 +198,7 @@ static struct bsg_breadcrumb_list_item *g_breadcrumbs_head;
 
 - (void)removeAllBreadcrumbs {
     @synchronized (self) {
-        struct bsg_breadcrumb_list_item *item = g_breadcrumbs_head;
-        g_breadcrumbs_head = NULL;
+        struct bsg_breadcrumb_list_item *item = atomic_exchange(&g_breadcrumbs_head, NULL);
         while (item) {
             struct bsg_breadcrumb_list_item *next = item->next;
             free(item);
@@ -288,11 +289,17 @@ static struct bsg_breadcrumb_list_item *g_breadcrumbs_head;
 #pragma mark -
 
 void BugsnagBreadcrumbsWriteCrashReport(const BSG_KSCrashReportWriter *writer) {
+    atomic_store(&g_writing_crash_report, true);
+    
     writer->beginArray(writer, "breadcrumbs");
     
-    for (struct bsg_breadcrumb_list_item *item = g_breadcrumbs_head; item != NULL; item = item->next) {
+    struct bsg_breadcrumb_list_item *item = atomic_load(&g_breadcrumbs_head);
+    while (item) {
         writer->addJSONElement(writer, NULL, item->jsonData);
+        item = item->next;
     }
     
     writer->endContainer(writer);
+    
+    atomic_store(&g_writing_crash_report, false);
 }

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -16,6 +16,9 @@ Changelog
 * Prevent reporting of OOMs on simulators. 
   [#1421](https://github.com/bugsnag/bugsnag-cocoa/pull/1421)
 
+* Fix a rare crash in `BugsnagBreadcrumbsWriteCrashReport()`.
+  [#1430](https://github.com/bugsnag/bugsnag-cocoa/pull/1430)
+
 ## 6.19.0 (2022-06-29)
 
 ### Enhancements


### PR DESCRIPTION
## Goal

Fix a rare crash that has been observed in `BugsnagBreadcrumbsWriteCrashReport()`.

A small number of crashes have been seen with the signature:

```
EXC_BAD_ACCESS

0 libsystem_platform.dylib _platform_strlen
1 Bugsnag                  bsg_kscrw_i_addJSONElement
2 Bugsnag                  BugsnagBreadcrumbsWriteCrashReport
3 Bugsnag                  BSSerializeDataCrashHandler
4 Bugsnag                  bsg_kscrashreport_writeStandardReport
5 Bugsnag                  ksmachexc_i_handleExceptions
6 libsystem_pthread.dylib  _pthread_start
```

... which appears to be due to `BugsnagBreadcrumbsWriteCrashReport()` accessing breadcrumbs that have been freed.

In theory this should not occur, because all possible writer threads should be suspended while this function runs, but it's possible that a call to `thread_suspend` fails or a thread is spawned after the thread list has been captured, leading to an active writer.

## Changeset

Adds an `atomic_bool` to prevent memory being freed while `BugsnagBreadcrumbsWriteCrashReport()` is running, and makes `g_breadcrumbs_head` atomic to ensure it is fully stored before memory is freed.

## Testing

Amends `-testCrashReportWriterConcurrency` to verify that `BugsnagBreadcrumbsWriteCrashReport()` is safe to call while writer threads are running.