### PR TITLE
[PLAT-4549] Enable MallocScribble and friends for E2E

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -129,8 +129,6 @@ test-fixtures: ## Build the end-to-end test fixture
 
 e2e_ios_local:
 	@./features/scripts/export_ios_app.sh
-	# Recent Appium versions don't always uninstall the old version of the app ¯\_(ツ)_/¯
-	-ideviceinstaller --uninstall com.bugsnag.iOSTestApp
 	bundle exec maze-runner --app=features/fixtures/ios/output/iOSTestApp.ipa --farm=local --os=ios --apple-team-id=372ZUL2ZB7 --udid="$(shell idevice_id -l)" $(FEATURES)
 
 e2e_macos:

--- a/features/steps/app_steps.rb
+++ b/features/steps/app_steps.rb
@@ -142,7 +142,7 @@ def run_macos_app
     Process.waitpid $fixture_pid
   end
   $fixture_pid = Process.spawn(
-    { 'MAZE_RUNNER' => 'TRUE', 'LLVM_PROFILE_FILE' => '%c%p.profraw' },
+    $app_env,
     'features/fixtures/macos/output/macOSTestApp.app/Contents/MacOS/macOSTestApp',
     %i[err out] => '/dev/null'
   )

--- a/features/support/env.rb
+++ b/features/support/env.rb
@@ -3,10 +3,30 @@ require 'fileutils'
 BeforeAll do
   $api_key = "12312312312312312312312312312312"
 
+  $app_env = {
+    'LLVM_PROFILE_FILE' => '%c%p.profraw',
+    'MallocCheckHeapAbort' => 'TRUE',
+    'MallocCheckHeapStart' => '1000',
+    'MallocErrorAbort' => 'TRUE',
+    'MallocGuardEdges' => 'TRUE',
+    'MallocScribble' => 'TRUE',
+    'MAZE_RUNNER' => 'TRUE' }
+
   Maze.config.receive_no_requests_wait = 15
 
   # Setup a 3 minute timeout for receiving requests is STRESS_TEST env var is set
   Maze.config.receive_requests_wait = 180 unless ENV['STRESS_TEST'].nil?
+
+  if Maze.config.os == 'ios' && Maze.config.farm == :local
+    # Recent Appium versions don't always uninstall the old version of the app ¯\_(ツ)_/¯
+    system('ideviceinstaller --uninstall com.bugsnag.iOSTestApp')
+  end
+
+  if Maze.config.os == 'ios'
+    capabilities = JSON.parse(Maze.config.capabilities_option)
+    capabilities['processArguments'] = { 'env' => $app_env }
+    Maze.config.capabilities_option = JSON.dump(capabilities)
+  end
 
   # Additional require MacOS configuration
   if Maze.config.os == 'macos'


### PR DESCRIPTION
## Goal

Increase chances of catching memory access issues during E2E tests by enabling extra malloc checks.

## Changeset

Sets `MallocScribble` and other related environment variables to enable malloc checks.

## Testing

Tested locally (adding debug code to verify environment is passed as expected) and on CI.