### PR TITLE
Enable -Wundef and fix warnings

### DIFF
--- a/Bugsnag.xcconfig
+++ b/Bugsnag.xcconfig
@@ -91,7 +91,7 @@ CLANG_WARN__ARC_BRIDGE_CAST_NONARC                     = YES // -Warc-bridge-cas
 
 // Warning flags that have no dedicated Xcode build settings
 
-WARNING_CFLAGS = -Wcast-qual -Wconditional-uninitialized -Wcustom-atomic-properties -Wdirect-ivar-access -Wdocumentation-unknown-command -Wformat-nonliteral -Widiomatic-parentheses -Wimplicit-int-float-conversion -Wimport-preprocessor-directive-pedantic -Wincomplete-implementation -Wmissing-variable-declarations -Wno-unknown-warning-option -Wnonportable-include-path -Wnullable-to-nonnull-conversion -Woverriding-method-mismatch -Wpointer-sign -Wswitch-enum -Wunused-macros
+WARNING_CFLAGS = -Wcast-qual -Wconditional-uninitialized -Wcustom-atomic-properties -Wdirect-ivar-access -Wdocumentation-unknown-command -Wformat-nonliteral -Widiomatic-parentheses -Wimplicit-int-float-conversion -Wimport-preprocessor-directive-pedantic -Wincomplete-implementation -Wmissing-variable-declarations -Wno-unknown-warning-option -Wnonportable-include-path -Wnullable-to-nonnull-conversion -Woverriding-method-mismatch -Wpointer-sign -Wswitch-enum -Wundef -Wunused-macros
 
 // Some flags that were considered and rejected:
 //

--- a/Bugsnag/Breadcrumbs/BSGNotificationBreadcrumbs.m
+++ b/Bugsnag/Breadcrumbs/BSGNotificationBreadcrumbs.m
@@ -273,9 +273,8 @@
 }
 
 - (BOOL)tryAddSceneNotification:(NSNotification *)notification {
-#if !TARGET_OS_WATCH && \
-    ((defined(__IPHONE_13_0) && __IPHONE_OS_VERSION_MAX_ALLOWED >= __IPHONE_13_0) || \
-    (defined(__TVOS_13_0) && __TV_OS_VERSION_MAX_ALLOWED >= __TVOS_13_0))
+#if (TARGET_OS_IOS && defined(__IPHONE_13_0) && __IPHONE_OS_VERSION_MAX_ALLOWED >= __IPHONE_13_0) || \
+    (TARGET_OS_TV && defined(__TVOS_13_0) && __TV_OS_VERSION_MAX_ALLOWED >= __TVOS_13_0)
     if (@available(iOS 13.0, tvOS 13.0, *)) {
         if ([notification.name hasPrefix:@"UIScene"] && [notification.object isKindOfClass:UISCENE]) {
             UIScene *scene = notification.object;
@@ -304,13 +303,12 @@ static NSString *nullStringIfBlank(NSString *str) {
 - (BOOL)tryAddWindowNotification:(NSNotification *)notification {
 #if BSG_HAVE_WINDOW
 
-#if !TARGET_OS_OSX && \
-    (defined(__IPHONE_2_0) || (defined(__TVOS_9_0) && __TV_OS_VERSION_MAX_ALLOWED >= __TVOS_9_0))
+#if TARGET_OS_IOS || TARGET_OS_TV
     if ([notification.name hasPrefix:@"UIWindow"] && [notification.object isKindOfClass:UIWINDOW]) {
         UIWindow *window = notification.object;
         NSMutableDictionary *metadata = [NSMutableDictionary dictionary];
         metadata[@"description"] = nullStringIfBlank(window.description);
-#if !TARGET_OS_TV && (defined(__IPHONE_13_0) && __IPHONE_OS_VERSION_MAX_ALLOWED >= __IPHONE_13_0)
+#if TARGET_OS_IOS && defined(__IPHONE_13_0) && __IPHONE_OS_VERSION_MAX_ALLOWED >= __IPHONE_13_0
         if (@available(iOS 13.0, *)) {
             UIWindowScene *scene = window.windowScene;
             metadata[@"sceneTitle"] = nullStringIfBlank(scene.title);
@@ -327,13 +325,14 @@ static NSString *nullStringIfBlank(NSString *str) {
         return YES;
     }
 #endif
+
 #if TARGET_OS_OSX
     if ([notification.name hasPrefix:@"NSWindow"] && [notification.object isKindOfClass:NSWINDOW]) {
         NSWindow *window = notification.object;
         NSMutableDictionary *metadata = [NSMutableDictionary dictionary];
         metadata[@"description"] = nullStringIfBlank(window.description);
         metadata[@"title"] = nullStringIfBlank(window.title);
-#if defined(__MAC_11_0) && __MAC_OS_VERSION_MAX_ALLOWED >= __MAC_11_0
+#if defined(__MAC_11_0) && __MAC_OS_X_VERSION_MAX_ALLOWED >= __MAC_11_0
         if (@available(macOS 11.0, *)) {
             metadata[@"subtitle"] = nullStringIfBlank(window.subtitle);
         }

--- a/Bugsnag/Configuration/BugsnagConfiguration.m
+++ b/Bugsnag/Configuration/BugsnagConfiguration.m
@@ -213,7 +213,7 @@ static NSUserDefaults *userDefaults;
     _telemetry = BSGTelemetryAll;
     
     NSString *releaseStage = nil;
-    #if DEBUG
+    #if defined(DEBUG) && DEBUG
         releaseStage = BSGKeyDevelopment;
     #else
         releaseStage = BSGKeyProduction;

--- a/Bugsnag/Helpers/BSGAppHangDetector.m
+++ b/Bugsnag/Helpers/BSGAppHangDetector.m
@@ -140,7 +140,7 @@
             shouldReportAppHang = NO;
         }
         
-#if DEBUG
+#if defined(DEBUG) && DEBUG
         if (shouldReportAppHang && bsg_ksmachisBeingTraced()) {
             bsg_log_debug(@"Ignoring app hang because debugger is attached");
             shouldReportAppHang = NO;

--- a/Bugsnag/KSCrash/Source/KSCrash/Recording/BSG_Jailbreak.h
+++ b/Bugsnag/KSCrash/Source/KSCrash/Recording/BSG_Jailbreak.h
@@ -105,7 +105,7 @@ static inline bool bsg_local_is_insert_libraries_env_var(const char* str) {
     } \
 } while(0)
 
-#elif TARGET_CPU_X86_64 && __GCC_ASM_FLAG_OUTPUTS__
+#elif TARGET_CPU_X86_64 && defined(__GCC_ASM_FLAG_OUTPUTS__)
 #define BSG_HAS_CUSTOM_SYSCALL 1
 
 // X86_64 3-parameter syscall

--- a/Bugsnag/KSCrash/Source/KSCrash/Recording/BSG_KSSystemInfo.m
+++ b/Bugsnag/KSCrash/Source/KSCrash/Recording/BSG_KSSystemInfo.m
@@ -418,7 +418,7 @@ static NSDictionary * bsg_systemversion() {
     sysInfo[@BSG_KSSystemField_BinaryArch] = [self CPUArchForCPUType:header->cputype subType:header->cpusubtype];
     sysInfo[@BSG_KSSystemField_DeviceAppHash] = [self deviceAndAppHash];
 
-#if TARGET_OS_OSX || TARGET_OS_MACCATALYST || TARGET_OS_SIMULATOR
+#if TARGET_OS_OSX || (defined(TARGET_OS_MACCATALYST) && TARGET_OS_MACCATALYST) || TARGET_OS_SIMULATOR
     // https://developer.apple.com/documentation/apple-silicon/about-the-rosetta-translation-environment
     int proc_translated = 0;
     size_t size = sizeof(proc_translated);

--- a/Bugsnag/KSCrash/Source/KSCrash/Recording/Sentry/BSG_KSCrashSentry_MachException.c
+++ b/Bugsnag/KSCrash/Source/KSCrash/Recording/Sentry/BSG_KSCrashSentry_MachException.c
@@ -46,7 +46,7 @@
 #define kThreadPrimary "KSCrash Exception Handler (Primary)"
 #define kThreadSecondary "KSCrash Exception Handler (Secondary)"
 
-#if __LP64__
+#ifdef __LP64__
     #define MACH_ERROR_CODE_MASK 0xFFFFFFFFFFFFFFFF
 #else
     #define MACH_ERROR_CODE_MASK 0xFFFFFFFF

--- a/Bugsnag/KSCrash/Source/KSCrash/Recording/Sentry/BSG_KSCrashSentry_NSException.m
+++ b/Bugsnag/KSCrash/Source/KSCrash/Recording/Sentry/BSG_KSCrashSentry_NSException.m
@@ -182,7 +182,7 @@ static void bsg_reportException(id self, SEL _cmd, NSException *exception) {
         bsg_kscrashsentry_endHandlingCrash();
     }
 
-#if TARGET_OS_MACCATALYST
+#if defined(TARGET_OS_MACCATALYST) && TARGET_OS_MACCATALYST
     // Mac Catalyst apps continue to run after an uncaught exception is thrown
     // while handling a UI event. Our crash sentries should remain installed to
     // catch any subsequent unhandled exceptions or crashes.

--- a/Bugsnag/KSCrash/Source/KSCrash/Recording/Tools/BSG_Symbolicate.c
+++ b/Bugsnag/KSCrash/Source/KSCrash/Recording/Tools/BSG_Symbolicate.c
@@ -136,7 +136,7 @@ void bsg_symbolicate(const uintptr_t instruction_addr, struct bsg_symbolicate_re
             if (leb128_uintptr_decode(&context, data[i], &delta) && delta) {
                 addr += delta;
                 uintptr_t next_func_start = addr;
-#if __arm__
+#if defined(__arm__)
 #define THUMB_INSTRUCTION_TAG 1ul
                 // ld64 sets the least significant bit for thumb instructions, which needs to be
                 // zeroed to recover the original address - see FunctionStartsAtom<A>::encode()


### PR DESCRIPTION
## Goal

Catch potential programming errors due to mis-spelled macros named in `#if` statements.

## Changeset

Adds `-Wundef` to `WARNING_CFLAGS`.

```
-Wundef

	Warn if an undefined identifier is evaluated in an #if directive.
	Such identifiers are replaced with zero.
```

Fixes resulting compiler warnings, including one mis-spelled `TARGET_OS_*` macro.

## Testing

N/A