### PR TITLE
[PLAT-8705] Enable reporting of background app hangs

### DIFF
--- a/Bugsnag/Configuration/BugsnagConfiguration.m
+++ b/Bugsnag/Configuration/BugsnagConfiguration.m
@@ -77,6 +77,7 @@ static NSUserDefaults *userDefaults;
     // Omit apiKey - it's set explicitly in the line above
 #if BSG_HAVE_APP_HANG_DETECTION
     [copy setAppHangThresholdMillis:self.appHangThresholdMillis];
+    [copy setReportBackgroundAppHangs:self.reportBackgroundAppHangs];
 #endif
     [copy setAppType:self.appType];
     [copy setAppVersion:self.appVersion];

--- a/Bugsnag/Helpers/BSGTelemetry.m
+++ b/Bugsnag/Helpers/BSGTelemetry.m
@@ -32,6 +32,7 @@ static NSDictionary * ConfigValue(BugsnagConfiguration *configuration) {
     
 #if BSG_HAVE_APP_HANG_DETECTION
     config[@"appHangThresholdMillis"] = IntegerValue(configuration.appHangThresholdMillis, defaults.appHangThresholdMillis);
+    config[@"reportBackgroundAppHangs"] = BooleanValue(configuration.reportBackgroundAppHangs, defaults.reportBackgroundAppHangs);
 #endif
     
     config[@"autoDetectErrors"] = BooleanValue(configuration.autoDetectErrors, defaults.autoDetectErrors);

--- a/Bugsnag/include/Bugsnag/BugsnagConfiguration.h
+++ b/Bugsnag/include/Bugsnag/BugsnagConfiguration.h
@@ -262,6 +262,13 @@ typedef id<NSObject> BugsnagOnSessionRef;
 @property (nonatomic) NSUInteger appHangThresholdMillis API_UNAVAILABLE(watchos);
 
 /**
+ * Whether Bugsnag should report app hangs that occur while the app is in the background.
+ *
+ * By default this is false.
+ */
+@property (nonatomic) BOOL reportBackgroundAppHangs API_UNAVAILABLE(watchos);
+
+/**
  * Determines whether app sessions should be tracked automatically. By default this value is true.
  * If this value is updated after +[Bugsnag start] is called, only subsequent automatic sessions
  * will be captured.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,9 @@ Changelog
 
 ### Enhancements
 
+* Add `configuration.reportBackgroundAppHangs` to allow background app hangs to be reported.
+  [#1439](https://github.com/bugsnag/bugsnag-cocoa/pull/1439)
+
 * Add `freeMemory`, `memoryLimit` and `memoryUsage` to `metaData.app`.
   Always report the device (not app) free memory in `device.freeMemory`.
   [#1435](https://github.com/bugsnag/bugsnag-cocoa/pull/1435)

--- a/features/app_hangs.feature
+++ b/features/app_hangs.feature
@@ -171,3 +171,14 @@ Feature: App hangs
     And the exception "errorClass" equals "App Hang"
     And the exception "message" equals "The app's main thread failed to respond to an event within 2000 milliseconds"
     And the exception "type" equals "cocoa"
+
+  @skip_macos
+  Scenario: Background app hangs should be reported if reportBackgroundAppHangs = true
+    When I run "ReportBackgroundAppHangScenario"
+    And I send the app to the background for 3 seconds
+    And I wait to receive an error
+    Then the exception "errorClass" equals "App Hang"
+    And the exception "message" equals "The app's main thread failed to respond to an event within 1000 milliseconds"
+    And the event "app.inForeground" is false
+    And the event "usage.config.appHangThresholdMillis" equals 1000
+    And the event "usage.config.reportBackgroundAppHangs" is true

--- a/features/fixtures/ios/iOSTestApp.xcodeproj/project.pbxproj
+++ b/features/fixtures/ios/iOSTestApp.xcodeproj/project.pbxproj
@@ -56,6 +56,7 @@
 		010BAB3D2833D2890003FF36 /* DisabledReleaseStageManualSessionScenario.swift in Sources */ = {isa = PBXBuildFile; fileRef = 010BAB3C2833D2890003FF36 /* DisabledReleaseStageManualSessionScenario.swift */; };
 		010BAB3F2833D29A0003FF36 /* EnabledReleaseStageManualSessionScenario.swift in Sources */ = {isa = PBXBuildFile; fileRef = 010BAB3E2833D29A0003FF36 /* EnabledReleaseStageManualSessionScenario.swift */; };
 		010BAB412833D2AA0003FF36 /* DisabledReleaseStageAutoSessionScenario.swift in Sources */ = {isa = PBXBuildFile; fileRef = 010BAB402833D2AA0003FF36 /* DisabledReleaseStageAutoSessionScenario.swift */; };
+		010BDFB92885562D007025F9 /* ReportBackgroundAppHangScenario.swift in Sources */ = {isa = PBXBuildFile; fileRef = 010BDFB82885562D007025F9 /* ReportBackgroundAppHangScenario.swift */; };
 		01221E55282E5538008095C3 /* MaxPersistedSessionsScenario.m in Sources */ = {isa = PBXBuildFile; fileRef = 01221E54282E5538008095C3 /* MaxPersistedSessionsScenario.m */; };
 		0163BFA72583B3CF008DC28B /* DiscardClassesHandledExceptionRegexScenario.swift in Sources */ = {isa = PBXBuildFile; fileRef = 0163BFA62583B3CF008DC28B /* DiscardClassesHandledExceptionRegexScenario.swift */; };
 		017B4134276B8D9B0054C91D /* OnSendErrorPersistenceScenario.m in Sources */ = {isa = PBXBuildFile; fileRef = 017B4133276B8D9B0054C91D /* OnSendErrorPersistenceScenario.m */; };
@@ -245,6 +246,7 @@
 		010BAB3C2833D2890003FF36 /* DisabledReleaseStageManualSessionScenario.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = DisabledReleaseStageManualSessionScenario.swift; sourceTree = "<group>"; };
 		010BAB3E2833D29A0003FF36 /* EnabledReleaseStageManualSessionScenario.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = EnabledReleaseStageManualSessionScenario.swift; sourceTree = "<group>"; };
 		010BAB402833D2AA0003FF36 /* DisabledReleaseStageAutoSessionScenario.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = DisabledReleaseStageAutoSessionScenario.swift; sourceTree = "<group>"; };
+		010BDFB82885562D007025F9 /* ReportBackgroundAppHangScenario.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = ReportBackgroundAppHangScenario.swift; sourceTree = "<group>"; };
 		01221E54282E5538008095C3 /* MaxPersistedSessionsScenario.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; path = MaxPersistedSessionsScenario.m; sourceTree = "<group>"; };
 		0163BFA62583B3CF008DC28B /* DiscardClassesHandledExceptionRegexScenario.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = DiscardClassesHandledExceptionRegexScenario.swift; sourceTree = "<group>"; };
 		017B4133276B8D9B0054C91D /* OnSendErrorPersistenceScenario.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; path = OnSendErrorPersistenceScenario.m; sourceTree = "<group>"; };
@@ -583,6 +585,7 @@
 				F4295871D1BCF211398CAEBA /* ReadOnlyPageScenario.m */,
 				0104B47D275A7B3C003EBDF0 /* RecrashScenarios.mm */,
 				F4295E71D7B2DFE77057F3DA /* ReleasedObjectScenario.m */,
+				010BDFB82885562D007025F9 /* ReportBackgroundAppHangScenario.swift */,
 				E7767F12221C21E30006648C /* ResumedSessionScenario.swift */,
 				8AF6FD79225E3FA00056EF9E /* ResumeSessionOOMScenario.m */,
 				F4295ABA693D273D52AA9F6B /* Scenario.h */,
@@ -888,6 +891,7 @@
 				E7B79CDA24800A5D0039FB88 /* MetadataMergeScenario.swift in Sources */,
 				E7B79CD8247FD7810039FB88 /* AutoContextNSExceptionScenario.swift in Sources */,
 				010BAB3B2833D2280003FF36 /* UnhandledErrorValidReleaseStageScenario.swift in Sources */,
+				010BDFB92885562D007025F9 /* ReportBackgroundAppHangScenario.swift in Sources */,
 				01E356C026CD5B6A00BE3F64 /* ThermalStateBreadcrumbScenario.swift in Sources */,
 				E7B79CD2247FD66E0039FB88 /* ManualContextClientScenario.swift in Sources */,
 				E7B79CD6247FD7750039FB88 /* AutoContextNSErrorScenario.swift in Sources */,

--- a/features/fixtures/shared/scenarios/ReportBackgroundAppHangScenario.swift
+++ b/features/fixtures/shared/scenarios/ReportBackgroundAppHangScenario.swift
@@ -1,0 +1,25 @@
+import UIKit
+
+class ReportBackgroundAppHangScenario: Scenario {
+
+    override func startBugsnag() {
+        self.config.appHangThresholdMillis = 1_000
+        self.config.reportBackgroundAppHangs = true
+        super.startBugsnag()
+    }
+
+    override func run() {
+        NotificationCenter.default.addObserver(forName: UIApplication.didEnterBackgroundNotification, object: nil, queue: nil) { _ in
+            let backgroundTask = UIApplication.shared.beginBackgroundTask()
+            
+            let timeInterval: TimeInterval = 2
+            NSLog("Simulating an app hang of \(timeInterval) seconds...")
+            Thread.sleep(forTimeInterval: timeInterval)
+            NSLog("Finished sleeping")
+            
+            DispatchQueue.main.asyncAfter(deadline: .now() + 1) {
+                UIApplication.shared.endBackgroundTask(backgroundTask)
+            }
+        }
+    }
+}


### PR DESCRIPTION
## Goal

Allow background app hangs to be reported, if enabled by developers.

## Changeset

Adds a `reportBackgroundAppHangs` property to `BugsnagConfiguration`, false by default.

Stops ignoring background app hangs if `reportBackgroundAppHangs` is true.

## Testing

Adds an E2E scenario to test reporting of background hangs. Existing scenarios verify that background hangs are not sent by default.