### PR TITLE
E2E fixes

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -133,7 +133,7 @@ e2e_ios_local:
 
 e2e_macos:
 	./features/scripts/export_mac_app.sh
-	bundle exec maze-runner --app=macOSTestApp --os=macOS --os-version=11 $(FEATURES)
+	bundle exec maze-runner --app=macOSTestApp --os=macOS --os-version=$(shell sw_vers -productVersion) $(FEATURES)
 ifeq ($(ENABLE_CODE_COVERAGE), YES)
 	xcrun llvm-profdata merge -sparse *.profraw -o default.profdata
 	rm -rf *.profraw

--- a/features/fixtures/shared/scenarios/ReportBackgroundAppHangScenario.swift
+++ b/features/fixtures/shared/scenarios/ReportBackgroundAppHangScenario.swift
@@ -5,6 +5,12 @@ class ReportBackgroundAppHangScenario: Scenario {
     override func startBugsnag() {
         self.config.appHangThresholdMillis = 1_000
         self.config.reportBackgroundAppHangs = true
+        self.config.addOnSendError { event in
+            !event.errors[0].stacktrace.contains { stackframe in
+                // CABackingStoreCollectBlocking is known to hang for several seconds upon entering the background
+                stackframe.method == "CABackingStoreCollectBlocking"
+            }
+        }
         super.startBugsnag()
     }
 

--- a/features/support/env.rb
+++ b/features/support/env.rb
@@ -5,12 +5,21 @@ BeforeAll do
 
   $app_env = {
     'LLVM_PROFILE_FILE' => '%c%p.profraw',
-    'MallocCheckHeapAbort' => 'TRUE',
-    'MallocCheckHeapStart' => '1000',
-    'MallocErrorAbort' => 'TRUE',
-    'MallocGuardEdges' => 'TRUE',
-    'MallocScribble' => 'TRUE',
-    'MAZE_RUNNER' => 'TRUE' }
+    'MAZE_RUNNER' => 'TRUE'
+  }
+
+  # MallocScribble results in intermittent crashes in CFNetwork on macOS 10.13
+  if Maze.config.os == 'macos' && Maze.config.os_version > 10.13
+    $logger.info 'Enabling MallocScribble'
+    env = {
+      'MallocCheckHeapAbort' => 'TRUE',
+      'MallocCheckHeapStart' => '1000',
+      'MallocErrorAbort' => 'TRUE',
+      'MallocGuardEdges' => 'TRUE',
+      'MallocScribble' => 'TRUE'
+    }
+    $app_env.merge!(env)
+  end
 
   Maze.config.receive_no_requests_wait = 15
 


### PR DESCRIPTION
## Goal

Fix E2E flakes

## Changeset

* Disables `MallocScribble` etc. on macOS 10.13 because CFNetwork was intermittently crashing with it enabled.
* Ignore background app hangs in `CABackingStoreCollectBlocking` - this was intermittently causing two hangs to be reported resulting in failure of that scenario.

## Testing

Passed full CI run - https://buildkite.com/bugsnag/bugsnag-cocoa/builds/5999