### PR TITLE
[PLAT-8726] Use `device.id` as fallback `user.id` for events & sessions

### DIFF
--- a/Bugsnag/BugsnagSessionTracker.m
+++ b/Bugsnag/BugsnagSessionTracker.m
@@ -8,7 +8,11 @@
 
 #import "BugsnagSessionTracker.h"
 
+#import "BSGAppKit.h"
+#import "BSGDefines.h"
 #import "BSGSessionUploader.h"
+#import "BSGUIKit.h"
+#import "BSGWatchKit.h"
 #import "BSG_KSSystemInfo.h"
 #import "BugsnagApp+Private.h"
 #import "BugsnagClient+Private.h"
@@ -17,10 +21,7 @@
 #import "BugsnagDevice+Private.h"
 #import "BugsnagLogger.h"
 #import "BugsnagSession+Private.h"
-#import "BSGDefines.h"
-#import "BSGAppKit.h"
-#import "BSGWatchKit.h"
-#import "BSGUIKit.h"
+#import "BugsnagUser+Private.h"
 
 /**
  Number of seconds in background required to make a new session
@@ -174,7 +175,7 @@ static NSTimeInterval const BSGNewSessionBackgroundDuration = 30;
 
     BugsnagSession *newSession = [[BugsnagSession alloc] initWithId:[[NSUUID UUID] UUIDString]
                                                           startedAt:[NSDate date]
-                                                               user:self.client.user
+                                                               user:[self.client.user withId]
                                                                 app:app
                                                              device:device];
 

--- a/Bugsnag/Client/BugsnagClient.m
+++ b/Bugsnag/Client/BugsnagClient.m
@@ -682,7 +682,7 @@ __attribute__((annotate("oclint:suppress[too many methods]")))
     BugsnagEvent *event = [[BugsnagEvent alloc] initWithApp:[self generateAppWithState:systemInfo]
                                                      device:[self generateDeviceWithState:systemInfo]
                                                handledState:handledState
-                                                       user:self.user
+                                                       user:[self.user withId]
                                                    metadata:metadata
                                                 breadcrumbs:self.breadcrumbs.breadcrumbs ?: @[]
                                                      errors:@[error]
@@ -724,6 +724,8 @@ __attribute__((annotate("oclint:suppress[too many methods]")))
             event.featureFlagStore = [self.featureFlagStore mutableCopy];
         }
     }
+
+    event.user = [event.user withId];
 
     BOOL originalUnhandledValue = event.unhandled;
     @try {
@@ -1041,7 +1043,7 @@ __attribute__((annotate("oclint:suppress[too many methods]")))
     [[BugsnagEvent alloc] initWithApp:app
                                device:device
                          handledState:handledState
-                                 user:self.configuration.user
+                                 user:[self.user withId]
                              metadata:metadata
                           breadcrumbs:breadcrumbs
                                errors:@[error]

--- a/Bugsnag/Configuration/BugsnagConfiguration.m
+++ b/Bugsnag/Configuration/BugsnagConfiguration.m
@@ -201,7 +201,6 @@ static NSUserDefaults *userDefaults;
     // Enabling OOM detection only happens in release builds, to avoid triggering
     // the heuristic when killing/restarting an app in Xcode or similar.
     _persistUser = YES;
-    // Only gets persisted user data if there is any, otherwise nil
     // persistUser isn't settable until post-init.
     _user = [self getPersistedUserData];
 
@@ -283,7 +282,7 @@ static NSUserDefaults *userDefaults;
 - (void)setUser:(NSString *_Nullable)userId
       withEmail:(NSString *_Nullable)email
         andName:(NSString *_Nullable)name {
-    self.user = [[BugsnagUser alloc] initWithUserId:userId name:name emailAddress:email];
+    self.user = [[BugsnagUser alloc] initWithId:userId name:name emailAddress:email];
 
     if (self.persistUser) {
         [self persistUserData];
@@ -410,20 +409,12 @@ static NSUserDefaults *userDefaults;
     }
 }
 
-/**
- * Retrieve a persisted user, if we have any valid, persisted fields, or nil otherwise
- */
 - (BugsnagUser *)getPersistedUserData {
     @synchronized(self) {
         NSString *email = [userDefaults objectForKey:kBugsnagUserEmailAddress];
         NSString *name = [userDefaults objectForKey:kBugsnagUserName];
         NSString *userId = [userDefaults objectForKey:kBugsnagUserUserId];
-
-        if (email || name || userId) {
-            return [[BugsnagUser alloc] initWithUserId:userId name:name emailAddress:email];
-        } else {
-            return [[BugsnagUser alloc] initWithUserId:nil name:nil emailAddress:nil];
-        }
+        return [[BugsnagUser alloc] initWithId:userId name:name emailAddress:email];
     }
 }
 

--- a/Bugsnag/Payload/BugsnagEvent.m
+++ b/Bugsnag/Payload/BugsnagEvent.m
@@ -530,7 +530,7 @@ NSDictionary *BSGParseCustomException(NSDictionary *report,
 - (void)setUser:(NSString *_Nullable)userId
       withEmail:(NSString *_Nullable)email
         andName:(NSString *_Nullable)name {
-    self.user = [[BugsnagUser alloc] initWithUserId:userId name:name emailAddress:email];
+    self.user = [[BugsnagUser alloc] initWithId:userId name:name emailAddress:email];
 }
 
 /**

--- a/Bugsnag/Payload/BugsnagSession.m
+++ b/Bugsnag/Payload/BugsnagSession.m
@@ -47,7 +47,7 @@
 - (void)setUser:(NSString *_Nullable)userId
       withEmail:(NSString *_Nullable)email
         andName:(NSString *_Nullable)name {
-    self.user = [[BugsnagUser alloc] initWithUserId:userId name:name emailAddress:email];
+    self.user = [[BugsnagUser alloc] initWithId:userId name:name emailAddress:email];
 }
 
 @end

--- a/Bugsnag/Payload/BugsnagUser+Private.h
+++ b/Bugsnag/Payload/BugsnagUser+Private.h
@@ -14,9 +14,12 @@ NS_ASSUME_NONNULL_BEGIN
 
 - (instancetype)initWithDictionary:(nullable NSDictionary *)dict;
 
-- (instancetype)initWithUserId:(nullable NSString *)userId name:(nullable NSString *)name emailAddress:(nullable NSString *)emailAddress;
+- (instancetype)initWithId:(nullable NSString *)id name:(nullable NSString *)name emailAddress:(nullable NSString *)emailAddress;
 
 - (NSDictionary *)toJson;
+
+/// Returns the receiver if it has a non-nil `id`, or a copy of the receiver with a `id` set to `[BSG_KSSystemInfo deviceAndAppHash]`. 
+- (BugsnagUser *)withId;
 
 @end
 

--- a/Bugsnag/Payload/BugsnagUser.m
+++ b/Bugsnag/Payload/BugsnagUser.m
@@ -8,7 +8,7 @@
 
 #import "BugsnagUser+Private.h"
 
-#import "BugsnagCollections.h"
+#import "BSG_KSSystemInfo.h"
 
 @implementation BugsnagUser
 
@@ -21,18 +21,13 @@
     return self;
 }
 
-- (instancetype)initWithUserId:(NSString *)userId name:(NSString *)name emailAddress:(NSString *)emailAddress {
-    self = [super init];
-    if (self) {
-        _id = userId;
+- (instancetype)initWithId:(NSString *)id name:(NSString *)name emailAddress:(NSString *)emailAddress {
+    if ((self = [super init])) {
+        _id = id;
         _name = name;
         _email = emailAddress;
     }
     return self;
-}
-
-+ (instancetype)userWithUserId:(NSString *)userId name:(NSString *)name emailAddress:(NSString *)emailAddress {
-    return [[self alloc] initWithUserId:userId name:name emailAddress:emailAddress];
 }
 
 - (NSDictionary *)toJson {
@@ -41,6 +36,16 @@
     dict[@"email"] = self.email;
     dict[@"name"] = self.name;
     return [NSDictionary dictionaryWithDictionary:dict];
+}
+
+- (BugsnagUser *)withId {
+    if (self.id) {
+        return self;
+    } else {
+        return [[BugsnagUser alloc] initWithId:[BSG_KSSystemInfo deviceAndAppHash]
+                                              name:self.name
+                                      emailAddress:self.email];
+    }
 }
 
 @end

--- a/Bugsnag/Payload/BugsnagUser.m
+++ b/Bugsnag/Payload/BugsnagUser.m
@@ -43,8 +43,8 @@
         return self;
     } else {
         return [[BugsnagUser alloc] initWithId:[BSG_KSSystemInfo deviceAndAppHash]
-                                              name:self.name
-                                      emailAddress:self.email];
+                                          name:self.name
+                                  emailAddress:self.email];
     }
 }
 

--- a/Bugsnag/include/Bugsnag/Bugsnag.h
+++ b/Bugsnag/include/Bugsnag/Bugsnag.h
@@ -289,6 +289,8 @@
  *  @param userId ID of the user
  *  @param name   Name of the user
  *  @param email  Email address of the user
+ *
+ *  If user ID is nil, a Bugsnag-generated Device ID is used for the `user.id` property of events and sessions.
  */
 + (void)setUser:(NSString *_Nullable)userId
        withEmail:(NSString *_Nullable)email

--- a/Bugsnag/include/Bugsnag/BugsnagConfiguration.h
+++ b/Bugsnag/include/Bugsnag/BugsnagConfiguration.h
@@ -375,6 +375,8 @@ typedef id<NSObject> BugsnagOnSessionRef;
  *  @param userId ID of the user
  *  @param name   Name of the user
  *  @param email  Email address of the user
+ *
+ *  If user ID is nil, a Bugsnag-generated Device ID is used for the `user.id` property of events and sessions.
  */
 - (void)setUser:(NSString *_Nullable)userId
       withEmail:(NSString *_Nullable)email

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,14 @@
 Changelog
 =========
 
+## TBD
+
+### Bug fixes
+
+* Set `user.id` to to `device.id` for all events and sessions if `BugsnagClient.user.id` is set to nil.
+  To prevent collection, set it to an empty string or update it in `OnSendError` / `OnSession`.
+  [#1442](https://github.com/bugsnag/bugsnag-cocoa/pull/1442)
+
 ## 6.21.0 (2022-07-20)
 
 ### Enhancements

--- a/Tests/BugsnagTests/BugsnagSessionTest.m
+++ b/Tests/BugsnagTests/BugsnagSessionTest.m
@@ -108,7 +108,7 @@
 
 - (void)testPayloadSerialization {
     NSDate *now = [NSDate date];
-    BugsnagUser *user = [[BugsnagUser alloc] initWithUserId:@"123" name:@"Joe Bloggs" emailAddress:@"joe@example.com"];
+    BugsnagUser *user = [[BugsnagUser alloc] initWithId:@"123" name:@"Joe Bloggs" emailAddress:@"joe@example.com"];
     BugsnagSession *payload = [[BugsnagSession alloc] initWithId:@"test"
                                                        startedAt:now
                                                             user:user

--- a/Tests/BugsnagTests/BugsnagUserTest.m
+++ b/Tests/BugsnagTests/BugsnagUserTest.m
@@ -32,7 +32,7 @@
 }
 
 - (void)testPayloadSerialisation {
-    BugsnagUser *payload = [[BugsnagUser alloc] initWithUserId:@"test" name:@"Tom Bombadil" emailAddress:@"fake@example.com"];
+    BugsnagUser *payload = [[BugsnagUser alloc] initWithId:@"test" name:@"Tom Bombadil" emailAddress:@"fake@example.com"];
     NSDictionary *rootNode = [payload toJson];
     XCTAssertNotNil(rootNode);
     XCTAssertEqual(3, [rootNode count]);

--- a/features/fixtures/ios/iOSTestApp.xcodeproj/project.pbxproj
+++ b/features/fixtures/ios/iOSTestApp.xcodeproj/project.pbxproj
@@ -57,6 +57,7 @@
 		010BAB3F2833D29A0003FF36 /* EnabledReleaseStageManualSessionScenario.swift in Sources */ = {isa = PBXBuildFile; fileRef = 010BAB3E2833D29A0003FF36 /* EnabledReleaseStageManualSessionScenario.swift */; };
 		010BAB412833D2AA0003FF36 /* DisabledReleaseStageAutoSessionScenario.swift in Sources */ = {isa = PBXBuildFile; fileRef = 010BAB402833D2AA0003FF36 /* DisabledReleaseStageAutoSessionScenario.swift */; };
 		010BDFB92885562D007025F9 /* ReportBackgroundAppHangScenario.swift in Sources */ = {isa = PBXBuildFile; fileRef = 010BDFB82885562D007025F9 /* ReportBackgroundAppHangScenario.swift */; };
+		010BDFBD28883714007025F9 /* UserNilScenario.swift in Sources */ = {isa = PBXBuildFile; fileRef = 010BDFBC28883714007025F9 /* UserNilScenario.swift */; };
 		01221E55282E5538008095C3 /* MaxPersistedSessionsScenario.m in Sources */ = {isa = PBXBuildFile; fileRef = 01221E54282E5538008095C3 /* MaxPersistedSessionsScenario.m */; };
 		0163BFA72583B3CF008DC28B /* DiscardClassesHandledExceptionRegexScenario.swift in Sources */ = {isa = PBXBuildFile; fileRef = 0163BFA62583B3CF008DC28B /* DiscardClassesHandledExceptionRegexScenario.swift */; };
 		017B4134276B8D9B0054C91D /* OnSendErrorPersistenceScenario.m in Sources */ = {isa = PBXBuildFile; fileRef = 017B4133276B8D9B0054C91D /* OnSendErrorPersistenceScenario.m */; };
@@ -247,6 +248,7 @@
 		010BAB3E2833D29A0003FF36 /* EnabledReleaseStageManualSessionScenario.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = EnabledReleaseStageManualSessionScenario.swift; sourceTree = "<group>"; };
 		010BAB402833D2AA0003FF36 /* DisabledReleaseStageAutoSessionScenario.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = DisabledReleaseStageAutoSessionScenario.swift; sourceTree = "<group>"; };
 		010BDFB82885562D007025F9 /* ReportBackgroundAppHangScenario.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = ReportBackgroundAppHangScenario.swift; sourceTree = "<group>"; };
+		010BDFBC28883714007025F9 /* UserNilScenario.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = UserNilScenario.swift; sourceTree = "<group>"; };
 		01221E54282E5538008095C3 /* MaxPersistedSessionsScenario.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; path = MaxPersistedSessionsScenario.m; sourceTree = "<group>"; };
 		0163BFA62583B3CF008DC28B /* DiscardClassesHandledExceptionRegexScenario.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = DiscardClassesHandledExceptionRegexScenario.swift; sourceTree = "<group>"; };
 		017B4133276B8D9B0054C91D /* OnSendErrorPersistenceScenario.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; path = OnSendErrorPersistenceScenario.m; sourceTree = "<group>"; };
@@ -629,6 +631,7 @@
 				E700EE4D247D1317008CFFB6 /* UserFromClientScenario.swift */,
 				AA6ACD1B2773E0B3006464C4 /* UserFromConfigScenario.swift */,
 				AA6ACD1F2773E3F0006464C4 /* UserInfoScenario.swift */,
+				010BDFBC28883714007025F9 /* UserNilScenario.swift */,
 				010BAAF12833CE570003FF36 /* UserPersistenceDontPersistUserScenario.m */,
 				010BAAFE2833CE570003FF36 /* UserPersistenceNoUserScenario.m */,
 				010BAAF22833CE570003FF36 /* UserPersistencePersistUserClientScenario.m */,
@@ -854,6 +857,7 @@
 				001E5502243B8FDA0009E31D /* AutoCaptureRunScenario.m in Sources */,
 				0104085F258CA0A100933C60 /* DispatchCrashScenario.swift in Sources */,
 				E700EE55247D3204008CFFB6 /* OnSendOverwriteScenario.swift in Sources */,
+				010BDFBD28883714007025F9 /* UserNilScenario.swift in Sources */,
 				CB0AE1F1287D89C90079B28E /* OnSendErrorCallbackFeatureFlagsScenario.swift in Sources */,
 				F429538D8941382EC2C857CE /* AsyncSafeThreadScenario.m in Sources */,
 				F42955869D33EE0E510B9651 /* ReadGarbagePointerScenario.m in Sources */,

--- a/features/fixtures/macos/macOSTestApp.xcodeproj/project.pbxproj
+++ b/features/fixtures/macos/macOSTestApp.xcodeproj/project.pbxproj
@@ -36,6 +36,7 @@
 		010BAB772833D34A0003FF36 /* DiscardClassesHandledExceptionRegexScenario.swift in Sources */ = {isa = PBXBuildFile; fileRef = 010BAB5B2833D34A0003FF36 /* DiscardClassesHandledExceptionRegexScenario.swift */; };
 		010BAB782833D34A0003FF36 /* EnabledReleaseStageManualSessionScenario.swift in Sources */ = {isa = PBXBuildFile; fileRef = 010BAB5C2833D34A0003FF36 /* EnabledReleaseStageManualSessionScenario.swift */; };
 		010BAB792833D34A0003FF36 /* HandledErrorInvalidReleaseStageScenario.swift in Sources */ = {isa = PBXBuildFile; fileRef = 010BAB5D2833D34A0003FF36 /* HandledErrorInvalidReleaseStageScenario.swift */; };
+		010BDFBB28883704007025F9 /* UserNilScenario.swift in Sources */ = {isa = PBXBuildFile; fileRef = 010BDFBA28883703007025F9 /* UserNilScenario.swift */; };
 		011B7A4C26CD52080071C3EB /* ThermalStateBreadcrumbScenario.swift in Sources */ = {isa = PBXBuildFile; fileRef = 011B7A4B26CD52080071C3EB /* ThermalStateBreadcrumbScenario.swift */; };
 		0123189C275921590007EFD7 /* RecrashScenarios.mm in Sources */ = {isa = PBXBuildFile; fileRef = 0123189B275921590007EFD7 /* RecrashScenarios.mm */; };
 		015AE23A276B88300044B1AE /* OnSendErrorPersistenceScenario.m in Sources */ = {isa = PBXBuildFile; fileRef = 015AE239276B88300044B1AE /* OnSendErrorPersistenceScenario.m */; };
@@ -230,6 +231,7 @@
 		010BAB5B2833D34A0003FF36 /* DiscardClassesHandledExceptionRegexScenario.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = DiscardClassesHandledExceptionRegexScenario.swift; sourceTree = "<group>"; };
 		010BAB5C2833D34A0003FF36 /* EnabledReleaseStageManualSessionScenario.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = EnabledReleaseStageManualSessionScenario.swift; sourceTree = "<group>"; };
 		010BAB5D2833D34A0003FF36 /* HandledErrorInvalidReleaseStageScenario.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = HandledErrorInvalidReleaseStageScenario.swift; sourceTree = "<group>"; };
+		010BDFBA28883703007025F9 /* UserNilScenario.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = UserNilScenario.swift; sourceTree = "<group>"; };
 		011B7A4B26CD52080071C3EB /* ThermalStateBreadcrumbScenario.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ThermalStateBreadcrumbScenario.swift; sourceTree = "<group>"; };
 		0123189B275921590007EFD7 /* RecrashScenarios.mm */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.objcpp; path = RecrashScenarios.mm; sourceTree = "<group>"; };
 		01452360254AFEA700D436AA /* macOSTestApp-Bridging-Header.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; path = "macOSTestApp-Bridging-Header.h"; sourceTree = "<group>"; };
@@ -515,10 +517,10 @@
 				01F47CBA254B1B3000B184AD /* OnErrorOverwriteScenario.swift */,
 				01ECBCF225A7522000FC0678 /* OnErrorOverwriteUnhandledFalseScenario.swift */,
 				01ECBCF325A7522000FC0678 /* OnErrorOverwriteUnhandledTrueScenario.swift */,
-				CB0AE1F2287DBA380079B28E /* OnSendErrorCallbackFeatureFlagsScenario.swift */,
 				01F47C30254B1B2D00B184AD /* OnSendCallbackOrderScenario.swift */,
 				01F47C9B254B1B2F00B184AD /* OnSendCallbackRemovalScenario.m */,
 				01F47C76254B1B2E00B184AD /* OnSendErrorCallbackCrashScenario.swift */,
+				CB0AE1F2287DBA380079B28E /* OnSendErrorCallbackFeatureFlagsScenario.swift */,
 				015AE239276B88300044B1AE /* OnSendErrorPersistenceScenario.m */,
 				01F47C6C254B1B2E00B184AD /* OnSendOverwriteScenario.swift */,
 				01F47C41254B1B2D00B184AD /* OOMAutoDetectErrorsScenario.swift */,
@@ -579,6 +581,7 @@
 				01F47CA3254B1B3000B184AD /* UserFromClientScenario.swift */,
 				AA6ACD192773E098006464C4 /* UserFromConfigScenario.swift */,
 				AA6ACD1D2773E39C006464C4 /* UserInfoScenario.swift */,
+				010BDFBA28883703007025F9 /* UserNilScenario.swift */,
 				017D9CF52833C81100B0AA87 /* UserPersistenceDontPersistUserScenario.m */,
 				017D9CF12833C81100B0AA87 /* UserPersistenceNoUserScenario.m */,
 				017D9CF02833C81100B0AA87 /* UserPersistencePersistUserClientScenario.m */,
@@ -881,6 +884,7 @@
 				010BAB712833D34A0003FF36 /* AppAndDeviceAttributesCallbackOverrideScenario.swift in Sources */,
 				010BAB6B2833D34A0003FF36 /* UnhandledErrorInvalidReleaseStageScenario.swift in Sources */,
 				010BAB652833D34A0003FF36 /* AppHangDisabledScenario.swift in Sources */,
+				010BDFBB28883704007025F9 /* UserNilScenario.swift in Sources */,
 				0176C0AE254AE81B0066E0F3 /* main.m in Sources */,
 				01F47CDB254B1B3100B184AD /* UnhandledMachExceptionScenario.m in Sources */,
 				01F47D12254B1B3100B184AD /* OnSendCallbackRemovalScenario.m in Sources */,

--- a/features/fixtures/shared/scenarios/UnhandledMachExceptionScenario.m
+++ b/features/fixtures/shared/scenarios/UnhandledMachExceptionScenario.m
@@ -19,6 +19,7 @@
 }
 
 - (void)run {
+    [Bugsnag setUser:nil withEmail:nil andName:nil];
     void (*ptr)(void) = (void *)0xDEADBEEF;
     ptr();
 }

--- a/features/fixtures/shared/scenarios/UserNilScenario.swift
+++ b/features/fixtures/shared/scenarios/UserNilScenario.swift
@@ -1,0 +1,28 @@
+class UserNilScenario: Scenario {
+
+    override func startBugsnag() {
+      self.config.autoTrackSessions = false;
+      super.startBugsnag()
+    }
+
+    override func run() {
+        Bugsnag.setUser(nil, withEmail: nil, andName: nil)
+
+        // This session should have a non-nil user.id
+        Bugsnag.startSession()
+
+        Bugsnag.addOnSession { session in
+            session.setUser(nil, withEmail: nil, andName: nil)
+            return true
+        }
+
+        // This session should have a nil user.id, due to the OnSession block
+        Bugsnag.startSession()
+
+        Bugsnag.notifyError(NSError(domain: "ErrorWithCallback", code: 100)) { event in
+            // This error should have a nil user.id
+            event.setUser(nil, withEmail: nil, andName: nil)
+            return true
+        }
+    }
+}

--- a/features/unhandled_mach_exception.feature
+++ b/features/unhandled_mach_exception.feature
@@ -23,6 +23,7 @@ Feature: Bugsnag captures an unhandled mach exception
     And the event "metaData.error.mach.subcode" equals "0xdeadbeef"
     And the event "severity" equals "error"
     And the event "unhandled" is true
+    And the event "user.id" is not null
     And the event "severityReason.type" equals "unhandledException"
 
   Scenario: Trigger a mach exception with unhandled override

--- a/features/user.feature
+++ b/features/user.feature
@@ -16,7 +16,8 @@ Feature: Reporting User Information
     # User fields set as null
     Then the error is valid for the error reporting API
     And the exception "message" equals "The operation couldn’t be completed. (UserDisabled error 100.)"
-    And the event "user.id" is null
+    And the error payload field "events.0.device.id" is stored as the value "device_id"
+    And the error payload field "events.0.user.id" equals the stored value "device_id"
     And the event "user.email" is null
     And the event "user.name" is null
     And I discard the oldest error
@@ -24,7 +25,7 @@ Feature: Reporting User Information
     # Only User email field set
     Then the error is valid for the error reporting API
     And the exception "message" equals "The operation couldn’t be completed. (UserEmail error 100.)"
-    And the event "user.id" is null
+    And the error payload field "events.0.user.id" equals the stored value "device_id"
     And the event "user.email" equals "user@example.com"
     And the event "user.name" is null
     And I discard the oldest error
@@ -74,3 +75,19 @@ Feature: Reporting User Information
     And the session "user.id" equals "def"
     And the session "user.email" equals "sue@gmail.com"
     And the session "user.name" equals "Sue"
+
+  Scenario: Setting the user ID to nil
+    When I run "UserNilScenario"
+    And I wait to receive 2 sessions
+    And I wait to receive an error
+    Then the session payload field "device.id" is stored as the value "device_id"
+    And the session payload field "sessions.0.user.id" equals the stored value "device_id"
+    And the session "user.email" is null
+    And the session "user.name" is null
+    And I discard the oldest session
+    And the session "user.id" is null
+    And the session "user.email" is null
+    And the session "user.name" is null
+    And the event "user.id" is null
+    And the event "user.email" is null
+    And the event "user.name" is null


### PR DESCRIPTION
## Goal

Makes behaviour of `user.id` consistent with other platform, crash errors, and our [online documentation](https://docs.bugsnag.com/platforms/ios/automatically-captured-data/#user-information).

After calling `Bugsnag.setUser(nil, withEmail: nil, andName: nil)`, events and sessions should have their `user.id` set to the default Bugsnag-generated device ID.

## Changeset

Adds `-[BugsnagUser withUserId]` to get a user object with the fallback `id` if required.

Updates `BugsnagSessionTracker` and `BugsnagClient` to use this method to populate sessions and events with a `user.id`.

Renames `-[BugsnagUser initWithUserId:name:emailAddress:]` to `-[BugsnagUser initWithId:name:emailAddress:]`.

Removes unused method `+[BugsnagUser userWithUserId:name:emailAddress:]`.

Simplifies `-[BugsnagConfiguration getPersistedUserData]`.

## Testing

Amends existing and adds a new scenario to verify that fallback `user.id` is sent when expected, while retaining ability to nullify it via callbacks.