### PR TITLE
Reduce use of `__attribute__`

### DIFF
--- a/Bugsnag/Breadcrumbs/BSGNotificationBreadcrumbs.m
+++ b/Bugsnag/Breadcrumbs/BSGNotificationBreadcrumbs.m
@@ -359,7 +359,7 @@ static NSString *nullStringIfBlank(NSString *str) {
     [self addBreadcrumbWithType:BSGBreadcrumbTypeState forNotificationName:notification.name];
 }
 
-- (void)addBreadcrumbForTableViewNotification:(__attribute__((unused)) NSNotification *)notification {
+- (void)addBreadcrumbForTableViewNotification:(__unused NSNotification *)notification {
 #if BSG_HAVE_TABLE_VIEW
 
 #if TARGET_OS_IOS || TARGET_OS_TV
@@ -375,7 +375,7 @@ static NSString *nullStringIfBlank(NSString *str) {
 #endif
 }
 
-- (void)addBreadcrumbForMenuItemNotification:(__attribute__((unused)) NSNotification *)notification {
+- (void)addBreadcrumbForMenuItemNotification:(__unused NSNotification *)notification {
 #if TARGET_OS_OSX
     NSMenuItem *menuItem = [[notification userInfo] valueForKey:@"MenuItem"];
     [self addBreadcrumbWithType:BSGBreadcrumbTypeState forNotificationName:notification.name metadata:
@@ -383,7 +383,7 @@ static NSString *nullStringIfBlank(NSString *str) {
 #endif
 }
 
-- (void)addBreadcrumbForControlNotification:(__attribute__((unused)) NSNotification *)notification {
+- (void)addBreadcrumbForControlNotification:(__unused NSNotification *)notification {
 #if TARGET_OS_IOS
     NSString *label = ((UIControl *)notification.object).accessibilityLabel;
     [self addBreadcrumbWithType:BSGBreadcrumbTypeUser forNotificationName:notification.name metadata:

--- a/Bugsnag/Client/BugsnagClient.m
+++ b/Bugsnag/Client/BugsnagClient.m
@@ -210,7 +210,7 @@ __attribute__((annotate("oclint:suppress[too many methods]")))
         self.breadcrumbs = [[BugsnagBreadcrumbs alloc] initWithConfiguration:self.configuration];
 
         // Start with a copy of the configuration metadata
-        self.metadata = [[_configuration metadata] deepCopy];
+        self.metadata = [[_configuration metadata] copy];
     }
     return self;
 }
@@ -604,7 +604,7 @@ __attribute__((annotate("oclint:suppress[too many methods]")))
 
 - (void)notifyErrorOrException:(id)errorOrException block:(BugsnagOnErrorBlock)block {
     NSDictionary *systemInfo = [BSG_KSSystemInfo systemInfo];
-    BugsnagMetadata *metadata = [self.metadata deepCopy];
+    BugsnagMetadata *metadata = [self.metadata copy];
     
     NSArray<NSNumber *> *callStack = nil;
     NSString *context = self.context;
@@ -1034,7 +1034,7 @@ __attribute__((annotate("oclint:suppress[too many methods]")))
 
     NSArray<BugsnagBreadcrumb *> *breadcrumbs = [self.breadcrumbs breadcrumbsBeforeDate:date];
 
-    BugsnagMetadata *metadata = [self.metadata deepCopy];
+    BugsnagMetadata *metadata = [self.metadata copy];
 
     [metadata addMetadata:BSGAppMetadataFromRunContext(bsg_runContext) toSection:BSGKeyApp];
     [metadata addMetadata:BSGDeviceMetadataFromRunContext(bsg_runContext) toSection:BSGKeyDevice];

--- a/Bugsnag/Client/BugsnagClient.m
+++ b/Bugsnag/Client/BugsnagClient.m
@@ -312,7 +312,7 @@ __attribute__((annotate("oclint:suppress[too many methods]")))
 #endif
 }
 
-- (void)appLaunchTimerFired:(__attribute__((unused)) NSTimer *)timer {
+- (void)appLaunchTimerFired:(__unused NSTimer *)timer {
     [self markLaunchCompleted];
 }
 

--- a/Bugsnag/Delivery/BSGConnectivity.m
+++ b/Bugsnag/Delivery/BSGConnectivity.m
@@ -88,9 +88,9 @@ NSString *BSGConnectivityFlagRepresentation(SCNetworkReachabilityFlags flags) {
  * Callback invoked by SCNetworkReachability, which calls an Objective-C block
  * that handles the connection change.
  */
-void BSGConnectivityCallback(__attribute__((unused)) SCNetworkReachabilityRef target,
+void BSGConnectivityCallback(__unused SCNetworkReachabilityRef target,
                              SCNetworkReachabilityFlags flags,
-                             __attribute__((unused)) void *info)
+                             __unused void *info)
 {
     if (bsg_reachability_change_block && BSGConnectivityShouldReportChange(flags)) {
         BOOL connected = (flags & kSCNetworkReachabilityFlagsReachable) != 0;

--- a/Bugsnag/Delivery/BSGEventUploadObjectOperation.m
+++ b/Bugsnag/Delivery/BSGEventUploadObjectOperation.m
@@ -20,7 +20,7 @@
     return self;
 }
 
-- (BugsnagEvent *)loadEventAndReturnError:(__attribute__((unused)) NSError * __autoreleasing *)errorPtr {
+- (BugsnagEvent *)loadEventAndReturnError:(__unused NSError * __autoreleasing *)errorPtr {
     [self.event symbolicateIfNeeded];
     return self.event;
 }

--- a/Bugsnag/Delivery/BSGEventUploadOperation.m
+++ b/Bugsnag/Delivery/BSGEventUploadOperation.m
@@ -131,7 +131,7 @@ typedef NS_ENUM(NSUInteger, BSGEventUploadOperationState) {
     
     __block NSData *HTTPBody =
     [delegate.apiClient sendJSONPayload:requestPayload headers:requestHeaders toURL:notifyURL
-                      completionHandler:^(BugsnagApiClientDeliveryStatus status, __attribute__((unused)) NSError *deliveryError) {
+                      completionHandler:^(BugsnagApiClientDeliveryStatus status, __unused NSError *deliveryError) {
         
         switch (status) {
             case BugsnagApiClientDeliveryStatusDelivered:
@@ -156,7 +156,7 @@ typedef NS_ENUM(NSUInteger, BSGEventUploadOperationState) {
 
 // MARK: Subclassing
 
-- (BugsnagEvent *)loadEventAndReturnError:(__attribute__((unused)) NSError * __autoreleasing *)errorPtr {
+- (BugsnagEvent *)loadEventAndReturnError:(__unused NSError * __autoreleasing *)errorPtr {
     // Must be implemented by all subclasses
     [self doesNotRecognizeSelector:_cmd];
     return nil;

--- a/Bugsnag/Delivery/BugsnagApiClient.m
+++ b/Bugsnag/Delivery/BugsnagApiClient.m
@@ -64,7 +64,7 @@ typedef NS_ENUM(NSInteger, HTTPStatusCode) {
     NSMutableURLRequest *request = [self prepareRequest:url headers:mutableHeaders];
     bsg_log_debug(@"Sending %lu byte payload to %@", (unsigned long)data.length, url);
     
-    [[self.session uploadTaskWithRequest:request fromData:data completionHandler:^(__attribute__((unused)) NSData *responseData,
+    [[self.session uploadTaskWithRequest:request fromData:data completionHandler:^(__unused NSData *responseData,
                                                                                    NSURLResponse *response, NSError *connectionError) {
         if (![response isKindOfClass:[NSHTTPURLResponse class]]) {
             bsg_log_debug(@"Request to %@ completed with error %@", url, error);

--- a/Bugsnag/Helpers/BSGAppHangDetector.m
+++ b/Bugsnag/Helpers/BSGAppHangDetector.m
@@ -72,7 +72,7 @@
     __block BOOL isProcessing = NO;
     
     void (^ observerBlock)(CFRunLoopObserverRef, CFRunLoopActivity) =
-    ^(__attribute__((unused)) CFRunLoopObserverRef observer, CFRunLoopActivity activity) {
+    ^(__unused CFRunLoopObserverRef observer, CFRunLoopActivity activity) {
         
         if (activity == kCFRunLoopAfterWaiting || activity == kCFRunLoopBeforeSources) {
             if (isProcessing) {
@@ -177,7 +177,7 @@
         threads = [BugsnagThread allThreads:YES callStackReturnAddresses:NSThread.callStackReturnAddresses];
         // By default the calling thread is marked as "Error reported from this thread", which is not correct case for app hangs.
         [threads enumerateObjectsUsingBlock:^(BugsnagThread * _Nonnull thread, NSUInteger idx,
-                                              __attribute__((unused)) BOOL * _Nonnull stop) {
+                                              __unused BOOL * _Nonnull stop) {
             thread.errorReportingThread = idx == 0;
         }];
     } else {

--- a/Bugsnag/Helpers/BSGSerialization.m
+++ b/Bugsnag/Helpers/BSGSerialization.m
@@ -39,7 +39,7 @@ NSDictionary *_Nonnull BSGSanitizeDict(NSDictionary *input) {
     __block NSMutableDictionary *output =
         [NSMutableDictionary dictionaryWithCapacity:[input count]];
     [input enumerateKeysAndObjectsUsingBlock:^(id _Nonnull key, id _Nonnull obj,
-                                               __attribute__((unused)) BOOL *_Nonnull stop) {
+                                               __unused BOOL *_Nonnull stop) {
       if ([key isKindOfClass:[NSString class]]) {
           id cleanedObject = BSGSanitizeObject(obj);
           if (cleanedObject)

--- a/Bugsnag/KSCrash/Source/KSCrash/Recording/Tools/BSG_KSMach_x86_64.c
+++ b/Bugsnag/KSCrash/Source/KSCrash/Recording/Tools/BSG_KSMach_x86_64.c
@@ -62,7 +62,7 @@ uintptr_t bsg_ksmachinstructionAddress(
 
 uintptr_t
 bsg_ksmachlinkRegister(const BSG_STRUCT_MCONTEXT_L *const machineContext
-                       __attribute__((unused))) {
+                       __unused) {
     return 0;
 }
 

--- a/Bugsnag/Metadata/BugsnagMetadata+Private.h
+++ b/Bugsnag/Metadata/BugsnagMetadata+Private.h
@@ -12,7 +12,7 @@ NS_ASSUME_NONNULL_BEGIN
 
 typedef void (^ BSGMetadataObserver)(BugsnagMetadata *);
 
-@interface BugsnagMetadata ()
+@interface BugsnagMetadata () <NSCopying>
 
 #pragma mark Properties
 
@@ -23,8 +23,6 @@ typedef void (^ BSGMetadataObserver)(BugsnagMetadata *);
 #pragma mark Methods
 
 - (NSDictionary *)toDictionary;
-
-- (instancetype)deepCopy;
 
 @end
 

--- a/Bugsnag/Metadata/BugsnagMetadata.m
+++ b/Bugsnag/Metadata/BugsnagMetadata.m
@@ -111,13 +111,13 @@
 
 // MARK: - <NSCopying>
 
-- (id)copyWithZone:(__attribute__((unused)) NSZone *)zone {
+- (id)copyWithZone:(__unused NSZone *)zone {
     return [self deepCopy];
 }
 
 // MARK: - <NSMutableCopying>
 
-- (instancetype)mutableCopyWithZone:(__attribute__((unused)) NSZone *)zone {
+- (instancetype)mutableCopyWithZone:(__unused NSZone *)zone {
     @synchronized(self) {
         NSMutableDictionary *dict = [self.dictionary mutableCopy];
         return [[BugsnagMetadata alloc] initWithDictionary:dict];

--- a/Bugsnag/Metadata/BugsnagMetadata.m
+++ b/Bugsnag/Metadata/BugsnagMetadata.m
@@ -111,16 +111,9 @@
 
 // MARK: - <NSCopying>
 
-- (id)copyWithZone:(__unused NSZone *)zone {
-    return [self deepCopy];
-}
-
-// MARK: - <NSMutableCopying>
-
-- (instancetype)mutableCopyWithZone:(__unused NSZone *)zone {
+- (id)copyWithZone:(NSZone *)zone {
     @synchronized(self) {
-        NSMutableDictionary *dict = [self.dictionary mutableCopy];
-        return [[BugsnagMetadata alloc] initWithDictionary:dict];
+        return [[BugsnagMetadata allocWithZone:zone] initWithDictionary:self.dictionary];
     }
 }
 
@@ -135,12 +128,6 @@
 {
     @synchronized(self) {
         return self.dictionary[sectionName][key];
-    }
-}
-
-- (instancetype)deepCopy {
-    @synchronized(self) {
-        return [[BugsnagMetadata alloc] initWithDictionary:self.dictionary];
     }
 }
 

--- a/Bugsnag/Payload/BugsnagEvent.m
+++ b/Bugsnag/Payload/BugsnagEvent.m
@@ -350,7 +350,7 @@ NSDictionary *BSGParseCustomException(NSDictionary *report,
         handledState.unhandledOverridden = isUnhandledOverridden;
     }
 
-    [[self parseOnCrashData:event] enumerateKeysAndObjectsUsingBlock:^(id key, id obj, __attribute__((unused)) BOOL *stop) {
+    [[self parseOnCrashData:event] enumerateKeysAndObjectsUsingBlock:^(id key, id obj, __unused BOOL *stop) {
         if ([key isKindOfClass:[NSString class]] &&
             [obj isKindOfClass:[NSDictionary class]]) {
             [metadata addMetadata:obj toSection:key];
@@ -565,7 +565,7 @@ NSDictionary *BSGParseCustomException(NSDictionary *report,
 
     event[BSGKeyExceptions] = ({
         NSMutableArray *array = [NSMutableArray array];
-        [self.errors enumerateObjectsUsingBlock:^(BugsnagError *error, NSUInteger idx, __attribute__((unused)) BOOL *stop) {
+        [self.errors enumerateObjectsUsingBlock:^(BugsnagError *error, NSUInteger idx, __unused BOOL *stop) {
             if (self.customException != nil && idx == 0) {
                 [array addObject:(NSDictionary * _Nonnull)self.customException];
             } else {

--- a/Bugsnag/include/Bugsnag/BugsnagBreadcrumb.h
+++ b/Bugsnag/include/Bugsnag/BugsnagBreadcrumb.h
@@ -25,14 +25,6 @@
 //
 #import <Foundation/Foundation.h>
 
-#ifndef NS_DESIGNATED_INITIALIZER
-#if __has_attribute(objc_designated_initializer)
-#define NS_DESIGNATED_INITIALIZER __attribute__((objc_designated_initializer))
-#else
-#define NS_DESIGNATED_INITIALIZER
-#endif
-#endif
-
 /**
  * Types of breadcrumbs
  */

--- a/Tests/BugsnagTests/BugsnagMetadataTests.m
+++ b/Tests/BugsnagTests/BugsnagMetadataTests.m
@@ -205,11 +205,15 @@
     BugsnagMetadata *metadata = [BugsnagMetadata new];
     [metadata addMetadata:@"myKey" withKey:@"myValue" toSection:@"section1"];
     
-    BugsnagMetadata *clone = [metadata deepCopy];
+    BugsnagMetadata *clone = [metadata copy];
     XCTAssertNotEqual(metadata, clone);
     
     // Until/unless it's decided otherwise the copy is a shallow one.
     XCTAssertEqualObjects([metadata getMetadataFromSection:@"section1"], [clone getMetadataFromSection:@"section1"]);
+    
+    [metadata clearMetadataFromSection:@"section1" withKey:@"myValue"];
+    XCTAssertEqualObjects([metadata getMetadataFromSection:@"section1"], @{});
+    XCTAssertEqualObjects([clone getMetadataFromSection:@"section1"], @{@"myValue":@"myKey"});
 }
 
 -(void)testClearMetadataInSectionWithKey {


### PR DESCRIPTION
## Goal

Reduce use of `__attribute__` where alternatives are available.

## Changeset

Replaces `__attribute__((unused))` with `__unused`.

Removes definition of `NS_DESIGNATED_INITIALIZER` - this was required to support Xcode versions prior to 5.1 and can now safely be removed. Xcode 10 is the oldest version we currently use / test with.

Removes unused method `-[BugsnagMetadata mutableCopyWithZone:]`.

Removes `-[BugsnagMetadata deepCopy]` because calling `-[BugsnagMetadata copy]` does the same thing.
`bugsnag-flutter` and `bugsnag-unreal` will be updated to stop calling `deepCopy`.

## Testing

Verified by unit & E2E tests on CI.