### PR TITLE
[PLAT-8732] Send queued sessions when connection regained

### DIFF
--- a/Bugsnag/BugsnagSessionTracker.h
+++ b/Bugsnag/BugsnagSessionTracker.h
@@ -11,6 +11,8 @@
 #import <Bugsnag/BugsnagConfiguration.h>
 #import <Bugsnag/BugsnagSession.h>
 
+#import "BSGSessionUploader.h"
+
 NS_ASSUME_NONNULL_BEGIN
 
 @interface BugsnagSessionTracker : NSObject
@@ -81,6 +83,8 @@ NS_ASSUME_NONNULL_BEGIN
  * Retrieves the running session, or nil if the session is stopped or has not yet been started/resumed.
  */
 @property (nullable, readonly, nonatomic) BugsnagSession *runningSession;
+
+@property (strong, nonatomic) BSGSessionUploader *sessionUploader;
 
 - (void)addRuntimeVersionInfo:(NSString *)info
                       withKey:(NSString *)key;

--- a/Bugsnag/BugsnagSessionTracker.m
+++ b/Bugsnag/BugsnagSessionTracker.m
@@ -10,7 +10,6 @@
 
 #import "BSGAppKit.h"
 #import "BSGDefines.h"
-#import "BSGSessionUploader.h"
 #import "BSGUIKit.h"
 #import "BSGWatchKit.h"
 #import "BSG_KSSystemInfo.h"
@@ -31,7 +30,6 @@ static NSTimeInterval const BSGNewSessionBackgroundDuration = 30;
 @interface BugsnagSessionTracker ()
 @property (strong, nonatomic) BugsnagConfiguration *config;
 @property (weak, nonatomic) BugsnagClient *client;
-@property (strong, nonatomic) BSGSessionUploader *sessionUploader;
 @property (strong, nonatomic) NSDate *backgroundStartTime;
 @property (nonatomic) NSMutableDictionary *extraRuntimeInfo;
 @end

--- a/Bugsnag/Client/BugsnagClient.m
+++ b/Bugsnag/Client/BugsnagClient.m
@@ -462,6 +462,7 @@ __attribute__((annotate("oclint:suppress[too many methods]")))
         __strong typeof(weakSelf) strongSelf = weakSelf;
         if (connected) {
             [strongSelf.eventUploader uploadStoredEvents];
+            [strongSelf.sessionTracker.sessionUploader processStoredSessions];
         }
 
         [strongSelf addAutoBreadcrumbOfType:BSGBreadcrumbTypeState

--- a/Bugsnag/Delivery/BSGSessionUploader.h
+++ b/Bugsnag/Delivery/BSGSessionUploader.h
@@ -17,6 +17,9 @@ NS_ASSUME_NONNULL_BEGIN
 
 - (instancetype)initWithConfig:(BugsnagConfiguration *)configuration notifier:(BugsnagNotifier *)notifier;
 
+/// Scans previously persisted sessions and either discards or attempts upload.
+- (void)processStoredSessions;
+
 - (void)uploadSession:(BugsnagSession *)session;
 
 @property (copy, nonatomic) NSString *codeBundleId;

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,9 @@ Changelog
 
 ### Bug fixes
 
+* Attempt to send sessions stored on disk when connection regained.
+  [#1445](https://github.com/bugsnag/bugsnag-cocoa/pull/1445)
+
 * Set `user.id` to to `device.id` for all events and sessions if `BugsnagClient.user.id` is set to nil.
   To prevent collection, set it to an empty string or update it in `OnSendError` / `OnSession`.
   [#1442](https://github.com/bugsnag/bugsnag-cocoa/pull/1442)


### PR DESCRIPTION
## Goal

Make session delivery behaviour similar to event delivery.

## Changeset

Schedules scan & upload of stored sessions upon regaining network connection.

Exposes the `BSGSessionUploader` object in order to call this from existing connectivity listener.

## Testing

Not covered by automated tests. Verified manually using example app.