### PR TITLE
[PLAT-8744] Make `stackframesWithCallStackReturnAddresses:` public

### DIFF
--- a/Bugsnag/Payload/BugsnagStackframe+Private.h
+++ b/Bugsnag/Payload/BugsnagStackframe+Private.h
@@ -14,8 +14,6 @@ NS_ASSUME_NONNULL_BEGIN
 
 + (NSArray<BugsnagStackframe *> *)stackframesWithBacktrace:(uintptr_t *)backtrace length:(NSUInteger)length;
 
-+ (NSArray<BugsnagStackframe *> *)stackframesWithCallStackReturnAddresses:(NSArray<NSNumber *> *)callStackReturnAddresses;
-
 /// Constructs a stackframe object from a stackframe dictionary and list of images captured by KSCrash.
 + (nullable instancetype)frameFromDict:(NSDictionary<NSString *, id> *)dict withImages:(NSArray<NSDictionary<NSString *, id> *> *)binaryImages;
 

--- a/Bugsnag/include/Bugsnag/BugsnagStackframe.h
+++ b/Bugsnag/include/Bugsnag/BugsnagStackframe.h
@@ -70,9 +70,19 @@ FOUNDATION_EXPORT BugsnagStackframeType const BugsnagStackframeTypeCocoa;
 @property (copy, nullable, nonatomic) BugsnagStackframeType type;
 
 /**
- * Returns an array of stackframe objects representing the provided call stack strings.
+ * Creates an array of stackframe objects representing the provided call stack.
  *
- * The call stack strings should follow the format used by `[NSThread callStackSymbols]` and `backtrace_symbols()`.
+ * @param callStackReturnAddresses An array containing the call stack return addresses, as returned by
+ * `NSThread.callStackReturnAddresses` or `NSException.callStackReturnAddresses`.
+ */
++ (NSArray<BugsnagStackframe *> *)stackframesWithCallStackReturnAddresses:(NSArray<NSNumber *> *)callStackReturnAddresses;
+
+/**
+ * Creates an array of stackframe objects representing the provided call stack.
+ *
+ * @param callStackSymbols An array containing the call stack symbols, as returned by `NSThread.callStackSymbols`.
+ * Each element should be in a format determined by the `backtrace_symbols()` function.
+
  */
 + (nullable NSArray<BugsnagStackframe *> *)stackframesWithCallStackSymbols:(NSArray<NSString *> *)callStackSymbols;
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,11 @@ Changelog
 
 ## TBD
 
+### Enhancements
+
+* Add `+[BugsnagStackframe stackframesWithCallStackReturnAddresses:]` to public headers. 
+  [#1446](https://github.com/bugsnag/bugsnag-cocoa/pull/1446)
+
 ### Bug fixes
 
 * Attempt to send sessions stored on disk when connection regained.


### PR DESCRIPTION
## Goal

Allow 3rd party code to call `+[BugsnagStackframe stackframesWithCallStackReturnAddresses:]`

* https://github.com/bugsnag/bugsnag-cocoa/issues/1443

## Changeset

Moves method declaration to public header file and adds documentation.

## Testing

N/A - no code has changed.