### PR TITLE
[PLAT-8091] Reduce set of exported symbols

### DIFF
--- a/Bugsnag.podspec.json
+++ b/Bugsnag.podspec.json
@@ -38,6 +38,9 @@
       "Security"
     ]
   },
+  "compiler_flags": [
+    "-fvisibility=hidden"
+  ],
   "libraries": [
     "c++", "z"
   ],

--- a/Bugsnag.xcodeproj/project.pbxproj
+++ b/Bugsnag.xcodeproj/project.pbxproj
@@ -699,6 +699,10 @@
 		01C17AE72542ED7F00C102C9 /* KSCrashReportWriterTests.m in Sources */ = {isa = PBXBuildFile; fileRef = 01C17AE62542ED7F00C102C9 /* KSCrashReportWriterTests.m */; };
 		01C17AE82542ED7F00C102C9 /* KSCrashReportWriterTests.m in Sources */ = {isa = PBXBuildFile; fileRef = 01C17AE62542ED7F00C102C9 /* KSCrashReportWriterTests.m */; };
 		01C17AE92542ED7F00C102C9 /* KSCrashReportWriterTests.m in Sources */ = {isa = PBXBuildFile; fileRef = 01C17AE62542ED7F00C102C9 /* KSCrashReportWriterTests.m */; };
+		01C41A28288FD3EA00BAE31A /* BugsnagDefines.h in Headers */ = {isa = PBXBuildFile; fileRef = 01C41A27288FD3EA00BAE31A /* BugsnagDefines.h */; settings = {ATTRIBUTES = (Public, ); }; };
+		01C41A29288FD3EB00BAE31A /* BugsnagDefines.h in Headers */ = {isa = PBXBuildFile; fileRef = 01C41A27288FD3EA00BAE31A /* BugsnagDefines.h */; settings = {ATTRIBUTES = (Public, ); }; };
+		01C41A2A288FD3EB00BAE31A /* BugsnagDefines.h in Headers */ = {isa = PBXBuildFile; fileRef = 01C41A27288FD3EA00BAE31A /* BugsnagDefines.h */; settings = {ATTRIBUTES = (Public, ); }; };
+		01C41A2B288FD3EB00BAE31A /* BugsnagDefines.h in Headers */ = {isa = PBXBuildFile; fileRef = 01C41A27288FD3EA00BAE31A /* BugsnagDefines.h */; settings = {ATTRIBUTES = (Public, ); }; };
 		01CB95BF278F0C830077744A /* BSG_KSFile.h in Headers */ = {isa = PBXBuildFile; fileRef = 01CB95BD278F0C830077744A /* BSG_KSFile.h */; };
 		01CB95C0278F0C830077744A /* BSG_KSFile.h in Headers */ = {isa = PBXBuildFile; fileRef = 01CB95BD278F0C830077744A /* BSG_KSFile.h */; };
 		01CB95C1278F0C830077744A /* BSG_KSFile.h in Headers */ = {isa = PBXBuildFile; fileRef = 01CB95BD278F0C830077744A /* BSG_KSFile.h */; };
@@ -1614,6 +1618,7 @@
 		01C17AE62542ED7F00C102C9 /* KSCrashReportWriterTests.m */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.objc; path = KSCrashReportWriterTests.m; sourceTree = "<group>"; };
 		01C2769B2601F44D006901EA /* CHANGELOG.md */ = {isa = PBXFileReference; lastKnownFileType = net.daringfireball.markdown; path = CHANGELOG.md; sourceTree = "<group>"; };
 		01C2769C2601F455006901EA /* CONTRIBUTING.md */ = {isa = PBXFileReference; lastKnownFileType = net.daringfireball.markdown; path = CONTRIBUTING.md; sourceTree = "<group>"; };
+		01C41A27288FD3EA00BAE31A /* BugsnagDefines.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = BugsnagDefines.h; sourceTree = "<group>"; };
 		01CB95BD278F0C830077744A /* BSG_KSFile.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; path = BSG_KSFile.h; sourceTree = "<group>"; };
 		01CB95BE278F0C830077744A /* BSG_KSFile.c */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.c; path = BSG_KSFile.c; sourceTree = "<group>"; };
 		01CCAEE825D414D60057268D /* BugsnagLastRunInfo.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; path = BugsnagLastRunInfo.h; sourceTree = "<group>"; };
@@ -2281,6 +2286,7 @@
 				3A700A8524A63A8E0068CD1B /* BugsnagBreadcrumb.h */,
 				3A700A8924A63A8E0068CD1B /* BugsnagClient.h */,
 				3A700A8D24A63A8E0068CD1B /* BugsnagConfiguration.h */,
+				01C41A27288FD3EA00BAE31A /* BugsnagDefines.h */,
 				3A700A8F24A63A8E0068CD1B /* BugsnagDevice.h */,
 				3A700A9224A63A8E0068CD1B /* BugsnagDeviceWithState.h */,
 				3A700A8424A63A8E0068CD1B /* BugsnagEndpointConfiguration.h */,
@@ -2374,6 +2380,7 @@
 				008969DE2486DAD100DC48C2 /* BSG_KSCrashC.h in Headers */,
 				0089699F2486DAD100DC48C2 /* BSG_KSJSONCodecObjC.h in Headers */,
 				0089697E2486DAD100DC48C2 /* BSG_KSArchSpecific.h in Headers */,
+				01C41A28288FD3EA00BAE31A /* BugsnagDefines.h in Headers */,
 				CB3744942845FA9500A3955E /* BSG_KSCrashStringConversion.h in Headers */,
 				0154E20228070AEA009044E4 /* BSGRunContext.h in Headers */,
 				008969BA2486DAD100DC48C2 /* BSG_KSJSONCodec.h in Headers */,
@@ -2476,6 +2483,7 @@
 				008969DF2486DAD100DC48C2 /* BSG_KSCrashC.h in Headers */,
 				008969A02486DAD100DC48C2 /* BSG_KSJSONCodecObjC.h in Headers */,
 				0089697F2486DAD100DC48C2 /* BSG_KSArchSpecific.h in Headers */,
+				01C41A29288FD3EB00BAE31A /* BugsnagDefines.h in Headers */,
 				CB3744952845FA9500A3955E /* BSG_KSCrashStringConversion.h in Headers */,
 				0154E20328070AEA009044E4 /* BSGRunContext.h in Headers */,
 				008969BB2486DAD100DC48C2 /* BSG_KSJSONCodec.h in Headers */,
@@ -2578,6 +2586,7 @@
 				008969E02486DAD100DC48C2 /* BSG_KSCrashC.h in Headers */,
 				008969A12486DAD100DC48C2 /* BSG_KSJSONCodecObjC.h in Headers */,
 				008969802486DAD100DC48C2 /* BSG_KSArchSpecific.h in Headers */,
+				01C41A2A288FD3EB00BAE31A /* BugsnagDefines.h in Headers */,
 				CB3744962845FA9500A3955E /* BSG_KSCrashStringConversion.h in Headers */,
 				0154E20428070AEA009044E4 /* BSGRunContext.h in Headers */,
 				008969BC2486DAD100DC48C2 /* BSG_KSJSONCodec.h in Headers */,
@@ -2660,6 +2669,7 @@
 				CBBDE95B280068FD0070DCD3 /* BugsnagBreadcrumb.h in Headers */,
 				CBBDE99B2800699C0070DCD3 /* BSG_KSCrashSentry_MachException.h in Headers */,
 				CBBDE917280068560070DCD3 /* BugsnagSessionTracker.h in Headers */,
+				01C41A2B288FD3EB00BAE31A /* BugsnagDefines.h in Headers */,
 				CBBDE93F280068D40070DCD3 /* BSGSerialization.h in Headers */,
 				CBBDE954280068FD0070DCD3 /* BugsnagEvent.h in Headers */,
 				CBBDE962280068FD0070DCD3 /* BugsnagFeatureFlag.h in Headers */,
@@ -3947,6 +3957,7 @@
 					"DEBUG=1",
 					"$(inherited)",
 				);
+				GCC_SYMBOLS_PRIVATE_EXTERN = YES;
 				INFOPLIST_FILE = ./Framework/Info.plist;
 				IPHONEOS_DEPLOYMENT_TARGET = 9.0;
 				MACOSX_DEPLOYMENT_TARGET = 10.11;
@@ -3989,6 +4000,7 @@
 				ENABLE_STRICT_OBJC_MSGSEND = YES;
 				GCC_C_LANGUAGE_STANDARD = gnu11;
 				GCC_NO_COMMON_BLOCKS = YES;
+				GCC_SYMBOLS_PRIVATE_EXTERN = YES;
 				INFOPLIST_FILE = ./Framework/Info.plist;
 				IPHONEOS_DEPLOYMENT_TARGET = 9.0;
 				MACOSX_DEPLOYMENT_TARGET = 10.11;

--- a/Bugsnag/Helpers/BSGDefines.h
+++ b/Bugsnag/Helpers/BSGDefines.h
@@ -10,8 +10,6 @@
 
 #include <TargetConditionals.h>
 
-#define BSG_PRIVATE __attribute__((visibility("hidden")))
-
 // Capabilities dependent upon system defines and files
 #define BSG_HAVE_APPKIT                       __has_include(<AppKit/AppKit.h>)
 #define BSG_HAVE_BATTERY                      (                 TARGET_OS_IOS                 || TARGET_OS_WATCH)

--- a/Bugsnag/Helpers/BSGInternalErrorReporter.h
+++ b/Bugsnag/Helpers/BSGInternalErrorReporter.h
@@ -19,7 +19,7 @@
 NS_ASSUME_NONNULL_BEGIN
 
 /// Returns a concise desription of the error including its domain, code, and debug description or localizedDescription.
-BSG_PRIVATE NSString *_Nullable BSGErrorDescription(NSError *_Nullable error);
+NSString *_Nullable BSGErrorDescription(NSError *_Nullable error);
 
 // MARK: -
 

--- a/Bugsnag/Helpers/BSGRunContext.h
+++ b/Bugsnag/Helpers/BSGRunContext.h
@@ -70,9 +70,9 @@ void BSGRunContextInit(NSString *_Nonnull path);
 
 #pragma mark -
 
-BSG_PRIVATE void BSGRunContextUpdateMemory(void);
+void BSGRunContextUpdateMemory(void);
 
-BSG_PRIVATE void BSGRunContextUpdateTimestamp(void);
+void BSGRunContextUpdateTimestamp(void);
 
 #pragma mark -
 

--- a/Bugsnag/Helpers/BSGUtils.h
+++ b/Bugsnag/Helpers/BSGUtils.h
@@ -16,7 +16,7 @@ __BEGIN_DECLS
 NS_ASSUME_NONNULL_BEGIN
 
 /// Returns a heap allocated null-terminated C string with the contents of `data`, or NULL if `data` is nil or empty.
-BSG_PRIVATE char *_Nullable BSGCStringWithData(NSData *_Nullable data);
+char *_Nullable BSGCStringWithData(NSData *_Nullable data);
 
 /// Changes the NSFileProtectionKey attribute of the specified file or directory from NSFileProtectionComplete to NSFileProtectionCompleteUnlessOpen.
 /// Has no effect if the specified file or directory does not have NSFileProtectionComplete.
@@ -24,7 +24,7 @@ BSG_PRIVATE char *_Nullable BSGCStringWithData(NSData *_Nullable data);
 /// Files with NSFileProtectionComplete cannot be read from or written to while the device is locked or booting.
 ///
 /// Files with NSFileProtectionCompleteUnlessOpen can be created while the device is locked, but once closed, cannot be opened again until the device is unlocked.
-BSG_PRIVATE BOOL BSGDisableNSFileProtectionComplete(NSString *path);
+BOOL BSGDisableNSFileProtectionComplete(NSString *path);
 
 dispatch_queue_t BSGGetFileSystemQueue(void);
 

--- a/Bugsnag/KSCrash/Source/KSCrash/Recording/BSG_KSSystemInfo.h
+++ b/Bugsnag/KSCrash/Source/KSCrash/Recording/BSG_KSSystemInfo.h
@@ -24,6 +24,9 @@
 // THE SOFTWARE.
 //
 
+#import <Bugsnag/BugsnagDefines.h>
+#import <Foundation/Foundation.h>
+
 #define BSG_KSSystemField_AppUUID "app_uuid"
 #define BSG_KSSystemField_BinaryArch "binary_arch"
 #define BSG_KSSystemField_BundleID "CFBundleIdentifier"
@@ -47,11 +50,10 @@
 #define BSG_KSSystemField_Translated "proc_translated"
 #define BSG_KSSystemField_iOSSupportVersion "iOSSupportVersion"
 
-#import <Foundation/Foundation.h>
-
 /**
  * Provides system information useful for a crash report.
  */
+BUGSNAG_EXTERN
 @interface BSG_KSSystemInfo : NSObject
 
 /** Get the system info.

--- a/Bugsnag/KSCrash/Source/KSCrash/Recording/Tools/BSG_KSLogger.h
+++ b/Bugsnag/KSCrash/Source/KSCrash/Recording/Tools/BSG_KSLogger.h
@@ -31,6 +31,7 @@
 extern "C" {
 #endif
 
+#include <Bugsnag/BugsnagDefines.h>
 
 #include "BugsnagLogger.h"
 
@@ -143,6 +144,7 @@ void bsg_i_kslog_logC(const char *level, const char *file, int line,
                       const char *function, const char *fmt, ...)
                                                 __printflike(5, 6);
 
+BUGSNAG_EXTERN
 void bsg_i_kslog_logCBasic(const char *fmt, ...) __printflike(1, 2);
 
 #define i_KSLOG_FULL bsg_i_kslog_logC
@@ -212,6 +214,7 @@ void bsg_i_kslog_logCBasic(const char *fmt, ...) __printflike(1, 2);
  *
  * @param overwrite If true, overwrite the log file.
  */
+BUGSNAG_EXTERN
 bool bsg_kslog_setLogFilename(const char *filename, bool overwrite);
 
 /** Tests if the logger would print at the specified level.

--- a/Bugsnag/Payload/BugsnagApp+Private.h
+++ b/Bugsnag/Payload/BugsnagApp+Private.h
@@ -32,6 +32,6 @@ NS_ASSUME_NONNULL_BEGIN
 
 NSDictionary *BSGParseAppMetadata(NSDictionary *event);
 
-BSG_PRIVATE NSDictionary *BSGAppMetadataFromRunContext(const struct BSGRunContext *context);
+NSDictionary *BSGAppMetadataFromRunContext(const struct BSGRunContext *context);
 
 NS_ASSUME_NONNULL_END

--- a/Bugsnag/Payload/BugsnagBreadcrumb+Private.h
+++ b/Bugsnag/Payload/BugsnagBreadcrumb+Private.h
@@ -7,6 +7,7 @@
 //
 
 #import <Bugsnag/BugsnagBreadcrumb.h>
+#import <Bugsnag/BugsnagDefines.h>
 
 NS_ASSUME_NONNULL_BEGIN
 
@@ -23,7 +24,7 @@ NS_ASSUME_NONNULL_BEGIN
 
 @end
 
-FOUNDATION_EXPORT NSString *BSGBreadcrumbTypeValue(BSGBreadcrumbType type);
-FOUNDATION_EXPORT BSGBreadcrumbType BSGBreadcrumbTypeFromString( NSString * _Nullable value);
+BUGSNAG_EXTERN NSString * BSGBreadcrumbTypeValue(BSGBreadcrumbType type);
+BUGSNAG_EXTERN BSGBreadcrumbType BSGBreadcrumbTypeFromString(NSString * _Nullable value);
 
 NS_ASSUME_NONNULL_END

--- a/Bugsnag/Payload/BugsnagDeviceWithState+Private.h
+++ b/Bugsnag/Payload/BugsnagDeviceWithState+Private.h
@@ -32,6 +32,6 @@ NS_ASSUME_NONNULL_BEGIN
 
 NSMutableDictionary *BSGParseDeviceMetadata(NSDictionary *event);
 
-BSG_PRIVATE NSDictionary * BSGDeviceMetadataFromRunContext(const struct BSGRunContext *context);
+NSDictionary * BSGDeviceMetadataFromRunContext(const struct BSGRunContext *context);
 
 NS_ASSUME_NONNULL_END

--- a/Bugsnag/Payload/BugsnagHandledState.h
+++ b/Bugsnag/Payload/BugsnagHandledState.h
@@ -32,7 +32,7 @@ typedef NS_ENUM(NSUInteger, SeverityReasonType) {
  *  @return converted severity level or BSGSeverityError if no conversion is
  * found
  */
-BSGSeverity BSGParseSeverity(NSString *severity);
+BUGSNAG_EXTERN BSGSeverity BSGParseSeverity(NSString *severity);
 
 /**
  *  Serialize a severity for JSON payloads
@@ -43,6 +43,7 @@ BSGSeverity BSGParseSeverity(NSString *severity);
  */
 NSString *BSGFormatSeverity(BSGSeverity severity);
 
+BUGSNAG_EXTERN
 @interface BugsnagHandledState : NSObject
 
 @property(nonatomic) BOOL unhandled;

--- a/Bugsnag/Payload/BugsnagNotifier.h
+++ b/Bugsnag/Payload/BugsnagNotifier.h
@@ -6,10 +6,12 @@
 //  Copyright © 2020 Bugsnag. All rights reserved.
 //
 
+#import <Bugsnag/BugsnagDefines.h>
 #import <Foundation/Foundation.h>
 
 NS_ASSUME_NONNULL_BEGIN
 
+BUGSNAG_EXTERN
 @interface BugsnagNotifier : NSObject
 
 /// Initializes the object with details of the Cocoa notifier.

--- a/Bugsnag/Payload/BugsnagSession+Private.h
+++ b/Bugsnag/Payload/BugsnagSession+Private.h
@@ -52,15 +52,15 @@ NSDictionary * BSGSessionToEventJson(BugsnagSession *session);
 BugsnagSession *_Nullable BSGSessionFromEventJson(NSDictionary *_Nullable json, BugsnagApp *app, BugsnagDevice *device, BugsnagUser *user);
 
 /// Saves the session info into bsg_runContext.
-BSG_PRIVATE void BSGSessionUpdateRunContext(BugsnagSession *_Nullable session);
+void BSGSessionUpdateRunContext(BugsnagSession *_Nullable session);
 
 /// Returns session information from bsg_lastRunContext.
-BSG_PRIVATE BugsnagSession *_Nullable BSGSessionFromLastRunContext(BugsnagApp *app, BugsnagDevice *device, BugsnagUser *user);
+BugsnagSession *_Nullable BSGSessionFromLastRunContext(BugsnagApp *app, BugsnagDevice *device, BugsnagUser *user);
 
 /// Saves current session information (from bsg_runContext) into a crash report.
-BSG_PRIVATE void BSGSessionWriteCrashReport(const BSG_KSCrashReportWriter *writer);
+void BSGSessionWriteCrashReport(const BSG_KSCrashReportWriter *writer);
 
 /// Returns session information from a crash report previously written to by BSGSessionWriteCrashReport or BSSerializeDataCrashHandler.
-BSG_PRIVATE BugsnagSession *_Nullable BSGSessionFromCrashReport(NSDictionary *report, BugsnagApp *app, BugsnagDevice *device, BugsnagUser *user);
+BugsnagSession *_Nullable BSGSessionFromCrashReport(NSDictionary *report, BugsnagApp *app, BugsnagDevice *device, BugsnagUser *user);
 
 NS_ASSUME_NONNULL_END

--- a/Bugsnag/include/Bugsnag/Bugsnag.h
+++ b/Bugsnag/include/Bugsnag/Bugsnag.h
@@ -29,6 +29,7 @@
 #import <Bugsnag/BugsnagAppWithState.h>
 #import <Bugsnag/BugsnagClient.h>
 #import <Bugsnag/BugsnagConfiguration.h>
+#import <Bugsnag/BugsnagDefines.h>
 #import <Bugsnag/BugsnagDevice.h>
 #import <Bugsnag/BugsnagDeviceWithState.h>
 #import <Bugsnag/BugsnagEndpointConfiguration.h>
@@ -46,6 +47,7 @@
 /**
  * Static access to a Bugsnag Client, the easiest way to use Bugsnag in your app.
  */
+BUGSNAG_EXTERN
 @interface Bugsnag : NSObject <BugsnagClassLevelMetadataStore>
 
 /**
@@ -103,7 +105,7 @@
 /**
  * @return YES if Bugsnag has been started and the previous launch crashed
  */
-+ (BOOL)appDidCrashLastLaunch BSG_DEPRECATED_WITH_REPLACEMENT("lastRunInfo.crashed");
++ (BOOL)appDidCrashLastLaunch BUGSNAG_DEPRECATED_WITH_REPLACEMENT("lastRunInfo.crashed");
 
 /**
  * Information about the last run of the app, and whether it crashed.
@@ -340,7 +342,7 @@
  * Deprecated
  */
 + (void)removeOnSessionBlock:(BugsnagOnSessionBlock _Nonnull)block
-    BSG_DEPRECATED_WITH_REPLACEMENT("removeOnSession:")
+    BUGSNAG_DEPRECATED_WITH_REPLACEMENT("removeOnSession:")
     NS_SWIFT_NAME(removeOnSession(block:));
 
 // =============================================================================
@@ -370,7 +372,7 @@
  * Deprecated
  */
 + (void)removeOnBreadcrumbBlock:(BugsnagOnBreadcrumbBlock _Nonnull)block
-    BSG_DEPRECATED_WITH_REPLACEMENT("removeOnBreadcrumb:")
+    BUGSNAG_DEPRECATED_WITH_REPLACEMENT("removeOnBreadcrumb:")
     NS_SWIFT_NAME(removeOnBreadcrumb(block:));
 
 @end

--- a/Bugsnag/include/Bugsnag/BugsnagApp.h
+++ b/Bugsnag/include/Bugsnag/BugsnagApp.h
@@ -8,10 +8,13 @@
 
 #import <Foundation/Foundation.h>
 
+#import <Bugsnag/BugsnagDefines.h>
+
 /**
  * Stateless information set by the notifier about your app can be found on this class. These values
  * can be accessed and amended if necessary.
  */
+BUGSNAG_EXTERN
 @interface BugsnagApp : NSObject
 
 /**

--- a/Bugsnag/include/Bugsnag/BugsnagAppWithState.h
+++ b/Bugsnag/include/Bugsnag/BugsnagAppWithState.h
@@ -9,11 +9,13 @@
 #import <Foundation/Foundation.h>
 
 #import <Bugsnag/BugsnagApp.h>
+#import <Bugsnag/BugsnagDefines.h>
 
 /**
  * Stateful information set by the notifier about your app can be found on this class. These values
  * can be accessed and amended if necessary.
  */
+BUGSNAG_EXTERN
 @interface BugsnagAppWithState : BugsnagApp
 
 /**

--- a/Bugsnag/include/Bugsnag/BugsnagBreadcrumb.h
+++ b/Bugsnag/include/Bugsnag/BugsnagBreadcrumb.h
@@ -25,6 +25,8 @@
 //
 #import <Foundation/Foundation.h>
 
+#import <Bugsnag/BugsnagDefines.h>
+
 /**
  * Types of breadcrumbs
  */
@@ -89,6 +91,7 @@ typedef NS_OPTIONS(NSUInteger, BSGEnabledBreadcrumbType) {
  */
 @class BugsnagBreadcrumb;
 
+BUGSNAG_EXTERN
 @interface BugsnagBreadcrumb : NSObject
 
 /**

--- a/Bugsnag/include/Bugsnag/BugsnagClient.h
+++ b/Bugsnag/include/Bugsnag/BugsnagClient.h
@@ -27,6 +27,7 @@
 #import <Foundation/Foundation.h>
 
 #import <Bugsnag/BugsnagConfiguration.h>
+#import <Bugsnag/BugsnagDefines.h>
 #import <Bugsnag/BugsnagLastRunInfo.h>
 #import <Bugsnag/BugsnagFeatureFlagStore.h>
 #import <Bugsnag/BugsnagMetadata.h>
@@ -39,6 +40,7 @@
  * 
  * Use the static access provided by the Bugsnag class instead.
  */
+BUGSNAG_EXTERN
 @interface BugsnagClient : NSObject<BSGBreadcrumbSink, BugsnagFeatureFlagStore, BugsnagMetadataStore>
 
 /**
@@ -206,7 +208,7 @@ NS_SWIFT_NAME(leaveBreadcrumb(_:metadata:type:));
  * Deprecated
  */
 - (void)removeOnSessionBlock:(BugsnagOnSessionBlock _Nonnull )block
-    BSG_DEPRECATED_WITH_REPLACEMENT("removeOnSession:")
+    BUGSNAG_DEPRECATED_WITH_REPLACEMENT("removeOnSession:")
     NS_SWIFT_NAME(removeOnSession(block:));
 
 // =============================================================================
@@ -221,7 +223,7 @@ NS_SWIFT_NAME(leaveBreadcrumb(_:metadata:type:));
 /**
  * @return YES if Bugsnag has been started and the previous launch crashed
  */
-- (BOOL)appDidCrashLastLaunch BSG_DEPRECATED_WITH_REPLACEMENT("lastRunInfo.crashed");
+- (BOOL)appDidCrashLastLaunch BUGSNAG_DEPRECATED_WITH_REPLACEMENT("lastRunInfo.crashed");
 
 /**
  * Information about the last run of the app, and whether it crashed.
@@ -283,7 +285,7 @@ NS_SWIFT_NAME(leaveBreadcrumb(_:metadata:type:));
  * Deprecated
  */
 - (void)removeOnBreadcrumbBlock:(BugsnagOnBreadcrumbBlock _Nonnull)block
-    BSG_DEPRECATED_WITH_REPLACEMENT("removeOnBreadcrumb:")
+    BUGSNAG_DEPRECATED_WITH_REPLACEMENT("removeOnBreadcrumb:")
     NS_SWIFT_NAME(removeOnBreadcrumb(block:));
 
 @end

--- a/Bugsnag/include/Bugsnag/BugsnagConfiguration.h
+++ b/Bugsnag/include/Bugsnag/BugsnagConfiguration.h
@@ -28,16 +28,12 @@
 
 #import <Bugsnag/BSG_KSCrashReportWriter.h>
 #import <Bugsnag/BugsnagBreadcrumb.h>
+#import <Bugsnag/BugsnagDefines.h>
 #import <Bugsnag/BugsnagEvent.h>
 #import <Bugsnag/BugsnagFeatureFlagStore.h>
 #import <Bugsnag/BugsnagMetadata.h>
 #import <Bugsnag/BugsnagMetadataStore.h>
 #import <Bugsnag/BugsnagPlugin.h>
-
-/**
- * Annotates methods and properties that will be removed in the next major release of Bugsnag.
- */
-#define BSG_DEPRECATED_WITH_REPLACEMENT(REPLACEMENT) __attribute__((deprecated("", REPLACEMENT)))
 
 @class BugsnagUser;
 @class BugsnagEndpointConfiguration;
@@ -92,7 +88,7 @@ typedef NS_OPTIONS(NSUInteger, BSGTelemetryOptions) {
  * Setting `BugsnagConfiguration.appHangThresholdMillis` to this value disables the reporting of
  * app hangs that ended before the app was terminated.
  */
-extern const NSUInteger BugsnagAppHangThresholdFatalOnly API_UNAVAILABLE(watchos);
+BUGSNAG_EXTERN const NSUInteger BugsnagAppHangThresholdFatalOnly API_UNAVAILABLE(watchos);
 
 /**
  *  A configuration block for modifying an error report
@@ -149,6 +145,7 @@ typedef id<NSObject> BugsnagOnSessionRef;
 /**
  * Contains user-provided configuration, including API key and endpoints.
  */
+BUGSNAG_EXTERN
 @interface BugsnagConfiguration : NSObject <BugsnagFeatureFlagStore, BugsnagMetadataStore>
 
 /**
@@ -408,7 +405,7 @@ typedef id<NSObject> BugsnagOnSessionRef;
  * Deprecated
  */
 - (void)removeOnSessionBlock:(BugsnagOnSessionBlock)block
-    BSG_DEPRECATED_WITH_REPLACEMENT("removeOnSession:")
+    BUGSNAG_DEPRECATED_WITH_REPLACEMENT("removeOnSession:")
     NS_SWIFT_NAME(removeOnSession(block:));
 
 // =============================================================================
@@ -438,7 +435,7 @@ typedef id<NSObject> BugsnagOnSessionRef;
  * Deprecated
  */
 - (void)removeOnSendErrorBlock:(BugsnagOnSendErrorBlock)block
-    BSG_DEPRECATED_WITH_REPLACEMENT("removeOnSendError:")
+    BUGSNAG_DEPRECATED_WITH_REPLACEMENT("removeOnSendError:")
     NS_SWIFT_NAME(removeOnSendError(block:));
 
 // =============================================================================
@@ -468,7 +465,7 @@ typedef id<NSObject> BugsnagOnSessionRef;
  * Deprecated
  */
 - (void)removeOnBreadcrumbBlock:(BugsnagOnBreadcrumbBlock)block
-    BSG_DEPRECATED_WITH_REPLACEMENT("removeOnBreadcrumb:")
+    BUGSNAG_DEPRECATED_WITH_REPLACEMENT("removeOnBreadcrumb:")
     NS_SWIFT_NAME(removeOnBreadcrumb(block:));
 
 // =============================================================================

--- a/Bugsnag/include/Bugsnag/BugsnagDefines.h
+++ b/Bugsnag/include/Bugsnag/BugsnagDefines.h
@@ -1,9 +1,8 @@
 //
-//  BugsnagMetaData.h
+//  BugsnagDefines.h
+//  Bugsnag
 //
-//  Created by Conrad Irwin on 2014-10-01.
-//
-//  Copyright (c) 2014 Bugsnag, Inc. All rights reserved.
+//  Copyright © 2022 Bugsnag Inc. All rights reserved.
 //
 // Permission is hereby granted, free of charge, to any person obtaining a copy
 // of this software and associated documentation files (the "Software"), to deal
@@ -24,25 +23,19 @@
 // THE SOFTWARE.
 //
 
-#import <Foundation/Foundation.h>
+#ifndef BugsnagDefines_h
+#define BugsnagDefines_h
 
-#import <Bugsnag/BugsnagDefines.h>
-#import <Bugsnag/BugsnagMetadataStore.h>
+#ifndef BUGSNAG_DEPRECATED_WITH_REPLACEMENT
+#define BUGSNAG_DEPRECATED_WITH_REPLACEMENT(REPLACEMENT) __attribute__((deprecated ("", REPLACEMENT)))
+#endif
 
-NS_ASSUME_NONNULL_BEGIN
+#ifndef BUGSNAG_EXTERN
+#ifdef __cplusplus
+#define BUGSNAG_EXTERN extern "C" __attribute__((visibility ("default")))
+#else
+#define BUGSNAG_EXTERN extern __attribute__((visibility ("default")))
+#endif
+#endif
 
-/// :nodoc:
-BUGSNAG_EXTERN
-@interface BugsnagMetadata : NSObject <BugsnagMetadataStore>
-
-- (instancetype)initWithDictionary:(NSDictionary *)dict;
-
-/// Configures the metadata object to serialize itself to the provided buffer and file immediately, and upon each change.
-- (void)setStorageBuffer:(char *_Nullable *_Nullable)buffer file:(nullable NSString *)file;
-
-/// Exposed to facilitate unit testing.
-- (void)writeData:(NSData *)data toBuffer:(char *_Nullable *_Nonnull)buffer;
-
-@end
-
-NS_ASSUME_NONNULL_END
+#endif

--- a/Bugsnag/include/Bugsnag/BugsnagDevice.h
+++ b/Bugsnag/include/Bugsnag/BugsnagDevice.h
@@ -8,10 +8,13 @@
 
 #import <Foundation/Foundation.h>
 
+#import <Bugsnag/BugsnagDefines.h>
+
 /**
  * Stateless information set by the notifier about the device on which the event occurred can be
  * found on this class. These values can be accessed and amended if necessary.
  */
+BUGSNAG_EXTERN
 @interface BugsnagDevice : NSObject
 
 /**

--- a/Bugsnag/include/Bugsnag/BugsnagDeviceWithState.h
+++ b/Bugsnag/include/Bugsnag/BugsnagDeviceWithState.h
@@ -8,12 +8,14 @@
 
 #import <Foundation/Foundation.h>
 
+#import <Bugsnag/BugsnagDefines.h>
 #import <Bugsnag/BugsnagDevice.h>
 
 /**
  * Stateful information set by the notifier about the device on which the event occurred can be
  * found on this class. These values can be accessed and amended if necessary.
  */
+BUGSNAG_EXTERN
 @interface BugsnagDeviceWithState : BugsnagDevice
 
 /**

--- a/Bugsnag/include/Bugsnag/BugsnagEndpointConfiguration.h
+++ b/Bugsnag/include/Bugsnag/BugsnagEndpointConfiguration.h
@@ -8,6 +8,8 @@
 
 #import <Foundation/Foundation.h>
 
+#import <Bugsnag/BugsnagDefines.h>
+
 NS_ASSUME_NONNULL_BEGIN
 
 /**
@@ -15,6 +17,7 @@ NS_ASSUME_NONNULL_BEGIN
  * https://notify.bugsnag.com, and sessions to https://sessions.bugsnag.com, but you can
  * override this if you are using Bugsnag Enterprise to point to your own Bugsnag endpoints.
  */
+BUGSNAG_EXTERN
 @interface BugsnagEndpointConfiguration : NSObject
 
 /**

--- a/Bugsnag/include/Bugsnag/BugsnagError.h
+++ b/Bugsnag/include/Bugsnag/BugsnagError.h
@@ -8,6 +8,8 @@
 
 #import <Foundation/Foundation.h>
 
+#import <Bugsnag/BugsnagDefines.h>
+
 @class BugsnagStackframe;
 
 /**
@@ -22,6 +24,7 @@ typedef NS_OPTIONS(NSUInteger, BSGErrorType) {
 /**
  * An Error represents information extracted from an NSError, NSException, or other error source.
  */
+BUGSNAG_EXTERN
 @interface BugsnagError : NSObject
 
 /**

--- a/Bugsnag/include/Bugsnag/BugsnagErrorTypes.h
+++ b/Bugsnag/include/Bugsnag/BugsnagErrorTypes.h
@@ -8,9 +8,12 @@
 
 #import <Foundation/Foundation.h>
 
+#import <Bugsnag/BugsnagDefines.h>
+
 /**
  * The types of error that should be reported.
  */
+BUGSNAG_EXTERN
 @interface BugsnagErrorTypes : NSObject
 
 /**

--- a/Bugsnag/include/Bugsnag/BugsnagEvent.h
+++ b/Bugsnag/include/Bugsnag/BugsnagEvent.h
@@ -8,6 +8,7 @@
 
 #import <Foundation/Foundation.h>
 
+#import <Bugsnag/BugsnagDefines.h>
 #import <Bugsnag/BugsnagFeatureFlagStore.h>
 #import <Bugsnag/BugsnagMetadataStore.h>
 
@@ -34,6 +35,7 @@ typedef NS_ENUM(NSUInteger, BSGSeverity) {
 /**
  * Represents an occurrence of an error, along with information about the state of the app and device.
  */
+BUGSNAG_EXTERN
 @interface BugsnagEvent : NSObject <BugsnagFeatureFlagStore, BugsnagMetadataStore>
 
 // -----------------------------------------------------------------------------

--- a/Bugsnag/include/Bugsnag/BugsnagFeatureFlag.h
+++ b/Bugsnag/include/Bugsnag/BugsnagFeatureFlag.h
@@ -8,8 +8,11 @@
 
 #import <Foundation/Foundation.h>
 
+#import <Bugsnag/BugsnagDefines.h>
+
 NS_ASSUME_NONNULL_BEGIN
 
+BUGSNAG_EXTERN
 @interface BugsnagFeatureFlag : NSObject
 
 + (instancetype)flagWithName:(NSString *)name;

--- a/Bugsnag/include/Bugsnag/BugsnagLastRunInfo.h
+++ b/Bugsnag/include/Bugsnag/BugsnagLastRunInfo.h
@@ -8,11 +8,14 @@
 
 #import <Foundation/Foundation.h>
 
+#import <Bugsnag/BugsnagDefines.h>
+
 NS_ASSUME_NONNULL_BEGIN
 
 /**
  * Contains information about the last run of the app.
  */
+BUGSNAG_EXTERN
 @interface BugsnagLastRunInfo : NSObject
 
 /**

--- a/Bugsnag/include/Bugsnag/BugsnagSession.h
+++ b/Bugsnag/include/Bugsnag/BugsnagSession.h
@@ -9,6 +9,7 @@
 #import <Foundation/Foundation.h>
 
 #import <Bugsnag/BugsnagApp.h>
+#import <Bugsnag/BugsnagDefines.h>
 #import <Bugsnag/BugsnagDevice.h>
 #import <Bugsnag/BugsnagUser.h>
 
@@ -17,6 +18,7 @@ NS_ASSUME_NONNULL_BEGIN
 /**
  * Represents a session of user interaction with your app.
  */
+BUGSNAG_EXTERN
 @interface BugsnagSession : NSObject
 
 @property (copy, nonatomic) NSString *id;

--- a/Bugsnag/include/Bugsnag/BugsnagStackframe.h
+++ b/Bugsnag/include/Bugsnag/BugsnagStackframe.h
@@ -8,15 +8,18 @@
 
 #import <Foundation/Foundation.h>
 
+#import <Bugsnag/BugsnagDefines.h>
+
 NS_ASSUME_NONNULL_BEGIN
 
 typedef NSString * BugsnagStackframeType NS_TYPED_ENUM;
 
-FOUNDATION_EXPORT BugsnagStackframeType const BugsnagStackframeTypeCocoa;
+BUGSNAG_EXTERN BugsnagStackframeType const BugsnagStackframeTypeCocoa;
 
 /**
  * Represents a single stackframe from a stacktrace.
  */
+BUGSNAG_EXTERN
 @interface BugsnagStackframe : NSObject
 
 /**

--- a/Bugsnag/include/Bugsnag/BugsnagThread.h
+++ b/Bugsnag/include/Bugsnag/BugsnagThread.h
@@ -8,6 +8,8 @@
 
 #import <Foundation/Foundation.h>
 
+#import <Bugsnag/BugsnagDefines.h>
+
 typedef NS_OPTIONS(NSUInteger, BSGThreadType) {
     BSGThreadTypeCocoa NS_SWIFT_NAME(cocoa) = 0,
     BSGThreadTypeReactNativeJs = 1 << 1
@@ -18,6 +20,7 @@ typedef NS_OPTIONS(NSUInteger, BSGThreadType) {
 /**
  * A representation of thread information recorded as part of a BugsnagEvent.
  */
+BUGSNAG_EXTERN
 @interface BugsnagThread : NSObject
 
 /**

--- a/Bugsnag/include/Bugsnag/BugsnagUser.h
+++ b/Bugsnag/include/Bugsnag/BugsnagUser.h
@@ -8,9 +8,12 @@
 
 #import <Foundation/Foundation.h>
 
+#import <Bugsnag/BugsnagDefines.h>
+
 /**
  * Information about the current user of your application.
  */
+BUGSNAG_EXTERN
 @interface BugsnagUser : NSObject
 
 @property (readonly, nullable, nonatomic) NSString *id;

--- a/Package.swift
+++ b/Package.swift
@@ -37,6 +37,7 @@ let package = Package(
                 .headerSearchPath("Payload"),
                 .headerSearchPath("Plugins"),
                 .headerSearchPath("Storage"),
+                .unsafeFlags(["-fvisibility=hidden"]),
             ],
             linkerSettings: [
                 .linkedLibrary("z"),

--- a/Tests/BugsnagTests/Tests-Bridging-Header.h
+++ b/Tests/BugsnagTests/Tests-Bridging-Header.h
@@ -2,5 +2,6 @@
 //  Public headers exposed to Swift
 //
 
-#import "BugsnagConfiguration.h"
+#import <Bugsnag/Bugsnag.h>
+
 #import "BugsnagTestConstants.h"


### PR DESCRIPTION
## Goal

Reduce the set of exported symbols to make the (dynamic) library / framework easier to maintain and faster to load.

See [Dynamic Library Design Guidelines](https://developer.apple.com/library/archive/documentation/DeveloperTools/Conceptual/DynamicLibraries/100-Articles/DynamicLibraryDesignGuidelines.html#//apple_ref/doc/uid/TP40002013-SW24).

Apps that link against Bugsnag as a static library are unaffected.

## Design

Uses the `-fvisibility=hidden` compiler option to hide symbols by default, and explicitly marks symbols which should be exported.

### Dependant notifiers

* `bugsnag-flutter` includes Bugsnag as a CocoaPod, so could be affected.
* `bugsnag-js` vendors in Bugsnag's code, so is unaffected.
* `bugsnag-unity` generates its own Xcode project for Bugsnag, so is unaffected.
* `bugsnag-unreal` uses `libBugsnagStatic.a`, so is unaffected.

## Changeset

Enables Xcode's `GCC_SYMBOLS_PRIVATE_EXTERN` build setting to hide symbols by default unless `ENABLE_TESTABILITY` is enabled (it is for unit testing).

Adds `-fvisibility=hidden` to the podspec and `Package.swift`.

Defines a new `BUGSNAG_EXTERN` macro and applies it to all public symbols in `include/Bugsnag`.

Applies `BUGSNAG_EXTERN` to some internal symbols currently used by the E2E fixture, `bugsnag-flutter` and `bugsnag-js`.

Removes the now-redundant `BSG_PRIVATE` macro.

## Testing

Tested manually with `bugsnag-flutter` and `bugsnag-js/react-native` to ensure there are no linking errors when using Bugsnag as a dynamic library.
