### PR TITLE
Fix session order flake in UserNilScenario

### DIFF
--- a/features/steps/cocoa_steps.rb
+++ b/features/steps/cocoa_steps.rb
@@ -1,15 +1,3 @@
-def request_matches_row(body, row)
-  row.each do |key, expected_value|
-    obs_val = Maze::Helper.read_key_path(body, key)
-    next if ('null'.eql? expected_value) && obs_val.nil? # Both are null/nil
-    next if !obs_val.nil? && (expected_value.to_s.eql? obs_val.to_s) # Values match
-    # Match not found - return false
-    return false
-  end
-  # All matched - return true
-  true
-end
-
 Then('I wait for the fixture to process the response') do
   sleep 2
 end

--- a/features/steps/reusable_steps.rb
+++ b/features/steps/reusable_steps.rb
@@ -125,3 +125,18 @@ Then('the stacktrace contains methods:') do |table|
   contains = actual.each_cons(expected.length).to_a.include? expected
   Maze.check.true(contains, "Stacktrace methods #{actual} did not contain #{expected}")
 end
+
+Then('the received sessions match:') do |table|
+  requests = Maze::Server.sessions.remaining
+  match_count = 0
+
+  # iterate through each row in the table. exactly 1 request should match each row.
+  table.hashes.each do |row|
+    requests.each do |request|
+      sessions = request.dig(:body, 'sessions')
+      Maze.check.equal(1, sessions.length, 'Expected exactly one session per request')
+      match_count += 1 if Maze::Assertions::RequestSetAssertions.request_matches_row(sessions[0], row)
+    end
+  end
+  Maze.check.equal(requests.size, match_count, 'Unexpected number of requests matched the received payloads')
+end

--- a/features/user.feature
+++ b/features/user.feature
@@ -79,15 +79,11 @@ Feature: Reporting User Information
   Scenario: Setting the user ID to nil
     When I run "UserNilScenario"
     And I wait to receive 2 sessions
+    Then the received sessions match:
+      | user.id   | user.email | user.name |
+      | @not_null | null       | null      |
+      | null      | null       | null      |
     And I wait to receive an error
-    Then the session payload field "device.id" is stored as the value "device_id"
-    And the session payload field "sessions.0.user.id" equals the stored value "device_id"
-    And the session "user.email" is null
-    And the session "user.name" is null
-    And I discard the oldest session
-    And the session "user.id" is null
-    And the session "user.email" is null
-    And the session "user.name" is null
     And the event "user.id" is null
     And the event "user.email" is null
     And the event "user.name" is null


### PR DESCRIPTION
## Goal

Fix flake due to sessions not always being received in the expected order in `UserNilScenario`.

## Changeset

Checks session payloads without requiring any ordering.

Adds a `the received sessions match:` step to achieve this, derived from https://github.com/bugsnag/maze-runner/blob/main/lib/features/steps/request_assertion_steps.rb#L90

## Testing

Verified locally, and on CI