### PR TITLE
[PLAT-8748] Truncate strings longer than `maxStringValueLength`

### DIFF
--- a/Bugsnag.xcodeproj/project.pbxproj
+++ b/Bugsnag.xcodeproj/project.pbxproj
@@ -723,6 +723,10 @@
 		01E8765E256684E700F4B70A /* URLSessionMock.m in Sources */ = {isa = PBXBuildFile; fileRef = 01E8765D256684E700F4B70A /* URLSessionMock.m */; };
 		01E8765F256684E700F4B70A /* URLSessionMock.m in Sources */ = {isa = PBXBuildFile; fileRef = 01E8765D256684E700F4B70A /* URLSessionMock.m */; };
 		01E87660256684E700F4B70A /* URLSessionMock.m in Sources */ = {isa = PBXBuildFile; fileRef = 01E8765D256684E700F4B70A /* URLSessionMock.m */; };
+		01F9FCB628929336005EDD8C /* BSGSerializationTests.m in Sources */ = {isa = PBXBuildFile; fileRef = 01F9FCB528929336005EDD8C /* BSGSerializationTests.m */; };
+		01F9FCB728929336005EDD8C /* BSGSerializationTests.m in Sources */ = {isa = PBXBuildFile; fileRef = 01F9FCB528929336005EDD8C /* BSGSerializationTests.m */; };
+		01F9FCB828929336005EDD8C /* BSGSerializationTests.m in Sources */ = {isa = PBXBuildFile; fileRef = 01F9FCB528929336005EDD8C /* BSGSerializationTests.m */; };
+		01F9FCB928929336005EDD8C /* BSGSerializationTests.m in Sources */ = {isa = PBXBuildFile; fileRef = 01F9FCB528929336005EDD8C /* BSGSerializationTests.m */; };
 		3A700A9424A63ABC0068CD1B /* BugsnagThread.h in Headers */ = {isa = PBXBuildFile; fileRef = 3A700A8024A63A8E0068CD1B /* BugsnagThread.h */; settings = {ATTRIBUTES = (Public, ); }; };
 		3A700A9524A63AC50068CD1B /* BugsnagSession.h in Headers */ = {isa = PBXBuildFile; fileRef = 3A700A8124A63A8E0068CD1B /* BugsnagSession.h */; settings = {ATTRIBUTES = (Public, ); }; };
 		3A700A9624A63AC60068CD1B /* BugsnagStackframe.h in Headers */ = {isa = PBXBuildFile; fileRef = 3A700A8224A63A8E0068CD1B /* BugsnagStackframe.h */; settings = {ATTRIBUTES = (Public, ); }; };
@@ -1628,6 +1632,7 @@
 		01DE903B26CEAF9E00455213 /* BSGUtilsTests.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; path = BSGUtilsTests.m; sourceTree = "<group>"; };
 		01E8765C256684E700F4B70A /* URLSessionMock.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; path = URLSessionMock.h; sourceTree = "<group>"; };
 		01E8765D256684E700F4B70A /* URLSessionMock.m */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.objc; path = URLSessionMock.m; sourceTree = "<group>"; };
+		01F9FCB528929336005EDD8C /* BSGSerializationTests.m */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.objc; path = BSGSerializationTests.m; sourceTree = "<group>"; };
 		3A700A8024A63A8E0068CD1B /* BugsnagThread.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; path = BugsnagThread.h; sourceTree = "<group>"; };
 		3A700A8124A63A8E0068CD1B /* BugsnagSession.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; path = BugsnagSession.h; sourceTree = "<group>"; };
 		3A700A8224A63A8E0068CD1B /* BugsnagStackframe.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; path = BugsnagStackframe.h; sourceTree = "<group>"; };
@@ -2033,6 +2038,7 @@
 				0163BF5825823D8D008DC28B /* BSGNotificationBreadcrumbsTests.m */,
 				008966C82486D43600DC48C2 /* BSGOutOfMemoryTests.m */,
 				0130DEF82880203A00E5953F /* BSGRunContextTests.m */,
+				01F9FCB528929336005EDD8C /* BSGSerializationTests.m */,
 				CB6419AA25A73E8C00613D25 /* BSGStorageMigratorTests.m */,
 				017DCF9A287422BB000ECB22 /* BSGTelemetryTests.m */,
 				01DE903B26CEAF9E00455213 /* BSGUtilsTests.m */,
@@ -3236,6 +3242,7 @@
 				CBA2249B251E429C00B87416 /* TestSupport.m in Sources */,
 				008967332486D43700DC48C2 /* BugsnagClientTests.m in Sources */,
 				004E353F2487B3BD007FBAE4 /* BugsnagSwiftConfigurationTests.swift in Sources */,
+				01F9FCB628929336005EDD8C /* BSGSerializationTests.m in Sources */,
 				008967542486D43700DC48C2 /* BugsnagOnCrashTest.m in Sources */,
 				008967152486D43700DC48C2 /* BugsnagCollectionsTests.m in Sources */,
 				01E8765E256684E700F4B70A /* URLSessionMock.m in Sources */,
@@ -3395,6 +3402,7 @@
 				0089671C2486D43700DC48C2 /* BugsnagSessionTest.m in Sources */,
 				008967AC2486D43700DC48C2 /* BSG_KSMachTests.m in Sources */,
 				0163BF5A25823D8D008DC28B /* BSGNotificationBreadcrumbsTests.m in Sources */,
+				01F9FCB728929336005EDD8C /* BSGSerializationTests.m in Sources */,
 				01BDB1FD25DEBFB300A91FAF /* BSGEventUploadKSCrashReportOperationTests.m in Sources */,
 				00896A452486DBF000DC48C2 /* BugsnagConfigurationTests.m in Sources */,
 				008967492486D43700DC48C2 /* BugsnagUserTest.m in Sources */,
@@ -3543,6 +3551,7 @@
 				E701FAAD2490EFD9008D842F /* EventApiValidationTest.m in Sources */,
 				008967472486D43700DC48C2 /* BugsnagTests.m in Sources */,
 				010993A6273D188B00128BBE /* BSGFeatureFlagStoreTests.m in Sources */,
+				01F9FCB828929336005EDD8C /* BSGSerializationTests.m in Sources */,
 				008967A72486D43700DC48C2 /* KSString_Tests.m in Sources */,
 				0089671A2486D43700DC48C2 /* BugsnagErrorTest.m in Sources */,
 				008967172486D43700DC48C2 /* BugsnagCollectionsTests.m in Sources */,
@@ -3843,6 +3852,7 @@
 				CB28F0A228294D4F003AB200 /* KSCrashReportWriterTests.m in Sources */,
 				CB28F0D3282A4B91003AB200 /* BugsnagErrorTest.m in Sources */,
 				CB28F0DE282A4BEE003AB200 /* BugsnagSessionTrackerStopTest.m in Sources */,
+				01F9FCB928929336005EDD8C /* BSGSerializationTests.m in Sources */,
 				CB28F0B328294DD0003AB200 /* BSGClientObserverTests.m in Sources */,
 				CB28F0B128294D4F003AB200 /* KSCrashSentry_Tests.m in Sources */,
 				CB28F0B228294D52003AB200 /* XCTestCase+KSCrash.m in Sources */,

--- a/Bugsnag/Breadcrumbs/BugsnagBreadcrumbs.h
+++ b/Bugsnag/Breadcrumbs/BugsnagBreadcrumbs.h
@@ -23,7 +23,7 @@ NS_ASSUME_NONNULL_BEGIN
 - (instancetype)initWithConfiguration:(BugsnagConfiguration *)config;
 
 /**
- * The breadcrumbs stored in memory.
+ * Returns an array of new objects representing the breadcrumbs stored in memory.
  */
 @property (readonly, nonatomic) NSArray<BugsnagBreadcrumb *> *breadcrumbs;
 

--- a/Bugsnag/Configuration/BugsnagConfiguration.m
+++ b/Bugsnag/Configuration/BugsnagConfiguration.m
@@ -94,6 +94,7 @@ static NSUserDefaults *userDefaults;
     [copy setSendLaunchCrashesSynchronously:self.sendLaunchCrashesSynchronously];
     [copy setMaxPersistedEvents:self.maxPersistedEvents];
     [copy setMaxPersistedSessions:self.maxPersistedSessions];
+    [copy setMaxStringValueLength:self.maxStringValueLength];
     [copy setMaxBreadcrumbs:self.maxBreadcrumbs];
     [copy setNotifier:self.notifier];
     [copy setFeatureFlagStore:self.featureFlagStore];
@@ -189,6 +190,7 @@ static NSUserDefaults *userDefaults;
     _maxBreadcrumbs = 50;
     _maxPersistedEvents = 32;
     _maxPersistedSessions = 128;
+    _maxStringValueLength = 10000;
     _autoTrackSessions = YES;
 #if BSG_HAVE_MACH_THREADS
     _sendThreads = BSGThreadSendPolicyAlways;

--- a/Bugsnag/Delivery/BSGEventUploadOperation.m
+++ b/Bugsnag/Delivery/BSGEventUploadOperation.m
@@ -95,9 +95,13 @@ typedef NS_ENUM(NSUInteger, BSGEventUploadOperationState) {
     
     NSDictionary *eventPayload;
     @try {
+        [event truncateStrings:configuration.maxStringValueLength];
         eventPayload = [event toJsonWithRedactedKeys:configuration.redactedKeys];
     } @catch (NSException *exception) {
         bsg_log_err(@"Discarding event %@ because an exception was thrown by -toJsonWithRedactedKeys: %@", self.name, exception);
+        [BSGInternalErrorReporter.sharedInstance reportException:exception diagnostics:nil groupingHash:
+         [NSString stringWithFormat:@"BSGEventUploadOperation -[runWithDelegate:completionHandler:] %@ %@",
+          exception.name, exception.reason]];
         [self deleteEvent];
         completionHandler();
         return;

--- a/Bugsnag/Helpers/BSGSerialization.h
+++ b/Bugsnag/Helpers/BSGSerialization.h
@@ -1,7 +1,6 @@
-#ifndef BugsnagJSONSerializable_h
-#define BugsnagJSONSerializable_h
-
 #import <Foundation/Foundation.h>
+
+NS_ASSUME_NONNULL_BEGIN
 
 /**
  Removes any values which would be rejected by NSJSONSerialization for
@@ -10,7 +9,7 @@
  @param input an array
  @return a new array
  */
-NSArray *_Nonnull BSGSanitizeArray(NSArray *_Nonnull input);
+NSArray * BSGSanitizeArray(NSArray *input);
 
 /**
  Removes any values which would be rejected by NSJSONSerialization for
@@ -19,7 +18,7 @@ NSArray *_Nonnull BSGSanitizeArray(NSArray *_Nonnull input);
  @param input a dictionary
  @return a new dictionary
  */
-NSDictionary *_Nonnull BSGSanitizeDict(NSDictionary *_Nonnull input);
+NSDictionary * BSGSanitizeDict(NSDictionary *input);
 
 /**
  Checks whether the base type would be accepted by the serialization process
@@ -37,4 +36,14 @@ BOOL BSGIsSanitizedType(id _Nullable obj);
  */
 id _Nullable BSGSanitizeObject(id _Nullable obj);
 
-#endif
+typedef struct _BSGTruncateContext {
+    NSUInteger maxLength;
+    NSUInteger strings;
+    NSUInteger length;
+} BSGTruncateContext;
+
+NSString * BSGTruncateString(BSGTruncateContext *context, NSString *string);
+
+id BSGTruncateStrings(BSGTruncateContext *context, id object);
+
+NS_ASSUME_NONNULL_END

--- a/Bugsnag/Helpers/BSGSerialization.h
+++ b/Bugsnag/Helpers/BSGSerialization.h
@@ -4,35 +4,18 @@ NS_ASSUME_NONNULL_BEGIN
 
 /**
  Removes any values which would be rejected by NSJSONSerialization for
- documented reasons
-
- @param input an array
- @return a new array
- */
-NSArray * BSGSanitizeArray(NSArray *input);
-
-/**
- Removes any values which would be rejected by NSJSONSerialization for
- documented reasons
+ documented reasons or is NSNull
 
  @param input a dictionary
  @return a new dictionary
  */
-NSDictionary * BSGSanitizeDict(NSDictionary *input);
-
-/**
- Checks whether the base type would be accepted by the serialization process
-
- @param obj any object or nil
- @return YES if the object is an Array, Dictionary, String, Number, or NSNull
- */
-BOOL BSGIsSanitizedType(id _Nullable obj);
+NSMutableDictionary * BSGSanitizeDict(NSDictionary *input);
 
 /**
  Cleans the object, including nested dictionary and array values
 
  @param obj any object or nil
- @return a new object for serialization or nil if the obj was incompatible
+ @return a new object for serialization or nil if the obj was incompatible or NSNull
  */
 id _Nullable BSGSanitizeObject(id _Nullable obj);
 

--- a/Bugsnag/Metadata/BugsnagMetadata.m
+++ b/Bugsnag/Metadata/BugsnagMetadata.m
@@ -56,51 +56,13 @@
     if ((self = [super init])) {
         // Ensure that the instantiating dictionary is mutable.
         // Saves checks later.
-        _dictionary = [self sanitizeDictionary:dict];
+        _dictionary = BSGSanitizeDict(dict);
         self.stateEventBlocks = [NSMutableArray new];
     }
     if (self.observer) {
         self.observer(self);
     }
     return self;
-}
-
-/**
- * Sanitizes the given dictionary to prevent [NSNull null] values from being added
- * to the metadata when deserializing a payload.
- *
- * @param dictionary the input dictionary
- * @return a sanitized dictionary
- */
-- (NSMutableDictionary *)sanitizeDictionary:(NSDictionary *)dictionary {
-    NSMutableDictionary *input = [dictionary mutableCopy];
-
-    for (NSString *key in [input allKeys]) {
-        id obj = input[key];
-
-        if (obj == [NSNull null]) {
-            [input removeObjectForKey:key];
-        } else if ([obj isKindOfClass:[NSDictionary class]]) {
-            input[key] = [self sanitizeDictionary:obj];
-        } else if ([obj isKindOfClass:[NSArray class]]) {
-            input[key] = [self sanitizeArray:obj];
-        }
-    }
-    return input;
-}
-
-- (NSMutableArray *)sanitizeArray:(NSArray *)obj {
-    NSMutableArray *ary = [obj mutableCopy];
-    [ary removeObject:[NSNull null]];
-
-    for (NSUInteger k = 0; k < [ary count]; ++k) {
-        if ([ary[k] isKindOfClass:[NSDictionary class]]) {
-            ary[k] = [self sanitizeDictionary:ary[k]];
-        } else if ([ary[k] isKindOfClass:[NSArray class]]) {
-            ary[k] = [self sanitizeArray:ary[k]];
-        }
-    }
-    return ary;
 }
 
 - (NSDictionary *)toDictionary {

--- a/Bugsnag/Payload/BugsnagEvent+Private.h
+++ b/Bugsnag/Payload/BugsnagEvent+Private.h
@@ -43,7 +43,7 @@ NS_ASSUME_NONNULL_BEGIN
 /// An array of string representations of BSGErrorType describing the types of stackframe / stacktrace in this error.
 @property (readonly, nonatomic) NSArray<NSString *> *stacktraceTypes;
 
-/// Usage telemetry info, from BSGTelemetryCreateUsage()
+/// Usage telemetry info, from BSGTelemetryCreateUsage(), or nil if BSGTelemetryUsage is not enabled.
 @property (readwrite, nullable, nonatomic) NSDictionary *usage;
 
 @property (readwrite, nonnull, nonatomic) BugsnagUser *user;
@@ -72,6 +72,8 @@ NS_ASSUME_NONNULL_BEGIN
 - (void)symbolicateIfNeeded;
 
 - (NSDictionary *)toJsonWithRedactedKeys:(nullable NSSet *)redactedKeys;
+
+- (void)truncateStrings:(NSUInteger)maxLength;
 
 - (void)notifyUnhandledOverridden;
 

--- a/Bugsnag/include/Bugsnag/BugsnagConfiguration.h
+++ b/Bugsnag/include/Bugsnag/BugsnagConfiguration.h
@@ -335,6 +335,15 @@ BUGSNAG_EXTERN
 @property (nonatomic) NSUInteger maxBreadcrumbs;
 
 /**
+ * The maximum length of breadcrumb messages and metadata string values.
+ * 
+ * Values longer than this will be truncated prior to sending, after running any OnSendError blocks.
+ *
+ * The default value is 10000.
+ */
+@property (nonatomic) NSUInteger maxStringValueLength;
+
+/**
  * Whether User information should be persisted to disk between application runs.
  * Defaults to True.
  */

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,9 @@ Changelog
 
 ### Enhancements
 
+* Truncate breadcrumb and metadata strings that are longer than `configuration.maxStringValueLength`.
+  [#1449](https://github.com/bugsnag/bugsnag-cocoa/pull/1449)
+
 * Add `+[BugsnagStackframe stackframesWithCallStackReturnAddresses:]` to public headers. 
   [#1446](https://github.com/bugsnag/bugsnag-cocoa/pull/1446)
 

--- a/Tests/BugsnagTests/BSGSerializationTests.m
+++ b/Tests/BugsnagTests/BSGSerializationTests.m
@@ -16,6 +16,21 @@
 
 @implementation BSGSerializationTests
 
+- (void)testSanitizeObject {
+    XCTAssertEqualObjects(BSGSanitizeObject(@""), @"");
+    XCTAssertEqualObjects(BSGSanitizeObject(@42), @42);
+    XCTAssertEqualObjects(BSGSanitizeObject(@[@42]), @[@42]);
+    XCTAssertEqualObjects(BSGSanitizeObject(@[self]), @[]);
+    XCTAssertEqualObjects(BSGSanitizeObject(@{@"a": @"b"}), @{@"a": @"b"});
+    XCTAssertEqualObjects(BSGSanitizeObject(@{@"self": self}), @{});
+    XCTAssertNil(BSGSanitizeObject(@(INFINITY)));
+    XCTAssertNil(BSGSanitizeObject(@(NAN)));
+    XCTAssertNil(BSGSanitizeObject([NSDate date]));
+    XCTAssertNil(BSGSanitizeObject([NSDecimalNumber notANumber]));
+    XCTAssertNil(BSGSanitizeObject([NSNull null]));
+    XCTAssertNil(BSGSanitizeObject(self));
+}
+
 - (void)testTruncateString {
     BSGTruncateContext context = {0};
     

--- a/Tests/BugsnagTests/BSGSerializationTests.m
+++ b/Tests/BugsnagTests/BSGSerializationTests.m
@@ -1,0 +1,82 @@
+//
+//  BSGSerializationTests.m
+//  Bugsnag
+//
+//  Created by Nick Dowell on 28/07/2022.
+//  Copyright © 2022 Bugsnag Inc. All rights reserved.
+//
+
+#import <XCTest/XCTest.h>
+
+#import "BSGSerialization.h"
+
+@interface BSGSerializationTests : XCTestCase
+
+@end
+
+@implementation BSGSerializationTests
+
+- (void)testTruncateString {
+    BSGTruncateContext context = {0};
+    
+    context.maxLength = NSUIntegerMax;
+    XCTAssertEqualObjects(BSGTruncateString(&context, @"Hello, world!"), @"Hello, world!");
+    XCTAssertEqual(context.strings, 0);
+    XCTAssertEqual(context.length, 0);
+    
+    context.maxLength = 5;
+    XCTAssertEqualObjects(BSGTruncateString(&context, @"Hello, world!"), @"Hello"
+                          "\n***8 CHARS TRUNCATED***");
+    XCTAssertEqual(context.strings, 1);
+    XCTAssertEqual(context.length, 8);
+    
+    // Verify that emoji (composed character sequences) are not partially truncated
+    // Note when adding tests that older OSes like iOS 9 don't understand more recently
+    // added emoji like 🏴󠁧󠁢󠁥󠁮󠁧󠁿 and 👩🏾‍🚀 and therefore won't be able to avoid slicing them.
+    
+    context.maxLength = 10;
+    XCTAssertEqualObjects(BSGTruncateString(&context, @"Emoji: 👍🏾"), @"Emoji: "
+                          "\n***4 CHARS TRUNCATED***");
+    XCTAssertEqual(context.strings, 2);
+    XCTAssertEqual(context.length, 12);
+}
+
+- (void)testTruncateStringsWithString {
+    BSGTruncateContext context = (BSGTruncateContext){.maxLength = 3};
+    XCTAssertEqualObjects(BSGTruncateStrings(&context, @"foo bar"), @"foo"
+                          "\n***4 CHARS TRUNCATED***");
+    XCTAssertEqual(context.strings, 1);
+    XCTAssertEqual(context.length, 4);
+}
+
+- (void)testTruncateStringsWithArray {
+    BSGTruncateContext context = (BSGTruncateContext){.maxLength = 3};
+    XCTAssertEqualObjects(BSGTruncateStrings(&context, @[@"foo bar"]),
+                          @[@"foo"
+                            "\n***4 CHARS TRUNCATED***"]);
+    XCTAssertEqual(context.strings, 1);
+    XCTAssertEqual(context.length, 4);
+}
+
+- (void)testTruncateStringsWithObject {
+    BSGTruncateContext context = (BSGTruncateContext){.maxLength = 3};
+    XCTAssertEqualObjects(BSGTruncateStrings(&context, @{@"name": @"foo bar"}),
+                          @{@"name": @"foo"
+                            "\n***4 CHARS TRUNCATED***"});
+    XCTAssertEqual(context.strings, 1);
+    XCTAssertEqual(context.length, 4);
+}
+
+- (void)testTruncateStringsWithNestedObjects {
+    BSGTruncateContext context = (BSGTruncateContext){.maxLength = 3};
+    XCTAssertEqualObjects(BSGTruncateStrings(&context, (@{@"one": @{@"key": @"foo bar"},
+                                                          @"two": @{@"foo": @"Baa, Baa, Black Sheep"}})),
+                          (@{@"one": @{@"key": @"foo"
+                                       "\n***4 CHARS TRUNCATED***"},
+                             @"two": @{@"foo": @"Baa"
+                                       "\n***18 CHARS TRUNCATED***"}}));
+    XCTAssertEqual(context.strings, 2);
+    XCTAssertEqual(context.length, 22);
+}
+
+@end

--- a/Tests/BugsnagTests/BugsnagConfigurationTests.m
+++ b/Tests/BugsnagTests/BugsnagConfigurationTests.m
@@ -650,6 +650,7 @@ NSString * const kBugsnagUserUserId = @"BugsnagUserUserId";
     XCTAssertEqualObjects(@"https://notify.bugsnag.com", config.endpoints.notify);
     XCTAssertEqualObjects(@"https://sessions.bugsnag.com", config.endpoints.sessions);
     XCTAssertEqual(50, config.maxBreadcrumbs);
+    XCTAssertEqual(config.maxStringValueLength, 10000);
     XCTAssertTrue(config.persistUser);
     XCTAssertEqual(1, [config.redactedKeys count]);
     XCTAssertEqualObjects(@"password", [config.redactedKeys allObjects][0]);
@@ -872,6 +873,7 @@ NSString * const kBugsnagUserUserId = @"BugsnagUserUserId";
 #if !TARGET_OS_WATCH
     [config setSendThreads:BSGThreadSendPolicyUnhandledOnly];
 #endif
+    [config setMaxStringValueLength:100];
     [config addPlugin:(id)[NSNull null]];
 
     BugsnagOnSendErrorBlock onSendBlock1 = ^BOOL(BugsnagEvent * _Nonnull event) { return true; };
@@ -928,6 +930,8 @@ NSString * const kBugsnagUserUserId = @"BugsnagUserUserId";
     // Plugins
     XCTAssert([clone.plugins containsObject:[NSNull null]]);
     XCTAssertNoThrow([clone.plugins removeObject:[NSNull null]]);
+    
+    XCTAssertEqual(clone.maxStringValueLength, 100);
 }
 
 - (void)testMetadataMutability {

--- a/features/barebone_tests.feature
+++ b/features/barebone_tests.feature
@@ -63,6 +63,7 @@ Feature: Barebone tests
     And the event "metaData.Exception.info" equals "Some error specific information"
     And the event "metaData.Flags.Testing" is true
     And the event "metaData.Other.password" equals "[REDACTED]"
+    And the event "metaData.Other.shouldBeTruncated" matches "\n\*\*\*345 CHARS TRUNCATED\*\*\*"
     And the event "metaData.error.nsexception.name" equals "NSRangeException"
     And the event "metaData.error.nsexception.userInfo.date" equals "2001-01-01 00:00:00 +0000"
     And the event "metaData.error.nsexception.userInfo.NSUnderlyingError" matches "Error Domain=ErrorDomain Code=0"
@@ -88,6 +89,8 @@ Feature: Barebone tests
       | ios     | true  |
       | macos   | @null |
       | watchos | @null |
+    And the event "usage.system.stringCharsTruncated" equals 345
+    And the event "usage.system.stringsTruncated" equals 1
     And the event "user.email" equals "foobar@example.com"
     And the event "user.id" equals "foobar"
     And the event "user.name" equals "Foo Bar"

--- a/features/fixtures/shared/scenarios/BareboneTestHandledScenario.swift
+++ b/features/fixtures/shared/scenarios/BareboneTestHandledScenario.swift
@@ -42,6 +42,7 @@ class BareboneTestHandledScenario: Scenario {
         config.addMetadata(["Testing": true], section: "Flags")
         config.addMetadata(["password": "123456"], section: "Other")
         config.launchDurationMillis = 0
+        config.maxStringValueLength = 100
 #if !os(watchOS)
         config.sendThreads = .unhandledOnly
 #endif
@@ -77,6 +78,15 @@ class BareboneTestHandledScenario: Scenario {
         Bugsnag.leaveBreadcrumb(withMessage: "This is super secret")
         
         self.afterSendErrorBlock = self.afterSendError
+        
+        Bugsnag.addMetadata("""
+            Lorem ipsum dolor sit amet, consectetur adipiscing elit, sed do eiusmod \
+            tempor incididunt ut labore et dolore magna aliqua. Ut enim ad minim veniam, \
+            quis nostrud exercitation ullamco laboris nisi ut aliquip ex ea commodo consequat. \
+            Duis aute irure dolor in reprehenderit in voluptate velit esse cillum dolore eu \
+            fugiat nulla pariatur. Excepteur sint occaecat cupidatat non proident, sunt in \
+            culpa qui officia deserunt mollit anim id est laborum.
+            """, key: "shouldBeTruncated", section: "Other")
         
         Bugsnag.notify(NSException(name: .rangeException,
                                    reason: "-[__NSSingleObjectArrayI objectAtIndex:]: index 1 beyond bounds [0 .. 0]",

--- a/features/fixtures/shared/scenarios/OversizedCrashReportScenario.swift
+++ b/features/fixtures/shared/scenarios/OversizedCrashReportScenario.swift
@@ -3,6 +3,7 @@ class OversizedCrashReportScenario: Scenario {
     override func startBugsnag() {
         config.autoTrackSessions = false
         config.enabledErrorTypes.ooms = false
+        config.maxStringValueLength = UInt.max
         config.addOnSendError {
             var data = Data(count: 1024 * 1024)
             _ = data.withUnsafeMutableBytes {

--- a/features/fixtures/shared/scenarios/OversizedHandledErrorScenario.swift
+++ b/features/fixtures/shared/scenarios/OversizedHandledErrorScenario.swift
@@ -3,6 +3,7 @@ class OversizedHandledErrorScenario: Scenario {
     override func startBugsnag() {
         config.autoTrackSessions = false
         config.enabledErrorTypes.ooms = false
+        config.maxStringValueLength = UInt.max
         config.addOnSendError {
             var data = Data(count: 1024 * 1024)
             _ = data.withUnsafeMutableBytes {


### PR DESCRIPTION
## Goal

Truncate app-provided strings that may lead to oversized payloads - metadata strings and breadcrumb messages.

## Changeset

Adds `maxStringValueLength` to `BugsnagConfiguration`.

Implements string truncation functions in `BSGSerialization.m`.

Implements `-[BugsnagEvent truncateStrings:]` to truncate breadcrumbs and metadata, called by `BSGEventUploadOperation` immediately prior to upload.

Updates `BugsnagMetadata` and `BSGSerialization.m` to avoid duplication of sanitization logic.

## Testing

Adds unit tests to verify truncation of strings, including checks that composed character sequences are not sliced.

Amends barebones test to very truncation.