### PR TITLE
Refactor BugsnagApiClient

### DIFF
--- a/Bugsnag/Configuration/BugsnagConfiguration+Private.h
+++ b/Bugsnag/Configuration/BugsnagConfiguration+Private.h
@@ -46,8 +46,6 @@ NS_ASSUME_NONNULL_BEGIN
 
 @property (readonly, nonatomic) BOOL shouldSendReports;
 
-@property (readonly, nonatomic) NSDictionary<NSString *, id> *sessionApiHeaders;
-
 @property (readonly, nullable, nonatomic) NSURL *sessionURL;
 
 @property (readwrite, retain, nonnull, nonatomic) BugsnagUser *user;

--- a/Bugsnag/Configuration/BugsnagConfiguration.m
+++ b/Bugsnag/Configuration/BugsnagConfiguration.m
@@ -28,7 +28,6 @@
 
 #import "BSGConfigurationBuilder.h"
 #import "BSGKeys.h"
-#import "BSG_RFC3339DateTool.h"
 #import "BugsnagApiClient.h"
 #import "BugsnagEndpointConfiguration.h"
 #import "BugsnagErrorTypes.h"
@@ -360,13 +359,6 @@ static NSUserDefaults *userDefaults;
 // =============================================================================
 // MARK: -
 // =============================================================================
-
-- (NSDictionary *)sessionApiHeaders {
-    return @{BugsnagHTTPHeaderNameApiKey: self.apiKey ?: @"",
-             BugsnagHTTPHeaderNamePayloadVersion: @"1.0",
-             BugsnagHTTPHeaderNameSentAt: [BSG_RFC3339DateTool stringFromDate:[NSDate date]]
-    };
-}
 
 - (void)setEndpoints:(BugsnagEndpointConfiguration *)endpoints {
     if ([self isValidURLString:endpoints.notify]) {

--- a/Bugsnag/Delivery/BSGEventUploadOperation.h
+++ b/Bugsnag/Delivery/BSGEventUploadOperation.h
@@ -54,8 +54,6 @@ static const NSUInteger MaxPersistedSize = 1000000;
 
 @protocol BSGEventUploadOperationDelegate <NSObject>
 
-@property (readonly, nonatomic) BugsnagApiClient *apiClient;
-
 @property (readonly, nonatomic) BugsnagConfiguration *configuration;
 
 @property (readonly, nonatomic) BugsnagNotifier *notifier;

--- a/Bugsnag/Delivery/BSGEventUploadOperation.m
+++ b/Bugsnag/Delivery/BSGEventUploadOperation.m
@@ -11,7 +11,6 @@
 #import "BSGFileLocations.h"
 #import "BSGInternalErrorReporter.h"
 #import "BSGKeys.h"
-#import "BSG_RFC3339DateTool.h"
 #import "BugsnagAppWithState+Private.h"
 #import "BugsnagConfiguration+Private.h"
 #import "BugsnagError+Private.h"
@@ -123,7 +122,6 @@ typedef NS_ENUM(NSUInteger, BSGEventUploadOperationState) {
     NSMutableDictionary *requestHeaders = [NSMutableDictionary dictionary];
     requestHeaders[BugsnagHTTPHeaderNameApiKey] = apiKey;
     requestHeaders[BugsnagHTTPHeaderNamePayloadVersion] = EventPayloadVersion;
-    requestHeaders[BugsnagHTTPHeaderNameSentAt] = [BSG_RFC3339DateTool stringFromDate:[NSDate date]];
     requestHeaders[BugsnagHTTPHeaderNameStacktraceTypes] = [event.stacktraceTypes componentsJoinedByString:@","];
     
     NSURL *notifyURL = configuration.notifyURL;

--- a/Bugsnag/Delivery/BSGEventUploadOperation.m
+++ b/Bugsnag/Delivery/BSGEventUploadOperation.m
@@ -140,9 +140,7 @@ typedef NS_ENUM(NSUInteger, BSGEventUploadOperationState) {
         return;
     }
     
-    [delegate.apiClient postJSONData:data headers:requestHeaders toURL:notifyURL
-                      completionHandler:^(BugsnagApiClientDeliveryStatus status, __unused NSError *deliveryError) {
-        
+    BSGPostJSONData(configuration.session, data, requestHeaders, notifyURL, ^(BugsnagApiClientDeliveryStatus status, __unused NSError *deliveryError) {
         switch (status) {
             case BugsnagApiClientDeliveryStatusDelivered:
                 bsg_log_debug(@"Uploaded event %@", self.name);
@@ -161,7 +159,7 @@ typedef NS_ENUM(NSUInteger, BSGEventUploadOperationState) {
         }
         
         completionHandler();
-    }];
+    });
 }
 
 // MARK: Subclassing

--- a/Bugsnag/Delivery/BSGEventUploadOperation.m
+++ b/Bugsnag/Delivery/BSGEventUploadOperation.m
@@ -140,19 +140,19 @@ typedef NS_ENUM(NSUInteger, BSGEventUploadOperationState) {
         return;
     }
     
-    BSGPostJSONData(configuration.session, data, requestHeaders, notifyURL, ^(BugsnagApiClientDeliveryStatus status, __unused NSError *deliveryError) {
+    BSGPostJSONData(configuration.session, data, requestHeaders, notifyURL, ^(BSGDeliveryStatus status, __unused NSError *deliveryError) {
         switch (status) {
-            case BugsnagApiClientDeliveryStatusDelivered:
+            case BSGDeliveryStatusDelivered:
                 bsg_log_debug(@"Uploaded event %@", self.name);
                 [self deleteEvent];
                 break;
                 
-            case BugsnagApiClientDeliveryStatusFailed:
+            case BSGDeliveryStatusFailed:
                 bsg_log_debug(@"Upload failed retryably for event %@", self.name);
                 [self prepareForRetry:originalPayload ?: eventPayload HTTPBodySize:data.length];
                 break;
                 
-            case BugsnagApiClientDeliveryStatusUndeliverable:
+            case BSGDeliveryStatusUndeliverable:
                 bsg_log_debug(@"Upload failed; will discard event %@", self.name);
                 [self deleteEvent];
                 break;

--- a/Bugsnag/Delivery/BSGEventUploader.m
+++ b/Bugsnag/Delivery/BSGEventUploader.m
@@ -40,13 +40,11 @@ static NSString * const RecrashReportPrefix = @"RecrashReport-";
 
 @implementation BSGEventUploader
 
-@synthesize apiClient = _apiClient;
 @synthesize configuration = _configuration;
 @synthesize notifier = _notifier;
 
 - (instancetype)initWithConfiguration:(BugsnagConfiguration *)configuration notifier:(BugsnagNotifier *)notifier {
     if ((self = [super init])) {
-        _apiClient = [[BugsnagApiClient alloc] initWithSession:configuration.session];
         _configuration = configuration;
         _eventsDirectory = [BSGFileLocations current].events;
         _kscrashReportsDirectory = [BSGFileLocations current].kscrashReports;

--- a/Bugsnag/Delivery/BSGSessionUploader.m
+++ b/Bugsnag/Delivery/BSGSessionUploader.m
@@ -30,7 +30,6 @@ static NSArray * SortedFiles(NSFileManager *fileManager, NSMutableDictionary<NSS
 
 @interface BSGSessionUploader ()
 @property (nonatomic) NSMutableSet *activeIds;
-@property (nonatomic) BugsnagApiClient *apiClient;
 @property(nonatomic) BugsnagConfiguration *config;
 @end
 
@@ -40,7 +39,6 @@ static NSArray * SortedFiles(NSFileManager *fileManager, NSMutableDictionary<NSS
 - (instancetype)initWithConfig:(BugsnagConfiguration *)config notifier:(BugsnagNotifier *)notifier {
     if ((self = [super init])) {
         _activeIds = [NSMutableSet new];
-        _apiClient = [[BugsnagApiClient alloc] initWithSession:config.session];
         _config = config;
         _notifier = notifier;
     }
@@ -173,7 +171,7 @@ static NSArray * SortedFiles(NSFileManager *fileManager, NSMutableDictionary<NSS
         return;
     }
     
-    [self.apiClient postJSONData:data headers:headers toURL:url completionHandler:^(BugsnagApiClientDeliveryStatus status, NSError *error) {
+    BSGPostJSONData(self.config.session, data, headers, url, ^(BugsnagApiClientDeliveryStatus status, NSError *error) {
         switch (status) {
             case BugsnagApiClientDeliveryStatusDelivered:
                 bsg_log_info(@"Sent session %@", session.id);
@@ -186,7 +184,7 @@ static NSArray * SortedFiles(NSFileManager *fileManager, NSMutableDictionary<NSS
                 break;
         }
         completionHandler(status);
-    }];
+    });
 }
 
 @end

--- a/Bugsnag/Delivery/BSGSessionUploader.m
+++ b/Bugsnag/Delivery/BSGSessionUploader.m
@@ -46,17 +46,17 @@ static NSArray * SortedFiles(NSFileManager *fileManager, NSMutableDictionary<NSS
 }
 
 - (void)uploadSession:(BugsnagSession *)session {
-    [self sendSession:session completionHandler:^(BugsnagApiClientDeliveryStatus status) {
+    [self sendSession:session completionHandler:^(BSGDeliveryStatus status) {
         switch (status) {
-            case BugsnagApiClientDeliveryStatusDelivered:
+            case BSGDeliveryStatusDelivered:
                 [self processStoredSessions];
                 break;
                 
-            case BugsnagApiClientDeliveryStatusFailed:
+            case BSGDeliveryStatusFailed:
                 [self storeSession:session]; // Retry later
                 break;
                 
-            case BugsnagApiClientDeliveryStatusUndeliverable:
+            case BSGDeliveryStatusUndeliverable:
                 break;
         }
     }];
@@ -106,8 +106,8 @@ static NSArray * SortedFiles(NSFileManager *fileManager, NSMutableDictionary<NSS
             [self.activeIds addObject:file];
         }
         
-        [self sendSession:session completionHandler:^(BugsnagApiClientDeliveryStatus status) {
-            if (status != BugsnagApiClientDeliveryStatusFailed) {
+        [self sendSession:session completionHandler:^(BSGDeliveryStatus status) {
+            if (status != BSGDeliveryStatusFailed) {
                 [fileManager removeItemAtPath:file error:nil];
             }
             @synchronized (self.activeIds) {
@@ -133,18 +133,18 @@ static NSArray * SortedFiles(NSFileManager *fileManager, NSMutableDictionary<NSS
 //
 // https://bugsnagsessiontrackingapi.docs.apiary.io/#reference/0/session/report-a-session-starting
 //
-- (void)sendSession:(BugsnagSession *)session completionHandler:(nonnull void (^)(BugsnagApiClientDeliveryStatus status))completionHandler {
+- (void)sendSession:(BugsnagSession *)session completionHandler:(nonnull void (^)(BSGDeliveryStatus status))completionHandler {
     NSString *apiKey = [self.config.apiKey copy];
     if (!apiKey) {
         bsg_log_err(@"Cannot send session because no apiKey is configured.");
-        completionHandler(BugsnagApiClientDeliveryStatusUndeliverable);
+        completionHandler(BSGDeliveryStatusUndeliverable);
         return;
     }
     
     NSURL *url = self.config.sessionURL;
     if (!url) {
         bsg_log_err(@"Cannot send session because no endpoint is configured.");
-        completionHandler(BugsnagApiClientDeliveryStatusUndeliverable);
+        completionHandler(BSGDeliveryStatusUndeliverable);
         return;
     }
     
@@ -167,19 +167,19 @@ static NSArray * SortedFiles(NSFileManager *fileManager, NSMutableDictionary<NSS
     NSData *data = BSGJSONDataFromDictionary(payload, NULL);
     if (!data) {
         bsg_log_err(@"Failed to encode session %@", session.id);
-        completionHandler(BugsnagApiClientDeliveryStatusUndeliverable);
+        completionHandler(BSGDeliveryStatusUndeliverable);
         return;
     }
     
-    BSGPostJSONData(self.config.session, data, headers, url, ^(BugsnagApiClientDeliveryStatus status, NSError *error) {
+    BSGPostJSONData(self.config.session, data, headers, url, ^(BSGDeliveryStatus status, NSError *error) {
         switch (status) {
-            case BugsnagApiClientDeliveryStatusDelivered:
+            case BSGDeliveryStatusDelivered:
                 bsg_log_info(@"Sent session %@", session.id);
                 break;
-            case BugsnagApiClientDeliveryStatusFailed:
+            case BSGDeliveryStatusFailed:
                 bsg_log_warn(@"Failed to send sessions: %@", error);
                 break;
-            case BugsnagApiClientDeliveryStatusUndeliverable:
+            case BSGDeliveryStatusUndeliverable:
                 bsg_log_warn(@"Failed to send sessions: %@", error);
                 break;
         }

--- a/Bugsnag/Delivery/BSGSessionUploader.m
+++ b/Bugsnag/Delivery/BSGSessionUploader.m
@@ -166,7 +166,14 @@ static NSArray * SortedFiles(NSFileManager *fileManager, NSMutableDictionary<NSS
         }]
     };
     
-    [self.apiClient sendJSONPayload:payload headers:headers toURL:url completionHandler:^(BugsnagApiClientDeliveryStatus status, NSError *error) {
+    NSData *data = BSGJSONDataFromDictionary(payload, NULL);
+    if (!data) {
+        bsg_log_err(@"Failed to encode session %@", session.id);
+        completionHandler(BugsnagApiClientDeliveryStatusUndeliverable);
+        return;
+    }
+    
+    [self.apiClient postJSONData:data headers:headers toURL:url completionHandler:^(BugsnagApiClientDeliveryStatus status, NSError *error) {
         switch (status) {
             case BugsnagApiClientDeliveryStatusDelivered:
                 bsg_log_info(@"Sent session %@", session.id);

--- a/Bugsnag/Delivery/BSGSessionUploader.m
+++ b/Bugsnag/Delivery/BSGSessionUploader.m
@@ -152,8 +152,7 @@ static NSArray * SortedFiles(NSFileManager *fileManager, NSMutableDictionary<NSS
     
     NSDictionary *headers = @{
         BugsnagHTTPHeaderNameApiKey: apiKey,
-        BugsnagHTTPHeaderNamePayloadVersion: @"1.0",
-        BugsnagHTTPHeaderNameSentAt: [BSG_RFC3339DateTool stringFromDate:[NSDate date]] ?: [NSNull null]
+        BugsnagHTTPHeaderNamePayloadVersion: @"1.0"
     };
     
     NSDictionary *payload = @{

--- a/Bugsnag/Delivery/BugsnagApiClient.h
+++ b/Bugsnag/Delivery/BugsnagApiClient.h
@@ -28,10 +28,10 @@ typedef NS_ENUM(NSInteger, BugsnagApiClientDeliveryStatus) {
 
 - (instancetype)initWithSession:(nullable NSURLSession *)session;
 
-- (nullable NSData *)sendJSONPayload:(NSDictionary *)payload
-                             headers:(NSDictionary<BugsnagHTTPHeaderName, NSString *> *)headers
-                               toURL:(NSURL *)url
-                   completionHandler:(void (^)(BugsnagApiClientDeliveryStatus status, NSError *_Nullable error))completionHandler;
+- (void)postJSONData:(NSData *)data
+             headers:(NSDictionary<BugsnagHTTPHeaderName, NSString *> *)headers
+               toURL:(NSURL *)url
+   completionHandler:(void (^)(BugsnagApiClientDeliveryStatus status, NSError *_Nullable error))completionHandler;
 
 + (NSString *)SHA1HashStringWithData:(NSData *)data;
 

--- a/Bugsnag/Delivery/BugsnagApiClient.h
+++ b/Bugsnag/Delivery/BugsnagApiClient.h
@@ -15,20 +15,20 @@ static BugsnagHTTPHeaderName const BugsnagHTTPHeaderNamePayloadVersion     = @"B
 static BugsnagHTTPHeaderName const BugsnagHTTPHeaderNameSentAt             = @"Bugsnag-Sent-At";
 static BugsnagHTTPHeaderName const BugsnagHTTPHeaderNameStacktraceTypes    = @"Bugsnag-Stacktrace-Types";
 
-typedef NS_ENUM(NSInteger, BugsnagApiClientDeliveryStatus) {
+typedef NS_ENUM(NSInteger, BSGDeliveryStatus) {
     /// The payload was delivered successfully and can be deleted.
-    BugsnagApiClientDeliveryStatusDelivered,
+    BSGDeliveryStatusDelivered,
     /// The payload was not delivered but can be retried, e.g. when there was a loss of connectivity.
-    BugsnagApiClientDeliveryStatusFailed,
+    BSGDeliveryStatusFailed,
     /// The payload cannot be delivered and should be deleted without attempting to retry.
-    BugsnagApiClientDeliveryStatusUndeliverable,
+    BSGDeliveryStatusUndeliverable,
 };
 
 void BSGPostJSONData(NSURLSession *URLSession,
                      NSData *data,
                      NSDictionary<BugsnagHTTPHeaderName, NSString *> *headers,
                      NSURL *url,
-                     void (^ completionHandler)(BugsnagApiClientDeliveryStatus status, NSError *_Nullable error));
+                     void (^ completionHandler)(BSGDeliveryStatus status, NSError *_Nullable error));
 
 NSString *_Nullable BSGIntegrityHeaderValue(NSData *_Nullable data);
 

--- a/Bugsnag/Delivery/BugsnagApiClient.h
+++ b/Bugsnag/Delivery/BugsnagApiClient.h
@@ -24,17 +24,12 @@ typedef NS_ENUM(NSInteger, BugsnagApiClientDeliveryStatus) {
     BugsnagApiClientDeliveryStatusUndeliverable,
 };
 
-@interface BugsnagApiClient : NSObject
+void BSGPostJSONData(NSURLSession *URLSession,
+                     NSData *data,
+                     NSDictionary<BugsnagHTTPHeaderName, NSString *> *headers,
+                     NSURL *url,
+                     void (^ completionHandler)(BugsnagApiClientDeliveryStatus status, NSError *_Nullable error));
 
-- (instancetype)initWithSession:(nullable NSURLSession *)session;
-
-- (void)postJSONData:(NSData *)data
-             headers:(NSDictionary<BugsnagHTTPHeaderName, NSString *> *)headers
-               toURL:(NSURL *)url
-   completionHandler:(void (^)(BugsnagApiClientDeliveryStatus status, NSError *_Nullable error))completionHandler;
-
-+ (NSString *)SHA1HashStringWithData:(NSData *)data;
-
-@end
+NSString *_Nullable BSGIntegrityHeaderValue(NSData *_Nullable data);
 
 NS_ASSUME_NONNULL_END

--- a/Bugsnag/Delivery/BugsnagApiClient.m
+++ b/Bugsnag/Delivery/BugsnagApiClient.m
@@ -35,7 +35,7 @@ void BSGPostJSONData(NSURLSession *URLSession,
                      NSData *data,
                      NSDictionary<BugsnagHTTPHeaderName, NSString *> *headers,
                      NSURL *url,
-                     void (^ completionHandler)(BugsnagApiClientDeliveryStatus status, NSError *_Nullable error)) {
+                     void (^ completionHandler)(BSGDeliveryStatus status, NSError *_Nullable error)) {
     
     NSMutableURLRequest *request = [NSMutableURLRequest requestWithURL:url cachePolicy:NSURLRequestReloadIgnoringLocalCacheData timeoutInterval:15];
     request.HTTPMethod = @"POST";
@@ -52,7 +52,7 @@ void BSGPostJSONData(NSURLSession *URLSession,
     [[URLSession uploadTaskWithRequest:request fromData:data completionHandler:^(__unused NSData *responseData, NSURLResponse *response, NSError *error) {
         if (![response isKindOfClass:[NSHTTPURLResponse class]]) {
             bsg_log_debug(@"Request to %@ completed with error %@", url, error);
-            completionHandler(BugsnagApiClientDeliveryStatusFailed, error ?:
+            completionHandler(BSGDeliveryStatusFailed, error ?:
                               [NSError errorWithDomain:@"BugsnagApiClientErrorDomain" code:0 userInfo:@{
                                   NSLocalizedDescriptionKey: @"Request failed: no response was received",
                                   NSURLErrorFailingURLErrorKey: url }]);
@@ -63,7 +63,7 @@ void BSGPostJSONData(NSURLSession *URLSession,
         bsg_log_debug(@"Request to %@ completed with status code %ld", url, (long)statusCode);
         
         if (statusCode / 100 == 2) {
-            completionHandler(BugsnagApiClientDeliveryStatusDelivered, nil);
+            completionHandler(BSGDeliveryStatusDelivered, nil);
             return;
         }
         
@@ -80,11 +80,11 @@ void BSGPostJSONData(NSURLSession *URLSession,
             statusCode != HTTPStatusCodeProxyAuthenticationRequired &&
             statusCode != HTTPStatusCodeClientTimeout &&
             statusCode != HTTPStatusCodeTooManyRequests) {
-            completionHandler(BugsnagApiClientDeliveryStatusUndeliverable, error);
+            completionHandler(BSGDeliveryStatusUndeliverable, error);
             return;
         }
         
-        completionHandler(BugsnagApiClientDeliveryStatusFailed, error);
+        completionHandler(BSGDeliveryStatusFailed, error);
     }] resume];
 }
 

--- a/Bugsnag/Helpers/BSGInternalErrorReporter.m
+++ b/Bugsnag/Helpers/BSGInternalErrorReporter.m
@@ -258,7 +258,7 @@ static void (^ startupBlock_)(BSGInternalErrorReporter *);
     
     NSMutableDictionary *headers = [NSMutableDictionary dictionary];
     headers[@"Content-Type"] = @"application/json";
-    headers[BugsnagHTTPHeaderNameIntegrity] = [NSString stringWithFormat:@"sha1 %@", [BugsnagApiClient SHA1HashStringWithData:data]];
+    headers[BugsnagHTTPHeaderNameIntegrity] = BSGIntegrityHeaderValue(data);
     headers[BugsnagHTTPHeaderNameInternalError] = @"bugsnag-cocoa";
     headers[BugsnagHTTPHeaderNamePayloadVersion] = EventPayloadVersion;
     headers[BugsnagHTTPHeaderNameSentAt] = [BSG_RFC3339DateTool stringFromDate:[NSDate date]];

--- a/Tests/BugsnagTests/BugsnagApiClientTest.m
+++ b/Tests/BugsnagTests/BugsnagApiClientTest.m
@@ -22,34 +22,34 @@
     NSURL *url = [NSURL URLWithString:@"https://example.com"];
     id URLSession = [[URLSessionMock alloc] init];
     
-    void (^ test)(NSInteger, BugsnagApiClientDeliveryStatus, BOOL) =
-    ^(NSInteger statusCode, BugsnagApiClientDeliveryStatus expectedDeliveryStatus, BOOL expectError) {
+    void (^ test)(NSInteger, BSGDeliveryStatus, BOOL) =
+    ^(NSInteger statusCode, BSGDeliveryStatus expectedDeliveryStatus, BOOL expectError) {
         XCTestExpectation *expectation = [self expectationWithDescription:@"completionHandler should be called"];
         id response = [[NSHTTPURLResponse alloc] initWithURL:url statusCode:statusCode HTTPVersion:@"1.1" headerFields:nil];
         [URLSession mockData:[NSData data] response:response error:nil];
-        BSGPostJSONData(URLSession, [NSData data], @{}, url, ^(BugsnagApiClientDeliveryStatus status, NSError * _Nullable error) {
+        BSGPostJSONData(URLSession, [NSData data], @{}, url, ^(BSGDeliveryStatus status, NSError * _Nullable error) {
             XCTAssertEqual(status, expectedDeliveryStatus);
             expectError ? XCTAssertNotNil(error) : XCTAssertNil(error);
             [expectation fulfill];
         });
     };
     
-    test(200, BugsnagApiClientDeliveryStatusDelivered, NO);
+    test(200, BSGDeliveryStatusDelivered, NO);
     
     // Permanent failures
-    test(400, BugsnagApiClientDeliveryStatusUndeliverable, YES);
-    test(401, BugsnagApiClientDeliveryStatusUndeliverable, YES);
-    test(403, BugsnagApiClientDeliveryStatusUndeliverable, YES);
-    test(404, BugsnagApiClientDeliveryStatusUndeliverable, YES);
-    test(405, BugsnagApiClientDeliveryStatusUndeliverable, YES);
-    test(406, BugsnagApiClientDeliveryStatusUndeliverable, YES);
+    test(400, BSGDeliveryStatusUndeliverable, YES);
+    test(401, BSGDeliveryStatusUndeliverable, YES);
+    test(403, BSGDeliveryStatusUndeliverable, YES);
+    test(404, BSGDeliveryStatusUndeliverable, YES);
+    test(405, BSGDeliveryStatusUndeliverable, YES);
+    test(406, BSGDeliveryStatusUndeliverable, YES);
     
     // Transient failures
-    test(402, BugsnagApiClientDeliveryStatusFailed, YES);
-    test(407, BugsnagApiClientDeliveryStatusFailed, YES);
-    test(408, BugsnagApiClientDeliveryStatusFailed, YES);
-    test(429, BugsnagApiClientDeliveryStatusFailed, YES);
-    test(500, BugsnagApiClientDeliveryStatusFailed, YES);
+    test(402, BSGDeliveryStatusFailed, YES);
+    test(407, BSGDeliveryStatusFailed, YES);
+    test(408, BSGDeliveryStatusFailed, YES);
+    test(429, BSGDeliveryStatusFailed, YES);
+    test(500, BSGDeliveryStatusFailed, YES);
     
     [self waitForExpectationsWithTimeout:1 handler:nil];
 }
@@ -62,8 +62,8 @@
     [URLSession mockData:nil response:nil error:[NSError errorWithDomain:NSURLErrorDomain code:NSURLErrorNotConnectedToInternet userInfo:@{
         NSURLErrorFailingURLErrorKey: url,
     }]];
-    BSGPostJSONData(URLSession, [NSData data], @{}, url, ^(BugsnagApiClientDeliveryStatus status, NSError * _Nullable error) {
-        XCTAssertEqual(status, BugsnagApiClientDeliveryStatusFailed);
+    BSGPostJSONData(URLSession, [NSData data], @{}, url, ^(BSGDeliveryStatus status, NSError * _Nullable error) {
+        XCTAssertEqual(status, BSGDeliveryStatusFailed);
         XCTAssertNotNil(error);
         XCTAssertEqualObjects(error.domain, NSURLErrorDomain);
         [expectation fulfill];

--- a/Tests/BugsnagTests/BugsnagApiClientTest.m
+++ b/Tests/BugsnagTests/BugsnagApiClientTest.m
@@ -18,12 +18,6 @@
 
 @implementation BugsnagApiClientTest
 
-- (void)testBadJSON {
-    BugsnagApiClient *client = [[BugsnagApiClient alloc] initWithSession:nil];
-    XCTAssertNoThrow([client sendJSONPayload:(id)@{@1: @"a"} headers:(id)@{@1: @"a"} toURL:[NSURL URLWithString:@"file:///dev/null"]
-                           completionHandler:^(BugsnagApiClientDeliveryStatus status, NSError * _Nullable error) {}]);
-}
-
 - (void)testHTTPStatusCodes {
     NSURL *url = [NSURL URLWithString:@"https://example.com"];
     URLSessionMock *session = [[URLSessionMock alloc] init];
@@ -34,7 +28,7 @@
         XCTestExpectation *expectation = [self expectationWithDescription:@"completionHandler should be called"];
         id response = [[NSHTTPURLResponse alloc] initWithURL:url statusCode:statusCode HTTPVersion:@"1.1" headerFields:nil];
         [session mockData:[NSData data] response:response error:nil];
-        [client sendJSONPayload:@{} headers:@{} toURL:url completionHandler:^(BugsnagApiClientDeliveryStatus status, NSError * _Nullable error) {
+        [client postJSONData:[NSData data] headers:@{} toURL:url completionHandler:^(BugsnagApiClientDeliveryStatus status, NSError * _Nullable error) {
             XCTAssertEqual(status, expectedDeliveryStatus);
             expectError ? XCTAssertNotNil(error) : XCTAssertNil(error);
             [expectation fulfill];
@@ -70,7 +64,7 @@
     [session mockData:nil response:nil error:[NSError errorWithDomain:NSURLErrorDomain code:NSURLErrorNotConnectedToInternet userInfo:@{
         NSURLErrorFailingURLErrorKey: url,
     }]];
-    [client sendJSONPayload:@{} headers:@{} toURL:url completionHandler:^(BugsnagApiClientDeliveryStatus status, NSError * _Nullable error) {
+    [client postJSONData:[NSData data] headers:@{} toURL:url completionHandler:^(BugsnagApiClientDeliveryStatus status, NSError * _Nullable error) {
         XCTAssertEqual(status, BugsnagApiClientDeliveryStatusFailed);
         XCTAssertNotNil(error);
         XCTAssertEqualObjects(error.domain, NSURLErrorDomain);

--- a/Tests/BugsnagTests/BugsnagConfigurationTests.m
+++ b/Tests/BugsnagTests/BugsnagConfigurationTests.m
@@ -38,14 +38,6 @@
     XCTAssertTrue([config autoTrackSessions]);
 }
 
-- (void)testSessionApiHeaders {
-    BugsnagConfiguration *config = [[BugsnagConfiguration alloc] initWithApiKey:DUMMY_APIKEY_32CHAR_1];
-    NSDictionary *headers = [config sessionApiHeaders];
-    XCTAssertEqualObjects(config.apiKey, headers[@"Bugsnag-Api-Key"]);
-    XCTAssertNotNil(headers[@"Bugsnag-Sent-At"]);
-    XCTAssertNotNil(headers[@"Bugsnag-Payload-Version"]);
-}
-
 - (void)testSessionEndpoints {
     BugsnagConfiguration *config = [[BugsnagConfiguration alloc] initWithApiKey:DUMMY_APIKEY_32CHAR_1];
 


### PR DESCRIPTION
## Goal

Make a change required for efficient implementation of breadcrumb trimming functionality (coming in a subsequent PR).

## Changeset

Changes `BugsnagApiClient` to accept `NSData` and leave JSON encoding to callers - this is the change required for efficient trimming.

Makes `BugsnagApiClient` responsible for setting `Bugsnag-Sent-At` header.

Removes unused `BugsnagConfiguration.sessionApiHeaders`.

Replaces `BugsnagApiClient` class with equivalent C functions.

Renames `BugsnagApiClientDeliveryStatus` to `BSGDeliveryStatus`.

Simplified integrity header generation by including "sha1 " prefix in function's result.

## Testing

Covered by existing unit and E2E tests.