### PR TITLE
[PLAT-8750] Increase maxBreadcrumbs

### DIFF
--- a/Bugsnag/Configuration/BugsnagConfiguration.m
+++ b/Bugsnag/Configuration/BugsnagConfiguration.m
@@ -186,7 +186,7 @@ static NSUserDefaults *userDefaults;
     _enabledBreadcrumbTypes = BSGEnabledBreadcrumbTypeAll;
     _launchDurationMillis = 5000;
     _sendLaunchCrashesSynchronously = YES;
-    _maxBreadcrumbs = 50;
+    _maxBreadcrumbs = 100;
     _maxPersistedEvents = 32;
     _maxPersistedSessions = 128;
     _maxStringValueLength = 10000;
@@ -509,15 +509,18 @@ static NSUserDefaults *userDefaults;
     }
 }
 
-- (void)setMaxBreadcrumbs:(NSUInteger)maxBreadcrumbs {
+- (void)setMaxBreadcrumbs:(NSUInteger)newValue {
+    static const NSUInteger maxAllowed = 500;
+    if (newValue > maxAllowed) {
+        bsg_log_err(@"Invalid configuration value detected. "
+                    "Option maxBreadcrumbs should be an integer between 0-%lu. "
+                    "Supplied value is %lu",
+                    (unsigned long)maxAllowed,
+                    (unsigned long)newValue);
+        return;
+    }
     @synchronized (self) {
-        if (maxBreadcrumbs <= 100) {
-            _maxBreadcrumbs = maxBreadcrumbs;
-        } else {
-            bsg_log_err(@"Invalid configuration value detected. Option maxBreadcrumbs "
-                        "should be an integer between 0-100. Supplied value is %lu",
-                        (unsigned long) maxBreadcrumbs);
-        }
+        _maxBreadcrumbs = newValue;
     }
 }
 

--- a/Bugsnag/include/Bugsnag/BugsnagConfiguration.h
+++ b/Bugsnag/include/Bugsnag/BugsnagConfiguration.h
@@ -330,7 +330,7 @@ BUGSNAG_EXTERN
  * Sets the maximum number of breadcrumbs which will be stored. Once the threshold is reached,
  * the oldest breadcrumbs will be deleted.
  *
- * By default, 25 breadcrumbs are stored: this can be amended up to a maximum of 100.
+ * By default, 100 breadcrumbs are stored: this can be amended up to a maximum of 500.
  */
 @property (nonatomic) NSUInteger maxBreadcrumbs;
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,9 @@ Changelog
 
 ### Enhancements
 
+* Increase default and maximum values for `configuration.maxBreadcrumbs` to 100 and 500, respectively.
+  [#1452](https://github.com/bugsnag/bugsnag-cocoa/pull/1452)
+
 * Trim breadcrumb messages & metadata in payloads that exceed the size limit.
   [#1451](https://github.com/bugsnag/bugsnag-cocoa/pull/1451)
 

--- a/Tests/BugsnagTests/BSGConfigurationBuilderTests.m
+++ b/Tests/BugsnagTests/BSGConfigurationBuilderTests.m
@@ -56,7 +56,7 @@
     XCTAssertTrue(config.autoTrackSessions);
     XCTAssertEqual(config.maxPersistedEvents, 32);
     XCTAssertEqual(config.maxPersistedSessions, 128);
-    XCTAssertEqual(config.maxBreadcrumbs, 50);
+    XCTAssertEqual(config.maxBreadcrumbs, 100);
     XCTAssertTrue(config.persistUser);
     XCTAssertEqualObjects(@[@"password"], [config.redactedKeys allObjects]);
     XCTAssertEqual(BSGEnabledBreadcrumbTypeAll, config.enabledBreadcrumbTypes);

--- a/Tests/BugsnagTests/BugsnagConfigurationTests.m
+++ b/Tests/BugsnagTests/BugsnagConfigurationTests.m
@@ -585,15 +585,15 @@ NSString * const kBugsnagUserUserId = @"BugsnagUserUserId";
 
 - (void)testMaxBreadcrumb {
     BugsnagConfiguration *config = [[BugsnagConfiguration alloc] initWithApiKey:DUMMY_APIKEY_32CHAR_1];
-    XCTAssertEqual(50, config.maxBreadcrumbs);
+    XCTAssertEqual(100, config.maxBreadcrumbs);
 
     // alter to valid value
     config.maxBreadcrumbs = 10;
     XCTAssertEqual(10, config.maxBreadcrumbs);
 
     // alter to max value
-    config.maxBreadcrumbs = 100;
-    XCTAssertEqual(100, config.maxBreadcrumbs);
+    config.maxBreadcrumbs = 500;
+    XCTAssertEqual(500, config.maxBreadcrumbs);
 
     // alter to min value
     config.maxBreadcrumbs = 0;
@@ -603,8 +603,8 @@ NSString * const kBugsnagUserUserId = @"BugsnagUserUserId";
     config.maxBreadcrumbs = -1;
     XCTAssertEqual(0, config.maxBreadcrumbs);
 
-    // alter to negative value (overflows)
-    config.maxBreadcrumbs = 500;
+    // alter to too large value
+    config.maxBreadcrumbs = 501;
     XCTAssertEqual(0, config.maxBreadcrumbs);
 }
 
@@ -641,7 +641,6 @@ NSString * const kBugsnagUserUserId = @"BugsnagUserUserId";
     XCTAssertNil(config.enabledReleaseStages);
     XCTAssertEqualObjects(@"https://notify.bugsnag.com", config.endpoints.notify);
     XCTAssertEqualObjects(@"https://sessions.bugsnag.com", config.endpoints.sessions);
-    XCTAssertEqual(50, config.maxBreadcrumbs);
     XCTAssertEqual(config.maxStringValueLength, 10000);
     XCTAssertTrue(config.persistUser);
     XCTAssertEqual(1, [config.redactedKeys count]);


### PR DESCRIPTION
## Goal

Allow more breadcrumbs now that there is trimming in place to mitigate oversized payloads.

## Changeset

Increases default `maxBreadcrumbs` from 50 to 100, and maximum allowed  from 100 to 500.

Deletes breadcrumbs on a background queue to prevent increased number of breadcrumbs from slowing execution time of `Bugsnag.start()`.

## Testing

Amends existing unit test cases for changed default and limit.

Passes existing stress test.