### PR TITLE
Fix potential deadlock in bsg_kscrw_i_writeThread()

### DIFF
--- a/Bugsnag/KSCrash/Source/KSCrash/Recording/Tools/BSG_KSMach.c
+++ b/Bugsnag/KSCrash/Source/KSCrash/Recording/Tools/BSG_KSMach.c
@@ -224,8 +224,8 @@ pthread_t bsg_ksmachpthreadFromMachThread(const thread_t thread) {
 
 bool bsg_ksmachgetThreadName(const thread_t thread, char *const buffer,
                              size_t bufLength) {
-    // WARNING: This implementation is only async-safe for the current thread
-    // as of libpthread-330.201.1, and is still unsafe for other threads.
+    // WARNING: This implementation is not async-safe because
+    // pthread_from_mach_thread_np() acquires an internal lock.
 
     const pthread_t pthread = pthread_from_mach_thread_np(thread);
     if (pthread == NULL) {

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -16,6 +16,9 @@ Changelog
 
 ### Bug fixes
 
+* Fix a potential deadlock when capturing the crashing thread's name.
+  [#1453](https://github.com/bugsnag/bugsnag-cocoa/pull/1453)
+
 * Attempt to send sessions stored on disk when connection regained.
   [#1445](https://github.com/bugsnag/bugsnag-cocoa/pull/1445)
 


### PR DESCRIPTION
## Goal

Fix a potential deadlock when capturing the crashed thread's name - see #1406

## Design

`bsg_ksmachgetThreadName()` uses `pthread_from_mach_thread_np()` which [acquires a lock](https://github.com/apple-oss-distributions/libpthread/blob/libpthread-330.201.1/src/pthread.c#L941-L959) and is therefore unsafe to call from a crash handler.

## Changeset

Replaces use of `bsg_ksmachgetThreadName()` with `pthread_getname_np(pthread_self(), ...)` to avoid potential deadlock.

## Testing

Thread name capture is verified for C++ exceptions and NSExceptions since #1406