### PR TITLE
Refactor leaveBreadcrumb

### DIFF
--- a/Bugsnag/Breadcrumbs/BugsnagBreadcrumbs.h
+++ b/Bugsnag/Breadcrumbs/BugsnagBreadcrumbs.h
@@ -12,10 +12,6 @@
 @class BugsnagConfiguration;
 typedef struct BSG_KSCrashReportWriter BSG_KSCrashReportWriter;
 
-typedef void (^BSGBreadcrumbConfiguration)(BugsnagBreadcrumb *_Nonnull);
-
-#pragma mark -
-
 NS_ASSUME_NONNULL_BEGIN
 
 @interface BugsnagBreadcrumbs : NSObject
@@ -28,16 +24,9 @@ NS_ASSUME_NONNULL_BEGIN
 @property (readonly, nonatomic) NSArray<BugsnagBreadcrumb *> *breadcrumbs;
 
 /**
- * Store a new breadcrumb with a provided message.
+ * Store a new breadcrumb.
  */
-- (void)addBreadcrumb:(NSString *)breadcrumbMessage;
-
-/**
- *  Store a new breadcrumb configured via block.
- *
- *  @param block configuration block
- */
-- (void)addBreadcrumbWithBlock:(BSGBreadcrumbConfiguration)block;
+- (void)addBreadcrumb:(BugsnagBreadcrumb *)breadcrumb;
 
 /**
  * Store a new serialized breadcrumb.

--- a/Bugsnag/Breadcrumbs/BugsnagBreadcrumbs.m
+++ b/Bugsnag/Breadcrumbs/BugsnagBreadcrumbs.m
@@ -97,18 +97,11 @@ static atomic_bool g_writing_crash_report;
     });
 }
 
-- (void)addBreadcrumb:(NSString *)breadcrumbMessage {
-    [self addBreadcrumbWithBlock:^(BugsnagBreadcrumb *_Nonnull crumb) {
-        crumb.message = breadcrumbMessage;
-    }];
-}
-
-- (void)addBreadcrumbWithBlock:(BSGBreadcrumbConfiguration)block {
+- (void)addBreadcrumb:(BugsnagBreadcrumb *)crumb {
     if (self.maxBreadcrumbs == 0) {
         return;
     }
-    BugsnagBreadcrumb *crumb = [BugsnagBreadcrumb breadcrumbWithBlock:block];
-    if (!crumb || ![self shouldSendBreadcrumb:crumb]) {
+    if (![crumb isValid] || ![self shouldSendBreadcrumb:crumb]) {
         return;
     }
     NSData *data = [self dataForBreadcrumb:crumb];

--- a/Bugsnag/Bugsnag.m
+++ b/Bugsnag/Bugsnag.m
@@ -155,13 +155,6 @@ static BugsnagClient *bsg_g_bugsnag_client = NULL;
     }
 }
 
-+ (void)leaveBreadcrumbWithBlock:
-    (void (^_Nonnull)(BugsnagBreadcrumb *_Nonnull))block {
-    if ([self bugsnagStarted]) {
-        [self.client addBreadcrumbWithBlock:block];
-    }
-}
-
 + (void)leaveBreadcrumbForNotificationName:
     (NSString *_Nonnull)notificationName {
     if ([self bugsnagStarted]) {

--- a/Bugsnag/Client/BugsnagClient+Private.h
+++ b/Bugsnag/Client/BugsnagClient+Private.h
@@ -95,8 +95,6 @@ typedef void (^ BSGClientObserver)(BSGClientObserverEvent event, _Nullable id va
 
 #pragma mark Methods
 
-- (void)addBreadcrumbWithBlock:(void (^)(BugsnagBreadcrumb *))block;
-
 - (void)addRuntimeVersionInfo:(NSString *)info withKey:(NSString *)key;
 
 - (NSDictionary *)collectAppWithState; // Used in BugsnagReactNative

--- a/Bugsnag/Payload/BugsnagBreadcrumb+Private.h
+++ b/Bugsnag/Payload/BugsnagBreadcrumb+Private.h
@@ -15,7 +15,7 @@ NS_ASSUME_NONNULL_BEGIN
 
 + (nullable instancetype)breadcrumbFromDict:(NSDictionary *)dict;
 
-+ (nullable instancetype)breadcrumbWithBlock:(void (^)(BugsnagBreadcrumb *))block;
+- (BOOL)isValid;
 
 - (nullable NSDictionary *)objectValue;
 

--- a/Bugsnag/Payload/BugsnagBreadcrumb.m
+++ b/Bugsnag/Payload/BugsnagBreadcrumb.m
@@ -28,8 +28,7 @@
 #import "BSGKeys.h"
 #import "BugsnagBreadcrumb+Private.h"
 #import "BugsnagBreadcrumbs.h"
-#import "Bugsnag.h"
-#import "BugsnagLogger.h"
+#import "BugsnagCollections.h"
 
 typedef void (^BSGBreadcrumbConfiguration)(BugsnagBreadcrumb *_Nonnull);
 
@@ -145,23 +144,17 @@ BSGBreadcrumbType BSGBreadcrumbTypeFromString(NSString *value) {
 }
 
 + (instancetype)breadcrumbFromDict:(NSDictionary *)dict {
-    BOOL isValidCrumb = [dict[BSGKeyType] isKindOfClass:[NSString class]]
-        && [dict[BSGKeyTimestamp] isKindOfClass:[NSString class]]
-        && [BSG_RFC3339DateTool isLikelyDateString:dict[BSGKeyTimestamp]]
-        && (
-            [dict[BSGKeyMetadata] isKindOfClass:[NSDictionary class]]
-            || [dict[@"metadata"] isKindOfClass:[NSDictionary class]] // react-native uses lowercase key
-            )
-        // Accept legacy 'name' value if provided.
-        && ([dict[BSGKeyMessage] isKindOfClass:[NSString class]]
-            || [dict[BSGKeyName] isKindOfClass:[NSString class]]);
-    if (isValidCrumb) {
-        return [self breadcrumbWithBlock:^(BugsnagBreadcrumb *crumb) {
-            crumb.message = dict[BSGKeyMessage] ?: dict[BSGKeyName];
-            crumb.metadata = dict[BSGKeyMetadata] ?: dict[@"metadata"];
-            crumb.timestampString = dict[BSGKeyTimestamp];
-            crumb.type = BSGBreadcrumbTypeFromString(dict[BSGKeyType]);
-        }];
+    NSDictionary *metadata = BSGDeserializeDict(dict[BSGKeyMetadata] ?: dict[@"metadata"] /* react-native uses lowercase key */);
+    NSString *message = BSGDeserializeString(dict[BSGKeyMessage] ?: dict[BSGKeyName] /* Accept legacy 'name' value */);
+    NSString *timestamp = BSGDeserializeString(dict[BSGKeyTimestamp]); 
+    NSString *type = BSGDeserializeString(dict[BSGKeyType]);
+    if (timestamp && type && message) {
+        BugsnagBreadcrumb *crumb = [BugsnagBreadcrumb new];
+        crumb.message = message;
+        crumb.metadata = metadata ?: @{};
+        crumb.timestampString = timestamp;
+        crumb.type = BSGBreadcrumbTypeFromString(type);
+        return [crumb isValid] ? crumb : nil;
     }
     return nil;
 }

--- a/Bugsnag/Payload/BugsnagBreadcrumb.m
+++ b/Bugsnag/Payload/BugsnagBreadcrumb.m
@@ -93,7 +93,7 @@ BSGBreadcrumbType BSGBreadcrumbTypeFromString(NSString *value) {
 }
 
 - (BOOL)isValid {
-    return self.message.length > 0 && (self.timestampString || self.timestamp);
+    return self.message.length > 0 && ([BSG_RFC3339DateTool isLikelyDateString:self.timestampString] || self.timestamp);
 }
 
 - (NSDictionary *)objectValue {
@@ -132,17 +132,6 @@ BSGBreadcrumbType BSGBreadcrumbTypeFromString(NSString *value) {
     self.timestamp = nil;
 }
 
-+ (instancetype)breadcrumbWithBlock:(BSGBreadcrumbConfiguration)block {
-    BugsnagBreadcrumb *crumb = [self new];
-    if (block) {
-        block(crumb);
-    }
-    if ([crumb isValid]) {
-        return crumb;
-    }
-    return nil;
-}
-
 + (instancetype)breadcrumbFromDict:(NSDictionary *)dict {
     NSDictionary *metadata = BSGDeserializeDict(dict[BSGKeyMetadata] ?: dict[@"metadata"] /* react-native uses lowercase key */);
     NSString *message = BSGDeserializeString(dict[BSGKeyMessage] ?: dict[BSGKeyName] /* Accept legacy 'name' value */);
@@ -160,4 +149,3 @@ BSGBreadcrumbType BSGBreadcrumbTypeFromString(NSString *value) {
 }
 
 @end
-

--- a/BugsnagNetworkRequestPlugin/BugsnagNetworkRequestPluginTests/BugsnagNetworkRequestPluginTests.m
+++ b/BugsnagNetworkRequestPlugin/BugsnagNetworkRequestPluginTests/BugsnagNetworkRequestPluginTests.m
@@ -65,11 +65,10 @@ static NSData *mock_nextData;
 - (void)leaveBreadcrumbWithMessage:(nonnull NSString *)message
                           metadata:(nullable NSDictionary *)metadata
                            andType:(BSGBreadcrumbType)type {
-    BugsnagBreadcrumb *crumb = [BugsnagBreadcrumb breadcrumbWithBlock:^(BugsnagBreadcrumb *_Nonnull crumbs) {
-        crumbs.message = message;
-        crumbs.metadata = metadata ?: @{};
-        crumbs.type = type;
-    }];
+    BugsnagBreadcrumb *crumb = [BugsnagBreadcrumb new];
+    crumb.message = message;
+    crumb.metadata = metadata ?: @{};
+    crumb.type = type;
     [self.breadcrumbs addObject:crumb];
 }
 

--- a/Tests/BugsnagTests/BSGNotificationBreadcrumbsTests.m
+++ b/Tests/BugsnagTests/BSGNotificationBreadcrumbsTests.m
@@ -135,11 +135,10 @@
 #pragma mark BSGBreadcrumbSink
 
 - (void)leaveBreadcrumbWithMessage:(NSString *)message metadata:(NSDictionary *)metadata andType:(BSGBreadcrumbType)type {
-    self.breadcrumb = [BugsnagBreadcrumb breadcrumbWithBlock:^(BugsnagBreadcrumb *breadcrumb) {
-        breadcrumb.message = message;
-        breadcrumb.metadata = metadata;
-        breadcrumb.type = type;
-    }];
+    self.breadcrumb = [BugsnagBreadcrumb new];
+    self.breadcrumb.message = message;
+    self.breadcrumb.metadata = metadata;
+    self.breadcrumb.type = type;
 }
 
 #define TEST(__NAME__, __TYPE__, __MESSAGE__, __METADATA__) do { \

--- a/Tests/BugsnagTests/BugsnagClientMirrorTest.m
+++ b/Tests/BugsnagTests/BugsnagClientMirrorTest.m
@@ -140,7 +140,6 @@
             @"client @16@0:8",
             @"getContext @16@0:8",
             @"instance @16@0:8",
-            @"leaveBreadcrumbWithBlock: v24@0:8@?16",
             @"purge v16@0:8",
             @"start @16@0:8",
             @"startWithApiKey: @24@0:8@16",

--- a/Tests/BugsnagTests/BugsnagClientMirrorTest.m
+++ b/Tests/BugsnagTests/BugsnagClientMirrorTest.m
@@ -32,7 +32,6 @@
             @".cxx_destruct v16@0:8",
             @"addAutoBreadcrumbForEvent: v24@0:8@16",
             @"addAutoBreadcrumbOfType:withMessage:andMetadata: v40@0:8Q16@24@32",
-            @"addBreadcrumbWithBlock: v24@0:8@?16",
             @"appHangDetectedAtDate:withThreads:systemInfo: v40@0:8@16@24@32",
             @"appHangDetector @16@0:8",
             @"appHangEnded v16@0:8",


### PR DESCRIPTION
## Goal

Remove unused code and reduce code size.

## Changeset

Removes unused & unexposed method `+[Bugsnag leaveBreadcrumbWithBlock:]`.

Simplifies `+[BugsnagBreadcrumb breadcrumbFromDict:]`.

Removes (internal-only) block-based breadcrumb APIs to reduce code size.

## Testing

Covered by existing unit and E2E tests.