### PR TITLE
[PLAT-8809] Fix incorrect C++ exception stack traces

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,14 @@
 Changelog
 =========
 
+## TBD
+
+### Bug fixes
+
+* Fix a regression introduced in 6.18.0 that caused incorrect C++ exception
+  stacktraces to be reported when Bugsnag is linked dynamically.
+  [#1463](https://github.com/bugsnag/bugsnag-cocoa/pull/1463)
+
 ## 6.22.1 (2022-08-10)
 
 ### Bug fixes


### PR DESCRIPTION
## Goal

Fix incorrect C++ exception stacktraces.

As reported in https://github.com/bugsnag/bugsnag-js/issues/1803, the wrong stack trace is reported for C++ exceptions when Bugsnag is linked dynamically:

```
0  zinspector3             bsg_kscrw_i_getBacktrace (BSG_KSCrashReport.c:459:13)
1  zinspector3             bsg_kscrw_i_writeThread (BSG_KSCrashReport.c:909:9)
2  zinspector3             bsg_kscrw_i_writeAllThreads (BSG_KSCrashReport.c:977:17)
3  zinspector3             bsg_kscrw_i_writeTraceInfo (BSG_KSCrashReport.c:1522:9)
4  zinspector3             bsg_kscrashreport_writeStandardReport (BSG_KSCrashReport.c:1472:9)
5  zinspector3             CPPExceptionTerminate() (BSG_KSCrashSentry_CPPException.mm:213:9)
6  libc++abi.dylib         std::__terminate(void (*)())
7  libc++abi.dylib         std::terminate()
8  libdispatch.dylib       __dispatch_client_callout
9  libdispatch.dylib       __dispatch_lane_serial_drain
10 libdispatch.dylib       __dispatch_lane_invoke
11 libdispatch.dylib       __dispatch_workloop_worker_thread
12 libsystem_pthread.dylib __pthread_wqthread
13 libsystem_pthread.dylib _start_wqthread
```

This is a regression introduced by [#1361](https://github.com/bugsnag/bugsnag-cocoa/pull/1361/files#diff-99ec2ac686bcfd0110fb48a1015e2629784db2068a2411a2a348a790c3b1f923R461-R474)

When Bugsnag is linked dynamically, we are not able to capture a stack trace of the throwing call site.

## Changeset

Removes fallback code from `bsg_kscrw_i_getBacktrace()` - it is unnecessary because the only supported crash types on watchOS are C++ & Objective-C exceptions, for which the sentries pass in stack traces:
* [BSG_KSCrashSentry_CPPException.mm#L206-L208](https://github.com/bugsnag/bugsnag-cocoa/blob/v6.22.1/Bugsnag/KSCrash/Source/KSCrash/Recording/Sentry/BSG_KSCrashSentry_CPPException.mm#L206-L208)
* [BSG_KSCrashSentry_NSException.m#L136-L137](https://github.com/bugsnag/bugsnag-cocoa/blob/v6.22.1/Bugsnag/KSCrash/Source/KSCrash/Recording/Sentry/BSG_KSCrashSentry_NSException.m#L136-L137)

## Testing

Verified locally using example apps that link to Bugsnag dynamically.