### PR TITLE
[PLAT-8816] Fix crash when using network request plugin with `GTMSessionFetcher`

### DIFF
--- a/BugsnagNetworkRequestPlugin/BugsnagNetworkRequestPlugin/BSGURLSessionTracingProxy.m
+++ b/BugsnagNetworkRequestPlugin/BugsnagNetworkRequestPlugin/BSGURLSessionTracingProxy.m
@@ -36,8 +36,24 @@
     return [self.delegate respondsToSelector:aSelector];
 }
 
+// Implementing this method prevents a crash when used alongside NewRelic
 - (id)forwardingTargetForSelector:(__unused SEL)aSelector {
     return self.delegate;
+}
+
+- (void)forwardInvocation:(NSInvocation *)invocation {
+    [invocation invokeWithTarget:self.delegate];
+}
+
+- (NSMethodSignature *)methodSignatureForSelector:(SEL)aSelector {
+    // Note: We allow a race condition on self.tracingDelegate.canTrace because the
+    //       caller has already determined that we respond to selector, and it would
+    //       break things to stop "supporting" it now. We'll catch this edge case in
+    //       forwardInvocation, and again in the call to tracingDelegate.
+    if (sel_isEqual(aSelector, METRICS_SELECTOR)) {
+        return [(NSObject *)self.tracingDelegate methodSignatureForSelector:aSelector];
+    }
+    return [(NSObject *)self.delegate methodSignatureForSelector:aSelector];
 }
 
 - (void)URLSession:(NSURLSession *)session task:(NSURLSessionTask *)task didFinishCollectingMetrics:(NSURLSessionTaskMetrics *)metrics

--- a/BugsnagNetworkRequestPlugin/BugsnagNetworkRequestPluginTests/BSGURLSessionTracingProxyTests.m
+++ b/BugsnagNetworkRequestPlugin/BugsnagNetworkRequestPluginTests/BSGURLSessionTracingProxyTests.m
@@ -85,12 +85,39 @@
     };
 }
 
+#pragma mark - NSProxy correctness
+
+- (void)testConformsToProtocol {
+    id sessionDelegate = [[BSGURLSessionTracingProxyTests_DidReceiveDataStub alloc] init];
+    id tracingDelegate = [[BSGURLSessionTracingProxyTests_TracingStub alloc] init];
+    id proxy = [[BSGURLSessionTracingProxy alloc] initWithDelegate:sessionDelegate tracingDelegate:tracingDelegate];
+    XCTAssertTrue([proxy conformsToProtocol:@protocol(NSURLSessionDataDelegate)]);
+    XCTAssertFalse([proxy conformsToProtocol:@protocol(NSURLSessionStreamDelegate)]);
+}
+
 - (void)testExceptionIsThrownForUnimplementedMethod {
-    BSGURLSessionTracingProxyTests_DidReceiveDataStub *sessionDelegate =
-    [[BSGURLSessionTracingProxyTests_DidReceiveDataStub alloc] init];
-    BSGURLSessionTracingProxyTests_TracingStub *tracingDelegate = [[BSGURLSessionTracingProxyTests_TracingStub alloc] init];
-    id proxy = [[BSGURLSessionTracingProxy alloc] initWithDelegate:sessionDelegate tracingDelegate:(id)tracingDelegate];
+    id sessionDelegate = [[BSGURLSessionTracingProxyTests_DidReceiveDataStub alloc] init];
+    id tracingDelegate = [[BSGURLSessionTracingProxyTests_TracingStub alloc] init];
+    id proxy = [[BSGURLSessionTracingProxy alloc] initWithDelegate:sessionDelegate tracingDelegate:tracingDelegate];
     XCTAssertThrowsSpecificNamed([proxy testExceptionIsThrownForUnimplementedMethod], NSException, NSInvalidArgumentException);
+}
+
+- (void)testIsKindOfClass {
+    id sessionDelegate = [[BSGURLSessionTracingProxyTests_DidReceiveDataStub alloc] init];
+    id tracingDelegate = [[BSGURLSessionTracingProxyTests_TracingStub alloc] init];
+    id proxy = [[BSGURLSessionTracingProxy alloc] initWithDelegate:sessionDelegate tracingDelegate:tracingDelegate];
+    XCTAssertTrue([proxy isKindOfClass:[NSObject class]]);
+    XCTAssertTrue([proxy isKindOfClass:[sessionDelegate class]]);
+    XCTAssertFalse([proxy isKindOfClass:[tracingDelegate class]]);
+}
+
+- (void)testRespondsToSelector {
+    id sessionDelegate = [[BSGURLSessionTracingProxyTests_DidReceiveDataStub alloc] init];
+    id tracingDelegate = [[BSGURLSessionTracingProxyTests_TracingStub alloc] init];
+    id proxy = [[BSGURLSessionTracingProxy alloc] initWithDelegate:sessionDelegate tracingDelegate:tracingDelegate];
+    XCTAssertTrue([proxy respondsToSelector:@selector(URLSession:dataTask:didReceiveData:)]);
+    XCTAssertTrue([proxy respondsToSelector:@selector(URLSession:task:didFinishCollectingMetrics:)]);
+    XCTAssertFalse([sessionDelegate respondsToSelector:@selector(URLSession:task:didFinishCollectingMetrics:)]);
 }
 
 @end

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,9 @@ Changelog
 
 ### Bug fixes
 
+* Fix a crash when using `BugsnagNetworkRequestPlugin` with `GTMSessionFetcher`.
+  [#1465](https://github.com/bugsnag/bugsnag-cocoa/pull/1465)
+
 * Fix a regression introduced in 6.18.0 that caused incorrect C++ exception
   stacktraces to be reported when Bugsnag is linked dynamically.
   [#1463](https://github.com/bugsnag/bugsnag-cocoa/pull/1463)


### PR DESCRIPTION
## Goal

Fix a crash that occurs when using `BugsnagNetworkRequestPlugin` in conjunction with `GTMSessionFetcher` (as used by `FirebaseAuth`, for example).

App crashes with `*** Terminating app due to uncaught exception 'NSInvalidArgumentException', reason: '*** -[NSProxy methodSignatureForSelector:] called!'` when [`GTMSessionFetcherService` calls `isKindOfClass:`](https://github.com/google/gtm-session-fetcher/blob/v2.0.0/Sources/Core/GTMSessionFetcherService.m#L440)

## Changeset

Reintroduce implementations of `forwardInvocation:` and `methodSignatureForSelector:` that were replaced with `forwardingTargetForSelector:` in #1324. The forwarding mechanism does not appear to use `forwardingTargetForSelector:` for methods such as `isKindOfClass:`.

There is some useful related information in the [Message Forwarding: Forwarding and Inheritance](https://developer.apple.com/library/archive/documentation/Cocoa/Conceptual/ObjCRuntimeGuide/Articles/ocrtForwarding.html#//apple_ref/doc/uid/TP40008048-CH105-SW12) documentation.

## Testing

Reproduced crash and verified fix in demo app.

Adds unit test cases that reproduced crash when calling `isKindOfClass:` etc.

Verified no regression of #1324 in example app that uses NewRelic and Moya.