### PR TITLE
Fix watchOS E2E when run without `--os-version`

### DIFF
--- a/features/steps/reusable_steps.rb
+++ b/features/steps/reusable_steps.rb
@@ -14,9 +14,10 @@ Then(/^on (iOS|macOS|watchOS), (.+)/) do |platform, step_text|
   step(step_text) if platform_matches?(platform)
 end
 
-Then(/^on (iOS|macOS|watchOS) ([0-9.]+) and later, (.+)/) do |platform, version, step_text|
+Then(/^on (iOS|macOS) ([0-9.]+) and later, (.+)/) do |platform, version, step_text|
+  next unless platform_matches?(platform)
   raise 'Maze.config.os_version is not defined' if Maze.config.os_version.nil?
-  step(step_text) if platform_matches?(platform) && Gem::Version.new(Maze.config.os_version) >= Gem::Version.new(version)
+  step(step_text) if Gem::Version.new(Maze.config.os_version) >= Gem::Version.new(version)
 end
 
 Then(/^on !(iOS|macOS|watchOS), (.+)/) do |platform, step_text|


### PR DESCRIPTION
## Goal

Fix watchOS E2E when run without `--os-version`

The [Makefile](https://github.com/bugsnag/bugsnag-cocoa/blob/b6b9fd27b1d5e78aadeb226dbec6db3e53bdf3f8/Makefile#L147-L151) is unable to pass `--os-version` because we don't have a way to determine the OS version of the connected watch.

## Changeset

Skips version check unless platform matches.

Changes step definition to clarify that watchOS is not a supported target platform.

## Testing

Verified by running `make e2e_watchos`.