### PR TITLE
E2E: Disable unexpectedly quit dialog on macOS 11

### DIFF
--- a/features/support/env.rb
+++ b/features/support/env.rb
@@ -52,29 +52,19 @@ BeforeAll do
   end
 end
 
-AfterAll do
-  $after_all_blocks.each(&:call) unless $after_all_blocks.nil?
-end
-
 # Disables the "macOSTestApp quit unexpectedly" dialog to prevent focus being stolen from the fixture.
 def disable_unexpectedly_quit_dialog
   if Maze.config.os_version.floor == 11
     # com.apple.CrashReporter defaults seem to be ignored on macOS 11
     # Note: unloading com.apple.ReportCrash disables creation of crash reports in ~/Library/Logs/DiagnosticReports
     `/bin/launchctl unload /System/Library/LaunchAgents/com.apple.ReportCrash.plist`
-    after_all do
+    at_exit do
       `/bin/launchctl load /System/Library/LaunchAgents/com.apple.ReportCrash.plist`
     end
   else
     # Use Notification Center instead of showing dialog.
     `defaults write com.apple.CrashReporter UseUNC 1`
   end
-end
-
-# There is no "Maze.hooks.after_all"
-def after_all(&block)
-  $after_all_blocks = [] if $after_all_blocks.nil?
-  $after_all_blocks << block
 end
 
 def skip_below(os, version)

--- a/features/support/env.rb
+++ b/features/support/env.rb
@@ -37,11 +37,8 @@ BeforeAll do
     Maze.config.capabilities_option = JSON.dump(capabilities)
   end
 
-  # Additional require MacOS configuration
   if Maze.config.os == 'macos'
-    # The default macOS Crash Reporter "#{app_name} quit unexpectedly" alert grabs focus which can cause tests to flake.
-    # This option, which appears to have been introduced in macOS 10.11, displays a notification instead of the alert.
-    `defaults write com.apple.CrashReporter UseUNC 1`
+    disable_unexpectedly_quit_dialog
 
     fixture_dir = 'features/fixtures/macos/output'
     zip_name = "#{Maze.config.app}.zip"
@@ -53,6 +50,31 @@ BeforeAll do
       system("cd #{fixture_dir} && unzip -q #{zip_name}", exception: true)
     end
   end
+end
+
+AfterAll do
+  $after_all_blocks.each(&:call) unless $after_all_blocks.nil?
+end
+
+# Disables the "macOSTestApp quit unexpectedly" dialog to prevent focus being stolen from the fixture.
+def disable_unexpectedly_quit_dialog
+  if Maze.config.os_version.floor == 11
+    # com.apple.CrashReporter defaults seem to be ignored on macOS 11
+    # Note: unloading com.apple.ReportCrash disables creation of crash reports in ~/Library/Logs/DiagnosticReports
+    `/bin/launchctl unload /System/Library/LaunchAgents/com.apple.ReportCrash.plist`
+    after_all do
+      `/bin/launchctl load /System/Library/LaunchAgents/com.apple.ReportCrash.plist`
+    end
+  else
+    # Use Notification Center instead of showing dialog.
+    `defaults write com.apple.CrashReporter UseUNC 1`
+  end
+end
+
+# There is no "Maze.hooks.after_all"
+def after_all(&block)
+  $after_all_blocks = [] if $after_all_blocks.nil?
+  $after_all_blocks << block
 end
 
 def skip_below(os, version)


### PR DESCRIPTION
## Goal

Fix intermittent E2E `did not GET /command` flakes on macOS 11.

These were caused by the "macOSTestApp quit unexpectedly" dialog stealing focus from the fixture. Becoming foreground is what triggers the fixture to GET /command.

## Changeset

Unloads the `com.apple.ReportCrash` service while running tests on macOS 11. It was found through manual experimentation that the usual preferences (configurable through `CrashReporterPrefs.app`) have no effect on this OS version.

On other versions the `UseUNC` option is still used because it is sometimes useful to inspect Apple's crash reports.

## Testing

Verified locally and through a [dedicated CI run](https://buildkite.com/bugsnag/bugsnag-cocoa/builds/6174#0182b048-6033-4219-9300-70244ae7bce4).