### PR TITLE
Simplify running E2E tests on macOS

### DIFF
--- a/.buildkite/pipeline.full.yml
+++ b/.buildkite/pipeline.full.yml
@@ -257,8 +257,6 @@ steps:
       - bundle install
       - bundle exec maze-runner
         --os=macos
-        --os-version=11.0
-        --app=macOSTestApp
         --fail-fast
         --order=random
 
@@ -279,8 +277,6 @@ steps:
       - bundle install
       - bundle exec maze-runner
         --os=macos
-        --os-version=12
-        --app=macOSTestApp
         --fail-fast
         --order=random
 
@@ -298,8 +294,6 @@ steps:
       - bundle install
       - bundle exec maze-runner
         --os=macos
-        --os-version=10.13
-        --app=macOSTestApp
         --fail-fast
         --order=random
 
@@ -317,8 +311,6 @@ steps:
       - bundle install
       - bundle exec maze-runner
         --os=macos
-        --os-version=10.14
-        --app=macOSTestApp
         --fail-fast
         --order=random
 

--- a/.buildkite/pipeline.yml
+++ b/.buildkite/pipeline.yml
@@ -350,8 +350,6 @@ steps:
       - bundle exec maze-runner
         features/barebone_tests.feature
         --os=macos
-        --os-version=10.13
-        --app=macOSTestApp
         --fail-fast
         --order=random
 
@@ -369,8 +367,6 @@ steps:
       - bundle install
       - bundle exec maze-runner
         --os=macos
-        --os-version=10.15
-        --app=macOSTestApp
         --fail-fast
         --order=random
 
@@ -392,8 +388,6 @@ steps:
       - bundle exec maze-runner
         features/barebone_tests.feature
         --os=macos
-        --os-version=12
-        --app=macOSTestApp
         --fail-fast
         --order=random
 

--- a/Makefile
+++ b/Makefile
@@ -133,7 +133,7 @@ e2e_ios_local:
 
 e2e_macos:
 	./features/scripts/export_mac_app.sh
-	bundle exec maze-runner --app=macOSTestApp --os=macOS --os-version=$(shell sw_vers -productVersion) $(FEATURES)
+	bundle exec maze-runner --os=macOS $(FEATURES)
 ifeq ($(ENABLE_CODE_COVERAGE), YES)
 	xcrun llvm-profdata merge -sparse *.profraw -o default.profdata
 	rm -rf *.profraw

--- a/features/steps/app_steps.rb
+++ b/features/steps/app_steps.rb
@@ -141,11 +141,10 @@ def run_macos_app
     Process.kill 'KILL', $fixture_pid
     Process.waitpid $fixture_pid
   end
-  $fixture_pid = Process.spawn(
-    $app_env,
-    'features/fixtures/macos/output/macOSTestApp.app/Contents/MacOS/macOSTestApp',
-    %i[err out] => '/dev/null'
-  )
+  dir = 'features/fixtures/macos/output'
+  exe = "#{dir}/macOSTestApp.app/Contents/MacOS/macOSTestApp"
+  system("unzip -qd #{dir} #{dir}/macOSTestApp.zip", exception: true) unless File.exist? exe
+  $fixture_pid = Process.spawn($app_env, exe, %i[err out] => '/dev/null')
 end
 
 def run_watchos_app


### PR DESCRIPTION
## Goal

Make it easier to run maze-runner when targeting macOS.

## Changeset

Moves OS version detection to `env.rb`, removing need to pass `--os-version` on command line.

Stops using `--app` command line argument (`Maze.config.app`) - passing anything other than `macOSTestApp` has never been supported.

## Testing

Tested by running locally.