### PR TITLE
Fix test flake in `testAddOnBreadcrumbRejection`

### DIFF
--- a/.buildkite/pipeline.yml
+++ b/.buildkite/pipeline.yml
@@ -140,7 +140,7 @@ steps:
     agents:
       queue: opensource-mac-cocoa-10.13
     commands:
-      - ./scripts/run-unit-tests.sh PLATFORM=iOS OS=9.0 DEVICE=iPhone\ 5s XCODEBUILD_EXTRA_ARGS=-skip-testing:BugsnagNetworkRequestPlugin-iOSTests
+      - ./scripts/run-unit-tests.sh PLATFORM=iOS OS=9.0 DEVICE=iPhone\ 5s
     artifact_paths:
       - logs/*
 
@@ -185,7 +185,7 @@ steps:
     agents:
       queue: opensource-mac-cocoa-10.13
     commands:
-      - ./scripts/run-unit-tests.sh PLATFORM=tvOS OS=9.2 XCODEBUILD_EXTRA_ARGS=-skip-testing:BugsnagNetworkRequestPlugin-tvOSTests
+      - ./scripts/run-unit-tests.sh PLATFORM=tvOS OS=9.2
     artifact_paths:
       - logs/*
 

--- a/Tests/BugsnagTests/BugsnagOnBreadcrumbTest.m
+++ b/Tests/BugsnagTests/BugsnagOnBreadcrumbTest.m
@@ -194,10 +194,14 @@
     BugsnagClient *client = [[BugsnagClient alloc] initWithConfiguration:config];
     [client start];
 
+    // Not always zero - breadcrumbs from previous tests can appear due to async behaviour
+    NSUInteger countBefore = client.breadcrumbs.breadcrumbs.count;
+
     // Call onbreadcrumb blocks
-    XCTAssertEqual([client.breadcrumbs.breadcrumbs count], 0);
     [client leaveBreadcrumbWithMessage:@"Hello"];
-    XCTAssertEqual([client.breadcrumbs.breadcrumbs count], 0);
+    NSArray *breadcrumbs = client.breadcrumbs.breadcrumbs;
+    XCTAssertEqual(breadcrumbs.count, countBefore, @"Expected %lu breadcrumbs, got %@",
+                   (unsigned long)countBefore, [breadcrumbs valueForKeyPath:@"objectValue"]);
 }
 
 @end

--- a/Tests/TestHost-iOS/Info.plist
+++ b/Tests/TestHost-iOS/Info.plist
@@ -20,6 +20,11 @@
 	<string>1</string>
 	<key>LSRequiresIPhoneOS</key>
 	<true/>
+	<key>NSAppTransportSecurity</key>
+	<dict>
+		<key>NSAllowsArbitraryLoads</key>
+		<true/>
+	</dict>
 	<key>UILaunchStoryboardName</key>
 	<string>LaunchScreen</string>
 	<key>UIMainStoryboardFile</key>


### PR DESCRIPTION
## Goal

Fix a intermitted unit test failure in `testAddOnBreadcrumbRejection` (mostly observed on iOS 9 simulator)

## Changeset

Replaces assertion to verify that no breadcrumbs have been added, but without assuming there are no breadcrumbs.
Logs added to the test revealed that a connectivity change breadcrumb was sometimes appearing unexpectedly.
Because breadcrumbs exist in a globally shared store, it's possible for BugsnagClient objects created by previous test cases to add breadcrumbs that bypass the newly added OnBreadcrumb callback.

Fixes passing of the `-resultBundlePath` argument to capture unit test result bundles on iOS 9.
`XCODEBUILD_EXTRA_ARGS=[...]` in `pipeline.yml` was overriding this.

Configures App Transport Security in TestHost-iOS to stop warnings emitted during test runs.

## Testing

Verified locally and on CI