### PR TITLE
[PLAT-8863] Fix crash when reporting internal errors during `+[Bugsnag start]`

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,9 @@ Changelog
 
 ### Bug fixes
 
+* Fix a crash that could occur when reporting internal errors during `+[Bugsnag start]`.
+  [#1474](https://github.com/bugsnag/bugsnag-cocoa/pull/1474)
+
 * Fix accuracy of `isLR` and `isPC` stack frame values.
   [#1470](https://github.com/bugsnag/bugsnag-cocoa/pull/1470)
 


### PR DESCRIPTION
## Goal

Fix a crash that could occur when reporting internal errors during `+[Bugsnag start]`.

## Changeset

Initializes `BSGInternalErrorReporter` AFTER `bsg_runContext` to ensure the latter is non-null.

Considered moving `BSGRunContextInit` to a `+initialize` method instead, but that would hinder testing - it would not be possible to set `bsg_runContext` to `NULL` and have it re-initialized when starting a new `BugsnagClient`.

## Testing

Adds a unit test case that reproduced the problem and verifies the fix.