### PR TITLE
[PLAT-8866] Add E2E test for Internal Error at startup

### DIFF
--- a/Tests/BugsnagTests/BugsnagClientTests.m
+++ b/Tests/BugsnagTests/BugsnagClientTests.m
@@ -132,28 +132,6 @@ NSString *BSGFormatSeverity(BSGSeverity severity);
                                  @"A missing apiKey should cause [BugsnagClient start] to throw an exception.");
 }
 
-- (void)testInternalErrorBeforeStart {
-    BSGInternalErrorReporter.sharedInstance = nil;
-#pragma clang diagnostic push
-#pragma clang diagnostic ignored "-Wnonnull"
-    bsg_runContext = NULL;
-#pragma clang diagnostic pop 
-    
-    __block BOOL didPerformBlock = NO;
-    
-    [BSGInternalErrorReporter performBlock:^(BSGInternalErrorReporter *reporter) {
-        XCTAssertNotEqual(bsg_runContext, NULL);
-        
-        NSException *exception = [NSException exceptionWithName:NSInternalInconsistencyException reason:nil userInfo:nil];
-        [reporter reportException:exception diagnostics:nil groupingHash:nil];
-        didPerformBlock = YES;
-    }];
-    
-    [[[BugsnagClient alloc] initWithConfiguration:[[BugsnagConfiguration alloc] initWithApiKey:DUMMY_APIKEY_32CHAR_1]] start];
-    
-    XCTAssertTrue(didPerformBlock);
-}
-
 - (void)testInvalidApiKey {
     BugsnagConfiguration *configuration = [[BugsnagConfiguration alloc] initWithApiKey:@"INVALID-API-KEY"];
     BugsnagClient *client = [[BugsnagClient alloc] initWithConfiguration:configuration];

--- a/features/fixtures/ios/iOSTestApp.xcodeproj/project.pbxproj
+++ b/features/fixtures/ios/iOSTestApp.xcodeproj/project.pbxproj
@@ -64,6 +64,7 @@
 		017BA42428A1558A00CB985E /* OversizedBreadcrumbsScenario.swift in Sources */ = {isa = PBXBuildFile; fileRef = 017BA42328A1558A00CB985E /* OversizedBreadcrumbsScenario.swift */; };
 		017DCFA028743FB5000ECB22 /* TelemetryUsageDisabledScenario.swift in Sources */ = {isa = PBXBuildFile; fileRef = 017DCF9F28743FB5000ECB22 /* TelemetryUsageDisabledScenario.swift */; };
 		01847DD626453D4E00ADA4C7 /* InvalidCrashReportScenario.m in Sources */ = {isa = PBXBuildFile; fileRef = 01847DD526453D4E00ADA4C7 /* InvalidCrashReportScenario.m */; };
+		0184DBE028C63F51006AF50B /* CouldNotCreateDirectoryScenario.swift in Sources */ = {isa = PBXBuildFile; fileRef = 0184DBDF28C63F50006AF50B /* CouldNotCreateDirectoryScenario.swift */; };
 		01AF6A53258A112F00FFC803 /* BareboneTestHandledScenario.swift in Sources */ = {isa = PBXBuildFile; fileRef = 01AF6A52258A112F00FFC803 /* BareboneTestHandledScenario.swift */; };
 		01AFCFCB282CE9F700D48D45 /* OldSessionScenario.m in Sources */ = {isa = PBXBuildFile; fileRef = 01AFCFCA282CE9F700D48D45 /* OldSessionScenario.m */; };
 		01B6BB7525D5748800FC4DE6 /* LastRunInfoScenario.swift in Sources */ = {isa = PBXBuildFile; fileRef = 01B6BB7425D5748800FC4DE6 /* LastRunInfoScenario.swift */; };
@@ -256,6 +257,7 @@
 		017BA42328A1558A00CB985E /* OversizedBreadcrumbsScenario.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = OversizedBreadcrumbsScenario.swift; sourceTree = "<group>"; };
 		017DCF9F28743FB5000ECB22 /* TelemetryUsageDisabledScenario.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = TelemetryUsageDisabledScenario.swift; sourceTree = "<group>"; };
 		01847DD526453D4E00ADA4C7 /* InvalidCrashReportScenario.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; path = InvalidCrashReportScenario.m; sourceTree = "<group>"; };
+		0184DBDF28C63F50006AF50B /* CouldNotCreateDirectoryScenario.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = CouldNotCreateDirectoryScenario.swift; sourceTree = "<group>"; };
 		01AF6A52258A112F00FFC803 /* BareboneTestHandledScenario.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = BareboneTestHandledScenario.swift; sourceTree = "<group>"; };
 		01AFCFCA282CE9F700D48D45 /* OldSessionScenario.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; path = OldSessionScenario.m; sourceTree = "<group>"; };
 		01B6BB7425D5748800FC4DE6 /* LastRunInfoScenario.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = LastRunInfoScenario.swift; sourceTree = "<group>"; };
@@ -500,6 +502,7 @@
 				E7F6087B244F0A3A00F1532A /* BugsnagHooks.h */,
 				F42956D34274D4ED16B4D491 /* BuiltinTrapScenario.m */,
 				01DCB82A27985D2C0048640A /* ConcurrentCrashesScenario.mm */,
+				0184DBDF28C63F50006AF50B /* CouldNotCreateDirectoryScenario.swift */,
 				01DE903726CE99B800455213 /* CriticalThermalStateScenario.swift */,
 				8A72A0372396574F00328051 /* CustomPluginNotifierDescriptionScenario.m */,
 				8A096DFB27C7E77600DB6ECC /* CxxBareThrowScenario.mm */,
@@ -877,6 +880,7 @@
 				E700EE72247D79FF008CFFB6 /* SIGBUSScenario.m in Sources */,
 				E7767F11221C21D90006648C /* StoppedSessionScenario.swift in Sources */,
 				F4295D19B9E67F5786011698 /* OverwriteLinkRegisterScenario.m in Sources */,
+				0184DBE028C63F51006AF50B /* CouldNotCreateDirectoryScenario.swift in Sources */,
 				F42959124DB949EEF1420957 /* ReadOnlyPageScenario.m in Sources */,
 				F4295B75B2244F442D84D9CA /* StackOverflowScenario.m in Sources */,
 				010BAB1B2833CF810003FF36 /* AppAndDeviceAttributesUnhandledExceptionAfterLaunchScenario.swift in Sources */,

--- a/features/fixtures/macos/macOSTestApp.xcodeproj/project.pbxproj
+++ b/features/fixtures/macos/macOSTestApp.xcodeproj/project.pbxproj
@@ -64,6 +64,7 @@
 		017FBFB8254B09C300809042 /* MainWindowController.m in Sources */ = {isa = PBXBuildFile; fileRef = 017FBFB6254B09C300809042 /* MainWindowController.m */; };
 		017FBFB9254B09C300809042 /* MainWindowController.xib in Resources */ = {isa = PBXBuildFile; fileRef = 017FBFB7254B09C300809042 /* MainWindowController.xib */; };
 		01847DCD26443DF000ADA4C7 /* InvalidCrashReportScenario.m in Sources */ = {isa = PBXBuildFile; fileRef = 01847DCC26443DF000ADA4C7 /* InvalidCrashReportScenario.m */; };
+		0184DBDE28C6317C006AF50B /* CouldNotCreateDirectoryScenario.swift in Sources */ = {isa = PBXBuildFile; fileRef = 0184DBDD28C6317C006AF50B /* CouldNotCreateDirectoryScenario.swift */; };
 		01AF6A84258BB38A00FFC803 /* DispatchCrashScenario.swift in Sources */ = {isa = PBXBuildFile; fileRef = 01AF6A83258BB38A00FFC803 /* DispatchCrashScenario.swift */; };
 		01AFCFC7282C058D00D48D45 /* OldSessionScenario.m in Sources */ = {isa = PBXBuildFile; fileRef = 01AFCFC6282C058D00D48D45 /* OldSessionScenario.m */; };
 		01B6BB7225D56CBF00FC4DE6 /* LastRunInfoScenario.swift in Sources */ = {isa = PBXBuildFile; fileRef = 01B6BB7125D56CBF00FC4DE6 /* LastRunInfoScenario.swift */; };
@@ -266,6 +267,7 @@
 		017FBFB6254B09C300809042 /* MainWindowController.m */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.objc; path = MainWindowController.m; sourceTree = "<group>"; };
 		017FBFB7254B09C300809042 /* MainWindowController.xib */ = {isa = PBXFileReference; lastKnownFileType = file.xib; path = MainWindowController.xib; sourceTree = "<group>"; };
 		01847DCC26443DF000ADA4C7 /* InvalidCrashReportScenario.m */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.objc; path = InvalidCrashReportScenario.m; sourceTree = "<group>"; };
+		0184DBDD28C6317C006AF50B /* CouldNotCreateDirectoryScenario.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = CouldNotCreateDirectoryScenario.swift; sourceTree = "<group>"; };
 		01AF6A83258BB38A00FFC803 /* DispatchCrashScenario.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = DispatchCrashScenario.swift; sourceTree = "<group>"; };
 		01AFCFC6282C058D00D48D45 /* OldSessionScenario.m */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.objc; path = OldSessionScenario.m; sourceTree = "<group>"; };
 		01B6BB7125D56CBF00FC4DE6 /* LastRunInfoScenario.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = LastRunInfoScenario.swift; sourceTree = "<group>"; };
@@ -454,6 +456,7 @@
 				01F47CAC254B1B3000B184AD /* BugsnagHooks.h */,
 				01F47C2B254B1B2D00B184AD /* BuiltinTrapScenario.m */,
 				01DCB82C279868160048640A /* ConcurrentCrashesScenario.mm */,
+				0184DBDD28C6317C006AF50B /* CouldNotCreateDirectoryScenario.swift */,
 				01DE903926CEAD1200455213 /* CriticalThermalStateScenario.swift */,
 				01F47C85254B1B2F00B184AD /* CustomPluginNotifierDescriptionScenario.m */,
 				8A096DF927C7E6D800DB6ECC /* CxxBareThrowScenario.mm */,
@@ -821,6 +824,7 @@
 				01F47CDC254B1B3100B184AD /* HandledErrorScenario.swift in Sources */,
 				01F47CFD254B1B3100B184AD /* OnCrashHandlerScenario.m in Sources */,
 				CBB7878E2578FB3F0071BDE4 /* MarkUnhandledHandledScenario.m in Sources */,
+				0184DBDE28C6317C006AF50B /* CouldNotCreateDirectoryScenario.swift in Sources */,
 				01F47CCC254B1B3100B184AD /* OnSendCallbackOrderScenario.swift in Sources */,
 				017D9D042833C81100B0AA87 /* HandledErrorThreadSendAlwaysScenario.m in Sources */,
 				01F47D04254B1B3100B184AD /* ModifyBreadcrumbScenario.swift in Sources */,

--- a/features/fixtures/shared/scenarios/CouldNotCreateDirectoryScenario.swift
+++ b/features/fixtures/shared/scenarios/CouldNotCreateDirectoryScenario.swift
@@ -1,0 +1,35 @@
+//
+//  CouldNotCreateDirectoryScenario.swift
+//  macOSTestApp
+//
+//  Created by Nick Dowell on 05/09/2022.
+//  Copyright © 2022 Bugsnag Inc. All rights reserved.
+//
+
+class CouldNotCreateDirectoryScenario: Scenario {
+    
+    override func startBugsnag() {
+        // Prevent Bugsnag from creating its subdirectories
+        
+        Scenario.clearPersistentData()
+        
+        let fileManager = FileManager()
+        
+        let dir = fileManager.urls(for: .applicationSupportDirectory, in: .userDomainMask)[0]
+            .appendingPathComponent("com.bugsnag.Bugsnag")
+            .appendingPathComponent(Bundle.main.bundleIdentifier!)
+        
+        try? fileManager.removeItem(at: dir)
+        
+        do {
+            try fileManager.createDirectory(at: dir, withIntermediateDirectories: true)
+            try fileManager.setAttributes([.posixPermissions: 0o600], ofItemAtPath: dir.path)
+            super.startBugsnag()
+        } catch {
+            NSLog("\(error)")
+        }
+    }
+    
+    override func run() {
+    }
+}

--- a/features/telemetry.feature
+++ b/features/telemetry.feature
@@ -22,6 +22,21 @@ Feature: Telemetry
     And the exception "errorClass" equals "Invalid crash report"
     And the exception "message" matches "NSCocoaErrorDomain 3840: No string key for value in object around .+\."
 
+  Scenario: An internal error report is sent if directories cannot be created
+    When I run "CouldNotCreateDirectoryScenario"
+    And I wait to receive an error
+    And the error "Bugsnag-Api-Key" header is null
+    And the error "Bugsnag-Internal-Error" header equals "bugsnag-cocoa"
+    And the error payload field "events.0.exceptions.0.stacktrace" is an array with 0 elements
+    And the error payload field "events.0.threads" is an array with 0 elements
+    And the event "apiKey" is null
+    And the event "context" equals "v1"
+    And the event "metaData.BugsnagDiagnostics.apiKey" equals "12312312312312312312312312312312"
+    And the event "metaData.BugsnagDiagnostics.NSFilePath" matches "com.bugsnag.Bugsnag"
+    And the event "unhandled" is false
+    And the exception "errorClass" equals "Could not create directory"
+    And the exception "message" matches "NSCocoaErrorDomain 513: You don’t have permission"
+
   Scenario: Internal errors are not sent if disabled
     When I run "InvalidCrashReportScenario" and relaunch the crashed app
     And I set the app to "internalErrorsDisabled" mode


### PR DESCRIPTION
## Goal

Verify correct behaviour of Internal Error reporting when notifier directories cannot be created.

* https://github.com/bugsnag/bugsnag-cocoa/pull/1474

## Changeset

Adds `CouldNotCreateDirectoryScenario` which modifies file system permissions to prevent creation of Bugsnag's directories and triggers internal errors.

Removes the `testInternalErrorBeforeStart` unit test case because it is flakey - the result of `bsg_runContext = NULL` is unpredictable because of previous calls to `-[BugsnagClient start]`.

## Testing

Verified that `CouldNotCreateDirectoryScenario` triggers the crash when branched from older commit: https://buildkite.com/bugsnag/bugsnag-cocoa/builds/6270

Verified that test passes when rebased on `next`: https://buildkite.com/bugsnag/bugsnag-cocoa/builds/6275