### PR TITLE
[PLAT-8737] Use __attribute__((objc_direct_members))

### DIFF
--- a/Bugsnag.xcodeproj/project.pbxproj
+++ b/Bugsnag.xcodeproj/project.pbxproj
@@ -3984,6 +3984,10 @@
 				DYLIB_COMPATIBILITY_VERSION = 1;
 				DYLIB_CURRENT_VERSION = 1;
 				DYLIB_INSTALL_NAME_BASE = "@rpath";
+				GCC_PREPROCESSOR_DEFINITIONS = (
+					"$(inherited)",
+					"BSG_OBJC_DIRECT_MEMBERS=''",
+				);
 				INSTALL_PATH = "$(LOCAL_LIBRARY_DIR)/Frameworks";
 				LD_RUNPATH_SEARCH_PATHS = (
 					"$(inherited)",
@@ -4024,6 +4028,10 @@
 			buildSettings = {
 				CODE_SIGN_STYLE = Automatic;
 				DEVELOPMENT_TEAM = 372ZUL2ZB7;
+				GCC_PREPROCESSOR_DEFINITIONS = (
+					"$(inherited)",
+					"BSG_OBJC_DIRECT_MEMBERS=''",
+				);
 				INFOPLIST_FILE = Tests/BugsnagTests/Info.plist;
 				LD_RUNPATH_SEARCH_PATHS = (
 					"$(inherited)",
@@ -4070,6 +4078,10 @@
 				DYLIB_COMPATIBILITY_VERSION = 1;
 				DYLIB_CURRENT_VERSION = 1;
 				DYLIB_INSTALL_NAME_BASE = "@rpath";
+				GCC_PREPROCESSOR_DEFINITIONS = (
+					"$(inherited)",
+					"BSG_OBJC_DIRECT_MEMBERS=''",
+				);
 				INSTALL_PATH = "$(LOCAL_LIBRARY_DIR)/Frameworks";
 				LD_RUNPATH_SEARCH_PATHS = (
 					"$(inherited)",
@@ -4110,6 +4122,10 @@
 			buildSettings = {
 				CODE_SIGN_STYLE = Automatic;
 				COMBINE_HIDPI_IMAGES = YES;
+				GCC_PREPROCESSOR_DEFINITIONS = (
+					"$(inherited)",
+					"BSG_OBJC_DIRECT_MEMBERS=''",
+				);
 				INFOPLIST_FILE = Tests/BugsnagTests/Info.plist;
 				LD_RUNPATH_SEARCH_PATHS = (
 					"$(inherited)",
@@ -4152,6 +4168,10 @@
 				DYLIB_COMPATIBILITY_VERSION = 1;
 				DYLIB_CURRENT_VERSION = 1;
 				DYLIB_INSTALL_NAME_BASE = "@rpath";
+				GCC_PREPROCESSOR_DEFINITIONS = (
+					"$(inherited)",
+					"BSG_OBJC_DIRECT_MEMBERS=''",
+				);
 				INSTALL_PATH = "$(LOCAL_LIBRARY_DIR)/Frameworks";
 				LD_RUNPATH_SEARCH_PATHS = (
 					"$(inherited)",
@@ -4191,6 +4211,10 @@
 			isa = XCBuildConfiguration;
 			buildSettings = {
 				CODE_SIGN_STYLE = Automatic;
+				GCC_PREPROCESSOR_DEFINITIONS = (
+					"$(inherited)",
+					"BSG_OBJC_DIRECT_MEMBERS=''",
+				);
 				INFOPLIST_FILE = Tests/BugsnagTests/Info.plist;
 				LD_RUNPATH_SEARCH_PATHS = (
 					"$(inherited)",
@@ -4315,6 +4339,10 @@
 				DYLIB_COMPATIBILITY_VERSION = 1;
 				DYLIB_CURRENT_VERSION = 1;
 				DYLIB_INSTALL_NAME_BASE = "@rpath";
+				GCC_PREPROCESSOR_DEFINITIONS = (
+					"$(inherited)",
+					"BSG_OBJC_DIRECT_MEMBERS=''",
+				);
 				GCC_WARN_64_TO_32_BIT_CONVERSION = YES;
 				GCC_WARN_ABOUT_RETURN_TYPE = YES_ERROR;
 				GCC_WARN_UNDECLARED_SELECTOR = YES;
@@ -4426,6 +4454,10 @@
 				CODE_SIGN_STYLE = Automatic;
 				CURRENT_PROJECT_VERSION = 1;
 				DEVELOPMENT_TEAM = 372ZUL2ZB7;
+				GCC_PREPROCESSOR_DEFINITIONS = (
+					"$(inherited)",
+					"BSG_OBJC_DIRECT_MEMBERS=''",
+				);
 				GCC_WARN_64_TO_32_BIT_CONVERSION = YES;
 				GCC_WARN_ABOUT_RETURN_TYPE = YES_ERROR;
 				GCC_WARN_UNDECLARED_SELECTOR = YES;

--- a/Bugsnag/Breadcrumbs/BSGNotificationBreadcrumbs.h
+++ b/Bugsnag/Breadcrumbs/BSGNotificationBreadcrumbs.h
@@ -8,12 +8,15 @@
 
 #import <Bugsnag/BugsnagBreadcrumb.h>
 
+#import "BSGDefines.h"
+
 @class BugsnagConfiguration;
 
 NS_ASSUME_NONNULL_BEGIN
 
 static NSString * const BSGNotificationBreadcrumbsMessageAppWillTerminate = @"App Will Terminate";
 
+BSG_OBJC_DIRECT_MEMBERS
 @interface BSGNotificationBreadcrumbs : NSObject
 
 #pragma mark Initializers

--- a/Bugsnag/Breadcrumbs/BSGNotificationBreadcrumbs.m
+++ b/Bugsnag/Breadcrumbs/BSGNotificationBreadcrumbs.m
@@ -19,13 +19,33 @@
 #define BSG_HAVE_TABLE_VIEW    (TARGET_OS_OSX || TARGET_OS_IOS || TARGET_OS_TV)
 #define BSG_HAVE_TEXT_CONTROL  (TARGET_OS_OSX || TARGET_OS_IOS                )
 
+BSG_OBJC_DIRECT_MEMBERS
 @interface BSGNotificationBreadcrumbs ()
 
 @property (nonatomic) NSDictionary<NSNotificationName, NSString *> *notificationNameMap;
 
 @end
 
+@interface BSGNotificationBreadcrumbs (/* not objc_direct */)
 
+- (void)addBreadcrumbForNotification:(NSNotification *)notification;
+
+- (void)addBreadcrumbForControlNotification:(NSNotification *)notification;
+
+- (void)addBreadcrumbForMenuItemNotification:(NSNotification *)notification;
+
+- (void)addBreadcrumbForTableViewNotification:(NSNotification *)notification;
+
+#if TARGET_OS_IOS
+- (void)orientationDidChange:(NSNotification *)notification;
+#endif
+
+- (void)thermalStateDidChange:(NSNotification *)notification API_AVAILABLE(ios(11.0), tvos(11.0));
+
+@end
+
+
+BSG_OBJC_DIRECT_MEMBERS
 @implementation BSGNotificationBreadcrumbs
 
 - (instancetype)initWithConfiguration:(BugsnagConfiguration *)configuration

--- a/Bugsnag/Breadcrumbs/BugsnagBreadcrumbs.h
+++ b/Bugsnag/Breadcrumbs/BugsnagBreadcrumbs.h
@@ -8,12 +8,15 @@
 
 #import <Foundation/Foundation.h>
 
+#import "BSGDefines.h"
+
 @class BugsnagBreadcrumb;
 @class BugsnagConfiguration;
 typedef struct BSG_KSCrashReportWriter BSG_KSCrashReportWriter;
 
 NS_ASSUME_NONNULL_BEGIN
 
+BSG_OBJC_DIRECT_MEMBERS
 @interface BugsnagBreadcrumbs : NSObject
 
 - (instancetype)initWithConfiguration:(BugsnagConfiguration *)config;

--- a/Bugsnag/Breadcrumbs/BugsnagBreadcrumbs.m
+++ b/Bugsnag/Breadcrumbs/BugsnagBreadcrumbs.m
@@ -47,6 +47,7 @@ static atomic_bool g_writing_crash_report;
 
 #pragma mark -
 
+BSG_OBJC_DIRECT_MEMBERS
 @implementation BugsnagBreadcrumbs
 
 - (instancetype)initWithConfiguration:(BugsnagConfiguration *)config {

--- a/Bugsnag/Bugsnag+Private.h
+++ b/Bugsnag/Bugsnag+Private.h
@@ -8,15 +8,16 @@
 
 #import <Bugsnag/Bugsnag.h>
 
+#import "BSGDefines.h"
+
 NS_ASSUME_NONNULL_BEGIN
 
+BSG_OBJC_DIRECT_MEMBERS
 @interface Bugsnag ()
 
 #pragma mark Methods
 
 + (void)purge;
-
-+ (void)removeOnBreadcrumbBlock:(BugsnagOnBreadcrumbBlock)block;
 
 @end
 

--- a/Bugsnag/Bugsnag.m
+++ b/Bugsnag/Bugsnag.m
@@ -35,6 +35,7 @@
 
 static BugsnagClient *bsg_g_bugsnag_client = NULL;
 
+BSG_OBJC_DIRECT_MEMBERS
 @implementation Bugsnag
 
 + (BugsnagClient *_Nonnull)start {

--- a/Bugsnag/BugsnagSessionTracker.h
+++ b/Bugsnag/BugsnagSessionTracker.h
@@ -15,6 +15,7 @@
 
 NS_ASSUME_NONNULL_BEGIN
 
+BSG_OBJC_DIRECT_MEMBERS
 @interface BugsnagSessionTracker : NSObject
 
 /**
@@ -42,21 +43,6 @@ NS_ASSUME_NONNULL_BEGIN
 - (void)startNewSessionIfAutoCaptureEnabled;
 
 /**
- Handle the app foregrounding event. If more than 30s has elapsed since being
- sent to the background, records a new session if session auto-capture is
- enabled.
- Must be called from the main thread.
- */
-- (void)handleAppForegroundEvent;
-
-/**
- Handle the app backgrounding event. Tracks time between foreground and
- background to determine when to automatically record a session.
- Must be called from the main thread.
- */
-- (void)handleAppBackgroundEvent;
-
-/**
  Handle some variation of Bugsnag.notify() being called.
  Increments the number of handled or unhandled errors recorded for the current session, if
  a session exists.
@@ -76,6 +62,25 @@ NS_ASSUME_NONNULL_BEGIN
 
 - (void)addRuntimeVersionInfo:(NSString *)info
                       withKey:(NSString *)key;
+
+@end
+
+@interface BugsnagSessionTracker (/* not objc_direct */)
+
+/**
+ Handle the app foregrounding event. If more than 30s has elapsed since being
+ sent to the background, records a new session if session auto-capture is
+ enabled.
+ Must be called from the main thread.
+ */
+- (void)handleAppForegroundEvent;
+
+/**
+ Handle the app backgrounding event. Tracks time between foreground and
+ background to determine when to automatically record a session.
+ Must be called from the main thread.
+ */
+- (void)handleAppBackgroundEvent;
 
 @end
 

--- a/Bugsnag/BugsnagSessionTracker.m
+++ b/Bugsnag/BugsnagSessionTracker.m
@@ -27,6 +27,7 @@
  */
 static NSTimeInterval const BSGNewSessionBackgroundDuration = 30;
 
+BSG_OBJC_DIRECT_MEMBERS
 @interface BugsnagSessionTracker ()
 @property (strong, nonatomic) BugsnagConfiguration *config;
 @property (weak, nonatomic) BugsnagClient *client;
@@ -34,6 +35,7 @@ static NSTimeInterval const BSGNewSessionBackgroundDuration = 30;
 @property (nonatomic) NSMutableDictionary *extraRuntimeInfo;
 @end
 
+BSG_OBJC_DIRECT_MEMBERS
 @implementation BugsnagSessionTracker
 
 - (instancetype)initWithConfig:(BugsnagConfiguration *)config client:(BugsnagClient *)client {

--- a/Bugsnag/BugsnagSystemState.h
+++ b/Bugsnag/BugsnagSystemState.h
@@ -10,6 +10,7 @@
 
 #import <Bugsnag/BugsnagConfiguration.h>
 
+#import "BSGDefines.h"
 #import "BSGKeys.h"
 
 #define SYSTEMSTATE_KEY_APP @"app"
@@ -19,6 +20,7 @@
 
 NS_ASSUME_NONNULL_BEGIN
 
+BSG_OBJC_DIRECT_MEMBERS
 @interface BugsnagSystemState : NSObject
 
 @property(readonly,nonatomic) NSDictionary *lastLaunchState;

--- a/Bugsnag/BugsnagSystemState.m
+++ b/Bugsnag/BugsnagSystemState.m
@@ -106,6 +106,7 @@ static NSDictionary *copyDictionary(NSDictionary *launchState) {
     return dictionary;
 }
 
+BSG_OBJC_DIRECT_MEMBERS
 @interface BugsnagSystemState ()
 
 @property(readwrite,atomic) NSDictionary *currentLaunchState;
@@ -114,6 +115,7 @@ static NSDictionary *copyDictionary(NSDictionary *launchState) {
 
 @end
 
+BSG_OBJC_DIRECT_MEMBERS
 @implementation BugsnagSystemState
 
 - (instancetype)initWithConfiguration:(BugsnagConfiguration *)config {

--- a/Bugsnag/Client/BugsnagClient+Private.h
+++ b/Bugsnag/Client/BugsnagClient+Private.h
@@ -6,6 +6,7 @@
 //  Copyright © 2020 Bugsnag Inc. All rights reserved.
 //
 
+#import "BSGDefines.h"
 #import "BugsnagInternals.h"
 
 @class BSGAppHangDetector;
@@ -21,6 +22,7 @@
 
 NS_ASSUME_NONNULL_BEGIN
 
+BSG_OBJC_DIRECT_MEMBERS
 @interface BugsnagClient ()
 
 #pragma mark Properties

--- a/Bugsnag/Client/BugsnagClient.m
+++ b/Bugsnag/Client/BugsnagClient.m
@@ -149,6 +149,7 @@ static void BSSerializeDataCrashHandler(const BSG_KSCrashReportWriter *writer) {
 
 // MARK: -
 
+BSG_OBJC_DIRECT_MEMBERS
 @interface BugsnagClient () <BSGBreadcrumbSink, BSGInternalErrorReporterDataSource>
 
 @property (nonatomic) BSGNotificationBreadcrumbs *notificationBreadcrumbs;
@@ -163,6 +164,14 @@ static void BSSerializeDataCrashHandler(const BSG_KSCrashReportWriter *writer) {
 
 @end
 
+@interface BugsnagClient (/* not objc_direct */)
+
+- (void)appLaunchTimerFired:(NSTimer *)timer;
+
+- (void)applicationWillTerminate:(NSNotification *)notification;
+
+@end
+
 #if BSG_HAVE_APP_HANG_DETECTION
 @interface BugsnagClient () <BSGAppHangDetectorDelegate>
 @end
@@ -174,6 +183,7 @@ static void BSSerializeDataCrashHandler(const BSG_KSCrashReportWriter *writer) {
 __attribute__((annotate("oclint:suppress[long class]")))
 __attribute__((annotate("oclint:suppress[too many methods]")))
 #endif
+BSG_OBJC_DIRECT_MEMBERS
 @implementation BugsnagClient
 
 - (instancetype)initWithConfiguration:(BugsnagConfiguration *)configuration {

--- a/Bugsnag/Configuration/BugsnagConfiguration+Private.h
+++ b/Bugsnag/Configuration/BugsnagConfiguration+Private.h
@@ -6,12 +6,14 @@
 //  Copyright © 2020 Bugsnag Inc. All rights reserved.
 //
 
+#import "BSGDefines.h"
 #import "BugsnagInternals.h"
 
 @class BugsnagNotifier;
 
 NS_ASSUME_NONNULL_BEGIN
 
+BSG_OBJC_DIRECT_MEMBERS
 @interface BugsnagConfiguration ()
 
 #pragma mark Initializers
@@ -48,6 +50,9 @@ NS_ASSUME_NONNULL_BEGIN
 /// Logs a warning message if the API key is not in the expected format.
 - (void)validate;
 
+@end
+
+@interface BugsnagConfiguration (/* not objc_direct */) <NSCopying>
 @end
 
 NS_ASSUME_NONNULL_END

--- a/Bugsnag/Configuration/BugsnagConfiguration.m
+++ b/Bugsnag/Configuration/BugsnagConfiguration.m
@@ -45,6 +45,7 @@ static const int BSGApiKeyLength = 32;
 // MARK: - BugsnagConfiguration
 // =============================================================================
 
+BSG_OBJC_DIRECT_MEMBERS
 @implementation BugsnagConfiguration
 
 + (instancetype _Nonnull)loadConfig {

--- a/Bugsnag/Delivery/BSGConnectivity.h
+++ b/Bugsnag/Delivery/BSGConnectivity.h
@@ -45,6 +45,7 @@ typedef void (^BSGConnectivityChangeBlock)(BOOL connected, NSString *typeDescrip
  * Monitors network connectivity using SCNetworkReachability callbacks,
  * providing a customizable callback block invoked when connectivity changes.
  */
+BSG_OBJC_DIRECT_MEMBERS
 @interface BSGConnectivity : NSObject
 
 /**

--- a/Bugsnag/Delivery/BSGEventUploadFileOperation.h
+++ b/Bugsnag/Delivery/BSGEventUploadFileOperation.h
@@ -8,11 +8,14 @@
 
 #import "BSGEventUploadOperation.h"
 
+#import "BSGDefines.h"
+
 NS_ASSUME_NONNULL_BEGIN
 
 /**
  * A concrete operation class for uploading an event that is stored on disk.
  */
+BSG_OBJC_DIRECT_MEMBERS
 @interface BSGEventUploadFileOperation : BSGEventUploadOperation
 
 - (instancetype)initWithFile:(NSString *)file delegate:(id<BSGEventUploadOperationDelegate>)delegate;

--- a/Bugsnag/Delivery/BSGEventUploadFileOperation.m
+++ b/Bugsnag/Delivery/BSGEventUploadFileOperation.m
@@ -16,6 +16,7 @@
 #import "BugsnagLogger.h"
 
 
+BSG_OBJC_DIRECT_MEMBERS
 @implementation BSGEventUploadFileOperation
 
 - (instancetype)initWithFile:(NSString *)file delegate:(id<BSGEventUploadOperationDelegate>)delegate {

--- a/Bugsnag/Delivery/BSGEventUploadKSCrashReportOperation.h
+++ b/Bugsnag/Delivery/BSGEventUploadKSCrashReportOperation.h
@@ -8,11 +8,14 @@
 
 #import "BSGEventUploadFileOperation.h"
 
+#import "BSGDefines.h"
+
 NS_ASSUME_NONNULL_BEGIN
 
 /**
  * A concrete operation class for reading a KSCrashReport from disk, converting it into a BugsnagEvent, and uploading.
  */
+BSG_OBJC_DIRECT_MEMBERS
 @interface BSGEventUploadKSCrashReportOperation : BSGEventUploadFileOperation
 
 @end

--- a/Bugsnag/Delivery/BSGEventUploadKSCrashReportOperation.m
+++ b/Bugsnag/Delivery/BSGEventUploadKSCrashReportOperation.m
@@ -51,6 +51,7 @@ static NSArray * CrashReportKeys(NSData *data, NSError *error) {
 }
 
 
+BSG_OBJC_DIRECT_MEMBERS
 @implementation BSGEventUploadKSCrashReportOperation
 
 - (BugsnagEvent *)loadEventAndReturnError:(NSError * __autoreleasing *)errorPtr {

--- a/Bugsnag/Delivery/BSGEventUploadObjectOperation.h
+++ b/Bugsnag/Delivery/BSGEventUploadObjectOperation.h
@@ -8,6 +8,8 @@
 
 #import "BSGEventUploadOperation.h"
 
+#import "BSGDefines.h"
+
 NS_ASSUME_NONNULL_BEGIN
 
 /**
@@ -15,6 +17,7 @@ NS_ASSUME_NONNULL_BEGIN
  *
  * If the upload needs to be retried, the event will be persisted to disk.
  */
+BSG_OBJC_DIRECT_MEMBERS
 @interface BSGEventUploadObjectOperation : BSGEventUploadOperation
 
 - (instancetype)initWithEvent:(BugsnagEvent *)event delegate:(id<BSGEventUploadOperationDelegate>)delegate;

--- a/Bugsnag/Delivery/BSGEventUploadObjectOperation.m
+++ b/Bugsnag/Delivery/BSGEventUploadObjectOperation.m
@@ -12,6 +12,7 @@
 #import "BugsnagInternals.h"
 #import "BugsnagLogger.h"
 
+BSG_OBJC_DIRECT_MEMBERS
 @implementation BSGEventUploadObjectOperation
 
 - (instancetype)initWithEvent:(BugsnagEvent *)event delegate:(id<BSGEventUploadOperationDelegate>)delegate {

--- a/Bugsnag/Delivery/BSGEventUploader.h
+++ b/Bugsnag/Delivery/BSGEventUploader.h
@@ -8,6 +8,8 @@
 
 #import <Foundation/Foundation.h>
 
+#import "BSGDefines.h"
+
 @class BugsnagApiClient;
 @class BugsnagConfiguration;
 @class BugsnagEvent;
@@ -15,6 +17,7 @@
 
 NS_ASSUME_NONNULL_BEGIN
 
+BSG_OBJC_DIRECT_MEMBERS
 @interface BSGEventUploader : NSObject
 
 - (instancetype)initWithConfiguration:(BugsnagConfiguration *)configuration notifier:(BugsnagNotifier *)notifier;

--- a/Bugsnag/Delivery/BSGEventUploader.m
+++ b/Bugsnag/Delivery/BSGEventUploader.m
@@ -39,6 +39,7 @@ static NSString * const RecrashReportPrefix = @"RecrashReport-";
 
 // MARK: -
 
+BSG_OBJC_DIRECT_MEMBERS
 @implementation BSGEventUploader
 
 @synthesize configuration = _configuration;

--- a/Bugsnag/Delivery/BSGSessionUploader.h
+++ b/Bugsnag/Delivery/BSGSessionUploader.h
@@ -7,12 +7,15 @@
 
 #import <Foundation/Foundation.h>
 
+#import "BSGDefines.h"
+
 @class BugsnagConfiguration;
 @class BugsnagNotifier;
 @class BugsnagSession;
 
 NS_ASSUME_NONNULL_BEGIN
 
+BSG_OBJC_DIRECT_MEMBERS
 @interface BSGSessionUploader : NSObject
 
 - (instancetype)initWithConfig:(BugsnagConfiguration *)configuration notifier:(BugsnagNotifier *)notifier;

--- a/Bugsnag/Delivery/BSGSessionUploader.m
+++ b/Bugsnag/Delivery/BSGSessionUploader.m
@@ -28,12 +28,14 @@ static const NSTimeInterval MaxPersistedAge = 60 * 24 * 60 * 60;
 static NSArray * SortedFiles(NSFileManager *fileManager, NSMutableDictionary<NSString *, NSDate *> **creationDates);
 
 
+BSG_OBJC_DIRECT_MEMBERS
 @interface BSGSessionUploader ()
 @property (nonatomic) NSMutableSet *activeIds;
 @property(nonatomic) BugsnagConfiguration *config;
 @end
 
 
+BSG_OBJC_DIRECT_MEMBERS
 @implementation BSGSessionUploader
 
 - (instancetype)initWithConfig:(BugsnagConfiguration *)config notifier:(BugsnagNotifier *)notifier {

--- a/Bugsnag/Helpers/BSGAppHangDetector.h
+++ b/Bugsnag/Helpers/BSGAppHangDetector.h
@@ -21,6 +21,7 @@ NS_ASSUME_NONNULL_BEGIN
 @protocol BSGAppHangDetectorDelegate;
 
 
+BSG_OBJC_DIRECT_MEMBERS
 @interface BSGAppHangDetector : NSObject
 
 - (void)startWithDelegate:(id<BSGAppHangDetectorDelegate>)delegate;

--- a/Bugsnag/Helpers/BSGDefines.h
+++ b/Bugsnag/Helpers/BSGDefines.h
@@ -29,6 +29,17 @@
 // Capabilities dependent upon previously defined capabilities
 #define BSG_HAVE_APP_HANG_DETECTION           (BSG_HAVE_MACH_THREADS)
 
+// Causes methods to have no associated Objective-C metadata and use C function calling convention.
+// See https://reviews.llvm.org/D69991
+// Overridden when building for unit testing to make private interfaces accessible. 
+#ifndef BSG_OBJC_DIRECT_MEMBERS
+#if __has_attribute(objc_direct_members)
+#define BSG_OBJC_DIRECT_MEMBERS __attribute__((objc_direct_members))
+#else
+#define BSG_OBJC_DIRECT_MEMBERS
+#endif
+#endif
+
 // Reference: http://iphonedevwiki.net/index.php/CoreFoundation.framework
 #define kCFCoreFoundationVersionNumber_iOS_12_0 1556.00
 

--- a/Bugsnag/Helpers/BSGDefines.h
+++ b/Bugsnag/Helpers/BSGDefines.h
@@ -33,7 +33,7 @@
 // See https://reviews.llvm.org/D69991
 // Overridden when building for unit testing to make private interfaces accessible. 
 #ifndef BSG_OBJC_DIRECT_MEMBERS
-#if __has_attribute(objc_direct_members)
+#if __has_attribute(objc_direct_members) && (__clang_major__ > 11)
 #define BSG_OBJC_DIRECT_MEMBERS __attribute__((objc_direct_members))
 #else
 #define BSG_OBJC_DIRECT_MEMBERS

--- a/Bugsnag/Helpers/BSGInternalErrorReporter.h
+++ b/Bugsnag/Helpers/BSGInternalErrorReporter.h
@@ -35,6 +35,7 @@ NSString *_Nullable BSGErrorDescription(NSError *_Nullable error);
 
 // MARK: -
 
+BSG_OBJC_DIRECT_MEMBERS
 @interface BSGInternalErrorReporter : NSObject
 
 @property (class, nullable, nonatomic) BSGInternalErrorReporter *sharedInstance;
@@ -45,18 +46,6 @@ NSString *_Nullable BSGErrorDescription(NSError *_Nullable error);
 - (instancetype)initWithDataSource:(id<BSGInternalErrorReporterDataSource>)dataSource NS_DESIGNATED_INITIALIZER;
 
 - (instancetype)init UNAVAILABLE_ATTRIBUTE;
-
-/// Reports an error to Bugsnag's internal bugsnag-cocoa project dashboard.
-/// @param errorClass The class of error which occurred. This field is used to group the errors together so should not contain any contextual
-/// information that would prevent correct grouping. This would ordinarily be the Exception name when dealing with an exception.
-/// @param context The context to associate with this event. Errors are grouped by errorClass:context
-/// @param message The error message associated with the error. Usually this will contain some information about this specific instance of the error
-/// and is not used to group the errors.
-/// @param diagnostics JSON compatible information to include in the `BugsnagDiagnostics` metadata section.
-- (void)reportErrorWithClass:(NSString *)errorClass
-                     context:(nullable NSString *)context
-                     message:(nullable NSString *)message
-                 diagnostics:(nullable NSDictionary<NSString *, id> *)diagnostics;
 
 - (void)reportException:(NSException *)exception
             diagnostics:(nullable NSDictionary<NSString *, id> *)diagnostics
@@ -78,6 +67,22 @@ NSString *_Nullable BSGErrorDescription(NSError *_Nullable error);
 - (nullable BugsnagEvent *)eventWithRecrashReport:(NSDictionary *)recrashReport;
 
 - (nullable NSURLRequest *)requestForEvent:(BugsnagEvent *)event error:(NSError * __autoreleasing *)errorPtr;
+
+@end
+
+@interface BSGInternalErrorReporter (/* not objc_direct */)
+
+/// Reports an error to Bugsnag's internal bugsnag-cocoa project dashboard.
+/// @param errorClass The class of error which occurred. This field is used to group the errors together so should not contain any contextual
+/// information that would prevent correct grouping. This would ordinarily be the Exception name when dealing with an exception.
+/// @param context The context to associate with this event. Errors are grouped by errorClass:context
+/// @param message The error message associated with the error. Usually this will contain some information about this specific instance of the error
+/// and is not used to group the errors.
+/// @param diagnostics JSON compatible information to include in the `BugsnagDiagnostics` metadata section.
+- (void)reportErrorWithClass:(NSString *)errorClass
+                     context:(nullable NSString *)context
+                     message:(nullable NSString *)message
+                 diagnostics:(nullable NSDictionary<NSString *, id> *)diagnostics;
 
 @end
 

--- a/Bugsnag/Helpers/BSGInternalErrorReporter.m
+++ b/Bugsnag/Helpers/BSGInternalErrorReporter.m
@@ -53,6 +53,7 @@ static NSString * DeviceId(void);
 
 // MARK: -
 
+BSG_OBJC_DIRECT_MEMBERS
 @interface BSGInternalErrorReporter ()
 
 @property (weak, nullable, nonatomic) id<BSGInternalErrorReporterDataSource> dataSource;
@@ -61,6 +62,7 @@ static NSString * DeviceId(void);
 @end
 
 
+BSG_OBJC_DIRECT_MEMBERS
 @implementation BSGInternalErrorReporter
 
 static BSGInternalErrorReporter *sharedInstance_;

--- a/Bugsnag/Helpers/BSG_RFC3339DateTool.h
+++ b/Bugsnag/Helpers/BSG_RFC3339DateTool.h
@@ -24,9 +24,11 @@
 
 #import <Foundation/Foundation.h>
 
+#import "BSGDefines.h"
 /**
  * Tool for converting to/from RFC3339 compliant date strings.
  */
+BSG_OBJC_DIRECT_MEMBERS
 @interface BSG_RFC3339DateTool : NSObject
 
 /** Convert a date to an RFC3339 string representation.

--- a/Bugsnag/KSCrash/Source/KSCrash/Recording/BSG_KSCrash.h
+++ b/Bugsnag/KSCrash/Source/KSCrash/Recording/BSG_KSCrash.h
@@ -26,6 +26,7 @@
 
 #import <Foundation/Foundation.h>
 
+#import "BSGDefines.h"
 #import "BSG_KSCrashType.h"
 
 /**
@@ -33,6 +34,7 @@
  *
  * The crash reports will be located in $APP_HOME/Library/Caches/KSCrashReports
  */
+BSG_OBJC_DIRECT_MEMBERS
 @interface BSG_KSCrash : NSObject
 
 /** Get the singleton instance of the crash reporter.

--- a/Bugsnag/KSCrash/Source/KSCrash/Recording/BSG_KSCrashDoctor.h
+++ b/Bugsnag/KSCrash/Source/KSCrash/Recording/BSG_KSCrashDoctor.h
@@ -8,6 +8,9 @@
 
 #import <Foundation/Foundation.h>
 
+#import "BSGDefines.h"
+
+BSG_OBJC_DIRECT_MEMBERS
 @interface BSG_KSCrashDoctor : NSObject
 
 - (NSString *)diagnoseCrash:(NSDictionary *)crashReport;

--- a/Bugsnag/KSCrash/Source/KSCrash/Recording/BSG_KSCrashDoctor.m
+++ b/Bugsnag/KSCrash/Source/KSCrash/Recording/BSG_KSCrashDoctor.m
@@ -12,6 +12,7 @@
 #import "BSG_KSSystemInfo.h"
 #import "BugsnagLogger.h"
 
+BSG_OBJC_DIRECT_MEMBERS
 @implementation BSG_KSCrashDoctor
 
 - (NSDictionary *)crashReport:(NSDictionary *)report {

--- a/Bugsnag/KSCrash/Source/KSCrash/Recording/BSG_KSSystemInfo.h
+++ b/Bugsnag/KSCrash/Source/KSCrash/Recording/BSG_KSSystemInfo.h
@@ -27,6 +27,8 @@
 #import <Bugsnag/BugsnagDefines.h>
 #import <Foundation/Foundation.h>
 
+#import "BSGDefines.h"
+
 #define BSG_KSSystemField_AppUUID "app_uuid"
 #define BSG_KSSystemField_BinaryArch "binary_arch"
 #define BSG_KSSystemField_BundleID "CFBundleIdentifier"
@@ -53,7 +55,7 @@
 /**
  * Provides system information useful for a crash report.
  */
-BUGSNAG_EXTERN
+BSG_OBJC_DIRECT_MEMBERS
 @interface BSG_KSSystemInfo : NSObject
 
 /** Get the system info.

--- a/Bugsnag/KSCrash/Source/KSCrash/Recording/BSG_KSSystemInfo.m
+++ b/Bugsnag/KSCrash/Source/KSCrash/Recording/BSG_KSSystemInfo.m
@@ -109,6 +109,7 @@ static NSDictionary * bsg_systemversion() {
 }
 #endif
 
+BSG_OBJC_DIRECT_MEMBERS
 @implementation BSG_KSSystemInfo
 
 // ============================================================================

--- a/Bugsnag/Metadata/BugsnagMetadata+Private.h
+++ b/Bugsnag/Metadata/BugsnagMetadata+Private.h
@@ -8,10 +8,13 @@
 
 #import "BugsnagInternals.h"
 
+#import "BSGDefines.h"
+
 NS_ASSUME_NONNULL_BEGIN
 
 typedef void (^ BSGMetadataObserver)(BugsnagMetadata *);
 
+BSG_OBJC_DIRECT_MEMBERS
 @interface BugsnagMetadata () <NSCopying>
 
 #pragma mark Properties

--- a/Bugsnag/Metadata/BugsnagMetadata.m
+++ b/Bugsnag/Metadata/BugsnagMetadata.m
@@ -32,6 +32,7 @@
 #import "BugsnagLogger.h"
 
 
+BSG_OBJC_DIRECT_MEMBERS
 @interface BugsnagMetadata ()
 
 @property(atomic, readwrite, strong) NSMutableArray *stateEventBlocks;
@@ -45,6 +46,7 @@
 
 // MARK: -
 
+BSG_OBJC_DIRECT_MEMBERS
 @implementation BugsnagMetadata
 
 - (instancetype)init {

--- a/Bugsnag/Payload/BugsnagBreadcrumb+Private.h
+++ b/Bugsnag/Payload/BugsnagBreadcrumb+Private.h
@@ -6,15 +6,15 @@
 //  Copyright © 2020 Bugsnag Inc. All rights reserved.
 //
 
+#import "BSGDefines.h"
 #import "BugsnagInternals.h"
 
 NS_ASSUME_NONNULL_BEGIN
 
+BSG_OBJC_DIRECT_MEMBERS
 @interface BugsnagBreadcrumb ()
 
 - (BOOL)isValid;
-
-- (nullable NSDictionary *)objectValue;
 
 /// String representation of `timestamp` used to avoid unnecessary date <--> string conversions
 @property (copy, nullable, nonatomic) NSString *timestampString;

--- a/Bugsnag/Payload/BugsnagBreadcrumb.m
+++ b/Bugsnag/Payload/BugsnagBreadcrumb.m
@@ -81,6 +81,7 @@ BSGBreadcrumbType BSGBreadcrumbTypeFromString(NSString *value) {
 @end
 
 
+BSG_OBJC_DIRECT_MEMBERS
 @implementation BugsnagBreadcrumb
 
 - (instancetype)init {

--- a/Bugsnag/Payload/BugsnagError+Private.h
+++ b/Bugsnag/Payload/BugsnagError+Private.h
@@ -6,12 +6,14 @@
 //  Copyright © 2020 Bugsnag Inc. All rights reserved.
 //
 
+#import "BSGDefines.h"
 #import "BugsnagInternals.h"
 
 NS_ASSUME_NONNULL_BEGIN
 
 @class BugsnagThread;
 
+BSG_OBJC_DIRECT_MEMBERS
 @interface BugsnagError ()
 
 - (instancetype)initWithKSCrashReport:(NSDictionary *)event stacktrace:(NSArray<BugsnagStackframe *> *)stacktrace;

--- a/Bugsnag/Payload/BugsnagError.m
+++ b/Bugsnag/Payload/BugsnagError.m
@@ -79,6 +79,7 @@ NSString *BSGParseErrorMessage(NSDictionary *report, NSDictionary *error, NSStri
     return diagnosis ?: reason ?: @"";
 }
 
+BSG_OBJC_DIRECT_MEMBERS
 @implementation BugsnagError
 
 @dynamic type;

--- a/Bugsnag/Payload/BugsnagEvent+Private.h
+++ b/Bugsnag/Payload/BugsnagEvent+Private.h
@@ -6,11 +6,13 @@
 //  Copyright © 2020 Bugsnag Inc. All rights reserved.
 //
 
+#import "BSGDefines.h"
 #import "BSGFeatureFlagStore.h"
 #import "BugsnagInternals.h"
 
 NS_ASSUME_NONNULL_BEGIN
 
+BSG_OBJC_DIRECT_MEMBERS
 @interface BugsnagEvent ()
 
 @property (copy, nonatomic) NSString *codeBundleId;

--- a/Bugsnag/Payload/BugsnagEvent.m
+++ b/Bugsnag/Payload/BugsnagEvent.m
@@ -127,6 +127,7 @@ NSDictionary *BSGParseCustomException(NSDictionary *report,
 
 // MARK: -
 
+BSG_OBJC_DIRECT_MEMBERS
 @implementation BugsnagEvent
 
 /**

--- a/Bugsnag/Payload/BugsnagHandledState.m
+++ b/Bugsnag/Payload/BugsnagHandledState.m
@@ -8,6 +8,7 @@
 
 #import "BugsnagHandledState.h"
 
+#import "BSGDefines.h"
 #import "BSGKeys.h"
 
 BSGSeverity BSGParseSeverity(NSString *severity) {
@@ -49,6 +50,7 @@ static NSString *const kHandledException = @"handledException";
 static NSString *const kUserSpecifiedSeverity = @"userSpecifiedSeverity";
 static NSString *const kUserCallbackSetSeverity = @"userCallbackSetSeverity";
 
+BSG_OBJC_DIRECT_MEMBERS
 @implementation BugsnagHandledState
 
 + (instancetype)handledStateFromJson:(NSDictionary *)json {

--- a/Bugsnag/Payload/BugsnagSession+Private.h
+++ b/Bugsnag/Payload/BugsnagSession+Private.h
@@ -14,6 +14,7 @@ NS_ASSUME_NONNULL_BEGIN
 
 @class BugsnagUser;
 
+BSG_OBJC_DIRECT_MEMBERS
 @interface BugsnagSession () <NSCopying>
 
 #pragma mark Initializers

--- a/Bugsnag/Payload/BugsnagSession.m
+++ b/Bugsnag/Payload/BugsnagSession.m
@@ -15,6 +15,7 @@
 #import "BugsnagDevice+Private.h"
 #import "BugsnagUser+Private.h"
 
+BSG_OBJC_DIRECT_MEMBERS
 @implementation BugsnagSession
 
 - (instancetype)initWithId:(NSString *)sessionId
@@ -33,7 +34,7 @@
 }
 
 - (instancetype)copyWithZone:(NSZone *)zone {
-    BugsnagSession *session = [[[self class] allocWithZone:zone]
+    BugsnagSession *session = [[BugsnagSession allocWithZone:zone]
                                initWithId:self.id
                                startedAt:self.startedAt
                                user:self.user

--- a/Bugsnag/Payload/BugsnagStackframe+Private.h
+++ b/Bugsnag/Payload/BugsnagStackframe+Private.h
@@ -6,10 +6,12 @@
 //  Copyright © 2020 Bugsnag Inc. All rights reserved.
 //
 
+#import "BSGDefines.h"
 #import "BugsnagInternals.h"
 
 NS_ASSUME_NONNULL_BEGIN
 
+BSG_OBJC_DIRECT_MEMBERS
 @interface BugsnagStackframe ()
 
 + (NSArray<BugsnagStackframe *> *)stackframesWithBacktrace:(uintptr_t *)backtrace length:(NSUInteger)length;

--- a/Bugsnag/Payload/BugsnagStackframe.m
+++ b/Bugsnag/Payload/BugsnagStackframe.m
@@ -26,6 +26,7 @@ static NSString * _Nullable FormatMemoryAddress(NSNumber * _Nullable address) {
 
 // MARK: -
 
+BSG_OBJC_DIRECT_MEMBERS
 @implementation BugsnagStackframe
 
 static NSDictionary * _Nullable FindImage(NSArray *images, uintptr_t addr) {

--- a/Bugsnag/Payload/BugsnagStacktrace.h
+++ b/Bugsnag/Payload/BugsnagStacktrace.h
@@ -8,11 +8,14 @@
 
 #import <Foundation/Foundation.h>
 
+#import "BSGDefines.h"
+
 @class BugsnagStackframe;
 
 /**
  * Representation of a stacktrace in a bugsnag error report
  */
+BSG_OBJC_DIRECT_MEMBERS
 @interface BugsnagStacktrace : NSObject
 
 - (instancetype)initWithTrace:(NSArray<NSDictionary *> *)trace

--- a/Bugsnag/Payload/BugsnagStacktrace.m
+++ b/Bugsnag/Payload/BugsnagStacktrace.m
@@ -11,6 +11,7 @@
 #import "BSGKeys.h"
 #import "BugsnagStackframe+Private.h"
 
+BSG_OBJC_DIRECT_MEMBERS
 @implementation BugsnagStacktrace
 
 + (instancetype)stacktraceFromJson:(NSArray<NSDictionary *> *)json {

--- a/Bugsnag/Payload/BugsnagThread+Private.h
+++ b/Bugsnag/Payload/BugsnagThread+Private.h
@@ -11,6 +11,7 @@
 
 NS_ASSUME_NONNULL_BEGIN
 
+BSG_OBJC_DIRECT_MEMBERS
 @interface BugsnagThread ()
 
 - (instancetype)initWithId:(nullable NSString *)identifier

--- a/Bugsnag/Payload/BugsnagThread.m
+++ b/Bugsnag/Payload/BugsnagThread.m
@@ -68,6 +68,7 @@ NSString *BSGSerializeThreadType(BSGThreadType type) {
     return type == BSGThreadTypeCocoa ? @"cocoa" : @"reactnativejs";
 }
 
+BSG_OBJC_DIRECT_MEMBERS
 @implementation BugsnagThread
 
 + (instancetype)threadFromJson:(NSDictionary *)json {

--- a/Bugsnag/Payload/BugsnagUser+Private.h
+++ b/Bugsnag/Payload/BugsnagUser+Private.h
@@ -6,10 +6,12 @@
 //  Copyright © 2020 Bugsnag Inc. All rights reserved.
 //
 
+#import "BSGDefines.h"
 #import "BugsnagInternals.h"
 
 NS_ASSUME_NONNULL_BEGIN
 
+BSG_OBJC_DIRECT_MEMBERS
 @interface BugsnagUser ()
 
 - (instancetype)initWithId:(nullable NSString *)id name:(nullable NSString *)name emailAddress:(nullable NSString *)emailAddress;

--- a/Bugsnag/Payload/BugsnagUser.m
+++ b/Bugsnag/Payload/BugsnagUser.m
@@ -10,6 +10,7 @@
 
 #import "BSG_KSSystemInfo.h"
 
+BSG_OBJC_DIRECT_MEMBERS
 @implementation BugsnagUser
 
 - (instancetype)initWithDictionary:(NSDictionary *)dict {

--- a/Bugsnag/Storage/BSGFileLocations.h
+++ b/Bugsnag/Storage/BSGFileLocations.h
@@ -8,8 +8,11 @@
 
 #import <Foundation/Foundation.h>
 
+#import "BSGDefines.h"
+
 NS_ASSUME_NONNULL_BEGIN
 
+BSG_OBJC_DIRECT_MEMBERS
 @interface BSGFileLocations : NSObject
 
 @property (readonly, nonatomic) NSString *breadcrumbs;

--- a/Bugsnag/Storage/BSGFileLocations.m
+++ b/Bugsnag/Storage/BSGFileLocations.m
@@ -68,6 +68,7 @@ static NSString *getAndCreateSubdir(NSString *rootPath, NSString *relativePath) 
     return subdirPath;
 }
 
+BSG_OBJC_DIRECT_MEMBERS
 @implementation BSGFileLocations
 
 + (instancetype) current {

--- a/Bugsnag/Storage/BSGStorageMigratorV0V1.h
+++ b/Bugsnag/Storage/BSGStorageMigratorV0V1.h
@@ -8,8 +8,11 @@
 
 #import <Foundation/Foundation.h>
 
+#import "BSGDefines.h"
+
 NS_ASSUME_NONNULL_BEGIN
 
+BSG_OBJC_DIRECT_MEMBERS
 @interface BSGStorageMigratorV0V1 : NSObject
 
 + (BOOL) migrate;

--- a/Bugsnag/Storage/BSGStorageMigratorV0V1.m
+++ b/Bugsnag/Storage/BSGStorageMigratorV0V1.m
@@ -11,6 +11,7 @@
 #import "BSGFileLocations.h"
 #import "BugsnagLogger.h"
 
+BSG_OBJC_DIRECT_MEMBERS
 @implementation BSGStorageMigratorV0V1
 
 static void RemoveItem(NSFileManager *fileManager, NSString *path) {


### PR DESCRIPTION
## Goal

Reduce binary code size.

## Design

Use `__attribute__((objc_direct_members))` on private `@interfaces` and `@implementations` to cause their methods to have no associated Objective-C metadata and use C function calling convention.

For information about this attribute, see
* https://reviews.llvm.org/D69991
* https://clang.llvm.org/docs/AttributeReference.html#objc-direct

## Changeset

Adds `BSG_OBJC_DIRECT_MEMBERS` macro to `BSGDefines.h`.

Applies `BSG_OBJC_DIRECT_MEMBERS` to private `@interfaces` and `@implementations` not delared in the public headers or `BugsnagInternals.h`.

## Testing

Tested via existing unit and E2E tests.

Use of `__attribute__((objc_direct_members))` is disabled when building for testing to allow linking to private methods - direct methods have enforced hidden visibility and hence unreachable cross image.