### PR TITLE
Remove more unreachable code

### DIFF
--- a/Bugsnag/Helpers/BSGKeys.h
+++ b/Bugsnag/Helpers/BSGKeys.h
@@ -111,6 +111,4 @@ static BSGKey const BSGKeyVariant                   = @"variant";
 static BSGKey const BSGKeyVersion                   = @"version";
 static BSGKey const BSGKeyWarning                   = @"warning";
 
-#define BSGKeyHwCputype "hw.cputype"
-#define BSGKeyHwCpusubtype "hw.cpusubtype"
 #define BSGKeyDefaultMacName "en0"

--- a/Bugsnag/KSCrash/Source/KSCrash/Recording/Tools/BSG_KSSysCtl.c
+++ b/Bugsnag/KSCrash/Source/KSCrash/Recording/Tools/BSG_KSSysCtl.c
@@ -42,24 +42,6 @@
         return 0;                                                              \
     }
 
-#define CHECK_SYSCTL_CMD(TYPE, CALL)                                           \
-    if (0 != (CALL)) {                                                         \
-        BSG_KSLOG_ERROR("Could not get %s value for %d,%d: %s", #CALL,         \
-                        major_cmd, minor_cmd, strerror(errno));                \
-        return 0;                                                              \
-    }
-
-int32_t bsg_kssysctl_int32(const int major_cmd, const int minor_cmd) {
-    int cmd[2] = {major_cmd, minor_cmd};
-    int32_t value = 0;
-    size_t size = sizeof(value);
-
-    CHECK_SYSCTL_CMD(
-        int32, sysctl(cmd, sizeof(cmd) / sizeof(*cmd), &value, &size, NULL, 0));
-
-    return value;
-}
-
 int32_t bsg_kssysctl_int32ForName(const char *const name) {
     int32_t value = 0;
     size_t size = sizeof(value);
@@ -69,77 +51,6 @@ int32_t bsg_kssysctl_int32ForName(const char *const name) {
     return value;
 }
 
-uint32_t bsg_kssysctl_uint32(const int major_cmd, const int minor_cmd) {
-    int cmd[2] = {major_cmd, minor_cmd};
-    uint32_t value = 0;
-    size_t size = sizeof(value);
-
-    CHECK_SYSCTL_CMD(uint32, sysctl(cmd, sizeof(cmd) / sizeof(*cmd), &value,
-                                    &size, NULL, 0));
-
-    return value;
-}
-
-uint32_t bsg_kssysctl_uint32ForName(const char *const name) {
-    uint32_t value = 0;
-    size_t size = sizeof(value);
-
-    CHECK_SYSCTL_NAME(uint32, sysctlbyname(name, &value, &size, NULL, 0));
-
-    return value;
-}
-
-int64_t bsg_kssysctl_int64(const int major_cmd, const int minor_cmd) {
-    int cmd[2] = {major_cmd, minor_cmd};
-    int64_t value = 0;
-    size_t size = sizeof(value);
-
-    CHECK_SYSCTL_CMD(
-        int64, sysctl(cmd, sizeof(cmd) / sizeof(*cmd), &value, &size, NULL, 0));
-
-    return value;
-}
-
-int64_t bsg_kssysctl_int64ForName(const char *const name) {
-    int64_t value = 0;
-    size_t size = sizeof(value);
-
-    CHECK_SYSCTL_NAME(int64, sysctlbyname(name, &value, &size, NULL, 0));
-
-    return value;
-}
-
-uint64_t bsg_kssysctl_uint64(const int major_cmd, const int minor_cmd) {
-    int cmd[2] = {major_cmd, minor_cmd};
-    uint64_t value = 0;
-    size_t size = sizeof(value);
-
-    CHECK_SYSCTL_CMD(uint64, sysctl(cmd, sizeof(cmd) / sizeof(*cmd), &value,
-                                    &size, NULL, 0));
-
-    return value;
-}
-
-uint64_t bsg_kssysctl_uint64ForName(const char *const name) {
-    uint64_t value = 0;
-    size_t size = sizeof(value);
-
-    CHECK_SYSCTL_NAME(uint64, sysctlbyname(name, &value, &size, NULL, 0));
-
-    return value;
-}
-
-size_t bsg_kssysctl_string(const int major_cmd, const int minor_cmd,
-                           char *const value, const size_t maxSize) {
-    int cmd[2] = {major_cmd, minor_cmd};
-    size_t size = value == NULL ? 0 : maxSize;
-
-    CHECK_SYSCTL_CMD(
-        string, sysctl(cmd, sizeof(cmd) / sizeof(*cmd), value, &size, NULL, 0));
-
-    return size;
-}
-
 size_t bsg_kssysctl_stringForName(const char *const name, char *const value,
                                   const size_t maxSize) {
     size_t size = value == NULL ? 0 : maxSize;
@@ -147,45 +58,6 @@ size_t bsg_kssysctl_stringForName(const char *const name, char *const value,
     CHECK_SYSCTL_NAME(string, sysctlbyname(name, value, &size, NULL, 0));
 
     return size;
-}
-
-struct timeval bsg_kssysctl_timeval(const int major_cmd, const int minor_cmd) {
-    int cmd[2] = {major_cmd, minor_cmd};
-    struct timeval value = {0};
-    size_t size = sizeof(value);
-
-    if (0 != sysctl(cmd, sizeof(cmd) / sizeof(*cmd), &value, &size, NULL, 0)) {
-        BSG_KSLOG_ERROR("Could not get timeval value for %d,%d: %s", major_cmd,
-                        minor_cmd, strerror(errno));
-    }
-
-    return value;
-}
-
-struct timeval bsg_kssysctl_timevalForName(const char *const name) {
-    struct timeval value = {0};
-    size_t size = sizeof(value);
-
-    if (0 != sysctlbyname(name, &value, &size, NULL, 0)) {
-        BSG_KSLOG_ERROR("Could not get timeval value for %s: %s", name,
-                        strerror(errno));
-    }
-
-    return value;
-}
-
-bool bsg_kssysctl_getProcessInfo(const int pid,
-                                 struct kinfo_proc *const procInfo) {
-    int cmd[4] = {CTL_KERN, KERN_PROC, KERN_PROC_PID, pid};
-    size_t size = sizeof(*procInfo);
-
-    if (0 !=
-        sysctl(cmd, sizeof(cmd) / sizeof(*cmd), procInfo, &size, NULL, 0)) {
-        BSG_KSLOG_ERROR("Could not get the name for process %d: %s", pid,
-                        strerror(errno));
-        return false;
-    }
-    return true;
 }
 
 bool bsg_kssysctl_getMacAddress(const char *const name,

--- a/Bugsnag/KSCrash/Source/KSCrash/Recording/Tools/BSG_KSSysCtl.h
+++ b/Bugsnag/KSCrash/Source/KSCrash/Recording/Tools/BSG_KSSysCtl.h
@@ -39,16 +39,6 @@ extern "C" {
 #include <sys/sysctl.h>
 #include <sys/types.h>
 
-/** Get an int32 value via sysctl.
- *
- * @param major_cmd The major part of the command or name.
- *
- * @param minor_cmd The minor part of the command or name.
- *
- * @return The value returned by sysctl.
- */
-int32_t bsg_kssysctl_int32(int major_cmd, int minor_cmd);
-
 /** Get an int32 value via sysctl by name.
  *
  * @param name The name of the command.
@@ -56,77 +46,6 @@ int32_t bsg_kssysctl_int32(int major_cmd, int minor_cmd);
  * @return The value returned by sysctl.
  */
 int32_t bsg_kssysctl_int32ForName(const char *name);
-
-/** Get a uint32 value via sysctl.
- *
- * @param major_cmd The major part of the command or name.
- *
- * @param minor_cmd The minor part of the command or name.
- *
- * @return The value returned by sysctl.
- */
-uint32_t bsg_kssysctl_uint32(int major_cmd, int minor_cmd);
-
-/** Get a uint32 value via sysctl by name.
- *
- * @param name The name of the command.
- *
- * @return The value returned by sysctl.
- */
-uint32_t bsg_kssysctl_uint32ForName(const char *name);
-
-/** Get an int64 value via sysctl.
- *
- * @param major_cmd The major part of the command or name.
- *
- * @param minor_cmd The minor part of the command or name.
- *
- * @return The value returned by sysctl.
- */
-int64_t bsg_kssysctl_int64(int major_cmd, int minor_cmd);
-
-/** Get an int64 value via sysctl by name.
- *
- * @param name The name of the command.
- *
- * @return The value returned by sysctl.
- */
-int64_t bsg_kssysctl_int64ForName(const char *name);
-
-/** Get a uint64 value via sysctl.
- *
- * @param major_cmd The major part of the command or name.
- *
- * @param minor_cmd The minor part of the command or name.
- *
- * @return The value returned by sysctl.
- */
-uint64_t bsg_kssysctl_uint64(int major_cmd, int minor_cmd);
-
-/** Get a uint64 value via sysctl by name.
- *
- * @param name The name of the command.
- *
- * @return The value returned by sysctl.
- */
-uint64_t bsg_kssysctl_uint64ForName(const char *name);
-
-/** Get a string value via sysctl.
- *
- * @param major_cmd The major part of the command or name.
- *
- * @param minor_cmd The minor part of the command or name.
- *
- * @param value Pointer to a buffer to fill out. If NULL, does not fill
- *              anything out.
- *
- * @param maxSize The size of the buffer pointed to by value.
- *
- * @return The number of bytes written (or that would have been written if
- *         value is NULL).
- */
-size_t bsg_kssysctl_string(int major_cmd, int minor_cmd, char *value,
-                           size_t maxSize);
 
 /** Get a string value via sysctl by name.
  *
@@ -142,34 +61,6 @@ size_t bsg_kssysctl_string(int major_cmd, int minor_cmd, char *value,
  */
 size_t bsg_kssysctl_stringForName(const char *name, char *value,
                                   size_t maxSize);
-
-/** Get a timeval value via sysctl.
- *
- * @param major_cmd The major part of the command or name.
- *
- * @param minor_cmd The minor part of the command or name.
- *
- * @return The value returned by sysctl.
- */
-struct timeval bsg_kssysctl_timeval(int major_cmd, int minor_cmd);
-
-/** Get a timeval value via sysctl by name.
- *
- * @param name The name of the command.
- *
- * @return The value returned by sysctl.
- */
-struct timeval bsg_kssysctl_timevalForName(const char *name);
-
-/** Get information about a process.
- *
- * @param pid The process ID.
- *
- * @param procInfo Struct to hold the proces information.
- *
- * @return true if the operation was successful.
- */
-bool bsg_kssysctl_getProcessInfo(int pid, struct kinfo_proc *procInfo);
 
 /** Get the MAC address of the specified interface.
  * Note: As of iOS 7 this will always return a fixed value of 02:00:00:00:00:00.

--- a/Tests/KSCrashTests/KSSysCtl_Tests.m
+++ b/Tests/KSCrashTests/KSSysCtl_Tests.m
@@ -35,18 +35,6 @@
 
 @implementation KSSysCtl_Tests
 
-- (void) testSysCtlInt32
-{
-    int32_t result = bsg_kssysctl_int32(CTL_HW, HW_NCPU);
-    XCTAssertTrue(result > 0, @"");
-}
-
-- (void) testSysCtlInt32Invalid
-{
-    int32_t result = bsg_kssysctl_int32(CTL_KERN, 1000000);
-    XCTAssertTrue(result == 0, @"");
-}
-
 - (void) testSysCtlInt32ForName
 {
     int32_t result = bsg_kssysctl_int32ForName("hw.ncpu");
@@ -57,94 +45,6 @@
 {
     int32_t result = bsg_kssysctl_int32ForName("kernblah.posix1version");
     XCTAssertTrue(result == 0, @"");
-}
-
-- (void) testSysCtlInt64
-{
-    int64_t result = bsg_kssysctl_int64(CTL_KERN, KERN_USRSTACK64);
-    XCTAssertTrue(result > 0, @"");
-}
-
-- (void) testSysCtlInt64Invalid
-{
-    int64_t result = bsg_kssysctl_int64(CTL_KERN, 1000000);
-    XCTAssertTrue(result == 0, @"");
-}
-
-- (void) testSysCtlInt64ForName
-{
-    int64_t result = bsg_kssysctl_int64ForName("kern.usrstack64");
-    XCTAssertTrue(result > 0, @"");
-}
-
-- (void) testSysCtlInt64ForNameInvalid
-{
-    int64_t result = bsg_kssysctl_int64ForName("kernblah.usrstack64");
-    XCTAssertTrue(result == 0, @"");
-}
-
-- (void) testSysCtlUInt32
-{
-    uint32_t result = bsg_kssysctl_uint32(CTL_HW, HW_NCPU);
-    XCTAssertTrue(result > 0, @"");
-}
-
-- (void) testSysCtlUInt32Invalid
-{
-    uint32_t result = bsg_kssysctl_uint32(CTL_KERN, 1000000);
-    XCTAssertTrue(result == 0, @"");
-}
-
-- (void) testSysCtlUInt32ForName
-{
-    uint32_t result = bsg_kssysctl_uint32ForName("hw.ncpu");
-    XCTAssertTrue(result > 0, @"");
-}
-
-- (void) testSysCtlUInt32ForNameInvalid
-{
-    uint32_t result = bsg_kssysctl_uint32ForName("kernblah.posix1version");
-    XCTAssertTrue(result == 0, @"");
-}
-
-- (void) testSysCtlUInt64
-{
-    uint64_t result = bsg_kssysctl_uint64(CTL_KERN, KERN_USRSTACK64);
-    XCTAssertTrue(result > 0, @"");
-}
-
-- (void) testSysCtlUInt64Invalid
-{
-    uint64_t result = bsg_kssysctl_uint64(CTL_KERN, 1000000);
-    XCTAssertTrue(result == 0, @"");
-}
-
-- (void) testSysCtlUInt64ForName
-{
-    uint64_t result = bsg_kssysctl_uint64ForName("kern.usrstack64");
-    XCTAssertTrue(result > 0, @"");
-}
-
-- (void) testSysCtlUInt64ForNameInvalid
-{
-    uint64_t result = bsg_kssysctl_uint64ForName("kernblah.usrstack64");
-    XCTAssertTrue(result == 0, @"");
-}
-
-- (void) testSysCtlString
-{
-    char buff[100] = {0};
-    bool success = bsg_kssysctl_string(CTL_KERN, KERN_OSTYPE, buff, sizeof(buff));
-    XCTAssertTrue(success, @"");
-    XCTAssertTrue(buff[0] != 0, @"");
-}
-
-- (void) testSysCtlStringInvalid
-{
-    char buff[100] = {0};
-    bool success = bsg_kssysctl_string(CTL_KERN, 1000000, buff, sizeof(buff));
-    XCTAssertFalse(success, @"");
-    XCTAssertTrue(buff[0] == 0, @"");
 }
 
 - (void) testSysCtlStringForName
@@ -162,49 +62,6 @@
     XCTAssertFalse(success, @"");
     XCTAssertTrue(buff[0] == 0, @"");
 }
-
-- (void) testSysCtlDate
-{
-    struct timeval value = bsg_kssysctl_timeval(CTL_KERN, KERN_BOOTTIME);
-    XCTAssertTrue(value.tv_sec > 0, @"");
-}
-
-- (void) testSysCtlDateInvalid
-{
-    struct timeval value = bsg_kssysctl_timeval(CTL_KERN, 1000000);
-    XCTAssertTrue(value.tv_sec == 0, @"");
-}
-
-- (void) testSysCtlDateForName
-{
-    struct timeval value = bsg_kssysctl_timevalForName("kern.boottime");
-    XCTAssertTrue(value.tv_sec > 0, @"");
-}
-
-- (void) testSysCtlDateForNameInvalid
-{
-    struct timeval value = bsg_kssysctl_timevalForName("kernblah.boottime");
-    XCTAssertTrue(value.tv_sec == 0, @"");
-}
-
-- (void) testGetProcessInfo
-{
-    int pid = getpid();
-    struct kinfo_proc procInfo = {{{{0}}}};
-    bool success = bsg_kssysctl_getProcessInfo(pid, &procInfo);
-    XCTAssertTrue(success, @"");
-    NSString* processName = [NSString stringWithCString:procInfo.kp_proc.p_comm encoding:NSUTF8StringEncoding];
-    XCTAssertEqualObjects(processName, NSProcessInfo.processInfo.processName);
-}
-
-// This sysctl always returns true for some reason...
-//- (void) testGetProcessInfoInvalid
-//{
-//    int pid = 1000000;
-//    struct kinfo_proc procInfo = {{{{0}}}};
-//    bool success = kssysctl_getProcessInfo(pid, &procInfo);
-//    XCTAssertFalse(success, @"");
-//}
 
 - (void) testGetMacAddress
 {


### PR DESCRIPTION
## Goal

Further binary code size savings. 

## Changeset

Removes more unused code identified with the aid of E2E coverage reports.

Removes unnecessary `respondsToSelector:@selector(identifierForVendor)` check for API added in iOS 6.0.

## Testing

Verified no change in behaviour with E2E and unit tests.

Removed tests related to remove code.