### PR TITLE
[PLAT-8918] Mac Catalyst: fix crash in `addBreadcrumbForTableViewNotification:`

### DIFF
--- a/Bugsnag/Breadcrumbs/BSGNotificationBreadcrumbs.m
+++ b/Bugsnag/Breadcrumbs/BSGNotificationBreadcrumbs.m
@@ -188,12 +188,12 @@ BSG_OBJC_DIRECT_MEMBERS
 }
 
 - (NSArray<NSNotificationName> *)automaticBreadcrumbTableItemEvents {
-#if !BSG_HAVE_TABLE_VIEW
-    return @[];
-#elif BSG_HAVE_APPKIT
-    return @[ NSTableViewSelectionDidChangeNotification ];
+#if TARGET_OS_IOS || TARGET_OS_TV
+    return @[UITableViewSelectionDidChangeNotification];
+#elif TARGET_OS_OSX
+    return @[NSTableViewSelectionDidChangeNotification];
 #else
-    return @[ UITableViewSelectionDidChangeNotification ];
+    return @[];
 #endif
 }
 

--- a/Bugsnag/Breadcrumbs/BSGNotificationBreadcrumbs.m
+++ b/Bugsnag/Breadcrumbs/BSGNotificationBreadcrumbs.m
@@ -8,16 +8,13 @@
 
 #import "BSGNotificationBreadcrumbs.h"
 
+#import "BSGAppKit.h"
+#import "BSGDefines.h"
+#import "BSGKeys.h"
+#import "BSGUIKit.h"
+#import "BSGUtils.h"
 #import "BugsnagBreadcrumbs.h"
 #import "BugsnagConfiguration+Private.h"
-#import "BSGKeys.h"
-#import "BSGUtils.h"
-#import "BSGDefines.h"
-#import "BSGAppKit.h"
-#import "BSGUIKit.h"
-
-#define BSG_HAVE_TABLE_VIEW    (TARGET_OS_OSX || TARGET_OS_IOS || TARGET_OS_TV)
-#define BSG_HAVE_TEXT_CONTROL  (TARGET_OS_OSX || TARGET_OS_IOS                )
 
 BSG_OBJC_DIRECT_MEMBERS
 @interface BSGNotificationBreadcrumbs ()
@@ -170,20 +167,20 @@ BSG_OBJC_DIRECT_MEMBERS
 }
 
 - (NSArray<NSNotificationName> *)automaticBreadcrumbControlEvents {
-#if !BSG_HAVE_TEXT_CONTROL
-    return nil;
-#elif BSG_HAVE_APPKIT
-    return @[
-        NSControlTextDidBeginEditingNotification,
-        NSControlTextDidEndEditingNotification
-    ];
-#else
+#if TARGET_OS_IOS
     return @[
         UITextFieldTextDidBeginEditingNotification,
         UITextFieldTextDidEndEditingNotification,
         UITextViewTextDidBeginEditingNotification,
         UITextViewTextDidEndEditingNotification
     ];
+#elif TARGET_OS_OSX
+    return @[
+        NSControlTextDidBeginEditingNotification,
+        NSControlTextDidEndEditingNotification
+    ];
+#else
+    return nil;
 #endif
 }
 
@@ -321,8 +318,6 @@ static NSString *nullStringIfBlank(NSString *str) {
 #endif
 
 - (BOOL)tryAddWindowNotification:(NSNotification *)notification {
-#if BSG_HAVE_WINDOW
-
 #if TARGET_OS_IOS || TARGET_OS_TV
     if ([notification.name hasPrefix:@"UIWindow"] && [notification.object isKindOfClass:UIWINDOW]) {
         UIWindow *window = notification.object;
@@ -365,7 +360,6 @@ static NSString *nullStringIfBlank(NSString *str) {
     }
 #endif
 
-#endif
     return NO;
 }
 
@@ -380,8 +374,6 @@ static NSString *nullStringIfBlank(NSString *str) {
 }
 
 - (void)addBreadcrumbForTableViewNotification:(__unused NSNotification *)notification {
-#if BSG_HAVE_TABLE_VIEW
-
 #if TARGET_OS_IOS || TARGET_OS_TV
     NSIndexPath *indexPath = ((UITableView *)notification.object).indexPathForSelectedRow;
     [self addBreadcrumbWithType:BSGBreadcrumbTypeNavigation forNotificationName:notification.name metadata:
@@ -390,8 +382,6 @@ static NSString *nullStringIfBlank(NSString *str) {
     NSTableView *tableView = notification.object;
     [self addBreadcrumbWithType:BSGBreadcrumbTypeNavigation forNotificationName:notification.name metadata:
      tableView ? @{@"selectedRow" : @(tableView.selectedRow), @"selectedColumn" : @(tableView.selectedColumn)} : nil];
-#endif
-
 #endif
 }
 

--- a/Bugsnag/BugsnagSessionTracker.m
+++ b/Bugsnag/BugsnagSessionTracker.m
@@ -66,7 +66,7 @@ BSG_OBJC_DIRECT_MEMBERS
         bsg_log_debug(@"Not starting session because app is not in the foreground");
     }
 
-#if BSG_HAVE_APPKIT
+#if TARGET_OS_OSX
     [notificationCenter addObserver:self
                selector:@selector(handleAppForegroundEvent)
                    name:NSApplicationWillBecomeActiveNotification
@@ -81,7 +81,7 @@ BSG_OBJC_DIRECT_MEMBERS
                selector:@selector(handleAppBackgroundEvent)
                    name:NSApplicationDidResignActiveNotification
                  object:nil];
-#elif BSG_HAVE_WATCHKIT
+#elif TARGET_OS_WATCH
     [notificationCenter addObserver:self
                selector:@selector(handleAppForegroundEvent)
                    name:WKApplicationWillEnterForegroundNotification

--- a/Bugsnag/Client/BugsnagClient.m
+++ b/Bugsnag/Client/BugsnagClient.m
@@ -275,7 +275,7 @@ BSG_OBJC_DIRECT_MEMBERS
 
     [center addObserver:self
                selector:@selector(applicationWillTerminate:)
-#if BSG_HAVE_APPKIT
+#if TARGET_OS_OSX
                    name:NSApplicationWillTerminateNotification
 #else
                    name:UIApplicationWillTerminateNotification

--- a/Bugsnag/Helpers/BSGAppKit.h
+++ b/Bugsnag/Helpers/BSGAppKit.h
@@ -6,8 +6,6 @@
 //  Copyright © 2021 Bugsnag Inc. All rights reserved.
 //
 
-#include "BSGDefines.h"
-
 #if __has_include(<AppKit/AppKit.h>)
 
 #import <AppKit/AppKit.h>

--- a/Bugsnag/Helpers/BSGDefines.h
+++ b/Bugsnag/Helpers/BSGDefines.h
@@ -11,7 +11,6 @@
 #include <TargetConditionals.h>
 
 // Capabilities dependent upon system defines and files
-#define BSG_HAVE_APPKIT                       __has_include(<AppKit/AppKit.h>)
 #define BSG_HAVE_BATTERY                      (                 TARGET_OS_IOS                 || TARGET_OS_WATCH)
 #define BSG_HAVE_MACH_EXCEPTIONS              (TARGET_OS_OSX || TARGET_OS_IOS                                   )
 #define BSG_HAVE_MACH_THREADS                 (TARGET_OS_OSX || TARGET_OS_IOS || TARGET_OS_TV                   )
@@ -22,8 +21,6 @@
 #define BSG_HAVE_SIGALTSTACK                  (TARGET_OS_OSX || TARGET_OS_IOS                                   )
 #define BSG_HAVE_SYSCALL                      (TARGET_OS_OSX || TARGET_OS_IOS || TARGET_OS_TV                   )
 #define BSG_HAVE_UIDEVICE                     __has_include(<UIKit/UIDevice.h>)
-#define BSG_HAVE_UIKIT                        __has_include(<UIKit/UIKit.h>)
-#define BSG_HAVE_WATCHKIT                     __has_include(<WatchKit/WatchKit.h>)
 #define BSG_HAVE_WINDOW                       (TARGET_OS_OSX || TARGET_OS_IOS || TARGET_OS_TV                   )
 
 // Capabilities dependent upon previously defined capabilities

--- a/Bugsnag/Helpers/BSGUIKit.h
+++ b/Bugsnag/Helpers/BSGUIKit.h
@@ -6,8 +6,6 @@
 //  Copyright © 2020 Bugsnag Inc. All rights reserved.
 //
 
-#import "BSGDefines.h"
-
 #if __has_include(<UIKit/UIKit.h>)
 
 #import <UIKit/UIKit.h>

--- a/Bugsnag/KSCrash/Source/KSCrash/Recording/BSG_KSCrash.m
+++ b/Bugsnag/KSCrash/Source/KSCrash/Recording/BSG_KSCrash.m
@@ -26,12 +26,12 @@
 
 #import "BSG_KSCrash.h"
 
-#import "BSG_KSCrashC.h"
-#import "BSG_KSCrashIdentifier.h"
-#import "BSGDefines.h"
 #import "BSGAppKit.h"
+#import "BSGDefines.h"
 #import "BSGUIKit.h"
 #import "BSGWatchKit.h"
+#import "BSG_KSCrashC.h"
+#import "BSG_KSCrashIdentifier.h"
 
 // ============================================================================
 #pragma mark - Constants -
@@ -71,7 +71,7 @@
     free(recrashReportPath);
     
     NSNotificationCenter *nCenter = [NSNotificationCenter defaultCenter];
-#if BSG_HAVE_APPKIT
+#if TARGET_OS_OSX
     // MacOS "active" serves the same purpose as "foreground" in iOS
     [nCenter addObserver:self
                 selector:@selector(applicationDidEnterBackground)
@@ -81,7 +81,7 @@
                 selector:@selector(applicationWillEnterForeground)
                     name:NSApplicationDidBecomeActiveNotification
                   object:nil];
-#elif BSG_HAVE_WATCHKIT
+#elif TARGET_OS_WATCH
     [nCenter addObserver:self
                 selector:@selector(applicationDidBecomeActive)
                     name:WKApplicationDidBecomeActiveNotification

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,14 @@
 Changelog
 =========
 
+## TBD
+
+### Bug fixes
+
+* Fix a crash on Mac Catalyst when user interacts with help menu.
+  [#1484](https://github.com/bugsnag/bugsnag-cocoa/issues/1484)
+  [#1485](https://github.com/bugsnag/bugsnag-cocoa/pull/1485)
+
 ## 6.23.0 (2022-09-14)
 
 ### Enhancements

--- a/Tests/BugsnagTests/BugsnagSessionTrackerTest.m
+++ b/Tests/BugsnagTests/BugsnagSessionTrackerTest.m
@@ -155,9 +155,9 @@
 - (void)testStartInBackground {
     [self.sessionTracker startWithNotificationCenter:NSNotificationCenter.defaultCenter isInForeground:NO];
     XCTAssertNil(self.sessionTracker.runningSession, @"There should be no running session after starting tracker in background");
-#if BSG_HAVE_WATCHKIT
+#if TARGET_OS_WATCH
     [NSNotificationCenter.defaultCenter postNotificationName:WKApplicationDidBecomeActiveNotification object:nil];
-#elif BSG_HAVE_APPKIT
+#elif TARGET_OS_OSX
     [NSNotificationCenter.defaultCenter postNotificationName:NSApplicationDidBecomeActiveNotification object:nil];
 #else
     [NSNotificationCenter.defaultCenter postNotificationName:UIApplicationDidBecomeActiveNotification object:nil];


### PR DESCRIPTION
## Goal

Fix a crash in `-[BSGNotificationBreadcrumbs addBreadcrumbForTableViewNotification:]`

<details><summary>Error:</summary>

```
-[SCTTableView indexPathForSelectedRow]: unrecognized selector sent to instance 0x7f86f6095400

0   CoreFoundation                      0x000000019f4d51a8 __exceptionPreprocess + 240
1   libobjc.A.dylib                     0x000000019f21fe04 objc_exception_throw + 60
2   CoreFoundation                      0x000000019f568f4c -[NSObject(NSObject) __retain_OA] + 0
3   CoreFoundation                      0x000000019f434554 ___forwarding___ + 1764
4   CoreFoundation                      0x000000019f433db0 _CF_forwarding_prep_0 + 96
5   Vectornator                         0x00000001048fc3e8 -[BSGNotificationBreadcrumbs addBreadcrumbForTableViewNotification:] + 96
6   CoreFoundation                      0x000000019f44951c __CFNOTIFICATIONCENTER_IS_CALLING_OUT_TO_AN_OBSERVER__ + 28
7   CoreFoundation                      0x000000019f4edc18 ___CFXRegistrationPost_block_invoke + 52
8   CoreFoundation                      0x000000019f4edb84 _CFXRegistrationPost + 456
9   CoreFoundation                      0x000000019f4181c0 _CFXNotificationPost + 732
10  Foundation                          0x00000001a02ddc98 -[NSNotificationCenter postNotificationName:object:userInfo:] + 96
11  AppKit                              0x00000001a20e1f8c -[NSTableView _sendSelectionChangedNotificationForRows:columns:] + 244
12  AppKit                              0x00000001a20e143c -[NSTableView _doSelectIndexes:byExtendingSelection:indexType:funnelThroughSingleIndexVersion:] + 1788
13  AppKit                              0x00000001a20e0d1c -[NSTableView selectRowIndexes:byExtendingSelection:] + 136
14  Shortcut                            0x00000001d6ad7390 -[SCTMenuView mouseMoved:] + 388
15  AppKit                              0x00000001a21b11d4 forwardMethod + 200
16  AppKit                              0x00000001a21b11d4 forwardMethod + 200
17  AppKit                              0x00000001a21b11d4 forwardMethod + 200
18  AppKit                              0x00000001a21b11d4 forwardMethod + 200
19  AppKit                              0x00000001a21b0f18 -[NSTextView mouseMoved:] + 684
20  AppKit                              0x00000001a212be88 -[NSWindow(NSEventRouting) _reallySendEvent:isDelayedEvent:] + 5908
21  AppKit                              0x00000001a212a50c -[NSWindow(NSEventRouting) sendEvent:] + 348
22  AppKit                              0x00000001a28d970c NSMenuWindowManagerMenuItemCarbonEventHandler + 4160
23  HIToolbox                           0x00000001a806a6c8 _ZL23DispatchEventToHandlersP14EventTargetRecP14OpaqueEventRefP14HandlerCallRec + 1084
24  HIToolbox                           0x00000001a8069b4c _ZL30SendEventToEventTargetInternalP14OpaqueEventRefP20OpaqueEventTargetRefP14HandlerCallRec + 356
25  HIToolbox                           0x00000001a807fe50 SendEventToEventTarget + 40
26  HIToolbox                           0x00000001a80aa638 _ZL29ToolboxEventDispatcherHandlerP25OpaqueEventHandlerCallRefP14OpaqueEventRefPv + 2520
27  HIToolbox                           0x00000001a806ab14 _ZL23DispatchEventToHandlersP14EventTargetRecP14OpaqueEventRefP14HandlerCallRec + 2184
28  HIToolbox                           0x00000001a8069b4c _ZL30SendEventToEventTargetInternalP14OpaqueEventRefP20OpaqueEventTargetRefP14HandlerCallRec + 356
29  HIToolbox                           0x00000001a807fe50 SendEventToEventTarget + 40
30  HIToolbox                           0x00000001a80fb3bc _ZL19IsUserStillTrackingP14MenuSelectDataPh + 3604
31  HIToolbox                           0x00000001a82392bc _ZL15TrackMenuCommonR14MenuSelectDataPhP13SelectionDataP10MenuResultS5_ + 1260
32  HIToolbox                           0x00000001a8106054 _ZL14MenuSelectCoreP8MenuData5PointdjPP13OpaqueMenuRefPt + 348
33  HIToolbox                           0x00000001a8105e48 _HandleMenuSelection2 + 416
34  AppKit                              0x00000001a21576f0 _NSHandleCarbonMenuEvent + 300
35  AppKit                              0x00000001a21574d0 _DPSEventHandledByCarbon + 68
36  AppKit                              0x00000001a1fb95b4 -[NSApplication(NSEvent) _nextEventMatchingEventMask:untilDate:inMode:dequeue:] + 3280
37  AppKit                              0x00000001a1faafe0 -[NSApplication run] + 596
38  AppKit                              0x00000001a1f7c6fc NSApplicationMain + 1132
39  AppKit                              0x00000001a2252640 +[NSWindow _savedFrameFromString:] + 0
40  UIKitMacHelper                      0x00000001b4d173c0 UINSApplicationMain + 1276
41  UIKitCore                           0x00000001c74b4c2c UIApplicationMain + 164
42  Vectornator                         0x000000010484ee04 $s11Vectornator15ApplicationMainV4mainyyFZTf4d_n + 224
43  Vectornator                         0x00000001043502c0 main + 12
44  dyld                                0x0000000108c4908c start + 520
```

</details>

## Analysis

The crash was caused by `-[BSGNotificationBreadcrumbs addBreadcrumbForTableViewNotification:]` being passed a (subclass of) `NSTableView` when compiling for Mac Catalyst.

This method expects a `UITableView` to be passed when compiling for `TARGET_OS_IOS || TARGET_OS_TV`.

`BSGNotificationBreadcrumbs` was erroneously listening for `NSTableViewSelectionDidChangeNotification` instead of `UITableViewSelectionDidChangeNotification` because `BSG_HAVE_APPKIT` is true when compiling for Mac Catalyst.

This bug was introduced by [#1361 (watchOS support)](https://github.com/bugsnag/bugsnag-cocoa/pull/1361/files#diff-ab2818c9d43b403af9d6ab542c5830487c5bed9dcac7ae30f2f1b7c9d2983513) in [v6.18.0](https://github.com/bugsnag/bugsnag-cocoa/releases/tag/v6.18.0).

## Changeset

Makes `automaticBreadcrumbTableItemEvents` use `TARGET_OS_IOS || TARGET_OS_TV` to determine which notification to listen for.

Removes `BSG_HAVE_APPKIT` and related macros to avoid this confusion in the future.

Tidies up some imports.

## Testing

Manually reproduced issue in `examples/objective-c-ios` and verified the fix.