### PR TITLE
[PLAT-8949] Disable OOM detection for Mac Catalyst apps

### DIFF
--- a/Bugsnag/Helpers/BSGDefines.h
+++ b/Bugsnag/Helpers/BSGDefines.h
@@ -14,7 +14,7 @@
 #define BSG_HAVE_BATTERY                      (                 TARGET_OS_IOS                 || TARGET_OS_WATCH)
 #define BSG_HAVE_MACH_EXCEPTIONS              (TARGET_OS_OSX || TARGET_OS_IOS                                   )
 #define BSG_HAVE_MACH_THREADS                 (TARGET_OS_OSX || TARGET_OS_IOS || TARGET_OS_TV                   )
-#define BSG_HAVE_OOM_DETECTION                (                 TARGET_OS_IOS || TARGET_OS_TV                   ) && !TARGET_OS_SIMULATOR
+#define BSG_HAVE_OOM_DETECTION                (                 TARGET_OS_IOS || TARGET_OS_TV                   ) && !TARGET_OS_SIMULATOR && !TARGET_OS_MACCATALYST
 #define BSG_HAVE_REACHABILITY                 (TARGET_OS_OSX || TARGET_OS_IOS || TARGET_OS_TV                   )
 #define BSG_HAVE_REACHABILITY_WWAN            (                 TARGET_OS_IOS || TARGET_OS_TV                   )
 #define BSG_HAVE_SIGNAL                       (TARGET_OS_OSX || TARGET_OS_IOS || TARGET_OS_TV                   )

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,11 @@ Changelog
   Objective-C exceptions to be sent at crash time, prior to app termination.
   [#1488](https://github.com/bugsnag/bugsnag-cocoa/pull/1488)
 
+### Bug fixes
+
+* Disable OOM detection for Mac Catalyst apps.
+  [#1489](https://github.com/bugsnag/bugsnag-cocoa/pull/1489)
+
 ## 6.23.1 (2022-09-21)
 
 ### Bug fixes


### PR DESCRIPTION
## Goal

Prevent erroneous OOMs from being reported for Mac Catalyst apps.

> [Speaking of memory, the Mac memory model applies which means there are no enforced memory limits.](https://developer.apple.com/videos/play/wwdc2019-235/?time=2483)

## Changeset

Disables OOM detection when targeting Mac Catalyst.

## Testing

Modified the example app's `OutOfMemoryController` to attempt to force an OOM to occur, but even after filling over 100 GB of memory with random data (to thwart the memory compressor) I was unable to reproduce one, confirming the statement made in the WWDC video.