### PR TITLE
Fix header search paths for E2E fixtures

### DIFF
--- a/Bugsnag.xcodeproj/project.pbxproj
+++ b/Bugsnag.xcodeproj/project.pbxproj
@@ -538,6 +538,10 @@
 		010FF28825ED2A8D00E4F2B0 /* BSGAppHangDetector.m in Sources */ = {isa = PBXBuildFile; fileRef = 010FF28325ED2A8D00E4F2B0 /* BSGAppHangDetector.m */; };
 		010FF28925ED2A8D00E4F2B0 /* BSGAppHangDetector.m in Sources */ = {isa = PBXBuildFile; fileRef = 010FF28325ED2A8D00E4F2B0 /* BSGAppHangDetector.m */; };
 		010FF28A25ED2A8D00E4F2B0 /* BSGAppHangDetector.m in Sources */ = {isa = PBXBuildFile; fileRef = 010FF28325ED2A8D00E4F2B0 /* BSGAppHangDetector.m */; };
+		01151ACA28EAC7D70086B706 /* BugsnagDefines.h in CopyFiles */ = {isa = PBXBuildFile; fileRef = 01C41A27288FD3EA00BAE31A /* BugsnagDefines.h */; };
+		01151ACB28EAC7F50086B706 /* BugsnagFeatureFlag.h in CopyFiles */ = {isa = PBXBuildFile; fileRef = 01099391273D123800128BBE /* BugsnagFeatureFlag.h */; };
+		01151ACC28EAC7F80086B706 /* BugsnagFeatureFlagStore.h in CopyFiles */ = {isa = PBXBuildFile; fileRef = 010993B0273D2F6100128BBE /* BugsnagFeatureFlagStore.h */; };
+		01151ACD28EAC8000086B706 /* BugsnagLastRunInfo.h in CopyFiles */ = {isa = PBXBuildFile; fileRef = 01CCAEE825D414D60057268D /* BugsnagLastRunInfo.h */; };
 		012482A325627B51003F7243 /* UIKitTests.m in Sources */ = {isa = PBXBuildFile; fileRef = 012482A225627B51003F7243 /* UIKitTests.m */; };
 		0126F78B25DD508C008483C2 /* BSGEventUploadOperation.h in Headers */ = {isa = PBXBuildFile; fileRef = 0126F78925DD508C008483C2 /* BSGEventUploadOperation.h */; };
 		0126F78C25DD508C008483C2 /* BSGEventUploadOperation.h in Headers */ = {isa = PBXBuildFile; fileRef = 0126F78925DD508C008483C2 /* BSGEventUploadOperation.h */; };
@@ -1154,53 +1158,6 @@
 		E746293B24890C7E00F92D67 /* libz.tbd in Frameworks */ = {isa = PBXBuildFile; fileRef = E746293A24890C7900F92D67 /* libz.tbd */; };
 		E746293C24890C9F00F92D67 /* Foundation.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = E746292424890BFE00F92D67 /* Foundation.framework */; };
 		E746293D24890CA400F92D67 /* SystemConfiguration.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = E746292624890C1100F92D67 /* SystemConfiguration.framework */; };
-		E746293E24890D2F00F92D67 /* BugsnagBreadcrumbs.h in CopyFiles */ = {isa = PBXBuildFile; fileRef = 008967B32486D9D700DC48C2 /* BugsnagBreadcrumbs.h */; };
-		E746294024890D2F00F92D67 /* BugsnagClient+Private.h in CopyFiles */ = {isa = PBXBuildFile; fileRef = 008967BC2486DA1900DC48C2 /* BugsnagClient+Private.h */; };
-		E746294124890D2F00F92D67 /* BSGConfigurationBuilder.h in CopyFiles */ = {isa = PBXBuildFile; fileRef = 008967CA2486DA2D00DC48C2 /* BSGConfigurationBuilder.h */; };
-		E746294524890D2F00F92D67 /* BSGConnectivity.h in CopyFiles */ = {isa = PBXBuildFile; fileRef = 008967F22486DA4500DC48C2 /* BSGConnectivity.h */; };
-		E746294624890D2F00F92D67 /* BugsnagApiClient.h in CopyFiles */ = {isa = PBXBuildFile; fileRef = 008967ED2486DA4400DC48C2 /* BugsnagApiClient.h */; };
-		E746294824890D2F00F92D67 /* BSGSessionUploader.h in CopyFiles */ = {isa = PBXBuildFile; fileRef = 008967EC2486DA4400DC48C2 /* BSGSessionUploader.h */; };
-		E746294924890D2F00F92D67 /* BSGSerialization.h in CopyFiles */ = {isa = PBXBuildFile; fileRef = 008968112486DA5600DC48C2 /* BSGSerialization.h */; };
-		E746294A24890D2F00F92D67 /* BugsnagCollections.h in CopyFiles */ = {isa = PBXBuildFile; fileRef = 008968102486DA5600DC48C2 /* BugsnagCollections.h */; };
-		E746294B24890D2F00F92D67 /* BSGKeys.h in CopyFiles */ = {isa = PBXBuildFile; fileRef = 008968152486DA5600DC48C2 /* BSGKeys.h */; };
-		E746294C24890D2F00F92D67 /* BugsnagLogger.h in CopyFiles */ = {isa = PBXBuildFile; fileRef = 008968142486DA5600DC48C2 /* BugsnagLogger.h */; };
-		E746295824890D3000F92D67 /* BugsnagHandledState.h in CopyFiles */ = {isa = PBXBuildFile; fileRef = 0089684E2486DA9400DC48C2 /* BugsnagHandledState.h */; };
-		E746295924890D3000F92D67 /* BugsnagNotifier.h in CopyFiles */ = {isa = PBXBuildFile; fileRef = 008968622486DA9500DC48C2 /* BugsnagNotifier.h */; };
-		E746295E24890D3000F92D67 /* BugsnagStacktrace.h in CopyFiles */ = {isa = PBXBuildFile; fileRef = 0089684F2486DA9400DC48C2 /* BugsnagStacktrace.h */; };
-		E746296624890D3000F92D67 /* BSGOnErrorSentBlock.h in CopyFiles */ = {isa = PBXBuildFile; fileRef = 008968FD2486DAD000DC48C2 /* BSGOnErrorSentBlock.h */; };
-		E746296824890D3000F92D67 /* BSG_KSBacktrace.h in CopyFiles */ = {isa = PBXBuildFile; fileRef = 008969022486DAD000DC48C2 /* BSG_KSBacktrace.h */; };
-		E746296924890D3000F92D67 /* BSG_KSSysCtl.h in CopyFiles */ = {isa = PBXBuildFile; fileRef = 008969042486DAD000DC48C2 /* BSG_KSSysCtl.h */; };
-		E746296B24890D3100F92D67 /* BSG_KSFileUtils.h in CopyFiles */ = {isa = PBXBuildFile; fileRef = 008969092486DAD000DC48C2 /* BSG_KSFileUtils.h */; };
-		E746296C24890D3100F92D67 /* BSG_KSSignalInfo.h in CopyFiles */ = {isa = PBXBuildFile; fileRef = 0089690A2486DAD000DC48C2 /* BSG_KSSignalInfo.h */; };
-		E746296E24890D3100F92D67 /* BSG_KSArchSpecific.h in CopyFiles */ = {isa = PBXBuildFile; fileRef = 0089690E2486DAD000DC48C2 /* BSG_KSArchSpecific.h */; };
-		E746297024890D3100F92D67 /* BSG_KSMachApple.h in CopyFiles */ = {isa = PBXBuildFile; fileRef = 008969112486DAD000DC48C2 /* BSG_KSMachApple.h */; };
-		E746297124890D3100F92D67 /* BSG_KSString.h in CopyFiles */ = {isa = PBXBuildFile; fileRef = 008969122486DAD000DC48C2 /* BSG_KSString.h */; };
-		E746297224890D3100F92D67 /* BSG_KSLogger.h in CopyFiles */ = {isa = PBXBuildFile; fileRef = 008969152486DAD000DC48C2 /* BSG_KSLogger.h */; };
-		E746297324890D3100F92D67 /* BSG_KSBacktrace_Private.h in CopyFiles */ = {isa = PBXBuildFile; fileRef = 008969162486DAD000DC48C2 /* BSG_KSBacktrace_Private.h */; };
-		E746297824890D3100F92D67 /* BSG_KSJSONCodec.h in CopyFiles */ = {isa = PBXBuildFile; fileRef = 008969222486DAD000DC48C2 /* BSG_KSJSONCodec.h */; };
-		E746297924890D3100F92D67 /* BSG_KSMachHeaders.h in CopyFiles */ = {isa = PBXBuildFile; fileRef = 008969232486DAD000DC48C2 /* BSG_KSMachHeaders.h */; };
-		E746297A24890D3100F92D67 /* BSG_RFC3339DateTool.h in CopyFiles */ = {isa = PBXBuildFile; fileRef = 008969272486DAD000DC48C2 /* BSG_RFC3339DateTool.h */; };
-		E746297B24890D3100F92D67 /* BSG_KSMach.h in CopyFiles */ = {isa = PBXBuildFile; fileRef = 008969282486DAD000DC48C2 /* BSG_KSMach.h */; };
-		E746297C24890D3100F92D67 /* BSG_KSCrashContext.h in CopyFiles */ = {isa = PBXBuildFile; fileRef = 0089692A2486DAD000DC48C2 /* BSG_KSCrashContext.h */; };
-		E746297D24890D3100F92D67 /* BSG_KSCrash.h in CopyFiles */ = {isa = PBXBuildFile; fileRef = 0089692D2486DAD000DC48C2 /* BSG_KSCrash.h */; };
-		E746297E24890D3100F92D67 /* BSG_KSCrashC.h in CopyFiles */ = {isa = PBXBuildFile; fileRef = 0089692E2486DAD000DC48C2 /* BSG_KSCrashC.h */; };
-		E746297F24890D3100F92D67 /* BSG_KSSystemInfo.h in CopyFiles */ = {isa = PBXBuildFile; fileRef = 0089692F2486DAD000DC48C2 /* BSG_KSSystemInfo.h */; };
-		E746298024890D3100F92D67 /* BSG_KSSystemInfoC.h in CopyFiles */ = {isa = PBXBuildFile; fileRef = 008969312486DAD000DC48C2 /* BSG_KSSystemInfoC.h */; };
-		E746298124890D3100F92D67 /* BSG_KSCrashReport.h in CopyFiles */ = {isa = PBXBuildFile; fileRef = 008969322486DAD000DC48C2 /* BSG_KSCrashReport.h */; };
-		E746298224890D3100F92D67 /* BSG_KSCrashDoctor.h in CopyFiles */ = {isa = PBXBuildFile; fileRef = 008969332486DAD000DC48C2 /* BSG_KSCrashDoctor.h */; };
-		E746298324890D3200F92D67 /* BSG_KSCrashReportFields.h in CopyFiles */ = {isa = PBXBuildFile; fileRef = 008969342486DAD000DC48C2 /* BSG_KSCrashReportFields.h */; };
-		E746298424890D3200F92D67 /* BSG_KSCrashState.h in CopyFiles */ = {isa = PBXBuildFile; fileRef = 008969352486DAD000DC48C2 /* BSG_KSCrashState.h */; };
-		E746298524890D3200F92D67 /* BSG_KSCrashReportVersion.h in CopyFiles */ = {isa = PBXBuildFile; fileRef = 008969372486DAD000DC48C2 /* BSG_KSCrashReportVersion.h */; };
-		E746298824890D3200F92D67 /* BSG_KSCrashSentry_MachException.h in CopyFiles */ = {isa = PBXBuildFile; fileRef = 0089693C2486DAD000DC48C2 /* BSG_KSCrashSentry_MachException.h */; };
-		E746298924890D3200F92D67 /* BSG_KSCrashSentry_Private.h in CopyFiles */ = {isa = PBXBuildFile; fileRef = 0089693D2486DAD000DC48C2 /* BSG_KSCrashSentry_Private.h */; };
-		E746298A24890D3200F92D67 /* BSG_KSCrashSentry.h in CopyFiles */ = {isa = PBXBuildFile; fileRef = 0089693F2486DAD000DC48C2 /* BSG_KSCrashSentry.h */; };
-		E746298B24890D3200F92D67 /* BSG_KSCrashSentry_CPPException.h in CopyFiles */ = {isa = PBXBuildFile; fileRef = 008969402486DAD000DC48C2 /* BSG_KSCrashSentry_CPPException.h */; };
-		E746298C24890D3200F92D67 /* BSG_KSCrashSentry_NSException.h in CopyFiles */ = {isa = PBXBuildFile; fileRef = 008969442486DAD000DC48C2 /* BSG_KSCrashSentry_NSException.h */; };
-		E746298E24890D3200F92D67 /* BSG_KSCrashSentry_Signal.h in CopyFiles */ = {isa = PBXBuildFile; fileRef = 008969472486DAD000DC48C2 /* BSG_KSCrashSentry_Signal.h */; };
-		E746298F24890D3200F92D67 /* BSG_KSCrashType.h in CopyFiles */ = {isa = PBXBuildFile; fileRef = 008969482486DAD000DC48C2 /* BSG_KSCrashType.h */; };
-		E746299024890D3200F92D67 /* BSG_KSCrashIdentifier.h in CopyFiles */ = {isa = PBXBuildFile; fileRef = 0089694A2486DAD000DC48C2 /* BSG_KSCrashIdentifier.h */; };
-		E746299524890D3200F92D67 /* BSGCrashSentry.h in CopyFiles */ = {isa = PBXBuildFile; fileRef = 00AD1F002486A17900A27979 /* BSGCrashSentry.h */; };
-		E746299624890D3200F92D67 /* BugsnagSessionTracker.h in CopyFiles */ = {isa = PBXBuildFile; fileRef = 00AD1EF82486A17700A27979 /* BugsnagSessionTracker.h */; };
 /* End PBXBuildFile section */
 
 /* Begin PBXContainerItemProxy section */
@@ -1252,76 +1209,33 @@
 		00AD1CE224869C6C00A27979 /* CopyFiles */ = {
 			isa = PBXCopyFilesBuildPhase;
 			buildActionMask = 2147483647;
-			dstPath = "include/$(PRODUCT_NAME)";
+			dstPath = include/Bugsnag;
 			dstSubfolderSpec = 16;
 			files = (
-				3A700AE724A6492F0068CD1B /* BugsnagThread.h in CopyFiles */,
-				3A700AE824A6492F0068CD1B /* BugsnagSession.h in CopyFiles */,
-				3A700AE924A6492F0068CD1B /* BugsnagStackframe.h in CopyFiles */,
-				3A700AEA24A6492F0068CD1B /* BugsnagMetadataStore.h in CopyFiles */,
-				3A700AEB24A6492F0068CD1B /* BugsnagEndpointConfiguration.h in CopyFiles */,
-				3A700AEC24A6492F0068CD1B /* BugsnagBreadcrumb.h in CopyFiles */,
 				3A700AED24A6492F0068CD1B /* BSG_KSCrashReportWriter.h in CopyFiles */,
+				3A700AF324A6492F0068CD1B /* Bugsnag.h in CopyFiles */,
+				3A700AF724A6492F0068CD1B /* BugsnagApp.h in CopyFiles */,
+				3A700AF224A6492F0068CD1B /* BugsnagAppWithState.h in CopyFiles */,
+				3A700AEC24A6492F0068CD1B /* BugsnagBreadcrumb.h in CopyFiles */,
+				3A700AF024A6492F0068CD1B /* BugsnagClient.h in CopyFiles */,
+				3A700AF424A6492F0068CD1B /* BugsnagConfiguration.h in CopyFiles */,
+				01151ACA28EAC7D70086B706 /* BugsnagDefines.h in CopyFiles */,
+				3A700AF624A6492F0068CD1B /* BugsnagDevice.h in CopyFiles */,
+				3A700AF924A6492F0068CD1B /* BugsnagDeviceWithState.h in CopyFiles */,
+				3A700AEB24A6492F0068CD1B /* BugsnagEndpointConfiguration.h in CopyFiles */,
+				3A700AF824A6492F0068CD1B /* BugsnagError.h in CopyFiles */,
 				3A700AEE24A6492F0068CD1B /* BugsnagErrorTypes.h in CopyFiles */,
 				3A700AEF24A6492F0068CD1B /* BugsnagEvent.h in CopyFiles */,
-				3A700AF024A6492F0068CD1B /* BugsnagClient.h in CopyFiles */,
-				3A700AF124A6492F0068CD1B /* BugsnagUser.h in CopyFiles */,
-				3A700AF224A6492F0068CD1B /* BugsnagAppWithState.h in CopyFiles */,
-				3A700AF324A6492F0068CD1B /* Bugsnag.h in CopyFiles */,
-				3A700AF424A6492F0068CD1B /* BugsnagConfiguration.h in CopyFiles */,
-				3A700AF524A6492F0068CD1B /* BugsnagPlugin.h in CopyFiles */,
-				3A700AF624A6492F0068CD1B /* BugsnagDevice.h in CopyFiles */,
-				3A700AF724A6492F0068CD1B /* BugsnagApp.h in CopyFiles */,
-				3A700AF824A6492F0068CD1B /* BugsnagError.h in CopyFiles */,
-				3A700AF924A6492F0068CD1B /* BugsnagDeviceWithState.h in CopyFiles */,
+				01151ACB28EAC7F50086B706 /* BugsnagFeatureFlag.h in CopyFiles */,
+				01151ACC28EAC7F80086B706 /* BugsnagFeatureFlagStore.h in CopyFiles */,
+				01151ACD28EAC8000086B706 /* BugsnagLastRunInfo.h in CopyFiles */,
 				3A700AFA24A6492F0068CD1B /* BugsnagMetadata.h in CopyFiles */,
-				E746293E24890D2F00F92D67 /* BugsnagBreadcrumbs.h in CopyFiles */,
-				E746294024890D2F00F92D67 /* BugsnagClient+Private.h in CopyFiles */,
-				E746294124890D2F00F92D67 /* BSGConfigurationBuilder.h in CopyFiles */,
-				E746294524890D2F00F92D67 /* BSGConnectivity.h in CopyFiles */,
-				E746294624890D2F00F92D67 /* BugsnagApiClient.h in CopyFiles */,
-				E746294824890D2F00F92D67 /* BSGSessionUploader.h in CopyFiles */,
-				E746294924890D2F00F92D67 /* BSGSerialization.h in CopyFiles */,
-				E746294A24890D2F00F92D67 /* BugsnagCollections.h in CopyFiles */,
-				E746294B24890D2F00F92D67 /* BSGKeys.h in CopyFiles */,
-				E746294C24890D2F00F92D67 /* BugsnagLogger.h in CopyFiles */,
-				E746295824890D3000F92D67 /* BugsnagHandledState.h in CopyFiles */,
-				E746295924890D3000F92D67 /* BugsnagNotifier.h in CopyFiles */,
-				E746295E24890D3000F92D67 /* BugsnagStacktrace.h in CopyFiles */,
-				E746296624890D3000F92D67 /* BSGOnErrorSentBlock.h in CopyFiles */,
-				E746296824890D3000F92D67 /* BSG_KSBacktrace.h in CopyFiles */,
-				E746296924890D3000F92D67 /* BSG_KSSysCtl.h in CopyFiles */,
-				E746296B24890D3100F92D67 /* BSG_KSFileUtils.h in CopyFiles */,
-				E746296C24890D3100F92D67 /* BSG_KSSignalInfo.h in CopyFiles */,
-				E746296E24890D3100F92D67 /* BSG_KSArchSpecific.h in CopyFiles */,
-				E746297024890D3100F92D67 /* BSG_KSMachApple.h in CopyFiles */,
-				E746297124890D3100F92D67 /* BSG_KSString.h in CopyFiles */,
-				E746297224890D3100F92D67 /* BSG_KSLogger.h in CopyFiles */,
-				E746297324890D3100F92D67 /* BSG_KSBacktrace_Private.h in CopyFiles */,
-				E746297824890D3100F92D67 /* BSG_KSJSONCodec.h in CopyFiles */,
-				E746297924890D3100F92D67 /* BSG_KSMachHeaders.h in CopyFiles */,
-				E746297A24890D3100F92D67 /* BSG_RFC3339DateTool.h in CopyFiles */,
-				E746297B24890D3100F92D67 /* BSG_KSMach.h in CopyFiles */,
-				E746297C24890D3100F92D67 /* BSG_KSCrashContext.h in CopyFiles */,
-				E746297D24890D3100F92D67 /* BSG_KSCrash.h in CopyFiles */,
-				E746297E24890D3100F92D67 /* BSG_KSCrashC.h in CopyFiles */,
-				E746297F24890D3100F92D67 /* BSG_KSSystemInfo.h in CopyFiles */,
-				E746298024890D3100F92D67 /* BSG_KSSystemInfoC.h in CopyFiles */,
-				E746298124890D3100F92D67 /* BSG_KSCrashReport.h in CopyFiles */,
-				E746298224890D3100F92D67 /* BSG_KSCrashDoctor.h in CopyFiles */,
-				E746298324890D3200F92D67 /* BSG_KSCrashReportFields.h in CopyFiles */,
-				E746298424890D3200F92D67 /* BSG_KSCrashState.h in CopyFiles */,
-				E746298524890D3200F92D67 /* BSG_KSCrashReportVersion.h in CopyFiles */,
-				E746298824890D3200F92D67 /* BSG_KSCrashSentry_MachException.h in CopyFiles */,
-				E746298924890D3200F92D67 /* BSG_KSCrashSentry_Private.h in CopyFiles */,
-				E746298A24890D3200F92D67 /* BSG_KSCrashSentry.h in CopyFiles */,
-				E746298B24890D3200F92D67 /* BSG_KSCrashSentry_CPPException.h in CopyFiles */,
-				E746298C24890D3200F92D67 /* BSG_KSCrashSentry_NSException.h in CopyFiles */,
-				E746298E24890D3200F92D67 /* BSG_KSCrashSentry_Signal.h in CopyFiles */,
-				E746298F24890D3200F92D67 /* BSG_KSCrashType.h in CopyFiles */,
-				E746299024890D3200F92D67 /* BSG_KSCrashIdentifier.h in CopyFiles */,
-				E746299524890D3200F92D67 /* BSGCrashSentry.h in CopyFiles */,
-				E746299624890D3200F92D67 /* BugsnagSessionTracker.h in CopyFiles */,
+				3A700AEA24A6492F0068CD1B /* BugsnagMetadataStore.h in CopyFiles */,
+				3A700AF524A6492F0068CD1B /* BugsnagPlugin.h in CopyFiles */,
+				3A700AE824A6492F0068CD1B /* BugsnagSession.h in CopyFiles */,
+				3A700AE924A6492F0068CD1B /* BugsnagStackframe.h in CopyFiles */,
+				3A700AE724A6492F0068CD1B /* BugsnagThread.h in CopyFiles */,
+				3A700AF124A6492F0068CD1B /* BugsnagUser.h in CopyFiles */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};

--- a/Bugsnag/BugsnagInternals.h
+++ b/Bugsnag/BugsnagInternals.h
@@ -19,8 +19,8 @@
  * or bugfix releases, and should not be used by projects outside of Bugsnag.
  */
 
-#import "Payload/BugsnagHandledState.h"
-#import "Payload/BugsnagNotifier.h"
+#import "BugsnagHandledState.h"
+#import "BugsnagNotifier.h"
 
 @interface BSGFeatureFlagStore : NSObject <NSCopying>
 @end

--- a/BugsnagNetworkRequestPlugin/BugsnagNetworkRequestPlugin.xcodeproj/project.pbxproj
+++ b/BugsnagNetworkRequestPlugin/BugsnagNetworkRequestPlugin.xcodeproj/project.pbxproj
@@ -7,6 +7,7 @@
 	objects = {
 
 /* Begin PBXBuildFile section */
+		01151ACF28EAC8C50086B706 /* BugsnagNetworkRequestPlugin.h in CopyFiles */ = {isa = PBXBuildFile; fileRef = CB487C2F26DE3EFB004F6B87 /* BugsnagNetworkRequestPlugin.h */; };
 		016113862716EFBE002A50D4 /* BSGURLSessionTracingProxyTests.m in Sources */ = {isa = PBXBuildFile; fileRef = 016113852716EFBE002A50D4 /* BSGURLSessionTracingProxyTests.m */; };
 		016113872716EFBE002A50D4 /* BSGURLSessionTracingProxyTests.m in Sources */ = {isa = PBXBuildFile; fileRef = 016113852716EFBE002A50D4 /* BSGURLSessionTracingProxyTests.m */; };
 		016113882716EFBE002A50D4 /* BSGURLSessionTracingProxyTests.m in Sources */ = {isa = PBXBuildFile; fileRef = 016113852716EFBE002A50D4 /* BSGURLSessionTracingProxyTests.m */; };
@@ -128,9 +129,10 @@
 		CB2430D526F1DA8A00CB5EC4 /* CopyFiles */ = {
 			isa = PBXCopyFilesBuildPhase;
 			buildActionMask = 2147483647;
-			dstPath = "include/$(PRODUCT_NAME)";
+			dstPath = include/BugsnagNetworkRequestPlugin;
 			dstSubfolderSpec = 16;
 			files = (
+				01151ACF28EAC8C50086B706 /* BugsnagNetworkRequestPlugin.h in CopyFiles */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};

--- a/features/fixtures/ios/iOSTestApp.xcodeproj/project.pbxproj
+++ b/features/fixtures/ios/iOSTestApp.xcodeproj/project.pbxproj
@@ -301,7 +301,6 @@
 		8AB8866A20404DD30003E444 /* Assets.xcassets */ = {isa = PBXFileReference; lastKnownFileType = folder.assetcatalog; path = Assets.xcassets; sourceTree = "<group>"; };
 		8AB8866D20404DD30003E444 /* Base */ = {isa = PBXFileReference; lastKnownFileType = file.storyboard; name = Base; path = Base.lproj/LaunchScreen.storyboard; sourceTree = "<group>"; };
 		8AB8866F20404DD30003E444 /* Info.plist */ = {isa = PBXFileReference; lastKnownFileType = text.plist.xml; path = Info.plist; sourceTree = "<group>"; };
-		8AB88675204052990003E444 /* iOSTestApp-Bridging-Header.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; path = "iOSTestApp-Bridging-Header.h"; sourceTree = "<group>"; };
 		8AEEBBCF20FC9E1D00C60763 /* AutoSessionMixedEventsScenario.m */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.objc; path = AutoSessionMixedEventsScenario.m; sourceTree = "<group>"; };
 		8AEFC73020F8D1A000A78779 /* AutoSessionWithUserScenario.m */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.objc; path = AutoSessionWithUserScenario.m; sourceTree = "<group>"; };
 		8AEFC73320F8D1BB00A78779 /* ManualSessionWithUserScenario.m */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.objc; path = ManualSessionWithUserScenario.m; sourceTree = "<group>"; };
@@ -436,7 +435,6 @@
 				8AB8866320404DD30003E444 /* AppDelegate.swift */,
 				8AB8866A20404DD30003E444 /* Assets.xcassets */,
 				8AB8866F20404DD30003E444 /* Info.plist */,
-				8AB88675204052990003E444 /* iOSTestApp-Bridging-Header.h */,
 				8AB8866C20404DD30003E444 /* LaunchScreen.storyboard */,
 				8AB8866520404DD30003E444 /* ViewController.swift */,
 				8AB8866720404DD30003E444 /* Main.storyboard */,
@@ -1077,8 +1075,8 @@
 				GCC_TREAT_INCOMPATIBLE_POINTER_TYPE_WARNINGS_AS_ERRORS = YES;
 				GCC_TREAT_WARNINGS_AS_ERRORS = YES;
 				HEADER_SEARCH_PATHS = (
-					../../../Bugsnag/include,
-					../../../BugsnagNetworkRequestPlugin/BugsnagNetworkRequestPlugin/include,
+					../../../Bugsnag,
+					../../../Bugsnag/Payload,
 				);
 				INFOPLIST_FILE = iOSTestApp/Info.plist;
 				IPHONEOS_DEPLOYMENT_TARGET = 9.0;
@@ -1092,10 +1090,11 @@
 				STRIP_STYLE = all;
 				STRIP_SWIFT_SYMBOLS = NO;
 				SWIFT_INSTALL_OBJC_HEADER = YES;
-				SWIFT_OBJC_BRIDGING_HEADER = "iOSTestApp/iOSTestApp-Bridging-Header.h";
+				SWIFT_OBJC_BRIDGING_HEADER = ../shared/scenarios/Scenario.h;
 				SWIFT_OPTIMIZATION_LEVEL = "-Onone";
 				SWIFT_TREAT_WARNINGS_AS_ERRORS = YES;
 				SWIFT_VERSION = 4.2;
+				SYSTEM_HEADER_SEARCH_PATHS = "$(BUILT_PRODUCTS_DIR)/include";
 				TARGETED_DEVICE_FAMILY = "1,2";
 			};
 			name = Debug;
@@ -1118,8 +1117,8 @@
 				GCC_TREAT_INCOMPATIBLE_POINTER_TYPE_WARNINGS_AS_ERRORS = YES;
 				GCC_TREAT_WARNINGS_AS_ERRORS = YES;
 				HEADER_SEARCH_PATHS = (
-					../../../Bugsnag/include,
-					../../../BugsnagNetworkRequestPlugin/BugsnagNetworkRequestPlugin/include,
+					../../../Bugsnag,
+					../../../Bugsnag/Payload,
 				);
 				INFOPLIST_FILE = iOSTestApp/Info.plist;
 				IPHONEOS_DEPLOYMENT_TARGET = 9.0;
@@ -1134,10 +1133,11 @@
 				STRIP_STYLE = all;
 				STRIP_SWIFT_SYMBOLS = NO;
 				SWIFT_INSTALL_OBJC_HEADER = YES;
-				SWIFT_OBJC_BRIDGING_HEADER = "iOSTestApp/iOSTestApp-Bridging-Header.h";
+				SWIFT_OBJC_BRIDGING_HEADER = ../shared/scenarios/Scenario.h;
 				SWIFT_OPTIMIZATION_LEVEL = "-Onone";
 				SWIFT_TREAT_WARNINGS_AS_ERRORS = YES;
 				SWIFT_VERSION = 4.2;
+				SYSTEM_HEADER_SEARCH_PATHS = "$(BUILT_PRODUCTS_DIR)/include";
 				TARGETED_DEVICE_FAMILY = "1,2";
 			};
 			name = Release;

--- a/features/fixtures/ios/iOSTestApp/iOSTestApp-Bridging-Header.h
+++ b/features/fixtures/ios/iOSTestApp/iOSTestApp-Bridging-Header.h
@@ -1,7 +1,0 @@
-//
-//  Use this file to import your target's public headers that you would like to expose to Swift.
-//
-
-#import "Scenario.h"
-#import <Bugsnag/Bugsnag.h>
-#import <BugsnagNetworkRequestPlugin/BugsnagNetworkRequestPlugin.h>

--- a/features/fixtures/macos/macOSTestApp.xcodeproj/project.pbxproj
+++ b/features/fixtures/macos/macOSTestApp.xcodeproj/project.pbxproj
@@ -237,7 +237,6 @@
 		010BDFBA28883703007025F9 /* UserNilScenario.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = UserNilScenario.swift; sourceTree = "<group>"; };
 		011B7A4B26CD52080071C3EB /* ThermalStateBreadcrumbScenario.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ThermalStateBreadcrumbScenario.swift; sourceTree = "<group>"; };
 		0123189B275921590007EFD7 /* RecrashScenarios.mm */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.objcpp; path = RecrashScenarios.mm; sourceTree = "<group>"; };
-		01452360254AFEA700D436AA /* macOSTestApp-Bridging-Header.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; path = "macOSTestApp-Bridging-Header.h"; sourceTree = "<group>"; };
 		015AE239276B88300044B1AE /* OnSendErrorPersistenceScenario.m */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.objc; path = OnSendErrorPersistenceScenario.m; sourceTree = "<group>"; };
 		0176C0A8254AE81B0066E0F3 /* macOSTestApp.app */ = {isa = PBXFileReference; explicitFileType = wrapper.application; includeInIndex = 0; path = macOSTestApp.app; sourceTree = BUILT_PRODUCTS_DIR; };
 		0176C0AC254AE81B0066E0F3 /* Info.plist */ = {isa = PBXFileReference; lastKnownFileType = text.plist.xml; path = Info.plist; sourceTree = "<group>"; usesTabs = 1; };
@@ -631,7 +630,6 @@
 				0176C0B0254AE81B0066E0F3 /* AppDelegate.m */,
 				0176C0B2254AE81B0066E0F3 /* Images.xcassets */,
 				0176C0AC254AE81B0066E0F3 /* Info.plist */,
-				01452360254AFEA700D436AA /* macOSTestApp-Bridging-Header.h */,
 				0176C0AD254AE81B0066E0F3 /* main.m */,
 				0176C0B4254AE81B0066E0F3 /* MainMenu.xib */,
 				017FBFB5254B09C300809042 /* MainWindowController.h */,
@@ -1083,13 +1081,18 @@
 				CODE_SIGN_IDENTITY = "-";
 				COMBINE_HIDPI_IMAGES = YES;
 				COPY_PHASE_STRIP = NO;
+				HEADER_SEARCH_PATHS = (
+					"$(inherited)",
+					../../../Bugsnag,
+					../../../Bugsnag/Payload,
+				);
 				INFOPLIST_FILE = macOSTestApp/Info.plist;
 				LD_RUNPATH_SEARCH_PATHS = "$(inherited) @executable_path/../Frameworks";
 				PRODUCT_BUNDLE_IDENTIFIER = com.bugsnag.macOSTestApp;
 				PRODUCT_NAME = "$(TARGET_NAME)";
 				STRIP_INSTALLED_PRODUCT = NO;
 				STRIP_SWIFT_SYMBOLS = NO;
-				SWIFT_OBJC_BRIDGING_HEADER = "macOSTestApp/macOSTestApp-Bridging-Header.h";
+				SWIFT_OBJC_BRIDGING_HEADER = ../shared/scenarios/Scenario.h;
 				SWIFT_OPTIMIZATION_LEVEL = "-Onone";
 				SWIFT_VERSION = 4.2;
 			};
@@ -1104,13 +1107,18 @@
 				CODE_SIGN_IDENTITY = "-";
 				COMBINE_HIDPI_IMAGES = YES;
 				COPY_PHASE_STRIP = NO;
+				HEADER_SEARCH_PATHS = (
+					"$(inherited)",
+					../../../Bugsnag,
+					../../../Bugsnag/Payload,
+				);
 				INFOPLIST_FILE = macOSTestApp/Info.plist;
 				LD_RUNPATH_SEARCH_PATHS = "$(inherited) @executable_path/../Frameworks";
 				PRODUCT_BUNDLE_IDENTIFIER = com.bugsnag.macOSTestApp;
 				PRODUCT_NAME = "$(TARGET_NAME)";
 				STRIP_INSTALLED_PRODUCT = NO;
 				STRIP_SWIFT_SYMBOLS = NO;
-				SWIFT_OBJC_BRIDGING_HEADER = "macOSTestApp/macOSTestApp-Bridging-Header.h";
+				SWIFT_OBJC_BRIDGING_HEADER = ../shared/scenarios/Scenario.h;
 				SWIFT_VERSION = 4.2;
 			};
 			name = Release;

--- a/features/fixtures/macos/macOSTestApp/macOSTestApp-Bridging-Header.h
+++ b/features/fixtures/macos/macOSTestApp/macOSTestApp-Bridging-Header.h
@@ -1,7 +1,0 @@
-//
-//  Use this file to import your target's public headers that you would like to expose to Swift.
-//
-
-#import "Scenario.h"
-#import <Bugsnag/Bugsnag.h>
-#import <BugsnagNetworkRequestPlugin/BugsnagNetworkRequestPlugin.h>

--- a/features/fixtures/shared/scenarios/Scenario.h
+++ b/features/fixtures/shared/scenarios/Scenario.h
@@ -4,8 +4,8 @@
 //
 
 #import <Bugsnag/Bugsnag.h>
-
-#import "../../../../Bugsnag/BugsnagInternals.h"
+#import <BugsnagNetworkRequestPlugin/BugsnagNetworkRequestPlugin.h>
+#import "BugsnagInternals.h"
 
 NS_ASSUME_NONNULL_BEGIN
 

--- a/features/fixtures/watchos/watchOSTestApp WatchKit Extension/Swift-Objc-Bridging-Header.h
+++ b/features/fixtures/watchos/watchOSTestApp WatchKit Extension/Swift-Objc-Bridging-Header.h
@@ -1,7 +1,0 @@
-//
-//  Use this file to import your target's public headers that you would like to expose to Swift.
-//
-
-#import "Scenario.h"
-#import <Bugsnag/Bugsnag.h>
-#import <BugsnagNetworkRequestPlugin/BugsnagNetworkRequestPlugin.h>

--- a/features/fixtures/watchos/watchOSTestApp.xcodeproj/project.pbxproj
+++ b/features/fixtures/watchos/watchOSTestApp.xcodeproj/project.pbxproj
@@ -77,7 +77,6 @@
 		01479A352847775800E53BB9 /* Info.plist */ = {isa = PBXFileReference; lastKnownFileType = text.plist.xml; path = Info.plist; sourceTree = "<group>"; usesTabs = 1; };
 		01479A46284779A400E53BB9 /* Scenario.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = Scenario.h; sourceTree = "<group>"; };
 		01479AA6284779A400E53BB9 /* Scenario.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; path = Scenario.m; sourceTree = "<group>"; };
-		01479BA628477A0000E53BB9 /* Swift-Objc-Bridging-Header.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; path = "Swift-Objc-Bridging-Header.h"; sourceTree = "<group>"; };
 		01479BA72847923A00E53BB9 /* BareboneTestHandledScenario.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = BareboneTestHandledScenario.swift; sourceTree = "<group>"; };
 		01479BA9284792B100E53BB9 /* BareboneTestUnhandledErrorScenario.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = BareboneTestUnhandledErrorScenario.swift; sourceTree = "<group>"; };
 		01515B1728508BA600E498EC /* Interface.storyboard */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = file.storyboard; path = Interface.storyboard; sourceTree = "<group>"; };
@@ -138,7 +137,6 @@
 				01479A2E2847775600E53BB9 /* ComplicationController.swift */,
 				01515B1B28508DBB00E498EC /* ExtensionDelegate.swift */,
 				01515B1A28508DBB00E498EC /* InterfaceController.swift */,
-				01479BA628477A0000E53BB9 /* Swift-Objc-Bridging-Header.h */,
 				01479A302847775800E53BB9 /* Assets.xcassets */,
 				01479A352847775800E53BB9 /* Info.plist */,
 				01479A43284779A400E53BB9 /* scenarios */,
@@ -510,6 +508,11 @@
 				DEVELOPMENT_TEAM = 372ZUL2ZB7;
 				ENABLE_PREVIEWS = YES;
 				GENERATE_INFOPLIST_FILE = YES;
+				HEADER_SEARCH_PATHS = (
+					"$(inherited)",
+					../../../Bugsnag,
+					../../../Bugsnag/Payload,
+				);
 				INFOPLIST_FILE = "watchOSTestApp WatchKit Extension/Info.plist";
 				INFOPLIST_KEY_CFBundleDisplayName = "watchOSTestApp WatchKit Extension";
 				INFOPLIST_KEY_CLKComplicationPrincipalClass = "$(PRODUCT_MODULE_NAME).ComplicationController";
@@ -527,7 +530,7 @@
 				SDKROOT = watchos;
 				SKIP_INSTALL = YES;
 				SWIFT_EMIT_LOC_STRINGS = YES;
-				SWIFT_OBJC_BRIDGING_HEADER = "watchOSTestApp WatchKit Extension/Swift-Objc-Bridging-Header.h";
+				SWIFT_OBJC_BRIDGING_HEADER = ../shared/scenarios/Scenario.h;
 				SWIFT_VERSION = 5.0;
 				TARGETED_DEVICE_FAMILY = 4;
 			};
@@ -544,6 +547,11 @@
 				DEVELOPMENT_TEAM = 372ZUL2ZB7;
 				ENABLE_PREVIEWS = YES;
 				GENERATE_INFOPLIST_FILE = YES;
+				HEADER_SEARCH_PATHS = (
+					"$(inherited)",
+					../../../Bugsnag,
+					../../../Bugsnag/Payload,
+				);
 				INFOPLIST_FILE = "watchOSTestApp WatchKit Extension/Info.plist";
 				INFOPLIST_KEY_CFBundleDisplayName = "watchOSTestApp WatchKit Extension";
 				INFOPLIST_KEY_CLKComplicationPrincipalClass = "$(PRODUCT_MODULE_NAME).ComplicationController";
@@ -561,7 +569,7 @@
 				SDKROOT = watchos;
 				SKIP_INSTALL = YES;
 				SWIFT_EMIT_LOC_STRINGS = YES;
-				SWIFT_OBJC_BRIDGING_HEADER = "watchOSTestApp WatchKit Extension/Swift-Objc-Bridging-Header.h";
+				SWIFT_OBJC_BRIDGING_HEADER = ../shared/scenarios/Scenario.h;
 				SWIFT_VERSION = 5.0;
 				TARGETED_DEVICE_FAMILY = 4;
 			};


### PR DESCRIPTION
## Goal

Ensure that dependent notifiers will still build.

I realised that the relative path `#import` introduced in #1488 would break bugsnag-unreal's custom build process that copies all headers to a single directory.

## Changeset

Reverts to non-relative `#import` in `BugsnagInternals.h`.

Updates `Bugsnag.xcodeproj` and `BugsnagNetworkRequestPlugin.xcodeproj` to copy all public headers to `$(BUILT_PRODUCTS_DIR)/include/<name>`.

Updates `iOSTestsApp.xcodeproj` to import public headers from `$(BUILT_PRODUCTS_DIR)/include`.

Updates `HEADER_SEARCH_PATHS` for all test fixtures to allow `BugsnagInternals.h` to be imported.

Uses `shared/scenarios/Scenario.h` as the `SWIFT_OBJC_BRIDGING_HEADER` for all projects, avoiding duplication and ensuring consistency.

## Testing

Verified by building fixtures locally.