### PR TITLE
Revise attemptDeliveryOnCrash changelog and header docs

### DIFF
--- a/Bugsnag/include/Bugsnag/BugsnagConfiguration.h
+++ b/Bugsnag/include/Bugsnag/BugsnagConfiguration.h
@@ -299,6 +299,29 @@ BUGSNAG_EXTERN
 @property (nonatomic) BOOL sendLaunchCrashesSynchronously;
 
 /**
+ * Whether Bugsnag should try to send crashing errors prior to app termination.
+ *
+ * Delivery will only be attempted for uncaught Objective-C exceptions, and
+ * while in progress will block the crashing thread for up to 3 seconds.
+ *
+ * Delivery will be unreliable due to the necessary short timeout and potential
+ * memory corruption that caused the crashing error in the first place.
+ *
+ * If it fails prior to termination, delivery will be reattempted at next launch
+ * (the default behavior). 
+ *
+ * Use of this feature is discouraged because it:
+ * - may cause the app to hang while delivery occurs and impact the hang rate
+ *   reported in Xcode Organizer
+ * - will result in duplicate crashes in your dashboard for crashes that were
+ *   fully sent but without receiving an HTTP response within the timeout
+ * - may prevent other crash reporters from detecting the crash.
+ *
+ * By default this value is false.
+ */
+@property (nonatomic) BOOL attemptDeliveryOnCrash;
+
+/**
  * The types of breadcrumbs which will be captured. By default, this is all types.
  */
 @property (nonatomic) BSGEnabledBreadcrumbType enabledBreadcrumbTypes;
@@ -487,33 +510,6 @@ BUGSNAG_EXTERN
  * By default all types of telemetry are enabled.
  */
 @property (nonatomic) BSGTelemetryOptions telemetry;
-
-// =============================================================================
-// MARK: - Experimental
-// =============================================================================
-
-/**
- * Whether Bugsnag should try to send crashing errors prior to app termination.
- *
- * Delivery will only be attempted for uncaught Objective-C exceptions, and
- * while in progress will block the crashing thread for up to 3 seconds.
- *
- * Delivery will be unreliable due to the necessary short timeout and potential
- * memory corruption that caused the crashing error in the first place.
- *
- * If it fails prior to termination, delivery will be reattempted at next launch
- * (the default behavior). 
- *
- * Use of this feature is discouraged because it:
- * - may cause the app to hang while delivery occurs and impact the hang rate
- *   reported in Xcode Organizer
- * - will result in duplicate crashes in your dashboard for crashes that were
- *   fully sent but without receiving an HTTP response within the timeout
- * - may prevent other crash reporters from detecting the crash.
- *
- * By default this value is false.
- */
-@property (nonatomic) BOOL attemptDeliveryOnCrash;
 
 // =============================================================================
 // MARK: - Plugins

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,8 +5,10 @@ Changelog
 
 ### Enhancements
 
-* Add (experimental) `configuration.attemptDeliveryOnCrash` to allow uncaught
-  Objective-C exceptions to be sent at crash time, prior to app termination.
+* Add `configuration.attemptDeliveryOnCrash` to allow uncaught Objective-C
+  exceptions to be sent at crash time, prior to app termination. Use of this
+  feature may impair user experience and other crash reporters; please read
+  https://docs.bugsnag.com/platforms/ios/configuration-options/#attemptdeliveryoncrash
   [#1488](https://github.com/bugsnag/bugsnag-cocoa/pull/1488)
 
 ### Bug fixes


### PR DESCRIPTION
## Goal

Remove "experimental" label from `attemptDeliveryOnCrash` configuration option, to clarify that there is no expectation that it will be removed.

See https://github.com/bugsnag/bugsnag-cocoa/pull/1488