### PR TITLE
Lock BSGRunContext in memory

### DIFF
--- a/Bugsnag/Helpers/BSGRunContext.m
+++ b/Bugsnag/Helpers/BSGRunContext.m
@@ -504,6 +504,7 @@ static void ResizeAndMapFile(int fd) {
     }
     
     memset(ptr, 0, SIZEOF_STRUCT);
+    mlock(ptr, SIZEOF_STRUCT);
     bsg_runContext = ptr;
     return;
     


### PR DESCRIPTION
## Goal

Ensure that BSGRunContext's physical pages are locked in memory.

A handful of `EXC_BAD_ACCESS`:[`KERN_MEMORY_ERROR`](https://github.com/apple-oss-distributions/xnu/blob/xnu-8020.140.41/osfmk/mach/kern_return.h#L118-L124) errors in crash handling have been observed which could be explained by BSGRunContext's backing pages being mapped out due to memory pressure.

## Changeset

Adds call to `mlock`.

## Testing

<!-- How was it tested? What manual and automated tests were
     run/added? -->