### PR TITLE
Expand attemptDeliveryOnCrash to Mach exceptions

### DIFF
--- a/Bugsnag/KSCrash/Source/KSCrash/Recording/Sentry/BSG_KSCrashSentry_MachException.c
+++ b/Bugsnag/KSCrash/Source/KSCrash/Recording/Sentry/BSG_KSCrashSentry_MachException.c
@@ -289,6 +289,14 @@ void *ksmachexc_i_handleExceptions(void *const userData) {
             "Crash handling complete. Restoring original handlers.");
         bsg_kscrashsentry_uninstall(BSG_KSCrashTypeAsyncSafe);
         bsg_kscrashsentry_resumeThreads();
+
+        // Must run before endHandlingCrash unblocks secondary crashed threads.
+        BSG_KSCrash_Context *context = crashContext();
+        if (context->crash.attemptDelivery) {
+            BSG_KSLOG_DEBUG("Attempting delivery.");
+            context->crash.attemptDelivery();
+        }
+
         bsg_kscrashsentry_endHandlingCrash();
     }
 

--- a/Bugsnag/include/Bugsnag/BugsnagConfiguration.h
+++ b/Bugsnag/include/Bugsnag/BugsnagConfiguration.h
@@ -301,8 +301,9 @@ BUGSNAG_EXTERN
 /**
  * Whether Bugsnag should try to send crashing errors prior to app termination.
  *
- * Delivery will only be attempted for uncaught Objective-C exceptions, and
- * while in progress will block the crashing thread for up to 3 seconds.
+ * Delivery will only be attempted for uncaught Objective-C exceptions and Mach
+ * exceptions, and while in progress will block the crashing thread for up to 3
+ * seconds.
  *
  * Delivery will be unreliable due to the necessary short timeout and potential
  * memory corruption that caused the crashing error in the first place.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,14 @@
 Changelog
 =========
 
+## TBD
+
+### Enhancements
+
+* Expand `configuration.attemptDeliveryOnCrash` to send Mach exceptions (e.g.
+  Swift fatal errors and bad memory accesses) at crash time.
+  [#1496](https://github.com/bugsnag/bugsnag-cocoa/pull/1496)
+
 ## 6.24.0 (2022-10-05)
 
 ### Enhancements

--- a/features/delivery.feature
+++ b/features/delivery.feature
@@ -157,13 +157,15 @@ Feature: Delivery of errors
     And the event "usage.system.stringCharsTruncated" is not null
     And the event "usage.system.stringsTruncated" is not null
 
-  Scenario: Attempt Delivery On Crash
-    When I run "AttemptDeliveryOnCrashScenario"
+  Scenario Outline: Attempt Delivery On Crash
+    When I set the app to "<scenario_mode>" mode
+    And I run "AttemptDeliveryOnCrashScenario"
     And I wait to receive an error
     Then the error is valid for the error reporting API
     And the event "context" equals "OnSendError"
-    And the event "metaData.error.nsexception.name" equals "NSRangeException"
-    And the event "metaData.error.type" equals "nsexception"
+    And the exception "errorClass" equals "<error_class>"
+    And the exception "message" equals "<message>"
+    And the event "metaData.error.type" equals "<error_type>"
     And the event "unhandled" is true
     And the event "usage.config.attemptDeliveryOnCrash" is true
     And I discard the oldest error
@@ -171,3 +173,8 @@ Feature: Delivery of errors
     And I configure Bugsnag for "AttemptDeliveryOnCrashScenario"
     And I wait to receive 2 sessions
     Then I should receive no error
+    Examples:
+      | scenario_mode   | error_type  | error_class      | message                                                                    |
+      | NSException     | nsexception | NSRangeException | *** -[__NSArray0 objectAtIndex:]: index 42 beyond bounds for empty NSArray |
+      | SwiftFatalError | mach        | Fatal error      | Unexpectedly found nil while unwrapping an Optional value                  |
+      | BadAccess       | mach        | EXC_BAD_ACCESS   | Attempted to dereference garbage pointer 0x20.                             |

--- a/features/fixtures/shared/scenarios/AttemptDeliveryOnCrashScenario.swift
+++ b/features/fixtures/shared/scenarios/AttemptDeliveryOnCrashScenario.swift
@@ -19,6 +19,24 @@ class AttemptDeliveryOnCrashScenario: Scenario {
     }
     
     override func run() {
-        NSArray().object(at: 42)
+        guard let eventMode = eventMode else { return } 
+        switch eventMode {
+        case "BadAccess":
+            if let ptr = UnsafePointer<CChar>(bitPattern: 42) {
+                strlen(ptr)
+            }
+            break
+            
+        case "NSException":
+            NSArray().object(at: 42)
+            break
+            
+        case "SwiftFatalError":
+            _ = URL(string: "")!
+            break
+            
+        default:
+            break
+        }
     }
 }


### PR DESCRIPTION
## Goal

Allow Mach exceptions to be delivered at crash time when `config.attemptDeliveryOnCrash` is enabled.

## Design

Delivery is on a best-effort basis and more likely to fail than for Objective-C exceptions due to the increased likelihood of deadlocks - the crashed thread may be holding global locks that the delivery subsystem needs.

## Changeset

Invoke delivery mechanism from `BSG_KSCrashSentry_MachException.c`

## Testing

Extends E2E scenario to verify delivery of Swift fatal errors and `EXC_BAD_ACCESS`.