### PR TITLE
Stop using strcpy

### DIFF
--- a/Bugsnag.xcconfig
+++ b/Bugsnag.xcconfig
@@ -89,6 +89,17 @@ CLANG_WARN_OBJC_IMPLICIT_RETAIN_SELF                   = YES // -Wimplicit-retai
 CLANG_WARN_OBJC_REPEATED_USE_OF_WEAK                   = YES // -Warc-repeated-use-of-weak -Wno-arc-maybe-repeated-use-of-weak
 CLANG_WARN__ARC_BRIDGE_CAST_NONARC                     = YES // -Warc-bridge-casts-disallowed-in-nonarc
 
+// Static Analysis - Issues - Security
+
+CLANG_ANALYZER_SECURITY_FLOATLOOPCOUNTER               = YES
+CLANG_ANALYZER_SECURITY_INSECUREAPI_RAND               = YES 
+CLANG_ANALYZER_SECURITY_INSECUREAPI_STRCPY             = YES
+
+// Static Analysis - Issues - Unused Code
+
+CLANG_TIDY_BUGPRONE_REDUNDANT_BRANCH_CONDITION         = YES
+CLANG_TIDY_MISC_REDUNDANT_EXPRESSION                   = YES
+
 // Warning flags that have no dedicated Xcode build settings
 
 WARNING_CFLAGS = -Wcast-qual -Wconditional-uninitialized -Wcustom-atomic-properties -Wdirect-ivar-access -Wdocumentation-unknown-command -Wformat-nonliteral -Widiomatic-parentheses -Wimplicit-int-float-conversion -Wimport-preprocessor-directive-pedantic -Wincomplete-implementation -Wmissing-variable-declarations -Wno-unknown-warning-option -Wnonportable-include-path -Wnullable-to-nonnull-conversion -Woverriding-method-mismatch -Wpointer-sign -Wswitch-enum -Wundef -Wunused-macros

--- a/Bugsnag/KSCrash/Source/KSCrash/Recording/Tools/BSG_KSCrashStringConversion.c
+++ b/Bugsnag/KSCrash/Source/KSCrash/Recording/Tools/BSG_KSCrashStringConversion.c
@@ -100,13 +100,13 @@ static size_t positive_double_to_string(const double value, char* dst, int max_s
 
     // isnan() is basically ((x) != (x))
     if(isnan(value)) {
-        strcpy(dst, "nan");
+        strlcpy(dst, "nan", 4);
         return 3;
     }
 
     // isinf() is a compiler intrinsic.
     if(isinf(value)) {
-        strcpy(dst, "inf");
+        strlcpy(dst, "inf", 4);
         return 3;
     }
 

--- a/Tests/BugsnagTests/BugsnagMetadataTests.m
+++ b/Tests/BugsnagTests/BugsnagMetadataTests.m
@@ -422,7 +422,8 @@
         while (!threads[i]) {}
     }
     
-    char *scratch = malloc(1024 * 1024);
+    size_t size = 1024 * 1024;
+    char *scratch = malloc(size);
     
     for (int i = 0; i < 10000; i++) {
         // Threads must be suspended to prevent the metadata buffer from being freed while
@@ -432,7 +433,7 @@
             thread_suspend(threads[i]);
         }
         
-        strcpy(scratch, buffer);
+        strlcpy(scratch, buffer, size);
         
         for (int i = 0; i < threadCount; i++) {
             thread_resume(threads[i]);


### PR DESCRIPTION
Enables all static analyzer checks that are not enabled by default.

Replaces uses of `strcpy` with `strlcpy`.