### PR TITLE
[PLAT-8864] Remove BSGInternalErrorReporterDataSource

### DIFF
--- a/Bugsnag/Client/BugsnagClient.m
+++ b/Bugsnag/Client/BugsnagClient.m
@@ -150,7 +150,7 @@ static void BSSerializeDataCrashHandler(const BSG_KSCrashReportWriter *writer) {
 // MARK: -
 
 BSG_OBJC_DIRECT_MEMBERS
-@interface BugsnagClient () <BSGBreadcrumbSink, BSGInternalErrorReporterDataSource>
+@interface BugsnagClient () <BSGBreadcrumbSink>
 
 @property (nonatomic) BSGNotificationBreadcrumbs *notificationBreadcrumbs;
 
@@ -246,7 +246,9 @@ BSG_OBJC_DIRECT_MEMBERS
     [self computeDidCrashLastLaunch];
 
     if (self.configuration.telemetry & BSGTelemetryInternalErrors) {
-        BSGInternalErrorReporter.sharedInstance = [[BSGInternalErrorReporter alloc] initWithDataSource:self];
+        BSGInternalErrorReporter.sharedInstance =
+        [[BSGInternalErrorReporter alloc] initWithApiKey:self.configuration.apiKey
+                                                endpoint:(NSURL *_Nonnull)self.configuration.notifyURL];
     } else {
         bsg_log_debug(@"Internal error reporting was disabled in config");
     }

--- a/Bugsnag/Helpers/BSGInternalErrorReporter.h
+++ b/Bugsnag/Helpers/BSGInternalErrorReporter.h
@@ -10,28 +10,12 @@
 
 #import "BSGDefines.h"
 
-@class BugsnagAppWithState;
-@class BugsnagConfiguration;
-@class BugsnagDeviceWithState;
 @class BugsnagEvent;
-@class BugsnagNotifier;
 
 NS_ASSUME_NONNULL_BEGIN
 
 /// Returns a concise desription of the error including its domain, code, and debug description or localizedDescription.
 NSString *_Nullable BSGErrorDescription(NSError *_Nullable error);
-
-// MARK: -
-
-@protocol BSGInternalErrorReporterDataSource <NSObject>
-
-@property (readonly, nonatomic) BugsnagConfiguration *configuration;
-
-- (BugsnagAppWithState *)generateAppWithState:(NSDictionary *)systemInfo;
-
-- (BugsnagDeviceWithState *)generateDeviceWithState:(NSDictionary *)systemInfo;
-
-@end
 
 // MARK: -
 
@@ -43,7 +27,7 @@ BSG_OBJC_DIRECT_MEMBERS
 /// Runs the block immediately if sharedInstance exists, otherwise runs the block once sharedInstance has been created.
 + (void)performBlock:(void (^)(BSGInternalErrorReporter *))block;
 
-- (instancetype)initWithDataSource:(id<BSGInternalErrorReporterDataSource>)dataSource NS_DESIGNATED_INITIALIZER;
+- (instancetype)initWithApiKey:(NSString *)apiKey endpoint:(NSURL *)endpoint NS_DESIGNATED_INITIALIZER;
 
 - (instancetype)init UNAVAILABLE_ATTRIBUTE;
 

--- a/Bugsnag/include/Bugsnag/BugsnagDevice.h
+++ b/Bugsnag/include/Bugsnag/BugsnagDevice.h
@@ -38,12 +38,12 @@ BUGSNAG_EXTERN
 @property (copy, nullable, nonatomic) NSString *manufacturer;
 
 /**
- * The model name of the device used
+ * The model ID of the device used, e.g. "iPhone14,1" or "MacBookPro17,1"
  */
 @property (copy, nullable, nonatomic) NSString *model;
 
 /**
- * The model number of the device used
+ * The model number of the device used, e.g. "N841AP"
  */
 @property (copy, nullable, nonatomic) NSString *modelNumber;
 

--- a/Tests/BugsnagTests/BSGInternalErrorReporterTests.m
+++ b/Tests/BugsnagTests/BSGInternalErrorReporterTests.m
@@ -17,7 +17,7 @@
 #import "BugsnagEvent+Private.h"
 #import "BugsnagNotifier.h"
 
-@interface BSGInternalErrorReporterTests : XCTestCase <BSGInternalErrorReporterDataSource>
+@interface BSGInternalErrorReporterTests : XCTestCase
 
 @property (nonatomic) BugsnagConfiguration *configuration;
 
@@ -33,9 +33,13 @@
     self.configuration = [[BugsnagConfiguration alloc] initWithApiKey:@"0192837465afbecd0192837465afbecd"];
 }
 
+- (BSGInternalErrorReporter *)makeReporter {
+    return [[BSGInternalErrorReporter alloc] initWithApiKey:self.configuration.apiKey endpoint:[NSURL URLWithString:self.configuration.endpoints.notify]];
+}
+
 - (void)testEventWithErrorClass {
     BugsnagConfiguration *configuration = [[BugsnagConfiguration alloc] initWithApiKey:@"0192837465afbecd0192837465afbecd"];
-    BSGInternalErrorReporter *reporter = [[BSGInternalErrorReporter alloc] initWithDataSource:self];
+    BSGInternalErrorReporter *reporter = [self makeReporter];
     
     BugsnagEvent *event = [reporter eventWithErrorClass:@"Internal error" context:@"test" message:@"Something went wrong" diagnostics:@{}];
     XCTAssertEqualObjects(event.errors[0].errorClass, @"Internal error");
@@ -54,7 +58,7 @@
 
 - (void)testEventWithException {
     BugsnagConfiguration *configuration = [[BugsnagConfiguration alloc] initWithApiKey:@"0192837465afbecd0192837465afbecd"];
-    BSGInternalErrorReporter *reporter = [[BSGInternalErrorReporter alloc] initWithDataSource:self];
+    BSGInternalErrorReporter *reporter = [self makeReporter];
     
     NSException *exception = nil;
     @try {
@@ -80,7 +84,7 @@
 
 - (void)testEventWithRecrashReport {
     BugsnagConfiguration *configuration = [[BugsnagConfiguration alloc] initWithApiKey:@"0192837465afbecd0192837465afbecd"];
-    BSGInternalErrorReporter *reporter = [[BSGInternalErrorReporter alloc] initWithDataSource:self];
+    BSGInternalErrorReporter *reporter = [self makeReporter];
     
     NSString *path = [[NSBundle bundleForClass:[self class]] pathForResource:@"RecrashReport" ofType:@"json" inDirectory:@"Data"];
     id recrashReport = [NSJSONSerialization JSONObjectWithData:[NSData dataWithContentsOfFile:path] options:0 error:nil];
@@ -105,7 +109,7 @@
     self.configuration.endpoints.notify = @"https://notify.example.com";
     
     BugsnagNotifier *notifier = [[BugsnagNotifier alloc] init];
-    BSGInternalErrorReporter *reporter = [[BSGInternalErrorReporter alloc] initWithDataSource:self];
+    BSGInternalErrorReporter *reporter = [self makeReporter];
 
     BugsnagEvent *event = [[BugsnagEvent alloc] init];
     
@@ -132,7 +136,7 @@
         XCTAssertNotNil(reporter);
         [expectation fulfill];
     }];
-    [BSGInternalErrorReporter setSharedInstance:[[BSGInternalErrorReporter alloc] initWithDataSource:self]];
+    [BSGInternalErrorReporter setSharedInstance:[[BSGInternalErrorReporter alloc] initWithApiKey:self.configuration.apiKey endpoint:[NSURL URLWithString:self.configuration.endpoints.notify]]];
     [self waitForExpectations:@[expectation] timeout:1];
     
     expectation = [self expectationWithDescription:@"+performBlock: block is called immediately"];


### PR DESCRIPTION
## Goal

Make `BSGInternalErrorReporter` more independent from rest of notifier, to reduce likelihood of issues like that fixed by https://github.com/bugsnag/bugsnag-cocoa/pull/1474.

## Changeset

Removes `BSGInternalErrorReporterDataSource` protocol.

Makes `BSGInternalErrorReporter` populate (limited) device information itself.

## Testing

Verified by unit tests & E2E scenarios.