### PR TITLE
Remove trigger of RN tests

### DIFF
--- a/.buildkite/pipeline.yml
+++ b/.buildkite/pipeline.yml
@@ -2,16 +2,6 @@ env:
   LANG: "en_GB.UTF-8"
 
 steps:
-  - label: 'Trigger RN tests for all builds of our next branch'
-    if: build.branch == "next"
-    trigger: 'bugsnag-js'
-    build:
-      branch: 'next'
-      message: 'Run RN tests with latest Cocoa next branch'
-      env:
-        BUILD_RN_WITH_LATEST_NATIVES: "true"
-    async: true
-
   ##############################################################################
   #
   # Build


### PR DESCRIPTION
## Goal

Remove trigger of RN tests in the build.

## Design

A new mechanism for testing our cross-platform notifiers is being developed and the older mechanism has already been removed from bugsnag-js.

## Testing

Covered by CI.