### PR TITLE
Truncate error class, error message and context

### DIFF
--- a/Bugsnag/Helpers/BSGSerialization.h
+++ b/Bugsnag/Helpers/BSGSerialization.h
@@ -25,7 +25,7 @@ typedef struct _BSGTruncateContext {
     NSUInteger length;
 } BSGTruncateContext;
 
-NSString * BSGTruncateString(BSGTruncateContext *context, NSString *string);
+NSString * BSGTruncateString(BSGTruncateContext *context, NSString *_Nullable string);
 
 id BSGTruncateStrings(BSGTruncateContext *context, id object);
 

--- a/Bugsnag/Payload/BugsnagEvent.m
+++ b/Bugsnag/Payload/BugsnagEvent.m
@@ -728,6 +728,15 @@ BSG_OBJC_DIRECT_MEMBERS
         .maxLength = maxLength
     };
     
+    if (self.context) {
+        self.context = BSGTruncateString(&context, self.context);
+    }
+    
+    for (BugsnagError *error in self.errors) {
+        error.errorClass = BSGTruncateString(&context, error.errorClass);
+        error.errorMessage = BSGTruncateString(&context, error.errorMessage);
+    }
+    
     for (BugsnagBreadcrumb *breadcrumb in self.breadcrumbs) {
         breadcrumb.message = BSGTruncateString(&context, breadcrumb.message);
         breadcrumb.metadata = BSGTruncateStrings(&context, breadcrumb.metadata);

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,13 @@
 Changelog
 =========
 
+## TBD
+
+### Bug fixes
+
+* Truncate additional data to reduce number of oversized payloads.
+  [#1501](https://github.com/bugsnag/bugsnag-cocoa/pull/1501)
+
 ## 6.25.0 (2022-10-26)
 
 ### Enhancements


### PR DESCRIPTION
## Goal

Reduce number of oversized payloads due to exceeding back-end's size limit.

Follow-up to https://github.com/bugsnag/bugsnag-cocoa/pull/1449

## Changeset

Truncates additional strings that can potentially get long:
* `context`
* `errorClass`
* `errorMessage`

## Testing

<!-- How was it tested? What manual and automated tests were
     run/added? -->