### PR TITLE
Relax multiplatform stacktrace checks

### DIFF
--- a/features/crashprobe.feature
+++ b/features/crashprobe.feature
@@ -139,7 +139,7 @@ Feature: Reporting crash events
     And the exception "message" matches "Attempted to dereference (garbage|null) pointer"
     And the exception "errorClass" equals "EXC_BAD_ACCESS"
     And the "method" of stack frame 0 equals "objc_msgSend"
-    And the "method" of stack frame 1 equals one of:
+    And the stacktrace contains one of the following methods:
       | ARM   | __29-[ReleasedObjectScenario run]_block_invoke |
       | Intel | -[ReleasedObjectScenario run]                  |
     And the "isPC" of stack frame 0 is true

--- a/features/steps/reusable_steps.rb
+++ b/features/steps/reusable_steps.rb
@@ -129,7 +129,7 @@ Then('the stacktrace contains one of the following methods:') do |possible_value
   expected = possible_values.raw.flatten
   stacktrace = Maze::Helper.read_key_path(Maze::Server.errors.current[:body], field)
   methods = stacktrace.map { |frame| frame["method"] }
-  contains = expected.any { |expected_method| methods.include?(expected_method) }
+  contains = expected.any? { |expected_method| methods.include?(expected_method) }
   Maze.check.true(contains, "Stacktrace methods #{methods} did not contain #{expected}")
 end
 

--- a/features/steps/reusable_steps.rb
+++ b/features/steps/reusable_steps.rb
@@ -124,6 +124,15 @@ Then('the stacktrace contains methods:') do |table|
   Maze.check.true(contains, "Stacktrace methods #{actual} did not contain #{expected}")
 end
 
+Then('the stacktrace contains one of the following methods:') do |possible_values|
+  field = "events.0.exceptions.0.stacktrace"
+  expected = possible_values.raw.flatten
+  stacktrace = Maze::Helper.read_key_path(Maze::Server.errors.current[:body], field)
+  methods = stacktrace.map { |frame| frame["method"] }
+  contains = expected.any { |expected_method| methods.include?(expected_method) }
+  Maze.check.true(contains, "Stacktrace methods #{methods} did not contain #{expected}")
+end
+
 Then('the received sessions match:') do |table|
   requests = Maze::Server.sessions.remaining
   match_count = 0


### PR DESCRIPTION
## Goal

We have some potential issues with MacOS tests running on Intel and ARM architectures, where stacktraces can differ in small ways.

This change adds a new test step that verifies that a specific method appears in the stacktrace, without worrying about what specific stackframe it's in.

Note - I've kept the check validating the entire stack method, as the makes it more explicit which frame methods are reliable on each platform, even if the check could be relaxed to just ensuring a specific string is present.