### PR TITLE
Add e2e tests for iOS 16

### DIFF
--- a/.buildkite/pipeline.full.yml
+++ b/.buildkite/pipeline.full.yml
@@ -7,6 +7,64 @@ steps:
   # E2E tests
   #
 
+  - label: 'iOS 15 E2E tests batch 1'
+    depends_on:
+      - cocoa_fixture
+    timeout_in_minutes: 60
+    agents:
+      queue: opensource
+    plugins:
+      artifacts#v1.5.0:
+        download: "features/fixtures/ios/output/ipa_url.txt"
+        upload: "maze_output/failed/**/*"
+      docker-compose#v3.7.0:
+        pull: cocoa-maze-runner
+        run: cocoa-maze-runner
+        command:
+          - "--app=@build/ipa_url.txt"
+          - "--farm=bs"
+          - "--device=IOS_15"
+          - "--appium-version=1.21.0"
+          - "--fail-fast"
+          - "--exclude=features/[e-z].*.feature$"
+          - "--order=random"
+    concurrency: 24
+    concurrency_group: browserstack-app
+    concurrency_method: eager
+    retry:
+      automatic:
+        - exit_status: -1  # Agent was lost
+          limit: 2
+
+  - label: 'iOS 15 E2E tests batch 2'
+    depends_on:
+      - cocoa_fixture
+    timeout_in_minutes: 60
+    agents:
+      queue: opensource
+    plugins:
+      artifacts#v1.5.0:
+        download: "features/fixtures/ios/output/ipa_url.txt"
+        upload: "maze_output/failed/**/*"
+      docker-compose#v3.7.0:
+        pull: cocoa-maze-runner
+        run: cocoa-maze-runner
+        command:
+          - "--app=@build/ipa_url.txt"
+          - "--farm=bs"
+          - "--device=IOS_15"
+          - "--appium-version=1.21.0"
+          - "--fail-fast"
+          - "--exclude=features/[a-d].*.feature$"
+          - "--order=random"
+    concurrency: 24
+    concurrency_group: browserstack-app
+    concurrency_method: eager
+    retry:
+      automatic:
+        - exit_status: -1  # Agent was lost
+          limit: 2
+
   - label: 'iOS 14 E2E tests batch 1'
     depends_on:
       - cocoa_fixture

--- a/.buildkite/pipeline.yml
+++ b/.buildkite/pipeline.yml
@@ -206,7 +206,7 @@ steps:
   # Barebones E2E tests
   #
 
-  - label: 'iOS 15 E2E tests batch 1'
+  - label: 'iOS 16 E2E tests batch 1'
     depends_on:
       - cocoa_fixture
     timeout_in_minutes: 60
@@ -222,7 +222,7 @@ steps:
         command:
           - "--app=@build/ipa_url.txt"
           - "--farm=bs"
-          - "--device=IOS_15"
+          - "--device=IOS_16"
           - "--appium-version=1.21.0"
           - "--fail-fast"
           - "--exclude=features/[e-z].*.feature$"
@@ -235,7 +235,7 @@ steps:
         - exit_status: -1  # Agent was lost
           limit: 2
 
-  - label: 'iOS 15 E2E tests batch 2'
+  - label: 'iOS 16 E2E tests batch 2'
     depends_on:
       - cocoa_fixture
     timeout_in_minutes: 60
@@ -251,7 +251,7 @@ steps:
         command:
           - "--app=@build/ipa_url.txt"
           - "--farm=bs"
-          - "--device=IOS_15"
+          - "--device=IOS_16"
           - "--appium-version=1.21.0"
           - "--fail-fast"
           - "--exclude=features/[a-d].*.feature$"


### PR DESCRIPTION
## Goal

Add e2e tests for iOS 16.

## Design

Moves the existing iOS 15 tests to the full pipelines (straight copy-paste) and adds iOS 16 to the basic pipeline.

## Testing

Covered by a basic CI run.