### PR TITLE
Fix flaky test AppHangDidBecomeActiveScenario

### DIFF
--- a/features/fixtures/shared/scenarios/AppHangDidBecomeActiveScenario.swift
+++ b/features/fixtures/shared/scenarios/AppHangDidBecomeActiveScenario.swift
@@ -4,12 +4,13 @@ class AppHangDidBecomeActiveScenario: Scenario {
     
     override func startBugsnag() {
         config.appHangThresholdMillis = 2_000
+        self.config.autoTrackSessions = false;
         super.startBugsnag()
     }
     
     override func run() {
         NotificationCenter.default.addObserver(forName: UIApplication.didBecomeActiveNotification, object: nil, queue: nil) {
-            NSLog("Recevied \($0.name), now sleeping for 3 seconds...")
+            NSLog("Received \($0.name), now sleeping for 3 seconds...")
             Thread.sleep(forTimeInterval: 3)
         }
     }

--- a/features/fixtures/shared/scenarios/AppHangDidEnterBackgroundScenario.swift
+++ b/features/fixtures/shared/scenarios/AppHangDidEnterBackgroundScenario.swift
@@ -4,7 +4,7 @@ class AppHangDidEnterBackgroundScenario: Scenario {
     
     override func run() {
         NotificationCenter.default.addObserver(forName: UIApplication.didEnterBackgroundNotification, object: nil, queue: nil) {
-            NSLog("Recevied \($0.name), now hanging indefinitely...")
+            NSLog("Received \($0.name), now hanging indefinitely...")
             while true {}
         }
     }


### PR DESCRIPTION
## Goal

Fix flaky test AppHangDidBecomeActiveScenario.

## Design

This test has failed a couple of times on iOS 12 recently due to session requests being cut off mid transit (due to the app being shut down by Maze Runner.

The fix it to simply disable sessions for the scenario, as it does not care about them.

## Testing

Covered by CI.