### PR TITLE
[PLAT-9335] sanitize nsnull

### DIFF
--- a/Bugsnag/Helpers/BSGSerialization.m
+++ b/Bugsnag/Helpers/BSGSerialization.m
@@ -21,6 +21,9 @@ id BSGSanitizeObject(id obj) {
 }
 
 NSMutableDictionary * BSGSanitizeDict(NSDictionary *input) {
+    if (![input isKindOfClass:[NSDictionary class]]) {
+        return nil;
+    }
     __block NSMutableDictionary *output =
         [NSMutableDictionary dictionaryWithCapacity:[input count]];
     [input enumerateKeysAndObjectsUsingBlock:^(id _Nonnull key, id _Nonnull obj,
@@ -45,6 +48,9 @@ static NSArray * BSGSanitizeArray(NSArray *input) {
 }
 
 NSString * BSGTruncateString(BSGTruncateContext *context, NSString *string) {
+    if (![string isKindOfClass:[NSString class]]) {
+        return nil;
+    }
     const NSUInteger inputLength = string.length;
     if (inputLength <= context->maxLength) return string;
     // Prevent chopping in the middle of a composed character sequence


### PR DESCRIPTION
## Goal

The react-native client is passing NSNull to cocoa, which is not being properly sanitized. This PR makes sure these values are properly checked.

## Testing

Re-ran all tests.
Checked that this indeed fixes the CI failures in bugsnag-js: https://github.com/bugsnag/bugsnag-js/pull/1889
