### PR TITLE
Plat 9367 thermal state workaround

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,16 @@
 Changelog
 =========
 
+## TBD
+
+### Bug fixes
+
+* Workaround for thermal state lock re-entry bug on iOS 15.0.2-15.1.1.
+  [1514]https://github.com/bugsnag/bugsnag-cocoa/pull/1514
+
+* Clean up compiler warnings about data races and nullability.
+  [1515](https://github.com/bugsnag/bugsnag-cocoa/pull/1515)
+
 ## 6.25.1 (2022-12-07)
 
 ### Bug fixes


### PR DESCRIPTION
## Goal

A bug from iOS 15.0.2 to 15.1.1 causes `ThermalStateDidChangeNotification` to on rare occasions be posted from within `-[NSProcessInfo thermalState]`, which triggers a recursive call for any listeners since they will in turn call `-[NSProcessInfo thermalState]` and trigger recursion detection in `_os_unfair_lock` (`_os_unfair_lock_recursive_abort`).

See https://github.com/bugsnag/bugsnag-cocoa/issues/1511

Ref: https://github.com/Tencent/matrix/blob/master/matrix/matrix-iOS/Matrix/WCCrashBlockMonitor/CrashBlockPlugin/Main/BlockMonitor/WCBlockMonitorMgr.mm#L493

## Design

This PR defers the `-[NSProcessInfo thermalState]` call to a background thread as a workaround.

## Testing

Manually tested