### PR TITLE
onError blocked from running if releaseStage not in enabledReleaseStages

### DIFF
--- a/Bugsnag/Client/BugsnagClient.m
+++ b/Bugsnag/Client/BugsnagClient.m
@@ -747,6 +747,12 @@ BSG_OBJC_DIRECT_MEMBERS
 - (void)notifyInternal:(BugsnagEvent *_Nonnull)event
                  block:(BugsnagOnErrorBlock)block
 {
+    // Checks whether releaseStage is in enabledReleaseStages, blocking onError callback from running if it is not.
+    if (!self.configuration.shouldSendReports || ![event shouldBeSent]) {
+        bsg_log_info("Discarding error because releaseStage '%@' not in enabledReleaseStages", self.configuration.releaseStage);
+        return;
+    }
+    
     NSString *errorClass = event.errors.firstObject.errorClass;
     if ([self.configuration shouldDiscardErrorClass:errorClass]) {
         bsg_log_info(@"Discarding event because errorClass \"%@\" matched configuration.discardClasses", errorClass);

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,12 @@
 Changelog
 =========
+## TBD
+
+## Bug fixes
+
+* onError blocked from running if releaseStage not in enabledReleaseStages.
+  [1518](https://github.com/bugsnag/bugsnag-cocoa/pull/1518)
+
 
 ## 6.25.2 (2023-01-18)
 


### PR DESCRIPTION
## Goal

Modify BugSnag cocoa so that onError blocks will not run/be applied if `releaseStage` not in `enabledReleaseStages`. This is to bring BugSnag cocoas functionality in to line with the products specifications.

## Design

I tested at which point `BugsnagClient.m` runs onError callbacks (defined at Bugsnag.notify), identifying this as a part of the `notifyInternal` method. This was done by printing the `event` objects metadata to the console to check whether metadata from the `onError` callback had been applied yet.  

## Changeset

The relevant `try catch` block has been nested inside an` if else` statement. 

The `if` statement checks if `enabledReleaseStages` contains `releaseStage` (based on values in self.configuration), allowing the callback `try catch` block to run if it does. If not, the `try catch` block is skipped, and `bsg_log_info` is used to print print an info message to the console. 

## Testing

This has been tested manually by modifying the `releaseStage` and `enabledReleaseStages` in the Bugsnag configuration. From manual testing this works fine. 

I am currently trying to work out how creating new automatic tests works.