### PR TITLE
build: remove infer due to homebrew deprecation

### DIFF
--- a/.github/workflows/pull_request.yml
+++ b/.github/workflows/pull_request.yml
@@ -14,11 +14,9 @@ jobs:
       with:
         ref: ${{ github.event.pull_request.head.sha }}
     - name: Install dependencies
-      run: brew install infer oclint && gem install xcpretty
+      run: brew install oclint && gem install xcpretty
     - name: Build framework
       run: make compile_commands.json
-    - name: Infer
-      run: make infer
     - name: OCLint
       run: make oclint
 

--- a/examples/objective-c-ios/objective-c-ios.xcodeproj/project.xcworkspace/contents.xcworkspacedata
+++ b/examples/objective-c-ios/objective-c-ios.xcodeproj/project.xcworkspace/contents.xcworkspacedata
@@ -1,0 +1,7 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<Workspace
+   version = "1.0">
+   <FileRef
+      location = "self:">
+   </FileRef>
+</Workspace>


### PR DESCRIPTION
## Goal

The static analysis tool [Infer](https://github.com/facebook/infer) has now been deprecated in Homebrew as it doesn't build in the latest Xcode (see [change](https://github.com/iMichka/homebrew-core/commit/790c3b085c023cb69586c3abfb65562b77c44a6b)).

## Changeset

Removing the check temporarily to get the build pipelines running whilst we look at our options and alternative tools.