### PR TITLE
[Plat-9721] fix race condition in BSGRunContext

### DIFF
--- a/Bugsnag/Helpers/BSGRunContext.m
+++ b/Bugsnag/Helpers/BSGRunContext.m
@@ -74,12 +74,12 @@ static void InitRunContext() {
     }
     
     BSGRunContextUpdateTimestamp();
-    InstallTimer();
-    
     BSGRunContextUpdateMemory();
     if (!bsg_runContext->memoryLimit) {
         bsg_log_debug(@"Cannot query `memoryLimit` on this device");
     }
+
+    InstallTimer();
     
     // Set `structVersion` last so that BSGRunContextLoadLast() will reject data
     // that is not fully initialised.


### PR DESCRIPTION
## Goal

`BSGRunContext.InitRunContext()` was spawning a BG task that calls `BSGRunContextUpdateMemory()`, which `InitRunContext()` is also calling, resulting in a race condition.

## Design

Change the order to call `BSGRunContextUpdateMemory()` before spawning the BG task.

## Testing

Tested manually.