### PR TITLE
[Plat-9721] fix race condition in BSGRunContext

### DIFF
--- a/Bugsnag/Helpers/BSGHardware.h
+++ b/Bugsnag/Helpers/BSGHardware.h
@@ -18,11 +18,11 @@
 #pragma mark Device
 
 #if TARGET_OS_IOS
-static inline UIDevice *BSGGetDevice() {
+static inline UIDevice *BSGGetDevice(void) {
     return [UIDEVICE currentDevice];
 }
 #elif TARGET_OS_WATCH
-static inline WKInterfaceDevice *BSGGetDevice() {
+static inline WKInterfaceDevice *BSGGetDevice(void) {
     return [WKInterfaceDevice currentDevice];
 }
 #endif

--- a/Bugsnag/Helpers/BSGInternalErrorReporter.m
+++ b/Bugsnag/Helpers/BSGInternalErrorReporter.m
@@ -283,7 +283,7 @@ static void (^ startupBlock_)(BSGInternalErrorReporter *);
 
 // Intentionally differs from +[BSG_KSSystemInfo deviceAndAppHash]
 // See ROAD-1488
-static NSString * DeviceId() {
+static NSString * DeviceId(void) {
     CC_SHA1_CTX ctx;
     CC_SHA1_Init(&ctx);
 

--- a/Bugsnag/Helpers/BSGRunContext.h
+++ b/Bugsnag/Helpers/BSGRunContext.h
@@ -77,7 +77,7 @@ void BSGRunContextUpdateTimestamp(void);
 #pragma mark -
 
 #ifdef FOUNDATION_EXTERN
-static inline bool BSGRunContextWasCriticalThermalState() {
+static inline bool BSGRunContextWasCriticalThermalState(void) {
 #pragma clang diagnostic push
 #pragma clang diagnostic ignored "-Wunguarded-availability-new"
     return bsg_lastRunContext && bsg_lastRunContext->thermalState == NSProcessInfoThermalStateCritical;
@@ -89,16 +89,16 @@ static inline bool BSGRunContextWasCriticalThermalState() {
 bool BSGRunContextWasKilled(void);
 #endif
 
-static inline bool BSGRunContextWasLaunching() {
+static inline bool BSGRunContextWasLaunching(void) {
     return bsg_lastRunContext && bsg_lastRunContext->isLaunching;
 }
 
 #if BSG_HAVE_OOM_DETECTION
-static inline bool BSGRunContextWasMemoryWarning() {
+static inline bool BSGRunContextWasMemoryWarning(void) {
     return bsg_lastRunContext && bsg_lastRunContext->memoryPressure > DISPATCH_MEMORYPRESSURE_NORMAL;
 }
 #endif
 
-static inline bool BSGRunContextWasTerminating() {
+static inline bool BSGRunContextWasTerminating(void) {
     return bsg_lastRunContext && bsg_lastRunContext->isTerminating;
 }

--- a/Bugsnag/Helpers/BSGRunContext.m
+++ b/Bugsnag/Helpers/BSGRunContext.m
@@ -45,7 +45,7 @@ static void InstallTimer(void);
 #pragma mark - Initial setup
 
 /// Populates `bsg_runContext`
-static void InitRunContext() {
+static void InitRunContext(void) {
     bsg_runContext->isDebuggerAttached = bsg_ksmachisBeingTraced();
     
     bsg_runContext->isLaunching = YES;
@@ -74,19 +74,19 @@ static void InitRunContext() {
     }
     
     BSGRunContextUpdateTimestamp();
-    InstallTimer();
-    
     BSGRunContextUpdateMemory();
     if (!bsg_runContext->memoryLimit) {
         bsg_log_debug(@"Cannot query `memoryLimit` on this device");
     }
+
+    InstallTimer();
     
     // Set `structVersion` last so that BSGRunContextLoadLast() will reject data
     // that is not fully initialised.
     bsg_runContext->structVersion = BSGRUNCONTEXT_VERSION;
 }
 
-static uint64_t GetBootTime() {
+static uint64_t GetBootTime(void) {
     struct timeval tv;
     size_t len = sizeof(tv);
     int ret = sysctl((int[]){CTL_KERN, KERN_BOOTTIME}, 2, &tv, &len, NULL, 0);
@@ -94,7 +94,7 @@ static uint64_t GetBootTime() {
     return (uint64_t)tv.tv_sec * USEC_PER_SEC + (uint64_t)tv.tv_usec;
 }
 
-static bool GetIsActive() {
+static bool GetIsActive(void) {
 #if TARGET_OS_OSX
     return GetIsForeground();
 #endif
@@ -110,7 +110,7 @@ static bool GetIsActive() {
 #endif
 }
 
-static bool GetIsForeground() {
+static bool GetIsForeground(void) {
 #if TARGET_OS_OSX
     return [[NSAPPLICATION sharedApplication] isActive];
 #endif
@@ -182,7 +182,7 @@ static UIApplication * GetUIApplication(void) {
 
 #endif
 
-static void InstallTimer() {
+static void InstallTimer(void) {
     static dispatch_source_t timer;
     
     dispatch_queue_t queue = dispatch_get_global_queue(QOS_CLASS_UTILITY, 0);
@@ -206,27 +206,43 @@ static void InstallTimer() {
 
 #if TARGET_OS_IOS || TARGET_OS_TV || TARGET_OS_OSX
 
-static void NoteAppActive() {
+static void NoteAppActive(__unused CFNotificationCenterRef center,
+                          __unused void *observer,
+                          __unused CFNotificationName name,
+                          __unused const void *object,
+                          __unused CFDictionaryRef userInfo) {
     bsg_runContext->isActive = YES;
     bsg_runContext->isForeground = YES;
     BSGRunContextUpdateTimestamp();
 }
 
-static void NoteAppBackground() {
+static void NoteAppBackground(__unused CFNotificationCenterRef center,
+                              __unused void *observer,
+                              __unused CFNotificationName name,
+                              __unused const void *object,
+                              __unused CFDictionaryRef userInfo) {
     bsg_runContext->isActive = NO;
     bsg_runContext->isForeground = NO;
     BSGRunContextUpdateTimestamp();
 }
 
 #if !TARGET_OS_OSX
-static void NoteAppInactive() {
+static void NoteAppInactive(__unused CFNotificationCenterRef center,
+                            __unused void *observer,
+                            __unused CFNotificationName name,
+                            __unused const void *object,
+                            __unused CFDictionaryRef userInfo) {
     bsg_runContext->isActive = NO;
     bsg_runContext->isForeground = YES;
     BSGRunContextUpdateTimestamp();
 }
 #endif
 
-static void NoteAppWillTerminate() {
+static void NoteAppWillTerminate(__unused CFNotificationCenterRef center,
+                                 __unused void *observer,
+                                 __unused CFNotificationName name,
+                                 __unused const void *object,
+                                 __unused CFDictionaryRef userInfo) {
     bsg_runContext->isTerminating = YES;
     BSGRunContextUpdateTimestamp();
 }
@@ -235,15 +251,27 @@ static void NoteAppWillTerminate() {
 
 #if TARGET_OS_IOS
 
-static void NoteBatteryLevel() {
+static void NoteBatteryLevel(__unused CFNotificationCenterRef center,
+                             __unused void *observer,
+                             __unused CFNotificationName name,
+                             __unused const void *object,
+                             __unused CFDictionaryRef userInfo) {
     bsg_runContext->batteryLevel = BSGGetDevice().batteryLevel;
 }
 
-static void NoteBatteryState() {
+static void NoteBatteryState(__unused CFNotificationCenterRef center,
+                             __unused void *observer,
+                             __unused CFNotificationName name,
+                             __unused const void *object,
+                             __unused CFDictionaryRef userInfo) {
     bsg_runContext->batteryState = BSGGetDevice().batteryState;
 }
 
-static void NoteOrientation() {
+static void NoteOrientation(__unused CFNotificationCenterRef center,
+                            __unused void *observer,
+                            __unused CFNotificationName name,
+                            __unused const void *object,
+                            __unused CFDictionaryRef userInfo) {
     UIDeviceOrientation orientation = [UIDEVICE currentDevice].orientation;
     if (orientation != UIDeviceOrientationUnknown) {
         bsg_runContext->lastKnownOrientation = orientation;
@@ -272,7 +300,7 @@ static void NoteThermalState(__unused CFNotificationCenterRef center,
 
 #if BSG_HAVE_OOM_DETECTION
 
-static void ObserveMemoryPressure() {
+static void ObserveMemoryPressure(void) {
     // DISPATCH_SOURCE_TYPE_MEMORYPRESSURE arrives slightly sooner than
     // UIApplicationDidReceiveMemoryWarningNotification
     dispatch_source_t source =
@@ -293,7 +321,7 @@ static void ObserveMemoryPressure() {
 
 #endif
 
-static void AddObservers() {
+static void AddObservers(void) {
     CFNotificationCenterRef center = CFNotificationCenterGetLocalCenter();
     
 #define OBSERVE(name, function) CFNotificationCenterAddObserver(\
@@ -341,11 +369,11 @@ static void AddObservers() {
 
 #pragma mark - Misc
 
-void BSGRunContextUpdateTimestamp() {
+void BSGRunContextUpdateTimestamp(void) {
     ATOMIC_SET(bsg_runContext->timestamp, CFAbsoluteTimeGetCurrent());
 }
 
-static void UpdateHostMemory() {
+static void UpdateHostMemory(void) {
     static _Atomic mach_port_t host_atomic = 0;
     mach_port_t host = atomic_load(&host_atomic);
     if (!host) {
@@ -366,7 +394,7 @@ static void UpdateHostMemory() {
     bsg_runContext->hostMemoryFree = hostMemoryFree;
 }
 
-static void UpdateTaskMemory() {
+static void UpdateTaskMemory(void) {
     task_vm_info_data_t task_vm = {0};
     mach_msg_type_number_t count = TASK_VM_INFO_COUNT;
     kern_return_t kr = task_info(current_task(), TASK_VM_INFO,
@@ -391,7 +419,7 @@ static void UpdateTaskMemory() {
 #endif
 }
 
-void BSGRunContextUpdateMemory() {
+void BSGRunContextUpdateMemory(void) {
     UpdateTaskMemory();
     UpdateHostMemory();
 }
@@ -401,7 +429,7 @@ void BSGRunContextUpdateMemory() {
 
 #if !TARGET_OS_WATCH
 
-bool BSGRunContextWasKilled() {
+bool BSGRunContextWasKilled(void) {
     // App extensions have a different lifecycle and the heuristic used for
     // finding app terminations rooted in fixable code does not apply
     if ([BSG_KSSystemInfo isRunningInAppExtension]) {

--- a/Bugsnag/KSCrash/Source/KSCrash/Recording/BSG_KSCrashState.m
+++ b/Bugsnag/KSCrash/Source/KSCrash/Recording/BSG_KSCrashState.m
@@ -208,7 +208,7 @@ void bsg_kscrashstate_notifyAppCrash(void) {
     bsg_kscrashstate_i_saveState(bsg_g_state, bsg_g_stateFilePath);
 }
 
-void bsg_kscrashstate_updateDurationStats() {
+void bsg_kscrashstate_updateDurationStats(void) {
     uint64_t timeNow = mach_absolute_time();
     const double duration = bsg_ksmachtimeDifferenceInSeconds(
         timeNow, bsg_g_state->lastUpdateDurationsTime ?: bsg_g_state->appLaunchTime);

--- a/Bugsnag/KSCrash/Source/KSCrash/Recording/BSG_KSSystemInfo.m
+++ b/Bugsnag/KSCrash/Source/KSCrash/Recording/BSG_KSSystemInfo.m
@@ -48,7 +48,7 @@
 #import <CommonCrypto/CommonDigest.h>
 #import <mach-o/dyld.h>
 
-static inline bool is_jailbroken() {
+static inline bool is_jailbroken(void) {
     static bool initialized_jb;
     static bool is_jb;
     if(!initialized_jb) {
@@ -72,7 +72,7 @@ static inline bool is_jailbroken() {
  * https://opensource.apple.com/source/xnu/xnu-7195.81.3/libsyscall/wrappers/system-version-compat.c.auto.html
  */
 #if !TARGET_OS_SIMULATOR
-static NSDictionary * bsg_systemversion() {
+static NSDictionary * bsg_systemversion(void) {
     int fd = -1;
     char buffer[1024] = {0};
     const char *file = "/System/Library/CoreServices/SystemVersion.plist";

--- a/Bugsnag/KSCrash/Source/KSCrash/Recording/Tools/BSG_KSMach.c
+++ b/Bugsnag/KSCrash/Source/KSCrash/Recording/Tools/BSG_KSMach.c
@@ -152,7 +152,7 @@ bool bsg_ksmachfillState(const thread_t thread, const thread_state_t state,
 }
 #endif
 
-thread_t bsg_ksmachthread_self() {
+thread_t bsg_ksmachthread_self(void) {
     thread_t thread_self = mach_thread_self();
     mach_port_deallocate(mach_task_self(), thread_self);
     return thread_self;

--- a/Bugsnag/KSCrash/Source/KSCrash/Recording/Tools/BSG_KSMachHeaders.c
+++ b/Bugsnag/KSCrash/Source/KSCrash/Recording/Tools/BSG_KSMachHeaders.c
@@ -50,7 +50,7 @@ static dispatch_queue_t bsg_g_serial_queue;
 
 static BSG_Mach_Header_Info *g_self_image;
 
-BSG_Mach_Header_Info *bsg_mach_headers_get_images() {
+BSG_Mach_Header_Info *bsg_mach_headers_get_images(void) {
     if (!bsg_g_mach_headers_images_head) {
         bsg_mach_headers_initialize();
         bsg_mach_headers_register_dyld_images();
@@ -59,7 +59,7 @@ BSG_Mach_Header_Info *bsg_mach_headers_get_images() {
     return bsg_g_mach_headers_images_head;
 }
 
-BSG_Mach_Header_Info *bsg_mach_headers_get_main_image() {
+BSG_Mach_Header_Info *bsg_mach_headers_get_main_image(void) {
     for (BSG_Mach_Header_Info *img = bsg_mach_headers_get_images(); img != NULL; img = img->next) {
         if (img->header->filetype == MH_EXECUTE) {
             return img;
@@ -73,7 +73,7 @@ BSG_Mach_Header_Info *bsg_mach_headers_get_self_image(void) {
     return g_self_image;
 }
 
-void bsg_mach_headers_initialize() {
+void bsg_mach_headers_initialize(void) {
     
     // Clear any existing headers to reset the head/tail pointers
     for (BSG_Mach_Header_Info *img = bsg_g_mach_headers_images_head; img != NULL; ) {
@@ -88,7 +88,7 @@ void bsg_mach_headers_initialize() {
     g_self_image = NULL;
 }
 
-static void bsg_mach_headers_register_dyld_images() {
+static void bsg_mach_headers_register_dyld_images(void) {
     // /usr/lib/dyld's mach header is is not exposed via the _dyld APIs, so to be able to include information
     // about stack frames in dyld`start (for example) we need to acess "_dyld_all_image_infos"
     task_dyld_info_data_t dyld_info = {0};
@@ -114,7 +114,7 @@ static void bsg_mach_headers_register_dyld_images() {
     }
 }
 
-static void bsg_mach_headers_register_for_changes() {
+static void bsg_mach_headers_register_for_changes(void) {
     // Register for binary images being loaded and unloaded. dyld calls the add function once
     // for each library that has already been loaded and then keeps this cache up-to-date
     // with future changes

--- a/Bugsnag/Payload/BugsnagThread.m
+++ b/Bugsnag/Payload/BugsnagThread.m
@@ -26,12 +26,12 @@
 // Protect access to thread-unsafe bsg_kscrashsentry_suspendThreads()
 static pthread_mutex_t bsg_suspend_threads_mutex = PTHREAD_MUTEX_INITIALIZER;
 
-static void suspend_threads() {
+static void suspend_threads(void) {
     pthread_mutex_lock(&bsg_suspend_threads_mutex);
     bsg_kscrashsentry_suspendThreads();
 }
 
-static void resume_threads() {
+static void resume_threads(void) {
     bsg_kscrashsentry_resumeThreads();
     pthread_mutex_unlock(&bsg_suspend_threads_mutex);
 }

--- a/Bugsnag/include/Bugsnag/BSG_KSCrashReportWriter.h
+++ b/Bugsnag/include/Bugsnag/BSG_KSCrashReportWriter.h
@@ -190,7 +190,7 @@ typedef struct BSG_KSCrashReportWriter {
      *
      * @param name The name to give this element.
      *
-     * @param value A pointer to the JSON data.
+     * @param jsonElement A pointer to the JSON data.
      */
     void (*addJSONElement)(const struct BSG_KSCrashReportWriter *writer,
                            const char *name, const char *jsonElement);


### PR DESCRIPTION
## Goal

`BSGRunContext.InitRunContext()` was spawning a BG task that calls `BSGRunContextUpdateMemory()`, which `InitRunContext()` is also calling, resulting in a race condition.

## Design

Change the order to call `BSGRunContextUpdateMemory()` before spawning the BG task.

Also changed all functions defined as `func()` to `func(void)` because xcode cloud no longer allows it.

## Testing

Tested manually.