### PR TITLE
[Plat-9721] race condition  in hostMemoryFree

### DIFF
--- a/Bugsnag/Helpers/BSGRunContext.m
+++ b/Bugsnag/Helpers/BSGRunContext.m
@@ -391,7 +391,7 @@ static void UpdateHostMemory(void) {
     }
     
     size_t hostMemoryFree = host_vm.free_count * vm_kernel_page_size;
-    bsg_runContext->hostMemoryFree = hostMemoryFree;
+    ATOMIC_SET(bsg_runContext->hostMemoryFree, hostMemoryFree);
 }
 
 static void UpdateTaskMemory(void) {


### PR DESCRIPTION
## Goal

Another race condition identified by Apple. Use atomics like for the other fields of this type.
