### PR TITLE
[PLAT-9724] Disable oom test on ios 16

### DIFF
--- a/features/barebone_tests.feature
+++ b/features/barebone_tests.feature
@@ -243,6 +243,7 @@ Feature: Barebone tests
     And the "isLR" of stack frame 0 is null
 
   @skip_macos
+  @skip_ios_16 # https://smartbear.atlassian.net/browse/PLAT-9724
   Scenario: Barebone test: Out Of Memory
     When I run "OOMScenario"
 

--- a/features/support/env.rb
+++ b/features/support/env.rb
@@ -69,6 +69,14 @@ def skip_below(os, version)
   skip_this_scenario("Skipping scenario") if Maze::Helper.get_current_platform == os and Maze.config.os_version < version
 end
 
+def skip_between(os, version_lo, version_hi)
+  skip_this_scenario("Skipping scenario") if Maze::Helper.get_current_platform == os and Maze.config.os_version >= version_lo and Maze.config.os_version <= version_hi
+end
+
+Before('@skip_ios_16') do |scenario|
+  skip_between('ios', 16, 16.99)
+end
+
 Before('@skip_below_ios_11') do |scenario|
   skip_below('ios', 11)
 end


### PR DESCRIPTION
## Goal

The OOM scenario flakes often on ios 16, so disable it on that OS for now.
