### PR TITLE
Disable breadcrumb disk storage when not required

### DIFF
--- a/Bugsnag/Breadcrumbs/BugsnagBreadcrumbs.h
+++ b/Bugsnag/Breadcrumbs/BugsnagBreadcrumbs.h
@@ -33,8 +33,6 @@ BSG_OBJC_DIRECT_MEMBERS
 
 /**
  * Store a new serialized breadcrumb.
- *
- * This method is not intended to be used from other classes, it is exposed to facilitate unit testing.
  */
 - (void)addBreadcrumbWithData:(NSData *)data writeToDisk:(BOOL)writeToDisk;
 

--- a/Bugsnag/Breadcrumbs/BugsnagBreadcrumbs.m
+++ b/Bugsnag/Breadcrumbs/BugsnagBreadcrumbs.m
@@ -109,7 +109,7 @@ BSG_OBJC_DIRECT_MEMBERS
     if (!data) {
         return;
     }
-    [self addBreadcrumbWithData:data writeToDisk:YES];
+    [self addBreadcrumbWithData:data writeToDisk:[self shouldWriteToDisk]];
 }
 
 - (void)addBreadcrumbWithData:(NSData *)data writeToDisk:(BOOL)writeToDisk {
@@ -188,6 +188,14 @@ BSG_OBJC_DIRECT_MEMBERS
         }
     }
     return YES;
+}
+
+- (BOOL)shouldWriteToDisk {
+#if TARGET_OS_WATCH
+    return NO;
+#else
+    return self.config.enabledErrorTypes.ooms || self.config.enabledErrorTypes.thermalKills;
+#endif
 }
 
 - (void)removeAllBreadcrumbs {

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,12 @@
 Changelog
 =========
 
+## TBD
+
+### Bug fixes
+
+* Disabled breadcrumb disk storage when not required
+
 ## 6.26.0 (2023-03-08)
 
 ### Enhancements

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,7 @@ Changelog
 ### Bug fixes
 
 * Disabled breadcrumb disk storage when not required
+  [1534](https://github.com/bugsnag/bugsnag-cocoa/pull/1534)
 
 ## 6.26.0 (2023-03-08)
 

--- a/Tests/BugsnagTests/BugsnagBreadcrumbsTest.m
+++ b/Tests/BugsnagTests/BugsnagBreadcrumbsTest.m
@@ -564,6 +564,42 @@ static void * executeBlock(void *ptr) {
     }];
 }
 
+- (void)testShouldCacheBreadcrumbsIfOOMErrorsAreSupported {
+    BugsnagConfiguration *config = [[BugsnagConfiguration alloc] initWithApiKey:DUMMY_APIKEY_32CHAR_1];
+    config.enabledErrorTypes.thermalKills = NO;
+    config.enabledErrorTypes.ooms = YES;
+    self.crumbs = [[BugsnagBreadcrumbs alloc] initWithConfiguration:config];
+    [self.crumbs removeAllBreadcrumbs];
+    [self.crumbs addBreadcrumb:WithMessage(@"this is a test")];
+    awaitBreadcrumbSync(self.crumbs);
+    NSArray *cachedBredcrumbs = [self.crumbs cachedBreadcrumbs];
+    XCTAssertEqual(1, cachedBredcrumbs.count);
+}
+
+- (void)testShouldCacheBreadcrumbsIfThermalKillsAreSupported {
+    BugsnagConfiguration *config = [[BugsnagConfiguration alloc] initWithApiKey:DUMMY_APIKEY_32CHAR_1];
+    config.enabledErrorTypes.ooms = NO;
+    config.enabledErrorTypes.thermalKills = YES;
+    self.crumbs = [[BugsnagBreadcrumbs alloc] initWithConfiguration:config];
+    [self.crumbs removeAllBreadcrumbs];
+    [self.crumbs addBreadcrumb:WithMessage(@"this is a test")];
+    awaitBreadcrumbSync(self.crumbs);
+    NSArray *cachedBredcrumbs = [self.crumbs cachedBreadcrumbs];
+    XCTAssertEqual(1, cachedBredcrumbs.count);
+}
+
+- (void)testShouldNotCacheBreadcrumbsIfOOMsAndThermalKillsAreNotSupported {
+    BugsnagConfiguration *config = [[BugsnagConfiguration alloc] initWithApiKey:DUMMY_APIKEY_32CHAR_1];
+    config.enabledErrorTypes.thermalKills = NO;
+    config.enabledErrorTypes.ooms = NO;
+    self.crumbs = [[BugsnagBreadcrumbs alloc] initWithConfiguration:config];
+    [self.crumbs removeAllBreadcrumbs];
+    [self.crumbs addBreadcrumb:WithMessage(@"this is a test")];
+    awaitBreadcrumbSync(self.crumbs);
+    NSArray *cachedBredcrumbs = [self.crumbs cachedBreadcrumbs];
+    XCTAssertEqual(0, cachedBredcrumbs.count);
+}
+
 @end
 
 #pragma mark -

--- a/Tests/BugsnagTests/BugsnagBreadcrumbsTest.m
+++ b/Tests/BugsnagTests/BugsnagBreadcrumbsTest.m
@@ -176,6 +176,7 @@ BSGBreadcrumbType BSGBreadcrumbTypeFromString(NSString *value);
     XCTAssertEqualObjects(value[0][@"type"], @"state");
 }
 
+#if !TARGET_OS_WATCH
 - (void)testPersistentCrumbManual {
     awaitBreadcrumbSync(self.crumbs);
     NSArray<BugsnagBreadcrumb *> *breadcrumbs = [self.crumbs cachedBreadcrumbs];
@@ -205,6 +206,7 @@ BSGBreadcrumbType BSGBreadcrumbTypeFromString(NSString *value);
     XCTAssertEqualObjects(breadcrumbs[3].metadata[@"captain"], @"Bob");
     XCTAssertNotNil(breadcrumbs[3].timestamp);
 }
+#endif
 
 - (void)testDefaultDiscardByType {
     BugsnagConfiguration *config = [[BugsnagConfiguration alloc] initWithApiKey:DUMMY_APIKEY_32CHAR_1];
@@ -564,6 +566,20 @@ static void * executeBlock(void *ptr) {
     }];
 }
 
+#if TARGET_OS_WATCH
+
+- (void)testShouldNotCacheBreadcrumbsOnWatchOs {
+    BugsnagConfiguration *config = [[BugsnagConfiguration alloc] initWithApiKey:DUMMY_APIKEY_32CHAR_1];
+    self.crumbs = [[BugsnagBreadcrumbs alloc] initWithConfiguration:config];
+    [self.crumbs removeAllBreadcrumbs];
+    [self.crumbs addBreadcrumb:WithMessage(@"this is a test")];
+    awaitBreadcrumbSync(self.crumbs);
+    NSArray *cachedBredcrumbs = [self.crumbs cachedBreadcrumbs];
+    XCTAssertEqual(0, cachedBredcrumbs.count);
+}
+
+#else
+
 - (void)testShouldCacheBreadcrumbsIfOOMErrorsAreSupported {
     BugsnagConfiguration *config = [[BugsnagConfiguration alloc] initWithApiKey:DUMMY_APIKEY_32CHAR_1];
     config.enabledErrorTypes.thermalKills = NO;
@@ -599,6 +615,8 @@ static void * executeBlock(void *ptr) {
     NSArray *cachedBredcrumbs = [self.crumbs cachedBreadcrumbs];
     XCTAssertEqual(0, cachedBredcrumbs.count);
 }
+
+#endif
 
 @end
 


### PR DESCRIPTION
## Goal

Breadcrumbs are currently stored on disk so that they can be included in OOM and Thermal Kill events.

If these event types are disabled or not supported on the target platform, storage should be disabled to reduce overhead.

Seems particularly important on watchOS.

## Changeset

Disable breadcrumb disk storage when not required

## Testing

Unit tests