### PR TITLE
Move iOS 14 tests to BitBar from BrowserStack

### DIFF
--- a/.buildkite/pipeline.full.yml
+++ b/.buildkite/pipeline.full.yml
@@ -58,68 +58,71 @@ steps:
     concurrency_group: 'bitbar-app'
     concurrency_method: eager
 
-  #
-  # BrowserStack
-  #
-
-  - label: ':browserstack: iOS 14 E2E tests batch 1'
+  - label: ':bitbar: iOS 14 E2E tests batch 1'
     depends_on:
       - cocoa_fixture
     timeout_in_minutes: 60
     agents:
       queue: opensource
     plugins:
-      artifacts#v1.5.0:
-        download: "features/fixtures/ios/output/ipa_url.txt"
+      artifacts#v1.9.0:
+        download: "features/fixtures/ios/output/iOSTestApp.ipa"
         upload: "maze_output/failed/**/*"
-      docker-compose#v3.7.0:
-        pull: cocoa-maze-runner
-        run: cocoa-maze-runner
+      docker-compose#v4.7.0:
+        pull: cocoa-maze-runner-bitbar
+        run: cocoa-maze-runner-bitbar
+        service-ports: true
         command:
-          - "--app=@build/ipa_url.txt"
-          - "--farm=bs"
+          - "--app=/app/build/iOSTestApp.ipa"
+          - "--farm=bb"
           - "--device=IOS_14"
-          - "--appium-version=1.21.0"
+          - "--no-tunnel"
+          - "--aws-public-ip"
           - "--fail-fast"
           - "--exclude=features/[e-z].*.feature$"
           - "--order=random"
-    concurrency: 24
-    concurrency_group: browserstack-app
+    concurrency: 25
+    concurrency_group: 'bitbar-app'
     concurrency_method: eager
     retry:
       automatic:
         - exit_status: -1  # Agent was lost
           limit: 2
 
-  - label: ':browserstack: iOS 14 E2E tests batch 2'
+  - label: ':bitbar: iOS 14 E2E tests batch 2'
     depends_on:
       - cocoa_fixture
     timeout_in_minutes: 60
     agents:
       queue: opensource
     plugins:
-      artifacts#v1.5.0:
-        download: "features/fixtures/ios/output/ipa_url.txt"
+      artifacts#v1.9.0:
+        download: "features/fixtures/ios/output/iOSTestApp.ipa"
         upload: "maze_output/failed/**/*"
-      docker-compose#v3.7.0:
-        pull: cocoa-maze-runner
-        run: cocoa-maze-runner
+      docker-compose#v4.7.0:
+        pull: cocoa-maze-runner-bitbar
+        run: cocoa-maze-runner-bitbar
+        service-ports: true
         command:
-          - "--app=@build/ipa_url.txt"
-          - "--farm=bs"
+          - "--app=/app/build/iOSTestApp.ipa"
+          - "--farm=bb"
           - "--device=IOS_14"
-          - "--appium-version=1.21.0"
+          - "--no-tunnel"
+          - "--aws-public-ip"
           - "--fail-fast"
           - "--exclude=features/[a-d].*.feature$"
           - "--order=random"
-    concurrency: 24
-    concurrency_group: browserstack-app
+    concurrency: 25
+    concurrency_group: 'bitbar-app'
     concurrency_method: eager
     retry:
       automatic:
         - exit_status: -1  # Agent was lost
           limit: 2
 
+  #
+  # BrowserStack
+  #
   - label: ':browserstack: iOS 13 E2E tests batch 1'
     depends_on:
       - cocoa_fixture

--- a/.buildkite/pipeline.yml
+++ b/.buildkite/pipeline.yml
@@ -316,6 +316,36 @@ steps:
         - exit_status: -1  # Agent was lost
           limit: 2
 
+  - label: ':bitbar: iOS 14 barebone tests'
+    depends_on:
+      - cocoa_fixture
+    timeout_in_minutes: 60
+    agents:
+      queue: opensource
+    plugins:
+      artifacts#v1.9.0:
+        download: "features/fixtures/ios/output/iOSTestApp.ipa"
+        upload: "maze_output/failed/**/*"
+      docker-compose#v4.7.0:
+        pull: cocoa-maze-runner-bitbar
+        run: cocoa-maze-runner-bitbar
+        service-ports: true
+        command:
+          - "--app=/app/build/iOSTestApp.ipa"
+          - "--farm=bb"
+          - "--device=IOS_14"
+          - "--no-tunnel"
+          - "--aws-public-ip"
+          - "--fail-fast"
+          - "features/barebone_tests.feature"
+    concurrency: 25
+    concurrency_group: 'bitbar-app'
+    concurrency_method: eager
+    retry:
+      automatic:
+        - exit_status: -1  # Agent was lost
+          limit: 2
+
   #
   # BrowserStack
   #
@@ -369,34 +399,6 @@ steps:
           - "--fail-fast"
           - "--exclude=features/[a-d].*.feature$"
           - "--order=random"
-    concurrency: 24
-    concurrency_group: browserstack-app
-    concurrency_method: eager
-    retry:
-      automatic:
-        - exit_status: -1  # Agent was lost
-          limit: 2
-
-  - label: ':browserstack: iOS 14 barebone tests'
-    depends_on:
-      - cocoa_fixture
-    timeout_in_minutes: 60
-    agents:
-      queue: opensource
-    plugins:
-      artifacts#v1.5.0:
-        download: "features/fixtures/ios/output/ipa_url.txt"
-        upload: "maze_output/failed/**/*"
-      docker-compose#v3.7.0:
-        pull: cocoa-maze-runner
-        run: cocoa-maze-runner
-        command:
-          - "--app=@build/ipa_url.txt"
-          - "--farm=bs"
-          - "--device=IOS_14"
-          - "--appium-version=1.21.0"
-          - "--fail-fast"
-          - "features/barebone_tests.feature"
     concurrency: 24
     concurrency_group: browserstack-app
     concurrency_method: eager


### PR DESCRIPTION
## Goal

Moves all iOS 14 e2e tests from using the BrowserStack device farm to BitBar.
This PR targets another set of test moves, and these can be chained together or re-targeted as required.