### PR TITLE
Move BrowserStack iOS 12 e2e tests to BitBar

### DIFF
--- a/.buildkite/pipeline.full.yml
+++ b/.buildkite/pipeline.full.yml
@@ -182,67 +182,71 @@ steps:
         - exit_status: -1  # Agent was lost
           limit: 2
 
-  #
-  # BrowserStack
-  #
-  - label: ':browserstack: iOS 12 E2E tests batch 1'
+  - label: ':bitbar: iOS 12 E2E tests batch 1'
     depends_on:
       - cocoa_fixture
     timeout_in_minutes: 60
     agents:
       queue: opensource
     plugins:
-      artifacts#v1.5.0:
-        download: "features/fixtures/ios/output/ipa_url.txt"
+      artifacts#v1.9.0:
+        download: "features/fixtures/ios/output/iOSTestApp.ipa"
         upload: "maze_output/failed/**/*"
-      docker-compose#v3.7.0:
-        pull: cocoa-maze-runner
-        run: cocoa-maze-runner
+      docker-compose#v4.7.0:
+        pull: cocoa-maze-runner-bitbar
+        run: cocoa-maze-runner-bitbar
+        service-ports: true
         command:
-          - "--app=@build/ipa_url.txt"
-          - "--farm=bs"
-          - "--device=IOS_12"
-          - "--appium-version=1.17.0"
+          - "--app=/app/build/iOSTestApp.ipa"
+          - "--farm=bb"
+          - "--device=IOS_13"
+          - "--no-tunnel"
+          - "--aws-public-ip"
           - "--fail-fast"
           - "--exclude=features/[e-z].*.feature$"
           - "--order=random"
-    concurrency: 24
-    concurrency_group: browserstack-app
+    concurrency: 25
+    concurrency_group: 'bitbar-app'
     concurrency_method: eager
     retry:
       automatic:
         - exit_status: -1  # Agent was lost
           limit: 2
 
-  - label: ':browserstack: iOS 12 E2E tests batch 2'
+  - label: ':bitbar: iOS 12 E2E tests batch 2'
     depends_on:
       - cocoa_fixture
     timeout_in_minutes: 60
     agents:
       queue: opensource
     plugins:
-      artifacts#v1.5.0:
-        download: "features/fixtures/ios/output/ipa_url.txt"
+      artifacts#v1.9.0:
+        download: "features/fixtures/ios/output/iOSTestApp.ipa"
         upload: "maze_output/failed/**/*"
-      docker-compose#v3.7.0:
-        pull: cocoa-maze-runner
-        run: cocoa-maze-runner
+      docker-compose#v4.7.0:
+        pull: cocoa-maze-runner-bitbar
+        run: cocoa-maze-runner-bitbar
+        service-ports: true
         command:
-          - "--app=@build/ipa_url.txt"
-          - "--farm=bs"
-          - "--device=IOS_12"
-          - "--appium-version=1.17.0"
+          - "--app=/app/build/iOSTestApp.ipa"
+          - "--farm=bb"
+          - "--device=IOS_13"
+          - "--no-tunnel"
+          - "--aws-public-ip"
           - "--fail-fast"
           - "--exclude=features/[a-d].*.feature$"
           - "--order=random"
-    concurrency: 24
-    concurrency_group: browserstack-app
+    concurrency: 25
+    concurrency_group: 'bitbar-app'
     concurrency_method: eager
     retry:
       automatic:
         - exit_status: -1  # Agent was lost
           limit: 2
 
+  #
+  # BrowserStack
+  #
   - label: ':browserstack: iOS 11 E2E tests batch 1'
     depends_on:
       - cocoa_fixture

--- a/.buildkite/pipeline.yml
+++ b/.buildkite/pipeline.yml
@@ -376,6 +376,36 @@ steps:
         - exit_status: -1  # Agent was lost
           limit: 2
 
+  - label: ':bitbar: iOS 12 barebone tests'
+    depends_on:
+      - cocoa_fixture
+    timeout_in_minutes: 60
+    agents:
+      queue: opensource
+    plugins:
+      artifacts#v1.9.0:
+        download: "features/fixtures/ios/output/iOSTestApp.ipa"
+        upload: "maze_output/failed/**/*"
+      docker-compose#v4.7.0:
+        pull: cocoa-maze-runner-bitbar
+        run: cocoa-maze-runner-bitbar
+        service-ports: true
+        command:
+          - "--app=/app/build/iOSTestApp.ipa"
+          - "--farm=bb"
+          - "--device=IOS_13"
+          - "--no-tunnel"
+          - "--aws-public-ip"
+          - "--fail-fast"
+          - "features/barebone_tests.feature"
+    concurrency: 25
+    concurrency_group: 'bitbar-app'
+    concurrency_method: eager
+    retry:
+      automatic:
+        - exit_status: -1  # Agent was lost
+          limit: 2
+
   #
   # BrowserStack
   #
@@ -429,34 +459,6 @@ steps:
           - "--fail-fast"
           - "--exclude=features/[a-d].*.feature$"
           - "--order=random"
-    concurrency: 24
-    concurrency_group: browserstack-app
-    concurrency_method: eager
-    retry:
-      automatic:
-        - exit_status: -1  # Agent was lost
-          limit: 2
-
-  - label: ':browserstack: iOS 12 barebone tests'
-    depends_on:
-      - cocoa_fixture
-    timeout_in_minutes: 60
-    agents:
-      queue: opensource
-    plugins:
-      artifacts#v1.5.0:
-        download: "features/fixtures/ios/output/ipa_url.txt"
-        upload: "maze_output/failed/**/*"
-      docker-compose#v3.7.0:
-        pull: cocoa-maze-runner
-        run: cocoa-maze-runner
-        command:
-          - "--app=@build/ipa_url.txt"
-          - "--farm=bs"
-          - "--device=IOS_12"
-          - "--appium-version=1.17.0"
-          - "--fail-fast"
-          - "features/barebone_tests.feature"
     concurrency: 24
     concurrency_group: browserstack-app
     concurrency_method: eager


### PR DESCRIPTION
## Goal

Moves all iOS 12 e2e tests from using the BrowserStack device farm to BitBar.
This PR targets another set of test moves, and these can be chained together or re-targeted as required.