### PR TITLE
[Plat-9942] race condition getting host memory

### DIFF
--- a/Bugsnag/Helpers/BSGRunContext.h
+++ b/Bugsnag/Helpers/BSGRunContext.h
@@ -70,6 +70,8 @@ void BSGRunContextInit(NSString *_Nonnull path);
 
 #pragma mark -
 
+size_t bsg_getHostMemory(void);
+
 void BSGRunContextUpdateMemory(void);
 
 void BSGRunContextUpdateTimestamp(void);

--- a/Bugsnag/KSCrash/Source/KSCrash/Recording/BSG_KSSystemInfo.m
+++ b/Bugsnag/KSCrash/Source/KSCrash/Recording/BSG_KSSystemInfo.m
@@ -378,7 +378,7 @@ BSG_OBJC_DIRECT_MEMBERS
     sysInfo[@BSG_KSSystemField_Jailbroken] = @(is_jailbroken());
     sysInfo[@BSG_KSSystemField_TimeZone] = [[NSTimeZone localTimeZone] abbreviation];
     sysInfo[@BSG_KSSystemField_Memory] = @{
-        @BSG_KSCrashField_Free: @(bsg_runContext->hostMemoryFree),
+        @BSG_KSCrashField_Free: @(bsg_getHostMemory()),
         @BSG_KSCrashField_Size: @(NSProcessInfo.processInfo.physicalMemory)
     };
 

--- a/examples/objective-c-ios/objective-c-ios.xcodeproj/xcshareddata/xcschemes/objective-c-ios.xcscheme
+++ b/examples/objective-c-ios/objective-c-ios.xcodeproj/xcshareddata/xcschemes/objective-c-ios.xcscheme
@@ -34,6 +34,8 @@
       buildConfiguration = "Release"
       selectedDebuggerIdentifier = ""
       selectedLauncherIdentifier = "Xcode.IDEFoundation.Launcher.PosixSpawn"
+      enableThreadSanitizer = "YES"
+      enableUBSanitizer = "YES"
       launchStyle = "0"
       useCustomWorkingDirectory = "NO"
       ignoresPersistentStateOnLaunch = "NO"

--- a/examples/objective-c-osx/objective-c-osx.xcodeproj/xcshareddata/xcschemes/objective-c-osx.xcscheme
+++ b/examples/objective-c-osx/objective-c-osx.xcodeproj/xcshareddata/xcschemes/objective-c-osx.xcscheme
@@ -44,6 +44,8 @@
       buildConfiguration = "Release"
       selectedDebuggerIdentifier = ""
       selectedLauncherIdentifier = "Xcode.IDEFoundation.Launcher.PosixSpawn"
+      enableThreadSanitizer = "YES"
+      enableUBSanitizer = "YES"
       launchStyle = "0"
       useCustomWorkingDirectory = "NO"
       ignoresPersistentStateOnLaunch = "NO"


### PR DESCRIPTION
## Goal

There was a race condition accessing `bsg_runContext` from `BSG_KSSystemInfo.m`.

## Design

Rather than add more atomics to access parts of `bsg_runContext`, just have KSSystemInfo call the function to fetch the data directly since it's only ever done once.

## Testing

Existing tests cover the expected behaviour, and manual testing under OSX with the thread sanitizer on verifies that the race condition is fixed.
