### PR TITLE
[PLAT-10016] Use original unhandled value for persisting user-reported events 

### DIFF
--- a/Bugsnag/Client/BugsnagClient.m
+++ b/Bugsnag/Client/BugsnagClient.m
@@ -794,7 +794,7 @@ BSG_OBJC_DIRECT_MEMBERS
 
     event.usage = BSGTelemetryCreateUsage(self.configuration);
 
-    if (event.unhandled) {
+    if (event.handledState.originalUnhandledValue) {
         // Unhandled Javscript exceptions from React Native result in the app being terminated shortly after the
         // call to notifyInternal, so the event needs to be persisted to disk for sending in the next session.
         // The fatal "RCTFatalException" / "Unhandled JS Exception" is explicitly ignored by

--- a/Bugsnag/Payload/BugsnagHandledState.h
+++ b/Bugsnag/Payload/BugsnagHandledState.h
@@ -48,6 +48,7 @@ BUGSNAG_EXTERN
 
 @property(nonatomic) BOOL unhandled;
 @property(nonatomic) BOOL unhandledOverridden;
+@property(nonatomic, readonly) BOOL originalUnhandledValue;
 @property(nonatomic, readonly) SeverityReasonType severityReasonType;
 @property(nonatomic, readonly) BSGSeverity originalSeverity;
 @property(nonatomic) BSGSeverity currentSeverity;

--- a/Bugsnag/Payload/BugsnagHandledState.m
+++ b/Bugsnag/Payload/BugsnagHandledState.m
@@ -236,4 +236,8 @@ BSG_OBJC_DIRECT_MEMBERS
     return dict;
 }
 
+- (BOOL)originalUnhandledValue {
+    return self.unhandledOverridden ? !self.unhandled : self.unhandled;
+}
+
 @end

--- a/Tests/BugsnagTests/BugsnagHandledStateTest.m
+++ b/Tests/BugsnagTests/BugsnagHandledStateTest.m
@@ -102,4 +102,22 @@
     XCTAssertNil(state.attrValue);
 }
 
+- (void)testOriginalUnhandled {
+    BugsnagHandledState *unhandledState =
+    [BugsnagHandledState handledStateWithSeverityReason:PromiseRejection];
+    XCTAssertTrue(unhandledState.originalUnhandledValue);
+    
+    unhandledState.unhandledOverridden = YES;
+    XCTAssertFalse(unhandledState.originalUnhandledValue);
+    
+    BugsnagHandledState *handledState =
+    [BugsnagHandledState handledStateWithSeverityReason:HandledError
+                                               severity:BSGSeverityWarning
+                                              attrValue:@"Test"];
+    XCTAssertFalse(handledState.originalUnhandledValue);
+    
+    handledState.unhandledOverridden = YES;
+    XCTAssertTrue(handledState.originalUnhandledValue);
+}
+
 @end


### PR DESCRIPTION
## Goal

Use the original unhandled state of an event and not the overridden unhandled value when determining whether to store an event or upload immediately.

This is more representative of whether the runtime is about to crash, rather than what the developer has changed it to (which is more likely to do with their stability score).

## Changeset

- Added a new property `originalUnhandledValue` to `BugsnagHandledState` that uses the `unhandledOverridden` flag to determine the original handled-ness of the event.
- Updated `notifyInternal` to check `originalUnhandledValue` when deciding whether to persist an event or send immediately

## Testing
- Added a new unit test for `originalUnhandledValue`
- Manually tested overriding the unhandled flag from a React Native (JS) callback and an `onError` block