### PR TITLE
Skip test scenarios tagged with @skip

### DIFF
--- a/features/support/env.rb
+++ b/features/support/env.rb
@@ -69,23 +69,27 @@ def skip_between(os, version_lo, version_hi)
   skip_this_scenario("Skipping scenario") if Maze::Helper.get_current_platform == os and Maze.config.os_version >= version_lo and Maze.config.os_version <= version_hi
 end
 
-Before('@skip_ios_16') do |scenario|
+Before('@skip') do |_scenario|
+  skip_this_scenario("Skipping scenario")
+end
+
+Before('@skip_ios_16') do |_scenario|
   skip_between('ios', 16, 16.99)
 end
 
-Before('@skip_below_ios_11') do |scenario|
+Before('@skip_below_ios_11') do |_scenario|
   skip_below('ios', 11)
 end
 
-Before('@skip_below_ios_13') do |scenario|
+Before('@skip_below_ios_13') do |_scenario|
   skip_below('ios', 13)
 end
 
-Before('@skip_below_macos_10_15') do |scenario|
+Before('@skip_below_macos_10_15') do |_scenario|
   skip_below('macos', 10.15)
 end
 
-Before('@skip_macos') do |scenario|
+Before('@skip_macos') do |_scenario|
   skip_this_scenario("Skipping scenario") if Maze::Helper.get_current_platform == 'macos'
 end
 


### PR DESCRIPTION
## Goal

#1546 intended to skip the Thermal State test scenarios pending further investigation, but there was no handling in place for the `@skip` tag.

## Testing

Tested locally by running against something other than iOS 16 (which also has a specific tag in place).