### PR TITLE
[Plat-9934] Don't generate URLSession on config copy

### DIFF
--- a/Bugsnag/Client/BugsnagClient.m
+++ b/Bugsnag/Client/BugsnagClient.m
@@ -341,7 +341,7 @@ BSG_OBJC_DIRECT_MEMBERS
 }
 
 - (void)sendLaunchCrashSynchronously {
-    if (self.configuration.session.delegateQueue == NSOperationQueue.currentQueue) {
+    if (self.configuration.sessionOrDefault.delegateQueue == NSOperationQueue.currentQueue) {
         bsg_log_warn(@"Cannot send launch crash synchronously because session.delegateQueue is set to the current queue.");
         return;
     }

--- a/Bugsnag/Configuration/BugsnagConfiguration+Private.h
+++ b/Bugsnag/Configuration/BugsnagConfiguration+Private.h
@@ -34,6 +34,8 @@ BSG_OBJC_DIRECT_MEMBERS
 
 @property (readonly, nonatomic) BOOL shouldSendReports;
 
+@property (readonly, nonnull, nonatomic) NSURLSession *sessionOrDefault;
+
 @property (readonly, nullable, nonatomic) NSURL *sessionURL;
 
 @property (readwrite, retain, nonnull, nonatomic) BugsnagUser *user;

--- a/Bugsnag/Configuration/BugsnagConfiguration.m
+++ b/Bugsnag/Configuration/BugsnagConfiguration.m
@@ -41,6 +41,18 @@ const NSUInteger BugsnagAppHangThresholdFatalOnly = INT_MAX;
 
 static const int BSGApiKeyLength = 32;
 
+static NSURLSession *getConfigDefaultURLSession(void);
+static NSURLSession *getConfigDefaultURLSession(void) {
+    static dispatch_once_t once_t;
+    static NSURLSession *session;
+    dispatch_once(&once_t, ^{
+        session = [NSURLSession
+                    sessionWithConfiguration:[NSURLSessionConfiguration
+                                              defaultSessionConfiguration]];
+    });
+    return session;
+}
+
 // =============================================================================
 // MARK: - BugsnagConfiguration
 // =============================================================================
@@ -190,12 +202,6 @@ BSG_OBJC_DIRECT_MEMBERS
     // persistUser isn't settable until post-init.
     _user = BSGGetPersistedUser();
 
-    if ([NSURLSession class]) {
-        _session = [NSURLSession
-            sessionWithConfiguration:[NSURLSessionConfiguration
-                                         defaultSessionConfiguration]];
-    }
-    
     _telemetry = BSGTelemetryAll;
     
     NSString *releaseStage = nil;
@@ -271,6 +277,11 @@ BSG_OBJC_DIRECT_MEMBERS
     if (self.persistUser) {
         BSGSetPersistedUser(user);
     }
+}
+
+- (NSURLSession *)sessionOrDefault {
+    NSURLSession *session = self.session;
+    return session ? session : getConfigDefaultURLSession();
 }
 
 // =============================================================================

--- a/Bugsnag/Delivery/BSGEventUploadOperation.m
+++ b/Bugsnag/Delivery/BSGEventUploadOperation.m
@@ -159,7 +159,7 @@ typedef NS_ENUM(NSUInteger, BSGEventUploadOperationState) {
         }
     }
     
-    BSGPostJSONData(configuration.session, data, requestHeaders, notifyURL, ^(BSGDeliveryStatus status, __unused NSError *deliveryError) {
+    BSGPostJSONData(configuration.sessionOrDefault, data, requestHeaders, notifyURL, ^(BSGDeliveryStatus status, __unused NSError *deliveryError) {
         switch (status) {
             case BSGDeliveryStatusDelivered:
                 bsg_log_debug(@"Uploaded event %@", self.name);

--- a/Bugsnag/Delivery/BSGSessionUploader.m
+++ b/Bugsnag/Delivery/BSGSessionUploader.m
@@ -173,7 +173,7 @@ BSG_OBJC_DIRECT_MEMBERS
         return;
     }
     
-    BSGPostJSONData(self.config.session, data, headers, url, ^(BSGDeliveryStatus status, NSError *error) {
+    BSGPostJSONData(self.config.sessionOrDefault, data, headers, url, ^(BSGDeliveryStatus status, NSError *error) {
         switch (status) {
             case BSGDeliveryStatusDelivered:
                 bsg_log_info(@"Sent session %@", session.id);

--- a/Tests/BugsnagTests/BugsnagConfigurationTests.m
+++ b/Tests/BugsnagTests/BugsnagConfigurationTests.m
@@ -35,7 +35,7 @@
 
 - (void)testDefaultSessionNotNil {
     BugsnagConfiguration *config = [[BugsnagConfiguration alloc] initWithApiKey:DUMMY_APIKEY_32CHAR_1];
-    XCTAssertNotNil(config.session);
+    XCTAssertNotNil(config.sessionOrDefault);
 }
 
 - (void)testDefaultSessionConfig {


### PR DESCRIPTION
## Goal

The configuration object was generating a fresh URLSession whenever none was provided, but since many internal functions end up calling along the same path, the client ended up creating many sessions. This PR cleans up the behaviour a bit.

## Design

Prevent `BugsnagConfiguration` from pre-emptively taking action. I've added a new method `sessionOrDefault`, which calls on a common internal shared session if there was no configured session. This code should ideally be situated elsewhere, but for now we want to keep any changes shallow while we decide how to handle sessions long-term (see PLAT-10067).

## Testing

Outward behaviour should be unaffected, so existing tests are sufficient.
