### PR TITLE
Add CSharp BSGErrorType

### DIFF
--- a/Bugsnag/Payload/BugsnagError.m
+++ b/Bugsnag/Payload/BugsnagError.m
@@ -23,6 +23,7 @@ typedef NSString * BSGErrorTypeString NS_TYPED_ENUM;
 static BSGErrorTypeString const BSGErrorTypeStringCocoa = @"cocoa";
 static BSGErrorTypeString const BSGErrorTypeStringC = @"c";
 static BSGErrorTypeString const BSGErrorTypeStringReactNativeJs = @"reactnativejs";
+static BSGErrorTypeString const BSGErrorTypeStringCSharp = @"csharp";
 
 
 NSString *_Nonnull BSGSerializeErrorType(BSGErrorType errorType) {
@@ -33,6 +34,8 @@ NSString *_Nonnull BSGSerializeErrorType(BSGErrorType errorType) {
             return BSGErrorTypeStringC;
         case BSGErrorTypeReactNativeJs:
             return BSGErrorTypeStringReactNativeJs;
+        case BSGErrorTypeCSharp:
+            return BSGErrorTypeStringCSharp;
     }
 }
 
@@ -43,6 +46,8 @@ BSGErrorType BSGParseErrorType(NSString *errorType) {
         return BSGErrorTypeC;
     } else if ([BSGErrorTypeStringReactNativeJs isEqualToString:errorType]) {
         return BSGErrorTypeReactNativeJs;
+    } else if ([BSGErrorTypeStringCSharp isEqualToString:errorType]) {
+        return BSGErrorTypeCSharp;
     } else {
         return BSGErrorTypeCocoa;
     }

--- a/Bugsnag/include/Bugsnag/BugsnagError.h
+++ b/Bugsnag/include/Bugsnag/BugsnagError.h
@@ -18,7 +18,8 @@
 typedef NS_OPTIONS(NSUInteger, BSGErrorType) {
     BSGErrorTypeCocoa NS_SWIFT_NAME(cocoa), // Swift won't bring in the zeroeth option by default
     BSGErrorTypeC NS_SWIFT_NAME(c), // Fix Swift auto-capitalisation
-    BSGErrorTypeReactNativeJs
+    BSGErrorTypeReactNativeJs,
+    BSGErrorTypeCSharp,
 };
 
 /**

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,11 @@
 Changelog
 =========
 
+## TBD
+
+* Added BSGErrorTypeCSharp
+  [1556](https://github.com/bugsnag/bugsnag-cocoa/pull/1556)
+
 ## 6.26.2 (2023-04-20)
 
 ### Bug fixes

--- a/Tests/BugsnagTests/BugsnagEventTests.m
+++ b/Tests/BugsnagTests/BugsnagEventTests.m
@@ -266,9 +266,14 @@
     
     error.type = BSGErrorTypeReactNativeJs;
     XCTAssertEqualObjects(event.stacktraceTypes, @[@"reactnativejs"]);
-    
+
+    error.type = BSGErrorTypeCSharp;
+    XCTAssertEqualObjects(event.stacktraceTypes, @[@"csharp"]);
+
     NSArray *(^ sorted)(NSArray *) = ^(NSArray *array) { return [array sortedArrayUsingSelector:@selector(compare:)]; };
     
+    error = [[BugsnagError alloc] init];
+    event.errors = @[error];
     error.stacktrace = @[
         [BugsnagStackframe frameFromJson:@{}],
         [BugsnagStackframe frameFromJson:@{@"type": @"cocoa"}],

--- a/Tests/BugsnagTests/BugsnagSwiftPublicAPITests.swift
+++ b/Tests/BugsnagTests/BugsnagSwiftPublicAPITests.swift
@@ -371,6 +371,7 @@ class BugsnagSwiftPublicAPITests: XCTestCase {
         e.type = .cocoa
         e.type = .c
         e.type = .reactNativeJs
+        e.type = .cSharp
     }
 
     func testBugsnagSessionClass() throws {


### PR DESCRIPTION
## Goal

Manually integrating bugsnag-cocoa into a Unity app requires a `BSGErrorTypeCSharp` enum.

## Testing

Updated tests to check the csharp type.
