### PR TITLE
Move iOS 16 tests over to BitBar

### DIFF
--- a/.buildkite/pipeline.yml
+++ b/.buildkite/pipeline.yml
@@ -303,7 +303,7 @@ steps:
         command:
           - "--app=/app/build/iOSTestApp.ipa"
           - "--farm=bb"
-          - "--device=IOS_15"
+          - "--device=IOS_16"
           - "--no-tunnel"
           - "--aws-public-ip"
           - "--fail-fast"
@@ -334,7 +334,7 @@ steps:
         command:
           - "--app=/app/build/iOSTestApp.ipa"
           - "--farm=bb"
-          - "--device=IOS_15"
+          - "--device=IOS_16"
           - "--no-tunnel"
           - "--aws-public-ip"
           - "--fail-fast"

--- a/.buildkite/pipeline.yml
+++ b/.buildkite/pipeline.yml
@@ -286,6 +286,68 @@ steps:
   #
   # BitBar
   #
+  - label: ':BitBar: iOS 16 E2E tests batch 1'
+    depends_on:
+      - cocoa_fixture
+    timeout_in_minutes: 60
+    agents:
+      queue: opensource
+    plugins:
+      artifacts#v1.9.0:
+        download: "features/fixtures/ios/output/iOSTestApp.ipa"
+        upload: "maze_output/failed/**/*"
+      docker-compose#v4.7.0:
+        pull: cocoa-maze-runner-bitbar
+        run: cocoa-maze-runner-bitbar
+        service-ports: true
+        command:
+          - "--app=/app/build/iOSTestApp.ipa"
+          - "--farm=bb"
+          - "--device=IOS_15"
+          - "--no-tunnel"
+          - "--aws-public-ip"
+          - "--fail-fast"
+          - "--exclude=features/[e-z].*.feature$"
+          - "--order=random"
+    concurrency: 25
+    concurrency_group: 'bitbar-app'
+    concurrency_method: eager
+    retry:
+      automatic:
+        - exit_status: -1  # Agent was lost
+          limit: 2
+
+  - label: ':BitBar: iOS 16 E2E tests batch 2'
+    depends_on:
+      - cocoa_fixture
+    timeout_in_minutes: 60
+    agents:
+      queue: opensource
+    plugins:
+      artifacts#v1.9.0:
+        download: "features/fixtures/ios/output/iOSTestApp.ipa"
+        upload: "maze_output/failed/**/*"
+      docker-compose#v4.7.0:
+        pull: cocoa-maze-runner-bitbar
+        run: cocoa-maze-runner-bitbar
+        service-ports: true
+        command:
+          - "--app=/app/build/iOSTestApp.ipa"
+          - "--farm=bb"
+          - "--device=IOS_15"
+          - "--no-tunnel"
+          - "--aws-public-ip"
+          - "--fail-fast"
+          - "--exclude=features/[a-d].*.feature$"
+          - "--order=random"
+    concurrency: 25
+    concurrency_group: 'bitbar-app'
+    concurrency_method: eager
+    retry:
+      automatic:
+        - exit_status: -1  # Agent was lost
+          limit: 2
+
   - label: ':BitBar: iOS 15 barebone tests'
     depends_on:
       - cocoa_fixture
@@ -409,64 +471,6 @@ steps:
   #
   # BrowserStack
   #
-  - label: ':browserstack: iOS 16 E2E tests batch 1'
-    depends_on:
-      - cocoa_fixture
-    timeout_in_minutes: 60
-    agents:
-      queue: opensource
-    plugins:
-      artifacts#v1.5.0:
-        download: "features/fixtures/ios/output/ipa_url.txt"
-        upload: "maze_output/failed/**/*"
-      docker-compose#v3.7.0:
-        pull: cocoa-maze-runner
-        run: cocoa-maze-runner
-        command:
-          - "--app=@build/ipa_url.txt"
-          - "--farm=bs"
-          - "--device=IOS_16"
-          - "--appium-version=1.21.0"
-          - "--fail-fast"
-          - "--exclude=features/[e-z].*.feature$"
-          - "--order=random"
-    concurrency: 5
-    concurrency_group: browserstack-app
-    concurrency_method: eager
-    retry:
-      automatic:
-        - exit_status: -1  # Agent was lost
-          limit: 2
-
-  - label: ':browserstack: iOS 16 E2E tests batch 2'
-    depends_on:
-      - cocoa_fixture
-    timeout_in_minutes: 60
-    agents:
-      queue: opensource
-    plugins:
-      artifacts#v1.5.0:
-        download: "features/fixtures/ios/output/ipa_url.txt"
-        upload: "maze_output/failed/**/*"
-      docker-compose#v3.7.0:
-        pull: cocoa-maze-runner
-        run: cocoa-maze-runner
-        command:
-          - "--app=@build/ipa_url.txt"
-          - "--farm=bs"
-          - "--device=IOS_16"
-          - "--appium-version=1.21.0"
-          - "--fail-fast"
-          - "--exclude=features/[a-d].*.feature$"
-          - "--order=random"
-    concurrency: 5
-    concurrency_group: browserstack-app
-    concurrency_method: eager
-    retry:
-      automatic:
-        - exit_status: -1  # Agent was lost
-          limit: 2
-
   - label: ':browserstack: iOS 11 barebone tests'
     depends_on:
       - cocoa_fixture

--- a/.buildkite/pipeline.yml
+++ b/.buildkite/pipeline.yml
@@ -286,7 +286,7 @@ steps:
   #
   # BitBar
   #
-  - label: ':BitBar: iOS 16 E2E tests batch 1'
+  - label: ':bitbar: iOS 16 E2E tests batch 1'
     depends_on:
       - cocoa_fixture
     timeout_in_minutes: 60
@@ -317,7 +317,7 @@ steps:
         - exit_status: -1  # Agent was lost
           limit: 2
 
-  - label: ':BitBar: iOS 16 E2E tests batch 2'
+  - label: ':bitbar: iOS 16 E2E tests batch 2'
     depends_on:
       - cocoa_fixture
     timeout_in_minutes: 60
@@ -348,7 +348,7 @@ steps:
         - exit_status: -1  # Agent was lost
           limit: 2
 
-  - label: ':BitBar: iOS 15 barebone tests'
+  - label: ':bitbar: iOS 15 barebone tests'
     depends_on:
       - cocoa_fixture
     timeout_in_minutes: 60


### PR DESCRIPTION
## Goal

Since appium 2.0 support is now included in maze-runner, the iOS 16 tests run successfully using BitBar as a device farm.