### PR TITLE
Fix visionOS support

### DIFF
--- a/Bugsnag/Breadcrumbs/BSGNotificationBreadcrumbs.m
+++ b/Bugsnag/Breadcrumbs/BSGNotificationBreadcrumbs.m
@@ -413,7 +413,7 @@ static NSString *nullStringIfBlank(NSString *str) {
 
 #pragma mark -
 
-#if TARGET_OS_IOS
+#if !TARGET_OS_XR && TARGET_OS_IOS
 
 - (void)orientationDidChange:(NSNotification *)notification {
     UIDevice *device = notification.object;

--- a/Bugsnag/Client/BugsnagClient.m
+++ b/Bugsnag/Client/BugsnagClient.m
@@ -435,7 +435,7 @@ BSG_OBJC_DIRECT_MEMBERS
     BSGGetDevice().batteryMonitoringEnabled = FALSE;
 #endif
 
-#if TARGET_OS_IOS
+#if !TARGET_OS_XR && TARGET_OS_IOS
     [[UIDEVICE currentDevice] endGeneratingDeviceOrientationNotifications];
 #endif
 }

--- a/Bugsnag/Helpers/BSGDefines.h
+++ b/Bugsnag/Helpers/BSGDefines.h
@@ -23,6 +23,12 @@
 #define BSG_HAVE_UIDEVICE                     __has_include(<UIKit/UIDevice.h>)
 #define BSG_HAVE_WINDOW                       (TARGET_OS_OSX || TARGET_OS_IOS || TARGET_OS_TV                   )
 
+// Capabilities from future OS versions to allow this to be merged during visionOS beta
+
+#ifndef TARGET_OS_XR
+  #define TARGET_OS_XR 0
+#endif
+
 // Capabilities dependent upon previously defined capabilities
 #define BSG_HAVE_APP_HANG_DETECTION           (BSG_HAVE_MACH_THREADS)
 

--- a/Bugsnag/Helpers/BSGRunContext.m
+++ b/Bugsnag/Helpers/BSGRunContext.m
@@ -253,7 +253,7 @@ static void NoteAppWillTerminate(__unused CFNotificationCenterRef center,
 
 #endif
 
-#if TARGET_OS_IOS
+#if !TARGET_OS_XR && TARGET_OS_IOS
 
 static void NoteBatteryLevel(__unused CFNotificationCenterRef center,
                              __unused void *observer,
@@ -356,7 +356,7 @@ static void AddObservers(void) {
     bsg_runContext->batteryState = BSGGetDevice().batteryState;
 #endif
 
-#if TARGET_OS_IOS
+#if !TARGET_OS_XR && TARGET_OS_IOS
     UIDevice *currentDevice = [UIDEVICE currentDevice];
     [currentDevice beginGeneratingDeviceOrientationNotifications];
     bsg_runContext->lastKnownOrientation = currentDevice.orientation;


### PR DESCRIPTION
## Goal

This fixes a build error when targeting visionOS (xrOS) devices in Xcode 15 beta 2
![Screenshot 2023-06-21 at 11 05 13 PM](https://github.com/bugsnag/bugsnag-cocoa/assets/1163880/22936d7f-3a59-426d-8956-4f7e2b1edba9)

## Design

Per the docs listed here:

https://developer.apple.com/documentation/visionos/bringing-your-app-to-visionos#Isolate-features-that-are-unavailable-in-visionOS

>When separating code for visionOS and iOS, understand that conditional checks for iOS also return true in visionOS, so place visionOS conditions first and execute the iOS code only if visionOS isn’t present.

## Changeset

Added a `!TARGET_OS_XR` condition on the front per recommendations from Apple docs.

## Testing

Imported my fork into my project and it built whereas it did not before.