### PR TITLE
[Plat-10752] no syscall on osx

### DIFF
--- a/Bugsnag/Helpers/BSGDefines.h
+++ b/Bugsnag/Helpers/BSGDefines.h
@@ -19,7 +19,7 @@
 #define BSG_HAVE_REACHABILITY_WWAN            (                 TARGET_OS_IOS || TARGET_OS_TV                   )
 #define BSG_HAVE_SIGNAL                       (TARGET_OS_OSX || TARGET_OS_IOS || TARGET_OS_TV                   )
 #define BSG_HAVE_SIGALTSTACK                  (TARGET_OS_OSX || TARGET_OS_IOS                                   )
-#define BSG_HAVE_SYSCALL                      (TARGET_OS_OSX || TARGET_OS_IOS || TARGET_OS_TV                   )
+#define BSG_HAVE_SYSCALL                      (TARGET_OS_IOS || TARGET_OS_TV                   )
 #define BSG_HAVE_UIDEVICE                     __has_include(<UIKit/UIDevice.h>)
 #define BSG_HAVE_WINDOW                       (TARGET_OS_OSX || TARGET_OS_IOS || TARGET_OS_TV                   )
 

--- a/Bugsnag/KSCrash/Source/KSCrash/Recording/BSG_Jailbreak.h
+++ b/Bugsnag/KSCrash/Source/KSCrash/Recording/BSG_Jailbreak.h
@@ -76,7 +76,7 @@ static inline bool bsg_local_is_insert_libraries_env_var(const char* str) {
 // - Use pointers for output parameters, with labels that identify them as such.
 // - Beware of global consts or defines bleeding through.
 
-#if TARGET_CPU_ARM64
+#if TARGET_CPU_ARM64 && !TARGET_OS_OSX
 #define BSG_HAS_CUSTOM_SYSCALL 1
 
 // ARM64 3-parameter syscall
@@ -105,7 +105,7 @@ static inline bool bsg_local_is_insert_libraries_env_var(const char* str) {
     } \
 } while(0)
 
-#elif TARGET_CPU_X86_64 && defined(__GCC_ASM_FLAG_OUTPUTS__)
+#elif TARGET_CPU_X86_64 && defined(__GCC_ASM_FLAG_OUTPUTS__) && !TARGET_OS_OSX
 #define BSG_HAS_CUSTOM_SYSCALL 1
 
 // X86_64 3-parameter syscall


### PR DESCRIPTION
## Goal

syscall has been deprecated on macos, so don't use it.

## Testing

Checked manually during the compilation phase.