### PR TITLE
[Plat-10822] duplicate -lc++

### DIFF
--- a/Bugsnag.podspec.json
+++ b/Bugsnag.podspec.json
@@ -42,7 +42,7 @@
     "-fvisibility=hidden"
   ],
   "libraries": [
-    "c++", "z"
+    "z"
   ],
   "platforms": {
     "ios": "9.0",

--- a/Bugsnag.xcodeproj/project.pbxproj
+++ b/Bugsnag.xcodeproj/project.pbxproj
@@ -3892,11 +3892,7 @@
 				MTL_ENABLE_DEBUG_INFO = INCLUDE_SOURCE;
 				MTL_FAST_MATH = YES;
 				ONLY_ACTIVE_ARCH = YES;
-				OTHER_LDFLAGS = (
-					"-lc++",
-					"-lz",
-					"-ObjC",
-				);
+				OTHER_LDFLAGS = "-ObjC";
 				PRODUCT_BUNDLE_IDENTIFIER = com.bugsnag.Bugsnag;
 				PRODUCT_NAME = Bugsnag;
 				RUN_CLANG_STATIC_ANALYZER = YES;
@@ -3934,11 +3930,7 @@
 				MACOSX_DEPLOYMENT_TARGET = 10.11;
 				MTL_ENABLE_DEBUG_INFO = NO;
 				MTL_FAST_MATH = YES;
-				OTHER_LDFLAGS = (
-					"-lc++",
-					"-lz",
-					"-ObjC",
-				);
+				OTHER_LDFLAGS = "-ObjC";
 				PRODUCT_BUNDLE_IDENTIFIER = com.bugsnag.Bugsnag;
 				PRODUCT_NAME = Bugsnag;
 				RUN_CLANG_STATIC_ANALYZER = YES;


### PR DESCRIPTION
## Goal

Xcode 15 now warns about duplicate library flags during the linking phase.

Since c++ is now inferred by the compiler, adding `-lc++` hasn't been necessary in Xcode for the past few versions.

This PR removes the manual `-lc++` flag in the project and podspec.

## Testing

Reran all tests to ensure that this doesn't break any builds.
