### PR TITLE
Fixes issue when using Bugsnag on a WatchOS app

### DIFF
--- a/Bugsnag/Helpers/BSGRunContext.m
+++ b/Bugsnag/Helpers/BSGRunContext.m
@@ -109,8 +109,13 @@ static bool GetIsActive(void) {
 #endif
 
 #if TARGET_OS_WATCH
-    WKExtension *ext = [WKExtension sharedExtension];
-    return ext && ext.applicationState == WKApplicationStateActive;
+    if ([BSG_KSSystemInfo isRunningInAppExtension]) {
+        WKExtension *ext = [WKExtension sharedExtension];
+        return ext && ext.applicationState == WKApplicationStateActive;
+    } else {
+        WKApplication *app = [WKApplication sharedApplication];
+        return app && app.applicationState == WKApplicationStateActive;
+    }
 #endif
 }
 
@@ -167,8 +172,13 @@ static bool GetIsForeground(void) {
 #endif
 
 #if TARGET_OS_WATCH
-    WKExtension *ext = [WKExtension sharedExtension];
-    return ext && ext.applicationState != WKApplicationStateBackground;
+    if ([BSG_KSSystemInfo isRunningInAppExtension]) {
+        WKExtension *ext = [WKExtension sharedExtension];
+        return ext && ext.applicationState != WKApplicationStateBackground;
+    } else {
+        WKApplication *app = [WKApplication sharedApplication];
+        return app && app.applicationState == WKApplicationStateBackground;
+    }
 #endif
 }
 


### PR DESCRIPTION
The code was trying to access an extension but on latest WatchOS we can have a standalone app. Related to [this issue](https://github.com/bugsnag/bugsnag-cocoa/issues/1582)

## Goal

Not crash when using Bugsnag on a standalone Apple watch app.

## Design

Just added some checks to see if code is running on an app or extension.

## Testing

See steps in [related issue](https://github.com/bugsnag/bugsnag-cocoa/issues/1582). With this branch the crash does not happen.