### PR TITLE
[Plat-10973] remove nxarchinfo

### DIFF
--- a/Bugsnag/KSCrash/Source/KSCrash/Recording/BSG_KSSystemInfo.m
+++ b/Bugsnag/KSCrash/Source/KSCrash/Recording/BSG_KSSystemInfo.m
@@ -239,11 +239,10 @@ BSG_OBJC_DIRECT_MEMBERS
 }
 
 + (NSString *)currentCPUArch {
-    NSString *result =
-        [self CPUArchForCPUType:bsg_kssysctl_int32ForName("hw.cputype")
-                        subType:bsg_kssysctl_int32ForName("hw.cpusubtype")];
-
-    return result ?: [NSString stringWithUTF8String:bsg_ksmachcurrentCPUArch()];
+    int32_t cpu_type = bsg_kssysctl_int32ForName("hw.cputype");
+    int32_t cpu_subtype = bsg_kssysctl_int32ForName("hw.cpusubtype");
+    NSString *result = [self CPUArchForCPUType:cpu_type subType:cpu_subtype];
+    return result ?: [NSString stringWithFormat:@"unknown (type %d, subtype %d)", cpu_type, cpu_subtype];
 }
 
 // ============================================================================

--- a/Bugsnag/KSCrash/Source/KSCrash/Recording/Tools/BSG_KSMach.c
+++ b/Bugsnag/KSCrash/Source/KSCrash/Recording/Tools/BSG_KSMach.c
@@ -43,11 +43,6 @@
 #pragma mark - General Information -
 // ============================================================================
 
-const char *bsg_ksmachcurrentCPUArch(void) {
-    const NXArchInfo *archInfo = NXGetLocalArchInfo();
-    return archInfo == NULL ? NULL : archInfo->name;
-}
-
 #define RETURN_NAME_FOR_ENUM(A)                                                \
     case A:                                                                    \
         return #A

--- a/Bugsnag/KSCrash/Source/KSCrash/Recording/Tools/BSG_KSMach.h
+++ b/Bugsnag/KSCrash/Source/KSCrash/Recording/Tools/BSG_KSMach.h
@@ -46,12 +46,6 @@ extern "C" {
 #pragma mark - General Information -
 // ============================================================================
 
-/** Get the current CPU architecture.
- *
- * @return The current architecture.
- */
-const char *bsg_ksmachcurrentCPUArch(void);
-
 /** Get the name of a mach exception.
  *
  * @param exceptionType The exception type.


### PR DESCRIPTION
## Goal

NXArchInfo has been deprecated, so remove code that uses it.

## Design

We already have different code that generates the CPU type and subtype, and the NXArchInfo code was just a fallback (and, incidentally, it crashes).

Instead, when the primary cpuarch code fails, it now returns a string of the form `unknown (type 19, subtype 2)`.

## Testing

We can't write an automated test for this fallback code because all known architectures are already handled by the existing primary code. The fallback code will only trigger on a new architecture that we haven't handled yet.
