### PR TITLE
Rationalise BitBar CI concurrency group

### DIFF
--- a/.buildkite/pipeline.full.yml
+++ b/.buildkite/pipeline.full.yml
@@ -31,7 +31,7 @@ steps:
           - "--no-tunnel"
           - "--aws-public-ip"
     concurrency: 25
-    concurrency_group: 'bitbar-app'
+    concurrency_group: 'bitbar'
     concurrency_method: eager
 
   - label: ':bitbar: iOS 15 E2E tests batch 2'
@@ -55,7 +55,7 @@ steps:
           - "--no-tunnel"
           - "--aws-public-ip"
     concurrency: 25
-    concurrency_group: 'bitbar-app'
+    concurrency_group: 'bitbar'
     concurrency_method: eager
 
   - label: ':bitbar: iOS 14 E2E tests batch 1'
@@ -82,7 +82,7 @@ steps:
           - "--exclude=features/[e-z].*.feature$"
           - "--order=random"
     concurrency: 25
-    concurrency_group: 'bitbar-app'
+    concurrency_group: 'bitbar'
     concurrency_method: eager
     retry:
       automatic:
@@ -113,7 +113,7 @@ steps:
           - "--exclude=features/[a-d].*.feature$"
           - "--order=random"
     concurrency: 25
-    concurrency_group: 'bitbar-app'
+    concurrency_group: 'bitbar'
     concurrency_method: eager
     retry:
       automatic:
@@ -144,7 +144,7 @@ steps:
           - "--exclude=features/[e-z].*.feature$"
           - "--order=random"
     concurrency: 25
-    concurrency_group: 'bitbar-app'
+    concurrency_group: 'bitbar'
     concurrency_method: eager
     retry:
       automatic:
@@ -175,7 +175,7 @@ steps:
           - "--exclude=features/[a-d].*.feature$"
           - "--order=random"
     concurrency: 25
-    concurrency_group: 'bitbar-app'
+    concurrency_group: 'bitbar'
     concurrency_method: eager
     retry:
       automatic:
@@ -206,7 +206,7 @@ steps:
           - "--exclude=features/[e-z].*.feature$"
           - "--order=random"
     concurrency: 25
-    concurrency_group: 'bitbar-app'
+    concurrency_group: 'bitbar'
     concurrency_method: eager
     retry:
       automatic:
@@ -237,7 +237,7 @@ steps:
           - "--exclude=features/[a-d].*.feature$"
           - "--order=random"
     concurrency: 25
-    concurrency_group: 'bitbar-app'
+    concurrency_group: 'bitbar'
     concurrency_method: eager
     retry:
       automatic:
@@ -271,7 +271,7 @@ steps:
           - "--exclude=features/[e-z].*.feature$"
           - "--order=random"
     concurrency: 5
-    concurrency_group: browserstack-app
+    concurrency_group: 'browserstack-app'
     concurrency_method: eager
     retry:
       automatic:
@@ -302,7 +302,7 @@ steps:
           - "--exclude=features/[a-d].*.feature$"
           - "--order=random"
     concurrency: 5
-    concurrency_group: browserstack-app
+    concurrency_group: 'browserstack-app'
     concurrency_method: eager
     retry:
       automatic:

--- a/.buildkite/pipeline.yml
+++ b/.buildkite/pipeline.yml
@@ -311,7 +311,7 @@ steps:
           - "--exclude=features/[e-z].*.feature$"
           - "--order=random"
     concurrency: 25
-    concurrency_group: 'bitbar-app'
+    concurrency_group: 'bitbar'
     concurrency_method: eager
     retry:
       automatic:
@@ -342,7 +342,7 @@ steps:
           - "--exclude=features/[a-d].*.feature$"
           - "--order=random"
     concurrency: 25
-    concurrency_group: 'bitbar-app'
+    concurrency_group: 'bitbar'
     concurrency_method: eager
     retry:
       automatic:
@@ -372,7 +372,7 @@ steps:
           - "--fail-fast"
           - "features/barebone_tests.feature"
     concurrency: 25
-    concurrency_group: 'bitbar-app'
+    concurrency_group: 'bitbar'
     concurrency_method: eager
     retry:
       automatic:
@@ -402,7 +402,7 @@ steps:
           - "--fail-fast"
           - "features/barebone_tests.feature"
     concurrency: 25
-    concurrency_group: 'bitbar-app'
+    concurrency_group: 'bitbar'
     concurrency_method: eager
     retry:
       automatic:
@@ -432,7 +432,7 @@ steps:
           - "--fail-fast"
           - "features/barebone_tests.feature"
     concurrency: 25
-    concurrency_group: 'bitbar-app'
+    concurrency_group: 'bitbar'
     concurrency_method: eager
     retry:
       automatic:
@@ -462,7 +462,7 @@ steps:
           - "--fail-fast"
           - "features/barebone_tests.feature"
     concurrency: 25
-    concurrency_group: 'bitbar-app'
+    concurrency_group: 'bitbar'
     concurrency_method: eager
     retry:
       automatic:
@@ -492,7 +492,7 @@ steps:
           - "--appium-version=1.16.0"
           - "features/barebone_tests.feature"
     concurrency: 5
-    concurrency_group: browserstack-app
+    concurrency_group: 'browserstack-app'
     concurrency_method: eager
     retry:
       automatic:
@@ -520,7 +520,7 @@ steps:
           - "--fail-fast"
           - "features/barebone_tests.feature"
     concurrency: 5
-    concurrency_group: browserstack-app
+    concurrency_group: 'browserstack-app'
     concurrency_method: eager
     retry:
       automatic:


### PR DESCRIPTION
## Goal

NOTE: Please let me merge this PR myself, it needs to be merged as the same time as several others to avoid unnecessary failures on CI.

Rationalise the Buildkite concurrency group used to control access to BitBar across all of our repos.

## Design

We were using separate groups fro web and device usage, when in fact they are counted towards the same usage limit.  All groups are now being renamed to simply 'bitbar' with a limit of 25.

The main mistake that I could make here is missing an instance of the old groups (`bitbar-app` and `bitbar-web`, so I am using the global find and replace function of my IDE.

## Changeset

Buildkite concurrency group changes only.

## Testing

Verified by peer review.  