### PR TITLE
Correct format specifier for logged messages

### DIFF
--- a/features/fixtures/ios/iOSTestApp/CommandReaderThread.swift
+++ b/features/fixtures/ios/iOSTestApp/CommandReaderThread.swift
@@ -81,19 +81,19 @@ class CommandReaderThread: Thread {
 }
 
 private func logInfo(_ message: String) {
-    let fullMessage = String(format: "bugsnagci info: %s", message)
+    let fullMessage = String(format: "bugsnagci info: %@", message)
     NSLog("%@", fullMessage)
     kslog("\(Date()) \(fullMessage)")
 }
 
 private func logWarn(_ message: String) {
-    let fullMessage = String(format: "bugsnagci warn: %s", message)
+    let fullMessage = String(format: "bugsnagci warn: %@", message)
     NSLog("%@", fullMessage)
     kslog("\(Date()) \(fullMessage)")
 }
 
 private func logError(_ message: String) {
-    let fullMessage = String(format: "bugsnagci error: %s", message)
+    let fullMessage = String(format: "bugsnagci error: %@", message)
     NSLog("%@", fullMessage)
     kslog("\(Date()) \(fullMessage)")
 }


### PR DESCRIPTION
## Goal

Correct format specifier for logged messages.  Log messages were coming out as garbage.

## Testing

Inspected the device log are a CI run, messages are now logged correctly.