### PR TITLE
[Plat-11112] check app version when detecting OOMs

### DIFF
--- a/Bugsnag/Helpers/BSGRunContext.h
+++ b/Bugsnag/Helpers/BSGRunContext.h
@@ -19,7 +19,7 @@
 // During development this is not strictly necessary since last run's data will
 // not be loaded if the struct's size has changed.
 //
-#define BSGRUNCONTEXT_VERSION 4
+#define BSGRUNCONTEXT_VERSION 5
 
 struct BSGRunContext {
     long structVersion;
@@ -50,6 +50,7 @@ struct BSGRunContext {
     unsigned long long memoryAvailable;
     unsigned long long memoryFootprint;
     unsigned long long memoryLimit;
+    char bundleVersion[32]; // Won't actually get this long but just to be sure.
 };
 
 /// Information about the current run of the app / process.

--- a/Bugsnag/Helpers/BSGUtils.h
+++ b/Bugsnag/Helpers/BSGUtils.h
@@ -39,6 +39,12 @@ static inline NSString * _Nullable BSGStringFromClass(Class _Nullable cls) {
     return cls ? NSStringFromClass((Class _Nonnull)cls) : nil;
 }
 
+/**
+ * Copy characters from src to dst, up to a maximum of length bytes (including the NUL terminator).
+ * Unlike strncpy, this function always ensures that dst is NUL terminated (if length > 0).
+ */
+void bsg_safe_strncpy(char *dst, const char *src, size_t length);
+
 NS_ASSUME_NONNULL_END
 
 __END_DECLS

--- a/Bugsnag/Helpers/BSGUtils.m
+++ b/Bugsnag/Helpers/BSGUtils.m
@@ -10,6 +10,13 @@
 
 #import "BugsnagLogger.h"
 
+void bsg_safe_strncpy(char *dst, const char *src, size_t length) {
+    if (length > 0) {
+        strncpy(dst, src, length);
+        dst[length-1] = 0;
+    }
+}
+
 char *_Nullable BSGCStringWithData(NSData *_Nullable data) {
     char *buffer;
     if (data.length && (buffer = calloc(1, data.length + 1))) {

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,14 @@
 Changelog
 =========
 
+## TBD
+
+### Bug fixes
+
+* Check app version to avoid detecting an app upgrade as an OOM
+  [1597](https://github.com/bugsnag/bugsnag-cocoa/pull/1597)
+
+
 ## 6.27.2 (2023-07-24)
 
 ### Enhancements

--- a/Tests/BugsnagTests/BSGOutOfMemoryTests.m
+++ b/Tests/BugsnagTests/BSGOutOfMemoryTests.m
@@ -133,6 +133,9 @@
     XCTAssertFalse(BSGRunContextWasKilled());
     uuid_copy(lastRunContext.machoUUID, bsg_runContext->machoUUID);
     
+    strncpy(lastRunContext.bundleVersion, "999.99", sizeof(lastRunContext.bundleVersion));
+    XCTAssertFalse(BSGRunContextWasKilled());
+
     lastRunContext.bootTime = 0;
     XCTAssertFalse(BSGRunContextWasKilled());
     lastRunContext.bootTime = bsg_runContext->bootTime;


### PR DESCRIPTION
## Goal

Add a check of the app's bundle version as an extra precaution in differentiating an app upgrade from an OOM.

## Design

The OOM detection currently uses the app's main image mach UUID to detect a new app version being deployed, but this code can sometimes fail, resulting in a false OOM. Since the bundle version MUST be updated on every release through the app store, this makes for a good failsafe.

## Testing

Added unit test.
