### PR TITLE
[Plat-11007] null user components

### DIFF
--- a/Bugsnag/BugsnagInternals.h
+++ b/Bugsnag/BugsnagInternals.h
@@ -231,6 +231,8 @@ typedef void (^ BSGClientObserver)(BSGClientObserverEvent event, _Nullable id va
 
 - (NSDictionary *)toJson;
 
+- (NSDictionary *)toJsonWithNSNulls;
+
 @end
 
 #pragma mark -

--- a/Bugsnag/Client/BugsnagClient.m
+++ b/Bugsnag/Client/BugsnagClient.m
@@ -560,7 +560,7 @@ BSG_OBJC_DIRECT_MEMBERS
 - (void)setUser:(NSString *)userId withEmail:(NSString *)email andName:(NSString *)name {
     @synchronized (self.configuration) {
         [self.configuration setUser:userId withEmail:email andName:name];
-        [self.state addMetadata:[self.configuration.user toJson] toSection:BSGKeyUser];
+        [self.state addMetadata:[self.configuration.user toJsonWithNSNulls] toSection:BSGKeyUser];
         if (self.observer) {
             self.observer(BSGClientObserverUpdateUser, self.user);
         }

--- a/Bugsnag/Payload/BugsnagUser.m
+++ b/Bugsnag/Payload/BugsnagUser.m
@@ -16,9 +16,19 @@ BSG_OBJC_DIRECT_MEMBERS
 
 - (instancetype)initWithDictionary:(NSDictionary *)dict {
     if ((self = [super init])) {
+        id nsnull = [NSNull null];
         _id = dict[@"id"];
+        if (_id == nsnull) {
+            _id = nil;
+        }
         _email = dict[@"email"];
+        if (_email == nsnull) {
+            _email = nil;
+        }
         _name = dict[@"name"];
+        if (_name == nsnull) {
+            _name = nil;
+        }
     }
     return self;
 }
@@ -32,6 +42,14 @@ BSG_OBJC_DIRECT_MEMBERS
     return self;
 }
 
+- (NSDictionary *)toJsonWithNSNulls {
+    NSMutableDictionary *dict = [NSMutableDictionary new];
+    dict[@"id"] = self.id ?: [NSNull null];
+    dict[@"email"] = self.email ?: [NSNull null];
+    dict[@"name"] = self.name ?: [NSNull null];
+    return [NSDictionary dictionaryWithDictionary:dict];
+}
+
 - (NSDictionary *)toJson {
     NSMutableDictionary *dict = [NSMutableDictionary new];
     dict[@"id"] = self.id;
@@ -39,6 +57,7 @@ BSG_OBJC_DIRECT_MEMBERS
     dict[@"name"] = self.name;
     return [NSDictionary dictionaryWithDictionary:dict];
 }
+
 
 - (BugsnagUser *)withId {
     if (self.id) {

--- a/Tests/BugsnagTests/BugsnagUserTest.m
+++ b/Tests/BugsnagTests/BugsnagUserTest.m
@@ -31,6 +31,35 @@
     XCTAssertEqualObjects(user.name, @"Tom Bombadil");
 }
 
+- (void)testDictNullDeserialisation {
+
+    NSDictionary *dict = @{
+            @"id": [NSNull null],
+            @"email": [NSNull null],
+            @"name": [NSNull null]
+    };
+    BugsnagUser *user = [[BugsnagUser alloc] initWithDictionary:dict];
+
+    XCTAssertNotNil(user);
+    XCTAssertNil(user.id);
+    XCTAssertNil(user.email);
+    XCTAssertNil(user.name);
+}
+
+- (void)testDictNullSerialisation {
+    BugsnagUser *user = [[BugsnagUser alloc] initWithId:nil name:nil emailAddress:nil];
+    NSDictionary *dict = [user toJson];
+    XCTAssertEqualObjects(@{}, dict);
+
+    dict = [user toJsonWithNSNulls];
+    NSDictionary *expected = @{
+            @"id": [NSNull null],
+            @"email": [NSNull null],
+            @"name": [NSNull null]
+    };
+    XCTAssertEqualObjects(expected, dict);
+}
+
 - (void)testPayloadSerialisation {
     BugsnagUser *payload = [[BugsnagUser alloc] initWithId:@"test" name:@"Tom Bombadil" emailAddress:@"fake@example.com"];
     NSDictionary *rootNode = [payload toJson];


### PR DESCRIPTION
## Goal

Setting user fields to nil wouldn't clear out their values when serializing a report because [user toJson] would produce dictionaries with the null fields missing, and then when merged with the existing data the old data would remain (because there's no new field value to override the old).

This PR ensures that the user object's produced dictionary always contains all keys, even if they've been set to null.

## Testing

Added unit tests.
