### PR TITLE
Skip app hang scenarios on all platforms and iOS versions

### DIFF
--- a/.buildkite/pipeline.full.yml
+++ b/.buildkite/pipeline.full.yml
@@ -80,7 +80,6 @@ steps:
           - "--aws-public-ip"
           - "--fail-fast"
           - "--exclude=features/[e-z].*.feature$"
-          - "--order=random"
     concurrency: 25
     concurrency_group: 'bitbar'
     concurrency_method: eager
@@ -111,7 +110,6 @@ steps:
           - "--aws-public-ip"
           - "--fail-fast"
           - "--exclude=features/[a-d].*.feature$"
-          - "--order=random"
     concurrency: 25
     concurrency_group: 'bitbar'
     concurrency_method: eager
@@ -142,7 +140,6 @@ steps:
           - "--aws-public-ip"
           - "--fail-fast"
           - "--exclude=features/[e-z].*.feature$"
-          - "--order=random"
     concurrency: 25
     concurrency_group: 'bitbar'
     concurrency_method: eager
@@ -173,7 +170,6 @@ steps:
           - "--aws-public-ip"
           - "--fail-fast"
           - "--exclude=features/[a-d].*.feature$"
-          - "--order=random"
     concurrency: 25
     concurrency_group: 'bitbar'
     concurrency_method: eager
@@ -204,7 +200,6 @@ steps:
           - "--aws-public-ip"
           - "--fail-fast"
           - "--exclude=features/[e-z].*.feature$"
-          - "--order=random"
     concurrency: 25
     concurrency_group: 'bitbar'
     concurrency_method: eager
@@ -235,7 +230,6 @@ steps:
           - "--aws-public-ip"
           - "--fail-fast"
           - "--exclude=features/[a-d].*.feature$"
-          - "--order=random"
     concurrency: 25
     concurrency_group: 'bitbar'
     concurrency_method: eager
@@ -270,7 +264,6 @@ steps:
           - "--appium-version=1.16.0"
           - "--fail-fast"
           - "--exclude=features/[e-z].*.feature$"
-          - "--order=random"
     concurrency: 5
     concurrency_group: 'browserstack-app'
     concurrency_method: eager
@@ -302,7 +295,6 @@ steps:
           - "--appium-version=1.16.0"
           - "--fail-fast"
           - "--exclude=features/[a-d].*.feature$"
-          - "--order=random"
     concurrency: 5
     concurrency_group: 'browserstack-app'
     concurrency_method: eager
@@ -326,7 +318,6 @@ steps:
       - bundle exec maze-runner
         --os=macos
         --fail-fast
-        --order=random
 
   - label: 'ARM macOS 12 E2E tests'
     depends_on:
@@ -345,7 +336,6 @@ steps:
       - bundle exec maze-runner
         --os=macos
         --fail-fast
-        --order=random
 
   - label: 'macOS 10.13 E2E tests'
     depends_on:
@@ -362,7 +352,6 @@ steps:
       - bundle exec maze-runner
         --os=macos
         --fail-fast
-        --order=random
 
   - label: 'macOS 10.14 E2E tests'
     depends_on:
@@ -379,7 +368,6 @@ steps:
       - bundle exec maze-runner
         --os=macos
         --fail-fast
-        --order=random
 
   ##############################################################################
   #

--- a/.buildkite/pipeline.yml
+++ b/.buildkite/pipeline.yml
@@ -221,7 +221,6 @@ steps:
         features/barebone_tests.feature
         --os=macos
         --fail-fast
-        --order=random
 
   - label: 'macOS 10.15 E2E tests'
     depends_on:
@@ -238,7 +237,6 @@ steps:
       - bundle exec maze-runner
         --os=macos
         --fail-fast
-        --order=random
 
   - label: 'ARM macOS 12 barebones E2E tests'
     depends_on:
@@ -258,7 +256,6 @@ steps:
         features/barebone_tests.feature
         --os=macos
         --fail-fast
-        --order=random
 
   - label: 'macOS 12 stress test'
     timeout_in_minutes: 3
@@ -309,7 +306,6 @@ steps:
           - "--aws-public-ip"
           - "--fail-fast"
           - "--exclude=features/[e-z].*.feature$"
-          - "--order=random"
     concurrency: 25
     concurrency_group: 'bitbar'
     concurrency_method: eager
@@ -340,7 +336,6 @@ steps:
           - "--aws-public-ip"
           - "--fail-fast"
           - "--exclude=features/[a-d].*.feature$"
-          - "--order=random"
     concurrency: 25
     concurrency_group: 'bitbar'
     concurrency_method: eager

--- a/features/app_hangs.feature
+++ b/features/app_hangs.feature
@@ -1,3 +1,4 @@
+@skip # https://smartbear.atlassian.net/browse/PLAT-11155
 Feature: App hangs
 
   Background:
@@ -105,7 +106,6 @@ Feature: App hangs
     When I run "AppHangDisabledScenario"
     Then I should receive no errors
 
-  @skip_ios_16 # https://smartbear.atlassian.net/browse/PLAT-11155
   Scenario: Fatal app hangs should be reported if appHangThresholdMillis = BugsnagAppHangThresholdFatalOnly
     When I run "AppHangFatalOnlyScenario"
     And I wait for 6 seconds
@@ -138,7 +138,6 @@ Feature: App hangs
     And the event "session.events.handled" equals 0
     And the event "session.events.unhandled" equals 1
 
-  @skip_ios_16 # https://smartbear.atlassian.net/browse/PLAT-11155
   Scenario: Fatal app hangs should not be reported if enabledErrorTypes.appHangs = false
     When I run "AppHangFatalDisabledScenario"
     And I wait for 5 seconds
@@ -147,7 +146,6 @@ Feature: App hangs
     Then I should receive no errors
 
   @skip_macos
-  @skip_ios_16 # https://smartbear.atlassian.net/browse/PLAT-11155
   Scenario: Fatal app hangs should be reported if the app hangs before going to the background
     When I run "AppHangFatalOnlyScenario"
     And I wait for 5 seconds


### PR DESCRIPTION
## Goal

Skip app hang scenarios on all platforms and iOS versions pending further investigation into flakes.

## Design

We had originally thought that only iOS 16 was affected by problems, but overnight we experienced failures across several other version of iOS.

## Changeset

I've also remove the random ordering of e2e test scenarios to provide a little more repeatability in the short term.

## Testing

Covered by a basic CI run.