### PR TITLE
Harmonize fixture logging

### DIFF
--- a/features/fixtures/ios/iOSTestApp.xcodeproj/project.pbxproj
+++ b/features/fixtures/ios/iOSTestApp.xcodeproj/project.pbxproj
@@ -86,6 +86,8 @@
 		01F6B75E2832757F00B75C5D /* OversizedCrashReportScenario.swift in Sources */ = {isa = PBXBuildFile; fileRef = 01F6B75C2832757F00B75C5D /* OversizedCrashReportScenario.swift */; };
 		01F6B75F2832757F00B75C5D /* OversizedHandledErrorScenario.swift in Sources */ = {isa = PBXBuildFile; fileRef = 01F6B75D2832757F00B75C5D /* OversizedHandledErrorScenario.swift */; };
 		01FA9EC426D63BB20059FF4A /* AppHangInTerminationScenario.swift in Sources */ = {isa = PBXBuildFile; fileRef = 01FA9EC326D63BB20059FF4A /* AppHangInTerminationScenario.swift */; };
+		095E095A2AF3BE8D00273F1F /* Logging.swift in Sources */ = {isa = PBXBuildFile; fileRef = 095E09592AF3BE8D00273F1F /* Logging.swift */; };
+		095E095D2AF3BFDA00273F1F /* Logging.m in Sources */ = {isa = PBXBuildFile; fileRef = 095E095C2AF3BFDA00273F1F /* Logging.m */; };
 		6526A0D4248A83350002E2C9 /* LoadConfigFromFileAutoScenario.swift in Sources */ = {isa = PBXBuildFile; fileRef = 6526A0D3248A83350002E2C9 /* LoadConfigFromFileAutoScenario.swift */; };
 		8A096DF627C7E56C00DB6ECC /* CxxUnexpectedScenario.mm in Sources */ = {isa = PBXBuildFile; fileRef = 8A096DF527C7E56C00DB6ECC /* CxxUnexpectedScenario.mm */; };
 		8A096DFC27C7E77600DB6ECC /* CxxBareThrowScenario.mm in Sources */ = {isa = PBXBuildFile; fileRef = 8A096DFB27C7E77600DB6ECC /* CxxBareThrowScenario.mm */; };
@@ -283,6 +285,9 @@
 		01F6B75C2832757F00B75C5D /* OversizedCrashReportScenario.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = OversizedCrashReportScenario.swift; sourceTree = "<group>"; };
 		01F6B75D2832757F00B75C5D /* OversizedHandledErrorScenario.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = OversizedHandledErrorScenario.swift; sourceTree = "<group>"; };
 		01FA9EC326D63BB20059FF4A /* AppHangInTerminationScenario.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AppHangInTerminationScenario.swift; sourceTree = "<group>"; };
+		095E09592AF3BE8D00273F1F /* Logging.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = Logging.swift; sourceTree = "<group>"; };
+		095E095B2AF3BFDA00273F1F /* Logging.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; path = Logging.h; sourceTree = "<group>"; };
+		095E095C2AF3BFDA00273F1F /* Logging.m */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.objc; path = Logging.m; sourceTree = "<group>"; };
 		6526A0D3248A83350002E2C9 /* LoadConfigFromFileAutoScenario.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = LoadConfigFromFileAutoScenario.swift; sourceTree = "<group>"; };
 		8A096DF527C7E56C00DB6ECC /* CxxUnexpectedScenario.mm */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.cpp.objcpp; path = CxxUnexpectedScenario.mm; sourceTree = "<group>"; };
 		8A096DFB27C7E77600DB6ECC /* CxxBareThrowScenario.mm */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.objcpp; path = CxxBareThrowScenario.mm; sourceTree = "<group>"; };
@@ -454,6 +459,7 @@
 			isa = PBXGroup;
 			children = (
 				AA4C7F1429AEA0C4009B09A9 /* BugsnagWrapper.swift */,
+				095E09592AF3BE8D00273F1F /* Logging.swift */,
 			);
 			name = utils;
 			path = ../shared/utils;
@@ -547,10 +553,13 @@
 				8AB1081823301FE600672818 /* HandledErrorValidReleaseStageScenario.swift */,
 				F429526319377A8848136413 /* HandledExceptionScenario.swift */,
 				8AF8FCAD22BD23BA00A967CA /* HandledInternalNotifyScenario.swift */,
+				967F6F1129B2236A0054EED8 /* InternalWorkingsScenario.swift */,
 				01847DD526453D4E00ADA4C7 /* InvalidCrashReportScenario.m */,
 				01B6BB7425D5748800FC4DE6 /* LastRunInfoScenario.swift */,
 				6526A0D3248A83350002E2C9 /* LoadConfigFromFileAutoScenario.swift */,
 				8AB65FCB22DC77CB001200AB /* LoadConfigFromFileScenario.swift */,
+				095E095B2AF3BFDA00273F1F /* Logging.h */,
+				095E095C2AF3BFDA00273F1F /* Logging.m */,
 				E7B79CD1247FD66E0039FB88 /* ManualContextClientScenario.swift */,
 				E7B79CCF247FD6660039FB88 /* ManualContextConfigurationScenario.swift */,
 				E7B79CD3247FD6760039FB88 /* ManualContextOnErrorScenario.swift */,
@@ -657,7 +666,6 @@
 				010BAAF22833CE570003FF36 /* UserPersistencePersistUserClientScenario.m */,
 				010BAAF82833CE570003FF36 /* UserPersistencePersistUserScenario.m */,
 				E700EE49247D1164008CFFB6 /* UserSessionOverrideScenario.swift */,
-				967F6F1129B2236A0054EED8 /* InternalWorkingsScenario.swift */,
 			);
 			name = scenarios;
 			path = ../shared/scenarios;
@@ -843,10 +851,12 @@
 				010BAB0B2833CE570003FF36 /* CxxExceptionOverrideScenario.mm in Sources */,
 				01DE903826CE99B800455213 /* CriticalThermalStateScenario.swift in Sources */,
 				01B6BBB625DA82B800FC4DE6 /* SendLaunchCrashesSynchronouslyScenario.swift in Sources */,
+				095E095D2AF3BFDA00273F1F /* Logging.m in Sources */,
 				F4295836C8AF75547C675E8D /* ReleasedObjectScenario.m in Sources */,
 				01E5EAD225B713990066EA8A /* OOMScenario.m in Sources */,
 				010BAB3D2833D2890003FF36 /* DisabledReleaseStageManualSessionScenario.swift in Sources */,
 				01F6B75E2832757F00B75C5D /* OversizedCrashReportScenario.swift in Sources */,
+				095E095A2AF3BE8D00273F1F /* Logging.swift in Sources */,
 				8A530CCC22FDDBF000F0C108 /* ManyConcurrentNotifyScenario.m in Sources */,
 				010BAB112833CEEC0003FF36 /* AppAndDeviceAttributesConfigOverrideScenario.swift in Sources */,
 				010BAB0A2833CE570003FF36 /* DisableSignalsExceptionScenario.m in Sources */,

--- a/features/fixtures/ios/iOSTestApp/AppDelegate.swift
+++ b/features/fixtures/ios/iOSTestApp/AppDelegate.swift
@@ -1,4 +1,5 @@
 import UIKit
+import os
 
 @UIApplicationMain
 class AppDelegate: UIResponder, UIApplicationDelegate {
@@ -6,6 +7,7 @@ class AppDelegate: UIResponder, UIApplicationDelegate {
     var window: UIWindow?
 
     func application(_ application: UIApplication, didFinishLaunchingWithOptions launchOptions: [UIApplication.LaunchOptionsKey: Any]?) -> Bool {
+        logInfo("========== Fixture app has launched ==========")
         return true
     }
 }

--- a/features/fixtures/ios/iOSTestApp/CommandReaderThread.swift
+++ b/features/fixtures/ios/iOSTestApp/CommandReaderThread.swift
@@ -79,21 +79,3 @@ class CommandReaderThread: Thread {
         return bsAddress;
     }
 }
-
-private func logInfo(_ message: String) {
-    let fullMessage = String(format: "bugsnagci info: %@", message)
-    NSLog("%@", fullMessage)
-    kslog("\(Date()) \(fullMessage)")
-}
-
-private func logWarn(_ message: String) {
-    let fullMessage = String(format: "bugsnagci warn: %@", message)
-    NSLog("%@", fullMessage)
-    kslog("\(Date()) \(fullMessage)")
-}
-
-private func logError(_ message: String) {
-    let fullMessage = String(format: "bugsnagci error: %@", message)
-    NSLog("%@", fullMessage)
-    kslog("\(Date()) \(fullMessage)")
-}

--- a/features/fixtures/ios/iOSTestApp/ViewController.swift
+++ b/features/fixtures/ios/iOSTestApp/ViewController.swift
@@ -25,6 +25,7 @@ class ViewController: UIViewController {
         self.view.addGestureRecognizer(UITapGestureRecognizer(target: self.view, action: #selector(UIView.endEditing(_:))))
         NotificationCenter.default.addObserver(self, selector: #selector(didEnterBackgroundNotification), name: UIApplication.didEnterBackgroundNotification, object: nil)
         apiKeyField.text = UserDefaults.standard.string(forKey: "apiKey")
+        logInfo("Read API key from UserDefaults: \(apiKeyField.text!)")
 
         // Poll for commands to run
         if #available(iOS 10.0, *) {
@@ -43,18 +44,18 @@ class ViewController: UIViewController {
         if Scenario.current == nil {
             prepareScenario()
 
-            log("Starting Bugsnag for scenario: \(Scenario.current!)")
+            logInfo("Starting Bugsnag for scenario: \(Scenario.current!)")
             Scenario.current!.startBugsnag()
         }
         
-        log("Running scenario: \(Scenario.current!)")
+        logInfo("Running scenario: \(Scenario.current!)")
         Scenario.current!.run()
     }
 
     @IBAction func startBugsnag() {
         prepareScenario()
 
-        log("Starting Bugsnag for scenario: \(Scenario.current!)")
+        logInfo("Starting Bugsnag for scenario: \(Scenario.current!)")
         Scenario.current!.startBugsnag()
     }
 
@@ -67,7 +68,7 @@ class ViewController: UIViewController {
         if (apiKeyField.text!.count > 0) {
             // Manual testing mode - use the real dashboard and the API key provided
             let apiKey = apiKeyField.text!
-            NSLog("Running in manual mode with API key: %@", apiKey)
+            logInfo("Running in manual mode with API key: \(apiKey)")
             UserDefaults.standard.setValue(apiKey, forKey: "apiKey")
             config = BugsnagConfiguration(apiKeyField.text!)
         }
@@ -80,9 +81,4 @@ class ViewController: UIViewController {
     @objc func didEnterBackgroundNotification() {
         Scenario.current?.didEnterBackgroundNotification()
     }
-}
-
-private func log(_ message: String) {
-    NSLog("%@", message)
-    kslog("\(Date()) \(message)")
 }

--- a/features/fixtures/macos/macOSTestApp.xcodeproj/project.pbxproj
+++ b/features/fixtures/macos/macOSTestApp.xcodeproj/project.pbxproj
@@ -182,6 +182,8 @@
 		01F6B74F2832381300B75C5D /* OversizedCrashReportScenario.swift in Sources */ = {isa = PBXBuildFile; fileRef = 01F6B74B2832381300B75C5D /* OversizedCrashReportScenario.swift */; };
 		01F7365A278D90440000113C /* NetworkBreadcrumbsScenario.swift in Sources */ = {isa = PBXBuildFile; fileRef = 01F73659278D90440000113C /* NetworkBreadcrumbsScenario.swift */; };
 		01FA9EC626D64FFF0059FF4A /* AppHangInTerminationScenario.swift in Sources */ = {isa = PBXBuildFile; fileRef = 01FA9EC526D64FFF0059FF4A /* AppHangInTerminationScenario.swift */; };
+		095E095F2AF3C98F00273F1F /* Logging.swift in Sources */ = {isa = PBXBuildFile; fileRef = 095E095E2AF3C98F00273F1F /* Logging.swift */; };
+		095E09622AF3C9A500273F1F /* Logging.m in Sources */ = {isa = PBXBuildFile; fileRef = 095E09612AF3C9A500273F1F /* Logging.m */; };
 		8A096DF827C7E63A00DB6ECC /* CxxUnexpectedScenario.mm in Sources */ = {isa = PBXBuildFile; fileRef = 8A096DF727C7E63A00DB6ECC /* CxxUnexpectedScenario.mm */; };
 		8A096DFA27C7E6D800DB6ECC /* CxxBareThrowScenario.mm in Sources */ = {isa = PBXBuildFile; fileRef = 8A096DF927C7E6D800DB6ECC /* CxxBareThrowScenario.mm */; };
 		967F6F1629B767CE0054EED8 /* InternalWorkingsScenario.swift in Sources */ = {isa = PBXBuildFile; fileRef = 967F6F1529B767CE0054EED8 /* InternalWorkingsScenario.swift */; };
@@ -388,6 +390,9 @@
 		01F6B74B2832381300B75C5D /* OversizedCrashReportScenario.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = OversizedCrashReportScenario.swift; sourceTree = "<group>"; };
 		01F73659278D90440000113C /* NetworkBreadcrumbsScenario.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = NetworkBreadcrumbsScenario.swift; sourceTree = "<group>"; };
 		01FA9EC526D64FFF0059FF4A /* AppHangInTerminationScenario.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = AppHangInTerminationScenario.swift; sourceTree = "<group>"; };
+		095E095E2AF3C98F00273F1F /* Logging.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = Logging.swift; sourceTree = "<group>"; };
+		095E09602AF3C9A500273F1F /* Logging.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = Logging.h; sourceTree = "<group>"; };
+		095E09612AF3C9A500273F1F /* Logging.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; path = Logging.m; sourceTree = "<group>"; };
 		2C49722B331FF4B0DC477462 /* Pods-macOSTestApp.release.xcconfig */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.xcconfig; name = "Pods-macOSTestApp.release.xcconfig"; path = "Target Support Files/Pods-macOSTestApp/Pods-macOSTestApp.release.xcconfig"; sourceTree = "<group>"; };
 		5C65BFC9838298CFA8A35072 /* Pods_macOSTestApp.framework */ = {isa = PBXFileReference; explicitFileType = wrapper.framework; includeInIndex = 0; path = Pods_macOSTestApp.framework; sourceTree = BUILT_PRODUCTS_DIR; };
 		8A096DF727C7E63A00DB6ECC /* CxxUnexpectedScenario.mm */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.objcpp; path = CxxUnexpectedScenario.mm; sourceTree = "<group>"; };
@@ -494,6 +499,8 @@
 				01B6BB7125D56CBF00FC4DE6 /* LastRunInfoScenario.swift */,
 				01F47C23254B1B2C00B184AD /* LoadConfigFromFileAutoScenario.swift */,
 				01F47C94254B1B2F00B184AD /* LoadConfigFromFileScenario.swift */,
+				095E09602AF3C9A500273F1F /* Logging.h */,
+				095E09612AF3C9A500273F1F /* Logging.m */,
 				01F47C3B254B1B2D00B184AD /* ManualContextClientScenario.swift */,
 				01F47C47254B1B2D00B184AD /* ManualContextConfigurationScenario.swift */,
 				01F47C82254B1B2F00B184AD /* ManualContextOnErrorScenario.swift */,
@@ -658,6 +665,7 @@
 			isa = PBXGroup;
 			children = (
 				AA4C7F1729AEA31D009B09A9 /* BugsnagWrapper.swift */,
+				095E095E2AF3C98F00273F1F /* Logging.swift */,
 			);
 			name = utils;
 			path = ../shared/utils;
@@ -795,6 +803,7 @@
 				01F47D08254B1B3100B184AD /* AutoSessionCustomVersionScenario.m in Sources */,
 				01F47CC6254B1B3100B184AD /* HandledExceptionScenario.swift in Sources */,
 				01F47D0D254B1B3100B184AD /* LoadConfigFromFileScenario.swift in Sources */,
+				095E09622AF3C9A500273F1F /* Logging.m in Sources */,
 				01F47CF5254B1B3100B184AD /* StoppedSessionScenario.swift in Sources */,
 				010BAB772833D34A0003FF36 /* DiscardClassesHandledExceptionRegexScenario.swift in Sources */,
 				01F47D23254B1B3100B184AD /* SwiftAssertionScenario.swift in Sources */,
@@ -849,6 +858,7 @@
 				010BAB722833D34A0003FF36 /* BareboneTestHandledScenario.swift in Sources */,
 				017D9CFC2833C81100B0AA87 /* DisableMachExceptionScenario.m in Sources */,
 				01DE903A26CEAD1200455213 /* CriticalThermalStateScenario.swift in Sources */,
+				095E095F2AF3C98F00273F1F /* Logging.swift in Sources */,
 				01F47CF9254B1B3100B184AD /* BreadcrumbCallbackDiscardScenario.swift in Sources */,
 				AA6ACD1E2773E39C006464C4 /* UserInfoScenario.swift in Sources */,
 				01018BAB25E417EC000312C6 /* AsyncSafeMallocScenario.m in Sources */,

--- a/features/fixtures/macos/macOSTestApp/MainWindowController.m
+++ b/features/fixtures/macos/macOSTestApp/MainWindowController.m
@@ -48,7 +48,7 @@
 }
 
 - (IBAction)runScenario:(id)sender {
-    logInfo(@"%s %@", __PRETTY_FUNCTION__, self.scenarioName);
+    logDebug(@"%s %@", __PRETTY_FUNCTION__, self.scenarioName);
     
     // Cater for multiple calls to -run
     if (!Scenario.currentScenario) {
@@ -70,7 +70,7 @@
 }
 
 - (IBAction)startBugsnag:(id)sender {
-    logInfo(@"%s %@", __PRETTY_FUNCTION__, self.scenarioName);
+    logDebug(@"%s %@", __PRETTY_FUNCTION__, self.scenarioName);
 
     [Scenario createScenarioNamed:self.scenarioName withConfig:[self configuration]];
     Scenario.currentScenario.eventMode = self.scenarioMetadata;

--- a/features/fixtures/macos/macOSTestApp/MainWindowController.m
+++ b/features/fixtures/macos/macOSTestApp/MainWindowController.m
@@ -9,11 +9,9 @@
 #import "MainWindowController.h"
 
 #import "Scenario.h"
+#import "Logging.h"
 
 #import <Bugsnag/Bugsnag.h>
-
-static void BSLog(NSString *format, ...) NS_FORMAT_FUNCTION(1,2) NS_NO_TAIL_CALL;
-
 
 @interface MainWindowController ()
 
@@ -50,39 +48,39 @@ static void BSLog(NSString *format, ...) NS_FORMAT_FUNCTION(1,2) NS_NO_TAIL_CALL
 }
 
 - (IBAction)runScenario:(id)sender {
-    BSLog(@"%s %@", __PRETTY_FUNCTION__, self.scenarioName);
+    logInfo(@"%s %@", __PRETTY_FUNCTION__, self.scenarioName);
     
     // Cater for multiple calls to -run
     if (!Scenario.currentScenario) {
         [Scenario createScenarioNamed:self.scenarioName withConfig:[self configuration]];
         Scenario.currentScenario.eventMode = self.scenarioMetadata;
 
-        BSLog(@"Starting Bugsnag for scenario: %@", Scenario.currentScenario);
+        logInfo(@"Starting Bugsnag for scenario: %@", Scenario.currentScenario);
         [Scenario.currentScenario startBugsnag];
     }
 
-    BSLog(@"Will run scenario: %@", Scenario.currentScenario);
+    logInfo(@"Will run scenario: %@", Scenario.currentScenario);
     // Using dispatch_async to prevent AppleEvents swallowing exceptions.
     // For more info see https://www.chimehq.com/blog/sad-state-of-exceptions
     // 0.1s delay allows accessibility APIs to finish handling the mouse click and returns control to the tests framework.
     dispatch_after(dispatch_time(DISPATCH_TIME_NOW, (int64_t)(0.1 * NSEC_PER_SEC)), dispatch_get_main_queue(), ^{
-        BSLog(@"Running scenario: %@", Scenario.currentScenario);
+        logInfo(@"Running scenario: %@", Scenario.currentScenario);
         [Scenario.currentScenario run];
     });
 }
 
 - (IBAction)startBugsnag:(id)sender {
-    BSLog(@"%s %@", __PRETTY_FUNCTION__, self.scenarioName);
+    logInfo(@"%s %@", __PRETTY_FUNCTION__, self.scenarioName);
 
     [Scenario createScenarioNamed:self.scenarioName withConfig:[self configuration]];
     Scenario.currentScenario.eventMode = self.scenarioMetadata;
 
-    BSLog(@"Starting Bugsnag for scenario: %@", Scenario.currentScenario);
+    logInfo(@"Starting Bugsnag for scenario: %@", Scenario.currentScenario);
     [Scenario.currentScenario startBugsnag];
 }
 
 - (IBAction)clearPersistentData:(id)sender {
-    BSLog(@"Clearing persistent data");
+    logInfo(@"Clearing persistent data");
     [Scenario clearPersistentData];
 }
 
@@ -100,13 +98,3 @@ static void BSLog(NSString *format, ...) NS_FORMAT_FUNCTION(1,2) NS_NO_TAIL_CALL
 }
 
 @end
-
-
-static void BSLog(NSString *format, ...) {
-    va_list vl;
-    va_start(vl, format);
-    NSString *message = [[NSString alloc] initWithFormat:format arguments:vl];
-    NSLog(@"%@", message);
-    kslog(message.UTF8String);
-    va_end(vl);
-}

--- a/features/fixtures/shared/scenarios/AbortOverrideScenario.m
+++ b/features/fixtures/shared/scenarios/AbortOverrideScenario.m
@@ -25,6 +25,7 @@
  */
 
 #import "MarkUnhandledHandledScenario.h"
+#import "Logging.h"
 
 @interface AbortOverrideScenario : MarkUnhandledHandledScenario
 @end

--- a/features/fixtures/shared/scenarios/AbortScenario.m
+++ b/features/fixtures/shared/scenarios/AbortScenario.m
@@ -25,6 +25,7 @@
  */
 
 #import "Scenario.h"
+#import "Logging.h"
 
 @interface AbortScenario : Scenario
 @end

--- a/features/fixtures/shared/scenarios/AccessNonObjectScenario.m
+++ b/features/fixtures/shared/scenarios/AccessNonObjectScenario.m
@@ -25,6 +25,7 @@
  */
 
 #import "Scenario.h"
+#import "Logging.h"
 
 /**
  * Call NSLog(@"%@", 16);, causing a crash when the runtime attempts to treat 16 as a pointer to an object.

--- a/features/fixtures/shared/scenarios/AppHangDefaultConfigScenario.swift
+++ b/features/fixtures/shared/scenarios/AppHangDefaultConfigScenario.swift
@@ -2,8 +2,8 @@ class AppHangDefaultConfigScenario: Scenario {
     
     override func run() {
         let timeInterval: TimeInterval = 5
-        NSLog("Simulating an app hang of \(timeInterval) seconds...")
+        logInfo("Simulating an app hang of \(timeInterval) seconds...")
         Thread.sleep(forTimeInterval: timeInterval)
-        NSLog("Finished sleeping")
+        logInfo("Finished sleeping")
     }
 }

--- a/features/fixtures/shared/scenarios/AppHangDefaultConfigScenario.swift
+++ b/features/fixtures/shared/scenarios/AppHangDefaultConfigScenario.swift
@@ -2,8 +2,8 @@ class AppHangDefaultConfigScenario: Scenario {
     
     override func run() {
         let timeInterval: TimeInterval = 5
-        logInfo("Simulating an app hang of \(timeInterval) seconds...")
+        logDebug("Simulating an app hang of \(timeInterval) seconds...")
         Thread.sleep(forTimeInterval: timeInterval)
-        logInfo("Finished sleeping")
+        logDebug("Finished sleeping")
     }
 }

--- a/features/fixtures/shared/scenarios/AppHangDidBecomeActiveScenario.swift
+++ b/features/fixtures/shared/scenarios/AppHangDidBecomeActiveScenario.swift
@@ -10,7 +10,7 @@ class AppHangDidBecomeActiveScenario: Scenario {
     
     override func run() {
         NotificationCenter.default.addObserver(forName: UIApplication.didBecomeActiveNotification, object: nil, queue: nil) {
-            NSLog("Received \($0.name), now sleeping for 3 seconds...")
+            logInfo("Received \($0.name), now sleeping for 3 seconds...")
             Thread.sleep(forTimeInterval: 3)
         }
     }

--- a/features/fixtures/shared/scenarios/AppHangDidBecomeActiveScenario.swift
+++ b/features/fixtures/shared/scenarios/AppHangDidBecomeActiveScenario.swift
@@ -10,7 +10,7 @@ class AppHangDidBecomeActiveScenario: Scenario {
     
     override func run() {
         NotificationCenter.default.addObserver(forName: UIApplication.didBecomeActiveNotification, object: nil, queue: nil) {
-            logInfo("Received \($0.name), now sleeping for 3 seconds...")
+            logDebug("Received \($0.name), now sleeping for 3 seconds...")
             Thread.sleep(forTimeInterval: 3)
         }
     }

--- a/features/fixtures/shared/scenarios/AppHangDidEnterBackgroundScenario.swift
+++ b/features/fixtures/shared/scenarios/AppHangDidEnterBackgroundScenario.swift
@@ -4,7 +4,7 @@ class AppHangDidEnterBackgroundScenario: Scenario {
     
     override func run() {
         NotificationCenter.default.addObserver(forName: UIApplication.didEnterBackgroundNotification, object: nil, queue: nil) {
-            logInfo("Received \($0.name), now hanging indefinitely...")
+            logDebug("Received \($0.name), now hanging indefinitely...")
             while true {}
         }
     }

--- a/features/fixtures/shared/scenarios/AppHangDidEnterBackgroundScenario.swift
+++ b/features/fixtures/shared/scenarios/AppHangDidEnterBackgroundScenario.swift
@@ -4,7 +4,7 @@ class AppHangDidEnterBackgroundScenario: Scenario {
     
     override func run() {
         NotificationCenter.default.addObserver(forName: UIApplication.didEnterBackgroundNotification, object: nil, queue: nil) {
-            NSLog("Received \($0.name), now hanging indefinitely...")
+            logInfo("Received \($0.name), now hanging indefinitely...")
             while true {}
         }
     }

--- a/features/fixtures/shared/scenarios/AppHangDisabledScenario.swift
+++ b/features/fixtures/shared/scenarios/AppHangDisabledScenario.swift
@@ -7,8 +7,8 @@ class AppHangDisabledScenario: Scenario {
     
     override func run() {
         let timeInterval: TimeInterval = 5
-        logInfo("Simulating an app hang of \(timeInterval) seconds...")
+        logDebug("Simulating an app hang of \(timeInterval) seconds...")
         Thread.sleep(forTimeInterval: timeInterval)
-        logInfo("Finished sleeping")
+        logDebug("Finished sleeping")
     }
 }

--- a/features/fixtures/shared/scenarios/AppHangDisabledScenario.swift
+++ b/features/fixtures/shared/scenarios/AppHangDisabledScenario.swift
@@ -7,8 +7,8 @@ class AppHangDisabledScenario: Scenario {
     
     override func run() {
         let timeInterval: TimeInterval = 5
-        NSLog("Simulating an app hang of \(timeInterval) seconds...")
+        logInfo("Simulating an app hang of \(timeInterval) seconds...")
         Thread.sleep(forTimeInterval: timeInterval)
-        NSLog("Finished sleeping")
+        logInfo("Finished sleeping")
     }
 }

--- a/features/fixtures/shared/scenarios/AppHangFatalDisabledScenario.swift
+++ b/features/fixtures/shared/scenarios/AppHangFatalDisabledScenario.swift
@@ -7,7 +7,7 @@ class AppHangFatalDisabledScenario: Scenario {
     }
     
     override func run() {
-        NSLog("Hanging indefinitely...")
+        logInfo("Hanging indefinitely...")
         // Use asyncAfter to allow the Appium click event to be handled
         DispatchQueue.main.asyncAfter(deadline: .now() + 0.1) {
             while true {}

--- a/features/fixtures/shared/scenarios/AppHangFatalDisabledScenario.swift
+++ b/features/fixtures/shared/scenarios/AppHangFatalDisabledScenario.swift
@@ -7,7 +7,7 @@ class AppHangFatalDisabledScenario: Scenario {
     }
     
     override func run() {
-        logInfo("Hanging indefinitely...")
+        logDebug("Hanging indefinitely...")
         // Use asyncAfter to allow the Appium click event to be handled
         DispatchQueue.main.asyncAfter(deadline: .now() + 0.1) {
             while true {}

--- a/features/fixtures/shared/scenarios/AppHangFatalOnlyScenario.swift
+++ b/features/fixtures/shared/scenarios/AppHangFatalOnlyScenario.swift
@@ -9,7 +9,7 @@ class AppHangFatalOnlyScenario: Scenario {
     }
     
     override func run() {
-        logInfo("Hanging indefinitely...")
+        logDebug("Hanging indefinitely...")
         // Use asyncAfter to allow the Appium click event to be handled
         DispatchQueue.main.asyncAfter(deadline: .now() + 3.0) {
             while true {}

--- a/features/fixtures/shared/scenarios/AppHangFatalOnlyScenario.swift
+++ b/features/fixtures/shared/scenarios/AppHangFatalOnlyScenario.swift
@@ -9,7 +9,7 @@ class AppHangFatalOnlyScenario: Scenario {
     }
     
     override func run() {
-        NSLog("Hanging indefinitely...")
+        logInfo("Hanging indefinitely...")
         // Use asyncAfter to allow the Appium click event to be handled
         DispatchQueue.main.asyncAfter(deadline: .now() + 3.0) {
             while true {}

--- a/features/fixtures/shared/scenarios/AppHangInTerminationScenario.swift
+++ b/features/fixtures/shared/scenarios/AppHangInTerminationScenario.swift
@@ -27,7 +27,7 @@ class AppHangInTerminationScenario: Scenario {
         #endif
         
         NotificationCenter.default.addObserver(forName: willTerminate, object: nil, queue: nil) {
-            logInfo("Received \($0.name.rawValue), simulating an app hang...")
+            logDebug("Received \($0.name.rawValue), simulating an app hang...")
             Thread.sleep(forTimeInterval: 3)
         }
         

--- a/features/fixtures/shared/scenarios/AppHangInTerminationScenario.swift
+++ b/features/fixtures/shared/scenarios/AppHangInTerminationScenario.swift
@@ -27,7 +27,7 @@ class AppHangInTerminationScenario: Scenario {
         #endif
         
         NotificationCenter.default.addObserver(forName: willTerminate, object: nil, queue: nil) {
-            NSLog("Received \($0.name.rawValue), simulating an app hang...")
+            logInfo("Received \($0.name.rawValue), simulating an app hang...")
             Thread.sleep(forTimeInterval: 3)
         }
         

--- a/features/fixtures/shared/scenarios/AppHangScenario.swift
+++ b/features/fixtures/shared/scenarios/AppHangScenario.swift
@@ -18,7 +18,7 @@ class AppHangScenario: Scenario {
     override func run() {
         Bugsnag.setContext("App Hang Scenario")
         let timeInterval = TimeInterval(eventMode!)!
-        logInfo("Simulating an app hang of \(timeInterval) seconds...")
+        logDebug("Simulating an app hang of \(timeInterval) seconds...")
         if timeInterval > 2 {
             Thread.sleep(forTimeInterval: 1.5)
             Bugsnag.leaveBreadcrumb(withMessage: "This breadcrumb was left during the hang, before detection")
@@ -27,6 +27,6 @@ class AppHangScenario: Scenario {
             Thread.sleep(forTimeInterval: timeInterval)
         }
         Bugsnag.leaveBreadcrumb(withMessage: "This breadcrumb was left after the hang")
-        logInfo("Finished sleeping")
+        logDebug("Finished sleeping")
     }
 }

--- a/features/fixtures/shared/scenarios/AppHangScenario.swift
+++ b/features/fixtures/shared/scenarios/AppHangScenario.swift
@@ -18,7 +18,7 @@ class AppHangScenario: Scenario {
     override func run() {
         Bugsnag.setContext("App Hang Scenario")
         let timeInterval = TimeInterval(eventMode!)!
-        NSLog("Simulating an app hang of \(timeInterval) seconds...")
+        logInfo("Simulating an app hang of \(timeInterval) seconds...")
         if timeInterval > 2 {
             Thread.sleep(forTimeInterval: 1.5)
             Bugsnag.leaveBreadcrumb(withMessage: "This breadcrumb was left during the hang, before detection")
@@ -27,6 +27,6 @@ class AppHangScenario: Scenario {
             Thread.sleep(forTimeInterval: timeInterval)
         }
         Bugsnag.leaveBreadcrumb(withMessage: "This breadcrumb was left after the hang")
-        NSLog("Finished sleeping")
+        logInfo("Finished sleeping")
     }
 }

--- a/features/fixtures/shared/scenarios/AsyncSafeMallocScenario.m
+++ b/features/fixtures/shared/scenarios/AsyncSafeMallocScenario.m
@@ -7,6 +7,7 @@
 //
 
 #import "Scenario.h"
+#import "Logging.h"
 #include "spin_malloc.h"
 
 @interface AsyncSafeMallocScenario : Scenario

--- a/features/fixtures/shared/scenarios/AsyncSafeThreadScenario.m
+++ b/features/fixtures/shared/scenarios/AsyncSafeThreadScenario.m
@@ -25,6 +25,7 @@
  */
 
 #import "Scenario.h"
+#import "Logging.h"
 #import <pthread.h>
 
 /**
@@ -46,7 +47,7 @@
 
     /* This is unreachable, but prevents clang from applying TCO to the above when
      * optimization is enabled. */
-    NSLog(@"I'm here from the tail call prevention department.");
+    logInfo(@"I'm here from the tail call prevention department.");
 }
 
 @end

--- a/features/fixtures/shared/scenarios/AutoCaptureRunScenario.m
+++ b/features/fixtures/shared/scenarios/AutoCaptureRunScenario.m
@@ -7,6 +7,7 @@
 //
 
 #import "Scenario.h"
+#import "Logging.h"
 
 @interface AutoCaptureRunScenario : Scenario
 @end

--- a/features/fixtures/shared/scenarios/AutoSessionCustomVersionScenario.m
+++ b/features/fixtures/shared/scenarios/AutoSessionCustomVersionScenario.m
@@ -7,6 +7,7 @@
 //
 
 #import "Scenario.h"
+#import "Logging.h"
 
 @interface AutoSessionCustomVersionScenario : Scenario
 @end

--- a/features/fixtures/shared/scenarios/AutoSessionHandledEventsScenario.m
+++ b/features/fixtures/shared/scenarios/AutoSessionHandledEventsScenario.m
@@ -7,6 +7,7 @@
 //
 
 #import "Scenario.h"
+#import "Logging.h"
 
 @interface AutoSessionHandledEventsScenario : Scenario
 @end

--- a/features/fixtures/shared/scenarios/AutoSessionMixedEventsScenario.m
+++ b/features/fixtures/shared/scenarios/AutoSessionMixedEventsScenario.m
@@ -7,6 +7,7 @@
 //
 
 #import "Scenario.h"
+#import "Logging.h"
 
 @interface AutoSessionMixedEventsScenario : Scenario
 

--- a/features/fixtures/shared/scenarios/AutoSessionScenario.m
+++ b/features/fixtures/shared/scenarios/AutoSessionScenario.m
@@ -4,6 +4,7 @@
 //
 
 #import "Scenario.h"
+#import "Logging.h"
 
 /**
  * Sends an automatic session payload to Bugsnag.

--- a/features/fixtures/shared/scenarios/AutoSessionUnhandledScenario.m
+++ b/features/fixtures/shared/scenarios/AutoSessionUnhandledScenario.m
@@ -7,6 +7,7 @@
 //
 
 #import "Scenario.h"
+#import "Logging.h"
 
 @interface AutoSessionUnhandledScenario : Scenario
 @end

--- a/features/fixtures/shared/scenarios/AutoSessionWithUserScenario.m
+++ b/features/fixtures/shared/scenarios/AutoSessionWithUserScenario.m
@@ -7,6 +7,7 @@
 //
 
 #import "Scenario.h"
+#import "Logging.h"
 
 @interface AutoSessionWithUserScenario : Scenario
 @end

--- a/features/fixtures/shared/scenarios/BreadcrumbCallbackRemovalScenario.m
+++ b/features/fixtures/shared/scenarios/BreadcrumbCallbackRemovalScenario.m
@@ -7,6 +7,7 @@
 //
 
 #import "Scenario.h"
+#import "Logging.h"
 
 @interface BreadcrumbCallbackRemovalScenario : Scenario
 @end

--- a/features/fixtures/shared/scenarios/BuiltinTrapScenario.m
+++ b/features/fixtures/shared/scenarios/BuiltinTrapScenario.m
@@ -4,6 +4,7 @@
 //
 
 #import "Scenario.h"
+#import "Logging.h"
 
 #import "spin_malloc.h"
 

--- a/features/fixtures/shared/scenarios/ConcurrentCrashesScenario.mm
+++ b/features/fixtures/shared/scenarios/ConcurrentCrashesScenario.mm
@@ -7,6 +7,7 @@
 //
 
 #import "Scenario.h"
+#import "Logging.h"
 
 #import <pthread.h>
 #import <stdexcept>

--- a/features/fixtures/shared/scenarios/CouldNotCreateDirectoryScenario.swift
+++ b/features/fixtures/shared/scenarios/CouldNotCreateDirectoryScenario.swift
@@ -26,7 +26,7 @@ class CouldNotCreateDirectoryScenario: Scenario {
             try fileManager.setAttributes([.posixPermissions: 0o600], ofItemAtPath: dir.path)
             super.startBugsnag()
         } catch {
-            NSLog("\(error)")
+            logError("\(error)")
         }
     }
     

--- a/features/fixtures/shared/scenarios/CustomPluginNotifierDescriptionScenario.m
+++ b/features/fixtures/shared/scenarios/CustomPluginNotifierDescriptionScenario.m
@@ -1,4 +1,5 @@
 #import "Scenario.h"
+#import "Logging.h"
 
 @interface CustomPluginNotifierDescriptionScenario : Scenario
 @end

--- a/features/fixtures/shared/scenarios/CxxBareThrowScenario.mm
+++ b/features/fixtures/shared/scenarios/CxxBareThrowScenario.mm
@@ -7,6 +7,7 @@
 //
 
 #import "Scenario.h"
+#import "Logging.h"
 #import <stdexcept>
 
 @interface CxxBareThrowScenario : Scenario

--- a/features/fixtures/shared/scenarios/CxxExceptionOverrideScenario.mm
+++ b/features/fixtures/shared/scenarios/CxxExceptionOverrideScenario.mm
@@ -25,6 +25,7 @@
  */
 
 #import "MarkUnhandledHandledScenario.h"
+#import "Logging.h"
 
 #import <stdexcept>
 

--- a/features/fixtures/shared/scenarios/CxxExceptionScenario.mm
+++ b/features/fixtures/shared/scenarios/CxxExceptionScenario.mm
@@ -25,6 +25,7 @@
  */
 
 #import "Scenario.h"
+#import "Logging.h"
 
 #import <stdexcept>
 

--- a/features/fixtures/shared/scenarios/CxxUnexpectedScenario.mm
+++ b/features/fixtures/shared/scenarios/CxxUnexpectedScenario.mm
@@ -7,6 +7,7 @@
 //
 
 #import "Scenario.h"
+#import "Logging.h"
 #import <stdexcept>
 
 @interface CxxUnexpectedScenario : Scenario

--- a/features/fixtures/shared/scenarios/DisableAllExceptManualExceptionsAndCrashScenario.m
+++ b/features/fixtures/shared/scenarios/DisableAllExceptManualExceptionsAndCrashScenario.m
@@ -9,6 +9,7 @@
 // C++ crashes are handled in a separate scenario, and OOM is not tested for.
 
 #import "Scenario.h"
+#import "Logging.h"
 
 /**
  * Disable all crash reporting (except, implicitly, manual) and crash the app

--- a/features/fixtures/shared/scenarios/DisableMachExceptionScenario.m
+++ b/features/fixtures/shared/scenarios/DisableMachExceptionScenario.m
@@ -9,6 +9,7 @@
 // C++ crashes are handled in a separate scenario, and OOM is not tested for.
 
 #import "Scenario.h"
+#import "Logging.h"
 
 @interface DisableMachExceptionScenario : Scenario
 @end

--- a/features/fixtures/shared/scenarios/DisableNSExceptionScenario.m
+++ b/features/fixtures/shared/scenarios/DisableNSExceptionScenario.m
@@ -9,6 +9,7 @@
 // C++ crashes are handled in a separate scenario, and OOM is not tested for.
 
 #import "Scenario.h"
+#import "Logging.h"
 
 @interface DisableNSExceptionScenario : Scenario
 @end

--- a/features/fixtures/shared/scenarios/DisableSignalsExceptionScenario.m
+++ b/features/fixtures/shared/scenarios/DisableSignalsExceptionScenario.m
@@ -9,6 +9,7 @@
 // C++ crashes are handled in a separate scenario, and OOM is not tested for.
 
 #import "Scenario.h"
+#import "Logging.h"
 
 @interface DisableSignalsExceptionScenario : Scenario
 @end

--- a/features/fixtures/shared/scenarios/DisabledSessionTrackingScenario.m
+++ b/features/fixtures/shared/scenarios/DisabledSessionTrackingScenario.m
@@ -4,6 +4,7 @@
 //
 
 #import "Scenario.h"
+#import "Logging.h"
 
 @interface DisabledSessionTrackingScenario : Scenario
 @end

--- a/features/fixtures/shared/scenarios/EnabledErrorTypesCxxScenario.mm
+++ b/features/fixtures/shared/scenarios/EnabledErrorTypesCxxScenario.mm
@@ -1,4 +1,5 @@
 #import "Scenario.h"
+#import "Logging.h"
 
 #import <exception>
 

--- a/features/fixtures/shared/scenarios/HandledErrorThreadSendAlwaysScenario.m
+++ b/features/fixtures/shared/scenarios/HandledErrorThreadSendAlwaysScenario.m
@@ -7,6 +7,7 @@
 //
 
 #import "Scenario.h"
+#import "Logging.h"
 
 @interface HandledErrorThreadSendAlwaysScenario : Scenario
 @end

--- a/features/fixtures/shared/scenarios/HandledErrorThreadSendUnhandledOnlyScenario.m
+++ b/features/fixtures/shared/scenarios/HandledErrorThreadSendUnhandledOnlyScenario.m
@@ -7,6 +7,7 @@
 //
 
 #import "Scenario.h"
+#import "Logging.h"
 
 @interface HandledErrorThreadSendUnhandledOnlyScenario : Scenario
 @end

--- a/features/fixtures/shared/scenarios/InvalidCrashReportScenario.m
+++ b/features/fixtures/shared/scenarios/InvalidCrashReportScenario.m
@@ -7,6 +7,7 @@
 //
 
 #import "Scenario.h"
+#import "Logging.h"
 
 @interface InvalidCrashReportScenario : Scenario
 @end

--- a/features/fixtures/shared/scenarios/LastRunInfoScenario.swift
+++ b/features/fixtures/shared/scenarios/LastRunInfoScenario.swift
@@ -46,7 +46,7 @@ class LastRunInfoScenario: Scenario {
         
         while try! !FileManager.default.contentsOfDirectory(at: dir, includingPropertiesForKeys: nil, options: [])
                 .filter({ $0.lastPathComponent.hasPrefix("CrashReport-") }).isEmpty {
-            NSLog("LastRunInfoScenario: waiting for delivery of crash reports...")
+            logInfo("LastRunInfoScenario: waiting for delivery of crash reports...")
             Thread.sleep(forTimeInterval: 0.1)
         }
     }

--- a/features/fixtures/shared/scenarios/LastRunInfoScenario.swift
+++ b/features/fixtures/shared/scenarios/LastRunInfoScenario.swift
@@ -46,7 +46,7 @@ class LastRunInfoScenario: Scenario {
         
         while try! !FileManager.default.contentsOfDirectory(at: dir, includingPropertiesForKeys: nil, options: [])
                 .filter({ $0.lastPathComponent.hasPrefix("CrashReport-") }).isEmpty {
-            logInfo("LastRunInfoScenario: waiting for delivery of crash reports...")
+            logDebug("LastRunInfoScenario: waiting for delivery of crash reports...")
             Thread.sleep(forTimeInterval: 0.1)
         }
     }

--- a/features/fixtures/shared/scenarios/Logging.h
+++ b/features/fixtures/shared/scenarios/Logging.h
@@ -8,6 +8,7 @@
 
 #import <Foundation/Foundation.h>
 
+void logDebugObjC(NSString *format, ...);
 void logInfoObjC(NSString *format, ...);
 void logWarnObjC(NSString *format, ...);
 void logErrorObjC(NSString *format, ...);
@@ -16,6 +17,7 @@ void logErrorObjC(NSString *format, ...);
 //#define logWarn(FMT, ...)  logWarnObjC(FMT, __VA_ARGS__)
 //#define logError(FMT, ...) logErrorObjC(FMT, __VA_ARGS__)
 
+#define logDebug  logDebugObjC
 #define logInfo  logInfoObjC
 #define logWarn  logWarnObjC
 #define logError logErrorObjC

--- a/features/fixtures/shared/scenarios/Logging.h
+++ b/features/fixtures/shared/scenarios/Logging.h
@@ -1,0 +1,21 @@
+//
+//  Logging.h
+//  iOSTestApp
+//
+//  Created by Karl Stenerud on 02.11.23.
+//  Copyright © 2023 Bugsnag. All rights reserved.
+//
+
+#import <Foundation/Foundation.h>
+
+void logInfoObjC(NSString *format, ...);
+void logWarnObjC(NSString *format, ...);
+void logErrorObjC(NSString *format, ...);
+
+//#define logInfo(FMT, ...)  logInfoObjC(FMT, __VA_ARGS__)
+//#define logWarn(FMT, ...)  logWarnObjC(FMT, __VA_ARGS__)
+//#define logError(FMT, ...) logErrorObjC(FMT, __VA_ARGS__)
+
+#define logInfo  logInfoObjC
+#define logWarn  logWarnObjC
+#define logError logErrorObjC

--- a/features/fixtures/shared/scenarios/Logging.m
+++ b/features/fixtures/shared/scenarios/Logging.m
@@ -22,6 +22,13 @@ void logInternal(const char* level, NSString *format, va_list args) {
 
 }
 
+void logDebugObjC(NSString *format, ...) {
+    va_list args;
+    va_start(args, format);
+    logInternal("debug", format, args);
+    va_end(args);
+}
+
 void logInfoObjC(NSString *format, ...) {
     va_list args;
     va_start(args, format);

--- a/features/fixtures/shared/scenarios/Logging.m
+++ b/features/fixtures/shared/scenarios/Logging.m
@@ -1,0 +1,44 @@
+//
+//  Logging.m
+//  iOSTestApp
+//
+//  Created by Karl Stenerud on 02.11.23.
+//  Copyright © 2023 Bugsnag. All rights reserved.
+//
+
+#import "Logging.h"
+
+extern void bsg_i_kslog_logCBasic(const char *fmt, ...) __printflike(1, 2);
+
+void logInternal(const char* level, NSString *format, va_list args) {
+    NSString *formatted = [[NSString alloc] initWithFormat:format arguments:args];
+    NSString *fullMessage = [NSString stringWithFormat:@"bugsnagci %s: %@", level, formatted];
+
+    NSLog(@"%@", fullMessage);
+    bsg_i_kslog_logCBasic("%s",
+                          [[NSString stringWithFormat:@"%@ %@",
+                            [NSDate date], fullMessage]
+                           cStringUsingEncoding:NSUTF8StringEncoding]);
+
+}
+
+void logInfoObjC(NSString *format, ...) {
+    va_list args;
+    va_start(args, format);
+    logInternal("info", format, args);
+    va_end(args);
+}
+
+void logWarnObjC(NSString *format, ...) {
+    va_list args;
+    va_start(args, format);
+    logInternal("warn", format, args);
+    va_end(args);
+}
+
+void logErrorObjC(NSString *format, ...) {
+    va_list args;
+    va_start(args, format);
+    logInternal("error", format, args);
+    va_end(args);
+}

--- a/features/fixtures/shared/scenarios/ManualSessionScenario.m
+++ b/features/fixtures/shared/scenarios/ManualSessionScenario.m
@@ -4,6 +4,7 @@
 //
 
 #import "Scenario.h"
+#import "Logging.h"
 
 /**
  * Sends a manual session payload to Bugsnag.

--- a/features/fixtures/shared/scenarios/ManualSessionWithUserScenario.m
+++ b/features/fixtures/shared/scenarios/ManualSessionWithUserScenario.m
@@ -7,6 +7,7 @@
 //
 
 #import "Scenario.h"
+#import "Logging.h"
 
 @interface ManualSessionWithUserScenario : Scenario
 @end

--- a/features/fixtures/shared/scenarios/ManyConcurrentNotifyScenario.m
+++ b/features/fixtures/shared/scenarios/ManyConcurrentNotifyScenario.m
@@ -1,4 +1,5 @@
 #import "Scenario.h"
+#import "Logging.h"
 
 @interface ManyConcurrentNotifyScenario : Scenario
 @property (nonatomic) dispatch_queue_t queue1;

--- a/features/fixtures/shared/scenarios/MarkUnhandledHandledScenario.m
+++ b/features/fixtures/shared/scenarios/MarkUnhandledHandledScenario.m
@@ -7,6 +7,7 @@
 //
 
 #import "MarkUnhandledHandledScenario.h"
+#import "Logging.h"
 
 @implementation MarkUnhandledHandledScenario
 

--- a/features/fixtures/shared/scenarios/MaxPersistedSessionsScenario.m
+++ b/features/fixtures/shared/scenarios/MaxPersistedSessionsScenario.m
@@ -7,6 +7,7 @@
 //
 
 #import "Scenario.h"
+#import "Logging.h"
 
 @interface MaxPersistedSessionsScenario : Scenario
 @end

--- a/features/fixtures/shared/scenarios/NSExceptionShiftScenario.m
+++ b/features/fixtures/shared/scenarios/NSExceptionShiftScenario.m
@@ -1,4 +1,5 @@
 #import "Scenario.h"
+#import "Logging.h"
 
 @interface NSExceptionShiftScenario : Scenario
 @end

--- a/features/fixtures/shared/scenarios/NonExistentMethodScenario.m
+++ b/features/fixtures/shared/scenarios/NonExistentMethodScenario.m
@@ -4,6 +4,7 @@
 //
 
 #import "Scenario.h"
+#import "Logging.h"
 
 /**
  * Calls a non-existent method on an object

--- a/features/fixtures/shared/scenarios/NullPointerScenario.m
+++ b/features/fixtures/shared/scenarios/NullPointerScenario.m
@@ -24,6 +24,7 @@
  * OTHER DEALINGS IN THE SOFTWARE.
  */
 #import "Scenario.h"
+#import "Logging.h"
 
 #import "spin_malloc.h"
 

--- a/features/fixtures/shared/scenarios/OOMInactiveScenario.swift
+++ b/features/fixtures/shared/scenarios/OOMInactiveScenario.swift
@@ -22,7 +22,7 @@ class OOMInactiveScenario: Scenario {
         NotificationCenter.default.post(name: UIApplication.willResignActiveNotification,
                                         object: UIApplication.shared, userInfo: nil)
         
-        logInfo("Killing app to fake an OOM")
+        logDebug("Killing app to fake an OOM")
         kill(getpid(), SIGKILL)
     }
 }

--- a/features/fixtures/shared/scenarios/OOMInactiveScenario.swift
+++ b/features/fixtures/shared/scenarios/OOMInactiveScenario.swift
@@ -22,7 +22,7 @@ class OOMInactiveScenario: Scenario {
         NotificationCenter.default.post(name: UIApplication.willResignActiveNotification,
                                         object: UIApplication.shared, userInfo: nil)
         
-        NSLog("Killing app to fake an OOM")
+        logInfo("Killing app to fake an OOM")
         kill(getpid(), SIGKILL)
     }
 }

--- a/features/fixtures/shared/scenarios/OOMScenario.m
+++ b/features/fixtures/shared/scenarios/OOMScenario.m
@@ -58,7 +58,7 @@ void onCrashHandler(const BSG_KSCrashReportWriter *writer) {
     [Bugsnag setContext:@"OOM Scenario"];
     [NSNotificationCenter.defaultCenter addObserverForName:UIApplicationDidReceiveMemoryWarningNotification object:nil
                                                      queue:nil usingBlock:^(NSNotification *note) {
-        logInfo(@"*** Received memory warning");
+        logDebug(@"*** Received memory warning");
     }];
     // Delay to allow session payload to be sent
     [self performSelector:@selector(consumeAllMemory) withObject:nil afterDelay:2];
@@ -67,11 +67,11 @@ void onCrashHandler(const BSG_KSCrashReportWriter *writer) {
 - (void)consumeAllMemory {
     struct utsname system = {0};
     uname(&system);
-    logInfo(@"*** Device = %s", system.machine);
+    logDebug(@"*** Device = %s", system.machine);
     
     NSUInteger physicalMemory = (NSUInteger)NSProcessInfo.processInfo.physicalMemory;
     NSUInteger megabytes = physicalMemory / MEGABYTE;
-    logInfo(@"*** Physical memory = %lu MB", (unsigned long)megabytes);
+    logDebug(@"*** Physical memory = %lu MB", (unsigned long)megabytes);
     
     //
     // The ActiveHard limit and point at which a memory warning is sent varies by device
@@ -105,21 +105,21 @@ void onCrashHandler(const BSG_KSCrashReportWriter *writer) {
     kern_return_t result = task_info(mach_task_self(), TASK_VM_INFO, (task_info_t)&vm_info, &count);
     if (result == KERN_SUCCESS && count >= TASK_VM_INFO_REV4_COUNT) {
         limit = (NSUInteger)(vm_info.phys_footprint + vm_info.limit_bytes_remaining) / MEGABYTE;
-        logInfo(@"*** Memory limit = %lu MB", (unsigned long)limit);
+        logDebug(@"*** Memory limit = %lu MB", (unsigned long)limit);
     } else if (!strcmp(system.machine, "iPhone6,2")) {
         limit = 650;
-        logInfo(@"*** Memory limit = %lu MB", (unsigned long)limit);
+        logDebug(@"*** Memory limit = %lu MB", (unsigned long)limit);
     } else {
         limit = MIN(2098, megabytes * 70 / 100);
-        logInfo(@"*** Memory limit = %lu MB (estimated)", (unsigned long)limit);
+        logDebug(@"*** Memory limit = %lu MB (estimated)", (unsigned long)limit);
     }
     
     // The size of the initial block needs to be under the memory warning limit in order for one to be reliably sent.
     NSUInteger initial = limit * 70 / 100;
-    logInfo(@"*** Dirtying an initial block of %lu MB", (unsigned long)initial);
+    logDebug(@"*** Dirtying an initial block of %lu MB", (unsigned long)initial);
     [self consumeMegabytes:initial];
     
-    logInfo(@"*** Dirtying remaining memory in ~2 seconds");
+    logDebug(@"*** Dirtying remaining memory in ~2 seconds");
     NSTimeInterval timeInterval = 2.0 / (limit - initial);
     [NSTimer scheduledTimerWithTimeInterval:timeInterval target:self selector:@selector(timerFired) userInfo:nil repeats:YES];
 }

--- a/features/fixtures/shared/scenarios/OOMScenario.m
+++ b/features/fixtures/shared/scenarios/OOMScenario.m
@@ -7,6 +7,7 @@
 //
 
 #import "Scenario.h"
+#import "Logging.h"
 
 #import <UIKit/UIKit.h>
 
@@ -57,7 +58,7 @@ void onCrashHandler(const BSG_KSCrashReportWriter *writer) {
     [Bugsnag setContext:@"OOM Scenario"];
     [NSNotificationCenter.defaultCenter addObserverForName:UIApplicationDidReceiveMemoryWarningNotification object:nil
                                                      queue:nil usingBlock:^(NSNotification *note) {
-        NSLog(@"*** Received memory warning");
+        logInfo(@"*** Received memory warning");
     }];
     // Delay to allow session payload to be sent
     [self performSelector:@selector(consumeAllMemory) withObject:nil afterDelay:2];
@@ -66,11 +67,11 @@ void onCrashHandler(const BSG_KSCrashReportWriter *writer) {
 - (void)consumeAllMemory {
     struct utsname system = {0};
     uname(&system);
-    NSLog(@"*** Device = %s", system.machine);
+    logInfo(@"*** Device = %s", system.machine);
     
     NSUInteger physicalMemory = (NSUInteger)NSProcessInfo.processInfo.physicalMemory;
     NSUInteger megabytes = physicalMemory / MEGABYTE;
-    NSLog(@"*** Physical memory = %lu MB", (unsigned long)megabytes);
+    logInfo(@"*** Physical memory = %lu MB", (unsigned long)megabytes);
     
     //
     // The ActiveHard limit and point at which a memory warning is sent varies by device
@@ -104,21 +105,21 @@ void onCrashHandler(const BSG_KSCrashReportWriter *writer) {
     kern_return_t result = task_info(mach_task_self(), TASK_VM_INFO, (task_info_t)&vm_info, &count);
     if (result == KERN_SUCCESS && count >= TASK_VM_INFO_REV4_COUNT) {
         limit = (NSUInteger)(vm_info.phys_footprint + vm_info.limit_bytes_remaining) / MEGABYTE;
-        NSLog(@"*** Memory limit = %lu MB", (unsigned long)limit);
+        logInfo(@"*** Memory limit = %lu MB", (unsigned long)limit);
     } else if (!strcmp(system.machine, "iPhone6,2")) {
         limit = 650;
-        NSLog(@"*** Memory limit = %lu MB", (unsigned long)limit);
+        logInfo(@"*** Memory limit = %lu MB", (unsigned long)limit);
     } else {
         limit = MIN(2098, megabytes * 70 / 100);
-        NSLog(@"*** Memory limit = %lu MB (estimated)", (unsigned long)limit);
+        logInfo(@"*** Memory limit = %lu MB (estimated)", (unsigned long)limit);
     }
     
     // The size of the initial block needs to be under the memory warning limit in order for one to be reliably sent.
     NSUInteger initial = limit * 70 / 100;
-    NSLog(@"*** Dirtying an initial block of %lu MB", (unsigned long)initial);
+    logInfo(@"*** Dirtying an initial block of %lu MB", (unsigned long)initial);
     [self consumeMegabytes:initial];
     
-    NSLog(@"*** Dirtying remaining memory in ~2 seconds");
+    logInfo(@"*** Dirtying remaining memory in ~2 seconds");
     NSTimeInterval timeInterval = 2.0 / (limit - initial);
     [NSTimer scheduledTimerWithTimeInterval:timeInterval target:self selector:@selector(timerFired) userInfo:nil repeats:YES];
 }

--- a/features/fixtures/shared/scenarios/OOMSessionlessScenario.m
+++ b/features/fixtures/shared/scenarios/OOMSessionlessScenario.m
@@ -7,6 +7,7 @@
 //
 
 #import "Scenario.h"
+#import "Logging.h"
 
 @interface OOMSessionlessScenario : Scenario
 

--- a/features/fixtures/shared/scenarios/OOMWillTerminateScenario.m
+++ b/features/fixtures/shared/scenarios/OOMWillTerminateScenario.m
@@ -1,5 +1,6 @@
 
 #import "Scenario.h"
+#import "Logging.h"
 
 #import <signal.h>
 

--- a/features/fixtures/shared/scenarios/ObjCExceptionOverrideScenario.m
+++ b/features/fixtures/shared/scenarios/ObjCExceptionOverrideScenario.m
@@ -25,6 +25,7 @@
  */
 
 #import "MarkUnhandledHandledScenario.h"
+#import "Logging.h"
 
 /**
  * Throw an uncaught Objective-C exception. It's possible to generate a better crash report here

--- a/features/fixtures/shared/scenarios/ObjCExceptionScenario.m
+++ b/features/fixtures/shared/scenarios/ObjCExceptionScenario.m
@@ -25,6 +25,7 @@
  */
 
 #import "MarkUnhandledHandledScenario.h"
+#import "Logging.h"
 
 /**
  * Throw an uncaught Objective-C exception. It's possible to generate a better crash report here

--- a/features/fixtures/shared/scenarios/ObjCMsgSendScenario.m
+++ b/features/fixtures/shared/scenarios/ObjCMsgSendScenario.m
@@ -25,6 +25,7 @@
  */
 
 #import "Scenario.h"
+#import "Logging.h"
 
 #import <objc/message.h>
 

--- a/features/fixtures/shared/scenarios/OldCrashReportScenario.swift
+++ b/features/fixtures/shared/scenarios/OldCrashReportScenario.swift
@@ -24,7 +24,7 @@ class OldCrashReportScenario: Scenario {
             for name in try FileManager.default.contentsOfDirectory(atPath: dir) {
                 let file = (dir as NSString).appendingPathComponent(name)
                 try FileManager.default.setAttributes([.creationDate: creationDate], ofItemAtPath: file)
-                logInfo("OldCrashReportScenario: Updated creation date of \((file as NSString).lastPathComponent) to \(creationDate)")
+                logDebug("OldCrashReportScenario: Updated creation date of \((file as NSString).lastPathComponent) to \(creationDate)")
             }
         } catch {
             logError("\(error)")

--- a/features/fixtures/shared/scenarios/OldCrashReportScenario.swift
+++ b/features/fixtures/shared/scenarios/OldCrashReportScenario.swift
@@ -24,10 +24,10 @@ class OldCrashReportScenario: Scenario {
             for name in try FileManager.default.contentsOfDirectory(atPath: dir) {
                 let file = (dir as NSString).appendingPathComponent(name)
                 try FileManager.default.setAttributes([.creationDate: creationDate], ofItemAtPath: file)
-                NSLog("OldCrashReportScenario: Updated creation date of \((file as NSString).lastPathComponent) to \(creationDate)")
+                logInfo("OldCrashReportScenario: Updated creation date of \((file as NSString).lastPathComponent) to \(creationDate)")
             }
         } catch {
-            NSLog("\(error)")
+            logError("\(error)")
         }
     }
 }

--- a/features/fixtures/shared/scenarios/OldHandledErrorScenario.swift
+++ b/features/fixtures/shared/scenarios/OldHandledErrorScenario.swift
@@ -24,7 +24,7 @@ class OldHandledErrorScenario: Scenario {
             for name in try FileManager.default.contentsOfDirectory(atPath: dir) {
                 let file = (dir as NSString).appendingPathComponent(name)
                 try FileManager.default.setAttributes([.creationDate: creationDate], ofItemAtPath: file)
-                logInfo("OldCrashReportScenario: Updated creation date of \((file as NSString).lastPathComponent) to \(creationDate)")
+                logDebug("OldCrashReportScenario: Updated creation date of \((file as NSString).lastPathComponent) to \(creationDate)")
             }
         } catch {
             logError("\(error)")

--- a/features/fixtures/shared/scenarios/OldHandledErrorScenario.swift
+++ b/features/fixtures/shared/scenarios/OldHandledErrorScenario.swift
@@ -24,10 +24,10 @@ class OldHandledErrorScenario: Scenario {
             for name in try FileManager.default.contentsOfDirectory(atPath: dir) {
                 let file = (dir as NSString).appendingPathComponent(name)
                 try FileManager.default.setAttributes([.creationDate: creationDate], ofItemAtPath: file)
-                NSLog("OldCrashReportScenario: Updated creation date of \((file as NSString).lastPathComponent) to \(creationDate)")
+                logInfo("OldCrashReportScenario: Updated creation date of \((file as NSString).lastPathComponent) to \(creationDate)")
             }
         } catch {
-            NSLog("\(error)")
+            logError("\(error)")
         }
     }
 }

--- a/features/fixtures/shared/scenarios/OldSessionScenario.m
+++ b/features/fixtures/shared/scenarios/OldSessionScenario.m
@@ -41,7 +41,7 @@
     NSString *file = [dir stringByAppendingPathComponent:name];
     NSError *error;
     if ([NSFileManager.defaultManager setAttributes:@{NSFileCreationDate: creationDate} ofItemAtPath:file error:&error]) {
-        logInfo(@"OldSessionScenario: Updated creation date of %@ to %@", file.lastPathComponent,
+        logDebug(@"OldSessionScenario: Updated creation date of %@ to %@", file.lastPathComponent,
               [NSFileManager.defaultManager attributesOfItemAtPath:file error:nil].fileCreationDate);
     } else {
         logError(@"OldSessionScenario: %@", error);

--- a/features/fixtures/shared/scenarios/OldSessionScenario.m
+++ b/features/fixtures/shared/scenarios/OldSessionScenario.m
@@ -7,6 +7,7 @@
 //
 
 #import "Scenario.h"
+#import "Logging.h"
 
 @interface OldSessionScenario : Scenario
 @end
@@ -40,10 +41,10 @@
     NSString *file = [dir stringByAppendingPathComponent:name];
     NSError *error;
     if ([NSFileManager.defaultManager setAttributes:@{NSFileCreationDate: creationDate} ofItemAtPath:file error:&error]) {
-        NSLog(@"OldSessionScenario: Updated creation date of %@ to %@", file.lastPathComponent,
+        logInfo(@"OldSessionScenario: Updated creation date of %@ to %@", file.lastPathComponent,
               [NSFileManager.defaultManager attributesOfItemAtPath:file error:nil].fileCreationDate);
     } else {
-        NSLog(@"OldSessionScenario: %@", error);
+        logError(@"OldSessionScenario: %@", error);
         abort();
     }
 }

--- a/features/fixtures/shared/scenarios/OnCrashHandlerScenario.m
+++ b/features/fixtures/shared/scenarios/OnCrashHandlerScenario.m
@@ -7,6 +7,7 @@
 //
 
 #import "Scenario.h"
+#import "Logging.h"
 
 // Create crash handler
 void HandleCrashedThread(const BSG_KSCrashReportWriter *writer) {

--- a/features/fixtures/shared/scenarios/OnSendCallbackRemovalScenario.m
+++ b/features/fixtures/shared/scenarios/OnSendCallbackRemovalScenario.m
@@ -7,6 +7,7 @@
 //
 
 #import "Scenario.h"
+#import "Logging.h"
 
 /**
  * Verifies that removing an OnSend callback does not affect other OnSend callbacks

--- a/features/fixtures/shared/scenarios/OnSendErrorPersistenceScenario.m
+++ b/features/fixtures/shared/scenarios/OnSendErrorPersistenceScenario.m
@@ -7,6 +7,7 @@
 //
 
 #import "Scenario.h"
+#import "Logging.h"
 
 NSString * const HasNotifiedKey = @"OnSendErrorPersistenceScenario.hasNotified";
 

--- a/features/fixtures/shared/scenarios/OverwriteLinkRegisterScenario.m
+++ b/features/fixtures/shared/scenarios/OverwriteLinkRegisterScenario.m
@@ -25,6 +25,7 @@
  */
 
 #import "Scenario.h"
+#import "Logging.h"
 
 #import "spin_malloc.h"
 

--- a/features/fixtures/shared/scenarios/PrivilegedInstructionScenario.m
+++ b/features/fixtures/shared/scenarios/PrivilegedInstructionScenario.m
@@ -25,6 +25,7 @@
  */
 
 #import "Scenario.h"
+#import "Logging.h"
 
 #import "spin_malloc.h"
 

--- a/features/fixtures/shared/scenarios/ReadGarbagePointerScenario.m
+++ b/features/fixtures/shared/scenarios/ReadGarbagePointerScenario.m
@@ -25,6 +25,7 @@
  */
 
 #import "Scenario.h"
+#import "Logging.h"
 
 #import "spin_malloc.h"
 

--- a/features/fixtures/shared/scenarios/ReadOnlyPageScenario.m
+++ b/features/fixtures/shared/scenarios/ReadOnlyPageScenario.m
@@ -25,6 +25,7 @@
  */
 
 #import "Scenario.h"
+#import "Logging.h"
 
 #import "spin_malloc.h"
 

--- a/features/fixtures/shared/scenarios/RecrashScenarios.mm
+++ b/features/fixtures/shared/scenarios/RecrashScenarios.mm
@@ -7,6 +7,7 @@
 //
 
 #import "Scenario.h"
+#import "Logging.h"
 
 #import <stdexcept>
 

--- a/features/fixtures/shared/scenarios/ReleasedObjectScenario.m
+++ b/features/fixtures/shared/scenarios/ReleasedObjectScenario.m
@@ -25,6 +25,7 @@
  */
 
 #import "Scenario.h"
+#import "Logging.h"
 
 #import <objc/message.h>
 

--- a/features/fixtures/shared/scenarios/ReportBackgroundAppHangScenario.swift
+++ b/features/fixtures/shared/scenarios/ReportBackgroundAppHangScenario.swift
@@ -19,9 +19,9 @@ class ReportBackgroundAppHangScenario: Scenario {
             let backgroundTask = UIApplication.shared.beginBackgroundTask()
             
             let timeInterval: TimeInterval = 2
-            NSLog("Simulating an app hang of \(timeInterval) seconds...")
+            logInfo("Simulating an app hang of \(timeInterval) seconds...")
             Thread.sleep(forTimeInterval: timeInterval)
-            NSLog("Finished sleeping")
+            logInfo("Finished sleeping")
             
             DispatchQueue.main.asyncAfter(deadline: .now() + 3) {
                 UIApplication.shared.endBackgroundTask(backgroundTask)

--- a/features/fixtures/shared/scenarios/ReportBackgroundAppHangScenario.swift
+++ b/features/fixtures/shared/scenarios/ReportBackgroundAppHangScenario.swift
@@ -19,9 +19,9 @@ class ReportBackgroundAppHangScenario: Scenario {
             let backgroundTask = UIApplication.shared.beginBackgroundTask()
             
             let timeInterval: TimeInterval = 2
-            logInfo("Simulating an app hang of \(timeInterval) seconds...")
+            logDebug("Simulating an app hang of \(timeInterval) seconds...")
             Thread.sleep(forTimeInterval: timeInterval)
-            logInfo("Finished sleeping")
+            logDebug("Finished sleeping")
             
             DispatchQueue.main.asyncAfter(deadline: .now() + 3) {
                 UIApplication.shared.endBackgroundTask(backgroundTask)

--- a/features/fixtures/shared/scenarios/ResumeSessionOOMScenario.m
+++ b/features/fixtures/shared/scenarios/ResumeSessionOOMScenario.m
@@ -1,4 +1,5 @@
 #import "Scenario.h"
+#import "Logging.h"
 
 @interface ResumeSessionOOMScenario : Scenario
 @end

--- a/features/fixtures/shared/scenarios/SIGBUSScenario.m
+++ b/features/fixtures/shared/scenarios/SIGBUSScenario.m
@@ -7,6 +7,7 @@
 //
 
 #import "Scenario.h"
+#import "Logging.h"
 
 @interface SIGBUSScenario : Scenario
 @end

--- a/features/fixtures/shared/scenarios/SIGFPEScenario.m
+++ b/features/fixtures/shared/scenarios/SIGFPEScenario.m
@@ -7,6 +7,7 @@
 //
 
 #import "Scenario.h"
+#import "Logging.h"
 
 @interface SIGFPEScenario : Scenario
 @end

--- a/features/fixtures/shared/scenarios/SIGILLScenario.m
+++ b/features/fixtures/shared/scenarios/SIGILLScenario.m
@@ -7,6 +7,7 @@
 //
 
 #import "Scenario.h"
+#import "Logging.h"
 
 @interface SIGILLScenario : Scenario
 @end

--- a/features/fixtures/shared/scenarios/SIGPIPEIgnoredScenario.m
+++ b/features/fixtures/shared/scenarios/SIGPIPEIgnoredScenario.m
@@ -7,6 +7,7 @@
 //
 
 #import "Scenario.h"
+#import "Logging.h"
 
 @interface SIGPIPEIgnoredScenario : Scenario
 

--- a/features/fixtures/shared/scenarios/SIGPIPEScenario.m
+++ b/features/fixtures/shared/scenarios/SIGPIPEScenario.m
@@ -7,6 +7,7 @@
 //
 
 #import "Scenario.h"
+#import "Logging.h"
 
 @interface SIGPIPEScenario : Scenario
 @end

--- a/features/fixtures/shared/scenarios/SIGSEGVScenario.m
+++ b/features/fixtures/shared/scenarios/SIGSEGVScenario.m
@@ -7,6 +7,7 @@
 //
 
 #import "Scenario.h"
+#import "Logging.h"
 
 @interface SIGSEGVScenario : Scenario
 @end

--- a/features/fixtures/shared/scenarios/SIGSYSScenario.m
+++ b/features/fixtures/shared/scenarios/SIGSYSScenario.m
@@ -7,6 +7,7 @@
 //
 
 #import "Scenario.h"
+#import "Logging.h"
 
 @interface SIGSYSScenario : Scenario
 @end

--- a/features/fixtures/shared/scenarios/SIGTRAPScenario.m
+++ b/features/fixtures/shared/scenarios/SIGTRAPScenario.m
@@ -7,6 +7,7 @@
 //
 
 #import "Scenario.h"
+#import "Logging.h"
 
 @interface SIGTRAPScenario : Scenario
 @end

--- a/features/fixtures/shared/scenarios/Scenario.h
+++ b/features/fixtures/shared/scenarios/Scenario.h
@@ -9,7 +9,7 @@
 
 NS_ASSUME_NONNULL_BEGIN
 
-void kslog(const char *message);
+void logInternal(const char* level, NSString *format, va_list args);
 
 void markErrorHandledCallback(const BSG_KSCrashReportWriter *writer);
 

--- a/features/fixtures/shared/scenarios/Scenario.m
+++ b/features/fixtures/shared/scenarios/Scenario.m
@@ -3,6 +3,7 @@
 // Copyright (c) 2018 Bugsnag. All rights reserved.
 //
 #import "Scenario.h"
+#import "Logging.h"
 
 #import <objc/runtime.h>
 
@@ -18,12 +19,6 @@
 #endif
 
 extern bool bsg_kslog_setLogFilename(const char *filename, bool overwrite);
-
-extern void bsg_i_kslog_logCBasic(const char *fmt, ...) __printflike(1, 2);
-
-void kslog(const char *message) {
-    bsg_i_kslog_logCBasic("%s", message);
-}
 
 void markErrorHandledCallback(const BSG_KSCrashReportWriter *writer) {
     writer->addBooleanElement(writer, "unhandled", false);
@@ -65,7 +60,7 @@ static char ksLogPath[PATH_MAX];
             return;
         }
 #endif
-        NSLog(@"%@", notification.name);
+        logInfo(@"Received notification %@", notification.name);
     }];
 }
 
@@ -184,7 +179,7 @@ static NSURLSessionUploadTask * uploadTaskWithRequest_fromData_completionHandler
 }
 
 + (void)clearPersistentData {
-    NSLog(@"%s", __PRETTY_FUNCTION__);
+    logInfo(@"%s", __PRETTY_FUNCTION__);
     [NSUserDefaults.standardUserDefaults removePersistentDomainForName:NSBundle.mainBundle.bundleIdentifier];
     NSString *cachesDir = NSSearchPathForDirectoriesInDomains(NSCachesDirectory, NSUserDomainMask, YES).firstObject;
     NSArray<NSString *> *entries = @[
@@ -200,7 +195,7 @@ static NSURLSessionUploadTask * uploadTaskWithRequest_fromData_completionHandler
         NSError *error = nil;
         if (![NSFileManager.defaultManager removeItemAtPath:path error:&error]) {
             if (![error.domain isEqualToString:NSCocoaErrorDomain] && error.code != NSFileNoSuchFileError) {
-                NSLog(@"%@", error);
+                logError(@"Error removing path %@: %@", path, error);
             }
         }
     }
@@ -209,7 +204,7 @@ static NSURLSessionUploadTask * uploadTaskWithRequest_fromData_completionHandler
     NSError *error = nil;
     if (![NSFileManager.defaultManager removeItemAtPath:rootDir error:&error]) {
         if (![error.domain isEqualToString:NSCocoaErrorDomain] && error.code != NSFileNoSuchFileError) {
-            NSLog(@"%@", error);
+            logError(@"Error removing path %@: %@", rootDir, error);
         }
     }
 #if !TARGET_OS_WATCH
@@ -218,28 +213,29 @@ static NSURLSessionUploadTask * uploadTaskWithRequest_fromData_completionHandler
 }
 
 + (void)executeMazeRunnerCommand:(void (^)(NSString *scenarioName, NSString *scenarioMode))preHandler {
-    NSLog(@"%s", __PRETTY_FUNCTION__);
+    logInfo(@"%s", __PRETTY_FUNCTION__);
     NSURLSession *session = [NSURLSession sessionWithConfiguration:[NSURLSessionConfiguration ephemeralSessionConfiguration]];
     NSString *commandEndpoint = [NSString stringWithFormat:@"%@/command", theBaseMazeAddress];
     NSURLRequest *request = [NSURLRequest requestWithURL:[NSURL URLWithString:commandEndpoint]];
+    logInfo(@"%s: Sending command request to %@", __PRETTY_FUNCTION__, commandEndpoint);
     [[session dataTaskWithRequest:request completionHandler:^(NSData *data, NSURLResponse *response, NSError *error) {
         if (![response isKindOfClass:[NSHTTPURLResponse class]] || [(NSHTTPURLResponse *)response statusCode] != 200) {
-            NSLog(@"%s request failed with %@", __PRETTY_FUNCTION__, response ?: error);
+            logError(@"%s: command request failed with %@", __PRETTY_FUNCTION__, response ?: error);
             preHandler(@"", NULL);
             return;
         }
-        NSLog(@"%s response body:  %@", __PRETTY_FUNCTION__, [[NSString alloc] initWithData:data encoding:NSUTF8StringEncoding]);
+        logInfo(@"%s: command response body:  %@", __PRETTY_FUNCTION__, [[NSString alloc] initWithData:data encoding:NSUTF8StringEncoding]);
         NSDictionary *command = [NSJSONSerialization JSONObjectWithData:data options:0 error:&error];
         
         NSString *action = [command objectForKey:@"action"];
+        NSParameterAssert([action isKindOfClass:[NSString class]]);
+
         if ([action isEqualToString:@"noop"]) {
-            NSLog(@"No Maze Runner command queued at present");
+            logInfo(@"%s: No Maze Runner command queued at present", __PRETTY_FUNCTION__);
             preHandler(@"", NULL);
             return;
         }
-        
-        NSParameterAssert([action isKindOfClass:[NSString class]]);
-        
+
         NSString *scenarioName = [command objectForKey:@"scenario_name"];
         NSParameterAssert([scenarioName isKindOfClass:[NSString class]]);
         
@@ -270,7 +266,7 @@ static NSURLSessionUploadTask * uploadTaskWithRequest_fromData_completionHandler
 }
 
 + (void)runScenario:(NSString *)scenarioName eventMode:(NSString *)eventMode {
-    NSLog(@"%s %@ %@", __PRETTY_FUNCTION__, scenarioName, eventMode);
+    logInfo(@"%s %@ %@", __PRETTY_FUNCTION__, scenarioName, eventMode);
     
     [self startBugsnagForScenario:scenarioName eventMode:eventMode];
     
@@ -278,12 +274,12 @@ static NSURLSessionUploadTask * uploadTaskWithRequest_fromData_completionHandler
 }
 
 + (void)startBugsnagForScenario:(NSString *)scenarioName eventMode:(NSString *)eventMode {
-    NSLog(@"%s %@ %@", __PRETTY_FUNCTION__, scenarioName, eventMode);
+    logInfo(@"%s %@ %@", __PRETTY_FUNCTION__, scenarioName, eventMode);
     
     theScenario = [Scenario createScenarioNamed:scenarioName withConfig:nil];
     theScenario.eventMode = eventMode;
     
-    NSLog(@"Starting scenario \"%@\"", NSStringFromClass([self class]));
+    logInfo(@"%s: Starting scenario \"%@\"", __PRETTY_FUNCTION__, NSStringFromClass([self class]));
     [theScenario startBugsnag];
 }
 

--- a/features/fixtures/shared/scenarios/Scenario.m
+++ b/features/fixtures/shared/scenarios/Scenario.m
@@ -60,7 +60,7 @@ static char ksLogPath[PATH_MAX];
             return;
         }
 #endif
-        logInfo(@"Received notification %@", notification.name);
+        logDebug(@"Received notification %@", notification.name);
     }];
 }
 
@@ -213,11 +213,11 @@ static NSURLSessionUploadTask * uploadTaskWithRequest_fromData_completionHandler
 }
 
 + (void)executeMazeRunnerCommand:(void (^)(NSString *scenarioName, NSString *scenarioMode))preHandler {
-    logInfo(@"%s", __PRETTY_FUNCTION__);
+    logDebug(@"%s", __PRETTY_FUNCTION__);
     NSURLSession *session = [NSURLSession sessionWithConfiguration:[NSURLSessionConfiguration ephemeralSessionConfiguration]];
     NSString *commandEndpoint = [NSString stringWithFormat:@"%@/command", theBaseMazeAddress];
     NSURLRequest *request = [NSURLRequest requestWithURL:[NSURL URLWithString:commandEndpoint]];
-    logInfo(@"%s: Sending command request to %@", __PRETTY_FUNCTION__, commandEndpoint);
+    logDebug(@"%s: Sending command request to %@", __PRETTY_FUNCTION__, commandEndpoint);
     [[session dataTaskWithRequest:request completionHandler:^(NSData *data, NSURLResponse *response, NSError *error) {
         if (![response isKindOfClass:[NSHTTPURLResponse class]] || [(NSHTTPURLResponse *)response statusCode] != 200) {
             logError(@"%s: command request failed with %@", __PRETTY_FUNCTION__, response ?: error);
@@ -266,7 +266,7 @@ static NSURLSessionUploadTask * uploadTaskWithRequest_fromData_completionHandler
 }
 
 + (void)runScenario:(NSString *)scenarioName eventMode:(NSString *)eventMode {
-    logInfo(@"%s %@ %@", __PRETTY_FUNCTION__, scenarioName, eventMode);
+    logDebug(@"%s %@ %@", __PRETTY_FUNCTION__, scenarioName, eventMode);
     
     [self startBugsnagForScenario:scenarioName eventMode:eventMode];
     
@@ -274,7 +274,7 @@ static NSURLSessionUploadTask * uploadTaskWithRequest_fromData_completionHandler
 }
 
 + (void)startBugsnagForScenario:(NSString *)scenarioName eventMode:(NSString *)eventMode {
-    logInfo(@"%s %@ %@", __PRETTY_FUNCTION__, scenarioName, eventMode);
+    logDebug(@"%s %@ %@", __PRETTY_FUNCTION__, scenarioName, eventMode);
     
     theScenario = [Scenario createScenarioNamed:scenarioName withConfig:nil];
     theScenario.eventMode = eventMode;

--- a/features/fixtures/shared/scenarios/SendLaunchCrashesSynchronouslyLaunchCompletedScenario.swift
+++ b/features/fixtures/shared/scenarios/SendLaunchCrashesSynchronouslyLaunchCompletedScenario.swift
@@ -2,7 +2,7 @@ class SendLaunchCrashesSynchronouslyLaunchCompletedScenario: SendLaunchCrashesSy
     
     override func run() {
         if eventMode != "report" {
-            logInfo(">>> Calling markLaunchCompleted()")
+            logDebug(">>> Calling markLaunchCompleted()")
             Bugsnag.markLaunchCompleted()
         }
         super.run()

--- a/features/fixtures/shared/scenarios/SendLaunchCrashesSynchronouslyLaunchCompletedScenario.swift
+++ b/features/fixtures/shared/scenarios/SendLaunchCrashesSynchronouslyLaunchCompletedScenario.swift
@@ -2,7 +2,7 @@ class SendLaunchCrashesSynchronouslyLaunchCompletedScenario: SendLaunchCrashesSy
     
     override func run() {
         if eventMode != "report" {
-            NSLog(">>> Calling markLaunchCompleted()")
+            logInfo(">>> Calling markLaunchCompleted()")
             Bugsnag.markLaunchCompleted()
         }
         super.run()

--- a/features/fixtures/shared/scenarios/SendLaunchCrashesSynchronouslyScenario.swift
+++ b/features/fixtures/shared/scenarios/SendLaunchCrashesSynchronouslyScenario.swift
@@ -20,7 +20,7 @@ class SendLaunchCrashesSynchronouslyScenario: Scenario {
     
     override func run() {
         if eventMode == "report" {
-            NSLog(">>> Delaying to allow previous run's crash report to be sent")
+            logInfo(">>> Delaying to allow previous run's crash report to be sent")
             DispatchQueue.main.asyncAfter(deadline: .now() + 5) { [startDuration] in
                 NSLog(">>> Calling notify() with startDuration = \(startDuration)")
                 Bugsnag.notifyError(NSError(domain: "DummyError", code: 0)) {
@@ -29,7 +29,7 @@ class SendLaunchCrashesSynchronouslyScenario: Scenario {
                 }
             }
         } else {
-            NSLog(">>> Calling fatalError()")
+            logInfo(">>> Calling fatalError()")
             fatalError()
         }
     }

--- a/features/fixtures/shared/scenarios/SendLaunchCrashesSynchronouslyScenario.swift
+++ b/features/fixtures/shared/scenarios/SendLaunchCrashesSynchronouslyScenario.swift
@@ -20,7 +20,7 @@ class SendLaunchCrashesSynchronouslyScenario: Scenario {
     
     override func run() {
         if eventMode == "report" {
-            logInfo(">>> Delaying to allow previous run's crash report to be sent")
+            logDebug(">>> Delaying to allow previous run's crash report to be sent")
             DispatchQueue.main.asyncAfter(deadline: .now() + 5) { [startDuration] in
                 NSLog(">>> Calling notify() with startDuration = \(startDuration)")
                 Bugsnag.notifyError(NSError(domain: "DummyError", code: 0)) {
@@ -29,7 +29,7 @@ class SendLaunchCrashesSynchronouslyScenario: Scenario {
                 }
             }
         } else {
-            logInfo(">>> Calling fatalError()")
+            logDebug(">>> Calling fatalError()")
             fatalError()
         }
     }

--- a/features/fixtures/shared/scenarios/SessionCallbackRemovalScenario.m
+++ b/features/fixtures/shared/scenarios/SessionCallbackRemovalScenario.m
@@ -7,6 +7,7 @@
 //
 
 #import "Scenario.h"
+#import "Logging.h"
 
 @interface SessionCallbackRemovalScenario : Scenario
 @end

--- a/features/fixtures/shared/scenarios/SessionOOMScenario.m
+++ b/features/fixtures/shared/scenarios/SessionOOMScenario.m
@@ -1,4 +1,5 @@
 #import "Scenario.h"
+#import "Logging.h"
 
 #import <signal.h>
 

--- a/features/fixtures/shared/scenarios/StackOverflowScenario.m
+++ b/features/fixtures/shared/scenarios/StackOverflowScenario.m
@@ -25,6 +25,7 @@
  */
 
 #import "Scenario.h"
+#import "Logging.h"
 
 /**
  * Execute an infinitely recursive method, which overflows the stack and

--- a/features/fixtures/shared/scenarios/StopSessionOOMScenario.m
+++ b/features/fixtures/shared/scenarios/StopSessionOOMScenario.m
@@ -1,4 +1,5 @@
 #import "Scenario.h"
+#import "Logging.h"
 
 @interface StopSessionOOMScenario : Scenario
 @end

--- a/features/fixtures/shared/scenarios/UndefinedInstructionScenario.m
+++ b/features/fixtures/shared/scenarios/UndefinedInstructionScenario.m
@@ -25,6 +25,7 @@
  */
 
 #import "Scenario.h"
+#import "Logging.h"
 
 #import "spin_malloc.h"
 

--- a/features/fixtures/shared/scenarios/UnhandledErrorThreadSendAlwaysScenario.m
+++ b/features/fixtures/shared/scenarios/UnhandledErrorThreadSendAlwaysScenario.m
@@ -7,6 +7,7 @@
 //
 
 #import "Scenario.h"
+#import "Logging.h"
 
 @interface UnhandledErrorThreadSendAlwaysScenario : Scenario
 @end

--- a/features/fixtures/shared/scenarios/UnhandledErrorThreadSendNeverScenario.m
+++ b/features/fixtures/shared/scenarios/UnhandledErrorThreadSendNeverScenario.m
@@ -7,6 +7,7 @@
 //
 
 #import "Scenario.h"
+#import "Logging.h"
 
 @interface UnhandledErrorThreadSendNeverScenario : Scenario
 @end

--- a/features/fixtures/shared/scenarios/UnhandledMachExceptionOverrideScenario.m
+++ b/features/fixtures/shared/scenarios/UnhandledMachExceptionOverrideScenario.m
@@ -7,6 +7,7 @@
 //
 
 #import "MarkUnhandledHandledScenario.h"
+#import "Logging.h"
 
 @interface UnhandledMachExceptionOverrideScenario : MarkUnhandledHandledScenario
 @end

--- a/features/fixtures/shared/scenarios/UnhandledMachExceptionScenario.m
+++ b/features/fixtures/shared/scenarios/UnhandledMachExceptionScenario.m
@@ -7,6 +7,7 @@
 //
 
 #import "Scenario.h"
+#import "Logging.h"
 
 @interface UnhandledMachExceptionScenario : Scenario
 @end

--- a/features/fixtures/shared/scenarios/UserPersistenceDontPersistUserScenario.m
+++ b/features/fixtures/shared/scenarios/UserPersistenceDontPersistUserScenario.m
@@ -7,6 +7,7 @@
 //
 
 #import "Scenario.h"
+#import "Logging.h"
 
 /**
  * Set a user but don't persist it

--- a/features/fixtures/shared/scenarios/UserPersistenceNoUserScenario.m
+++ b/features/fixtures/shared/scenarios/UserPersistenceNoUserScenario.m
@@ -7,6 +7,7 @@
 //
 
 #import "Scenario.h"
+#import "Logging.h"
 
 /**
  * Don't set a user, don't change persistence (defaults to True).

--- a/features/fixtures/shared/scenarios/UserPersistencePersistUserClientScenario.m
+++ b/features/fixtures/shared/scenarios/UserPersistencePersistUserClientScenario.m
@@ -7,6 +7,7 @@
 //
 
 #import "Scenario.h"
+#import "Logging.h"
 
 /**
  * Set a user on the client and persist it

--- a/features/fixtures/shared/scenarios/UserPersistencePersistUserScenario.m
+++ b/features/fixtures/shared/scenarios/UserPersistencePersistUserScenario.m
@@ -7,6 +7,7 @@
 //
 
 #import "Scenario.h"
+#import "Logging.h"
 
 /**
  * Set a user on the config and persist it

--- a/features/fixtures/shared/utils/BugsnagWrapper.swift
+++ b/features/fixtures/shared/utils/BugsnagWrapper.swift
@@ -19,8 +19,8 @@ class BugsnagWrapper : Bugsnag {
         plistNotifyEndpoint = configuration.endpoints.notify;
         plistSessionsEndpoint = configuration.endpoints.sessions;
         
-        NSLog("Plist notify endpoint: %@", plistNotifyEndpoint);
-        NSLog("Plist sessions endpoint: %@", plistSessionsEndpoint);
+        logInfo("Plist notify endpoint: %@", plistNotifyEndpoint);
+        logInfo("Plist sessions endpoint: %@", plistSessionsEndpoint);
 
         if (plistNotifyEndpoint != "http://example.com/notify"
             || plistSessionsEndpoint != "http://example.com/sessions") {

--- a/features/fixtures/shared/utils/Logging.swift
+++ b/features/fixtures/shared/utils/Logging.swift
@@ -8,6 +8,15 @@
 
 import Foundation
 
+//public func logDebug(_ format: String) {
+//    logDebug(format: format, args: 0 as Int)
+//}
+public func logDebug(_ format: String, _ args: CVarArg...) {
+    withVaList(args) {
+        logInternal("debug", format, $0)
+    }
+}
+
 //public func logInfo(_ format: String) {
 //    logInfo(format: format, args: 0 as Int)
 //}

--- a/features/fixtures/shared/utils/Logging.swift
+++ b/features/fixtures/shared/utils/Logging.swift
@@ -1,0 +1,36 @@
+//
+//  logging.swift
+//  iOSTestApp
+//
+//  Created by Karl Stenerud on 02.11.23.
+//  Copyright © 2023 Bugsnag. All rights reserved.
+//
+
+import Foundation
+
+//public func logInfo(_ format: String) {
+//    logInfo(format: format, args: 0 as Int)
+//}
+public func logInfo(_ format: String, _ args: CVarArg...) {
+    withVaList(args) {
+        logInternal("info", format, $0)
+    }
+}
+
+//public func logWarn(_ format: String) {
+//    logWarn(format: format, args: 0 as Int)
+//}
+public func logWarn(_ format: String, _ args: CVarArg...) {
+    withVaList(args) {
+        logInternal("warn", format, $0)
+    }
+}
+
+//public func logError(_ format: String) {
+//    logError(format: format, args: 0 as Int)
+//}
+public func logError(_ format: String, _ args: CVarArg...) {
+    withVaList(args) {
+        logInternal("error", format, $0)
+    }
+}


### PR DESCRIPTION
## Goal

This PR harmonizes all of the logging in the CI fixtures so that they all use the same function names (`logInfo`, `logWarn`, `logError`) in Swift and Objective-C, and support optional varargs. These log functions all go to the same "channel" that prefixes `bugsnagci <level>` so that the fixture messages can easily be filtered by common tooling.
