### PR TITLE
Fix watchOS CI builds/tests

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -34,8 +34,9 @@ else
    DESTINATION?=platform=iOS Simulator,name=$(DEVICE),OS=$(OS)
    RELEASE_DIR=Release-iphoneos
   else
-   SDK?=watchsimulator8.5
-   DEVICE?=Apple Watch Series 5 - 40mm
+   SDK?=watchsimulator
+#   Due to the inconsistency of device names as a result of running; xcodebuild -downloadAllPlatforms, this dynamically selects the watchOS device.
+   DEVICE?=$(shell xcrun simctl list --json | jq -r '.devices."com.apple.CoreSimulator.SimRuntime.watchOS-8-5"[] | select(.name | test("Apple Watch Series 5 .+ ?40mm ?")) | .name')
    DESTINATION?=platform=watchOS Simulator,name=$(DEVICE),OS=$(OS)
    RELEASE_DIR=Release-watchos
   endif


### PR DESCRIPTION
## Goal

Fix the flakey watchOS  7/8 tests on CI

## Changeset

Change the default SDK for watchOS tests to `watchsimulator`

Dynamically get the name of the watchOS device due to an issue with naming after running `xcodebuild -downloadAllPlatforms`

## Testing

Covered by CI