### PR TITLE
Fix Compliation Errors for Xcode 15

### DIFF
--- a/Bugsnag/include/Bugsnag/BSG_KSCrashReportWriter.h
+++ b/Bugsnag/include/Bugsnag/BSG_KSCrashReportWriter.h
@@ -32,11 +32,13 @@
 #define HDR_BSG_KSCrashReportWriter_h
 
 #ifdef __cplusplus
+#include <sys/types.h>
+
 extern "C" {
 #endif
 
 #include <stdbool.h>
-#include <sys/types.h>
+#include <stddef.h>
 
 /**
  * Encapsulates report writing functionality.
@@ -190,7 +192,7 @@ typedef struct BSG_KSCrashReportWriter {
      *
      * @param name The name to give this element.
      *
-     * @param jsonElement A pointer to the JSON data.
+     * @param value A pointer to the JSON data.
      */
     void (*addJSONElement)(const struct BSG_KSCrashReportWriter *writer,
                            const char *name, const char *jsonElement);

--- a/Bugsnag/include/Bugsnag/BSG_KSCrashReportWriter.h
+++ b/Bugsnag/include/Bugsnag/BSG_KSCrashReportWriter.h
@@ -192,7 +192,7 @@ typedef struct BSG_KSCrashReportWriter {
      *
      * @param name The name to give this element.
      *
-     * @param value A pointer to the JSON data.
+     * @param jsonElement A pointer to the JSON data.
      */
     void (*addJSONElement)(const struct BSG_KSCrashReportWriter *writer,
                            const char *name, const char *jsonElement);


### PR DESCRIPTION
## Goal
- Get Bugsnag-Cocoa Library to compile on Xcode 15.0.1 and above.

## Design
- Initial Error `Darwin.POSIX.sys.types' appears within extern "C" language linkage specification`. The `#include <sys/types.h>` contains C++ code. When nested in `extern "C"` block the code is expected be only C, so the solution is to move the include outside of the extern. This seems to be a new error with the complier that ships with XCode 15. 

- Second Error after moving the include `Declaration of 'size_t' must be imported from module 'Darwin.C.stddef' before it is required`, this just necessitated including `<stddef.h>` in the extern C again.

## Changeset
- Needed to change the order of include statements and add missing header for C code.

## Testing
- tested compiling and running Bugsnag code in our app.