### PR TITLE
Tms/app hangs bs

### DIFF
--- a/.buildkite/pipeline.full.yml
+++ b/.buildkite/pipeline.full.yml
@@ -267,7 +267,7 @@ steps:
           - "--app=@build/ipa_url_bs.txt"
           - "--farm=bs"
           - "--device=IOS_15"
-          - "--appium-version=1.22.0"
+          - "--appium-version=1.21.0"
           - "features/app_hangs.feature"
     concurrency: 5
     concurrency_group: 'browserstack-app'
@@ -295,7 +295,7 @@ steps:
           - "--app=@build/ipa_url_bs.txt"
           - "--farm=bs"
           - "--device=IOS_14"
-          - "--appium-version=1.22.0"
+          - "--appium-version=1.21.0"
           - "features/app_hangs.feature"
     concurrency: 5
     concurrency_group: 'browserstack-app'
@@ -323,7 +323,7 @@ steps:
           - "--app=@build/ipa_url_bs.txt"
           - "--farm=bs"
           - "--device=IOS_13"
-          - "--appium-version=1.22.0"
+          - "--appium-version=1.21.0"
           - "features/app_hangs.feature"
     concurrency: 5
     concurrency_group: 'browserstack-app'
@@ -351,7 +351,7 @@ steps:
           - "--app=@build/ipa_url_bs.txt"
           - "--farm=bs"
           - "--device=IOS_12"
-          - "--appium-version=1.22.0"
+          - "--appium-version=1.21.0"
           - "features/app_hangs.feature"
     concurrency: 5
     concurrency_group: 'browserstack-app'

--- a/.buildkite/pipeline.full.yml
+++ b/.buildkite/pipeline.full.yml
@@ -24,6 +24,8 @@ steps:
         run: cocoa-maze-runner-bitbar
         service-ports: true
         command:
+          # PLAT-11155: App hang scenarios run on BrowserStack
+          - "--exclude=features/app_hangs.feature"
           - "--exclude=features/[e-z].*.feature$"
           - "--app=@/app/build/ipa_url_bb.txt"
           - "--farm=bb"
@@ -79,6 +81,8 @@ steps:
           - "--no-tunnel"
           - "--aws-public-ip"
           - "--fail-fast"
+          # PLAT-11155: App hang scenarios run on BrowserStack
+          - "--exclude=features/app_hangs.feature"
           - "--exclude=features/[e-z].*.feature$"
     concurrency: 25
     concurrency_group: 'bitbar'
@@ -139,6 +143,8 @@ steps:
           - "--no-tunnel"
           - "--aws-public-ip"
           - "--fail-fast"
+          # PLAT-11155: App hang scenarios run on BrowserStack
+          - "--exclude=features/app_hangs.feature"
           - "--exclude=features/[e-z].*.feature$"
     concurrency: 25
     concurrency_group: 'bitbar'
@@ -199,6 +205,8 @@ steps:
           - "--no-tunnel"
           - "--aws-public-ip"
           - "--fail-fast"
+          # PLAT-11155: App hang scenarios run on BrowserStack
+          - "--exclude=features/app_hangs.feature"
           - "--exclude=features/[e-z].*.feature$"
     concurrency: 25
     concurrency_group: 'bitbar'
@@ -241,6 +249,118 @@ steps:
   #
   # BrowserStack
   #
+  # PLAT-11155: App hang tests run on BrowserStack (Appium 1.x) for now
+  - label: ':browserstack: iOS 15 app hang tests'
+    depends_on:
+      - cocoa_fixture
+    timeout_in_minutes: 10
+    agents:
+      queue: opensource
+    plugins:
+      artifacts#v1.5.0:
+        download: "features/fixtures/ios/output/ipa_url_bs.txt"
+        upload: "maze_output/failed/**/*"
+      docker-compose#v3.7.0:
+        pull: cocoa-maze-runner
+        run: cocoa-maze-runner
+        command:
+          - "--app=@build/ipa_url_bs.txt"
+          - "--farm=bs"
+          - "--device=IOS_15"
+          - "--appium-version=1.22.0"
+          - "features/app_hangs.feature"
+    concurrency: 5
+    concurrency_group: 'browserstack-app'
+    concurrency_method: eager
+    retry:
+      automatic:
+        - exit_status: -1  # Agent was lost
+          limit: 2
+
+  # PLAT-11155: App hang tests run on BrowserStack (Appium 1.x) for now
+  - label: ':browserstack: iOS 14 app hang tests'
+    depends_on:
+      - cocoa_fixture
+    timeout_in_minutes: 10
+    agents:
+      queue: opensource
+    plugins:
+      artifacts#v1.5.0:
+        download: "features/fixtures/ios/output/ipa_url_bs.txt"
+        upload: "maze_output/failed/**/*"
+      docker-compose#v3.7.0:
+        pull: cocoa-maze-runner
+        run: cocoa-maze-runner
+        command:
+          - "--app=@build/ipa_url_bs.txt"
+          - "--farm=bs"
+          - "--device=IOS_14"
+          - "--appium-version=1.22.0"
+          - "features/app_hangs.feature"
+    concurrency: 5
+    concurrency_group: 'browserstack-app'
+    concurrency_method: eager
+    retry:
+      automatic:
+        - exit_status: -1  # Agent was lost
+          limit: 2
+
+  # PLAT-11155: App hang tests run on BrowserStack (Appium 1.x) for now
+  - label: ':browserstack: iOS 13 app hang tests'
+    depends_on:
+      - cocoa_fixture
+    timeout_in_minutes: 10
+    agents:
+      queue: opensource
+    plugins:
+      artifacts#v1.5.0:
+        download: "features/fixtures/ios/output/ipa_url_bs.txt"
+        upload: "maze_output/failed/**/*"
+      docker-compose#v3.7.0:
+        pull: cocoa-maze-runner
+        run: cocoa-maze-runner
+        command:
+          - "--app=@build/ipa_url_bs.txt"
+          - "--farm=bs"
+          - "--device=IOS_13"
+          - "--appium-version=1.22.0"
+          - "features/app_hangs.feature"
+    concurrency: 5
+    concurrency_group: 'browserstack-app'
+    concurrency_method: eager
+    retry:
+      automatic:
+        - exit_status: -1  # Agent was lost
+          limit: 2
+
+  # PLAT-11155: App hang tests run on BrowserStack (Appium 1.x) for now
+  - label: ':browserstack: iOS 12 app hang tests'
+    depends_on:
+      - cocoa_fixture
+    timeout_in_minutes: 10
+    agents:
+      queue: opensource
+    plugins:
+      artifacts#v1.5.0:
+        download: "features/fixtures/ios/output/ipa_url_bs.txt"
+        upload: "maze_output/failed/**/*"
+      docker-compose#v3.7.0:
+        pull: cocoa-maze-runner
+        run: cocoa-maze-runner
+        command:
+          - "--app=@build/ipa_url_bs.txt"
+          - "--farm=bs"
+          - "--device=IOS_12"
+          - "--appium-version=1.22.0"
+          - "features/app_hangs.feature"
+    concurrency: 5
+    concurrency_group: 'browserstack-app'
+    concurrency_method: eager
+    retry:
+      automatic:
+        - exit_status: -1  # Agent was lost
+          limit: 2
+
   - label: ':browserstack: iOS 11 E2E tests batch 1'
     skip: "https://smartbear.atlassian.net/browse/PLAT-11154"
     depends_on:

--- a/.buildkite/pipeline.yml
+++ b/.buildkite/pipeline.yml
@@ -364,7 +364,7 @@ steps:
           - "--app=@build/ipa_url_bs.txt"
           - "--farm=bs"
           - "--device=IOS_16"
-          - "--appium-version=1.22.0"
+          - "--appium-version=1.21.0"
           - "features/app_hangs.feature"
     concurrency: 5
     concurrency_group: 'browserstack-app'

--- a/.buildkite/pipeline.yml
+++ b/.buildkite/pipeline.yml
@@ -305,6 +305,8 @@ steps:
           - "--no-tunnel"
           - "--aws-public-ip"
           - "--fail-fast"
+          # App hang scenarios run on BrowserStack, see PLAT-11155
+          - "--exclude=features/app_hangs.feature"
           - "--exclude=features/[e-z].*.feature$"
     concurrency: 25
     concurrency_group: 'bitbar'

--- a/.buildkite/pipeline.yml
+++ b/.buildkite/pipeline.yml
@@ -305,7 +305,7 @@ steps:
           - "--no-tunnel"
           - "--aws-public-ip"
           - "--fail-fast"
-          # App hang scenarios run on BrowserStack, see PLAT-11155
+          # PLAT-11155: App hang scenarios run on BrowserStack
           - "--exclude=features/app_hangs.feature"
           - "--exclude=features/[e-z].*.feature$"
     concurrency: 25
@@ -340,6 +340,34 @@ steps:
           - "--exclude=features/[a-d].*.feature$"
     concurrency: 25
     concurrency_group: 'bitbar'
+    concurrency_method: eager
+    retry:
+      automatic:
+        - exit_status: -1  # Agent was lost
+          limit: 2
+
+  # PLAT-11155: App hang tests run on BrowserStack (Appium 1.x) for now
+  - label: ':browserstack: iOS 16 app hang tests'
+    depends_on:
+      - cocoa_fixture
+    timeout_in_minutes: 10
+    agents:
+      queue: opensource
+    plugins:
+      artifacts#v1.5.0:
+        download: "features/fixtures/ios/output/ipa_url_bs.txt"
+        upload: "maze_output/failed/**/*"
+      docker-compose#v3.7.0:
+        pull: cocoa-maze-runner
+        run: cocoa-maze-runner
+        command:
+          - "--app=@build/ipa_url_bs.txt"
+          - "--farm=bs"
+          - "--device=IOS_16"
+          - "--appium-version=1.22.0"
+          - "features/app_hangs.feature"
+    concurrency: 5
+    concurrency_group: 'browserstack-app'
     concurrency_method: eager
     retry:
       automatic:

--- a/.gitignore
+++ b/.gitignore
@@ -32,3 +32,4 @@ Package.resolved
 /docs/
 /infer-out
 /oclint.json
+bb.ready

--- a/features/app_hangs.feature
+++ b/features/app_hangs.feature
@@ -1,4 +1,3 @@
-@skip # https://smartbear.atlassian.net/browse/PLAT-11155
 Feature: App hangs
 
   Background:


### PR DESCRIPTION
## Goal

Reenable the app hang e2e test scenarios.

## Design

I discovered that the app hang tests do not run on Appium 2 currently - we have a separate ticket to investigate a fix for that.

BitBar only supports Appium 2, so in the meantime we'll run just the app hang scenarios using BrowserStack and Appium 1.

## Changeset

Pipeline updates to exclude app_hangs.feature on BitBar and steps added to run just that on BrowserStack for each version of iOS.

## Testing

Covered by a full CI run.