### PR TITLE
Move all include directives outside of the extern C sections

### DIFF
--- a/Bugsnag/KSCrash/Source/KSCrash/Recording/BSG_KSCrashC.h
+++ b/Bugsnag/KSCrash/Source/KSCrash/Recording/BSG_KSCrashC.h
@@ -30,13 +30,13 @@
 #ifndef HDR_BSG_KSCrashC_h
 #define HDR_BSG_KSCrashC_h
 
-#ifdef __cplusplus
-extern "C" {
-#endif
-
 #include "BSG_KSCrashContext.h"
 
 #include <stdbool.h>
+
+#ifdef __cplusplus
+extern "C" {
+#endif
 
 /** Initialize the KSCrash system. Call this once, before any other function.
  * Note: This gets called automatically by [BSG_KSCrash sharedInstance].

--- a/Bugsnag/KSCrash/Source/KSCrash/Recording/BSG_KSCrashContext.h
+++ b/Bugsnag/KSCrash/Source/KSCrash/Recording/BSG_KSCrashContext.h
@@ -30,16 +30,16 @@
 #ifndef HDR_BSG_KSCrashContext_h
 #define HDR_BSG_KSCrashContext_h
 
-#ifdef __cplusplus
-extern "C" {
-#endif
-
 #include "BSG_KSCrashReportWriter.h"
 #include "BSG_KSCrashSentry.h"
 #include "BSG_KSCrashState.h"
 
 #include <signal.h>
 #include <stdbool.h>
+
+#ifdef __cplusplus
+extern "C" {
+#endif
 
 typedef struct {
     /** A unique identifier (UUID). */

--- a/Bugsnag/KSCrash/Source/KSCrash/Recording/BSG_KSCrashIdentifier.h
+++ b/Bugsnag/KSCrash/Source/KSCrash/Recording/BSG_KSCrashIdentifier.h
@@ -1,5 +1,6 @@
 #ifndef HDR_BSG_KSCrashIdentifier_h
 #define HDR_BSG_KSCrashIdentifier_h
+
 #include <stdbool.h>
 
 #ifdef __cplusplus

--- a/Bugsnag/KSCrash/Source/KSCrash/Recording/BSG_KSCrashNames.h
+++ b/Bugsnag/KSCrash/Source/KSCrash/Recording/BSG_KSCrashNames.h
@@ -9,11 +9,11 @@
 #ifndef BSG_KSCrashNames_h
 #define BSG_KSCrashNames_h
 
+#include <mach/machine/vm_types.h>
+
 #ifdef __cplusplus
 extern "C" {
 #endif
-
-#include <mach/machine/vm_types.h>
 
 const char *bsg_kscrashthread_state_name(integer_t state);
 

--- a/Bugsnag/KSCrash/Source/KSCrash/Recording/BSG_KSCrashReport.h
+++ b/Bugsnag/KSCrash/Source/KSCrash/Recording/BSG_KSCrashReport.h
@@ -30,11 +30,11 @@
 #ifndef HDR_BSG_KSCrashReport_h
 #define HDR_BSG_KSCrashReport_h
 
+#include "BSG_KSCrashContext.h"
+
 #ifdef __cplusplus
 extern "C" {
 #endif
-
-#include "BSG_KSCrashContext.h"
 
 /** Write a standard crash report to a file.
  *

--- a/Bugsnag/KSCrash/Source/KSCrash/Recording/BSG_KSCrashState.h
+++ b/Bugsnag/KSCrash/Source/KSCrash/Recording/BSG_KSCrashState.h
@@ -31,12 +31,12 @@
 #ifndef HDR_BSG_KSCrashState_h
 #define HDR_BSG_KSCrashState_h
 
+#include <stdbool.h>
+#include <stdint.h>
+
 #ifdef __cplusplus
 extern "C" {
 #endif
-
-#include <stdbool.h>
-#include <stdint.h>
 
 typedef struct {
 

--- a/Bugsnag/KSCrash/Source/KSCrash/Recording/Sentry/BSG_KSCrashSentry.h
+++ b/Bugsnag/KSCrash/Source/KSCrash/Recording/Sentry/BSG_KSCrashSentry.h
@@ -30,10 +30,6 @@
 #ifndef HDR_BSG_KSCrashSentry_h
 #define HDR_BSG_KSCrashSentry_h
 
-#ifdef __cplusplus
-extern "C" {
-#endif
-
 #include "BSG_KSArchSpecific.h"
 #include "BSG_KSCrashType.h"
 
@@ -41,6 +37,10 @@ extern "C" {
 #include <mach/mach_types.h>
 #include <signal.h>
 #include <stdbool.h>
+
+#ifdef __cplusplus
+extern "C" {
+#endif
 
 // Some structures must be pre-allocated, so we must set an upper limit.
 // Note: Memory usage = 16 bytes per thread, pre-allocated once.

--- a/Bugsnag/KSCrash/Source/KSCrash/Recording/Sentry/BSG_KSCrashSentry_CPPException.h
+++ b/Bugsnag/KSCrash/Source/KSCrash/Recording/Sentry/BSG_KSCrashSentry_CPPException.h
@@ -25,11 +25,11 @@
 #ifndef HDR_BSG_KSCrashSentry_CPPException_h
 #define HDR_BSG_KSCrashSentry_CPPException_h
 
+#include "BSG_KSCrashSentry.h"
+
 #ifdef __cplusplus
 extern "C" {
 #endif
-
-#include "BSG_KSCrashSentry.h"
 
 /** Install the C++ exception handler.
  *

--- a/Bugsnag/KSCrash/Source/KSCrash/Recording/Sentry/BSG_KSCrashSentry_MachException.h
+++ b/Bugsnag/KSCrash/Source/KSCrash/Recording/Sentry/BSG_KSCrashSentry_MachException.h
@@ -30,17 +30,17 @@
 #ifndef HDR_BSG_KSCrashSentry_MachException_h
 #define HDR_BSG_KSCrashSentry_MachException_h
 
-#ifdef __cplusplus
-extern "C" {
-#endif
-
 #include "BSGDefines.h"
-
-#if BSG_HAVE_MACH_EXCEPTIONS
 
 #include "BSG_KSCrashSentry.h"
 #include <stdbool.h>
 #include <TargetConditionals.h>
+
+#if BSG_HAVE_MACH_EXCEPTIONS
+
+#ifdef __cplusplus
+extern "C" {
+#endif
 
 /** Install our custom mach exception handler.
  *

--- a/Bugsnag/KSCrash/Source/KSCrash/Recording/Sentry/BSG_KSCrashSentry_NSException.h
+++ b/Bugsnag/KSCrash/Source/KSCrash/Recording/Sentry/BSG_KSCrashSentry_NSException.h
@@ -30,11 +30,11 @@
 #ifndef HDR_BSG_KSCrashSentry_NSException_h
 #define HDR_BSG_KSCrashSentry_NSException_h
 
+#include "BSG_KSCrashSentry.h"
+
 #ifdef __cplusplus
 extern "C" {
 #endif
-
-#include "BSG_KSCrashSentry.h"
 
 /** Install our custom NSException handler.
  *

--- a/Bugsnag/KSCrash/Source/KSCrash/Recording/Sentry/BSG_KSCrashSentry_Private.h
+++ b/Bugsnag/KSCrash/Source/KSCrash/Recording/Sentry/BSG_KSCrashSentry_Private.h
@@ -27,12 +27,12 @@
 #ifndef HDR_BSG_KSCrashSentry_Private_h
 #define HDR_BSG_KSCrashSentry_Private_h
 
+#include "BSG_KSCrashSentry.h"
+#include "BSGDefines.h"
+
 #ifdef __cplusplus
 extern "C" {
 #endif
-
-#include "BSG_KSCrashSentry.h"
-#include "BSGDefines.h"
 
 #if BSG_HAVE_MACH_THREADS
 /** Suspend all non-reserved threads.

--- a/Bugsnag/KSCrash/Source/KSCrash/Recording/Sentry/BSG_KSCrashSentry_Signal.h
+++ b/Bugsnag/KSCrash/Source/KSCrash/Recording/Sentry/BSG_KSCrashSentry_Signal.h
@@ -30,15 +30,15 @@
 #ifndef HDR_BSG_KSCrashSentry_Signal_h
 #define HDR_BSG_KSCrashSentry_Signal_h
 
-#ifdef __cplusplus
-extern "C" {
-#endif
-
 #include "BSGDefines.h"
 
 #if BSG_HAVE_SIGNAL
 
 #include "BSG_KSCrashSentry.h"
+
+#ifdef __cplusplus
+extern "C" {
+#endif
 
 /** Install our custom signal handler.
  *

--- a/Bugsnag/KSCrash/Source/KSCrash/Recording/Tools/BSG_KSArchSpecific.h
+++ b/Bugsnag/KSCrash/Source/KSCrash/Recording/Tools/BSG_KSArchSpecific.h
@@ -30,20 +30,12 @@
 #ifndef HDR_BSG_KSArchSpecific_h
 #define HDR_BSG_KSArchSpecific_h
 
-#ifdef __cplusplus
-extern "C" {
-#endif
-
 #include <sys/_structs.h>
 
 #ifdef __arm64__
 #define BSG_STRUCT_MCONTEXT_L _STRUCT_MCONTEXT64
 #else
 #define BSG_STRUCT_MCONTEXT_L _STRUCT_MCONTEXT
-#endif
-
-#ifdef __cplusplus
-}
 #endif
 
 #endif // HDR_KSArchSpecific_h

--- a/Bugsnag/KSCrash/Source/KSCrash/Recording/Tools/BSG_KSBacktrace.h
+++ b/Bugsnag/KSCrash/Source/KSCrash/Recording/Tools/BSG_KSBacktrace.h
@@ -30,15 +30,15 @@
 #ifndef HDR_BSG_KSBacktrace_h
 #define HDR_BSG_KSBacktrace_h
 
-#ifdef __cplusplus
-extern "C" {
-#endif
-
 #include "BSG_Symbolicate.h"
 #include "BSGDefines.h"
 
 #include <mach/mach.h>
 #include <pthread.h>
+
+#ifdef __cplusplus
+extern "C" {
+#endif
 
 /**
  * Remove any pointer tagging from an instruction address

--- a/Bugsnag/KSCrash/Source/KSCrash/Recording/Tools/BSG_KSBacktrace_Private.h
+++ b/Bugsnag/KSCrash/Source/KSCrash/Recording/Tools/BSG_KSBacktrace_Private.h
@@ -27,15 +27,15 @@
 #ifndef HDR_BSG_KSBacktrace_private_h
 #define HDR_BSG_KSBacktrace_private_h
 
-#ifdef __cplusplus
-extern "C" {
-#endif
-
 #include "BSG_KSArchSpecific.h"
 #include "BSG_KSBacktrace.h"
 
 #include <stdbool.h>
 #include <sys/ucontext.h>
+
+#ifdef __cplusplus
+extern "C" {
+#endif
 
 /** Point at which bsg_ksbt_backtraceLength() will give up trying to count.
  *

--- a/Bugsnag/KSCrash/Source/KSCrash/Recording/Tools/BSG_KSCrashStringConversion.h
+++ b/Bugsnag/KSCrash/Source/KSCrash/Recording/Tools/BSG_KSCrashStringConversion.h
@@ -9,13 +9,12 @@
 #ifndef BSG_KSCrashStringConversion_h
 #define BSG_KSCrashStringConversion_h
 
+#include <stddef.h>
+#include <stdint.h>
+
 #ifdef __cplusplus
 extern "C" {
 #endif
-
-
-#include <stddef.h>
-#include <stdint.h>
 
 /**
  * Convert an unsigned integer to a string.

--- a/Bugsnag/KSCrash/Source/KSCrash/Recording/Tools/BSG_KSFileUtils.h
+++ b/Bugsnag/KSCrash/Source/KSCrash/Recording/Tools/BSG_KSFileUtils.h
@@ -30,13 +30,13 @@
 #ifndef HDR_BSG_KSFileUtils_h
 #define HDR_BSG_KSFileUtils_h
 
-#ifdef __cplusplus
-extern "C" {
-#endif
-
 #include <stdbool.h>
 #include <stdint.h>
 #include <sys/types.h>
+
+#ifdef __cplusplus
+extern "C" {
+#endif
 
 /** Get the last entry in a file path. Assumes UNIX style separators.
  *

--- a/Bugsnag/KSCrash/Source/KSCrash/Recording/Tools/BSG_KSJSONCodec.h
+++ b/Bugsnag/KSCrash/Source/KSCrash/Recording/Tools/BSG_KSJSONCodec.h
@@ -30,12 +30,12 @@
 #ifndef HDR_BSG_KSJSONCodec_h
 #define HDR_BSG_KSJSONCodec_h
 
+#include <stdbool.h>
+#include <sys/types.h>
+
 #ifdef __cplusplus
 extern "C" {
 #endif
-
-#include <stdbool.h>
-#include <sys/types.h>
 
 /* Tells the encoder to automatically determine the length of a field value.
  * Currently, this is done using strlen().

--- a/Bugsnag/KSCrash/Source/KSCrash/Recording/Tools/BSG_KSLogger.h
+++ b/Bugsnag/KSCrash/Source/KSCrash/Recording/Tools/BSG_KSLogger.h
@@ -27,13 +27,13 @@
 #ifndef HDR_BSG_KSLogger_h
 #define HDR_BSG_KSLogger_h
 
-#ifdef __cplusplus
-extern "C" {
-#endif
-
 #include <Bugsnag/BugsnagDefines.h>
 
 #include "BugsnagLogger.h"
+
+#ifdef __cplusplus
+extern "C" {
+#endif
 
 /**
  * Enables low-level logging.

--- a/Bugsnag/KSCrash/Source/KSCrash/Recording/Tools/BSG_KSMach.h
+++ b/Bugsnag/KSCrash/Source/KSCrash/Recording/Tools/BSG_KSMach.h
@@ -30,10 +30,6 @@
 #ifndef HDR_BSG_KSMach_h
 #define HDR_BSG_KSMach_h
 
-#ifdef __cplusplus
-extern "C" {
-#endif
-
 #include "BSG_KSArchSpecific.h"
 #include "BSGDefines.h"
 
@@ -41,6 +37,10 @@ extern "C" {
 #include <pthread.h>
 #include <stdbool.h>
 #include <sys/ucontext.h>
+
+#ifdef __cplusplus
+extern "C" {
+#endif
 
 // ============================================================================
 #pragma mark - General Information -

--- a/Bugsnag/KSCrash/Source/KSCrash/Recording/Tools/BSG_KSMachApple.h
+++ b/Bugsnag/KSCrash/Source/KSCrash/Recording/Tools/BSG_KSMachApple.h
@@ -19,13 +19,13 @@
 #ifndef HDR_BSG_KSMachApple_h
 #define HDR_BSG_KSMachApple_h
 
-#ifdef __cplusplus
-extern "C" {
-#endif
-
 #include <dispatch/dispatch.h>
 #include <sched.h>
 #include <sys/queue.h>
+
+#ifdef __cplusplus
+extern "C" {
+#endif
 
 // Avoid name clashes when copying structs from private headers
 #define pthread_t internal_pthread_t

--- a/Bugsnag/KSCrash/Source/KSCrash/Recording/Tools/BSG_KSSignalInfo.h
+++ b/Bugsnag/KSCrash/Source/KSCrash/Recording/Tools/BSG_KSSignalInfo.h
@@ -30,11 +30,11 @@
 #ifndef HDR_BSG_KSSignalInfo_h
 #define HDR_BSG_KSSignalInfo_h
 
+#include <mach/mach.h>
+
 #ifdef __cplusplus
 extern "C" {
 #endif
-
-#include <mach/mach.h>
 
 /** Get the name of a signal.
  *

--- a/Bugsnag/KSCrash/Source/KSCrash/Recording/Tools/BSG_KSSysCtl.h
+++ b/Bugsnag/KSCrash/Source/KSCrash/Recording/Tools/BSG_KSSysCtl.h
@@ -30,14 +30,14 @@
 #ifndef HDR_BSG_KSSysCtl_h
 #define HDR_BSG_KSSysCtl_h
 
-#ifdef __cplusplus
-extern "C" {
-#endif
-
 #include <stdbool.h>
 #include <stdint.h>
 #include <sys/sysctl.h>
 #include <sys/types.h>
+
+#ifdef __cplusplus
+extern "C" {
+#endif
 
 /** Get an int32 value via sysctl by name.
  *

--- a/Bugsnag/KSCrash/Source/KSCrash/Recording/Tools/BSG_Symbolicate.h
+++ b/Bugsnag/KSCrash/Source/KSCrash/Recording/Tools/BSG_Symbolicate.h
@@ -8,11 +8,11 @@
 #ifndef BSG_Symbolicate_h
 #define BSG_Symbolicate_h
 
+#include <stdint.h>
+
 #ifdef __cplusplus
 extern "C" {
 #endif
-
-#include <stdint.h>
 
 struct bsg_symbolicate_result {
     struct bsg_mach_image *image;

--- a/Bugsnag/include/Bugsnag/BSG_KSCrashReportWriter.h
+++ b/Bugsnag/include/Bugsnag/BSG_KSCrashReportWriter.h
@@ -31,10 +31,10 @@
 #ifndef HDR_BSG_KSCrashReportWriter_h
 #define HDR_BSG_KSCrashReportWriter_h
 
-#ifdef __cplusplus
 #include <stdbool.h>
 #include <sys/types.h>
 
+#ifdef __cplusplus
 extern "C" {
 #endif
 

--- a/Bugsnag/include/Bugsnag/BSG_KSCrashReportWriter.h
+++ b/Bugsnag/include/Bugsnag/BSG_KSCrashReportWriter.h
@@ -32,11 +32,11 @@
 #define HDR_BSG_KSCrashReportWriter_h
 
 #ifdef __cplusplus
-extern "C" {
-#endif
-
 #include <stdbool.h>
 #include <sys/types.h>
+
+extern "C" {
+#endif
 
 /**
  * Encapsulates report writing functionality.


### PR DESCRIPTION
Some of the include directives running from inside of `extern "C"` directives have issues on newer Xcode versions.

Relocate all include directives outside of these sections.
