### PR TITLE
[Plat-11044] remove stat

### DIFF
--- a/Bugsnag/Helpers/BSGRunContext.m
+++ b/Bugsnag/Helpers/BSGRunContext.m
@@ -557,13 +557,14 @@ static int OpenFile(NSString *_Nonnull path) {
 /// Loads the contents of the state file into memory and sets the
 /// `bsg_lastRunContext` pointer if the contents are valid.
 static void LoadLastRunContext(int fd) {
-    struct stat sb;
+    static struct BSGRunContext context;
+    uint8_t buff[SIZEOF_STRUCT+1]; // +1 to detect if the size grew
+
     // Only expose previous state if size matches...
-    if (fstat(fd, &sb) == 0 && sb.st_size == SIZEOF_STRUCT) {
-        static struct BSGRunContext context;
-        if (read(fd, &context, SIZEOF_STRUCT) == SIZEOF_STRUCT &&
-            // ...and so does the structVersion
-            context.structVersion == BSGRUNCONTEXT_VERSION) {
+    if (read(fd, buff, sizeof(buff)) == SIZEOF_STRUCT) {
+        memcpy(&context, buff, SIZEOF_STRUCT);
+        // ...and so does the structVersion
+        if (context.structVersion == BSGRUNCONTEXT_VERSION) {
             bsg_lastRunContext = &context;
         }
     }

--- a/Bugsnag/KSCrash/Source/KSCrash/Recording/BSG_Jailbreak.h
+++ b/Bugsnag/KSCrash/Source/KSCrash/Recording/BSG_Jailbreak.h
@@ -36,10 +36,10 @@
 #ifndef bsg_jailbreak_h
 #define bsg_jailbreak_h
 
+#include <dirent.h>
 #include <fcntl.h>
 #include <stdbool.h>
 #include <stdio.h>
-#include <sys/stat.h>
 #include <sys/types.h>
 #include <unistd.h>
 #include <TargetConditionals.h>
@@ -195,9 +195,10 @@ static inline bool bsg_local_is_insert_libraries_env_var(const char* str) {
     } \
  \
     const char* etc_apt_path = "/etc/apt"; \
-    struct stat st; \
-    if(stat(etc_apt_path, &st) == 0) { \
+    DIR *dirp = opendir(etc_apt_path); \
+    if(dirp) { \
         etc_apt_exists = true; \
+        closedir(dirp); \
     } \
  \
     for(int i = 0; environ[i] != NULL; i++) { \

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -160,6 +160,8 @@ GEM
     nanaimo (0.3.0)
     nap (1.1.0)
     netrc (0.11.0)
+    nokogiri (1.15.5-arm64-darwin)
+      racc (~> 1.4)
     nokogiri (1.15.5-x86_64-darwin)
       racc (~> 1.4)
     optimist (3.0.1)
@@ -208,6 +210,7 @@ GEM
       rexml (~> 3.2.4)
 
 PLATFORMS
+  arm64-darwin-22
   x86_64-darwin-19
 
 DEPENDENCIES


### PR DESCRIPTION
## Goal

`stat` and `fstat` are on Apple's grey list now because they can be used to assist in user tracking. Remove them since we have other alternatives.
