### PR TITLE
Run iOS 17 unit tests on Xcode 15

### DIFF
--- a/.buildkite/pipeline.yml
+++ b/.buildkite/pipeline.yml
@@ -99,6 +99,8 @@ steps:
       queue: macos-13-arm
     commands:
       - ./scripts/run-unit-tests.sh PLATFORM=iOS OS=17.0.1 DEVICE="iPhone 15"
+    env:
+      XCODE_VERSION: 15.0.1
     artifact_paths:
       - logs/*
 


### PR DESCRIPTION
## Goal

Fix the iOS 17 unit tests CI step by running with Xcode 15.

## Testing

Covered by a basic CI run.