### PR TITLE
Set Xcode version for CI build step

### DIFF
--- a/.buildkite/pipeline.yml
+++ b/.buildkite/pipeline.yml
@@ -29,6 +29,8 @@ steps:
     timeout_in_minutes: 10
     agents:
       queue: macos-13-arm
+    env:
+      DEVELOPER_DIR: /Applications/Xcode14.3.app
     commands:
       - make build_swift
       - make build_ios_static

--- a/.gitignore
+++ b/.gitignore
@@ -33,3 +33,4 @@ Package.resolved
 /infer-out
 /oclint.json
 bb.ready
+/maze_output


### PR DESCRIPTION
## Goal

The build server running this step regressed to using Xcode 14.0 for some reason, causing the build to fail.  This change forces it to use Xcode 14.3.

## Testing

Covered by CI.