### PR TITLE
Add auto retries on app-hang errors

### DIFF
--- a/.buildkite/pipeline.yml
+++ b/.buildkite/pipeline.yml
@@ -335,6 +335,8 @@ steps:
       automatic:
         - exit_status: -1  # Agent was lost
           limit: 2
+        - exit_status: 104 # App hang related error
+          limit: 2
 
   - label: ':bitbar: iOS 15 barebone tests'
     depends_on:

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -21,7 +21,7 @@ x-common-environment: &common-environment
 
 services:
   cocoa-maze-runner:
-    image: 855461928731.dkr.ecr.us-west-1.amazonaws.com/maze-runner:appium-app-hang-code-cli
+    image: 855461928731.dkr.ecr.us-west-1.amazonaws.com/maze-runner-releases:latest-v8-cli
     environment:
       <<: *common-environment
       BROWSER_STACK_USERNAME:
@@ -32,7 +32,7 @@ services:
       - ./maze_output:/app/maze_output
 
   cocoa-maze-runner-bitbar:
-    image: 855461928731.dkr.ecr.us-west-1.amazonaws.com/maze-runner:appium-app-hang-code-cli
+    image: 855461928731.dkr.ecr.us-west-1.amazonaws.com/maze-runner-releases:latest-v8-cli
     environment:
       <<: *common-environment
       BITBAR_USERNAME:
@@ -46,7 +46,7 @@ services:
       - /var/run/docker.sock:/var/run/docker.sock
 
   cocoa-maze-runner-legacy:
-    image: 855461928731.dkr.ecr.us-west-1.amazonaws.com/maze-runner:appium-app-hang-code-cli-legacy
+    image: 855461928731.dkr.ecr.us-west-1.amazonaws.com/maze-runner-releases:latest-v8-cli-legacy
     environment:
       <<: *common-environment
       BROWSER_STACK_USERNAME:

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -21,7 +21,7 @@ x-common-environment: &common-environment
 
 services:
   cocoa-maze-runner:
-    image: 855461928731.dkr.ecr.us-west-1.amazonaws.com/maze-runner-releases:latest-v8-cli
+    image: 855461928731.dkr.ecr.us-west-1.amazonaws.com/maze-runner:appium-app-hang-code-cli
     environment:
       <<: *common-environment
       BROWSER_STACK_USERNAME:
@@ -32,7 +32,7 @@ services:
       - ./maze_output:/app/maze_output
 
   cocoa-maze-runner-bitbar:
-    image: 855461928731.dkr.ecr.us-west-1.amazonaws.com/maze-runner-releases:latest-v8-cli
+    image: 855461928731.dkr.ecr.us-west-1.amazonaws.com/maze-runner:appium-app-hang-code-cli
     environment:
       <<: *common-environment
       BITBAR_USERNAME:
@@ -46,7 +46,7 @@ services:
       - /var/run/docker.sock:/var/run/docker.sock
 
   cocoa-maze-runner-legacy:
-    image: 855461928731.dkr.ecr.us-west-1.amazonaws.com/maze-runner-releases:latest-v8-cli-legacy
+    image: 855461928731.dkr.ecr.us-west-1.amazonaws.com/maze-runner:appium-app-hang-code-cli-legacy
     environment:
       <<: *common-environment
       BROWSER_STACK_USERNAME:

--- a/features/app_hangs.feature
+++ b/features/app_hangs.feature
@@ -1,3 +1,4 @@
+
 Feature: App hangs
 
   Background:

--- a/features/app_hangs.feature
+++ b/features/app_hangs.feature
@@ -1,4 +1,4 @@
-
+@app_hang_test
 Feature: App hangs
 
   Background:

--- a/features/support/env.rb
+++ b/features/support/env.rb
@@ -112,7 +112,7 @@ After('@app_hang_test') do |scenario|
 
   # If an assertion has failed, conditionally skip the retry
   unless scenario.result.exception.is_a?(Test::Unit::AssertionFailedError)
-    Maze::Hooks::ErrorCodeHook.exit_code = Maze::Api::ExitCode::APPIUM_APP_HANG_ERROR
+    Maze::Hooks::ErrorCodeHook.exit_code = Maze::Api::ExitCode::APPIUM_APP_HANG_FAILURE
   end
 end
 

--- a/features/support/env.rb
+++ b/features/support/env.rb
@@ -106,6 +106,16 @@ Before('@stress_test') do |_scenario|
   skip_this_scenario('Skipping: Run is not configured for stress tests') if ENV['STRESS_TEST'].nil?
 end
 
+# Handles app-hang test failures, enabling restarts if required
+After('@app_hang') do |scenario|
+  return unless scenario.failed?
+
+  # If an assertion has failed, conditionally skip the retry
+  unless scenario.result.exception.is_a?(Test::Unit::AssertionFailedError)
+    Maze::Hooks::ErrorCodeHook.exit_code = Maze::Api::ExitCode::APPIUM_APP_HANG_ERROR
+  end
+end
+
 Maze.hooks.before do |_scenario|
   # Reset to defaults in case previous scenario changed them
   Maze.config.captured_invalid_requests = Set[:errors, :sessions, :builds, :uploads, :sourcemaps]

--- a/features/support/env.rb
+++ b/features/support/env.rb
@@ -108,11 +108,12 @@ end
 
 # Handles app-hang test failures, enabling restarts if required
 After('@app_hang_test') do |scenario|
-  return unless scenario.failed?
+  if scenario.failed?
 
-  # If an assertion has failed, conditionally skip the retry
-  unless scenario.result.exception.is_a?(Test::Unit::AssertionFailedError)
-    Maze::Hooks::ErrorCodeHook.exit_code = Maze::Api::ExitCode::APPIUM_APP_HANG_FAILURE
+    # If an assertion has failed, conditionally skip the retry
+    unless scenario.result.exception.is_a?(Test::Unit::AssertionFailedError)
+      Maze::Hooks::ErrorCodeHook.exit_code = Maze::Api::ExitCode::APPIUM_APP_HANG_FAILURE
+    end
   end
 end
 

--- a/features/support/env.rb
+++ b/features/support/env.rb
@@ -107,7 +107,7 @@ Before('@stress_test') do |_scenario|
 end
 
 # Handles app-hang test failures, enabling restarts if required
-After('@app_hang') do |scenario|
+After('@app_hang_test') do |scenario|
   return unless scenario.failed?
 
   # If an assertion has failed, conditionally skip the retry


### PR DESCRIPTION
## Goal

To enable currently unstable tests to be retried without manual effort, we're adding automatic retries in the event the app-hang tests fail due to an appium error.

Note: This doesn't currently retry if the test fails due to no errors being received.  While this could very well be caused by an appium issue with the app-hang tests, it could also present due to changes in the notifier code, and should be (minimally) investigated.