### PR TITLE
Add app hang retries guard

### DIFF
--- a/features/support/env.rb
+++ b/features/support/env.rb
@@ -108,13 +108,13 @@ end
 
 # Handles app-hang test failures, enabling restarts if required
 After('@app_hang_test') do |scenario|
-  if scenario.failed?
+  # if scenario.failed?
 
-    # If an assertion has failed, conditionally skip the retry
-    unless scenario.result&.exception&.is_a?(Test::Unit::AssertionFailedError)
-      Maze::Hooks::ErrorCodeHook.exit_code = Maze::Api::ExitCode::APPIUM_APP_HANG_FAILURE
-    end
-  end
+  #   # If an assertion has failed, conditionally skip the retry
+  #   unless scenario.result&.exception&.is_a?(Test::Unit::AssertionFailedError)
+  #     Maze::Hooks::ErrorCodeHook.exit_code = Maze::Api::ExitCode::APPIUM_APP_HANG_FAILURE
+  #   end
+  # end
 end
 
 Maze.hooks.before do |_scenario|

--- a/features/support/env.rb
+++ b/features/support/env.rb
@@ -111,7 +111,7 @@ After('@app_hang_test') do |scenario|
   if scenario.failed?
 
     # If an assertion has failed, conditionally skip the retry
-    unless scenario.result.exception.is_a?(Test::Unit::AssertionFailedError)
+    unless scenario.result&.exception&.is_a?(Test::Unit::AssertionFailedError)
       Maze::Hooks::ErrorCodeHook.exit_code = Maze::Api::ExitCode::APPIUM_APP_HANG_FAILURE
     end
   end


### PR DESCRIPTION
## Goal

Adds conditional `&` (checks to see if an element is nil before accessing it's properties) in the logic to ensure `result` and `exception` are present.  