### PR TITLE
Use Xcode 15 in CI jobs

### DIFF
--- a/.buildkite/pipeline.full.yml
+++ b/.buildkite/pipeline.full.yml
@@ -350,7 +350,7 @@ steps:
   - label: 'examples/objective-c-ios'
     timeout_in_minutes: 30
     agents:
-      queue: macos-12-arm
+      queue: macos-13-arm
     commands:
       - bundle install
       - cd examples/objective-c-ios
@@ -366,7 +366,7 @@ steps:
   - label: 'examples/objective-c-osx'
     timeout_in_minutes: 30
     agents:
-      queue: macos-12-arm
+      queue: macos-13-arm
     commands:
       - bundle install
       - cd examples/objective-c-osx
@@ -380,7 +380,7 @@ steps:
   - label: 'examples/swift-ios'
     timeout_in_minutes: 30
     agents:
-      queue: macos-12-arm
+      queue: macos-13-arm
     commands:
       - bundle install
       - cd examples/swift-ios
@@ -394,7 +394,7 @@ steps:
   - label: 'examples/swift-package-manager'
     timeout_in_minutes: 30
     agents:
-      queue: macos-12-arm
+      queue: macos-13-arm
     commands:
       - bundle install
       - cd examples/swift-package-manager
@@ -409,7 +409,7 @@ steps:
   - label: 'examples/swiftui'
     timeout_in_minutes: 30
     agents:
-      queue: macos-12-arm
+      queue: macos-13-arm
     commands:
       - bundle install
       - cd examples/swiftui

--- a/.buildkite/pipeline.yml
+++ b/.buildkite/pipeline.yml
@@ -13,7 +13,7 @@ steps:
     agents:
       queue: macos-13-arm
     env:
-      DEVELOPER_DIR: /Applications/Xcode14.3.app
+      DEVELOPER_DIR: /Applications/Xcode15.app
     artifact_paths:
       - features/fixtures/ios/output/iOSTestApp.ipa
       - features/fixtures/macos/output/macOSTestApp.zip
@@ -30,7 +30,7 @@ steps:
     agents:
       queue: macos-13-arm
     env:
-      DEVELOPER_DIR: /Applications/Xcode14.3.app
+      DEVELOPER_DIR: /Applications/Xcode15.app
     commands:
       - make build_swift
       - make build_ios_static
@@ -145,9 +145,9 @@ steps:
   - label: watchOS 8 unit tests
     timeout_in_minutes: 60
     agents:
-      queue: opensource-arm-mac-cocoa-12
+      queue: macos-13-arm
     env:
-      DEVELOPER_DIR: /Applications/Xcode14.0.app
+      DEVELOPER_DIR: /Applications/Xcode15.app
     commands:
       - ./scripts/run-unit-tests.sh PLATFORM=watchOS OS=8.3 SDK=watchsimulator9.0
     artifact_paths:
@@ -156,9 +156,9 @@ steps:
   - label: watchOS 7 unit tests
     timeout_in_minutes: 60
     agents:
-      queue: opensource-arm-mac-cocoa-12
+      queue: macos-13-arm
     env:
-      DEVELOPER_DIR: /Applications/Xcode14.0.app
+      DEVELOPER_DIR: /Applications/Xcode14.app
     commands:
       - ./scripts/run-unit-tests.sh PLATFORM=watchOS OS=7.4 SDK=watchsimulator9.0
     artifact_paths:


### PR DESCRIPTION
## Goal

Bumps the test fixture build from Xcode 14.3 on macOS 12 to Xcode 15.2 on macOS 13.

## Testing

Covered by a full CI run.