### PR TITLE
Refresh iOS 16 and 17 e2e test strategy

### DIFF
--- a/.buildkite/pipeline.full.yml
+++ b/.buildkite/pipeline.full.yml
@@ -10,6 +10,68 @@ steps:
   #
   # BitBar
   #
+  - label: ':bitbar: iOS 16 E2E tests batch 1'
+    depends_on:
+      - cocoa_fixture
+    timeout_in_minutes: 60
+    agents:
+      queue: opensource
+    plugins:
+      artifacts#v1.9.0:
+        download: "features/fixtures/ios/output/ipa_url_bb.txt"
+        upload: "maze_output/failed/**/*"
+      docker-compose#v4.7.0:
+        pull: cocoa-maze-runner-bitbar
+        run: cocoa-maze-runner-bitbar
+        service-ports: true
+        command:
+          - "--app=@/app/build/ipa_url_bb.txt"
+          - "--farm=bb"
+          - "--device=IOS_16"
+          - "--no-tunnel"
+          - "--aws-public-ip"
+          - "--fail-fast"
+          # PLAT-11155: App hang scenarios run on BrowserStack
+          - "--exclude=features/app_hangs.feature"
+          - "--exclude=features/[e-z].*.feature$"
+    concurrency: 25
+    concurrency_group: 'bitbar'
+    concurrency_method: eager
+    retry:
+      automatic:
+        - exit_status: -1  # Agent was lost
+          limit: 2
+
+  - label: ':bitbar: iOS 16 E2E tests batch 2'
+    depends_on:
+      - cocoa_fixture
+    timeout_in_minutes: 60
+    agents:
+      queue: opensource
+    plugins:
+      artifacts#v1.9.0:
+        download: "features/fixtures/ios/output/ipa_url_bb.txt"
+        upload: "maze_output/failed/**/*"
+      docker-compose#v4.7.0:
+        pull: cocoa-maze-runner-bitbar
+        run: cocoa-maze-runner-bitbar
+        service-ports: true
+        command:
+          - "--app=@/app/build/ipa_url_bb.txt"
+          - "--farm=bb"
+          - "--device=IOS_16"
+          - "--no-tunnel"
+          - "--aws-public-ip"
+          - "--fail-fast"
+          - "--exclude=features/[a-d].*.feature$"
+    concurrency: 25
+    concurrency_group: 'bitbar'
+    concurrency_method: eager
+    retry:
+      automatic:
+        - exit_status: -1  # Agent was lost
+          limit: 2
+
   - label: ':bitbar: iOS 15 E2E tests batch 1'
     depends_on: "cocoa_fixture"
     timeout_in_minutes: 90
@@ -189,6 +251,37 @@ steps:
   #
   # BrowserStack
   #
+  # PLAT-11155: App hang tests run on BrowserStack (Appium 1.x) for now
+  - label: ':browserstack: iOS 16 app hang tests'
+    depends_on:
+      - cocoa_fixture
+    timeout_in_minutes: 30
+    agents:
+      queue: opensource
+    plugins:
+      artifacts#v1.5.0:
+        download: "features/fixtures/ios/output/ipa_url_bs.txt"
+        upload: "maze_output/failed/**/*"
+      docker-compose#v3.7.0:
+        pull: cocoa-maze-runner
+        run: cocoa-maze-runner
+        command:
+          - "--app=@build/ipa_url_bs.txt"
+          - "--farm=bs"
+          - "--device=IOS_16"
+          - "--appium-version=1.21.0"
+          - "--fail-fast"
+          - "features/app_hangs.feature"
+    concurrency: 5
+    concurrency_group: 'browserstack-app'
+    concurrency_method: eager
+    retry:
+      automatic:
+        - exit_status: -1  # Agent was lost
+          limit: 2
+        - exit_status: 104 # App hang related error
+          limit: 2
+
   # PLAT-11155: App hang tests run on BrowserStack (Appium 1.x) for now
   - label: ':browserstack: iOS 15 app hang tests'
     depends_on:

--- a/.buildkite/pipeline.yml
+++ b/.buildkite/pipeline.yml
@@ -240,68 +240,67 @@ steps:
 
   ##############################################################################
   #
-  # Basic build E2E tests
+  # Full set of E2E tests on one iOS version
   #
 
   #
-  # BitBar
+  # BrowserStack
   #
-  - label: ':bitbar: iOS 16 E2E tests batch 1'
+  - label: ':browserstack: iOS 17 E2E tests batch 1'
     depends_on:
       - cocoa_fixture
     timeout_in_minutes: 60
     agents:
       queue: opensource
     plugins:
-      artifacts#v1.9.0:
-        download: "features/fixtures/ios/output/ipa_url_bb.txt"
+      artifacts#v1.5.0:
+        download: "features/fixtures/ios/output/ipa_url_bs.txt"
         upload: "maze_output/failed/**/*"
-      docker-compose#v4.7.0:
-        pull: cocoa-maze-runner-bitbar
-        run: cocoa-maze-runner-bitbar
+      docker-compose#v3.7.0:
+        pull: cocoa-maze-runner
+        run: cocoa-maze-runner
         service-ports: true
         command:
-          - "--app=@/app/build/ipa_url_bb.txt"
-          - "--farm=bb"
-          - "--device=IOS_16"
-          - "--no-tunnel"
-          - "--aws-public-ip"
+          - "--app=@/app/build/ipa_url_bs.txt"
+          - "--farm=bs"
+          - "--device=IOS_17"
+          - "--appium-version=1.21.0"
+          - "--a11y-locator"
           - "--fail-fast"
-          # PLAT-11155: App hang scenarios run on BrowserStack
           - "--exclude=features/app_hangs.feature"
           - "--exclude=features/[e-z].*.feature$"
     concurrency: 25
-    concurrency_group: 'bitbar'
+    concurrency_group: 'browserstack-app'
     concurrency_method: eager
     retry:
       automatic:
         - exit_status: -1  # Agent was lost
           limit: 2
 
-  - label: ':bitbar: iOS 16 E2E tests batch 2'
+  - label: ':browserstack: iOS 17 E2E tests batch 2'
     depends_on:
       - cocoa_fixture
     timeout_in_minutes: 60
     agents:
       queue: opensource
     plugins:
-      artifacts#v1.9.0:
-        download: "features/fixtures/ios/output/ipa_url_bb.txt"
+      artifacts#v1.5.0:
+        download: "features/fixtures/ios/output/ipa_url_bs.txt"
         upload: "maze_output/failed/**/*"
-      docker-compose#v4.7.0:
-        pull: cocoa-maze-runner-bitbar
-        run: cocoa-maze-runner-bitbar
+      docker-compose#v3.7.0:
+        pull: cocoa-maze-runner
+        run: cocoa-maze-runner
         service-ports: true
         command:
-          - "--app=@/app/build/ipa_url_bb.txt"
-          - "--farm=bb"
-          - "--device=IOS_16"
-          - "--no-tunnel"
-          - "--aws-public-ip"
+          - "--app=@/app/build/ipa_url_bs.txt"
+          - "--farm=bs"
+          - "--device=IOS_17"
+          - "--appium-version=1.21.0"
+          - "--a11y-locator"
           - "--fail-fast"
           - "--exclude=features/[a-d].*.feature$"
     concurrency: 25
-    concurrency_group: 'bitbar'
+    concurrency_group: 'browserstack-app'
     concurrency_method: eager
     retry:
       automatic:
@@ -309,7 +308,7 @@ steps:
           limit: 2
 
   # PLAT-11155: App hang tests run on BrowserStack (Appium 1.x) for now
-  - label: ':browserstack: iOS 16 app hang tests'
+  - label: ':browserstack: iOS 17 app hang tests'
     depends_on:
       - cocoa_fixture
     timeout_in_minutes: 30
@@ -325,7 +324,7 @@ steps:
         command:
           - "--app=@build/ipa_url_bs.txt"
           - "--farm=bs"
-          - "--device=IOS_16"
+          - "--device=IOS_17"
           - "--appium-version=1.21.0"
           - "--fail-fast"
           - "features/app_hangs.feature"
@@ -338,6 +337,15 @@ steps:
           limit: 2
         - exit_status: 104 # App hang related error
           limit: 2
+
+  ##############################################################################
+  #
+  # Basic build E2E tests
+  #
+
+  #
+  # BitBar
+  #
 
   - label: ':bitbar: iOS 15 barebone tests'
     depends_on:
@@ -429,70 +437,6 @@ steps:
         - exit_status: -1  # Agent was lost
           limit: 2
 
-  #
-  # BrowserStack
-  #
-  - label: ':browserstack: iOS 17 E2E tests batch 1'
-    depends_on:
-      - cocoa_fixture
-    timeout_in_minutes: 60
-    agents:
-      queue: opensource
-    plugins:
-      artifacts#v1.5.0:
-        download: "features/fixtures/ios/output/ipa_url_bs.txt"
-        upload: "maze_output/failed/**/*"
-      docker-compose#v3.7.0:
-        pull: cocoa-maze-runner
-        run: cocoa-maze-runner
-        service-ports: true
-        command:
-          - "--app=@/app/build/ipa_url_bs.txt"
-          - "--farm=bs"
-          - "--device=IOS_17"
-          - "--appium-version=1.18.0"
-          - "--a11y-locator"
-          - "--fail-fast"
-          - "--exclude=features/[e-z].*.feature$"
-          - "--order=random"
-    concurrency: 25
-    concurrency_group: 'browserstack-app'
-    concurrency_method: eager
-    retry:
-      automatic:
-        - exit_status: -1  # Agent was lost
-          limit: 2
-
-  - label: ':browserstack: iOS 17 E2E tests batch 2'
-    depends_on:
-      - cocoa_fixture
-    timeout_in_minutes: 60
-    agents:
-      queue: opensource
-    plugins:
-      artifacts#v1.5.0:
-        download: "features/fixtures/ios/output/ipa_url_bs.txt"
-        upload: "maze_output/failed/**/*"
-      docker-compose#v3.7.0:
-        pull: cocoa-maze-runner
-        run: cocoa-maze-runner
-        service-ports: true
-        command:
-          - "--app=@/app/build/ipa_url_bs.txt"
-          - "--farm=bs"
-          - "--device=IOS_17"
-          - "--appium-version=1.18.0"
-          - "--a11y-locator"
-          - "--fail-fast"
-          - "--exclude=features/[a-d].*.feature$"
-          - "--order=random"
-    concurrency: 25
-    concurrency_group: 'browserstack-app'
-    concurrency_method: eager
-    retry:
-      automatic:
-        - exit_status: -1  # Agent was lost
-          limit: 2
 
   ##############################################################################
   #


### PR DESCRIPTION
## Goal

Refresh the iOS 16/17 e2e test strategy to:
- Run full set of e2e tests on iOS 17 for every Git push
- Run subset of tests on all other iOS versions for each push
- Always run app hang tests separately

## Changeset

- Full set of iOS 16 tests moved to the full pipeline
- Barebones tests for iOS 16 added to the basic pipeline
- App hang tests for iOS 17 factored into their own buildkite job

Due to the nature of the code diff, this PR would be best reviewed by inspecting the build results or each pipeline file as a whole.

## Testing

Covered by a full CI run.