### PR TITLE
[Plat-11749] buggy cpp runtime

### DIFF
--- a/Bugsnag/KSCrash/Source/KSCrash/Recording/Sentry/BSG_KSCrashSentry_CPPException.mm
+++ b/Bugsnag/KSCrash/Source/KSCrash/Recording/Sentry/BSG_KSCrashSentry_CPPException.mm
@@ -104,6 +104,20 @@ void __cxa_throw(void *thrown_exception, std::type_info *tinfo,
 }
 }
 
+static const char *getExceptionTypeName(std::type_info *tinfo) {
+    static char buff[sizeof(*tinfo)];
+    // Runtime bug workaround: In some situations, __cxa_current_exception_type returns an invalid address.
+    // Check to make sure it's in valid memory before we try to call tinfo->name().
+    if (tinfo != NULL && bsg_ksmachcopyMem(tinfo, buff, sizeof(buff)) == KERN_SUCCESS) {
+        const char *name = tinfo->name();
+        // Also make sure the name pointer is valid.
+        if (name != NULL && bsg_ksmachcopyMem(name, buff, 1) == KERN_SUCCESS) {
+            return name;
+        }
+    }
+    return NULL;
+}
+
 static void CPPExceptionTerminate(void) {
     BSG_KSLOG_DEBUG("Trapped c++ exception");
 
@@ -113,9 +127,7 @@ static void CPPExceptionTerminate(void) {
 
     BSG_KSLOG_DEBUG("Get exception type name.");
     std::type_info *tinfo = __cxxabiv1::__cxa_current_exception_type();
-    if (tinfo != NULL) {
-        name = tinfo->name();
-    } else {
+    if (tinfo == NULL) {
         name = "std::terminate";
         crashReason = "throw may have been called without an exception";
         if (!bsg_g_stackTraceCount) {
@@ -125,6 +137,13 @@ static void CPPExceptionTerminate(void) {
                       sizeof(bsg_g_stackTrace) / sizeof(*bsg_g_stackTrace));
         }
         goto after_rethrow; // Using goto to avoid indenting code below
+    }
+
+    name = getExceptionTypeName(tinfo);
+    if (name == NULL) {
+        name = "unknown";
+        crashReason = "unable to determine C++ exception type";
+        goto after_rethrow;
     }
 
     BSG_KSLOG_DEBUG("Discovering what kind of exception was thrown.");


### PR DESCRIPTION
## Goal

The C++ runtime is buggy on certain machines and can in rare cases return an invalid pointer to the C++ exception type information.

## Design

Try copying the memory location to ensure that it is valid before attempting to call any methods on the object. If we can't get the type info, note that in the exception metadata.
