### PR TITLE
Refresh unit and e2e tests to include macOS 13 and 14

### DIFF
--- a/.buildkite/pipeline.full.yml
+++ b/.buildkite/pipeline.full.yml
@@ -369,6 +369,54 @@ steps:
         - exit_status: -1  # Agent was lost
           limit: 2
 
+  - label: 'macOS 10.13 E2E tests'
+    depends_on:
+      - cocoa_fixture
+    timeout_in_minutes: 60
+    agents:
+      queue: opensource-mac-cocoa-10.13
+    plugins:
+      artifacts#v1.5.0:
+        download: ["features/fixtures/macos/output/macOSTestApp.zip"]
+        upload: ["macOSTestApp.log", "maze_output/failed/**/*"]
+    commands:
+      - bundle install
+      - bundle exec maze-runner
+        --os=macos
+        --fail-fast
+
+  - label: 'macOS 10.14 E2E tests'
+    depends_on:
+      - cocoa_fixture
+    timeout_in_minutes: 60
+    agents:
+      queue: opensource-mac-cocoa-10.14
+    plugins:
+      artifacts#v1.5.0:
+        download: ["features/fixtures/macos/output/macOSTestApp.zip"]
+        upload: ["macOSTestApp.log", "maze_output/failed/**/*"]
+    commands:
+      - bundle install
+      - bundle exec maze-runner
+        --os=macos
+        --fail-fast
+
+  - label: 'macOS 10.15 E2E tests'
+    depends_on:
+      - cocoa_fixture
+    timeout_in_minutes: 60
+    agents:
+      queue: macos-10.15
+    plugins:
+      artifacts#v1.5.0:
+        download: ["features/fixtures/macos/output/macOSTestApp.zip"]
+        upload: ["macOSTestApp.log", "maze_output/failed/**/*"]
+    commands:
+      - bundle install
+      - bundle exec maze-runner
+        --os=macos
+        --fail-fast
+
   - label: 'macOS 11 E2E tests'
     depends_on:
       - cocoa_fixture
@@ -403,32 +451,18 @@ steps:
         --os=macos
         --fail-fast
 
-  - label: 'macOS 10.13 E2E tests'
+  - label: 'ARM macOS 13 E2E tests'
     depends_on:
       - cocoa_fixture
     timeout_in_minutes: 60
     agents:
-      queue: opensource-mac-cocoa-10.13
+      queue: macos-13-arm
     plugins:
       artifacts#v1.5.0:
-        download: ["features/fixtures/macos/output/macOSTestApp.zip"]
-        upload: ["macOSTestApp.log", "maze_output/failed/**/*"]
-    commands:
-      - bundle install
-      - bundle exec maze-runner
-        --os=macos
-        --fail-fast
-
-  - label: 'macOS 10.14 E2E tests'
-    depends_on:
-      - cocoa_fixture
-    timeout_in_minutes: 60
-    agents:
-      queue: opensource-mac-cocoa-10.14
-    plugins:
-      artifacts#v1.5.0:
-        download: ["features/fixtures/macos/output/macOSTestApp.zip"]
-        upload: ["macOSTestApp.log", "maze_output/failed/**/*"]
+        download: "features/fixtures/macos/output/macOSTestApp.zip"
+        upload:
+          - "macOSTestApp.log"
+          - "maze_output/failed/**/*"
     commands:
       - bundle install
       - bundle exec maze-runner

--- a/.buildkite/pipeline.yml
+++ b/.buildkite/pipeline.yml
@@ -50,6 +50,24 @@ steps:
   # Unit tests
   #
 
+  - label: ARM macOS 14 unit tests
+    timeout_in_minutes: 10
+    agents:
+      queue: macos-14
+    commands:
+      - ./scripts/run-unit-tests.sh PLATFORM=macOS
+    artifact_paths:
+      - logs/*
+
+  - label: ARM macOS 13 unit tests
+    timeout_in_minutes: 10
+    agents:
+      queue: macos-13-arm
+    commands:
+      - ./scripts/run-unit-tests.sh PLATFORM=macOS
+    artifact_paths:
+      - logs/*
+
   - label: ARM macOS 12 unit tests
     timeout_in_minutes: 10
     agents:
@@ -183,7 +201,26 @@ steps:
         --os=macos
         --fail-fast
 
-  - label: 'macOS 10.15 E2E tests'
+  - label: 'macOS 10.14 barebones E2E tests'
+    depends_on:
+      - cocoa_fixture
+    timeout_in_minutes: 10
+    agents:
+      queue: opensource-mac-cocoa-10.14
+    plugins:
+      artifacts#v1.5.0:
+        download: "features/fixtures/macos/output/macOSTestApp.zip"
+        upload:
+          - "macOSTestApp.log"
+          - "maze_output/failed/**/*"
+    commands:
+      - bundle install
+      - bundle exec maze-runner
+        features/barebone_tests.feature
+        --os=macos
+        --fail-fast
+
+  - label: 'macOS 10.15 barebones E2E tests'
     depends_on:
       - cocoa_fixture
     timeout_in_minutes: 60
@@ -196,8 +233,26 @@ steps:
     commands:
       - bundle install
       - bundle exec maze-runner
+        features/barebone_tests.feature
         --os=macos
-#        --fail-fast
+        --fail-fast
+
+  - label: 'macOS 11 barebones E2E tests'
+    depends_on:
+      - cocoa_fixture
+    timeout_in_minutes: 60
+    agents:
+      queue: macos-11
+    plugins:
+      artifacts#v1.5.0:
+        download: ["features/fixtures/macos/output/macOSTestApp.zip"]
+        upload: ["macOSTestApp.log", "maze_output/failed/**/*"]
+    commands:
+      - bundle install
+      - bundle exec maze-runner
+        features/barebone_tests.feature
+        --os=macos
+        --fail-fast
 
   - label: 'ARM macOS 12 barebones E2E tests'
     depends_on:
@@ -237,6 +292,43 @@ steps:
     artifact_paths:
       - features/fixtures/macos-stress-test/*.log
       - features/fixtures/macos-stress-test/*.crash
+
+  - label: 'ARM macOS 13 barebones E2E tests'
+    depends_on:
+      - cocoa_fixture
+    timeout_in_minutes: 10
+    agents:
+      queue: macos-13-arm
+    plugins:
+      artifacts#v1.5.0:
+        download: "features/fixtures/macos/output/macOSTestApp.zip"
+        upload:
+          - "macOSTestApp.log"
+          - "maze_output/failed/**/*"
+    commands:
+      - bundle install
+      - bundle exec maze-runner
+        features/barebone_tests.feature
+        --os=macos
+        --fail-fast
+
+  - label: 'ARM macOS 14 E2E tests'
+    depends_on:
+      - cocoa_fixture
+    timeout_in_minutes: 60
+    agents:
+      queue: macos-14
+    plugins:
+      artifacts#v1.5.0:
+        download: "features/fixtures/macos/output/macOSTestApp.zip"
+        upload:
+          - "macOSTestApp.log"
+          - "maze_output/failed/**/*"
+    commands:
+      - bundle install
+      - bundle exec maze-runner
+        --os=macos
+        --fail-fast
 
   ##############################################################################
   #
@@ -346,6 +438,36 @@ steps:
   #
   # BitBar
   #
+
+  - label: ':bitbar: iOS 16 barebone tests'
+    depends_on:
+      - cocoa_fixture
+    timeout_in_minutes: 60
+    agents:
+      queue: opensource
+    plugins:
+      artifacts#v1.9.0:
+        download: "features/fixtures/ios/output/ipa_url_bb.txt"
+        upload: "maze_output/failed/**/*"
+      docker-compose#v4.7.0:
+        pull: cocoa-maze-runner-bitbar
+        run: cocoa-maze-runner-bitbar
+        service-ports: true
+        command:
+          - "--app=@/app/build/ipa_url_bb.txt"
+          - "--farm=bb"
+          - "--device=IOS_16"
+          - "--no-tunnel"
+          - "--aws-public-ip"
+          - "--fail-fast"
+          - "features/barebone_tests.feature"
+    concurrency: 25
+    concurrency_group: 'bitbar'
+    concurrency_method: eager
+    retry:
+      automatic:
+        - exit_status: -1  # Agent was lost
+          limit: 2
 
   - label: ':bitbar: iOS 15 barebone tests'
     depends_on:


### PR DESCRIPTION
## Goal

Adds unit and e2e tests for macOS 13 and 14.

## Design

The ordering of Buildkite jobs within the pipeline is currently inconsistent - sometimes starting with the newest version, sometimes the oldest.  I'll preset another PR shortly to make them consistent - I didn't want to do is as part of this change as it would make it much harder to review.

## Testing

Covered by a full CI run.