### PR TITLE
Reorder buildkite jobs

### DIFF
--- a/.buildkite/pipeline.full.yml
+++ b/.buildkite/pipeline.full.yml
@@ -369,28 +369,48 @@ steps:
         - exit_status: -1  # Agent was lost
           limit: 2
 
-  - label: 'macOS 10.13 E2E tests'
+  - label: 'ARM macOS 13 E2E tests'
     depends_on:
       - cocoa_fixture
     timeout_in_minutes: 60
     agents:
-      queue: opensource-mac-cocoa-10.13
+      queue: macos-13-arm
     plugins:
       artifacts#v1.5.0:
-        download: ["features/fixtures/macos/output/macOSTestApp.zip"]
-        upload: ["macOSTestApp.log", "maze_output/failed/**/*"]
+        download: "features/fixtures/macos/output/macOSTestApp.zip"
+        upload:
+          - "macOSTestApp.log"
+          - "maze_output/failed/**/*"
     commands:
       - bundle install
       - bundle exec maze-runner
         --os=macos
         --fail-fast
 
-  - label: 'macOS 10.14 E2E tests'
+  - label: 'ARM macOS 12 E2E tests'
     depends_on:
       - cocoa_fixture
     timeout_in_minutes: 60
     agents:
-      queue: opensource-mac-cocoa-10.14
+      queue: macos-12-arm
+    plugins:
+      artifacts#v1.5.0:
+        download: "features/fixtures/macos/output/macOSTestApp.zip"
+        upload:
+          - "macOSTestApp.log"
+          - "maze_output/failed/**/*"
+    commands:
+      - bundle install
+      - bundle exec maze-runner
+        --os=macos
+        --fail-fast
+
+  - label: 'macOS 11 E2E tests'
+    depends_on:
+      - cocoa_fixture
+    timeout_in_minutes: 60
+    agents:
+      queue: macos-11
     plugins:
       artifacts#v1.5.0:
         download: ["features/fixtures/macos/output/macOSTestApp.zip"]
@@ -417,12 +437,12 @@ steps:
         --os=macos
         --fail-fast
 
-  - label: 'macOS 11 E2E tests'
+  - label: 'macOS 10.14 E2E tests'
     depends_on:
       - cocoa_fixture
     timeout_in_minutes: 60
     agents:
-      queue: macos-11
+      queue: opensource-mac-cocoa-10.14
     plugins:
       artifacts#v1.5.0:
         download: ["features/fixtures/macos/output/macOSTestApp.zip"]
@@ -433,36 +453,16 @@ steps:
         --os=macos
         --fail-fast
 
-  - label: 'ARM macOS 12 E2E tests'
+  - label: 'macOS 10.13 E2E tests'
     depends_on:
       - cocoa_fixture
     timeout_in_minutes: 60
     agents:
-      queue: macos-12-arm
+      queue: opensource-mac-cocoa-10.13
     plugins:
       artifacts#v1.5.0:
-        download: "features/fixtures/macos/output/macOSTestApp.zip"
-        upload:
-          - "macOSTestApp.log"
-          - "maze_output/failed/**/*"
-    commands:
-      - bundle install
-      - bundle exec maze-runner
-        --os=macos
-        --fail-fast
-
-  - label: 'ARM macOS 13 E2E tests'
-    depends_on:
-      - cocoa_fixture
-    timeout_in_minutes: 60
-    agents:
-      queue: macos-13-arm
-    plugins:
-      artifacts#v1.5.0:
-        download: "features/fixtures/macos/output/macOSTestApp.zip"
-        upload:
-          - "macOSTestApp.log"
-          - "maze_output/failed/**/*"
+        download: ["features/fixtures/macos/output/macOSTestApp.zip"]
+        upload: ["macOSTestApp.log", "maze_output/failed/**/*"]
     commands:
       - bundle install
       - bundle exec maze-runner

--- a/.buildkite/pipeline.yml
+++ b/.buildkite/pipeline.yml
@@ -182,12 +182,12 @@ steps:
     artifact_paths:
       - logs/*
 
-  - label: 'macOS 10.13 barebones E2E tests'
+  - label: 'ARM macOS 14 E2E tests'
     depends_on:
       - cocoa_fixture
-    timeout_in_minutes: 10
+    timeout_in_minutes: 60
     agents:
-      queue: opensource-mac-cocoa-10.13
+      queue: macos-14
     plugins:
       artifacts#v1.5.0:
         download: "features/fixtures/macos/output/macOSTestApp.zip"
@@ -197,56 +197,21 @@ steps:
     commands:
       - bundle install
       - bundle exec maze-runner
-        features/barebone_tests.feature
         --os=macos
         --fail-fast
 
-  - label: 'macOS 10.14 barebones E2E tests'
+  - label: 'ARM macOS 13 barebones E2E tests'
     depends_on:
       - cocoa_fixture
     timeout_in_minutes: 10
     agents:
-      queue: opensource-mac-cocoa-10.14
+      queue: macos-13-arm
     plugins:
       artifacts#v1.5.0:
         download: "features/fixtures/macos/output/macOSTestApp.zip"
         upload:
           - "macOSTestApp.log"
           - "maze_output/failed/**/*"
-    commands:
-      - bundle install
-      - bundle exec maze-runner
-        features/barebone_tests.feature
-        --os=macos
-        --fail-fast
-
-  - label: 'macOS 10.15 barebones E2E tests'
-    depends_on:
-      - cocoa_fixture
-    timeout_in_minutes: 60
-    agents:
-      queue: macos-10.15
-    plugins:
-      artifacts#v1.5.0:
-        download: ["features/fixtures/macos/output/macOSTestApp.zip"]
-        upload: ["macOSTestApp.log", "maze_output/failed/**/*"]
-    commands:
-      - bundle install
-      - bundle exec maze-runner
-        features/barebone_tests.feature
-        --os=macos
-        --fail-fast
-
-  - label: 'macOS 11 barebones E2E tests'
-    depends_on:
-      - cocoa_fixture
-    timeout_in_minutes: 60
-    agents:
-      queue: macos-11
-    plugins:
-      artifacts#v1.5.0:
-        download: ["features/fixtures/macos/output/macOSTestApp.zip"]
-        upload: ["macOSTestApp.log", "maze_output/failed/**/*"]
     commands:
       - bundle install
       - bundle exec maze-runner
@@ -293,12 +258,46 @@ steps:
       - features/fixtures/macos-stress-test/*.log
       - features/fixtures/macos-stress-test/*.crash
 
-  - label: 'ARM macOS 13 barebones E2E tests'
+  - label: 'macOS 11 barebones E2E tests'
+    depends_on:
+      - cocoa_fixture
+    timeout_in_minutes: 60
+    agents:
+      queue: macos-11
+    plugins:
+      artifacts#v1.5.0:
+        download: ["features/fixtures/macos/output/macOSTestApp.zip"]
+        upload: ["macOSTestApp.log", "maze_output/failed/**/*"]
+    commands:
+      - bundle install
+      - bundle exec maze-runner
+        features/barebone_tests.feature
+        --os=macos
+        --fail-fast
+
+  - label: 'macOS 10.15 barebones E2E tests'
+    depends_on:
+      - cocoa_fixture
+    timeout_in_minutes: 60
+    agents:
+      queue: macos-10.15
+    plugins:
+      artifacts#v1.5.0:
+        download: ["features/fixtures/macos/output/macOSTestApp.zip"]
+        upload: ["macOSTestApp.log", "maze_output/failed/**/*"]
+    commands:
+      - bundle install
+      - bundle exec maze-runner
+        features/barebone_tests.feature
+        --os=macos
+        --fail-fast
+
+  - label: 'macOS 10.14 barebones E2E tests'
     depends_on:
       - cocoa_fixture
     timeout_in_minutes: 10
     agents:
-      queue: macos-13-arm
+      queue: opensource-mac-cocoa-10.14
     plugins:
       artifacts#v1.5.0:
         download: "features/fixtures/macos/output/macOSTestApp.zip"
@@ -312,12 +311,12 @@ steps:
         --os=macos
         --fail-fast
 
-  - label: 'ARM macOS 14 E2E tests'
+  - label: 'macOS 10.13 barebones E2E tests'
     depends_on:
       - cocoa_fixture
-    timeout_in_minutes: 60
+    timeout_in_minutes: 10
     agents:
-      queue: macos-14
+      queue: opensource-mac-cocoa-10.13
     plugins:
       artifacts#v1.5.0:
         download: "features/fixtures/macos/output/macOSTestApp.zip"
@@ -327,6 +326,7 @@ steps:
     commands:
       - bundle install
       - bundle exec maze-runner
+        features/barebone_tests.feature
         --os=macos
         --fail-fast
 


### PR DESCRIPTION
## Goal

Reorders the buildkite jobs to always appears in the same order - newest versions first.

## Testing

Covered by CI.