### PR TITLE
[Plat-11947] fix some timing flakes

### DIFF
--- a/features/fixtures/ios/iOSTestApp/ViewController.swift
+++ b/features/fixtures/ios/iOSTestApp/ViewController.swift
@@ -30,7 +30,7 @@ class ViewController: UIViewController {
         let args = scenarioMetaDataField.text!.count > 0 ? [scenarioMetaDataField.text!] : []
 
         fixture.setApiKey(apiKey: apiKey)
-        fixture.runScenario(scenarioName: scenarioName, args: args) {}
+        fixture.runScenario(scenarioName: scenarioName, args: args, launchCount: 1) {}
     }
 
     @IBAction func startBugsnag() {
@@ -39,7 +39,7 @@ class ViewController: UIViewController {
         let args = scenarioMetaDataField.text!.count > 0 ? [scenarioMetaDataField.text!] : []
         
         fixture.setApiKey(apiKey: apiKey)
-        fixture.startBugsnagForScenario(scenarioName: scenarioName, args: args) {}
+        fixture.startBugsnagForScenario(scenarioName: scenarioName, args: args, launchCount: 1) {}
     }
 
     @IBAction func clearPersistentData(_ sender: Any) {

--- a/features/fixtures/macos/macOSTestApp/MainWindowController.m
+++ b/features/fixtures/macos/macOSTestApp/MainWindowController.m
@@ -68,7 +68,7 @@ static NSString *defaultMazeRunnerURLString = @"http://localhost:9339";
     // 0.1s delay allows accessibility APIs to finish handling the mouse click and returns control to the tests framework.
     dispatch_after(dispatch_time(DISPATCH_TIME_NOW, (int64_t)(0.1 * NSEC_PER_SEC)), dispatch_get_main_queue(), ^{
         logInfo(@"Running scenario: %@", scenarioName);
-        [self.fixture runScenarioWithScenarioName:scenarioName args:args completion:^{}];
+        [self.fixture runScenarioWithScenarioName:scenarioName args:args launchCount:1 completion:^{}];
     });
 }
 
@@ -81,7 +81,7 @@ static NSString *defaultMazeRunnerURLString = @"http://localhost:9339";
         args = @[self.scenarioMetadata];
     }
 
-    [self.fixture startBugsnagForScenarioWithScenarioName:scenarioName args:args completion:^{}];
+    [self.fixture startBugsnagForScenarioWithScenarioName:scenarioName args:args launchCount:1 completion:^{}];
 }
 
 - (IBAction)clearPersistentData:(id)sender {

--- a/features/fixtures/shared/scenarios/AutoSessionUnhandledScenario.m
+++ b/features/fixtures/shared/scenarios/AutoSessionUnhandledScenario.m
@@ -16,20 +16,15 @@
 
 - (void)configure {
     [super configure];
-    if ([self.args[0] isEqualToString:@"noevent"]) {
-        self.config.autoTrackSessions = NO;
-    } else {
-        self.config.autoTrackSessions = YES;
-    }
+    // Only track sessions on the first launch
+    self.config.autoTrackSessions = self.launchCount == 1;
 }
 
 - (void)run {
-    if (![self.args[0] isEqualToString:@"noevent"]) {
-        // Just sleep because dispatching the code never runs.
-        sleep(2);
-        NSException *ex = [NSException exceptionWithName:@"Kaboom" reason:@"The connection exploded" userInfo:nil];
-        @throw ex;
-    }
+    // Wait for the session to be sent
+    dispatch_after(dispatch_time(DISPATCH_TIME_NOW, (int64_t)(2 * NSEC_PER_SEC)), dispatch_get_main_queue(), ^{
+        @throw [NSException exceptionWithName:@"Kaboom" reason:@"The connection exploded" userInfo:nil];
+    });
 }
 
 @end

--- a/features/fixtures/shared/scenarios/ManyConcurrentNotifyScenario.m
+++ b/features/fixtures/shared/scenarios/ManyConcurrentNotifyScenario.m
@@ -13,8 +13,8 @@
 
 @implementation ManyConcurrentNotifyScenario
 
-- (instancetype)initWithFixtureConfig:(FixtureConfig *)config args:( NSArray<NSString *> * _Nonnull )args {
-    if (self = [super initWithFixtureConfig:config args:args]) {
+- (instancetype)initWithFixtureConfig:(FixtureConfig *)config args:( NSArray<NSString *> * _Nonnull )args launchCount:(NSInteger)launchCount {
+    if (self = [super initWithFixtureConfig:config args:args launchCount:launchCount]) {
         _queue1 = dispatch_queue_create("Log Queue 1", DISPATCH_QUEUE_CONCURRENT);
         _queue2 = dispatch_queue_create("Log Queue 2", DISPATCH_QUEUE_CONCURRENT);
     }

--- a/features/fixtures/shared/scenarios/Scenario.h
+++ b/features/fixtures/shared/scenarios/Scenario.h
@@ -20,8 +20,9 @@ void markErrorHandledCallback(const BSG_KSCrashReportWriter *writer);
 @property (strong, nonatomic, nonnull) FixtureConfig *fixtureConfig;
 @property (strong, nonatomic, nonnull) BugsnagConfiguration *config;
 @property (strong, nonatomic, nonnull) NSArray<NSString *> *args;
+@property (nonatomic) NSInteger launchCount;
 
-- (instancetype)initWithFixtureConfig:(FixtureConfig *)config args:( NSArray<NSString *> * _Nonnull )args;
+- (instancetype)initWithFixtureConfig:(FixtureConfig *)config args:( NSArray<NSString *> * _Nonnull )args launchCount:(NSInteger)launchCount;
 
 - (void)configure;
 

--- a/features/fixtures/shared/scenarios/Scenario.m
+++ b/features/fixtures/shared/scenarios/Scenario.m
@@ -66,11 +66,12 @@ static __weak Scenario *currentScenario;
     }];
 }
 
-- (instancetype)initWithFixtureConfig:(FixtureConfig *)fixtureConfig args:(NSArray<NSString *> *)args {
+- (instancetype)initWithFixtureConfig:(FixtureConfig *)fixtureConfig args:(NSArray<NSString *> *)args launchCount:(NSInteger)launchCount {
     if (self = [super init]) {
         _fixtureConfig = fixtureConfig;
         _args = args;
         currentScenario = self;
+        _launchCount = launchCount;
     }
     return self;
 }

--- a/features/fixtures/shared/utils/Fixture.swift
+++ b/features/fixtures/shared/utils/Fixture.swift
@@ -63,13 +63,13 @@ class Fixture: NSObject, CommandReceiver {
             logInfo("Executing command [\(command.action)] with args \(command.args)")
             switch command.action {
             case "run_scenario":
-                self.runScenario(scenarioName: command.args[0], args: Array(command.args[1...]), completion: {
+                self.runScenario(scenarioName: command.args[0], args: Array(command.args[1...]), launchCount: command.launchCount, completion: {
                     self.readyToReceiveCommand = true
                 })
                 isReady = false;
                 break
             case "start_bugsnag":
-                self.startBugsnagForScenario(scenarioName: command.args[0], args: Array(command.args[1...]), completion: {
+                self.startBugsnagForScenario(scenarioName: command.args[0], args: Array(command.args[1...]), launchCount: command.launchCount, completion: {
                     self.readyToReceiveCommand = true
                 })
                 isReady = false;
@@ -95,18 +95,18 @@ class Fixture: NSObject, CommandReceiver {
         Scenario.clearPersistentData()
     }
 
-    @objc func startBugsnagForScenario(scenarioName: String, args: [String], completion: @escaping () -> ()) {
+    @objc func startBugsnagForScenario(scenarioName: String, args: [String], launchCount: Int, completion: @escaping () -> ()) {
         logInfo("---- Starting Bugsnag for scenario \(scenarioName) ----")
-        loadScenarioAndStartBugsnag(scenarioName: scenarioName, args: args)
+        loadScenarioAndStartBugsnag(scenarioName: scenarioName, args: args, launchCount: launchCount)
         logInfo("---- Completed starting Bugsnag for scenario \(String(describing: currentScenario.self)) ----")
         DispatchQueue.main.asyncAfter(deadline: .now() + 0.5) {
             completion()
         }
     }
 
-    @objc func runScenario(scenarioName: String, args: [String], completion: @escaping () -> ()) {
+    @objc func runScenario(scenarioName: String, args: [String], launchCount: Int, completion: @escaping () -> ()) {
         logInfo("---- Running scenario \(scenarioName) ----")
-        loadScenarioAndStartBugsnag(scenarioName: scenarioName, args: args)
+        loadScenarioAndStartBugsnag(scenarioName: scenarioName, args: args, launchCount: launchCount)
         logInfo("Starting scenario in class \(String(describing: currentScenario.self))")
         currentScenario!.run()
         logInfo("---- Completed running scenario \(String(describing: currentScenario.self)) ----")
@@ -149,11 +149,11 @@ class Fixture: NSObject, CommandReceiver {
         fatalError("Could not find class \(scenarioName) or \(namespace).\(scenarioName). Aborting scenario load...")
     }
 
-    private func loadScenarioAndStartBugsnag(scenarioName: String, args: [String]) {
+    private func loadScenarioAndStartBugsnag(scenarioName: String, args: [String], launchCount: Int) {
         logInfo("Loading scenario: \(scenarioName)")
         let scenarioClass: AnyClass = loadScenarioClass(named: scenarioName)
         logInfo("Initializing scenario class: \(scenarioClass)")
-        let scenario = (scenarioClass as! Scenario.Type).init(fixtureConfig: fixtureConfig, args:args)
+        let scenario = (scenarioClass as! Scenario.Type).init(fixtureConfig: fixtureConfig, args:args, launchCount: launchCount)
         currentScenario = scenario
         logInfo("Configuring scenario in class \(String(describing: scenario.self))")
         scenario.configure()

--- a/features/fixtures/shared/utils/MazeRunnerCommand.swift
+++ b/features/fixtures/shared/utils/MazeRunnerCommand.swift
@@ -13,8 +13,10 @@ class MazeRunnerCommand: Codable {
     let action: String
     let uuid: String
     let args: Array<String>
+    let launchCount: Int
     
-    init(uuid: String, action: String, args: Array<String>, message: String) {
+    init(launchCount: Int, uuid: String, action: String, args: Array<String>, message: String) {
+        self.launchCount = launchCount
         self.uuid = uuid
         self.message = message
         self.action = action
@@ -23,6 +25,7 @@ class MazeRunnerCommand: Codable {
 
     required init(from decoder: Decoder) throws {
         let container = try decoder.container(keyedBy: CodingKeys.self)
+        self.launchCount = try container.decodeIfPresent(Int.self, forKey: .launchCount) ?? 0
         self.uuid = try container.decodeIfPresent(String.self, forKey: .uuid) ?? ""
         self.message = try container.decodeIfPresent(String.self, forKey: .message) ?? ""
         self.action = try container.decodeIfPresent(String.self, forKey: .action) ?? ""

--- a/features/session_tracking.feature
+++ b/features/session_tracking.feature
@@ -104,12 +104,8 @@ Feature: Session Tracking
     And the error payload field "events.0.session.events.handled" equals 2
     And the error payload field "events.0.session.id" equals the stored value "session_id"
 
-  @skip_macos
   Scenario: Encountering an unhandled event during a session
-    When I run "AutoSessionUnhandledScenario"
-    And I wait for 4 seconds
-    And I kill and relaunch the app
-    And I set the app to "noevent" mode
+    When I run "AutoSessionUnhandledScenario" and relaunch the crashed app
     And I configure Bugsnag for "AutoSessionUnhandledScenario"
     And I wait to receive a session
     And I wait to receive an error
@@ -126,9 +122,7 @@ Feature: Session Tracking
     And the error payload field "events.0.session.id" equals the stored value "session_id"
 
   Scenario: Encountering handled and unhandled events during a session
-    When I run "AutoSessionMixedEventsScenario"
-    And I wait for 5 seconds
-    And I kill and relaunch the app
+    When I run "AutoSessionMixedEventsScenario" and relaunch the crashed app
     And I configure Bugsnag for "AutoSessionMixedEventsScenario"
     And I wait to receive 2 sessions
     Then the session is valid for the session reporting API

--- a/features/steps/app_steps.rb
+++ b/features/steps/app_steps.rb
@@ -59,7 +59,7 @@ Then('the app is not running') do
 end
 
 When('I invoke {string}') do |method_name|
-  Maze::Server.commands.add({ action: "invoke_method", args: [method_name] })
+  execute_command "invoke_method", [method_name]
   # Ensure fixture has read the command
   count = 100
   sleep 0.1 until Maze::Server.commands.remaining.empty? || (count -= 1) < 1
@@ -67,7 +67,7 @@ end
 
 When('I invoke {string} with parameter {string}') do |method_name, arg1|
   # Note: The method will usually be of the form "xyzWithParam:"
-  Maze::Server.commands.add({ action: "invoke_method", args: [method_name, arg1] })
+  execute_command "invoke_method", [method_name, arg1]
   # Ensure fixture has read the command
   count = 100
   sleep 0.1 until Maze::Server.commands.remaining.empty? || (count -= 1) < 1
@@ -81,7 +81,7 @@ end
 
 
 def execute_command(action, args)
-  Maze::Server.commands.add({ action: action, args: args })
+  Maze::Server.commands.add({ action: action, args: args, launch_count: $launch_count })
 end
 
 def launch_app
@@ -116,6 +116,7 @@ def relaunch_crashed_app
   else
     raise "Unsupported platform: #{Maze::Helper.get_current_platform}"
   end
+  $launch_count += 1
 end
 
 def kill_and_relaunch_app
@@ -130,6 +131,7 @@ def kill_and_relaunch_app
   else
     raise "Unsupported platform: #{Maze::Helper.get_current_platform}"
   end
+  $launch_count += 1
 end
 
 def wait_for_true(description)

--- a/features/support/env.rb
+++ b/features/support/env.rb
@@ -123,6 +123,7 @@ Maze.hooks.before do |_scenario|
   # Reset to defaults in case previous scenario changed them
   Maze.config.captured_invalid_requests = Set[:errors, :sessions, :builds, :uploads, :sourcemaps]
 
+  $launch_count = 1
   launch_app
 
   $started_at = Time.now


### PR DESCRIPTION
## Goal

Some of the flakes we're experiencing happen because maze runner only waits a certain time for things to happen and then assumes it worked. This is especially true of scenarios that require different configurations on subsequent launches.

## Design

Add a `launch_count` field to the scenario launch command so that the scenario always knows which launch number it is in the current scenario. Then it can configure itself accordingly.
