### PR TITLE
[Plat-12123] trace id in errors

### DIFF
--- a/Bugsnag.xcodeproj/project.pbxproj
+++ b/Bugsnag.xcodeproj/project.pbxproj
@@ -729,6 +729,29 @@
 		093EB6672AFE4580006EB7E3 /* BSGTestCase.mm in Sources */ = {isa = PBXBuildFile; fileRef = 093EB6652AFE4580006EB7E3 /* BSGTestCase.mm */; };
 		093EB6682AFE4580006EB7E3 /* BSGTestCase.mm in Sources */ = {isa = PBXBuildFile; fileRef = 093EB6652AFE4580006EB7E3 /* BSGTestCase.mm */; };
 		093EB6692AFE4580006EB7E3 /* BSGTestCase.mm in Sources */ = {isa = PBXBuildFile; fileRef = 093EB6652AFE4580006EB7E3 /* BSGTestCase.mm */; };
+		09E312EF2BF230660081F219 /* BugsnagCocoaPerformanceFromBugsnagCocoa.h in Headers */ = {isa = PBXBuildFile; fileRef = 09E312ED2BF230660081F219 /* BugsnagCocoaPerformanceFromBugsnagCocoa.h */; };
+		09E312F02BF230660081F219 /* BugsnagCocoaPerformanceFromBugsnagCocoa.h in Headers */ = {isa = PBXBuildFile; fileRef = 09E312ED2BF230660081F219 /* BugsnagCocoaPerformanceFromBugsnagCocoa.h */; };
+		09E312F12BF230660081F219 /* BugsnagCocoaPerformanceFromBugsnagCocoa.h in Headers */ = {isa = PBXBuildFile; fileRef = 09E312ED2BF230660081F219 /* BugsnagCocoaPerformanceFromBugsnagCocoa.h */; };
+		09E312F22BF230660081F219 /* BugsnagCocoaPerformanceFromBugsnagCocoa.h in Headers */ = {isa = PBXBuildFile; fileRef = 09E312ED2BF230660081F219 /* BugsnagCocoaPerformanceFromBugsnagCocoa.h */; };
+		09E312F32BF230660081F219 /* BugsnagCocoaPerformanceFromBugsnagCocoa.m in Sources */ = {isa = PBXBuildFile; fileRef = 09E312EE2BF230660081F219 /* BugsnagCocoaPerformanceFromBugsnagCocoa.m */; };
+		09E312F42BF230660081F219 /* BugsnagCocoaPerformanceFromBugsnagCocoa.m in Sources */ = {isa = PBXBuildFile; fileRef = 09E312EE2BF230660081F219 /* BugsnagCocoaPerformanceFromBugsnagCocoa.m */; };
+		09E312F52BF230660081F219 /* BugsnagCocoaPerformanceFromBugsnagCocoa.m in Sources */ = {isa = PBXBuildFile; fileRef = 09E312EE2BF230660081F219 /* BugsnagCocoaPerformanceFromBugsnagCocoa.m */; };
+		09E312F62BF230660081F219 /* BugsnagCocoaPerformanceFromBugsnagCocoa.m in Sources */ = {isa = PBXBuildFile; fileRef = 09E312EE2BF230660081F219 /* BugsnagCocoaPerformanceFromBugsnagCocoa.m */; };
+		09E312F82BF248E70081F219 /* BugsnagCorrelation.h in Headers */ = {isa = PBXBuildFile; fileRef = 09E312F72BF248DD0081F219 /* BugsnagCorrelation.h */; settings = {ATTRIBUTES = (Public, ); }; };
+		09E312F92BF248E80081F219 /* BugsnagCorrelation.h in Headers */ = {isa = PBXBuildFile; fileRef = 09E312F72BF248DD0081F219 /* BugsnagCorrelation.h */; settings = {ATTRIBUTES = (Public, ); }; };
+		09E312FA2BF248E90081F219 /* BugsnagCorrelation.h in Headers */ = {isa = PBXBuildFile; fileRef = 09E312F72BF248DD0081F219 /* BugsnagCorrelation.h */; settings = {ATTRIBUTES = (Public, ); }; };
+		09E312FB2BF248E90081F219 /* BugsnagCorrelation.h in Headers */ = {isa = PBXBuildFile; fileRef = 09E312F72BF248DD0081F219 /* BugsnagCorrelation.h */; settings = {ATTRIBUTES = (Public, ); }; };
+		09E312FC2BF2492C0081F219 /* BugsnagCorrelation.h in CopyFiles */ = {isa = PBXBuildFile; fileRef = 09E312F72BF248DD0081F219 /* BugsnagCorrelation.h */; };
+		09E312FE2BF34D6D0081F219 /* BugsnagCorrelation.m in Sources */ = {isa = PBXBuildFile; fileRef = 09E312FD2BF34D6D0081F219 /* BugsnagCorrelation.m */; };
+		09E312FF2BF34D6D0081F219 /* BugsnagCorrelation.m in Sources */ = {isa = PBXBuildFile; fileRef = 09E312FD2BF34D6D0081F219 /* BugsnagCorrelation.m */; };
+		09E313002BF34D6D0081F219 /* BugsnagCorrelation.m in Sources */ = {isa = PBXBuildFile; fileRef = 09E312FD2BF34D6D0081F219 /* BugsnagCorrelation.m */; };
+		09E313012BF34D6D0081F219 /* BugsnagCorrelation.m in Sources */ = {isa = PBXBuildFile; fileRef = 09E312FD2BF34D6D0081F219 /* BugsnagCorrelation.m */; };
+		09E3132F2BF3867C0081F219 /* BugsnagPerformanceBridgeTests.m in Sources */ = {isa = PBXBuildFile; fileRef = 09E3132E2BF3867C0081F219 /* BugsnagPerformanceBridgeTests.m */; };
+		09E313302BF3867C0081F219 /* BugsnagPerformanceBridgeTests.m in Sources */ = {isa = PBXBuildFile; fileRef = 09E3132E2BF3867C0081F219 /* BugsnagPerformanceBridgeTests.m */; };
+		09E313312BF3867C0081F219 /* BugsnagPerformanceBridgeTests.m in Sources */ = {isa = PBXBuildFile; fileRef = 09E3132E2BF3867C0081F219 /* BugsnagPerformanceBridgeTests.m */; };
+		09E313322BF3867C0081F219 /* BugsnagPerformanceBridgeTests.m in Sources */ = {isa = PBXBuildFile; fileRef = 09E3132E2BF3867C0081F219 /* BugsnagPerformanceBridgeTests.m */; };
+		09E313362BF4A7BD0081F219 /* BugsnagCocoaPerformanceFromBugsnagCocoa.m in Sources */ = {isa = PBXBuildFile; fileRef = 09E312EE2BF230660081F219 /* BugsnagCocoaPerformanceFromBugsnagCocoa.m */; };
+		09E313372BF4A7CB0081F219 /* BugsnagCorrelation.m in Sources */ = {isa = PBXBuildFile; fileRef = 09E312FD2BF34D6D0081F219 /* BugsnagCorrelation.m */; };
 		3A700A9424A63ABC0068CD1B /* BugsnagThread.h in Headers */ = {isa = PBXBuildFile; fileRef = 3A700A8024A63A8E0068CD1B /* BugsnagThread.h */; settings = {ATTRIBUTES = (Public, ); }; };
 		3A700A9524A63AC50068CD1B /* BugsnagSession.h in Headers */ = {isa = PBXBuildFile; fileRef = 3A700A8124A63A8E0068CD1B /* BugsnagSession.h */; settings = {ATTRIBUTES = (Public, ); }; };
 		3A700A9624A63AC60068CD1B /* BugsnagStackframe.h in Headers */ = {isa = PBXBuildFile; fileRef = 3A700A8224A63A8E0068CD1B /* BugsnagStackframe.h */; settings = {ATTRIBUTES = (Public, ); }; };
@@ -1244,6 +1267,7 @@
 			dstPath = include/Bugsnag;
 			dstSubfolderSpec = 16;
 			files = (
+				09E312FC2BF2492C0081F219 /* BugsnagCorrelation.h in CopyFiles */,
 				3A700AED24A6492F0068CD1B /* BSG_KSCrashReportWriter.h in CopyFiles */,
 				3A700AF324A6492F0068CD1B /* Bugsnag.h in CopyFiles */,
 				3A700AF724A6492F0068CD1B /* BugsnagApp.h in CopyFiles */,
@@ -1551,6 +1575,12 @@
 		093EB65F2AFE447E006EB7E3 /* Swizzle.mm */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.objcpp; path = Swizzle.mm; sourceTree = "<group>"; };
 		093EB6642AFE4580006EB7E3 /* BSGTestCase.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; path = BSGTestCase.h; sourceTree = "<group>"; };
 		093EB6652AFE4580006EB7E3 /* BSGTestCase.mm */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.cpp.objcpp; path = BSGTestCase.mm; sourceTree = "<group>"; };
+		09E312ED2BF230660081F219 /* BugsnagCocoaPerformanceFromBugsnagCocoa.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; path = BugsnagCocoaPerformanceFromBugsnagCocoa.h; sourceTree = "<group>"; };
+		09E312EE2BF230660081F219 /* BugsnagCocoaPerformanceFromBugsnagCocoa.m */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.objc; path = BugsnagCocoaPerformanceFromBugsnagCocoa.m; sourceTree = "<group>"; };
+		09E312F72BF248DD0081F219 /* BugsnagCorrelation.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; path = BugsnagCorrelation.h; sourceTree = "<group>"; };
+		09E312FD2BF34D6D0081F219 /* BugsnagCorrelation.m */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.objc; path = BugsnagCorrelation.m; sourceTree = "<group>"; };
+		09E313022BF34E5E0081F219 /* BugsnagCorrelation+Private.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; path = "BugsnagCorrelation+Private.h"; sourceTree = "<group>"; };
+		09E3132E2BF3867C0081F219 /* BugsnagPerformanceBridgeTests.m */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.objc; path = BugsnagPerformanceBridgeTests.m; sourceTree = "<group>"; };
 		3A700A8024A63A8E0068CD1B /* BugsnagThread.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; path = BugsnagThread.h; sourceTree = "<group>"; };
 		3A700A8124A63A8E0068CD1B /* BugsnagSession.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; path = BugsnagSession.h; sourceTree = "<group>"; };
 		3A700A8224A63A8E0068CD1B /* BugsnagStackframe.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; path = BugsnagStackframe.h; sourceTree = "<group>"; };
@@ -1989,6 +2019,7 @@
 				008966CF2486D43600DC48C2 /* BugsnagNotifierTest.m */,
 				008966AB2486D43500DC48C2 /* BugsnagOnBreadcrumbTest.m */,
 				008966C92486D43600DC48C2 /* BugsnagOnCrashTest.m */,
+				09E3132E2BF3867C0081F219 /* BugsnagPerformanceBridgeTests.m */,
 				008966C72486D43600DC48C2 /* BugsnagPluginTest.m */,
 				008966B62486D43500DC48C2 /* BugsnagSessionTest.m */,
 				008966C32486D43600DC48C2 /* BugsnagSessionTrackerStopTest.m */,
@@ -2123,6 +2154,8 @@
 				008968142486DA5600DC48C2 /* BugsnagLogger.h */,
 				015F528325C15BB7000D1915 /* MRCCanary.m */,
 				CB37449B284756C100A3955E /* stb_sprintf.h */,
+				09E312ED2BF230660081F219 /* BugsnagCocoaPerformanceFromBugsnagCocoa.h */,
+				09E312EE2BF230660081F219 /* BugsnagCocoaPerformanceFromBugsnagCocoa.m */,
 			);
 			path = Helpers;
 			sourceTree = "<group>";
@@ -2145,6 +2178,8 @@
 				0126DED7257A87F40031A70C /* BugsnagAppWithState+Private.h */,
 				0089684B2486DA9400DC48C2 /* BugsnagBreadcrumb.m */,
 				0126DEDF257A89490031A70C /* BugsnagBreadcrumb+Private.h */,
+				09E312FD2BF34D6D0081F219 /* BugsnagCorrelation.m */,
+				09E313022BF34E5E0081F219 /* BugsnagCorrelation+Private.h */,
 				008968482486DA9400DC48C2 /* BugsnagDevice.m */,
 				0126DEE7257A8B0F0031A70C /* BugsnagDevice+Private.h */,
 				0089685A2486DA9500DC48C2 /* BugsnagDeviceWithState.m */,
@@ -2226,6 +2261,7 @@
 				3A700A8524A63A8E0068CD1B /* BugsnagBreadcrumb.h */,
 				3A700A8924A63A8E0068CD1B /* BugsnagClient.h */,
 				3A700A8D24A63A8E0068CD1B /* BugsnagConfiguration.h */,
+				09E312F72BF248DD0081F219 /* BugsnagCorrelation.h */,
 				01C41A27288FD3EA00BAE31A /* BugsnagDefines.h */,
 				3A700A8F24A63A8E0068CD1B /* BugsnagDevice.h */,
 				3A700A9224A63A8E0068CD1B /* BugsnagDeviceWithState.h */,
@@ -2287,6 +2323,7 @@
 				3A700A9924A63AC60068CD1B /* BugsnagBreadcrumb.h in Headers */,
 				0126F7AB25DD5118008483C2 /* BSGEventUploadFileOperation.h in Headers */,
 				3A700A9A24A63AC60068CD1B /* BSG_KSCrashReportWriter.h in Headers */,
+				09E312EF2BF230660081F219 /* BugsnagCocoaPerformanceFromBugsnagCocoa.h in Headers */,
 				3A700A9B24A63AC60068CD1B /* BugsnagErrorTypes.h in Headers */,
 				01847D962644140F00ADA4C7 /* BSGInternalErrorReporter.h in Headers */,
 				017DCF8C2874212F000ECB22 /* BSGTelemetry.h in Headers */,
@@ -2360,6 +2397,7 @@
 				0089698A2486DAD100DC48C2 /* BSG_KSString.h in Headers */,
 				008969962486DAD100DC48C2 /* BSG_KSBacktrace_Private.h in Headers */,
 				00896A112486DAD100DC48C2 /* BSG_KSCrashSentry_CPPException.h in Headers */,
+				09E312F82BF248E70081F219 /* BugsnagCorrelation.h in Headers */,
 				008969ED2486DAD100DC48C2 /* BSG_KSCrashDoctor.h in Headers */,
 				01CCAEEA25D414D60057268D /* BugsnagLastRunInfo.h in Headers */,
 				010993B1273D2F6200128BBE /* BugsnagFeatureFlagStore.h in Headers */,
@@ -2424,6 +2462,7 @@
 				00896A302486DAD100DC48C2 /* BSG_KSCrashIdentifier.h in Headers */,
 				01B79DAA267CC4A000C8CC5E /* BSGUtils.h in Headers */,
 				008967B92486D9D800DC48C2 /* BugsnagBreadcrumbs.h in Headers */,
+				09E312F92BF248E80081F219 /* BugsnagCorrelation.h in Headers */,
 				008969DF2486DAD100DC48C2 /* BSG_KSCrashC.h in Headers */,
 				0089697F2486DAD100DC48C2 /* BSG_KSArchSpecific.h in Headers */,
 				01C41A29288FD3EB00BAE31A /* BugsnagDefines.h in Headers */,
@@ -2452,6 +2491,7 @@
 				008967F52486DA4500DC48C2 /* BSGSessionUploader.h in Headers */,
 				010FF28525ED2A8D00E4F2B0 /* BSGAppHangDetector.h in Headers */,
 				008969E22486DAD100DC48C2 /* BSG_KSSystemInfo.h in Headers */,
+				09E312F02BF230660081F219 /* BugsnagCocoaPerformanceFromBugsnagCocoa.h in Headers */,
 				01CB95C0278F0C830077744A /* BSG_KSFile.h in Headers */,
 				00896A0F2486DAD100DC48C2 /* BSG_KSCrashSentry.h in Headers */,
 				008969D32486DAD100DC48C2 /* BSG_KSCrashContext.h in Headers */,
@@ -2528,6 +2568,7 @@
 				00896A312486DAD100DC48C2 /* BSG_KSCrashIdentifier.h in Headers */,
 				01B79DAB267CC4A000C8CC5E /* BSGUtils.h in Headers */,
 				008967BA2486D9D800DC48C2 /* BugsnagBreadcrumbs.h in Headers */,
+				09E312FA2BF248E90081F219 /* BugsnagCorrelation.h in Headers */,
 				008969E02486DAD100DC48C2 /* BSG_KSCrashC.h in Headers */,
 				008969802486DAD100DC48C2 /* BSG_KSArchSpecific.h in Headers */,
 				01C41A2A288FD3EB00BAE31A /* BugsnagDefines.h in Headers */,
@@ -2556,6 +2597,7 @@
 				008967F62486DA4500DC48C2 /* BSGSessionUploader.h in Headers */,
 				010FF28625ED2A8D00E4F2B0 /* BSGAppHangDetector.h in Headers */,
 				008969E32486DAD100DC48C2 /* BSG_KSSystemInfo.h in Headers */,
+				09E312F12BF230660081F219 /* BugsnagCocoaPerformanceFromBugsnagCocoa.h in Headers */,
 				01CB95C1278F0C830077744A /* BSG_KSFile.h in Headers */,
 				00896A102486DAD100DC48C2 /* BSG_KSCrashSentry.h in Headers */,
 				008969D42486DAD100DC48C2 /* BSG_KSCrashContext.h in Headers */,
@@ -2624,6 +2666,7 @@
 				CBBDE929280068AD0070DCD3 /* BSGEventUploadObjectOperation.h in Headers */,
 				CBBDE92A280068AD0070DCD3 /* BSGEventUploader.h in Headers */,
 				CBBDE950280068FD0070DCD3 /* BugsnagClient.h in Headers */,
+				09E312FB2BF248E90081F219 /* BugsnagCorrelation.h in Headers */,
 				CBBDE955280068FD0070DCD3 /* BugsnagPlugin.h in Headers */,
 				CBBDE9802800698F0070DCD3 /* BSG_KSCrashState.h in Headers */,
 				CBBDE9902800698F0070DCD3 /* BSG_KSCrashType.h in Headers */,
@@ -2680,6 +2723,7 @@
 				CBBDE959280068FD0070DCD3 /* BugsnagSession.h in Headers */,
 				CBBDE930280068AD0070DCD3 /* BSGSessionUploader.h in Headers */,
 				CBBDE93C280068D40070DCD3 /* BSGInternalErrorReporter.h in Headers */,
+				09E312F22BF230660081F219 /* BugsnagCocoaPerformanceFromBugsnagCocoa.h in Headers */,
 				CBBDE942280068E60070DCD3 /* BugsnagCollections.h in Headers */,
 				CBBDE9B0280069B20070DCD3 /* BSG_KSLogger.h in Headers */,
 				CBBDE936280068C40070DCD3 /* BSG_RFC3339DateTool.h in Headers */,
@@ -3074,9 +3118,11 @@
 				008968802486DA9600DC48C2 /* BugsnagAppWithState.m in Sources */,
 				008969572486DAD000DC48C2 /* BSG_KSCrashDoctor.m in Sources */,
 				008968B92486DA9600DC48C2 /* BugsnagStacktrace.m in Sources */,
+				09E312FE2BF34D6D0081F219 /* BugsnagCorrelation.m in Sources */,
 				00896A142486DAD100DC48C2 /* BSG_KSCrashSentry_Signal.c in Sources */,
 				01468F5525876DC1002B0519 /* BSGNotificationBreadcrumbs.m in Sources */,
 				008967BE2486DA1900DC48C2 /* BugsnagClient.m in Sources */,
+				09E312F32BF230660081F219 /* BugsnagCocoaPerformanceFromBugsnagCocoa.m in Sources */,
 				008968952486DA9600DC48C2 /* BugsnagHandledState.m in Sources */,
 				008967FE2486DA4500DC48C2 /* BSGSessionUploader.m in Sources */,
 				0089686B2486DA9500DC48C2 /* BugsnagEvent.m in Sources */,
@@ -3172,6 +3218,7 @@
 				010F80C228645B4200D6569E /* BSGDefinesTests.m in Sources */,
 				01BDB1F525DEBFB200A91FAF /* BSGEventUploadKSCrashReportOperationTests.m in Sources */,
 				008967782486D43700DC48C2 /* BSG_KSMachHeadersTests.m in Sources */,
+				09E3132F2BF3867C0081F219 /* BugsnagPerformanceBridgeTests.m in Sources */,
 				0089673F2486D43700DC48C2 /* BugsnagAppTest.m in Sources */,
 				0089675A2486D43700DC48C2 /* BugsnagEnabledBreadcrumbTest.m in Sources */,
 				01935AE2275E68E9007498B3 /* UIApplicationStub.m in Sources */,
@@ -3252,9 +3299,11 @@
 				0089699D2486DAD100DC48C2 /* BSG_KSFileUtils.c in Sources */,
 				008969762486DAD100DC48C2 /* BSG_KSJSONCodec.c in Sources */,
 				00896A2D2486DAD100DC48C2 /* BSG_KSCrashReport.c in Sources */,
+				09E312FF2BF34D6D0081F219 /* BugsnagCorrelation.m in Sources */,
 				008968812486DA9600DC48C2 /* BugsnagAppWithState.m in Sources */,
 				008969582486DAD000DC48C2 /* BSG_KSCrashDoctor.m in Sources */,
 				008968BA2486DA9600DC48C2 /* BugsnagStacktrace.m in Sources */,
+				09E312F42BF230660081F219 /* BugsnagCocoaPerformanceFromBugsnagCocoa.m in Sources */,
 				00896A152486DAD100DC48C2 /* BSG_KSCrashSentry_Signal.c in Sources */,
 				01468F5625876DC1002B0519 /* BSGNotificationBreadcrumbs.m in Sources */,
 				01CB95C3278F0C830077744A /* BSG_KSFile.c in Sources */,
@@ -3335,6 +3384,7 @@
 				008967822486D43700DC48C2 /* KSSystemInfo_Tests.m in Sources */,
 				008967612486D43700DC48C2 /* BugsnagBreadcrumbsTest.m in Sources */,
 				01DE903D26CEAF9E00455213 /* BSGUtilsTests.m in Sources */,
+				09E313302BF3867C0081F219 /* BugsnagPerformanceBridgeTests.m in Sources */,
 				093EB6672AFE4580006EB7E3 /* BSGTestCase.mm in Sources */,
 				CB156242270707740097334C /* KSCrashNames_Test.m in Sources */,
 				008967012486D43700DC48C2 /* BugsnagEventPersistLoadTest.m in Sources */,
@@ -3427,9 +3477,11 @@
 				008969772486DAD100DC48C2 /* BSG_KSJSONCodec.c in Sources */,
 				00896A2E2486DAD100DC48C2 /* BSG_KSCrashReport.c in Sources */,
 				008968822486DA9600DC48C2 /* BugsnagAppWithState.m in Sources */,
+				09E313002BF34D6D0081F219 /* BugsnagCorrelation.m in Sources */,
 				008969592486DAD000DC48C2 /* BSG_KSCrashDoctor.m in Sources */,
 				008968BB2486DA9600DC48C2 /* BugsnagStacktrace.m in Sources */,
 				00896A162486DAD100DC48C2 /* BSG_KSCrashSentry_Signal.c in Sources */,
+				09E312F52BF230660081F219 /* BugsnagCocoaPerformanceFromBugsnagCocoa.m in Sources */,
 				01468F5725876DC1002B0519 /* BSGNotificationBreadcrumbs.m in Sources */,
 				008967C02486DA1900DC48C2 /* BugsnagClient.m in Sources */,
 				008968972486DA9600DC48C2 /* BugsnagHandledState.m in Sources */,
@@ -3487,6 +3539,7 @@
 				010F80C428645B4200D6569E /* BSGDefinesTests.m in Sources */,
 				CBDD6D0F25AC3EFF00A2E12B /* BSGStorageMigratorV0V1Tests.m in Sources */,
 				008967502486D43700DC48C2 /* BugsnagPluginTest.m in Sources */,
+				09E313312BF3867C0081F219 /* BugsnagPerformanceBridgeTests.m in Sources */,
 				008967142486D43700DC48C2 /* BugsnagEventTests.m in Sources */,
 				0089675C2486D43700DC48C2 /* BugsnagEnabledBreadcrumbTest.m in Sources */,
 				008966ED2486D43700DC48C2 /* BugsnagDeviceTest.m in Sources */,
@@ -3582,6 +3635,7 @@
 				E7462912248907E500F92D67 /* BSG_KSMach_x86_64.c in Sources */,
 				CBCF77A925010648004AF22A /* BSGJSONSerialization.m in Sources */,
 				E7462913248907E500F92D67 /* BSG_KSSignalInfo.c in Sources */,
+				09E313362BF4A7BD0081F219 /* BugsnagCocoaPerformanceFromBugsnagCocoa.m in Sources */,
 				E7462914248907E500F92D67 /* BSG_KSString.c in Sources */,
 				01CCAEF025D414D60057268D /* BugsnagLastRunInfo.m in Sources */,
 				01A2958428B665F5005FCC8C /* BSGNetworkBreadcrumb.m in Sources */,
@@ -3601,6 +3655,7 @@
 				E7462905248907C100F92D67 /* BSG_KSCrash.m in Sources */,
 				E7462906248907C100F92D67 /* BSG_KSCrashSentry_NSException.m in Sources */,
 				E7462907248907C100F92D67 /* BSG_KSCrashSentry_CPPException.mm in Sources */,
+				09E313372BF4A7CB0081F219 /* BugsnagCorrelation.m in Sources */,
 				E7462908248907C100F92D67 /* BSG_KSSystemInfo.m in Sources */,
 				008968CA2486DA9600DC48C2 /* BugsnagApp.m in Sources */,
 				008967C12486DA1900DC48C2 /* BugsnagClient.m in Sources */,
@@ -3701,9 +3756,11 @@
 				CBBDE92C280068AD0070DCD3 /* BSGEventUploadObjectOperation.m in Sources */,
 				CBBDE910280068560070DCD3 /* BugsnagSessionTracker.m in Sources */,
 				CBBDE98C2800698F0070DCD3 /* BSG_KSCrashDoctor.m in Sources */,
+				09E313012BF34D6D0081F219 /* BugsnagCorrelation.m in Sources */,
 				CBBDE948280068E60070DCD3 /* MRCCanary.m in Sources */,
 				CBBDE93A280068D40070DCD3 /* BSGInternalErrorReporter.m in Sources */,
 				CBBDE923280068970070DCD3 /* BugsnagEndpointConfiguration.m in Sources */,
+				09E312F62BF230660081F219 /* BugsnagCocoaPerformanceFromBugsnagCocoa.m in Sources */,
 				CBBDE92E280068AD0070DCD3 /* BSGConnectivity.m in Sources */,
 				CBBDE912280068560070DCD3 /* BSGCrashSentry.m in Sources */,
 				CBBDE9BC280069B20070DCD3 /* BSG_Symbolicate.c in Sources */,
@@ -3783,6 +3840,7 @@
 				CB28F0D8282A4BA6003AB200 /* BugsnagMetadataRedactionTest.m in Sources */,
 				CB28F121282A7D49003AB200 /* BugsnagSwiftConfigurationTests.swift in Sources */,
 				CB28F0DF282A4BEE003AB200 /* BugsnagSessionTest.m in Sources */,
+				09E313322BF3867C0081F219 /* BugsnagPerformanceBridgeTests.m in Sources */,
 				CB28F0C2282A4857003AB200 /* BSGUtilsTests.m in Sources */,
 				CB28F0CA282A4A2E003AB200 /* BugsnagClientMirrorTest.m in Sources */,
 				CB28F120282A7D32003AB200 /* BugsnagSwiftTests.swift in Sources */,

--- a/Bugsnag/Helpers/BSGKeys.h
+++ b/Bugsnag/Helpers/BSGKeys.h
@@ -30,6 +30,7 @@ static BSGKey const BSGKeyClient                    = @"client";
 static BSGKey const BSGKeyCodeBundleId              = @"codeBundleId";
 static BSGKey const BSGKeyConfig                    = @"config";
 static BSGKey const BSGKeyContext                   = @"context";
+static BSGKey const BSGKeyCorrelation               = @"correlation";
 static BSGKey const BSGKeyCppException              = @"cpp_exception";
 static BSGKey const BSGKeyDevelopment               = @"development";
 static BSGKey const BSGKeyDevice                    = @"device";

--- a/Bugsnag/Helpers/BugsnagCocoaPerformanceFromBugsnagCocoa.h
+++ b/Bugsnag/Helpers/BugsnagCocoaPerformanceFromBugsnagCocoa.h
@@ -1,0 +1,40 @@
+//
+//  BugsnagCocoaPerformanceFromBugsnagCocoa.h
+//  Bugsnag
+//
+//  Created by Karl Stenerud on 13.05.24.
+//  Copyright © 2024 Bugsnag Inc. All rights reserved.
+//
+
+#import <Foundation/Foundation.h>
+
+NS_ASSUME_NONNULL_BEGIN
+
+/**
+ * Bridge from Bugsnag Coca to Bugsnag Cocoa Performance.
+ *
+ * IMPORTANT: This class name MUST be globally unique across ALL Bugsnag libraries that contain native code!
+ * When cloning this code as a template for your own bridge, always use the naming style "YourLibraryFromMyLibrary"
+ * For example:
+ * * "BugsnagCocoaPerformanceFromBugsnagUnity" (bridge from Bugsnag Unity to Bugsnag Cocoa Performance)
+ * * "BugsnagCocoaFromBugsnagReactNativePerformance" (bridge from Bugsnag Performance React Native to Bugsnag Cocoa)
+ */
+@interface BugsnagCocoaPerformanceFromBugsnagCocoa: NSObject
+
+#pragma mark Methods that will be bridged to BugsnagPerformance
+
+/**
+ * Return the current trace and span IDs as strings in a 2-entry array, or return nil if no current span exists.
+ *
+ * array[0] is an NSString containing the trace ID
+ * array[1] is an NSString containing the span ID
+ */
+- (NSArray * _Nullable)getCurrentTraceAndSpanId;
+
+#pragma mark Shared Instance
+
++ (instancetype _Nullable) sharedInstance;
+
+@end
+
+NS_ASSUME_NONNULL_END

--- a/Bugsnag/Helpers/BugsnagCocoaPerformanceFromBugsnagCocoa.m
+++ b/Bugsnag/Helpers/BugsnagCocoaPerformanceFromBugsnagCocoa.m
@@ -1,0 +1,62 @@
+//
+//  BugsnagCocoaPerformanceFromBugsnagCocoa.m
+//  Bugsnag
+//
+//  Created by Karl Stenerud on 13.05.24.
+//  Copyright © 2024 Bugsnag Inc. All rights reserved.
+//
+
+#import "BugsnagCocoaPerformanceFromBugsnagCocoa.h"
+#import "BugsnagLogger.h"
+
+// Bridged API methods won't have implementations until we connect them at runtime.
+#pragma clang diagnostic push
+#pragma clang diagnostic ignored "-Wincomplete-implementation"
+@implementation BugsnagCocoaPerformanceFromBugsnagCocoa
+
+static NSString *BSGUserInfoKeyMapped = @"mapped";
+static NSString *BSGUserInfoValueMappedYes = @"YES";
+
+static id bugsnagPerformanceCrossTalkAPI = nil;
+
++ (void)initialize {
+    // Look for a cross-talk API
+    Class cls = NSClassFromString(@"BugsnagPerformanceCrossTalkAPI");
+    if (cls != nil) {
+        NSError *err = nil;
+        // Map the methods we want to use, with the API versions we expect
+        if ((err = [cls mapAPINamed:@"getCurrentTraceAndSpanIdV1"
+                         toSelector:@selector(getCurrentTraceAndSpanId)]) != nil) {
+            bsg_log_err("Failed to map Bugsnag Performance API getCurrentTraceAndSpanIdV1: %@", err);
+            NSString *mapped = err.userInfo[BSGUserInfoKeyMapped];
+            if (![mapped isEqualToString:BSGUserInfoValueMappedYes]) {
+                // Must abort because this method is not mapped, so we'd crash if we tried to call it.
+                return;
+            }
+        }
+
+        // Our "sharedInstance" will actually be the cross-talk API whose class we loaded.
+        bugsnagPerformanceCrossTalkAPI = [cls sharedInstance];
+    }
+}
+
++ (instancetype _Nullable) sharedInstance {
+    // We're either going to return the API object we found in +initialize, or nil.
+    return bugsnagPerformanceCrossTalkAPI;
+}
+
+/**
+ * Map a named API to a method with the specified selector.
+ * If an error occurs, the user info dictionary of the error will contain a field "mapped".
+ * If "mapped" is "YES", then the selector has been mapped to a null implementation (does nothing, returns nil).
+ * If "mapped" is "NO", then no mapping has occurred, and the method doesn't exist (alling it will result in no such selector).
+ */
++ (NSError *)mapAPINamed:(NSString * _Nonnull __unused)apiName toSelector:(SEL __unused)toSelector {
+    // This exists only to make the mapAPINamed selector available on our side
+    // so that we can call it on the API class we found (see +initialize).
+    // This implementation is never actually called.
+    return nil;
+}
+
+@end
+#pragma clang diagnostic pop

--- a/Bugsnag/Payload/BugsnagCorrelation+Private.h
+++ b/Bugsnag/Payload/BugsnagCorrelation+Private.h
@@ -1,0 +1,28 @@
+//
+//  BugsnagCorrelation+Private.h
+//  Bugsnag
+//
+//  Created by Karl Stenerud on 14.05.24.
+//  Copyright © 2024 Bugsnag Inc. All rights reserved.
+//
+
+#import "BugsnagCorrelation.h"
+
+#ifndef BugsnagCorrelation_Private_h
+#define BugsnagCorrelation_Private_h
+
+NS_ASSUME_NONNULL_BEGIN
+
+@interface BugsnagCorrelation ()
+
+- (instancetype) initWithTraceId:(NSString * _Nullable) traceId spanId:(NSString * _Nullable)spanId;
+
+- (instancetype) initWithJsonDictionary:(NSDictionary<NSString *, NSObject *> * _Nullable) dict;
+
+- (NSDictionary<NSString *, NSObject *> *) toJsonDictionary;
+
+@end
+
+NS_ASSUME_NONNULL_END
+
+#endif /* BugsnagCorrelation_Private_h */

--- a/Bugsnag/Payload/BugsnagCorrelation.m
+++ b/Bugsnag/Payload/BugsnagCorrelation.m
@@ -1,0 +1,49 @@
+//
+//  BugsnagCorrelation.m
+//  Bugsnag
+//
+//  Created by Karl Stenerud on 14.05.24.
+//  Copyright © 2024 Bugsnag Inc. All rights reserved.
+//
+
+#import "BugsnagCorrelation+Private.h"
+
+@implementation BugsnagCorrelation
+
+- (instancetype) initWithTraceId:(NSString *) traceId spanId:(NSString *)spanId {
+    if ((self = [super init])) {
+        _traceId = traceId;
+        _spanId = spanId;
+    }
+    return self;
+}
+
+- (instancetype) initWithJsonDictionary:(NSDictionary<NSString *, NSObject *> *) dict {
+    if (dict.count == 0) {
+        return nil;
+    }
+
+    if ((self = [super init])) {
+        id nsnull = NSNull.null;
+        _traceId = (NSString *)dict[@"traceid"];
+        if (_traceId == nsnull) {
+            _traceId = nil;
+        }
+
+        _spanId = (NSString *)dict[@"spanid"];
+        if (_spanId == nsnull) {
+            _spanId = nil;
+        }
+
+    }
+    return self;
+}
+
+- (NSDictionary<NSString *, NSObject *> *) toJsonDictionary {
+    NSMutableDictionary *dict = [NSMutableDictionary new];
+    dict[@"traceid"] = self.traceId;
+    dict[@"spanid"] = self.spanId;
+    return dict;
+}
+
+@end

--- a/Bugsnag/Payload/BugsnagEvent.m
+++ b/Bugsnag/Payload/BugsnagEvent.m
@@ -23,6 +23,7 @@
 #import "BugsnagBreadcrumbs.h"
 #import "BugsnagCollections.h"
 #import "BugsnagConfiguration+Private.h"
+#import "BugsnagCorrelation+Private.h"
 #import "BugsnagDeviceWithState+Private.h"
 #import "BugsnagError+Private.h"
 #import "BugsnagHandledState.h"
@@ -187,6 +188,8 @@ BSG_OBJC_DIRECT_MEMBERS
         }) ?: @[];
 
         _context = BSGDeserializeString(json[BSGKeyContext]);
+
+        _correlation = [[BugsnagCorrelation alloc] initWithJsonDictionary:json[BSGKeyCorrelation]];
 
         _device = BSGDeserializeObject(json[BSGKeyDevice], ^id _Nullable(NSDictionary * _Nonnull dict) {
             return [BugsnagDeviceWithState deviceFromJson:dict];
@@ -592,6 +595,7 @@ BSG_OBJC_DIRECT_MEMBERS
     event[BSGKeyApp] = [self.app toDict];
 
     event[BSGKeyContext] = [self context];
+    event[BSGKeyCorrelation] = [self.correlation toJsonDictionary];
     event[BSGKeyFeatureFlags] = BSGFeatureFlagStoreToJSON(self.featureFlagStore);
     event[BSGKeyGroupingHash] = self.groupingHash;
 

--- a/Bugsnag/include/Bugsnag/BugsnagCorrelation.h
+++ b/Bugsnag/include/Bugsnag/BugsnagCorrelation.h
@@ -1,0 +1,26 @@
+//
+//  BugsnagCorrelation.h
+//  Bugsnag
+//
+//  Created by Karl Stenerud on 13.05.24.
+//  Copyright © 2024 Bugsnag Inc. All rights reserved.
+//
+
+#import <Foundation/Foundation.h>
+
+#ifndef BugsnagCorrelation_h
+#define BugsnagCorrelation_h
+
+NS_ASSUME_NONNULL_BEGIN
+
+@interface BugsnagCorrelation: NSObject
+
+@property (readwrite, nonatomic, strong, nullable) NSString *traceId;
+
+@property (readwrite, nonatomic, strong, nullable) NSString *spanId;
+
+@end
+
+NS_ASSUME_NONNULL_END
+
+#endif /* BugsnagCorrelation_h */

--- a/Bugsnag/include/Bugsnag/BugsnagEvent.h
+++ b/Bugsnag/include/Bugsnag/BugsnagEvent.h
@@ -11,6 +11,7 @@
 #import <Bugsnag/BugsnagDefines.h>
 #import <Bugsnag/BugsnagFeatureFlagStore.h>
 #import <Bugsnag/BugsnagMetadataStore.h>
+#import <Bugsnag/BugsnagCorrelation.h>
 
 @class BugsnagConfiguration;
 @class BugsnagHandledState;
@@ -112,6 +113,7 @@ BUGSNAG_EXTERN
  */
 @property (strong, nullable, nonatomic) id originalError;
 
+@property (readwrite, nonatomic, strong, nullable) BugsnagCorrelation *correlation;
 
 // =============================================================================
 // MARK: - User

--- a/Tests/BugsnagTests/BugsnagClientMirrorTest.m
+++ b/Tests/BugsnagTests/BugsnagClientMirrorTest.m
@@ -64,6 +64,7 @@
             @"generateOutOfMemoryEvent @16@0:8",
             @"generateThermalKillEvent @16@0:8",
             @"generateThreads @16@0:8",
+            @"getCurrentCorrelation @16@0:8",
             @"initWithConfiguration: @24@0:8@16",
             @"initializeNotificationNameMap v16@0:8",
             @"leaveBreadcrumbForEvent: v24@0:8@16",

--- a/Tests/BugsnagTests/BugsnagPerformanceBridgeTests.m
+++ b/Tests/BugsnagTests/BugsnagPerformanceBridgeTests.m
@@ -1,0 +1,25 @@
+//
+//  BugsnagPerformanceBridgeTests.m
+//  Bugsnag
+//
+//  Created by Karl Stenerud on 14.05.24.
+//  Copyright © 2024 Bugsnag Inc. All rights reserved.
+//
+
+#import <XCTest/XCTest.h>
+#import "BugsnagCocoaPerformanceFromBugsnagCocoa.h"
+
+@interface BugsnagPerformanceBridgeTests : XCTestCase
+
+@end
+
+@implementation BugsnagPerformanceBridgeTests
+
+- (void)testBridgeStability {
+    BugsnagCocoaPerformanceFromBugsnagCocoa *api = BugsnagCocoaPerformanceFromBugsnagCocoa.sharedInstance;
+    // With BugsnagPerformance not present, we should get nil calling this.
+    // And most importantly it should not crash!
+    XCTAssertNil([api getCurrentTraceAndSpanId]);
+}
+
+@end


### PR DESCRIPTION
## Goal

Add the current trace and span IDs to errors whenever possible.

It must work (i.e. not crash):

* When BugsnagPerformance is not present
* When BugsnagPerformance is not configured yet

## Design

Use bugsnag-cocoa-performance cross-talk API to fetch the current trace ID and span ID whenever an error occurs and we are in an environment that doesn't restrict us to async-safe calls.

This information (when available) is added to a new top-level "correlation" field in the event:

```json
"correlation": {
    "spanid": "84fe24c394f0b2fd",
    "traceid": "762ad72e35102a516a8f20895f9770a4"
}
```

## Testing

New unit tests for the cross-talk bridge.
Manual testing in an app with bugsnag-cocoa-performance linked, and not linked.
