### PR TITLE
[Plat-12123] trace id in nsexception

### DIFF
--- a/Bugsnag/Breadcrumbs/BugsnagBreadcrumbs.h
+++ b/Bugsnag/Breadcrumbs/BugsnagBreadcrumbs.h
@@ -60,4 +60,5 @@ NS_ASSUME_NONNULL_END
  * This function is async-signal-safe, but requires that any threads that could be adding
  * breadcrumbs are suspended.
  */
-void BugsnagBreadcrumbsWriteCrashReport(const BSG_KSCrashReportWriter * _Nonnull writer);
+void BugsnagBreadcrumbsWriteCrashReport(const BSG_KSCrashReportWriter * _Nonnull writer,
+                                        bool requiresAsyncSafety);

--- a/Bugsnag/Breadcrumbs/BugsnagBreadcrumbs.m
+++ b/Bugsnag/Breadcrumbs/BugsnagBreadcrumbs.m
@@ -289,7 +289,8 @@ BSG_OBJC_DIRECT_MEMBERS
 
 #pragma mark -
 
-void BugsnagBreadcrumbsWriteCrashReport(const BSG_KSCrashReportWriter *writer) {
+void BugsnagBreadcrumbsWriteCrashReport(const BSG_KSCrashReportWriter *writer,
+                                        bool __unused requiresAsyncSafety) {
     atomic_store(&g_writing_crash_report, true);
     
     writer->beginArray(writer, "breadcrumbs");

--- a/Bugsnag/KSCrash/Source/KSCrash/Recording/BSG_KSCrashReport.c
+++ b/Bugsnag/KSCrash/Source/KSCrash/Recording/BSG_KSCrashReport.c
@@ -1271,7 +1271,7 @@ void bsg_kscrashreport_writeStandardReport(
 
             // Write handled exception report info
             writer->beginObject(writer, BSG_KSCrashField_UserAtCrash);
-            crashContext->config.onCrashNotify(writer);
+            crashContext->config.onCrashNotify(writer, crashContext->crash.requiresAsyncSafety);
             writer->endContainer(writer);
         }
     }

--- a/Bugsnag/KSCrash/Source/KSCrash/Recording/Sentry/BSG_KSCrashSentry.h
+++ b/Bugsnag/KSCrash/Source/KSCrash/Recording/Sentry/BSG_KSCrashSentry.h
@@ -77,6 +77,9 @@ typedef struct BSG_KSCrash_SentryContext {
      */
     bool handlingCrash;
 
+    /** If true, any code called via the crash handler MUST be async-safe. */
+    bool requiresAsyncSafety;
+
     /** If true, a second crash occurred while handling a crash. */
     bool crashedDuringCrashHandling;
 

--- a/Bugsnag/KSCrash/Source/KSCrash/Recording/Sentry/BSG_KSCrashSentry_CPPException.mm
+++ b/Bugsnag/KSCrash/Source/KSCrash/Recording/Sentry/BSG_KSCrashSentry_CPPException.mm
@@ -221,6 +221,7 @@ after_rethrow:
 #endif
 
         bsg_g_context->crashType = BSG_KSCrashTypeCPPException;
+        bsg_g_context->requiresAsyncSafety = true;
         bsg_g_context->registersAreValid = false;
         bsg_g_context->stackTrace =
             bsg_g_stackTrace + 1; // Don't record __cxa_throw stack entry

--- a/Bugsnag/KSCrash/Source/KSCrash/Recording/Sentry/BSG_KSCrashSentry_MachException.c
+++ b/Bugsnag/KSCrash/Source/KSCrash/Recording/Sentry/BSG_KSCrashSentry_MachException.c
@@ -277,6 +277,7 @@ void *ksmachexc_i_handleExceptions(void *const userData) {
 
         BSG_KSLOG_DEBUG("Filling out context.");
         bsg_g_context->crashType = BSG_KSCrashTypeMachException;
+        bsg_g_context->requiresAsyncSafety = true;
         bsg_g_context->registersAreValid = true;
         bsg_g_context->mach.type = exceptionMessage.exception;
         bsg_g_context->mach.code = exceptionMessage.code[0] & (int64_t)MACH_ERROR_CODE_MASK;

--- a/Bugsnag/KSCrash/Source/KSCrash/Recording/Sentry/BSG_KSCrashSentry_NSException.m
+++ b/Bugsnag/KSCrash/Source/KSCrash/Recording/Sentry/BSG_KSCrashSentry_NSException.m
@@ -136,6 +136,7 @@ void bsg_recordException(NSException *exception) {
         }
 
         bsg_g_context->crashType = BSG_KSCrashTypeNSException;
+        bsg_g_context->requiresAsyncSafety = false;
         bsg_g_context->offendingThread = bsg_ksmachthread_self();
         bsg_g_context->registersAreValid = false;
         bsg_g_context->NSException.name = CopyUTF8String([exception name]);

--- a/Bugsnag/KSCrash/Source/KSCrash/Recording/Sentry/BSG_KSCrashSentry_Signal.c
+++ b/Bugsnag/KSCrash/Source/KSCrash/Recording/Sentry/BSG_KSCrashSentry_Signal.c
@@ -111,6 +111,7 @@ void bsg_kssighndl_i_handleSignal(int sigNum, siginfo_t *signalInfo,
 
         BSG_KSLOG_DEBUG("Filling out context.");
         bsg_g_context->crashType = BSG_KSCrashTypeSignal;
+        bsg_g_context->requiresAsyncSafety = true;
         bsg_g_context->registersAreValid = true;
         bsg_g_context->faultAddress = (uintptr_t)signalInfo->si_addr;
         bsg_g_context->signal.userContext = userContext;

--- a/Bugsnag/Payload/BugsnagEvent.m
+++ b/Bugsnag/Payload/BugsnagEvent.m
@@ -379,6 +379,10 @@ BSG_OBJC_DIRECT_MEMBERS
     BugsnagConfiguration *config = [[BugsnagConfiguration alloc] initWithDictionaryRepresentation:
                                     [configDict isKindOfClass:[NSDictionary class]] ? configDict : @{}];
 
+    NSDictionary *correlationDict = [event valueForKeyPath:@"user.correlation"];
+    NSString *traceId = correlationDict[@"traceid"];
+    NSString *spanId = correlationDict[@"spanid"];
+
     BugsnagAppWithState *app = [BugsnagAppWithState appWithDictionary:event config:config codeBundleId:self.codeBundleId];
 
     BugsnagSession *session = BSGSessionFromCrashReport(event, app, device, user);
@@ -402,6 +406,11 @@ BSG_OBJC_DIRECT_MEMBERS
     obj.customException = BSGParseCustomException(event, [errors[0].errorClass copy], [errors[0].errorMessage copy]);
     obj.depth = depth;
     obj.usage = [event valueForKeyPath:@"user._usage"];
+
+    if (traceId.length > 0 || spanId.length > 0) {
+        obj.correlation = [[BugsnagCorrelation alloc] initWithTraceId:traceId spanId:spanId];
+    }
+
     return obj;
 }
 

--- a/Bugsnag/Payload/BugsnagSession+Private.h
+++ b/Bugsnag/Payload/BugsnagSession+Private.h
@@ -54,7 +54,7 @@ void BSGSessionUpdateRunContext(BugsnagSession *_Nullable session);
 BugsnagSession *_Nullable BSGSessionFromLastRunContext(BugsnagApp *app, BugsnagDevice *device, BugsnagUser *user);
 
 /// Saves current session information (from bsg_runContext) into a crash report.
-void BSGSessionWriteCrashReport(const BSG_KSCrashReportWriter *writer);
+void BSGSessionWriteCrashReport(const BSG_KSCrashReportWriter *writer, bool requiresAsyncSafety);
 
 /// Returns session information from a crash report previously written to by BSGSessionWriteCrashReport or BSSerializeDataCrashHandler.
 BugsnagSession *_Nullable BSGSessionFromCrashReport(NSDictionary *report, BugsnagApp *app, BugsnagDevice *device, BugsnagUser *user);

--- a/Bugsnag/Payload/BugsnagSession.m
+++ b/Bugsnag/Payload/BugsnagSession.m
@@ -132,7 +132,7 @@ BugsnagSession * BSGSessionFromLastRunContext(BugsnagApp *app, BugsnagDevice *de
     }
 }
 
-void BSGSessionWriteCrashReport(const BSG_KSCrashReportWriter *writer) {
+void BSGSessionWriteCrashReport(const BSG_KSCrashReportWriter *writer, bool __unused requiresAsyncSafety) {
     if (bsg_runContext->sessionId[0] && bsg_runContext->sessionStartTime > 0) {
         writer->addStringElement(writer, "id", bsg_runContext->sessionId);
         writer->addFloatingPointElement(writer, "startedAt", bsg_runContext->sessionStartTime);

--- a/Bugsnag/include/Bugsnag/BSG_KSCrashReportWriter.h
+++ b/Bugsnag/include/Bugsnag/BSG_KSCrashReportWriter.h
@@ -229,7 +229,7 @@ typedef struct BSG_KSCrashReportWriter {
 } BSG_KSCrashReportWriter;
 
 typedef void (*BSG_KSReportWriteCallback)(
-    const BSG_KSCrashReportWriter *writer);
+    const BSG_KSCrashReportWriter *writer, bool requiresAsyncSafety);
 
 #ifdef __cplusplus
 }

--- a/Tests/BugsnagTests/BugsnagBreadcrumbsTest.m
+++ b/Tests/BugsnagTests/BugsnagBreadcrumbsTest.m
@@ -452,7 +452,7 @@ BSGBreadcrumbType BSGBreadcrumbTypeFromString(NSString *value);
 - (void)testCrashReportWriter {
     NSDictionary<NSString *, id> *object = JSONObject(^(BSG_KSCrashReportWriter *writer) {
         writer->beginObject(writer, "");
-        BugsnagBreadcrumbsWriteCrashReport(writer);
+        BugsnagBreadcrumbsWriteCrashReport(writer, true);
         writer->endContainer(writer);
     });
     
@@ -527,7 +527,7 @@ static void * executeBlock(void *ptr) {
         bsg_kscrw_i_prepareReportWriter(&writer, &context);
         bsg_ksjsonbeginEncode(&context, false, (BSG_KSJSONAddDataFunc)json_buffer_append, &buffer);
         writer.beginObject(&writer, "");
-        BugsnagBreadcrumbsWriteCrashReport(&writer);
+        BugsnagBreadcrumbsWriteCrashReport(&writer, true);
         writer.endContainer(&writer);
         
         NSError *error = nil;


### PR DESCRIPTION
## Goal

Since an uncaught NSException isn't handled in an async-safe requiring environment, try to capture the trace and span IDs if they are available.

## Design

Since all uncaught crashes are handled through the same channel, I had to change the crash callback signature to allow passing a flag that tells us whether we require async safety or not.

## Testing

Tested manually with a test app.
