### PR TITLE
[Plat-12062] privacy process

### DIFF
--- a/Package.swift
+++ b/Package.swift
@@ -20,7 +20,7 @@ let package = Package(
             dependencies: [],
             path: "Bugsnag",
             resources: [
-               .copy("resources/PrivacyInfo.xcprivacy")
+               .process("resources/PrivacyInfo.xcprivacy")
             ],
             publicHeadersPath: "include",
             cSettings: [


### PR DESCRIPTION
Use `process` instead of `copy` to handle the privacy manifest.