### PR TITLE
Fix error in e2e test run

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -40,6 +40,7 @@ services:
       BITBAR_ACCESS_KEY:
     ports:
       - "9000-9499:9339"
+      - "9000-9499:9340"
     volumes:
       - ./features/fixtures/ios/output:/app/build
       - ./features/:/app/features/


### PR DESCRIPTION
## Goal

Fixes an ugly but benign error in the e2e test runs.

## Design

The error resulted from a port not being exposed for the document server, but there are 2 instances of it and we use the other.

## Testing

Covered by a basic CI run.