### PR TITLE
Temporarily skip iOS 17 testing due to device farm issues

### DIFF
--- a/.buildkite/pipeline.yml
+++ b/.buildkite/pipeline.yml
@@ -339,6 +339,8 @@ steps:
   # BrowserStack
   #
   - label: ':browserstack: iOS 17 E2E tests batch 1'
+    # TODO Skipped pending PLAT-12209
+    skip: Skipped pending PLAT-12209
     depends_on:
       - cocoa_fixture
     timeout_in_minutes: 60
@@ -370,6 +372,8 @@ steps:
           limit: 2
 
   - label: ':browserstack: iOS 17 E2E tests batch 2'
+    # TODO Skipped pending PLAT-12209
+    skip: Skipped pending PLAT-12209
     depends_on:
       - cocoa_fixture
     timeout_in_minutes: 60
@@ -401,6 +405,8 @@ steps:
 
   # PLAT-11155: App hang tests run on BrowserStack (Appium 1.x) for now
   - label: ':browserstack: iOS 17 app hang tests'
+    # TODO Skipped pending PLAT-12209
+    skip: Skipped pending PLAT-12209
     depends_on:
       - cocoa_fixture
     timeout_in_minutes: 30


### PR DESCRIPTION
## Goal

Temporarily skip iOS 17 testing due to device farm issues.

## Testing

Covered by CI.