### PR TITLE
Fix test flake for foregrounding breadcrumb

### DIFF
--- a/features/breadcrumbs.feature
+++ b/features/breadcrumbs.feature
@@ -50,6 +50,8 @@ Feature: Attaching a series of notable events leading up to errors
     And I discard the oldest error
     # Now we know that the backgrounding will occur at an appropriate time
     And I switch to the web browser for 2 seconds
+    # Give iOS sufficient time to raise the notification for foregrounding the app
+    And I make the test fixture wait for 1 second
     # This next error should have the notification breadcrumbs
     And I invoke "notify_error"
     And I wait to receive an error

--- a/features/fixtures/shared/utils/Fixture.swift
+++ b/features/fixtures/shared/utils/Fixture.swift
@@ -83,6 +83,10 @@ class Fixture: NSObject, CommandReceiver {
             case "background":
                 self.currentScenario?.enterBackground(forSeconds: Int(command.args[0])!)
                 break
+            case "wait":
+                self.pauseCommandReader(forSeconds: Int(command.args[0])!)
+                isReady = false;
+                break
             case "noop":
                 break
             default:
@@ -118,6 +122,16 @@ class Fixture: NSObject, CommandReceiver {
         }
     }
 
+    func pauseCommandReader(forSeconds: Int) {
+        logInfo("Pausing command reader for \(forSeconds) seconds")
+
+        self.readyToReceiveCommand = false
+        DispatchQueue.main.asyncAfter(deadline: .now() + .seconds(forSeconds)) {
+            self.readyToReceiveCommand = true
+            logInfo("Resuming command reader")
+        }
+    }
+    
     @objc func setApiKey(apiKey: String) {
         self.fixtureConfig.apiKey = apiKey
     }

--- a/features/steps/app_steps.rb
+++ b/features/steps/app_steps.rb
@@ -32,6 +32,10 @@ When('I switch to the web browser for {int} second(s)') do |duration|
   execute_command "background", [duration.to_s]
 end
 
+When('I make the test fixture wait for {int} second(s)') do |duration|
+  execute_command "wait", [duration.to_s]
+end
+
 When('I switch to the web browser') do
   execute_command "background", ["-1"]
 end


### PR DESCRIPTION
## Goal

Fixes a test flake where we expect a breading for foregrounding the app.

## Design

The test would flake heavily because it wasn't giving enough time for the foreground notification to arrive and be processed.  This change introduces a new command where we can pause the processing of commands for a set period, giving the notifier time to receive and process the notification.

## Testing

Covered by CI and I've run it >20 times locally without failing once.