### PR TITLE
[Plat-12124] Basic visionOS support

### DIFF
--- a/Bugsnag/Breadcrumbs/BSGNotificationBreadcrumbs.m
+++ b/Bugsnag/Breadcrumbs/BSGNotificationBreadcrumbs.m
@@ -318,7 +318,7 @@ static NSString *nullStringIfBlank(NSString *str) {
 #endif
 
 - (BOOL)tryAddWindowNotification:(NSNotification *)notification {
-#if TARGET_OS_IOS || TARGET_OS_TV
+#if TARGET_OS_IOS || TARGET_OS_TV || TARGET_OS_VISION
     if ([notification.name hasPrefix:@"UIWindow"] && [notification.object isKindOfClass:UIWINDOW]) {
         UIWindow *window = notification.object;
         NSMutableDictionary *metadata = [NSMutableDictionary dictionary];

--- a/Bugsnag/Helpers/BSGDefines.h
+++ b/Bugsnag/Helpers/BSGDefines.h
@@ -11,17 +11,17 @@
 #include <TargetConditionals.h>
 
 // Capabilities dependent upon system defines and files
-#define BSG_HAVE_BATTERY                      (                 TARGET_OS_IOS                 || TARGET_OS_WATCH)
+#define BSG_HAVE_BATTERY                      (                 TARGET_OS_IOS                 || TARGET_OS_WATCH || TARGET_OS_VISION)
 #define BSG_HAVE_MACH_EXCEPTIONS              (TARGET_OS_OSX || TARGET_OS_IOS                                   )
-#define BSG_HAVE_MACH_THREADS                 (TARGET_OS_OSX || TARGET_OS_IOS || TARGET_OS_TV || TARGET_OS_VISION)
+#define BSG_HAVE_MACH_THREADS                 (TARGET_OS_OSX || TARGET_OS_IOS || TARGET_OS_TV                    || TARGET_OS_VISION)
 #define BSG_HAVE_OOM_DETECTION                (                 TARGET_OS_IOS || TARGET_OS_TV                   ) && !TARGET_OS_SIMULATOR && !TARGET_OS_MACCATALYST
-#define BSG_HAVE_REACHABILITY                 (TARGET_OS_OSX || TARGET_OS_IOS || TARGET_OS_TV || TARGET_OS_VISION)
+#define BSG_HAVE_REACHABILITY                 (TARGET_OS_OSX || TARGET_OS_IOS || TARGET_OS_TV                    || TARGET_OS_VISION)
 #define BSG_HAVE_REACHABILITY_WWAN            (                 TARGET_OS_IOS || TARGET_OS_TV                   )
-#define BSG_HAVE_SIGNAL                       (TARGET_OS_OSX || TARGET_OS_IOS || TARGET_OS_TV || TARGET_OS_VISION)
+#define BSG_HAVE_SIGNAL                       (TARGET_OS_OSX || TARGET_OS_IOS || TARGET_OS_TV                    || TARGET_OS_VISION)
 #define BSG_HAVE_SIGALTSTACK                  (TARGET_OS_OSX || TARGET_OS_IOS                                   )
 #define BSG_HAVE_SYSCALL                      (TARGET_OS_IOS || TARGET_OS_TV                   )
 #define BSG_HAVE_UIDEVICE                     __has_include(<UIKit/UIDevice.h>)
-#define BSG_HAVE_WINDOW                       (TARGET_OS_OSX || TARGET_OS_IOS || TARGET_OS_TV || TARGET_OS_VISION)
+#define BSG_HAVE_WINDOW                       (TARGET_OS_OSX || TARGET_OS_IOS || TARGET_OS_TV                    || TARGET_OS_VISION)
 
 // Capabilities dependent upon previously defined capabilities
 #define BSG_HAVE_APP_HANG_DETECTION           (BSG_HAVE_MACH_THREADS)

--- a/Bugsnag/Helpers/BSGDefines.h
+++ b/Bugsnag/Helpers/BSGDefines.h
@@ -10,6 +10,11 @@
 
 #include <TargetConditionals.h>
 
+#ifndef TARGET_OS_VISION
+    // For older Xcode that doesn't have VisionOS support...
+    #define TARGET_OS_VISION 0
+#endif
+
 // Capabilities dependent upon system defines and files
 #define BSG_HAVE_BATTERY                      (                 TARGET_OS_IOS                 || TARGET_OS_WATCH || TARGET_OS_VISION)
 #define BSG_HAVE_MACH_EXCEPTIONS              (TARGET_OS_OSX || TARGET_OS_IOS                                   )

--- a/Bugsnag/Helpers/BSGDefines.h
+++ b/Bugsnag/Helpers/BSGDefines.h
@@ -13,15 +13,15 @@
 // Capabilities dependent upon system defines and files
 #define BSG_HAVE_BATTERY                      (                 TARGET_OS_IOS                 || TARGET_OS_WATCH)
 #define BSG_HAVE_MACH_EXCEPTIONS              (TARGET_OS_OSX || TARGET_OS_IOS                                   )
-#define BSG_HAVE_MACH_THREADS                 (TARGET_OS_OSX || TARGET_OS_IOS || TARGET_OS_TV                   )
+#define BSG_HAVE_MACH_THREADS                 (TARGET_OS_OSX || TARGET_OS_IOS || TARGET_OS_TV || TARGET_OS_VISION)
 #define BSG_HAVE_OOM_DETECTION                (                 TARGET_OS_IOS || TARGET_OS_TV                   ) && !TARGET_OS_SIMULATOR && !TARGET_OS_MACCATALYST
-#define BSG_HAVE_REACHABILITY                 (TARGET_OS_OSX || TARGET_OS_IOS || TARGET_OS_TV                   )
+#define BSG_HAVE_REACHABILITY                 (TARGET_OS_OSX || TARGET_OS_IOS || TARGET_OS_TV || TARGET_OS_VISION)
 #define BSG_HAVE_REACHABILITY_WWAN            (                 TARGET_OS_IOS || TARGET_OS_TV                   )
-#define BSG_HAVE_SIGNAL                       (TARGET_OS_OSX || TARGET_OS_IOS || TARGET_OS_TV                   )
+#define BSG_HAVE_SIGNAL                       (TARGET_OS_OSX || TARGET_OS_IOS || TARGET_OS_TV || TARGET_OS_VISION)
 #define BSG_HAVE_SIGALTSTACK                  (TARGET_OS_OSX || TARGET_OS_IOS                                   )
 #define BSG_HAVE_SYSCALL                      (TARGET_OS_IOS || TARGET_OS_TV                   )
 #define BSG_HAVE_UIDEVICE                     __has_include(<UIKit/UIDevice.h>)
-#define BSG_HAVE_WINDOW                       (TARGET_OS_OSX || TARGET_OS_IOS || TARGET_OS_TV                   )
+#define BSG_HAVE_WINDOW                       (TARGET_OS_OSX || TARGET_OS_IOS || TARGET_OS_TV || TARGET_OS_VISION)
 
 // Capabilities dependent upon previously defined capabilities
 #define BSG_HAVE_APP_HANG_DETECTION           (BSG_HAVE_MACH_THREADS)

--- a/Bugsnag/Helpers/BSGHardware.h
+++ b/Bugsnag/Helpers/BSGHardware.h
@@ -17,7 +17,7 @@
 
 #pragma mark Device
 
-#if TARGET_OS_IOS
+#if TARGET_OS_IOS || TARGET_OS_VISION
 static inline UIDevice *BSGGetDevice(void) {
     return [UIDEVICE currentDevice];
 }
@@ -32,7 +32,7 @@ static inline WKInterfaceDevice *BSGGetDevice(void) {
 #if BSG_HAVE_BATTERY
 
 static inline BOOL BSGIsBatteryStateKnown(long battery_state) {
-#if TARGET_OS_IOS
+#if TARGET_OS_IOS || TARGET_OS_VISION
     const long state_unknown = UIDeviceBatteryStateUnknown;
 #elif TARGET_OS_WATCH
     const long state_unknown = WKInterfaceDeviceBatteryStateUnknown;
@@ -41,7 +41,7 @@ static inline BOOL BSGIsBatteryStateKnown(long battery_state) {
 }
 
 static inline BOOL BSGIsBatteryCharging(long battery_state) {
-#if TARGET_OS_IOS
+#if TARGET_OS_IOS || TARGET_OS_VISION
     const long state_charging = UIDeviceBatteryStateCharging;
 #elif TARGET_OS_WATCH
     const long state_charging = WKInterfaceDeviceBatteryStateCharging;

--- a/Bugsnag/Helpers/BSGRunContext.m
+++ b/Bugsnag/Helpers/BSGRunContext.m
@@ -128,6 +128,10 @@ static bool GetIsActive(void) {
         return true;
     }
 #endif
+
+#if TARGET_OS_VISION
+    return true;
+#endif
 }
 
 static bool GetIsForeground(void) {
@@ -192,6 +196,10 @@ static bool GetIsForeground(void) {
     } else {
         return true;
     }
+#endif
+
+#if TARGET_OS_VISION
+    return true;
 #endif
 }
 

--- a/Bugsnag/Helpers/BSGRunContext.m
+++ b/Bugsnag/Helpers/BSGRunContext.m
@@ -40,7 +40,7 @@
 static uint64_t GetBootTime(void);
 static bool GetIsActive(void);
 static bool GetIsForeground(void);
-#if TARGET_OS_IOS || TARGET_OS_TV
+#if TARGET_OS_IOS || TARGET_OS_TV || TARGET_OS_VISION
 static UIApplication * GetUIApplication(void);
 #endif
 static void InstallTimer(void);
@@ -112,7 +112,7 @@ static bool GetIsActive(void) {
     return GetIsForeground();
 #endif
 
-#if TARGET_OS_IOS || TARGET_OS_TV
+#if TARGET_OS_IOS || TARGET_OS_TV || TARGET_OS_VISION
     UIApplication *app = GetUIApplication();
     return app && app.applicationState == UIApplicationStateActive;
 #endif
@@ -160,7 +160,7 @@ static bool GetIsForeground(void) {
     }
 #endif
 
-#if TARGET_OS_IOS || TARGET_OS_TV
+#if TARGET_OS_IOS || TARGET_OS_TV || TARGET_OS_VISION
     UIApplication *application = GetUIApplication();
 
     // There will be no UIApplication if UIApplicationMain() has not yet been
@@ -195,7 +195,7 @@ static bool GetIsForeground(void) {
 #endif
 }
 
-#if TARGET_OS_IOS || TARGET_OS_TV
+#if TARGET_OS_IOS || TARGET_OS_TV || TARGET_OS_VISION
 
 static UIApplication * GetUIApplication(void) {
     // +sharedApplication is unavailable to app extensions

--- a/Bugsnag/KSCrash/Source/KSCrash/Recording/BSG_KSSystemInfo.m
+++ b/Bugsnag/KSCrash/Source/KSCrash/Recording/BSG_KSSystemInfo.m
@@ -319,6 +319,8 @@ BSG_OBJC_DIRECT_MEMBERS
     NSString *systemName = @"tvOS";
 #elif TARGET_OS_WATCH
     NSString *systemName = @"watchOS";
+#elif TARGET_OS_VISION
+    NSString *systemName = @"visionOS";
 #endif
 
     sysInfo[@BSG_KSSystemField_SystemName] = systemName;

--- a/Bugsnag/KSCrash/Source/KSCrash/Recording/BSG_KSSystemInfo.m
+++ b/Bugsnag/KSCrash/Source/KSCrash/Recording/BSG_KSSystemInfo.m
@@ -289,6 +289,8 @@ BSG_OBJC_DIRECT_MEMBERS
     sysInfo[@BSG_KSSystemField_SystemName] = @"tvOS";
 #elif TARGET_OS_WATCH
     sysInfo[@BSG_KSSystemField_SystemName] = @"watchOS";
+#elif TARGET_OS_VISION
+    sysInfo[@BSG_KSSystemField_SystemName] = @"visionOS";
 #endif // TARGET_OS_IOS
 
     NSDictionary *env = NSProcessInfo.processInfo.environment;


### PR DESCRIPTION
## Goal

Add basic support for visionOS. There is no visionOS target in the xcode project as there is currently an Xcode bug preventing the target and unit test target from being created properly (the framework target itself becomes a unit test target, and hilarity ensues).

Xcode project fixes will be integrated at a later time.
