### PR TITLE
[Plat-12269] Prevent inlining of stack trace entries that are going to be pruned

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,9 @@ Changelog
 
 ### Bug fixes
 
+* Prevent inlining of Bugsnag stack trace entries that are marked to be pruned away (to promote a consistent number of those frames).
+  [1661](https://github.com/bugsnag/bugsnag-cocoa/pull/1661)
+
 * Fix off-by-1 error when fetching register values on arm64 that could potentially run off the array.
   [1635](https://github.com/bugsnag/bugsnag-cocoa/pull/1635)
 


### PR DESCRIPTION
## Goal

We prune the top of the stack trace so that our stack trace gathering code doesn't show in customer traces. However, if the optimizer inlines any of the functions/methods along the path, it breaks the pruning.

## Design

Force everything along the trace gathering path to NOT be optimized, so that they are never folded or inlined.
