### PR TITLE
Wait longer for the macOS test fixture to stop running

### DIFF
--- a/features/steps/app_steps.rb
+++ b/features/steps/app_steps.rb
@@ -62,8 +62,6 @@ Then('the app is not running') do
     case Maze::Helper.get_current_platform
     when 'ios'
       Maze.driver.app_state('com.bugsnag.fixtures.cocoa') == :not_running
-    when 'macos'
-      `lsappinfo info -only pid -app com.bugsnag.fixtures.macOSTestApp`.empty?
     else
       raise "Don't know how to query app state on this platform"
     end
@@ -119,8 +117,7 @@ def relaunch_crashed_app
     step 'the app is not running'
     Maze.driver.launch_app
   when 'macos'
-    # Wait for the app to stop running before relaunching
-    step 'the app is not running'
+    sleep 4
     launch_app
   when 'watchos'
     sleep 5 # We have no way to poll the app state on watchOS


### PR DESCRIPTION
## Goal

Attempt to reduce test flakes by waiting longer for crash reports to be written.

## Design

I've noticed some test flakes recently where internal errors were being sent to Maze Runner due to invalid (truncated) crash report files.  It seem that the `lsappinfo` mechanism we were using to detect the app stopping running was not reliably giving enough time for crash reports to be written, so I have fallen back to a simple wait instead.  

## Testing

Before this change, I could hardly get the `RecrashObjcMachScenario` to pass at all - after the change it passed 20/20 times.  The down side of this change is that does increase the length of test runs from about 20 to 24 minutes.