### PR TITLE
Camelcase error correlation fields

### DIFF
--- a/Bugsnag/Payload/BugsnagCorrelation.m
+++ b/Bugsnag/Payload/BugsnagCorrelation.m
@@ -25,12 +25,12 @@
 
     if ((self = [super init])) {
         id nsnull = NSNull.null;
-        _traceId = (NSString *)dict[@"traceid"];
+        _traceId = (NSString *)dict[@"traceId"];
         if (_traceId == nsnull) {
             _traceId = nil;
         }
 
-        _spanId = (NSString *)dict[@"spanid"];
+        _spanId = (NSString *)dict[@"spanId"];
         if (_spanId == nsnull) {
             _spanId = nil;
         }
@@ -41,8 +41,8 @@
 
 - (NSDictionary<NSString *, NSObject *> *) toJsonDictionary {
     NSMutableDictionary *dict = [NSMutableDictionary new];
-    dict[@"traceid"] = self.traceId;
-    dict[@"spanid"] = self.spanId;
+    dict[@"traceId"] = self.traceId;
+    dict[@"spanId"] = self.spanId;
     return dict;
 }
 

--- a/Bugsnag/Payload/BugsnagEvent.m
+++ b/Bugsnag/Payload/BugsnagEvent.m
@@ -380,8 +380,8 @@ BSG_OBJC_DIRECT_MEMBERS
                                     [configDict isKindOfClass:[NSDictionary class]] ? configDict : @{}];
 
     NSDictionary *correlationDict = [event valueForKeyPath:@"user.correlation"];
-    NSString *traceId = correlationDict[@"traceid"];
-    NSString *spanId = correlationDict[@"spanid"];
+    NSString *traceId = correlationDict[@"traceId"];
+    NSString *spanId = correlationDict[@"spanId"];
 
     BugsnagAppWithState *app = [BugsnagAppWithState appWithDictionary:event config:config codeBundleId:self.codeBundleId];
 


### PR DESCRIPTION
## Goal

As per discussion, the PD wasn’t showing a consistent name for the span and trace ID fields.

They should now be:
`correlation: {traceId: string, spanId: string}`