### PR TITLE
Build xcframework on CI

### DIFF
--- a/.buildkite/pipeline.full.yml
+++ b/.buildkite/pipeline.full.yml
@@ -17,7 +17,7 @@ steps:
     agents:
       queue: opensource
     plugins:
-      artifacts#v1.9.0:
+      artifacts#v1.9.3:
         download: "features/fixtures/ios/output/ipa_url_bb.txt"
         upload: "maze_output/failed/**/*"
       docker-compose#v4.7.0:
@@ -49,7 +49,7 @@ steps:
     agents:
       queue: opensource
     plugins:
-      artifacts#v1.9.0:
+      artifacts#v1.9.3:
         download: "features/fixtures/ios/output/ipa_url_bb.txt"
         upload: "maze_output/failed/**/*"
       docker-compose#v4.7.0:
@@ -78,7 +78,7 @@ steps:
     agents:
       queue: opensource
     plugins:
-      artifacts#v1.9.0:
+      artifacts#v1.9.3:
         download: "features/fixtures/ios/output/ipa_url_bb.txt"
         upload: "maze_output/failed/**/*"
       docker-compose#v4.7.0:
@@ -105,7 +105,7 @@ steps:
     agents:
       queue: opensource
     plugins:
-      artifacts#v1.9.0:
+      artifacts#v1.9.3:
         download: "features/fixtures/ios/output/ipa_url_bb.txt"
         upload: "maze_output/failed/**/*"
       docker-compose#v4.7.0:
@@ -131,7 +131,7 @@ steps:
     agents:
       queue: opensource
     plugins:
-      artifacts#v1.9.0:
+      artifacts#v1.9.3:
         download: "features/fixtures/ios/output/ipa_url_bb.txt"
         upload: "maze_output/failed/**/*"
       docker-compose#v4.7.0:
@@ -163,7 +163,7 @@ steps:
     agents:
       queue: opensource
     plugins:
-      artifacts#v1.9.0:
+      artifacts#v1.9.3:
         download: "features/fixtures/ios/output/ipa_url_bb.txt"
         upload: "maze_output/failed/**/*"
       docker-compose#v4.7.0:
@@ -193,7 +193,7 @@ steps:
     agents:
       queue: opensource
     plugins:
-      artifacts#v1.9.0:
+      artifacts#v1.9.3:
         download: "features/fixtures/ios/output/ipa_url_bb.txt"
         upload: "maze_output/failed/**/*"
       docker-compose#v4.7.0:
@@ -225,7 +225,7 @@ steps:
     agents:
       queue: opensource
     plugins:
-      artifacts#v1.9.0:
+      artifacts#v1.9.3:
         download: "features/fixtures/ios/output/ipa_url_bb.txt"
         upload: "maze_output/failed/**/*"
       docker-compose#v4.7.0:

--- a/.buildkite/pipeline.yml
+++ b/.buildkite/pipeline.yml
@@ -7,13 +7,28 @@ steps:
   # Build
   #
 
+  - label: Static framework and Swift Package Manager builds
+    timeout_in_minutes: 10
+    agents:
+      queue: macos-14
+    env:
+      XCODE_VERSION: 15.3.0
+    commands:
+      - make build_xcframework
+      - make build_swift
+      - make build_ios_static
+    plugins:
+      - artifacts#v1.9.3:
+          upload: "build/xcframeworks/products/Bugsnag.xcframework"
+          compressed: xcframework.zip
+
   - label: Build test fixtures
     key: cocoa_fixture
     timeout_in_minutes: 30
     agents:
       queue: macos-14
     env:
-      DEVELOPER_DIR: /Applications/Xcode-15.app
+      XCODE_VERSION: 15.3.0
     artifact_paths:
       - features/fixtures/ios/output/iOSTestApp.ipa
       - features/fixtures/macos/output/macOSTestApp.zip
@@ -24,16 +39,6 @@ steps:
       - make test-fixtures
       - bundle exec upload-app --farm=bb --app=./features/fixtures/ios/output/iOSTestApp.ipa --app-id-file=./features/fixtures/ios/output/ipa_url_bb.txt
       - bundle exec upload-app --farm=bs --app=./features/fixtures/ios/output/iOSTestApp.ipa --app-id-file=./features/fixtures/ios/output/ipa_url_bs.txt
-
-  - label: Static framework and Swift Package Manager builds
-    timeout_in_minutes: 10
-    agents:
-      queue: macos-14
-    env:
-      DEVELOPER_DIR: /Applications/Xcode-15.app
-    commands:
-      - make build_swift
-      - make build_ios_static
 
   - label: Carthage
     timeout_in_minutes: 15
@@ -446,7 +451,7 @@ steps:
     agents:
       queue: opensource
     plugins:
-      artifacts#v1.9.0:
+      artifacts#v1.9.3:
         download: "features/fixtures/ios/output/ipa_url_bb.txt"
         upload: "maze_output/failed/**/*"
       docker-compose#v4.7.0:
@@ -476,7 +481,7 @@ steps:
     agents:
       queue: opensource
     plugins:
-      artifacts#v1.9.0:
+      artifacts#v1.9.3:
         download: "features/fixtures/ios/output/ipa_url_bb.txt"
         upload: "maze_output/failed/**/*"
       docker-compose#v4.7.0:
@@ -506,7 +511,7 @@ steps:
     agents:
       queue: opensource
     plugins:
-      artifacts#v1.9.0:
+      artifacts#v1.9.3:
         download: "features/fixtures/ios/output/ipa_url_bb.txt"
         upload: "maze_output/failed/**/*"
       docker-compose#v4.7.0:
@@ -536,7 +541,7 @@ steps:
     agents:
       queue: opensource
     plugins:
-      artifacts#v1.9.0:
+      artifacts#v1.9.3:
         download: "features/fixtures/ios/output/ipa_url_bb.txt"
         upload: "maze_output/failed/**/*"
       docker-compose#v4.7.0:


### PR DESCRIPTION
## Goal

Build the xcframework for the notifier as part of CI.

## Design

Simply calls the existing makefile target, attaching the compressed xcframework as a Buildkite build artifact.

## Testing

Covered by a basic CI run.