### PR TITLE
[PLAT-12346] Remove inlined frame from the Bugsnag notify call chain entirely so t…

### DIFF
--- a/Bugsnag/Bugsnag.m
+++ b/Bugsnag/Bugsnag.m
@@ -100,25 +100,25 @@ BSG_OBJC_DIRECT_MEMBERS
 
 + (void)notify:(NSException *)exception {
     if ([self bugsnagReadyForInternalCalls]) {
-        [self.client notify:exception];
+        [self.client notifyErrorOrException:exception bugsnagStackDepth:2 block:nil];
     }
 }
 
 + (void)notify:(NSException *)exception block:(BugsnagOnErrorBlock)block {
     if ([self bugsnagReadyForInternalCalls]) {
-        [self.client notify:exception block:block];
+        [self.client notifyErrorOrException:exception bugsnagStackDepth:2 block:block];
     }
 }
 
 + (void)notifyError:(NSError *)error {
     if ([self bugsnagReadyForInternalCalls]) {
-        [self.client notifyError:error];
+        [self.client notifyErrorOrException:error bugsnagStackDepth:2 block:nil];
     }
 }
 
 + (void)notifyError:(NSError *)error block:(BugsnagOnErrorBlock)block {
     if ([self bugsnagReadyForInternalCalls]) {
-        [self.client notifyError:error block:block];
+        [self.client notifyErrorOrException:error bugsnagStackDepth:2 block:block];
     }
 }
 

--- a/Bugsnag/Client/BugsnagClient+Private.h
+++ b/Bugsnag/Client/BugsnagClient+Private.h
@@ -75,6 +75,17 @@ BSG_OBJC_DIRECT_MEMBERS
 
 - (void)start;
 
+/**
+ * Notify an error or exception.
+ *
+ * @param errorOrException what to report
+ * @param bugsnagStackDepth The depth of the expected bugsnag portion of the stack trace (including the call to this method)
+ * @param block The block to call afterwards (if any)
+ */
+- (void)notifyErrorOrException:(_Nullable id)errorOrException
+             bugsnagStackDepth:(NSUInteger)bugsnagStackDepth
+                         block:(_Nullable BugsnagOnErrorBlock)block;
+
 @end
 
 NS_ASSUME_NONNULL_END

--- a/Tests/BugsnagTests/BugsnagClientMirrorTest.m
+++ b/Tests/BugsnagTests/BugsnagClientMirrorTest.m
@@ -132,6 +132,7 @@
             @"systemState @16@0:8",
             @"thermalStateDidChange: v24@0:8@16",
             @"updateSession: v24@0:8@?16",
+            @"notifyErrorOrException:bugsnagStackDepth:block: v40@0:8@16Q24@?32",
     ]];
 
     // the following methods are implemented on Bugsnag but do not need to


### PR DESCRIPTION
## Goal

Remove the call to functions that are getting inlined so that we don't have to worry about the size of the bugsnag portion of the stack (which will change if the call gets inlined).

**Note**: Do not merge this yet. We will also be trying a different approach.
