### PR TITLE
[PLAT-12346] Harmonize all calls to manual error reporting, and ensure proper frame stripping in all cases

### DIFF
--- a/Bugsnag/Client/BugsnagClient+Private.h
+++ b/Bugsnag/Client/BugsnagClient+Private.h
@@ -75,6 +75,26 @@ BSG_OBJC_DIRECT_MEMBERS
 
 - (void)start;
 
+/**
+ * Common entry point to notify an error or an exception.
+ * Bugsnag components MUST NOT call the regular notify methods in this class. ALWAYS call
+ * this method instead.
+ *
+ * You must provide the number of stack trace entries to strip from the top of the stack
+ * (INCLUDING this method) so that our own reporting methods don't show up in the reported stack trace.
+ *
+ * Example: stackStripDepth = 2 would strip the top two entries, which we would expect to be
+ * 1. +[Bugsnag notifyError:block:]
+ * 2. -[BugsnagClient notifyErrorOrException:stackStripDepth:block:]
+ *
+ * @param errorOrException the error or exception to report.
+ * @param stackStripDepth The number of stack trace entries to strip from the top of the stack.
+ * @param block Called after reporting.
+ */
+- (void)notifyErrorOrException:(id)errorOrException
+               stackStripDepth:(NSUInteger)stackStripDepth
+                         block:(_Nullable BugsnagOnErrorBlock)block;
+
 @end
 
 NS_ASSUME_NONNULL_END

--- a/Bugsnag/Client/BugsnagClient.m
+++ b/Bugsnag/Client/BugsnagClient.m
@@ -641,37 +641,35 @@ BSG_OBJC_DIRECT_MEMBERS
 
 // MARK: - Notify
 
-// Prevent the compiler from inlining or optimizing, which would reduce
-// the number of bugsnag-only stack entries and mess up our pruning.
-// We have to do it this way because you can't mark Objective-C methods noinline or optnone.
-// We leave it externable to further dissuade the optimizer.
-__attribute__((optnone))
-void bsg_notifyErrorOrException(BugsnagClient *self, id errorOrException, BugsnagOnErrorBlock block) {
-    [self notifyErrorOrException:errorOrException block:block];
-}
-
-// note - some duplication between notifyError calls is required to ensure
-// the same number of stackframes are used for each call.
-// see notify:handledState:block for further info
+// Here, we pass all public notify APIs to a common handling method
+// (notifyErrorOrException) and then prevent the compiler from performing
+// any inlining or outlining that would change the number of Bugsnag handler
+// methods on the stack and break our stack stripping.
+// Note: Each BSGPreventInlining call site within a module MUST pass a different
+//       string to prevent outlining!
 
 - (void)notifyError:(NSError *)error {
     bsg_log_debug(@"%s %@", __PRETTY_FUNCTION__, error);
-    bsg_notifyErrorOrException(self, error, nil);
+    BSGPreventInlining(@"Prevent");
+    [self notifyErrorOrException:error stackStripDepth:2 block:nil];
 }
 
 - (void)notifyError:(NSError *)error block:(BugsnagOnErrorBlock)block {
     bsg_log_debug(@"%s %@", __PRETTY_FUNCTION__, error);
-    bsg_notifyErrorOrException(self, error, block);
+    BSGPreventInlining(@"inlining");
+    [self notifyErrorOrException:error stackStripDepth:2 block:block];
 }
 
 - (void)notify:(NSException *)exception {
     bsg_log_debug(@"%s %@", __PRETTY_FUNCTION__, exception);
-    bsg_notifyErrorOrException(self, exception, nil);
+    BSGPreventInlining(@"and");
+    [self notifyErrorOrException:exception stackStripDepth:2 block:nil];
 }
 
 - (void)notify:(NSException *)exception block:(BugsnagOnErrorBlock)block {
     bsg_log_debug(@"%s %@", __PRETTY_FUNCTION__, exception);
-    bsg_notifyErrorOrException(self, exception, block);
+    BSGPreventInlining(@"outlining");
+    [self notifyErrorOrException:exception stackStripDepth:2 block:block];
 }
 
 // MARK: - Notify (Internal)
@@ -686,7 +684,9 @@ void bsg_notifyErrorOrException(BugsnagClient *self, id errorOrException, Bugsna
     return [[BugsnagCorrelation alloc] initWithTraceId:traceId spanId:spanId];
 }
 
-- (void)notifyErrorOrException:(id)errorOrException block:(BugsnagOnErrorBlock)block {
+- (void)notifyErrorOrException:(id)errorOrException
+               stackStripDepth:(NSUInteger)stackStripDepth
+                         block:(_Nullable BugsnagOnErrorBlock)block {
     BugsnagCorrelation *correlation = [self getCurrentCorrelation];
     NSDictionary *systemInfo = [BSG_KSSystemInfo systemInfo];
     BugsnagMetadata *metadata = [self.metadata copy];
@@ -730,25 +730,10 @@ void bsg_notifyErrorOrException(BugsnagClient *self, id errorOrException, Bugsna
         return;
     }
 
-    /**
-     * Stack frames starting from this one are removed by setting the depth.
-     * This helps remove bugsnag frames from showing in NSErrors as their
-     * trace is synthesized.
-     *
-     * For example, for [Bugsnag notifyError:block:], bugsnag adds the following
-     * frames which must be removed:
-     *
-     * 1. +[Bugsnag notifyError:block:]
-     * 2. -[BugsnagClient notifyError:block:]
-     * 3. bsg_notifyErrorOrException()
-     * 4. -[BugsnagClient notifyErrorOrException:block:]
-     */
-    NSUInteger depth = 4;
-    
     if (!callStack.count) {
         // If the NSException was not raised by the Objective-C runtime, it will be missing a call stack.
         // Use the current call stack instead.
-        callStack = BSGArraySubarrayFromIndex(NSThread.callStackReturnAddresses, depth);
+        callStack = BSGArraySubarrayFromIndex(NSThread.callStackReturnAddresses, stackStripDepth);
     }
     
 #if BSG_HAVE_MACH_THREADS

--- a/Bugsnag/Helpers/BSGUtils.h
+++ b/Bugsnag/Helpers/BSGUtils.h
@@ -45,6 +45,8 @@ static inline NSString * _Nullable BSGStringFromClass(Class _Nullable cls) {
  */
 void bsg_safe_strncpy(char *dst, const char *src, size_t length);
 
+NSString * _Nullable BSGPreventInlining(NSString * _Nullable someValue);
+
 NS_ASSUME_NONNULL_END
 
 __END_DECLS

--- a/Bugsnag/Helpers/BSGUtils.m
+++ b/Bugsnag/Helpers/BSGUtils.m
@@ -89,3 +89,10 @@ NSString *_Nullable BSGStringFromThermalState(NSProcessInfoThermalState thermalS
     }
     return nil;
 }
+
+NSString * _Nullable BSGPreventInlining(NSString * _Nullable someValue) {
+    static NSString *lastValue = nil;
+    NSString *returnValue = lastValue;
+    lastValue = someValue;
+    return returnValue;
+}

--- a/Tests/BugsnagTests/BugsnagClientMirrorTest.m
+++ b/Tests/BugsnagTests/BugsnagClientMirrorTest.m
@@ -132,6 +132,7 @@
             @"systemState @16@0:8",
             @"thermalStateDidChange: v24@0:8@16",
             @"updateSession: v24@0:8@?16",
+            @"notifyErrorOrException:stackStripDepth:block: v40@0:8@16Q24@?32",
     ]];
 
     // the following methods are implemented on Bugsnag but do not need to


### PR DESCRIPTION
## Goal

Code along the critical path responsible for generating a stack trace and stripping off the stack trace generation frames themselves must always always be present exactly as written so that the top of the stack is always consistent, and the code can accurately strip off the right number of frames.

Recently, Apple introduced optimizations that inline or outline objective-c code, and can't be turned off. We need to ensure that these optimizations are never run on our call stack generation and fixup code.

## Design

Since we can't instruct the compiler directly to not optimize these calls (`Bugsnag.notifyXYZ`, `BugsnagClient.notifyXYZ`), we must confound the compiler so that it gives up trying to optimize them.

I've added a new utility method `BSGPreventInlining()`, which takes a string and returns the last string it was given (no thread safety because the string contents don't matter at all and should never be used for anything).

The key concepts here are:

* By doing some minor "work" inside `BSGPreventInlining()`, the compiler won't be able to discover that it does nothing (and thus elide it).
* By calling a non-elidable function that is also defined in a different module - in addition to the actual work performed at the call site, the compiler won't be able to inline to the function/method that does the actual work.
* By accepting a string in `BSGPreventInlining()`, every call site can send different strings, making every call site "unique code" that can't be [outlined](https://developer.arm.com/documentation/101754/0620/armclang-Reference/armclang-Command-line-Options/-moutline---mno-outline).

Ultimately, this becomes a reverse-halting-problem kind of cat-and-mouse game, where each tries to outwit and outlast the other. I think that this current design should be enough to keep the optimizations at bay long enough (a few years at least) for someone to finally allow `optnone` compiler directives in objective-c code...

![rr](https://github.com/bugsnag/bugsnag-cocoa/assets/245857/e329fd41-6b39-4316-ab85-7bc9df5e6967)

**Note**: This new design also corrects a bug where too many stack entries get stripped if you call the `BugsnagClient` notify methods directly (rather than calling `Bugsnag.notifyXYZ`).

## Testing

Existing e2e tests check call stack integrity already, and I also verified manually just to be sure.
