### PR TITLE
Exposed BugsnagCorrelation init in BugsnagInternals.h

### DIFF
--- a/Bugsnag/BugsnagInternals.h
+++ b/Bugsnag/BugsnagInternals.h
@@ -237,6 +237,14 @@ typedef void (^ BSGClientObserver)(BSGClientObserverEvent event, _Nullable id va
 
 #pragma mark -
 
+@interface BugsnagCorrelation ()
+
+- (instancetype)initWithTraceId:(NSString * _Nullable) traceId spanId:(NSString * _Nullable)spanId;
+
+@end
+
+#pragma mark -
+
 BUGSNAG_EXTERN NSString * BSGGetDefaultDeviceId(void);
 
 BUGSNAG_EXTERN NSDictionary * BSGGetSystemInfo(void);

--- a/Bugsnag/Payload/BugsnagCorrelation+Private.h
+++ b/Bugsnag/Payload/BugsnagCorrelation+Private.h
@@ -7,6 +7,7 @@
 //
 
 #import "BugsnagCorrelation.h"
+#import "BugsnagInternals.h"
 
 #ifndef BugsnagCorrelation_Private_h
 #define BugsnagCorrelation_Private_h
@@ -14,8 +15,6 @@
 NS_ASSUME_NONNULL_BEGIN
 
 @interface BugsnagCorrelation ()
-
-- (instancetype) initWithTraceId:(NSString * _Nullable) traceId spanId:(NSString * _Nullable)spanId;
 
 - (instancetype) initWithJsonDictionary:(NSDictionary<NSString *, NSObject *> * _Nullable) dict;
 


### PR DESCRIPTION
## Goal

Make it possible for bugsnag-flutter plugin to create BugsnagCorrelation objects and assign them to events