### PR TITLE
Don't expose BugsnagCorrelation publicly

### DIFF
--- a/Bugsnag.xcodeproj/project.pbxproj
+++ b/Bugsnag.xcodeproj/project.pbxproj
@@ -737,10 +737,10 @@
 		09E312F42BF230660081F219 /* BugsnagCocoaPerformanceFromBugsnagCocoa.m in Sources */ = {isa = PBXBuildFile; fileRef = 09E312EE2BF230660081F219 /* BugsnagCocoaPerformanceFromBugsnagCocoa.m */; };
 		09E312F52BF230660081F219 /* BugsnagCocoaPerformanceFromBugsnagCocoa.m in Sources */ = {isa = PBXBuildFile; fileRef = 09E312EE2BF230660081F219 /* BugsnagCocoaPerformanceFromBugsnagCocoa.m */; };
 		09E312F62BF230660081F219 /* BugsnagCocoaPerformanceFromBugsnagCocoa.m in Sources */ = {isa = PBXBuildFile; fileRef = 09E312EE2BF230660081F219 /* BugsnagCocoaPerformanceFromBugsnagCocoa.m */; };
-		09E312F82BF248E70081F219 /* BugsnagCorrelation.h in Headers */ = {isa = PBXBuildFile; fileRef = 09E312F72BF248DD0081F219 /* BugsnagCorrelation.h */; settings = {ATTRIBUTES = (Public, ); }; };
-		09E312F92BF248E80081F219 /* BugsnagCorrelation.h in Headers */ = {isa = PBXBuildFile; fileRef = 09E312F72BF248DD0081F219 /* BugsnagCorrelation.h */; settings = {ATTRIBUTES = (Public, ); }; };
-		09E312FA2BF248E90081F219 /* BugsnagCorrelation.h in Headers */ = {isa = PBXBuildFile; fileRef = 09E312F72BF248DD0081F219 /* BugsnagCorrelation.h */; settings = {ATTRIBUTES = (Public, ); }; };
-		09E312FB2BF248E90081F219 /* BugsnagCorrelation.h in Headers */ = {isa = PBXBuildFile; fileRef = 09E312F72BF248DD0081F219 /* BugsnagCorrelation.h */; settings = {ATTRIBUTES = (Public, ); }; };
+		09E312F82BF248E70081F219 /* BugsnagCorrelation.h in Headers */ = {isa = PBXBuildFile; fileRef = 09E312F72BF248DD0081F219 /* BugsnagCorrelation.h */; };
+		09E312F92BF248E80081F219 /* BugsnagCorrelation.h in Headers */ = {isa = PBXBuildFile; fileRef = 09E312F72BF248DD0081F219 /* BugsnagCorrelation.h */; };
+		09E312FA2BF248E90081F219 /* BugsnagCorrelation.h in Headers */ = {isa = PBXBuildFile; fileRef = 09E312F72BF248DD0081F219 /* BugsnagCorrelation.h */; };
+		09E312FB2BF248E90081F219 /* BugsnagCorrelation.h in Headers */ = {isa = PBXBuildFile; fileRef = 09E312F72BF248DD0081F219 /* BugsnagCorrelation.h */; };
 		09E312FC2BF2492C0081F219 /* BugsnagCorrelation.h in CopyFiles */ = {isa = PBXBuildFile; fileRef = 09E312F72BF248DD0081F219 /* BugsnagCorrelation.h */; };
 		09E312FE2BF34D6D0081F219 /* BugsnagCorrelation.m in Sources */ = {isa = PBXBuildFile; fileRef = 09E312FD2BF34D6D0081F219 /* BugsnagCorrelation.m */; };
 		09E312FF2BF34D6D0081F219 /* BugsnagCorrelation.m in Sources */ = {isa = PBXBuildFile; fileRef = 09E312FD2BF34D6D0081F219 /* BugsnagCorrelation.m */; };
@@ -1577,9 +1577,8 @@
 		093EB6652AFE4580006EB7E3 /* BSGTestCase.mm */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.cpp.objcpp; path = BSGTestCase.mm; sourceTree = "<group>"; };
 		09E312ED2BF230660081F219 /* BugsnagCocoaPerformanceFromBugsnagCocoa.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; path = BugsnagCocoaPerformanceFromBugsnagCocoa.h; sourceTree = "<group>"; };
 		09E312EE2BF230660081F219 /* BugsnagCocoaPerformanceFromBugsnagCocoa.m */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.objc; path = BugsnagCocoaPerformanceFromBugsnagCocoa.m; sourceTree = "<group>"; };
-		09E312F72BF248DD0081F219 /* BugsnagCorrelation.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; path = BugsnagCorrelation.h; sourceTree = "<group>"; };
+		09E312F72BF248DD0081F219 /* BugsnagCorrelation.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; name = BugsnagCorrelation.h; path = ../include/Bugsnag/BugsnagCorrelation.h; sourceTree = "<group>"; };
 		09E312FD2BF34D6D0081F219 /* BugsnagCorrelation.m */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.objc; path = BugsnagCorrelation.m; sourceTree = "<group>"; };
-		09E313022BF34E5E0081F219 /* BugsnagCorrelation+Private.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; path = "BugsnagCorrelation+Private.h"; sourceTree = "<group>"; };
 		09E3132E2BF3867C0081F219 /* BugsnagPerformanceBridgeTests.m */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.objc; path = BugsnagPerformanceBridgeTests.m; sourceTree = "<group>"; };
 		3A700A8024A63A8E0068CD1B /* BugsnagThread.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; path = BugsnagThread.h; sourceTree = "<group>"; };
 		3A700A8124A63A8E0068CD1B /* BugsnagSession.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; path = BugsnagSession.h; sourceTree = "<group>"; };
@@ -2178,8 +2177,8 @@
 				0126DED7257A87F40031A70C /* BugsnagAppWithState+Private.h */,
 				0089684B2486DA9400DC48C2 /* BugsnagBreadcrumb.m */,
 				0126DEDF257A89490031A70C /* BugsnagBreadcrumb+Private.h */,
+				09E312F72BF248DD0081F219 /* BugsnagCorrelation.h */,
 				09E312FD2BF34D6D0081F219 /* BugsnagCorrelation.m */,
-				09E313022BF34E5E0081F219 /* BugsnagCorrelation+Private.h */,
 				008968482486DA9400DC48C2 /* BugsnagDevice.m */,
 				0126DEE7257A8B0F0031A70C /* BugsnagDevice+Private.h */,
 				0089685A2486DA9500DC48C2 /* BugsnagDeviceWithState.m */,
@@ -2261,7 +2260,6 @@
 				3A700A8524A63A8E0068CD1B /* BugsnagBreadcrumb.h */,
 				3A700A8924A63A8E0068CD1B /* BugsnagClient.h */,
 				3A700A8D24A63A8E0068CD1B /* BugsnagConfiguration.h */,
-				09E312F72BF248DD0081F219 /* BugsnagCorrelation.h */,
 				01C41A27288FD3EA00BAE31A /* BugsnagDefines.h */,
 				3A700A8F24A63A8E0068CD1B /* BugsnagDevice.h */,
 				3A700A9224A63A8E0068CD1B /* BugsnagDeviceWithState.h */,

--- a/Bugsnag/Client/BugsnagClient.m
+++ b/Bugsnag/Client/BugsnagClient.m
@@ -53,7 +53,6 @@
 #import "BugsnagBreadcrumbs.h"
 #import "BugsnagCollections.h"
 #import "BugsnagConfiguration+Private.h"
-#import "BugsnagCorrelation+Private.h"
 #import "BugsnagDeviceWithState+Private.h"
 #import "BugsnagError+Private.h"
 #import "BugsnagErrorTypes.h"

--- a/Bugsnag/Payload/BugsnagCorrelation.h
+++ b/Bugsnag/Payload/BugsnagCorrelation.h
@@ -1,19 +1,22 @@
 //
-//  BugsnagCorrelation+Private.h
+//  BugsnagCorrelation.h
 //  Bugsnag
 //
-//  Created by Karl Stenerud on 14.05.24.
+//  Created by Karl Stenerud on 13.05.24.
 //  Copyright © 2024 Bugsnag Inc. All rights reserved.
 //
 
-#import "BugsnagCorrelation.h"
-
-#ifndef BugsnagCorrelation_Private_h
-#define BugsnagCorrelation_Private_h
+#import <Foundation/Foundation.h>
+#import <Bugsnag/BugsnagDefines.h>
 
 NS_ASSUME_NONNULL_BEGIN
 
-@interface BugsnagCorrelation ()
+BUGSNAG_EXTERN
+@interface BugsnagCorrelation: NSObject
+
+@property (readonly, nonatomic, strong, nullable) NSString *traceId;
+
+@property (readonly, nonatomic, strong, nullable) NSString *spanId;
 
 - (instancetype) initWithTraceId:(NSString * _Nullable) traceId spanId:(NSString * _Nullable)spanId;
 
@@ -24,5 +27,3 @@ NS_ASSUME_NONNULL_BEGIN
 @end
 
 NS_ASSUME_NONNULL_END
-
-#endif /* BugsnagCorrelation_Private_h */

--- a/Bugsnag/Payload/BugsnagCorrelation.m
+++ b/Bugsnag/Payload/BugsnagCorrelation.m
@@ -6,7 +6,7 @@
 //  Copyright © 2024 Bugsnag Inc. All rights reserved.
 //
 
-#import "BugsnagCorrelation+Private.h"
+#import "BugsnagCorrelation.h"
 
 @implementation BugsnagCorrelation
 

--- a/Bugsnag/Payload/BugsnagEvent+Private.h
+++ b/Bugsnag/Payload/BugsnagEvent+Private.h
@@ -9,6 +9,7 @@
 #import "BSGDefines.h"
 #import "BSGFeatureFlagStore.h"
 #import "BugsnagInternals.h"
+#import "BugsnagCorrelation.h"
 
 NS_ASSUME_NONNULL_BEGIN
 
@@ -46,6 +47,8 @@ BSG_OBJC_DIRECT_MEMBERS
 @property (readwrite, nullable, nonatomic) NSDictionary *usage;
 
 @property (readwrite, nonnull, nonatomic) BugsnagUser *user;
+
+@property (readwrite, nonatomic, strong, nullable) BugsnagCorrelation *correlation;
 
 - (instancetype)initWithKSReport:(NSDictionary *)KSReport;
 

--- a/Bugsnag/Payload/BugsnagEvent.m
+++ b/Bugsnag/Payload/BugsnagEvent.m
@@ -23,7 +23,6 @@
 #import "BugsnagBreadcrumbs.h"
 #import "BugsnagCollections.h"
 #import "BugsnagConfiguration+Private.h"
-#import "BugsnagCorrelation+Private.h"
 #import "BugsnagDeviceWithState+Private.h"
 #import "BugsnagError+Private.h"
 #import "BugsnagHandledState.h"
@@ -543,6 +542,10 @@ BSG_OBJC_DIRECT_MEMBERS
       withEmail:(NSString *_Nullable)email
         andName:(NSString *_Nullable)name {
     self.user = [[BugsnagUser alloc] initWithId:userId name:name emailAddress:email];
+}
+
+- (void) setCorrelationTraceId:(NSString *_Nonnull)traceId spanId:(NSString *_Nonnull)spanId {
+    self.correlation = [[BugsnagCorrelation alloc] initWithTraceId:traceId spanId:spanId];
 }
 
 /**

--- a/Bugsnag/include/Bugsnag/BugsnagCorrelation.h
+++ b/Bugsnag/include/Bugsnag/BugsnagCorrelation.h
@@ -14,9 +14,15 @@ NS_ASSUME_NONNULL_BEGIN
 BUGSNAG_EXTERN
 @interface BugsnagCorrelation: NSObject
 
-@property (readwrite, nonatomic, strong, nullable) NSString *traceId;
+@property (readonly, nonatomic, strong, nullable) NSString *traceId;
 
-@property (readwrite, nonatomic, strong, nullable) NSString *spanId;
+@property (readonly, nonatomic, strong, nullable) NSString *spanId;
+
+- (instancetype) initWithTraceId:(NSString * _Nullable) traceId spanId:(NSString * _Nullable)spanId;
+
+- (instancetype) initWithJsonDictionary:(NSDictionary<NSString *, NSObject *> * _Nullable) dict;
+
+- (NSDictionary<NSString *, NSObject *> *) toJsonDictionary;
 
 @end
 

--- a/Bugsnag/include/Bugsnag/BugsnagEvent.h
+++ b/Bugsnag/include/Bugsnag/BugsnagEvent.h
@@ -11,7 +11,6 @@
 #import <Bugsnag/BugsnagDefines.h>
 #import <Bugsnag/BugsnagFeatureFlagStore.h>
 #import <Bugsnag/BugsnagMetadataStore.h>
-#import <Bugsnag/BugsnagCorrelation.h>
 
 @class BugsnagConfiguration;
 @class BugsnagHandledState;
@@ -113,8 +112,6 @@ BUGSNAG_EXTERN
  */
 @property (strong, nullable, nonatomic) id originalError;
 
-@property (readwrite, nonatomic, strong, nullable) BugsnagCorrelation *correlation;
-
 // =============================================================================
 // MARK: - User
 // =============================================================================
@@ -134,5 +131,7 @@ BUGSNAG_EXTERN
 - (void)setUser:(NSString *_Nullable)userId
       withEmail:(NSString *_Nullable)email
         andName:(NSString *_Nullable)name;
+
+- (void) setCorrelationTraceId:(NSString *_Nonnull)traceId spanId:(NSString *_Nonnull)spanId;
 
 @end


### PR DESCRIPTION
## Goal

Don't expose `BugsnagCorrelation` publicly.

Setting the correlation in an event callback is not a current use case, so use a setter instead.
