### PR TITLE
Add other downstream repos for automatic updates

### DIFF
--- a/.github/workflows/downstream_updates.yml
+++ b/.github/workflows/downstream_updates.yml
@@ -17,7 +17,7 @@ jobs:
       RELEASE_VERSION: ${{ github.event_name == 'workflow_dispatch' && inputs.target_version || github.event.release.tag_name }}
     strategy:
       matrix:
-        downstream_repo: ['bugsnag/bugsnag-unity', 'bugsnag/bugsnag-flutter']
+        downstream_repo: ['bugsnag/bugsnag-unity', 'bugsnag/bugsnag-flutter', 'bugsnag/bugsnag-js', 'bugsnag/bugsnag-unreal']
     steps:
       - name: Install libcurl4-openssl-dev and net-tools
         run: |


### PR DESCRIPTION
## Goal

Adds bugsnag JS (RN) and unreal to the downstream repos updated when a new version of the notifier is released.