### PR TITLE
Run e2e test in Debug configuration

### DIFF
--- a/.buildkite/pipeline.yml
+++ b/.buildkite/pipeline.yml
@@ -445,7 +445,7 @@ steps:
 
   ##############################################################################
   #
-  # Basic build E2E tests
+  # Basic build E2E tests - Release Configuration
   #
 
   #
@@ -572,6 +572,106 @@ steps:
         - exit_status: -1  # Agent was lost
           limit: 2
 
+  ##############################################################################
+  #
+  # Debug configration E2E tests
+  #
+
+  - label: ':browserstack: iOS 17 debug configuration tests'
+    depends_on:
+      - cocoa_fixture
+    timeout_in_minutes: 60
+    agents:
+      queue: opensource
+    plugins:
+      artifacts#v1.9.3:
+        download: "features/fixtures/ios/output/ipa_url_bs_debug.txt"
+        upload: "maze_output/failed/**/*"
+      docker-compose#v4.7.0:
+        pull: cocoa-maze-runner-bitbar
+        run: cocoa-maze-runner-bitbar
+        service-ports: true
+        command:
+          - "--app=@/app/build/ipa_url_bs_debug.txt"
+          - "--farm=bs"
+          - "--device=IOS_17"
+          - "--fail-fast"
+          - "features/debug"
+    concurrency: 5
+    concurrency_group: 'browserstack-app'
+    concurrency_method: eager
+    retry:
+      automatic:
+        - exit_status: -1  # Agent was lost
+          limit: 2
+
+  - label: ':bitbar: iOS 13 debug configuration tests'
+    depends_on:
+      - cocoa_fixture
+    timeout_in_minutes: 60
+    agents:
+      queue: opensource
+    plugins:
+      artifacts#v1.9.3:
+        download: "features/fixtures/ios/output/ipa_url_bb_debug.txt"
+        upload: "maze_output/failed/**/*"
+      docker-compose#v4.7.0:
+        pull: cocoa-maze-runner-bitbar
+        run: cocoa-maze-runner-bitbar
+        service-ports: true
+        command:
+          - "--app=@/app/build/ipa_url_bb_debug.txt"
+          - "--farm=bb"
+          - "--device=IOS_13"
+          - "--no-tunnel"
+          - "--aws-public-ip"
+          - "--fail-fast"
+          - "features/debug"
+    concurrency: 25
+    concurrency_group: 'bitbar'
+    concurrency_method: eager
+    retry:
+      automatic:
+        - exit_status: -1  # Agent was lost
+          limit: 2
+
+  - label: 'macOS 14 debug E2E tests'
+    depends_on:
+      - cocoa_fixture
+    timeout_in_minutes: 10
+    agents:
+      queue: macos-14
+    plugins:
+      artifacts#v1.5.0:
+        download: "features/fixtures/macos/output/macOSTestApp_Debug.zip"
+        upload:
+          - "macOSTestApp.log"
+          - "maze_output/failed/**/*"
+    commands:
+      - bundle install
+      - bundle exec maze-runner
+        features/debug
+        --os=macos
+        --fail-fast
+
+  - label: 'macOS 10.13 debug E2E tests'
+    depends_on:
+      - cocoa_fixture
+    timeout_in_minutes: 10
+    agents:
+      queue: opensource-mac-cocoa-10.13
+    plugins:
+      artifacts#v1.5.0:
+        download: "features/fixtures/macos/output/macOSTestApp_Debug.zip"
+        upload:
+          - "macOSTestApp.log"
+          - "maze_output/failed/**/*"
+    commands:
+      - bundle install
+      - bundle exec maze-runner
+        features/debug
+        --os=macos
+        --fail-fast
 
   ##############################################################################
   #

--- a/.buildkite/pipeline.yml
+++ b/.buildkite/pipeline.yml
@@ -590,7 +590,6 @@ steps:
       docker-compose#v4.7.0:
         pull: cocoa-maze-runner
         run: cocoa-maze-runner
-        service-ports: true
         command:
           - "--app=@/app/build/ipa_url_bs_debug.txt"
           - "--farm=bs"
@@ -618,6 +617,7 @@ steps:
       docker-compose#v4.7.0:
         pull: cocoa-maze-runner-bitbar
         run: cocoa-maze-runner-bitbar
+        service-ports: true
         command:
           - "--app=@/app/build/ipa_url_bb_debug.txt"
           - "--farm=bb"

--- a/.buildkite/pipeline.yml
+++ b/.buildkite/pipeline.yml
@@ -588,8 +588,8 @@ steps:
         download: "features/fixtures/ios/output/ipa_url_bs_debug.txt"
         upload: "maze_output/failed/**/*"
       docker-compose#v4.7.0:
-        pull: cocoa-maze-runner-bitbar
-        run: cocoa-maze-runner-bitbar
+        pull: cocoa-maze-runner
+        run: cocoa-maze-runner
         service-ports: true
         command:
           - "--app=@/app/build/ipa_url_bs_debug.txt"
@@ -618,7 +618,6 @@ steps:
       docker-compose#v4.7.0:
         pull: cocoa-maze-runner-bitbar
         run: cocoa-maze-runner-bitbar
-        service-ports: true
         command:
           - "--app=@/app/build/ipa_url_bb_debug.txt"
           - "--farm=bb"

--- a/features/release/crashprobe.feature
+++ b/features/release/crashprobe.feature
@@ -130,7 +130,7 @@ Feature: Reporting crash events
     And the "isPC" of stack frame 0 is true
     And the "isLR" of stack frame 0 is null
 
-  # TODO: Skipped Pending PLAT-12396
+  # TODO: Skipped Pending PLAT-12398
   @skip_macos
   Scenario: Crash within Swift code
     When I run "SwiftCrashScenario" and relaunch the crashed app

--- a/features/release/delivery.feature
+++ b/features/release/delivery.feature
@@ -160,7 +160,7 @@ Feature: Delivery of errors
     And the event "usage.system.stringsTruncated" is not null
 
   @skip_ios_17
-  # TODO: Skipped Pending PLAT-12396
+  # TODO: Skipped Pending PLAT-12398
   @skip_macos
   Scenario Outline: Attempt Delivery On Crash
     When I set the app to "<scenario_mode>" mode

--- a/features/scripts/export_ios_app.sh
+++ b/features/scripts/export_ios_app.sh
@@ -8,6 +8,7 @@ if [ "$1" != "Release" ] && [ "$1" != "Debug" ]; then
   exit 1
 fi
 
+BUILD_CONFIGURATION=$1
 pushd features/fixtures/ios
 
   echo "--- iOSTestApp: xcodebuild archive"
@@ -21,7 +22,7 @@ pushd features/fixtures/ios
     -scheme iOSTestApp \
     -workspace iOSTestApp.xcworkspace \
     -destination generic/platform=iOS \
-    -configuration $1 \
+    -configuration ${BUILD_CONFIGURATION} \
     -archivePath archive/iosTestApp.xcarchive \
     -allowProvisioningUpdates \
     -quiet \
@@ -40,6 +41,6 @@ pushd features/fixtures/ios
     -exportOptionsPlist exportOptions.plist
 
   pushd output
-    mv iOSTestApp.ipa iOSTestApp_$1.ipa
+    mv iOSTestApp.ipa iOSTestApp_$BUILD_CONFIGURATION.ipa
   popd
 popd

--- a/features/scripts/export_mac_app.sh
+++ b/features/scripts/export_mac_app.sh
@@ -20,7 +20,7 @@ BUILD_ARGS=(
   -workspace macOSTestApp.xcworkspace
   -scheme macOSTestApp
   -destination generic/platform=macOS
-  -configuration Release
+  -configuration $1
   -archivePath archive/macOSTestApp.xcarchive
   -quiet
   archive

--- a/features/scripts/export_mac_app.sh
+++ b/features/scripts/export_mac_app.sh
@@ -8,47 +8,49 @@ if [ "$1" != "Release" ] && [ "$1" != "Debug" ]; then
   exit 1
 fi
 
-cd features/fixtures/macos
+BUILD_CONFIGURATION=$1
 
-echo "--- macOSTestApp: pod install"
+pushd features/fixtures/macos
 
-pod install
+  echo "--- macOSTestApp: pod install"
 
-echo "--- macOSTestApp: xcodebuild archive"
+  pod install
 
-BUILD_ARGS=(
-  -workspace macOSTestApp.xcworkspace
-  -scheme macOSTestApp
-  -destination generic/platform=macOS
-  -configuration $1
-  -archivePath archive/macOSTestApp.xcarchive
-  -quiet
-  archive
-  ONLY_ACTIVE_ARCH=NO
-)
+  echo "--- macOSTestApp: xcodebuild archive"
 
-if [ "${ENABLE_CODE_COVERAGE:-}" = YES ]; then
-  BUILD_ARGS+=(
-    OTHER_CFLAGS='$(inherited) -fprofile-instr-generate -fcoverage-mapping'
-    OTHER_LDFLAGS='$(inherited) -fprofile-instr-generate'
-    OTHER_SWIFT_FLAGS='$(inherited) -profile-generate -profile-coverage-mapping'
+  BUILD_ARGS=(
+    -workspace macOSTestApp.xcworkspace
+    -scheme macOSTestApp
+    -destination generic/platform=macOS
+    -configuration ${BUILD_CONFIGURATION}
+    -archivePath archive/macOSTestApp.xcarchive
+    -quiet
+    archive
+    ONLY_ACTIVE_ARCH=NO
   )
-fi
 
-xcodebuild "${BUILD_ARGS[@]}"
+  if [ "${ENABLE_CODE_COVERAGE:-}" = YES ]; then
+    BUILD_ARGS+=(
+      OTHER_CFLAGS='$(inherited) -fprofile-instr-generate -fcoverage-mapping'
+      OTHER_LDFLAGS='$(inherited) -fprofile-instr-generate'
+      OTHER_SWIFT_FLAGS='$(inherited) -profile-generate -profile-coverage-mapping'
+    )
+  fi
 
-echo "--- macOSTestApp: xcodebuild -exportArchive"
+  xcodebuild "${BUILD_ARGS[@]}"
 
-xcrun xcodebuild \
-  -exportArchive \
-  -exportPath output/ \
-  -exportOptionsPlist exportOptions.plist \
-  -archivePath archive/macOSTestApp.xcarchive \
-  -destination generic/platform=macOS \
-  -quiet
+  echo "--- macOSTestApp: xcodebuild -exportArchive"
 
-cd output
+  xcrun xcodebuild \
+    -exportArchive \
+    -exportPath output/ \
+    -exportOptionsPlist exportOptions.plist \
+    -archivePath archive/macOSTestApp.xcarchive \
+    -destination generic/platform=macOS \
+    -quiet
 
-echo "--- macOSTestApp: zip"
-
-zip -qr macOSTestApp_$1.zip macOSTestApp.app
+  pushd output
+    echo "--- macOSTestApp: zip"
+    zip -qr macOSTestApp_$BUILD_CONFIGURATION.zip macOSTestApp.app
+  popd
+popd


### PR DESCRIPTION
## Goal

Run a limited set of e2e tests in Debug configuration

## Design

As there are a limited number of scenarios that need testing with Debug configuration, I have just added Buildkite jobs to the basic CI pipeline.  The earliest and latest major versions of macOS and iOS are covered.

## Testing

Covered by a basic CI run.