### PR TITLE
[Plat-12580] disable os_proc_available_memory on catalyst

### DIFF
--- a/Bugsnag/Helpers/BSGRunContext.m
+++ b/Bugsnag/Helpers/BSGRunContext.m
@@ -460,8 +460,10 @@ static void UpdateTaskMemory(void) {
     if (task_vm.limit_bytes_remaining) {
         setMemoryUsage(footprint, task_vm.limit_bytes_remaining);
     } else {
-#if !TARGET_OS_OSX
-    if (@available(iOS 13.0, tvOS 13.0, watchOS 6.0, macCatalyst 13.1, *)) {
+#if !TARGET_OS_OSX && !TARGET_OS_MACCATALYST
+        // We disable access to os_proc_available_memory() entirely on Catalyst
+        // because earlier versions are missing the API, causing linker errors on launch.
+    if (@available(iOS 13.0, tvOS 13.0, watchOS 6.0, *)) {
         setMemoryUsage(footprint, os_proc_available_memory());
     }
 #endif

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,13 @@
 Changelog
 =========
 
+## TBD
+
+### Bug Fixes
+
+* Disable calls to os_proc_available_memory() on Catalyst due to missing API in earlier versions.
+  [1689](https://github.com/bugsnag/bugsnag-cocoa/pull/1689)
+
 ## 6.30.1 (2024-07-25)
 
 ### Bug Fixes


### PR DESCRIPTION
## Goal

`os_proc_available_memory()` is not implemented on earlier Catalyst versions, causing a failed link crash on launch.

The only way around this is to remove the call in all Catalyst targets, regardless of version.
