### PR TITLE
Adjust Buildkite queues and timeouts

### DIFF
--- a/.buildkite/block.full.yml
+++ b/.buildkite/block.full.yml
@@ -4,4 +4,7 @@ steps:
 
   - label: 'Upload the full test pipeline'
     depends_on: 'trigger-full-build'
+    timeout_in_minutes: 5
+    agents:
+      queue: macos
     command: buildkite-agent pipeline upload .buildkite/pipeline.full.yml

--- a/.buildkite/pipeline.full.yml
+++ b/.buildkite/pipeline.full.yml
@@ -139,7 +139,7 @@ steps:
   - label: 'macOS 14 XcFramework barebone E2E tests'
     depends_on:
       - xcframework_cocoa_fixture
-    timeout_in_minutes: 30
+    timeout_in_minutes: 10
     agents:
       queue: macos-14
     plugins:
@@ -163,7 +163,7 @@ steps:
   - label: 'macOS 10.13 XcFramework barebone E2E tests'
     depends_on:
       - xcframework_cocoa_fixture
-    timeout_in_minutes: 30
+    timeout_in_minutes: 10
     agents:
       queue: opensource-mac-cocoa-10.13
     plugins:
@@ -830,7 +830,7 @@ steps:
   #
 
   - label: 'examples/objective-c-ios'
-    timeout_in_minutes: 30
+    timeout_in_minutes: 10
     agents:
       queue: macos-14
     commands:
@@ -846,7 +846,7 @@ steps:
       - xcodebuild -allowProvisioningUpdates -workspace objective-c-ios.xcworkspace -scheme objective-c-ios -configuration Debug -destination generic/platform=macOS -derivedDataPath DerivedData -quiet build
 
   - label: 'examples/objective-c-osx'
-    timeout_in_minutes: 30
+    timeout_in_minutes: 10
     agents:
       queue: macos-14
     commands:
@@ -860,7 +860,7 @@ steps:
       - xcodebuild -allowProvisioningUpdates -workspace objective-c-osx.xcworkspace -scheme objective-c-osx -configuration Debug -derivedDataPath DerivedData -quiet build GCC_TREAT_WARNINGS_AS_ERRORS=YES
 
   - label: 'examples/swift-ios'
-    timeout_in_minutes: 30
+    timeout_in_minutes: 10
     agents:
       queue: macos-14
     commands:
@@ -874,7 +874,7 @@ steps:
       - xcodebuild -allowProvisioningUpdates -workspace swift-ios.xcworkspace -scheme swift-ios -configuration Debug -destination generic/platform=iOS\ Simulator -derivedDataPath DerivedData -quiet build GCC_TREAT_WARNINGS_AS_ERRORS=YES
 
   - label: 'examples/swift-package-manager'
-    timeout_in_minutes: 30
+    timeout_in_minutes: 10
     agents:
       queue: macos-14
     commands:
@@ -889,7 +889,7 @@ steps:
       - xcodebuild -allowProvisioningUpdates -scheme swift-package-manager -configuration Debug -destination generic/platform=iOS\ Simulator -derivedDataPath DerivedData -quiet build GCC_TREAT_WARNINGS_AS_ERRORS=YES
 
   - label: 'examples/swiftui'
-    timeout_in_minutes: 30
+    timeout_in_minutes: 10
     agents:
       queue: macos-14
     commands:

--- a/.buildkite/pipeline.yml
+++ b/.buildkite/pipeline.yml
@@ -28,7 +28,7 @@ steps:
 
   - label: Build test fixtures
     key: cocoa_fixture
-    timeout_in_minutes: 30
+    timeout_in_minutes: 15
     agents:
       queue: macos-14
     env:
@@ -176,7 +176,7 @@ steps:
       - logs/*
 
   - label: watchOS 8 unit tests
-    timeout_in_minutes: 60
+    timeout_in_minutes: 10
     agents:
       queue: macos-14
     env:
@@ -187,7 +187,7 @@ steps:
       - logs/*
 
   - label: watchOS 7 unit tests
-    timeout_in_minutes: 60
+    timeout_in_minutes: 10
     agents:
       queue: macos-12-arm
     env:
@@ -289,7 +289,7 @@ steps:
   - label: 'macOS 11 barebones E2E tests'
     depends_on:
       - cocoa_fixture
-    timeout_in_minutes: 60
+    timeout_in_minutes: 10
     agents:
       queue: macos-11
     plugins:
@@ -310,7 +310,7 @@ steps:
   - label: 'macOS 10.15 barebones E2E tests'
     depends_on:
       - cocoa_fixture
-    timeout_in_minutes: 60
+    timeout_in_minutes: 10
     agents:
       queue: macos-10.15
     plugins:
@@ -772,4 +772,7 @@ steps:
   #
 
   - label: 'Conditionally trigger full set of tests'
+    timeout_in_minutes: 5
+    agents:
+      queue: macos
     command: sh -c .buildkite/pipeline_trigger.sh


### PR DESCRIPTION
## Goal

General tidy-up of the Buildkite pipeline to:
- Ensure all steps have an adequate but not excessive timeout
- Agent queues are explicitly stated in each file (even if a default is used)
- Generic `macos` queue is used instead of specific macOS versions where possible

## Testing

Covered by a full CI run.