### PR TITLE
Add Send Failure Callback API

### DIFF
--- a/Bugsnag/BugsnagInternals.h
+++ b/Bugsnag/BugsnagInternals.h
@@ -112,6 +112,8 @@ typedef void (^ BSGClientObserver)(BSGClientObserverEvent event, _Nullable id va
 
 @property (nonatomic) NSMutableArray<BugsnagOnSendErrorBlock> *onSendBlocks;
 
+@property (nonatomic) NSMutableArray<BugsnagOnSendFailureBlock> *onFailureBlocks;
+
 @property (nonatomic) NSMutableArray<BugsnagOnSessionBlock> *onSessionBlocks;
 
 @end

--- a/Bugsnag/Configuration/BugsnagConfiguration.m
+++ b/Bugsnag/Configuration/BugsnagConfiguration.m
@@ -119,6 +119,7 @@ BSG_OBJC_DIRECT_MEMBERS
     // as creating a copy of the array would prevent this
     [copy setOnBreadcrumbBlocks:self.onBreadcrumbBlocks];
     [copy setOnSendBlocks:self.onSendBlocks];
+    [copy setOnFailureBlocks:self.onFailureBlocks];
     [copy setOnSessionBlocks:self.onSessionBlocks];
     [copy setTelemetry:self.telemetry];
     return copy;
@@ -174,6 +175,7 @@ BSG_OBJC_DIRECT_MEMBERS
     _appHangThresholdMillis = BugsnagAppHangThresholdFatalOnly;
 #endif
     _onSendBlocks = [NSMutableArray new];
+    _onFailureBlocks = [NSMutableArray new];
     _onSessionBlocks = [NSMutableArray new];
     _onBreadcrumbBlocks = [NSMutableArray new];
     _plugins = [NSMutableSet new];
@@ -282,6 +284,24 @@ BSG_OBJC_DIRECT_MEMBERS
 - (NSURLSession *)sessionOrDefault {
     NSURLSession *session = self.session;
     return session ? session : getConfigDefaultURLSession();
+}
+
+// =============================================================================
+// MARK: - onSendFailure
+// =============================================================================
+
+- (BugsnagOnSendFailureRef)addOnSendFailureBlock:(BugsnagOnSendFailureBlock)block {
+    BugsnagOnSendFailureBlock callback = [block copy];
+    [self.onFailureBlocks addObject:callback];
+    return callback;
+}
+
+- (void)removeOnSendFailure:(BugsnagOnSendFailureRef)callback {
+    if (![callback isKindOfClass:NSClassFromString(@"NSBlock")]) {
+        bsg_log_err(@"Invalid object type passed to %@", NSStringFromSelector(_cmd));
+        return;
+    }
+    [self.onFailureBlocks removeObject:(id)callback];
 }
 
 // =============================================================================

--- a/Bugsnag/Helpers/BSGTelemetry.m
+++ b/Bugsnag/Helpers/BSGTelemetry.m
@@ -116,6 +116,7 @@ NSDictionary * BSGTelemetryCreateUsage(BugsnagConfiguration *configuration) {
     callbacks[@"onBreadcrumb"] = IntegerValue(configuration.onBreadcrumbBlocks.count, 0);
     callbacks[@"onCrashHandler"] = configuration.onCrashHandler ? @1 : nil;
     callbacks[@"onSendError"] = IntegerValue(configuration.onSendBlocks.count, 0);
+    callbacks[@"onFailure"] = IntegerValue(configuration.onFailureBlocks.count, 0);
     callbacks[@"onSession"] = IntegerValue(configuration.onSessionBlocks.count, 0);
     
     return @{

--- a/Bugsnag/include/Bugsnag/BugsnagConfiguration.h
+++ b/Bugsnag/include/Bugsnag/BugsnagConfiguration.h
@@ -115,6 +115,18 @@ typedef BOOL (^BugsnagOnSendErrorBlock)(BugsnagEvent *_Nonnull event);
 typedef id<NSObject> BugsnagOnSendErrorRef;
 
 /**
+ *  A configuration block for being notified when an event fails to send.
+ *
+ *  @param event The event report. NULL if the event cannot be loaded from disk.
+ */
+typedef void (^BugsnagOnSendFailureBlock)(BugsnagEvent *_Nullable event);
+
+/**
+ * An opaque object that identifies and allows the removal of a BugsnagOnSendFailureBlock.
+ */
+typedef id<NSObject> BugsnagOnSendFailureRef;
+
+/**
  *  A configuration block for modifying a captured breadcrumb
  *
  *  @param breadcrumb The breadcrumb
@@ -440,6 +452,29 @@ BUGSNAG_EXTERN
 - (void)removeOnSessionBlock:(BugsnagOnSessionBlock)block
     BUGSNAG_DEPRECATED_WITH_REPLACEMENT("removeOnSession:")
     NS_SWIFT_NAME(removeOnSession(block:));
+
+// =============================================================================
+// MARK: - onSendFailure
+// =============================================================================
+
+/**
+ *  Add a callback to be invoked when a report fails to be
+ *  send to Bugsnag.
+ *
+ *  @param block A block to be called on send failure.
+ *
+ *  @returns An opaque reference to the callback which can be passed to `removeOnSendFailure:`
+ */
+- (BugsnagOnSendFailureRef)addOnSendFailureBlock:(BugsnagOnSendFailureBlock)block
+NS_SWIFT_NAME(addOnSendFailure(block:));
+
+/**
+ * Remove the callback that would be invoked on send failure.
+ *
+ * @param callback The opaque reference of the callback, returned by `addOnSendFailureBlock:`
+ */
+- (void)removeOnSendFailure:(BugsnagOnSendFailureRef)callback
+NS_SWIFT_NAME(removeOnSendFailure(_:));
 
 // =============================================================================
 // MARK: - onSend

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,11 @@
 Changelog
 =========
 
+### Enhancements
+
+* Add callback for when an Error fails to send.
+  []()
+  
 ## 6.30.2 (2024-11-07)
 
 ### Bug Fixes

--- a/Tests/BugsnagTests/BugsnagSwiftConfigurationTests.swift
+++ b/Tests/BugsnagTests/BugsnagSwiftConfigurationTests.swift
@@ -20,6 +20,29 @@ class BugsnagSwiftConfigurationTests: BSGTestCase {
         XCTAssertEqual(config.apiKey, DUMMY_APIKEY_16CHAR)
     }
     
+    func testRemoveOnFailureError() {
+        let config = BugsnagConfiguration(DUMMY_APIKEY_16CHAR)
+        let onFailureBlocks: NSMutableArray = config.value(forKey: "onFailureBlocks") as! NSMutableArray
+        XCTAssertEqual(onFailureBlocks.count, 0)
+        
+        let onFailureError = config.addOnSendFailure { _ in }
+        XCTAssertEqual(onFailureBlocks.count, 1)
+        
+        config.removeOnSendFailure(onFailureError)
+        XCTAssertEqual(onFailureBlocks.count, 0)
+    }
+    
+    func testRemoveInvalidOnFailureDoesNotCrash() {
+        let config = BugsnagConfiguration(DUMMY_APIKEY_16CHAR)
+        let onSendFailureBlock: (BugsnagEvent?) -> Void = { _ in }
+        config.addOnSendFailure(block: onSendFailureBlock)
+        
+        // This does not compile:
+        // config.removeOnSendFailure(onSendErrorBlock)
+        
+        config.removeOnSendFailure("" as NSString)
+    }
+
     func testRemoveOnSendError() {
         let config = BugsnagConfiguration(DUMMY_APIKEY_16CHAR)
         let onSendBlocks: NSMutableArray = config.value(forKey: "onSendBlocks") as! NSMutableArray

--- a/Tests/BugsnagTests/ConfigurationApiValidationTest.m
+++ b/Tests/BugsnagTests/ConfigurationApiValidationTest.m
@@ -225,6 +225,14 @@
     XCTAssertEqual(0, [self.config.onSessionBlocks count]);
 }
 
+- (void)testValidOnSendFailureBlock {
+    void (^block)(BugsnagEvent *) = ^(BugsnagEvent *event) {};
+    BugsnagOnSendFailureRef callback = [self.config addOnSendFailureBlock:block];
+    XCTAssertEqual(1, [self.config.onFailureBlocks count]);
+    [self.config removeOnSendFailure:callback];
+    XCTAssertEqual(0, [self.config.onFailureBlocks count]);
+}
+
 - (void)testValidOnSendErrorBlock {
     BOOL (^block)(BugsnagEvent *) = ^BOOL(BugsnagEvent *event) {
         return NO;


### PR DESCRIPTION
Despite the newer features designed to limit report sizes, reports can still occasionally exceed the limit, resulting in them being silently deleted without being sent. When this happens frequently, there’s no way to detect it, which can lead to ticket prioritization problems and potential business losses.

This PR introduces a new callback, `onSendFailureBlock`, which is triggered when a report is dropped by the system without this being the intention of the sender.

I understand that Bugsnag typically doesn’t accept new features via PRs, but this one is straightforward and could provide significant value to end users. I’d greatly appreciate it if you could consider merging it as is or making any necessary adjustments before merging.

Thank you!