### PR TITLE
docs: add security policy and rebrand readme

### DIFF
--- a/.github/workflows/scorecard.yml
+++ b/.github/workflows/scorecard.yml
@@ -1,0 +1,73 @@
+# This workflow uses actions that are not certified by GitHub. They are provided
+# by a third-party and are governed by separate terms of service, privacy
+# policy, and support documentation.
+
+name: OpenSSF Scorecard
+on:
+  # For Branch-Protection check. Only the default branch is supported. See
+  # https://github.com/ossf/scorecard/blob/main/docs/checks.md#branch-protection
+  branch_protection_rule:
+  # To guarantee Maintained check is occasionally updated. See
+  # https://github.com/ossf/scorecard/blob/main/docs/checks.md#maintained
+  schedule:
+    - cron: '0 0 * * 0'
+  push:
+    branches: [ "next" ]
+
+# Declare default permissions as read only.
+permissions: read-all
+
+jobs:
+  analysis:
+    name: Scorecard analysis
+    runs-on: ubuntu-latest
+    permissions:
+      # Needed to upload the results to code-scanning dashboard.
+      security-events: write
+      # Needed to publish results and get a badge (see publish_results below).
+      id-token: write
+      # Uncomment the permissions below if installing in a private repository.
+      # contents: read
+      # actions: read
+
+    steps:
+      - name: "Checkout code"
+        uses: actions/checkout@b4ffde65f46336ab88eb53be808477a3936bae11 # v4.1.1
+        with:
+          persist-credentials: false
+
+      - name: "Run analysis"
+        uses: ossf/scorecard-action@0864cf19026789058feabb7e87baa5f140aac736 # v2.3.1
+        with:
+          results_file: results.sarif
+          results_format: sarif
+          # (Optional) "write" PAT token. Uncomment the `repo_token` line below if:
+          # - you want to enable the Branch-Protection check on a *public* repository, or
+          # - you are installing Scorecard on a *private* repository
+          # To create the PAT, follow the steps in https://github.com/ossf/scorecard-action?tab=readme-ov-file#authentication-with-fine-grained-pat-optional.
+          # repo_token: ${{ secrets.SCORECARD_TOKEN }}
+
+          # Public repositories:
+          #   - Publish results to OpenSSF REST API for easy access by consumers
+          #   - Allows the repository to include the Scorecard badge.
+          #   - See https://github.com/ossf/scorecard-action#publishing-results.
+          # For private repositories:
+          #   - `publish_results` will always be set to `false`, regardless
+          #     of the value entered here.
+          publish_results: true
+
+      # Upload the results as artifacts (optional). Commenting out will disable uploads of run results in SARIF
+      # format to the repository Actions tab.
+      - name: "Upload artifact"
+        uses: actions/upload-artifact@97a0fba1372883ab732affbe8f94b823f91727db # v3.pre.node20
+        with:
+          name: SARIF file
+          path: results.sarif
+          retention-days: 5
+
+      # Upload the results to GitHub's code scanning dashboard (optional).
+      # Commenting out will disable upload of results to your repo's Code Scanning dashboard
+      - name: "Upload to code-scanning"
+        uses: github/codeql-action/upload-sarif@v3
+        with:
+          sarif_file: results.sarif

--- a/README.md
+++ b/README.md
@@ -1,11 +1,18 @@
-# Bugsnag error monitoring & exception reporter for iOS, macOS, tvOS and watchOS
-[![iOS Documentation](https://img.shields.io/badge/ios_documentation-latest-blue.svg)](https://docs.bugsnag.com/platforms/ios/)
-[![macOS Documentation](https://img.shields.io/badge/macos_documentation-latest-blue.svg)](https://docs.bugsnag.com/platforms/macos/)
-[![tvOS Documentation](https://img.shields.io/badge/tvos_documentation-latest-blue.svg)](https://docs.bugsnag.com/platforms/tvos/)
-[![watchOS Documentation](https://img.shields.io/badge/watchos_documentation-latest-blue.svg)](https://docs.bugsnag.com/platforms/watchos/)
-[![Build status](https://badge.buildkite.com/bc15523ca2dc56d1a9fd61a1c0e93b99adba62f229a1c3379b.svg?branch=master)](https://buildkite.com/bugsnag/bugsnag-cocoa)
+<div align="center">
+  <a href="https://www.bugsnag.com/platforms/ios">
+    <picture>
+      <source media="(prefers-color-scheme: dark)" srcset="https://assets.smartbear.com/m/3dab7e6cf880aa2b/original/BugSnag-Repository-Header-Dark.svg">
+      <img alt="SmartBear BugSnag logo" src="https://assets.smartbear.com/m/3945e02cdc983893/original/BugSnag-Repository-Header-Light.svg">
+    </picture>
+  </a>
+  <h1>Error monitoring &amp; exception reporter for iOS, macOS, tvOS and watchOS</h1>
+</div>
 
-The Bugsnag crash reporter for Cocoa library automatically detects crashes in your iOS 9.0+, macOS 10.11+, tvOS 9.2+ and watchOS 6.3+ applications, collecting diagnostic information and immediately notifying your development team, helping you to understand and resolve issues as fast as possible. Learn more about [iOS crash reporting with Bugsnag](https://www.bugsnag.com/platforms/ios-crash-reporting/).
+[![Documentation](https://img.shields.io/badge/documentation-latest-blue.svg)](https://docs.bugsnag.com/platforms/ios/)
+[![Build status](https://badge.buildkite.com/bc15523ca2dc56d1a9fd61a1c0e93b99adba62f229a1c3379b.svg?branch=master)](https://buildkite.com/bugsnag/bugsnag-cocoa)
+[![OpenSSF Scorecard](https://api.scorecard.dev/projects/github.com/bugsnag/bugsnag-cocoa/badge)](https://scorecard.dev/viewer/?uri=github.com/bugsnag/bugsnag-cocoa)
+
+Detect crashes in your iOS, macOS, tvOS and watchOS applications: collecting diagnostic information and immediately notifying your development team, helping you to understand and resolve issues as fast as possible.
 
 ## Features
 
@@ -13,7 +20,6 @@ The Bugsnag crash reporter for Cocoa library automatically detects crashes in yo
 * Report handled exceptions
 * Log breadcrumbs which are attached to crash reports and add insight to users' actions
 * Attach user information and custom diagnostic data to determine how many people are affected by a crash
-
 
 ## Getting started
 
@@ -44,16 +50,10 @@ The Bugsnag crash reporter for Cocoa library automatically detects crashes in yo
 * [Search open and closed issues](https://github.com/bugsnag/bugsnag-cocoa/issues?utf8=✓&q=is%3Aissue) for similar problems
 * [Report a bug or request a feature](https://github.com/bugsnag/bugsnag-cocoa/issues/new)
 
-
 ## Contributing
 
-All contributors are welcome! For information on how to build, test,
-and release `bugsnag-cocoa`, see our
-[contributing guide](https://github.com/bugsnag/bugsnag-cocoa/blob/master/CONTRIBUTING.md).
-
+All contributors are welcome! For information on how to build, test and release `bugsnag-cocoa`, see our [contributing guide](https://github.com/bugsnag/bugsnag-cocoa/blob/master/CONTRIBUTING.md).
 
 ## License
 
-The Bugsnag Cocoa library is free software released under the MIT License.
-See [LICENSE.txt](https://github.com/bugsnag/bugsnag-cocoa/blob/master/LICENSE.txt)
-for details.
+The BugSnag Cocoa SDK is free software released under the MIT License. See the [LICENSE](https://github.com/bugsnag/bugsnag-cocoa/blob/master/LICENSE) for details.

--- a/SECURITY.md
+++ b/SECURITY.md
@@ -1,0 +1,12 @@
+# Security Policy
+
+## Supported Versions
+
+| Version | Supported             |
+| ------- | --------------------- |
+| 5.x     | Critical patches only |
+| 6.x     | Yes                   |
+
+## Reporting a Vulnerability
+
+If you find a vulnerability in this SDK, please report it to our [Support team](mailto:support@bugsnag.com) for review.


### PR DESCRIPTION
## Goal

Adds a security policy, brings the branding up-to-date and adds a weekly job for running the OpenSSF scorecard.