### PR TITLE
Add restrictions to the default github token in the signing workflow

### DIFF
--- a/.github/workflows/signing.yml
+++ b/.github/workflows/signing.yml
@@ -1,5 +1,7 @@
 name: Sign release assets
 
+permissions: read-all
+
 on:
   release:
     types: [released]


### PR DESCRIPTION
## Goal

To add restrictions to the default github token in the signing workflow.