### PR TITLE
[PLAT-13303] Disable assertions on release build

### DIFF
--- a/Package.swift
+++ b/Package.swift
@@ -24,6 +24,8 @@ let package = Package(
             ],
             publicHeadersPath: "include",
             cSettings: [
+                .define("NS_BLOCK_ASSERTIONS", .when(configuration: .release)),
+                .define("NDEBUG", .when(configuration: .release)),
                 .headerSearchPath("."),
                 .headerSearchPath("Breadcrumbs"),
                 .headerSearchPath("Client"),
@@ -53,6 +55,8 @@ let package = Package(
             path: "BugsnagNetworkRequestPlugin/BugsnagNetworkRequestPlugin",
             publicHeadersPath: "include",
             cSettings: [
+                .define("NS_BLOCK_ASSERTIONS", .when(configuration: .release)),
+                .define("NDEBUG", .when(configuration: .release)),
                 .headerSearchPath("."),
                 .headerSearchPath("include/BugsnagNetworkRequestPlugin"),
             ]


### PR DESCRIPTION
## Goal

Disable assertions on release build. There's nothing in the library using assertions other than the API key check at the start, but if in future we do start using them more, it will be good to have them disabled on a release build.

Ref: https://github.com/bugsnag/bugsnag-cocoa/issues/1705
