### PR TITLE
Correct pipeline concurrency group values

### DIFF
--- a/.buildkite/pipeline.yml
+++ b/.buildkite/pipeline.yml
@@ -397,7 +397,7 @@ steps:
         files: "reports/TEST-*.xml"
         format: "junit"
         branch: "^master|next$$"
-    concurrency: 25
+    concurrency: 5
     concurrency_group: 'browserstack-app'
     concurrency_method: eager
     retry:
@@ -432,7 +432,7 @@ steps:
         files: "reports/TEST-*.xml"
         format: "junit"
         branch: "^master|next$$"
-    concurrency: 25
+    concurrency: 5
     concurrency_group: 'browserstack-app'
     concurrency_method: eager
     retry:


### PR DESCRIPTION
## Goal

Corrects a couple of concurrency group limits in the Buildkite pipeline.

## Testing

Peer review suffices. 