### PR TITLE
build: add dependabot config for dependency updates and pin existing GHA

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,0 +1,19 @@
+# To get started with Dependabot version updates, you'll need to specify which
+# package ecosystems to update and where the package manifests are located.
+# Please see the documentation for all configuration options:
+# https://docs.github.com/code-security/dependabot/dependabot-version-updates/configuration-options-for-the-dependabot.yml-file
+
+version: 2
+updates:
+  - package-ecosystem: "bundler"
+    directory: "/"
+    schedule:
+      interval: "weekly"
+  - package-ecosystem: "github-actions"
+    directory: "/"
+    schedule:
+      interval: "weekly"
+  - package-ecosystem: "swift"
+    directory: "/"
+    schedule:
+      interval: "weekly"

--- a/.github/workflows/scorecard.yml
+++ b/.github/workflows/scorecard.yml
@@ -68,6 +68,6 @@ jobs:
       # Upload the results to GitHub's code scanning dashboard (optional).
       # Commenting out will disable upload of results to your repo's Code Scanning dashboard
       - name: "Upload to code-scanning"
-        uses: github/codeql-action/upload-sarif@v3
+        uses: github/codeql-action/upload-sarif@9e8d0789d4a0fa9ceb6b1738f7e269594bdd67f0 # v3.28.9
         with:
           sarif_file: results.sarif

--- a/.github/workflows/signing.yml
+++ b/.github/workflows/signing.yml
@@ -23,7 +23,7 @@ jobs:
         run: |
           echo "${{ secrets.PLATFORMS_GPG_KEY_BASE64 }}" | base64 --decode | gpg --batch --import
       - name: Sign assets
-        uses: bugsnag/platforms-release-signer@main
+        uses: bugsnag/platforms-release-signer@4d88944b11e503624f8a511cf6d0fa2901822b60 # v1.0.0
         with:
           github_token: ${{ secrets.PLATFORMS_SIGNING_GITHUB_TOKEN }}
           full_repository: ${{ github.repository }}


### PR DESCRIPTION
## Goal

Adds dependabot config to raise PRs for bundler and GHA. Also pins remaining GHA dependencies.