### PR TITLE
Expose [BSGCompositeFeatureFlagStore copyMemoryStore] in BugsnagInternals.h

### DIFF
--- a/Bugsnag/BugsnagInternals.h
+++ b/Bugsnag/BugsnagInternals.h
@@ -32,10 +32,11 @@
 @interface BSGAtomicFeatureFlagStore : NSObject <BSGFeatureFlagStore>
 @end
 
-@interface BSGCompositeFeatureFlagStore : NSObject <BSGFeatureFlagStore>
-@end
-
 NS_ASSUME_NONNULL_BEGIN
+
+@interface BSGCompositeFeatureFlagStore : NSObject <BSGFeatureFlagStore>
+- (id<BSGFeatureFlagStore>)copyMemoryStore;
+@end
 
 #pragma mark -
 

--- a/Bugsnag/FeatureFlags/BSGCompositeFeatureFlagStore.h
+++ b/Bugsnag/FeatureFlags/BSGCompositeFeatureFlagStore.h
@@ -22,7 +22,6 @@ BSG_OBJC_DIRECT_MEMBERS
                      persistentStore:(id<BSGFeatureFlagStore>)persistenStore
                          atomicStore:(id<BSGFeatureFlagStore>)atomicStore;
 
-- (id<BSGFeatureFlagStore>)copyMemoryStore;
 - (void)synchronizeFlagsWithMemoryStore;
 
 @end


### PR DESCRIPTION
## Goal

After Feature Flags refactor in Cocoa, we need to be able to access copyMemoryStore in FlutterPlugin.