### PR TITLE
Fixed the issue causing flags cleared by calling +[Bugsnag clearFeatureFlagWithName:] to appear in crash reports

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,13 @@
 Changelog
 =========
 
+## TBD
+
+### Bug Fixes
+
+* Fixed the issue causing flags cleared by calling `+[Bugsnag clearFeatureFlagWithName:]` to appear in crash reports.
+  [#1740](https://github.com/bugsnag/bugsnag-cocoa/pull/1740)
+
 ## 6.32.0 (2025-02-11)
 
 ### Enhancements

--- a/features/debug/unhandled_nsexception.feature
+++ b/features/debug/unhandled_nsexception.feature
@@ -41,3 +41,25 @@ Feature: Uncaught NSExceptions are captured by Bugsnag
     And the event "severityReason.type" equals "unhandledException"
     And on iOS 12 and later, the event "threads.0.name" equals "メインスレッド"
     And on macOS 10.14 and later, the event "threads.0.name" equals "メインスレッド"
+
+  Scenario: Throw a NSException with feature flags set
+    When I run "ObjCExceptionFeatureFlagsScenario" and relaunch the crashed app
+    And I configure Bugsnag for "ObjCExceptionFeatureFlagsScenario"
+    And I wait to receive an error
+    Then the error is valid for the error reporting API
+    And the exception "errorClass" equals "NSGenericException"
+    And the "method" of stack frame 0 equals the platform-dependent string:
+      | ios   | <redacted>            |
+      | macos | __exceptionPreprocess |
+    And the "method" of stack frame 1 equals "objc_exception_throw"
+    And the "method" of stack frame 2 equals "-[ObjCExceptionFeatureFlagsScenario run]"
+    And the error payload field "events.0.device.time" is a date
+    And the event "severity" equals "error"
+    And the event "unhandled" is true
+    And the error payload field "events.0.featureFlags" is an array with 3 elements
+    And the error payload field "events.0.featureFlags.0.featureFlag" equals "Feature Flag1"
+    And the error payload field "events.0.featureFlags.0.variant" equals "Variant1"
+    And the error payload field "events.0.featureFlags.1.featureFlag" equals "Feature Flag3"
+    And the error payload field "events.0.featureFlags.1.variant" equals "Variant3"
+    And the error payload field "events.0.featureFlags.2.featureFlag" equals "Feature Flag4"
+    And the error payload field "events.0.featureFlags.2.variant" is null

--- a/features/fixtures/ios/iOSTestApp.xcodeproj/project.pbxproj
+++ b/features/fixtures/ios/iOSTestApp.xcodeproj/project.pbxproj
@@ -121,6 +121,7 @@
 		8AF8FCAC22BD1E5400A967CA /* UnhandledInternalNotifyScenario.swift in Sources */ = {isa = PBXBuildFile; fileRef = 8AF8FCAB22BD1E5400A967CA /* UnhandledInternalNotifyScenario.swift */; };
 		8AF8FCAE22BD23BA00A967CA /* HandledInternalNotifyScenario.swift in Sources */ = {isa = PBXBuildFile; fileRef = 8AF8FCAD22BD23BA00A967CA /* HandledInternalNotifyScenario.swift */; };
 		967F6F1229B2236A0054EED8 /* InternalWorkingsScenario.swift in Sources */ = {isa = PBXBuildFile; fileRef = 967F6F1129B2236A0054EED8 /* InternalWorkingsScenario.swift */; };
+		96A25F322D66AFAE00A18116 /* ObjCExceptionFeatureFlagsScenario.m in Sources */ = {isa = PBXBuildFile; fileRef = 96A25F312D66AFAE00A18116 /* ObjCExceptionFeatureFlagsScenario.m */; };
 		A1117E552535A59100014FDA /* OOMLoadScenario.swift in Sources */ = {isa = PBXBuildFile; fileRef = A1117E542535A59100014FDA /* OOMLoadScenario.swift */; };
 		A1117E572535B22300014FDA /* OOMAutoDetectErrorsScenario.swift in Sources */ = {isa = PBXBuildFile; fileRef = A1117E562535B22300014FDA /* OOMAutoDetectErrorsScenario.swift */; };
 		A1117E592535B29800014FDA /* OOMEnabledErrorTypesScenario.swift in Sources */ = {isa = PBXBuildFile; fileRef = A1117E582535B29800014FDA /* OOMEnabledErrorTypesScenario.swift */; };
@@ -328,6 +329,7 @@
 		8AF8FCAB22BD1E5400A967CA /* UnhandledInternalNotifyScenario.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = UnhandledInternalNotifyScenario.swift; sourceTree = "<group>"; };
 		8AF8FCAD22BD23BA00A967CA /* HandledInternalNotifyScenario.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = HandledInternalNotifyScenario.swift; sourceTree = "<group>"; };
 		967F6F1129B2236A0054EED8 /* InternalWorkingsScenario.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = InternalWorkingsScenario.swift; sourceTree = "<group>"; };
+		96A25F312D66AFAE00A18116 /* ObjCExceptionFeatureFlagsScenario.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; path = ObjCExceptionFeatureFlagsScenario.m; sourceTree = "<group>"; };
 		A1117E542535A59100014FDA /* OOMLoadScenario.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = OOMLoadScenario.swift; sourceTree = "<group>"; };
 		A1117E562535B22300014FDA /* OOMAutoDetectErrorsScenario.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = OOMAutoDetectErrorsScenario.swift; sourceTree = "<group>"; };
 		A1117E582535B29800014FDA /* OOMEnabledErrorTypesScenario.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = OOMEnabledErrorTypesScenario.swift; sourceTree = "<group>"; };
@@ -545,6 +547,7 @@
 				8A096DFB27C7E77600DB6ECC /* CxxBareThrowScenario.mm */,
 				010BAAFA2833CE570003FF36 /* CxxExceptionOverrideScenario.mm */,
 				F429550B682F8F9677305881 /* CxxExceptionScenario.mm */,
+				09F025162BAD7B04007D9F73 /* DelayedNotifyErrorScenario.swift */,
 				010BAAF42833CE570003FF36 /* DisableAllExceptManualExceptionsAndCrashScenario.m */,
 				010BAB402833D2AA0003FF36 /* DisabledReleaseStageAutoSessionScenario.swift */,
 				010BAB3C2833D2890003FF36 /* DisabledReleaseStageManualSessionScenario.swift */,
@@ -595,6 +598,7 @@
 				E753F24524927409001FB671 /* NotifyCallbackCrashScenario.swift */,
 				8A32DB8122424E3000EDD92F /* NSExceptionShiftScenario.m */,
 				F4295E86DC0BE9DC731B0D1C /* NullPointerScenario.m */,
+				96A25F312D66AFAE00A18116 /* ObjCExceptionFeatureFlagsScenario.m */,
 				010BAAF52833CE570003FF36 /* ObjCExceptionOverrideScenario.m */,
 				F429521A8EEB435DCB6EACE1 /* ObjCExceptionScenario.m */,
 				F429511ED32FC9FB46649CAE /* ObjCMsgSendScenario.m */,
@@ -680,7 +684,6 @@
 				010BAAF22833CE570003FF36 /* UserPersistencePersistUserClientScenario.m */,
 				010BAAF82833CE570003FF36 /* UserPersistencePersistUserScenario.m */,
 				E700EE49247D1164008CFFB6 /* UserSessionOverrideScenario.swift */,
-				09F025162BAD7B04007D9F73 /* DelayedNotifyErrorScenario.swift */,
 			);
 			name = scenarios;
 			path = ../shared/scenarios;
@@ -948,6 +951,7 @@
 				010BAB332833D1E80003FF36 /* UnhandledErrorInvalidReleaseStageScenario.swift in Sources */,
 				E700EE4E247D1317008CFFB6 /* UserFromClientScenario.swift in Sources */,
 				E7B79CDA24800A5D0039FB88 /* MetadataMergeScenario.swift in Sources */,
+				96A25F322D66AFAE00A18116 /* ObjCExceptionFeatureFlagsScenario.m in Sources */,
 				E7B79CD8247FD7810039FB88 /* AutoContextNSExceptionScenario.swift in Sources */,
 				010BAB3B2833D2280003FF36 /* UnhandledErrorValidReleaseStageScenario.swift in Sources */,
 				010BDFB92885562D007025F9 /* ReportBackgroundAppHangScenario.swift in Sources */,

--- a/features/fixtures/ios/iOSTestAppXcFramework.xcodeproj/project.pbxproj
+++ b/features/fixtures/ios/iOSTestAppXcFramework.xcodeproj/project.pbxproj
@@ -120,6 +120,7 @@
 		8AF8FCAC22BD1E5400A967CA /* UnhandledInternalNotifyScenario.swift in Sources */ = {isa = PBXBuildFile; fileRef = 8AF8FCAB22BD1E5400A967CA /* UnhandledInternalNotifyScenario.swift */; };
 		8AF8FCAE22BD23BA00A967CA /* HandledInternalNotifyScenario.swift in Sources */ = {isa = PBXBuildFile; fileRef = 8AF8FCAD22BD23BA00A967CA /* HandledInternalNotifyScenario.swift */; };
 		967F6F1229B2236A0054EED8 /* InternalWorkingsScenario.swift in Sources */ = {isa = PBXBuildFile; fileRef = 967F6F1129B2236A0054EED8 /* InternalWorkingsScenario.swift */; };
+		96A25F342D66AFCC00A18116 /* ObjCExceptionFeatureFlagsScenario.m in Sources */ = {isa = PBXBuildFile; fileRef = 96A25F332D66AFCC00A18116 /* ObjCExceptionFeatureFlagsScenario.m */; };
 		A1117E552535A59100014FDA /* OOMLoadScenario.swift in Sources */ = {isa = PBXBuildFile; fileRef = A1117E542535A59100014FDA /* OOMLoadScenario.swift */; };
 		A1117E572535B22300014FDA /* OOMAutoDetectErrorsScenario.swift in Sources */ = {isa = PBXBuildFile; fileRef = A1117E562535B22300014FDA /* OOMAutoDetectErrorsScenario.swift */; };
 		A1117E592535B29800014FDA /* OOMEnabledErrorTypesScenario.swift in Sources */ = {isa = PBXBuildFile; fileRef = A1117E582535B29800014FDA /* OOMEnabledErrorTypesScenario.swift */; };
@@ -343,6 +344,7 @@
 		8AF8FCAB22BD1E5400A967CA /* UnhandledInternalNotifyScenario.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = UnhandledInternalNotifyScenario.swift; sourceTree = "<group>"; };
 		8AF8FCAD22BD23BA00A967CA /* HandledInternalNotifyScenario.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = HandledInternalNotifyScenario.swift; sourceTree = "<group>"; };
 		967F6F1129B2236A0054EED8 /* InternalWorkingsScenario.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = InternalWorkingsScenario.swift; sourceTree = "<group>"; };
+		96A25F332D66AFCC00A18116 /* ObjCExceptionFeatureFlagsScenario.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; path = ObjCExceptionFeatureFlagsScenario.m; sourceTree = "<group>"; };
 		A1117E542535A59100014FDA /* OOMLoadScenario.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = OOMLoadScenario.swift; sourceTree = "<group>"; };
 		A1117E562535B22300014FDA /* OOMAutoDetectErrorsScenario.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = OOMAutoDetectErrorsScenario.swift; sourceTree = "<group>"; };
 		A1117E582535B29800014FDA /* OOMEnabledErrorTypesScenario.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = OOMEnabledErrorTypesScenario.swift; sourceTree = "<group>"; };
@@ -562,6 +564,7 @@
 				8A096DFB27C7E77600DB6ECC /* CxxBareThrowScenario.mm */,
 				010BAAFA2833CE570003FF36 /* CxxExceptionOverrideScenario.mm */,
 				F429550B682F8F9677305881 /* CxxExceptionScenario.mm */,
+				09F025162BAD7B04007D9F73 /* DelayedNotifyErrorScenario.swift */,
 				010BAAF42833CE570003FF36 /* DisableAllExceptManualExceptionsAndCrashScenario.m */,
 				010BAB402833D2AA0003FF36 /* DisabledReleaseStageAutoSessionScenario.swift */,
 				010BAB3C2833D2890003FF36 /* DisabledReleaseStageManualSessionScenario.swift */,
@@ -612,6 +615,7 @@
 				E753F24524927409001FB671 /* NotifyCallbackCrashScenario.swift */,
 				8A32DB8122424E3000EDD92F /* NSExceptionShiftScenario.m */,
 				F4295E86DC0BE9DC731B0D1C /* NullPointerScenario.m */,
+				96A25F332D66AFCC00A18116 /* ObjCExceptionFeatureFlagsScenario.m */,
 				010BAAF52833CE570003FF36 /* ObjCExceptionOverrideScenario.m */,
 				F429521A8EEB435DCB6EACE1 /* ObjCExceptionScenario.m */,
 				F429511ED32FC9FB46649CAE /* ObjCMsgSendScenario.m */,
@@ -697,7 +701,6 @@
 				010BAAF22833CE570003FF36 /* UserPersistencePersistUserClientScenario.m */,
 				010BAAF82833CE570003FF36 /* UserPersistencePersistUserScenario.m */,
 				E700EE49247D1164008CFFB6 /* UserSessionOverrideScenario.swift */,
-				09F025162BAD7B04007D9F73 /* DelayedNotifyErrorScenario.swift */,
 			);
 			name = scenarios;
 			path = ../shared/scenarios;
@@ -966,6 +969,7 @@
 				010BAB332833D1E80003FF36 /* UnhandledErrorInvalidReleaseStageScenario.swift in Sources */,
 				E700EE4E247D1317008CFFB6 /* UserFromClientScenario.swift in Sources */,
 				E7B79CDA24800A5D0039FB88 /* MetadataMergeScenario.swift in Sources */,
+				96A25F342D66AFCC00A18116 /* ObjCExceptionFeatureFlagsScenario.m in Sources */,
 				E7B79CD8247FD7810039FB88 /* AutoContextNSExceptionScenario.swift in Sources */,
 				010BAB3B2833D2280003FF36 /* UnhandledErrorValidReleaseStageScenario.swift in Sources */,
 				010BDFB92885562D007025F9 /* ReportBackgroundAppHangScenario.swift in Sources */,

--- a/features/fixtures/macos/macOSTestApp.xcodeproj/project.pbxproj
+++ b/features/fixtures/macos/macOSTestApp.xcodeproj/project.pbxproj
@@ -194,6 +194,7 @@
 		09F025132BA30240007D9F73 /* CommandReaderThread.swift in Sources */ = {isa = PBXBuildFile; fileRef = 09F025122BA30240007D9F73 /* CommandReaderThread.swift */; };
 		8A096DFA27C7E6D800DB6ECC /* CxxBareThrowScenario.mm in Sources */ = {isa = PBXBuildFile; fileRef = 8A096DF927C7E6D800DB6ECC /* CxxBareThrowScenario.mm */; };
 		967F6F1629B767CE0054EED8 /* InternalWorkingsScenario.swift in Sources */ = {isa = PBXBuildFile; fileRef = 967F6F1529B767CE0054EED8 /* InternalWorkingsScenario.swift */; };
+		96A25F362D66B55E00A18116 /* ObjCExceptionFeatureFlagsScenario.m in Sources */ = {isa = PBXBuildFile; fileRef = 96A25F352D66B55E00A18116 /* ObjCExceptionFeatureFlagsScenario.m */; };
 		AA4C7F1829AEA31D009B09A9 /* BugsnagWrapper.swift in Sources */ = {isa = PBXBuildFile; fileRef = AA4C7F1729AEA31D009B09A9 /* BugsnagWrapper.swift */; };
 		AA6ACD1A2773E098006464C4 /* UserFromConfigScenario.swift in Sources */ = {isa = PBXBuildFile; fileRef = AA6ACD192773E098006464C4 /* UserFromConfigScenario.swift */; };
 		AA6ACD1E2773E39C006464C4 /* UserInfoScenario.swift in Sources */ = {isa = PBXBuildFile; fileRef = AA6ACD1D2773E39C006464C4 /* UserInfoScenario.swift */; };
@@ -415,6 +416,7 @@
 		09F025122BA30240007D9F73 /* CommandReaderThread.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = CommandReaderThread.swift; sourceTree = "<group>"; };
 		8A096DF927C7E6D800DB6ECC /* CxxBareThrowScenario.mm */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.cpp.objcpp; path = CxxBareThrowScenario.mm; sourceTree = "<group>"; };
 		967F6F1529B767CE0054EED8 /* InternalWorkingsScenario.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = InternalWorkingsScenario.swift; sourceTree = "<group>"; };
+		96A25F352D66B55E00A18116 /* ObjCExceptionFeatureFlagsScenario.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; path = ObjCExceptionFeatureFlagsScenario.m; sourceTree = "<group>"; };
 		AA4C7F1729AEA31D009B09A9 /* BugsnagWrapper.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = BugsnagWrapper.swift; sourceTree = "<group>"; };
 		AA6ACD192773E098006464C4 /* UserFromConfigScenario.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = UserFromConfigScenario.swift; sourceTree = "<group>"; };
 		AA6ACD1D2773E39C006464C4 /* UserInfoScenario.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = UserInfoScenario.swift; sourceTree = "<group>"; };
@@ -536,6 +538,7 @@
 				01F47C5E254B1B2E00B184AD /* NotifyCallbackCrashScenario.swift */,
 				01F47C99254B1B2F00B184AD /* NSExceptionShiftScenario.m */,
 				01F47C34254B1B2D00B184AD /* NullPointerScenario.m */,
+				96A25F352D66B55E00A18116 /* ObjCExceptionFeatureFlagsScenario.m */,
 				017D9CF92833C81100B0AA87 /* ObjCExceptionOverrideScenario.m */,
 				01F47C36254B1B2D00B184AD /* ObjCExceptionScenario.m */,
 				01F47CAB254B1B3000B184AD /* ObjCMsgSendScenario.m */,
@@ -768,6 +771,7 @@
 				01F115C727BAA67B00892B1E /* SIGPIPEIgnoredScenario.m in Sources */,
 				017DCFA228744035000ECB22 /* TelemetryUsageDisabledScenario.swift in Sources */,
 				01F7365A278D90440000113C /* NetworkBreadcrumbsScenario.swift in Sources */,
+				96A25F362D66B55E00A18116 /* ObjCExceptionFeatureFlagsScenario.m in Sources */,
 				01F47CCA254B1B3100B184AD /* ManualSessionScenario.m in Sources */,
 				01F47D31254B1B3100B184AD /* OverwriteLinkRegisterScenario.m in Sources */,
 				01F47D08254B1B3100B184AD /* AutoSessionCustomVersionScenario.m in Sources */,

--- a/features/fixtures/macos/macOSTestAppXcFramework.xcodeproj/project.pbxproj
+++ b/features/fixtures/macos/macOSTestAppXcFramework.xcodeproj/project.pbxproj
@@ -189,6 +189,7 @@
 		09F1E35B2CDCCAAF007F5933 /* Bugsnag.xcframework in Embed Frameworks */ = {isa = PBXBuildFile; fileRef = 09F1E3572CDCCA8D007F5933 /* Bugsnag.xcframework */; settings = {ATTRIBUTES = (CodeSignOnCopy, RemoveHeadersOnCopy, ); }; };
 		09F1E35D2CDCCAB2007F5933 /* BugsnagNetworkRequestPlugin.xcframework in Frameworks */ = {isa = PBXBuildFile; fileRef = 09F1E3562CDCCA8D007F5933 /* BugsnagNetworkRequestPlugin.xcframework */; };
 		09F1E35E2CDCCAB2007F5933 /* BugsnagNetworkRequestPlugin.xcframework in Embed Frameworks */ = {isa = PBXBuildFile; fileRef = 09F1E3562CDCCA8D007F5933 /* BugsnagNetworkRequestPlugin.xcframework */; settings = {ATTRIBUTES = (CodeSignOnCopy, RemoveHeadersOnCopy, ); }; };
+		96A25F382D66B57E00A18116 /* ObjCExceptionFeatureFlagsScenario.m in Sources */ = {isa = PBXBuildFile; fileRef = 96A25F372D66B57E00A18116 /* ObjCExceptionFeatureFlagsScenario.m */; };
 /* End PBXBuildFile section */
 
 /* Begin PBXCopyFilesBuildPhase section */
@@ -399,6 +400,7 @@
 		09F1E3562CDCCA8D007F5933 /* BugsnagNetworkRequestPlugin.xcframework */ = {isa = PBXFileReference; lastKnownFileType = wrapper.xcframework; name = BugsnagNetworkRequestPlugin.xcframework; path = ../../../../build/xcframeworks/products/BugsnagNetworkRequestPlugin.xcframework; sourceTree = "<group>"; };
 		09F1E3572CDCCA8D007F5933 /* Bugsnag.xcframework */ = {isa = PBXFileReference; lastKnownFileType = wrapper.xcframework; name = Bugsnag.xcframework; path = ../../../../build/xcframeworks/products/Bugsnag.xcframework; sourceTree = "<group>"; };
 		710618F62CF0BBCE00423249 /* Info.plist */ = {isa = PBXFileReference; lastKnownFileType = text.plist; path = Info.plist; sourceTree = "<group>"; };
+		96A25F372D66B57E00A18116 /* ObjCExceptionFeatureFlagsScenario.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; path = ObjCExceptionFeatureFlagsScenario.m; sourceTree = "<group>"; };
 /* End PBXFileReference section */
 
 /* Begin PBXFrameworksBuildPhase section */
@@ -535,6 +537,7 @@
 				09AABBB62CDCED61007D6FC0 /* NotifyCallbackCrashScenario.swift */,
 				09AABBB72CDCED61007D6FC0 /* NSExceptionShiftScenario.m */,
 				09AABBB82CDCED61007D6FC0 /* NullPointerScenario.m */,
+				96A25F372D66B57E00A18116 /* ObjCExceptionFeatureFlagsScenario.m */,
 				09AABBB92CDCED61007D6FC0 /* ObjCExceptionOverrideScenario.m */,
 				09AABBBA2CDCED61007D6FC0 /* ObjCExceptionScenario.m */,
 				09AABBBB2CDCED61007D6FC0 /* ObjCMsgSendScenario.m */,
@@ -893,6 +896,7 @@
 				09AABCBB2CDCED61007D6FC0 /* UnhandledMachExceptionOverrideScenario.m in Sources */,
 				09AABC1A2CDCED61007D6FC0 /* AppDurationScenario.swift in Sources */,
 				09AABC742CDCED61007D6FC0 /* ObjCExceptionOverrideScenario.m in Sources */,
+				96A25F382D66B57E00A18116 /* ObjCExceptionFeatureFlagsScenario.m in Sources */,
 				09AABC712CDCED61007D6FC0 /* NotifyCallbackCrashScenario.swift in Sources */,
 				09AABCB92CDCED61007D6FC0 /* UnhandledErrorValidReleaseStageScenario.swift in Sources */,
 				09AABC282CDCED61007D6FC0 /* AutoContextNSExceptionScenario.swift in Sources */,

--- a/features/fixtures/shared/scenarios/ObjCExceptionFeatureFlagsScenario.m
+++ b/features/fixtures/shared/scenarios/ObjCExceptionFeatureFlagsScenario.m
@@ -1,0 +1,25 @@
+#import "MarkUnhandledHandledScenario.h"
+#import "Logging.h"
+#import <Bugsnag/Bugsnag.h>
+
+@interface ObjCExceptionFeatureFlagsScenario: Scenario
+@end
+
+@implementation ObjCExceptionFeatureFlagsScenario
+
+- (void)configure {
+    [super configure];
+    self.config.autoTrackSessions = NO;
+}
+
+- (void)run  __attribute__((noreturn)) {
+    [Bugsnag addFeatureFlagWithName:@"Feature Flag1" variant: @"Variant1"];
+    [Bugsnag addFeatureFlagWithName:@"Feature Flag2" variant: @"Variant2"];
+    [Bugsnag addFeatureFlagWithName:@"Feature Flag3" variant: @"Variant3"];
+    [Bugsnag addFeatureFlagWithName:@"Feature Flag4"];
+    [Bugsnag clearFeatureFlagWithName:@"Feature Flag2"];
+    @throw [NSException exceptionWithName:NSGenericException reason:@"An uncaught exception"
+                                 userInfo:@{NSLocalizedDescriptionKey: @""}];
+}
+
+@end


### PR DESCRIPTION
## Goal

Due to a bug in BSGAtomicFeatureFlagStore, feature flags that are cleared by name were not removed completely and would appear in crash reports

## Changeset

Fixed the implementation of BSGAtomicFeatureFlagStore.

## Testing

E2E tests