### PR TITLE
[PLAT-13625] Move to new macOs 10.13 and 10.14 queue

### DIFF
--- a/.buildkite/pipeline.full.yml
+++ b/.buildkite/pipeline.full.yml
@@ -165,7 +165,7 @@ steps:
       - xcframework_cocoa_fixture
     timeout_in_minutes: 10
     agents:
-      queue: opensource-mac-cocoa-10.13
+      queue: macos-10.13
     plugins:
       artifacts#v1.9.3:
         download: "features/fixtures/macos/output/macOSTestAppXcFramework.zip"
@@ -812,7 +812,7 @@ steps:
       - cocoa_fixture
     timeout_in_minutes: 60
     agents:
-      queue: opensource-mac-cocoa-10.13
+      queue: macos-10.13
     plugins:
       artifacts#v1.9.3:
         download: ["features/fixtures/macos/output/macOSTestApp_Release.zip"]

--- a/.buildkite/pipeline.full.yml
+++ b/.buildkite/pipeline.full.yml
@@ -795,7 +795,7 @@ steps:
       - cocoa_fixture
     timeout_in_minutes: 60
     agents:
-      queue: opensource-mac-cocoa-10.14
+      queue: macos-10.14
     plugins:
       artifacts#v1.9.3:
         download: ["features/fixtures/macos/output/macOSTestApp_Release.zip"]

--- a/.buildkite/pipeline.yml
+++ b/.buildkite/pipeline.yml
@@ -113,7 +113,7 @@ steps:
   - label: macOS 10.14 unit tests
     timeout_in_minutes: 10
     agents:
-      queue: opensource-mac-cocoa-10.14
+      queue: macos-10.14
     commands:
       - ./scripts/run-unit-tests.sh PLATFORM=macOS
     artifact_paths:
@@ -329,7 +329,7 @@ steps:
       - cocoa_fixture
     timeout_in_minutes: 10
     agents:
-      queue: opensource-mac-cocoa-10.14
+      queue: macos-10.14
     plugins:
       artifacts#v1.5.0:
         download: "features/fixtures/macos/output/macOSTestApp_Release.zip"

--- a/.buildkite/pipeline.yml
+++ b/.buildkite/pipeline.yml
@@ -122,7 +122,7 @@ steps:
   - label: macOS 10.13 unit tests
     timeout_in_minutes: 10
     agents:
-      queue: opensource-mac-cocoa-10.13
+      queue: macos-10.13
     commands:
       - ./scripts/run-unit-tests.sh PLATFORM=macOS
     artifact_paths:
@@ -348,7 +348,7 @@ steps:
       - cocoa_fixture
     timeout_in_minutes: 10
     agents:
-      queue: opensource-mac-cocoa-10.13
+      queue: macos-10.13
     plugins:
       artifacts#v1.5.0:
         download: "features/fixtures/macos/output/macOSTestApp_Release.zip"
@@ -752,7 +752,7 @@ steps:
       - cocoa_fixture
     timeout_in_minutes: 10
     agents:
-      queue: opensource-mac-cocoa-10.13
+      queue: macos-10.13
     plugins:
       artifacts#v1.5.0:
         download: "features/fixtures/macos/output/macOSTestApp_Debug.zip"


### PR DESCRIPTION
## Goal

Move the macos 10.13 and 10.14 tests to a new queue.

## Testing

Covered by CI