### PR TITLE
Use Maze Runner API classes for performing Appium operations

### DIFF
--- a/features/steps/app_steps.rb
+++ b/features/steps/app_steps.rb
@@ -58,10 +58,11 @@ end
 # 4: The application is running in the foreground
 
 Then('the app is not running') do
+  manager = Maze::Api::Appium::AppManager.new
   wait_for_true('the app is not running') do
     case Maze::Helper.get_current_platform
     when 'ios'
-      Maze.driver.app_state('com.bugsnag.fixtures.cocoa') == :not_running
+      manager.state == :not_running
     else
       raise "Don't know how to query app state on this platform"
     end
@@ -115,7 +116,8 @@ def relaunch_crashed_app
   when 'ios'
     # Wait for the app to stop running before relaunching
     step 'the app is not running'
-    Maze.driver.activate_app Maze.driver.app_id
+
+    Maze::Api::Appium::AppManager.new.activate
   when 'macos'
     sleep 4
     launch_app
@@ -131,8 +133,9 @@ end
 def kill_and_relaunch_app
   case Maze::Helper.get_current_platform
   when 'ios'
-    Maze.driver.terminate_app Maze.driver&.app_id
-    Maze.driver.activate_app Maze.driver.app_id
+    manager = Maze::Api::Appium::AppManager.new
+    manager.terminate
+    manager.activate
   when 'macos'
     run_macos_app # This will kill the app if it's running
   when 'watchos'

--- a/features/support/env.rb
+++ b/features/support/env.rb
@@ -160,11 +160,12 @@ Maze.hooks.after do |scenario|
       end
     end
   when 'ios'
+    manager = Maze::Api::Appium::FileManager.new
     begin
-      data = Maze.driver.pull_file '@com.bugsnag.fixtures.cocoa/Documents/kscrash.log'
+      data = manager.read_app_file 'kscrash.log'
       File.open(File.join(path, 'kscrash.log'), 'wb') { |file| file << data }
     rescue StandardError
-      puts "Maze.driver.pull_file failed: #{$ERROR_INFO}"
+      puts "read_app_file failed: #{$ERROR_INFO}"
     end
   end
 end


### PR DESCRIPTION
## Goal

Use Maze Runner API classes for performing Appium operations, instead of accessing the raw Appium driver directly.

## Design

With this approach, Maze Runner will then handle driver failures and skip remaining scenarios if the driver fails, instead of continuing to use a failed driver and generate noise in both the console log and our Bugsnag dashboard for Maze Runner.

## Testing

Covered by a basic CI run.