### PR TITLE
Fixed a bug causing heap corruption in BSGAtomicFeatureFlagStore

### DIFF
--- a/Bugsnag.xcodeproj/project.pbxproj
+++ b/Bugsnag.xcodeproj/project.pbxproj
@@ -521,9 +521,9 @@
 		010993A0273D13D800128BBE /* BSGMemoryFeatureFlagStore.m in Sources */ = {isa = PBXBuildFile; fileRef = 0109939B273D13D800128BBE /* BSGMemoryFeatureFlagStore.m */; };
 		010993A1273D13D800128BBE /* BSGMemoryFeatureFlagStore.m in Sources */ = {isa = PBXBuildFile; fileRef = 0109939B273D13D800128BBE /* BSGMemoryFeatureFlagStore.m */; };
 		010993A2273D13D800128BBE /* BSGMemoryFeatureFlagStore.m in Sources */ = {isa = PBXBuildFile; fileRef = 0109939B273D13D800128BBE /* BSGMemoryFeatureFlagStore.m */; };
-		010993A4273D188B00128BBE /* BSGFeatureFlagStoreTests.m in Sources */ = {isa = PBXBuildFile; fileRef = 010993A3273D188B00128BBE /* BSGFeatureFlagStoreTests.m */; };
-		010993A5273D188B00128BBE /* BSGFeatureFlagStoreTests.m in Sources */ = {isa = PBXBuildFile; fileRef = 010993A3273D188B00128BBE /* BSGFeatureFlagStoreTests.m */; };
-		010993A6273D188B00128BBE /* BSGFeatureFlagStoreTests.m in Sources */ = {isa = PBXBuildFile; fileRef = 010993A3273D188B00128BBE /* BSGFeatureFlagStoreTests.m */; };
+		010993A4273D188B00128BBE /* BSGMemoryFeatureFlagStoreTests.m in Sources */ = {isa = PBXBuildFile; fileRef = 010993A3273D188B00128BBE /* BSGMemoryFeatureFlagStoreTests.m */; };
+		010993A5273D188B00128BBE /* BSGMemoryFeatureFlagStoreTests.m in Sources */ = {isa = PBXBuildFile; fileRef = 010993A3273D188B00128BBE /* BSGMemoryFeatureFlagStoreTests.m */; };
+		010993A6273D188B00128BBE /* BSGMemoryFeatureFlagStoreTests.m in Sources */ = {isa = PBXBuildFile; fileRef = 010993A3273D188B00128BBE /* BSGMemoryFeatureFlagStoreTests.m */; };
 		010993B1273D2F6200128BBE /* BugsnagFeatureFlagStore.h in Headers */ = {isa = PBXBuildFile; fileRef = 010993B0273D2F6100128BBE /* BugsnagFeatureFlagStore.h */; settings = {ATTRIBUTES = (Public, ); }; };
 		010993B2273D2F6200128BBE /* BugsnagFeatureFlagStore.h in Headers */ = {isa = PBXBuildFile; fileRef = 010993B0273D2F6100128BBE /* BugsnagFeatureFlagStore.h */; settings = {ATTRIBUTES = (Public, ); }; };
 		010993B3273D2F6200128BBE /* BugsnagFeatureFlagStore.h in Headers */ = {isa = PBXBuildFile; fileRef = 010993B0273D2F6100128BBE /* BugsnagFeatureFlagStore.h */; settings = {ATTRIBUTES = (Public, ); }; };
@@ -832,6 +832,14 @@
 		3A700AF824A6492F0068CD1B /* BugsnagError.h in CopyFiles */ = {isa = PBXBuildFile; fileRef = 3A700A9124A63A8E0068CD1B /* BugsnagError.h */; };
 		3A700AF924A6492F0068CD1B /* BugsnagDeviceWithState.h in CopyFiles */ = {isa = PBXBuildFile; fileRef = 3A700A9224A63A8E0068CD1B /* BugsnagDeviceWithState.h */; };
 		3A700AFA24A6492F0068CD1B /* BugsnagMetadata.h in CopyFiles */ = {isa = PBXBuildFile; fileRef = 3A700A9324A63A8E0068CD1B /* BugsnagMetadata.h */; };
+		9627A1352D91CF9300696E3C /* BSGAtomicFeatureFlagStoreTests.m in Sources */ = {isa = PBXBuildFile; fileRef = 9627A1342D91CF9300696E3C /* BSGAtomicFeatureFlagStoreTests.m */; };
+		9627A1362D91CF9300696E3C /* BSGAtomicFeatureFlagStoreTests.m in Sources */ = {isa = PBXBuildFile; fileRef = 9627A1342D91CF9300696E3C /* BSGAtomicFeatureFlagStoreTests.m */; };
+		9627A1372D91CF9300696E3C /* BSGAtomicFeatureFlagStoreTests.m in Sources */ = {isa = PBXBuildFile; fileRef = 9627A1342D91CF9300696E3C /* BSGAtomicFeatureFlagStoreTests.m */; };
+		9627A1382D91CF9300696E3C /* BSGAtomicFeatureFlagStoreTests.m in Sources */ = {isa = PBXBuildFile; fileRef = 9627A1342D91CF9300696E3C /* BSGAtomicFeatureFlagStoreTests.m */; };
+		9627A13B2D92201B00696E3C /* WriterTestsSupport.m in Sources */ = {isa = PBXBuildFile; fileRef = 9627A13A2D92201B00696E3C /* WriterTestsSupport.m */; };
+		9627A13C2D92201B00696E3C /* WriterTestsSupport.m in Sources */ = {isa = PBXBuildFile; fileRef = 9627A13A2D92201B00696E3C /* WriterTestsSupport.m */; };
+		9627A13D2D92201B00696E3C /* WriterTestsSupport.m in Sources */ = {isa = PBXBuildFile; fileRef = 9627A13A2D92201B00696E3C /* WriterTestsSupport.m */; };
+		9627A13E2D92201B00696E3C /* WriterTestsSupport.m in Sources */ = {isa = PBXBuildFile; fileRef = 9627A13A2D92201B00696E3C /* WriterTestsSupport.m */; };
 		968BFBCB2D011BBB00DCC24B /* BSGPersistentFeatureFlagStore.h in Headers */ = {isa = PBXBuildFile; fileRef = 968BFBC92D011BBB00DCC24B /* BSGPersistentFeatureFlagStore.h */; };
 		968BFBCC2D011BBB00DCC24B /* BSGPersistentFeatureFlagStore.m in Sources */ = {isa = PBXBuildFile; fileRef = 968BFBCA2D011BBB00DCC24B /* BSGPersistentFeatureFlagStore.m */; };
 		968BFBCD2D011BC300DCC24B /* BSGPersistentFeatureFlagStore.h in Headers */ = {isa = PBXBuildFile; fileRef = 968BFBC92D011BBB00DCC24B /* BSGPersistentFeatureFlagStore.h */; };
@@ -899,7 +907,7 @@
 		CB28F0B428294DE1003AB200 /* BSGJSONSerializationTests.m in Sources */ = {isa = PBXBuildFile; fileRef = CBCF77AA250142E0004AF22A /* BSGJSONSerializationTests.m */; };
 		CB28F0B528294DE1003AB200 /* BSGEventUploadKSCrashReportOperationTests.m in Sources */ = {isa = PBXBuildFile; fileRef = 01BDB1CE25DEBF4600A91FAF /* BSGEventUploadKSCrashReportOperationTests.m */; };
 		CB28F0B628294DE1003AB200 /* BSGInternalErrorReporterTests.m in Sources */ = {isa = PBXBuildFile; fileRef = 01847DAB26441A5E00ADA4C7 /* BSGInternalErrorReporterTests.m */; };
-		CB28F0B728294DE1003AB200 /* BSGFeatureFlagStoreTests.m in Sources */ = {isa = PBXBuildFile; fileRef = 010993A3273D188B00128BBE /* BSGFeatureFlagStoreTests.m */; };
+		CB28F0B728294DE1003AB200 /* BSGMemoryFeatureFlagStoreTests.m in Sources */ = {isa = PBXBuildFile; fileRef = 010993A3273D188B00128BBE /* BSGMemoryFeatureFlagStoreTests.m */; };
 		CB28F0B828294DE1003AB200 /* BSGConfigurationBuilderTests.m in Sources */ = {isa = PBXBuildFile; fileRef = 00896A3F2486DBDD00DC48C2 /* BSGConfigurationBuilderTests.m */; };
 		CB28F0B928294DE1003AB200 /* BSGNotificationBreadcrumbsTests.m in Sources */ = {isa = PBXBuildFile; fileRef = 0163BF5825823D8D008DC28B /* BSGNotificationBreadcrumbsTests.m */; };
 		CB28F0BB282A4817003AB200 /* Data in Resources */ = {isa = PBXBuildFile; fileRef = 01BDB21425DEC02900A91FAF /* Data */; };
@@ -1525,7 +1533,7 @@
 		01099392273D123800128BBE /* BugsnagFeatureFlag.m */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.objc; path = BugsnagFeatureFlag.m; sourceTree = "<group>"; };
 		0109939A273D13D800128BBE /* BSGMemoryFeatureFlagStore.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; path = BSGMemoryFeatureFlagStore.h; sourceTree = "<group>"; };
 		0109939B273D13D800128BBE /* BSGMemoryFeatureFlagStore.m */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.objc; path = BSGMemoryFeatureFlagStore.m; sourceTree = "<group>"; };
-		010993A3273D188B00128BBE /* BSGFeatureFlagStoreTests.m */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.objc; path = BSGFeatureFlagStoreTests.m; sourceTree = "<group>"; };
+		010993A3273D188B00128BBE /* BSGMemoryFeatureFlagStoreTests.m */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.objc; path = BSGMemoryFeatureFlagStoreTests.m; sourceTree = "<group>"; };
 		010993B0273D2F6100128BBE /* BugsnagFeatureFlagStore.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = BugsnagFeatureFlagStore.h; sourceTree = "<group>"; };
 		010F80C128645B4200D6569E /* BSGDefinesTests.m */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.objc; path = BSGDefinesTests.m; sourceTree = "<group>"; };
 		010FF28225ED2A8D00E4F2B0 /* BSGAppHangDetector.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; path = BSGAppHangDetector.h; sourceTree = "<group>"; };
@@ -1640,6 +1648,9 @@
 		3A700A9124A63A8E0068CD1B /* BugsnagError.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; path = BugsnagError.h; sourceTree = "<group>"; };
 		3A700A9224A63A8E0068CD1B /* BugsnagDeviceWithState.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; path = BugsnagDeviceWithState.h; sourceTree = "<group>"; };
 		3A700A9324A63A8E0068CD1B /* BugsnagMetadata.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; path = BugsnagMetadata.h; sourceTree = "<group>"; };
+		9627A1342D91CF9300696E3C /* BSGAtomicFeatureFlagStoreTests.m */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.objc; path = BSGAtomicFeatureFlagStoreTests.m; sourceTree = "<group>"; };
+		9627A1392D92200300696E3C /* WriterTestsSupport.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; path = WriterTestsSupport.h; sourceTree = "<group>"; };
+		9627A13A2D92201B00696E3C /* WriterTestsSupport.m */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.objc; path = WriterTestsSupport.m; sourceTree = "<group>"; };
 		968BFBC92D011BBB00DCC24B /* BSGPersistentFeatureFlagStore.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = BSGPersistentFeatureFlagStore.h; sourceTree = "<group>"; };
 		968BFBCA2D011BBB00DCC24B /* BSGPersistentFeatureFlagStore.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; path = BSGPersistentFeatureFlagStore.m; sourceTree = "<group>"; };
 		968BFBD42D0125C700DCC24B /* BSGStoredFeatureFlag.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; path = BSGStoredFeatureFlag.m; sourceTree = "<group>"; };
@@ -2028,14 +2039,15 @@
 			isa = PBXGroup;
 			children = (
 				019480D32625F3EB00E833ED /* BSGAppKitTests.m */,
+				9627A1342D91CF9300696E3C /* BSGAtomicFeatureFlagStoreTests.m */,
 				008966BD2486D43500DC48C2 /* BSGClientObserverTests.m */,
 				00896A3F2486DBDD00DC48C2 /* BSGConfigurationBuilderTests.m */,
 				008966C62486D43600DC48C2 /* BSGConnectivityTest.m */,
 				010F80C128645B4200D6569E /* BSGDefinesTests.m */,
 				01BDB1CE25DEBF4600A91FAF /* BSGEventUploadKSCrashReportOperationTests.m */,
-				010993A3273D188B00128BBE /* BSGFeatureFlagStoreTests.m */,
 				01847DAB26441A5E00ADA4C7 /* BSGInternalErrorReporterTests.m */,
 				CBCF77AA250142E0004AF22A /* BSGJSONSerializationTests.m */,
+				010993A3273D188B00128BBE /* BSGMemoryFeatureFlagStoreTests.m */,
 				01A2958528B667C2005FCC8C /* BSGNetworkBreadcrumbTests.m */,
 				0163BF5825823D8D008DC28B /* BSGNotificationBreadcrumbsTests.m */,
 				008966C82486D43600DC48C2 /* BSGOutOfMemoryTests.m */,
@@ -2107,6 +2119,8 @@
 				01E8765C256684E700F4B70A /* URLSessionMock.h */,
 				01E8765D256684E700F4B70A /* URLSessionMock.m */,
 				CB6419B325A7419400613D25 /* v0_files */,
+				9627A1392D92200300696E3C /* WriterTestsSupport.h */,
+				9627A13A2D92201B00696E3C /* WriterTestsSupport.m */,
 			);
 			path = BugsnagTests;
 			sourceTree = "<group>";
@@ -3275,7 +3289,7 @@
 				E701FAAB2490EFD9008D842F /* EventApiValidationTest.m in Sources */,
 				0089677E2486D43700DC48C2 /* KSLogger_Tests.m in Sources */,
 				012482A325627B51003F7243 /* UIKitTests.m in Sources */,
-				010993A4273D188B00128BBE /* BSGFeatureFlagStoreTests.m in Sources */,
+				010993A4273D188B00128BBE /* BSGMemoryFeatureFlagStoreTests.m in Sources */,
 				008967482486D43700DC48C2 /* BugsnagUserTest.m in Sources */,
 				008967962486D43700DC48C2 /* KSCrashState_Tests.m in Sources */,
 				008967122486D43700DC48C2 /* BugsnagEventTests.m in Sources */,
@@ -3289,6 +3303,7 @@
 				01DE903C26CEAF9E00455213 /* BSGUtilsTests.m in Sources */,
 				008966F42486D43700DC48C2 /* BugsnagThreadTests.m in Sources */,
 				008967692486D43700DC48C2 /* BugsnagSessionTrackerTest.m in Sources */,
+				9627A13B2D92201B00696E3C /* WriterTestsSupport.m in Sources */,
 				CB3744A428475F2A00A3955E /* BSG_KSCrashStringConversionTest.m in Sources */,
 				008967032486D43700DC48C2 /* BugsnagThreadSerializationTest.m in Sources */,
 				0089674B2486D43700DC48C2 /* BSGConnectivityTest.m in Sources */,
@@ -3329,6 +3344,7 @@
 				008967392486D43700DC48C2 /* BugsnagEventFromKSCrashReportTest.m in Sources */,
 				008967182486D43700DC48C2 /* BugsnagErrorTest.m in Sources */,
 				004E35352487AFDC007FBAE4 /* BugsnagHandledStateTest.m in Sources */,
+				9627A1352D91CF9300696E3C /* BSGAtomicFeatureFlagStoreTests.m in Sources */,
 				008967932486D43700DC48C2 /* KSSignalInfo_Tests.m in Sources */,
 				008967662486D43700DC48C2 /* BugsnagNotifierTest.m in Sources */,
 				004E35382487B2BC007FBAE4 /* BugsnagSwiftTests.swift in Sources */,
@@ -3467,6 +3483,7 @@
 				008967582486D43700DC48C2 /* BugsnagClientMirrorTest.m in Sources */,
 				0089676A2486D43700DC48C2 /* BugsnagSessionTrackerTest.m in Sources */,
 				008967792486D43700DC48C2 /* BSG_KSMachHeadersTests.m in Sources */,
+				9627A13C2D92201B00696E3C /* WriterTestsSupport.m in Sources */,
 				01847DAD26441A5E00ADA4C7 /* BSGInternalErrorReporterTests.m in Sources */,
 				0089672B2486D43700DC48C2 /* BugsnagStacktraceTest.m in Sources */,
 				008966F22486D43700DC48C2 /* BugsnagMetadataRedactionTest.m in Sources */,
@@ -3500,7 +3517,8 @@
 				0089679D2486D43700DC48C2 /* KSFileUtils_Tests.m in Sources */,
 				010F80C328645B4200D6569E /* BSGDefinesTests.m in Sources */,
 				008967A32486D43700DC48C2 /* KSCrashSentry_Signal_Tests.m in Sources */,
-				010993A5273D188B00128BBE /* BSGFeatureFlagStoreTests.m in Sources */,
+				9627A1362D91CF9300696E3C /* BSGAtomicFeatureFlagStoreTests.m in Sources */,
+				010993A5273D188B00128BBE /* BSGMemoryFeatureFlagStoreTests.m in Sources */,
 				004E353B2487B3B3007FBAE4 /* BugsnagSwiftPublicAPITests.swift in Sources */,
 				0089677C2486D43700DC48C2 /* RFC3339DateTool_Tests.m in Sources */,
 				CBEC89412A4ACD240088A3CE /* FileBasedTest.m in Sources */,
@@ -3630,6 +3648,7 @@
 				008967802486D43700DC48C2 /* KSLogger_Tests.m in Sources */,
 				008967352486D43700DC48C2 /* BugsnagClientTests.m in Sources */,
 				0089679B2486D43700DC48C2 /* FileBasedTestCase.m in Sources */,
+				9627A13D2D92201B00696E3C /* WriterTestsSupport.m in Sources */,
 				008967922486D43700DC48C2 /* KSJSONCodec_Tests.m in Sources */,
 				008967742486D43700DC48C2 /* KSSysCtl_Tests.m in Sources */,
 				010F80C428645B4200D6569E /* BSGDefinesTests.m in Sources */,
@@ -3641,7 +3660,7 @@
 				008966ED2486D43700DC48C2 /* BugsnagDeviceTest.m in Sources */,
 				E701FAAD2490EFD9008D842F /* EventApiValidationTest.m in Sources */,
 				008967472486D43700DC48C2 /* BugsnagTests.m in Sources */,
-				010993A6273D188B00128BBE /* BSGFeatureFlagStoreTests.m in Sources */,
+				010993A6273D188B00128BBE /* BSGMemoryFeatureFlagStoreTests.m in Sources */,
 				01F9FCB828929336005EDD8C /* BSGSerializationTests.m in Sources */,
 				0089671A2486D43700DC48C2 /* BugsnagErrorTest.m in Sources */,
 				008967172486D43700DC48C2 /* BugsnagCollectionsTests.m in Sources */,
@@ -3702,6 +3721,7 @@
 				008967682486D43700DC48C2 /* BugsnagNotifierTest.m in Sources */,
 				01447605256684500018AB94 /* BugsnagApiClientTest.m in Sources */,
 				0187D464255BD7B800C503D9 /* BugsnagApiClientTest.m in Sources */,
+				9627A1372D91CF9300696E3C /* BSGAtomicFeatureFlagStoreTests.m in Sources */,
 				0089676E2486D43700DC48C2 /* BugsnagTestsDummyClass.m in Sources */,
 				0130DEFB2880203A00E5953F /* BSGRunContextTests.m in Sources */,
 				008967412486D43700DC48C2 /* BugsnagAppTest.m in Sources */,
@@ -3936,7 +3956,7 @@
 				093EB6632AFE447E006EB7E3 /* Swizzle.mm in Sources */,
 				CB28F0DC282A4BEE003AB200 /* BugsnagSessionTrackerTest.m in Sources */,
 				093EB6692AFE4580006EB7E3 /* BSGTestCase.mm in Sources */,
-				CB28F0B728294DE1003AB200 /* BSGFeatureFlagStoreTests.m in Sources */,
+				CB28F0B728294DE1003AB200 /* BSGMemoryFeatureFlagStoreTests.m in Sources */,
 				010F80C528645B4200D6569E /* BSGDefinesTests.m in Sources */,
 				CB28F0A028294D44003AB200 /* BSG_KSFileTests.m in Sources */,
 				CB28F09E28294D44003AB200 /* BSG_KSMachHeadersTests.m in Sources */,
@@ -3963,6 +3983,7 @@
 				CB28F0B328294DD0003AB200 /* BSGClientObserverTests.m in Sources */,
 				CB28F0B128294D4F003AB200 /* KSCrashSentry_Tests.m in Sources */,
 				CB28F0B228294D52003AB200 /* XCTestCase+KSCrash.m in Sources */,
+				9627A1382D91CF9300696E3C /* BSGAtomicFeatureFlagStoreTests.m in Sources */,
 				CB28F0AA28294D4F003AB200 /* KSSignalInfo_Tests.m in Sources */,
 				CB28F122282A7D5E003AB200 /* BugsnagTests.m in Sources */,
 				CB28F0A628294D4F003AB200 /* KSCrashSentry_NSException_Tests.m in Sources */,
@@ -3988,6 +4009,7 @@
 				CB28F0D1282A4B91003AB200 /* BugsnagEnabledBreadcrumbTest.m in Sources */,
 				0130DEFC2880203A00E5953F /* BSGRunContextTests.m in Sources */,
 				CB28F125282A7DAB003AB200 /* BugsnagUserTest.m in Sources */,
+				9627A13E2D92201B00696E3C /* WriterTestsSupport.m in Sources */,
 				CB28F09F28294D44003AB200 /* BSG_KSMachTests.m in Sources */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;

--- a/Bugsnag/FeatureFlags/BSGAtomicFeatureFlagStore.m
+++ b/Bugsnag/FeatureFlags/BSGAtomicFeatureFlagStore.m
@@ -130,6 +130,9 @@ static NSMutableDictionary<NSString *, NSValue *> *nameToFlag;
         if (flag->previous) {
             flag->previous->next = flag->next;
         }
+        if (flag->next) {
+            flag->next->previous = flag->previous;
+        }
         if (flag == atomic_load(&g_feature_flags_head)) {
             atomic_store(&g_feature_flags_head, flag->next);
         }

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,13 @@
 Changelog
 =========
 
+## TBD
+
+### Bug Fixes
+
+* Fixed issue that could lead to an invalid pointer when removing a feature flag.
+  [#1754](https://github.com/bugsnag/bugsnag-cocoa/pull/1754)
+
 ## 6.32.1 (2025-02-27)
 
 ### Bug Fixes

--- a/Tests/BugsnagTests/BSGAtomicFeatureFlagStoreTests.m
+++ b/Tests/BugsnagTests/BSGAtomicFeatureFlagStoreTests.m
@@ -1,0 +1,221 @@
+//
+//  BSGAtomicFeatureFlagStoreTests.m
+//  Bugsnag
+//
+//  Created by Robert B on 24/03/2025.
+//  Copyright © 2025 Bugsnag Inc. All rights reserved.
+//
+
+#import "BSGTestCase.h"
+#import "BSGAtomicFeatureFlagStore.h"
+#import "WriterTestsSupport.h"
+#import "BugsnagFeatureFlag.h"
+
+@interface BSGAtomicFeatureFlagStoreTests : BSGTestCase
+
+@end
+
+@implementation BSGAtomicFeatureFlagStoreTests
+
+- (void)setUp {
+    BSGAtomicFeatureFlagStore *store = [BSGAtomicFeatureFlagStore store];
+    [store clear];
+}
+
+- (void)testStoreIsInitiallyEmpty {
+    BSGAtomicFeatureFlagStore *store = [BSGAtomicFeatureFlagStore store];
+    
+    NSDictionary<NSString *, id> *object = bsg_JSONObject(^(BSG_KSCrashReportWriter *writer) {
+        writer->beginObject(writer, "");
+        BugsnagFeatureFlagsWriteCrashReport(writer, true);
+        writer->endContainer(writer);
+    });
+    
+    XCTAssertEqualObjects(object.allKeys, @[@"featureFlags"]);
+    XCTAssertTrue([store isEmpty]);
+    
+    NSArray<NSDictionary *> *featureFlags = object[@"featureFlags"];
+    XCTAssertEqual(featureFlags.count, 0);
+}
+
+- (void)testAddMultipleFlagsAtOnce {
+    BSGAtomicFeatureFlagStore *store = [BSGAtomicFeatureFlagStore store];
+    [store addFeatureFlags:@[
+        [BugsnagFeatureFlag flagWithName:@"featureFlagA"],
+        [BugsnagFeatureFlag flagWithName:@"featureFlagB" variant:@"testingB"],
+        [BugsnagFeatureFlag flagWithName:@"featureFlagC" variant:@"testingC"]
+    ]];
+    
+    NSDictionary<NSString *, id> *object = bsg_JSONObject(^(BSG_KSCrashReportWriter *writer) {
+        writer->beginObject(writer, "");
+        BugsnagFeatureFlagsWriteCrashReport(writer, true);
+        writer->endContainer(writer);
+    });
+    
+    XCTAssertEqualObjects(object.allKeys, @[@"featureFlags"]);
+    
+    NSArray<NSDictionary *> *featureFlags = object[@"featureFlags"];
+    XCTAssertEqual(featureFlags.count, 3);
+    
+    XCTAssertTrue([featureFlags[0][@"featureFlag"] isEqualToString: @"featureFlagA"]);
+    XCTAssertNil(featureFlags[0][@"variant"]);
+    
+    XCTAssertTrue([featureFlags[1][@"featureFlag"] isEqualToString: @"featureFlagB"]);
+    XCTAssertTrue([featureFlags[1][@"variant"] isEqualToString: @"testingB"]);
+    
+    XCTAssertTrue([featureFlags[2][@"featureFlag"] isEqualToString: @"featureFlagC"]);
+    XCTAssertTrue([featureFlags[2][@"variant"] isEqualToString: @"testingC"]);
+}
+
+- (void)testAddAndReplace {
+    BSGAtomicFeatureFlagStore *store = [BSGAtomicFeatureFlagStore store];
+
+    [store addFeatureFlag:@"featureFlagA" withVariant:@"testingA"];
+    [store addFeatureFlag:@"featureFlagB" withVariant:@"testingB"];
+    [store addFeatureFlag:@"featureFlagC" withVariant:@"testingC"];
+    [store addFeatureFlag:@"featureFlagD" withVariant:@"testingD"];
+    [store addFeatureFlag:@"featureFlagA" withVariant:@"testingA2"];
+    [store addFeatureFlag:@"featureFlagB" withVariant:@"testingB2"];
+    [store addFeatureFlag:@"featureFlagC" withVariant:@"testingC2"];
+    [store addFeatureFlag:@"featureFlagB" withVariant:@"testingB3"];
+    [store addFeatureFlag:@"featureFlagA" withVariant:@"testingA3"];
+    
+    NSDictionary<NSString *, id> *object = bsg_JSONObject(^(BSG_KSCrashReportWriter *writer) {
+        writer->beginObject(writer, "");
+        BugsnagFeatureFlagsWriteCrashReport(writer, true);
+        writer->endContainer(writer);
+    });
+    
+    XCTAssertEqualObjects(object.allKeys, @[@"featureFlags"]);
+    
+    NSArray<NSDictionary *> *featureFlags = object[@"featureFlags"];
+    XCTAssertEqual(featureFlags.count, 4);
+    
+    XCTAssertTrue([featureFlags[0][@"featureFlag"] isEqualToString: @"featureFlagD"]);
+    XCTAssertTrue([featureFlags[0][@"variant"] isEqualToString: @"testingD"]);
+    
+    XCTAssertTrue([featureFlags[1][@"featureFlag"] isEqualToString: @"featureFlagC"]);
+    XCTAssertTrue([featureFlags[1][@"variant"] isEqualToString: @"testingC2"]);
+    
+    XCTAssertTrue([featureFlags[2][@"featureFlag"] isEqualToString: @"featureFlagB"]);
+    XCTAssertTrue([featureFlags[2][@"variant"] isEqualToString: @"testingB3"]);
+    
+    XCTAssertTrue([featureFlags[3][@"featureFlag"] isEqualToString: @"featureFlagA"]);
+    XCTAssertTrue([featureFlags[3][@"variant"] isEqualToString: @"testingA3"]);
+}
+
+- (void)testAddMultipleAndReplace {
+    BSGAtomicFeatureFlagStore *store = [BSGAtomicFeatureFlagStore store];
+    [store addFeatureFlags:@[
+        [BugsnagFeatureFlag flagWithName:@"featureFlagA"],
+        [BugsnagFeatureFlag flagWithName:@"featureFlagB" variant:@"testingB"],
+        [BugsnagFeatureFlag flagWithName:@"featureFlagC" variant:@"testingC"]
+    ]];
+    
+    [store addFeatureFlag:@"featureFlagA" withVariant:@"testingA2"];
+    [store addFeatureFlag:@"featureFlagB" withVariant:@"testingB2"];
+    [store addFeatureFlag:@"featureFlagD" withVariant:@"testingD"];
+    [store addFeatureFlag:@"featureFlagC" withVariant:@"testingC2"];
+    
+    NSDictionary<NSString *, id> *object = bsg_JSONObject(^(BSG_KSCrashReportWriter *writer) {
+        writer->beginObject(writer, "");
+        BugsnagFeatureFlagsWriteCrashReport(writer, true);
+        writer->endContainer(writer);
+    });
+    
+    XCTAssertEqualObjects(object.allKeys, @[@"featureFlags"]);
+    
+    NSArray<NSDictionary *> *featureFlags = object[@"featureFlags"];
+    XCTAssertEqual(featureFlags.count, 4);
+    
+    XCTAssertTrue([featureFlags[0][@"featureFlag"] isEqualToString: @"featureFlagA"]);
+    XCTAssertTrue([featureFlags[0][@"variant"] isEqualToString: @"testingA2"]);
+    
+    XCTAssertTrue([featureFlags[1][@"featureFlag"] isEqualToString: @"featureFlagB"]);
+    XCTAssertTrue([featureFlags[1][@"variant"] isEqualToString: @"testingB2"]);
+    
+    XCTAssertTrue([featureFlags[2][@"featureFlag"] isEqualToString: @"featureFlagD"]);
+    XCTAssertTrue([featureFlags[2][@"variant"] isEqualToString: @"testingD"]);
+    
+    XCTAssertTrue([featureFlags[3][@"featureFlag"] isEqualToString: @"featureFlagC"]);
+    XCTAssertTrue([featureFlags[3][@"variant"] isEqualToString: @"testingC2"]);
+}
+
+- (void)testClearShouldRemoveAllFlags {
+    BSGAtomicFeatureFlagStore *store = [BSGAtomicFeatureFlagStore store];
+
+    [store addFeatureFlag:@"featureFlagA" withVariant:@"testingA"];
+    [store addFeatureFlag:@"featureFlagB" withVariant:@"testingB"];
+    [store addFeatureFlag:@"featureFlagC" withVariant:@"testingC"];
+    [store addFeatureFlag:@"featureFlagD" withVariant:@"testingD"];
+    
+    [store clear];
+    
+    NSDictionary<NSString *, id> *object = bsg_JSONObject(^(BSG_KSCrashReportWriter *writer) {
+        writer->beginObject(writer, "");
+        BugsnagFeatureFlagsWriteCrashReport(writer, true);
+        writer->endContainer(writer);
+    });
+    
+    XCTAssertEqualObjects(object.allKeys, @[@"featureFlags"]);
+    XCTAssertTrue([store isEmpty]);
+    
+    NSArray<NSDictionary *> *featureFlags = object[@"featureFlags"];
+    XCTAssertEqual(featureFlags.count, 0);
+}
+
+- (void)testClearByNameShouldRemoveASingleFlag {
+    BSGAtomicFeatureFlagStore *store = [BSGAtomicFeatureFlagStore store];
+
+    [store addFeatureFlag:@"featureFlagA" withVariant:@"testingA"];
+    [store addFeatureFlag:@"featureFlagB" withVariant:@"testingB"];
+    [store addFeatureFlag:@"featureFlagC" withVariant:@"testingC"];
+    [store addFeatureFlag:@"featureFlagD" withVariant:@"testingD"];
+    
+    [store clear:@"featureFlagB"];
+    
+    NSDictionary<NSString *, id> *object = bsg_JSONObject(^(BSG_KSCrashReportWriter *writer) {
+        writer->beginObject(writer, "");
+        BugsnagFeatureFlagsWriteCrashReport(writer, true);
+        writer->endContainer(writer);
+    });
+    
+    XCTAssertEqualObjects(object.allKeys, @[@"featureFlags"]);
+    
+    NSArray<NSDictionary *> *featureFlags = object[@"featureFlags"];
+    XCTAssertEqual(featureFlags.count, 3);
+    
+    XCTAssertTrue([featureFlags[0][@"featureFlag"] isEqualToString: @"featureFlagA"]);
+    XCTAssertTrue([featureFlags[0][@"variant"] isEqualToString: @"testingA"]);
+    
+    XCTAssertTrue([featureFlags[1][@"featureFlag"] isEqualToString: @"featureFlagC"]);
+    XCTAssertTrue([featureFlags[1][@"variant"] isEqualToString: @"testingC"]);
+    
+    XCTAssertTrue([featureFlags[2][@"featureFlag"] isEqualToString: @"featureFlagD"]);
+    XCTAssertTrue([featureFlags[2][@"variant"] isEqualToString: @"testingD"]);
+}
+
+- (void)testClearByNameShouldRemoveAllFlagsIfNilIsProvided {
+    BSGAtomicFeatureFlagStore *store = [BSGAtomicFeatureFlagStore store];
+
+    [store addFeatureFlag:@"featureFlagA" withVariant:@"testingA"];
+    [store addFeatureFlag:@"featureFlagB" withVariant:@"testingB"];
+    [store addFeatureFlag:@"featureFlagC" withVariant:@"testingC"];
+    [store addFeatureFlag:@"featureFlagD" withVariant:@"testingD"];
+    
+    [store clear:nil];
+    
+    NSDictionary<NSString *, id> *object = bsg_JSONObject(^(BSG_KSCrashReportWriter *writer) {
+        writer->beginObject(writer, "");
+        BugsnagFeatureFlagsWriteCrashReport(writer, true);
+        writer->endContainer(writer);
+    });
+    
+    XCTAssertEqualObjects(object.allKeys, @[@"featureFlags"]);
+    XCTAssertTrue([store isEmpty]);
+    
+    NSArray<NSDictionary *> *featureFlags = object[@"featureFlags"];
+    XCTAssertEqual(featureFlags.count, 0);
+}
+
+@end

--- a/Tests/BugsnagTests/BSGMemoryFeatureFlagStoreTests.m
+++ b/Tests/BugsnagTests/BSGMemoryFeatureFlagStoreTests.m
@@ -1,5 +1,5 @@
 //
-//  BSGFeatureFlagStoreTests.m
+//  BSGMemoryFeatureFlagStoreTests.m
 //  Bugsnag
 //
 //  Created by Nick Dowell on 11/11/2021.
@@ -10,11 +10,11 @@
 
 #import "BSGMemoryFeatureFlagStore.h"
 
-@interface BSGFeatureFlagStoreTests : BSGTestCase
+@interface BSGMemoryFeatureFlagStoreTests : BSGTestCase
 
 @end
 
-@implementation BSGFeatureFlagStoreTests
+@implementation BSGMemoryFeatureFlagStoreTests
 
 - (void)test {
     BSGMemoryFeatureFlagStore *store = [[BSGMemoryFeatureFlagStore alloc] init];

--- a/Tests/BugsnagTests/WriterTestsSupport.h
+++ b/Tests/BugsnagTests/WriterTestsSupport.h
@@ -1,0 +1,12 @@
+//
+//  WriterTestsSupport.h
+//  Bugsnag
+//
+//  Created by Robert B on 24/03/2025.
+//  Copyright © 2025 Bugsnag Inc. All rights reserved.
+//
+
+#import "Bugsnag.h"
+#import "BSG_KSJSONCodec.h"
+
+id bsg_JSONObject(void (^ block)(BSG_KSCrashReportWriter *writer));

--- a/Tests/BugsnagTests/WriterTestsSupport.m
+++ b/Tests/BugsnagTests/WriterTestsSupport.m
@@ -1,0 +1,27 @@
+//
+//  WriterTestsSupport.m
+//  Bugsnag
+//
+//  Created by Robert B on 24/03/2025.
+//  Copyright © 2025 Bugsnag Inc. All rights reserved.
+//
+
+#import "WriterTestsSupport.h"
+
+// Defined in BSG_KSCrashReport.c
+void bsg_kscrw_i_prepareReportWriter(BSG_KSCrashReportWriter *const writer, BSG_KSJSONEncodeContext *const context);
+
+static int addJSONData(const char *data, size_t length, NSMutableData *userData) {
+    [userData appendBytes:data length:length];
+    return BSG_KSJSON_OK;
+}
+
+id bsg_JSONObject(void (^ block)(BSG_KSCrashReportWriter *writer)) {
+    NSMutableData *data = [NSMutableData data];
+    BSG_KSJSONEncodeContext encodeContext;
+    BSG_KSCrashReportWriter reportWriter;
+    bsg_kscrw_i_prepareReportWriter(&reportWriter, &encodeContext);
+    bsg_ksjsonbeginEncode(&encodeContext, false, (BSG_KSJSONAddDataFunc)addJSONData, (__bridge void *)data);
+    block(&reportWriter);
+    return [NSJSONSerialization JSONObjectWithData:data options:0 error:NULL];
+}


### PR DESCRIPTION
## Goal

Due to a bug in BSGAtomicFeatureFlagStore, clearing or updating a feature flag would cause memory corruption

Fixes #1751 

## Changeset

Fixed the implementation of BSGAtomicFeatureFlagStore

## Testing

Unit tests