### PR TITLE
NSError types now require @unchecked Sendable

### DIFF
--- a/features/fixtures/shared/scenarios/HandledErrorValidReleaseStageScenario.swift
+++ b/features/fixtures/shared/scenarios/HandledErrorValidReleaseStageScenario.swift
@@ -1,4 +1,4 @@
-class MagicError : NSError {}
+class MagicError : NSError, @unchecked Sendable {}
 
 class HandledErrorValidReleaseStageScenario : Scenario {
 


### PR DESCRIPTION
## Goal

Newer Xcode requires an NSError subclass to have `@unchecked Sendable`.

This is preventing the current codebase from compiling.
