### PR TITLE
Upload maze_output.zip as build artifact

### DIFF
--- a/.buildkite/pipeline.full.yml
+++ b/.buildkite/pipeline.full.yml
@@ -12,7 +12,7 @@ steps:
     env:
       XCODE_VERSION: 16.3.0
     plugins:
-      - artifacts#v1.9.3:
+      - artifacts#v1.9.4:
           download:
             - "Bugsnag.xcframework.zip"
             - "BugsnagNetworkRequestPlugin.xcframework.zip"
@@ -44,9 +44,11 @@ steps:
     agents:
       queue: opensource
     plugins:
-      artifacts#v1.9.3:
+      artifacts#v1.9.4:
         download: "features/fixtures/ios/output/xcframework_ipa_url_bb.txt"
-        upload: "maze_output/failed/**/*"
+        upload:
+          - "maze_output/failed/**/*"
+          - "maze_output/maze_output.zip"
       docker-compose#v4.7.0:
         pull: cocoa-maze-runner-bitbar
         run: cocoa-maze-runner-bitbar
@@ -58,7 +60,7 @@ steps:
           - "--no-tunnel"
           - "--aws-public-ip"
           - "features/release/barebone_tests.feature"
-      test-collector#v1.10.2:
+      test-collector#v1.11.0:
         files: "reports/TEST-*.xml"
         format: "junit"
         branch: "^master|next$$"
@@ -77,9 +79,11 @@ steps:
     agents:
       queue: opensource
     plugins:
-      artifacts#v1.9.3:
+      artifacts#v1.9.4:
         download: "features/fixtures/ios/output/xcframework_ipa_url_bb.txt"
-        upload: "maze_output/failed/**/*"
+        upload:
+          - "maze_output/failed/**/*"
+          - "maze_output/maze_output.zip"
       docker-compose#v4.7.0:
         pull: cocoa-maze-runner-bitbar
         run: cocoa-maze-runner-bitbar
@@ -91,7 +95,7 @@ steps:
           - "--no-tunnel"
           - "--aws-public-ip"
           - "features/release/barebone_tests.feature"
-      test-collector#v1.10.2:
+      test-collector#v1.11.0:
         files: "reports/TEST-*.xml"
         format: "junit"
         branch: "^master|next$$"
@@ -110,9 +114,11 @@ steps:
     agents:
       queue: opensource
     plugins:
-      artifacts#v1.9.3:
+      artifacts#v1.9.4:
         download: "features/fixtures/ios/output/xcframework_ipa_url_bb.txt"
-        upload: "maze_output/failed/**/*"
+        upload:
+          - "maze_output/failed/**/*"
+          - "maze_output/maze_output.zip"
       docker-compose#v4.7.0:
         pull: cocoa-maze-runner-bitbar
         run: cocoa-maze-runner-bitbar
@@ -124,7 +130,7 @@ steps:
           - "--no-tunnel"
           - "--aws-public-ip"
           - "features/release/barebone_tests.feature"
-      test-collector#v1.10.2:
+      test-collector#v1.11.0:
         files: "reports/TEST-*.xml"
         format: "junit"
         branch: "^master|next$$"
@@ -143,12 +149,13 @@ steps:
     agents:
       queue: macos-14-isolated
     plugins:
-      artifacts#v1.9.3:
+      artifacts#v1.9.4:
         download: "features/fixtures/macos/output/macOSTestAppXcFramework.zip"
         upload:
           - "*.log"
           - "maze_output/failed/**/*"
-      test-collector#v1.10.2:
+          - "maze_output/maze_output.zip"
+      test-collector#v1.11.0:
         files: "reports/TEST-*.xml"
         format: "junit"
         branch: "^master|next$$"
@@ -167,12 +174,13 @@ steps:
     agents:
       queue: macos-10.13
     plugins:
-      artifacts#v1.9.3:
+      artifacts#v1.9.4:
         download: "features/fixtures/macos/output/macOSTestAppXcFramework.zip"
         upload:
           - "*.log"
           - "maze_output/failed/**/*"
-      test-collector#v1.10.2:
+          - "maze_output/maze_output.zip"
+      test-collector#v1.11.0:
         files: "reports/TEST-*.xml"
         format: "junit"
         branch: "^master|next$$"
@@ -194,9 +202,11 @@ steps:
     agents:
       queue: opensource
     plugins:
-      artifacts#v1.9.3:
+      artifacts#v1.9.4:
         download: "features/fixtures/ios/output/ipa_url_bb_release.txt"
-        upload: "maze_output/failed/**/*"
+        upload:
+          - "maze_output/failed/**/*"
+          - "maze_output/maze_output.zip"
       docker-compose#v4.7.0:
         pull: cocoa-maze-runner-bitbar
         run: cocoa-maze-runner-bitbar
@@ -211,7 +221,7 @@ steps:
           # PLAT-11155: App hang scenarios run on BrowserStack
           - "features/release"
           - "--exclude=features/release/[e-z].*.feature$"
-      test-collector#v1.10.2:
+      test-collector#v1.11.0:
         files: "reports/TEST-*.xml"
         format: "junit"
         branch: "^master|next$$"
@@ -230,9 +240,11 @@ steps:
     agents:
       queue: opensource
     plugins:
-      artifacts#v1.9.3:
+      artifacts#v1.9.4:
         download: "features/fixtures/ios/output/ipa_url_bb_release.txt"
-        upload: "maze_output/failed/**/*"
+        upload:
+          - "maze_output/failed/**/*"
+          - "maze_output/maze_output.zip"
       docker-compose#v4.7.0:
         pull: cocoa-maze-runner-bitbar
         run: cocoa-maze-runner-bitbar
@@ -246,7 +258,7 @@ steps:
           - "--fail-fast"
           - "features/release"
           - "--exclude=features/release/[a-d].*.feature$"
-      test-collector#v1.10.2:
+      test-collector#v1.11.0:
         files: "reports/TEST-*.xml"
         format: "junit"
         branch: "^master|next$$"
@@ -264,9 +276,11 @@ steps:
     agents:
       queue: opensource
     plugins:
-      artifacts#v1.9.3:
+      artifacts#v1.9.4:
         download: "features/fixtures/ios/output/ipa_url_bb_release.txt"
-        upload: "maze_output/failed/**/*"
+        upload:
+          - "maze_output/failed/**/*"
+          - "maze_output/maze_output.zip"
       docker-compose#v4.7.0:
         pull: cocoa-maze-runner-bitbar
         run: cocoa-maze-runner-bitbar
@@ -281,7 +295,7 @@ steps:
           - "--no-tunnel"
           - "--aws-public-ip"
           - "--fail-fast"
-      test-collector#v1.10.2:
+      test-collector#v1.11.0:
         files: "reports/TEST-*.xml"
         format: "junit"
         branch: "^master|next$$"
@@ -295,9 +309,11 @@ steps:
     agents:
       queue: opensource
     plugins:
-      artifacts#v1.9.3:
+      artifacts#v1.9.4:
         download: "features/fixtures/ios/output/ipa_url_bb_release.txt"
-        upload: "maze_output/failed/**/*"
+        upload:
+          - "maze_output/failed/**/*"
+          - "maze_output/maze_output.zip"
       docker-compose#v4.7.0:
         pull: cocoa-maze-runner-bitbar
         run: cocoa-maze-runner-bitbar
@@ -311,7 +327,7 @@ steps:
           - "--no-tunnel"
           - "--aws-public-ip"
           - "--fail-fast"
-      test-collector#v1.10.2:
+      test-collector#v1.11.0:
         files: "reports/TEST-*.xml"
         format: "junit"
         branch: "^master|next$$"
@@ -326,9 +342,11 @@ steps:
     agents:
       queue: opensource
     plugins:
-      artifacts#v1.9.3:
+      artifacts#v1.9.4:
         download: "features/fixtures/ios/output/ipa_url_bb_release.txt"
-        upload: "maze_output/failed/**/*"
+        upload:
+          - "maze_output/failed/**/*"
+          - "maze_output/maze_output.zip"
       docker-compose#v4.7.0:
         pull: cocoa-maze-runner-bitbar
         run: cocoa-maze-runner-bitbar
@@ -343,7 +361,7 @@ steps:
           # PLAT-11155: App hang scenarios run on BrowserStack
           - "features/release"
           - "--exclude=features/release/[e-z].*.feature$"
-      test-collector#v1.10.2:
+      test-collector#v1.11.0:
         files: "reports/TEST-*.xml"
         format: "junit"
         branch: "^master|next$$"
@@ -362,9 +380,11 @@ steps:
     agents:
       queue: opensource
     plugins:
-      artifacts#v1.9.3:
+      artifacts#v1.9.4:
         download: "features/fixtures/ios/output/ipa_url_bb_release.txt"
-        upload: "maze_output/failed/**/*"
+        upload:
+          - "maze_output/failed/**/*"
+          - "maze_output/maze_output.zip"
       docker-compose#v4.7.0:
         pull: cocoa-maze-runner-bitbar
         run: cocoa-maze-runner-bitbar
@@ -378,7 +398,7 @@ steps:
           - "--fail-fast"
           - "features/release"
           - "--exclude=features/release/[a-d].*.feature$"
-      test-collector#v1.10.2:
+      test-collector#v1.11.0:
         files: "reports/TEST-*.xml"
         format: "junit"
         branch: "^master|next$$"
@@ -397,9 +417,11 @@ steps:
     agents:
       queue: opensource
     plugins:
-      artifacts#v1.9.3:
+      artifacts#v1.9.4:
         download: "features/fixtures/ios/output/ipa_url_bb_release.txt"
-        upload: "maze_output/failed/**/*"
+        upload:
+          - "maze_output/failed/**/*"
+          - "maze_output/maze_output.zip"
       docker-compose#v4.7.0:
         pull: cocoa-maze-runner-bitbar
         run: cocoa-maze-runner-bitbar
@@ -414,7 +436,7 @@ steps:
           # PLAT-11155: App hang scenarios run on BrowserStack
           - "features/release"
           - "--exclude=features/release/[e-z].*.feature$"
-      test-collector#v1.10.2:
+      test-collector#v1.11.0:
         files: "reports/TEST-*.xml"
         format: "junit"
         branch: "^master|next$$"
@@ -433,9 +455,11 @@ steps:
     agents:
       queue: opensource
     plugins:
-      artifacts#v1.9.3:
+      artifacts#v1.9.4:
         download: "features/fixtures/ios/output/ipa_url_bb_release.txt"
-        upload: "maze_output/failed/**/*"
+        upload:
+          - "maze_output/failed/**/*"
+          - "maze_output/maze_output.zip"
       docker-compose#v4.7.0:
         pull: cocoa-maze-runner-bitbar
         run: cocoa-maze-runner-bitbar
@@ -449,7 +473,7 @@ steps:
           - "--fail-fast"
           - "features/release"
           - "--exclude=features/release/[a-d].*.feature$"
-      test-collector#v1.10.2:
+      test-collector#v1.11.0:
         files: "reports/TEST-*.xml"
         format: "junit"
         branch: "^master|next$$"
@@ -471,9 +495,11 @@ steps:
     agents:
       queue: opensource
     plugins:
-      artifacts#v1.9.3:
+      artifacts#v1.9.4:
         download: "features/fixtures/ios/output/ipa_url_bb_release.txt"
-        upload: "maze_output/failed/**/*"
+        upload:
+          - "maze_output/failed/**/*"
+          - "maze_output/maze_output.zip"
       docker-compose#v4.7.0:
         pull: cocoa-maze-runner-bitbar
         run: cocoa-maze-runner-bitbar
@@ -488,7 +514,7 @@ steps:
           # PLAT-11155: App hang scenarios run on BrowserStack
           - "features/release"
           - "--exclude=features/release/[e-z].*.feature$"
-      test-collector#v1.10.2:
+      test-collector#v1.11.0:
         files: "reports/TEST-*.xml"
         format: "junit"
         branch: "^master|next$$"
@@ -507,9 +533,11 @@ steps:
     agents:
       queue: opensource
     plugins:
-      artifacts#v1.9.3:
+      artifacts#v1.9.4:
         download: "features/fixtures/ios/output/ipa_url_bb_release.txt"
-        upload: "maze_output/failed/**/*"
+        upload:
+          - "maze_output/failed/**/*"
+          - "maze_output/maze_output.zip"
       docker-compose#v4.7.0:
         pull: cocoa-maze-runner-bitbar
         run: cocoa-maze-runner-bitbar
@@ -523,7 +551,7 @@ steps:
           - "--fail-fast"
           - "features/release"
           - "--exclude=features/release/[a-d].*.feature$"
-      test-collector#v1.10.2:
+      test-collector#v1.11.0:
         files: "reports/TEST-*.xml"
         format: "junit"
         branch: "^master|next$$"
@@ -542,10 +570,12 @@ steps:
     agents:
       queue: opensource
     plugins:
-      artifacts#v1.9.3:
+      artifacts#v1.9.4:
         download: "features/fixtures/ios/output/ipa_url_bs_release.txt"
-        upload: "maze_output/failed/**/*"
-      docker-compose#v3.7.0:
+        upload:
+          - "maze_output/failed/**/*"
+          - "maze_output/maze_output.zip"
+      docker-compose#v5.8.0:
         pull: cocoa-maze-runner
         run: cocoa-maze-runner
         command:
@@ -555,7 +585,7 @@ steps:
           - "--appium-version=1.21.0"
           - "--fail-fast"
           - "features/app_hangs.feature"
-      test-collector#v1.10.2:
+      test-collector#v1.11.0:
         files: "reports/TEST-*.xml"
         format: "junit"
         branch: "^master|next$$"
@@ -577,10 +607,12 @@ steps:
     agents:
       queue: opensource
     plugins:
-      artifacts#v1.9.3:
+      artifacts#v1.9.4:
         download: "features/fixtures/ios/output/ipa_url_bs_release.txt"
-        upload: "maze_output/failed/**/*"
-      docker-compose#v3.7.0:
+        upload:
+          - "maze_output/failed/**/*"
+          - "maze_output/maze_output.zip"
+      docker-compose#v5.8.0:
         pull: cocoa-maze-runner
         run: cocoa-maze-runner
         command:
@@ -590,7 +622,7 @@ steps:
           - "--appium-version=1.21.0"
           - "--fail-fast"
           - "features/app_hangs.feature"
-      test-collector#v1.10.2:
+      test-collector#v1.11.0:
         files: "reports/TEST-*.xml"
         format: "junit"
         branch: "^master|next$$"
@@ -612,10 +644,12 @@ steps:
     agents:
       queue: opensource
     plugins:
-      artifacts#v1.9.3:
+      artifacts#v1.9.4:
         download: "features/fixtures/ios/output/ipa_url_bs_release.txt"
-        upload: "maze_output/failed/**/*"
-      docker-compose#v3.7.0:
+        upload:
+          - "maze_output/failed/**/*"
+          - "maze_output/maze_output.zip"
+      docker-compose#v5.8.0:
         pull: cocoa-maze-runner
         run: cocoa-maze-runner
         command:
@@ -625,7 +659,7 @@ steps:
           - "--appium-version=1.21.0"
           - "--fail-fast"
           - "features/app_hangs.feature"
-      test-collector#v1.10.2:
+      test-collector#v1.11.0:
         files: "reports/TEST-*.xml"
         format: "junit"
         branch: "^master|next$$"
@@ -645,10 +679,12 @@ steps:
     agents:
       queue: opensource
     plugins:
-      artifacts#v1.9.3:
+      artifacts#v1.9.4:
         download: "features/fixtures/ios/output/ipa_url_bs_release.txt"
-        upload: "maze_output/failed/**/*"
-      docker-compose#v3.7.0:
+        upload:
+          - "maze_output/failed/**/*"
+          - "maze_output/maze_output.zip"
+      docker-compose#v5.8.0:
         pull: cocoa-maze-runner
         run: cocoa-maze-runner
         command:
@@ -658,7 +694,7 @@ steps:
           - "--appium-version=1.21.0"
           - "--fail-fast"
           - "features/app_hangs.feature"
-      test-collector#v1.10.2:
+      test-collector#v1.11.0:
         files: "reports/TEST-*.xml"
         format: "junit"
         branch: "^master|next$$"
@@ -681,10 +717,10 @@ steps:
   #   agents:
   #     queue: opensource
   #   plugins:
-  #     artifacts#v1.9.3:
+  #     artifacts#v1.9.4:
   #       download: "features/fixtures/ios/output/ipa_url_bs_release.txt"
   #       upload: "maze_output/failed/**/*"
-  #     docker-compose#v3.7.0:
+  #     docker-compose#v5.8.0:
   #       pull: cocoa-maze-runner
   #       run: cocoa-maze-runner
   #       command:
@@ -694,7 +730,7 @@ steps:
   #         - "--appium-version=1.21.0"
   #         - "--fail-fast"
   #         - "features/app_hangs.feature"
-  #     test-collector#v1.10.2:
+  #     test-collector#v1.11.0:
   #       files: "reports/TEST-*.xml"
   #       format: "junit"
   #       branch: "^master|next$$"
@@ -713,12 +749,13 @@ steps:
     agents:
       queue: macos-14
     plugins:
-      artifacts#v1.9.3:
+      artifacts#v1.9.4:
         download: "features/fixtures/macos/output/macOSTestApp_Release.zip"
         upload:
           - "macOSTestApp.log"
           - "maze_output/failed/**/*"
-      test-collector#v1.10.2:
+          - "maze_output/maze_output.zip"
+      test-collector#v1.11.0:
         files: "reports/TEST-*.xml"
         format: "junit"
         branch: "^master|next$$"
@@ -736,12 +773,13 @@ steps:
     agents:
       queue: macos-13-arm
     plugins:
-      artifacts#v1.9.3:
+      artifacts#v1.9.4:
         download: "features/fixtures/macos/output/macOSTestApp_Release.zip"
         upload:
           - "macOSTestApp.log"
           - "maze_output/failed/**/*"
-      test-collector#v1.10.2:
+          - "maze_output/maze_output.zip"
+      test-collector#v1.11.0:
         files: "reports/TEST-*.xml"
         format: "junit"
         branch: "^master|next$$"
@@ -759,12 +797,13 @@ steps:
     agents:
       queue: macos-12-arm
     plugins:
-      artifacts#v1.9.3:
+      artifacts#v1.9.4:
         download: "features/fixtures/macos/output/macOSTestApp_Release.zip"
         upload:
           - "macOSTestApp.log"
           - "maze_output/failed/**/*"
-      test-collector#v1.10.2:
+          - "maze_output/maze_output.zip"
+      test-collector#v1.11.0:
         files: "reports/TEST-*.xml"
         format: "junit"
         branch: "^master|next$$"
@@ -782,10 +821,13 @@ steps:
     agents:
       queue: macos-11
     plugins:
-      artifacts#v1.9.3:
+      artifacts#v1.9.4:
         download: ["features/fixtures/macos/output/macOSTestApp_Release.zip"]
-        upload: ["macOSTestApp.log", "maze_output/failed/**/*"]
-      test-collector#v1.10.2:
+        upload:
+          - "macOSTestApp.log"
+          - "maze_output/failed/**/*"
+          - "maze_output/maze_output.zip"
+      test-collector#v1.11.0:
         files: "reports/TEST-*.xml"
         format: "junit"
         branch: "^master|next$$"
@@ -803,9 +845,12 @@ steps:
     agents:
       queue: macos-10.15
     plugins:
-      artifacts#v1.9.3:
+      artifacts#v1.9.4:
         download: ["features/fixtures/macos/output/macOSTestApp_Release.zip"]
-        upload: ["macOSTestApp.log", "maze_output/failed/**/*"]
+        upload:
+          - "macOSTestApp.log"
+          - "maze_output/failed/**/*"
+          - "maze_output/maze_output.zip"
     commands:
       - bundle install
       - bundle exec maze-runner
@@ -820,9 +865,12 @@ steps:
     agents:
       queue: macos-10.14
     plugins:
-      artifacts#v1.9.3:
+      artifacts#v1.9.4:
         download: ["features/fixtures/macos/output/macOSTestApp_Release.zip"]
-        upload: ["macOSTestApp.log", "maze_output/failed/**/*"]
+        upload:
+          - "macOSTestApp.log"
+          - "maze_output/failed/**/*"
+          - "maze_output/maze_output.zip"
     commands:
       - bundle install
       - bundle exec maze-runner
@@ -837,9 +885,12 @@ steps:
     agents:
       queue: macos-10.13
     plugins:
-      artifacts#v1.9.3:
+      artifacts#v1.9.4:
         download: ["features/fixtures/macos/output/macOSTestApp_Release.zip"]
-        upload: ["macOSTestApp.log", "maze_output/failed/**/*"]
+        upload:
+          - "macOSTestApp.log"
+          - "maze_output/failed/**/*"
+          - "maze_output/maze_output.zip"
     commands:
       - bundle install
       - bundle exec maze-runner

--- a/.buildkite/pipeline.yml
+++ b/.buildkite/pipeline.yml
@@ -21,7 +21,7 @@ steps:
       - zip -ry Bugsnag.xcframework.zip build/xcframeworks/products/Bugsnag.xcframework
       - zip -ry BugsnagNetworkRequestPlugin.xcframework.zip build/xcframeworks/products/BugsnagNetworkRequestPlugin.xcframework
     plugins:
-      - artifacts#v1.9.3:
+      - artifacts#v1.9.4:
           upload:
             - "Bugsnag.xcframework.zip"
             - "BugsnagNetworkRequestPlugin.xcframework.zip"
@@ -57,7 +57,7 @@ steps:
     commands:
       - ./scripts/build-carthage.sh
     plugins:
-      artifacts#v1.5.0:
+      artifacts#v1.9.4:
         upload: "features/fixtures/carthage/carthage-*.log"
 
   ##############################################################################
@@ -244,12 +244,13 @@ steps:
     agents:
       queue: macos-15-isolated
     plugins:
-      artifacts#v1.5.0:
+      artifacts#v1.9.4:
         download: "features/fixtures/macos/output/macOSTestApp_Release.zip"
         upload:
           - "macOSTestApp.log"
           - "maze_output/failed/**/*"
-      test-collector#v1.10.2:
+          - "maze_output/maze_output.zip"
+      test-collector#v1.11.0:
         files: "reports/TEST-*.xml"
         format: "junit"
         branch: "^master|next$$"
@@ -267,12 +268,13 @@ steps:
     agents:
       queue: macos-14-isolated
     plugins:
-      artifacts#v1.5.0:
+      artifacts#v1.9.4:
         download: "features/fixtures/macos/output/macOSTestApp_Release.zip"
         upload:
           - "macOSTestApp.log"
           - "maze_output/failed/**/*"
-      test-collector#v1.10.2:
+          - "maze_output/maze_output.zip"
+        test-collector#v1.11.0:
         files: "reports/TEST-*.xml"
         format: "junit"
         branch: "^master|next$$"
@@ -290,12 +292,13 @@ steps:
     agents:
       queue: macos-13-arm
     plugins:
-      artifacts#v1.5.0:
+      artifacts#v1.9.4:
         download: "features/fixtures/macos/output/macOSTestApp_Release.zip"
         upload:
           - "macOSTestApp.log"
           - "maze_output/failed/**/*"
-      test-collector#v1.10.2:
+          - "maze_output/maze_output.zip"
+        test-collector#v1.11.0:
         files: "reports/TEST-*.xml"
         format: "junit"
         branch: "^master|next$$"
@@ -313,12 +316,13 @@ steps:
     agents:
       queue: macos-12-arm
     plugins:
-      artifacts#v1.5.0:
+      artifacts#v1.9.4:
         download: "features/fixtures/macos/output/macOSTestApp_Release.zip"
         upload:
           - "macOSTestApp.log"
           - "maze_output/failed/**/*"
-      test-collector#v1.10.2:
+          - "maze_output/maze_output.zip"
+        test-collector#v1.11.0:
         files: "reports/TEST-*.xml"
         format: "junit"
         branch: "^master|next$$"
@@ -356,10 +360,13 @@ steps:
     agents:
       queue: macos-11
     plugins:
-      artifacts#v1.5.0:
+      artifacts#v1.9.4:
         download: ["features/fixtures/macos/output/macOSTestApp_Release.zip"]
-        upload: ["macOSTestApp.log", "maze_output/failed/**/*"]
-      test-collector#v1.10.2:
+        upload:
+          - "macOSTestApp.log"
+          - "maze_output/failed/**/*"
+          - "maze_output/maze_output.zip"
+      test-collector#v1.11.0:
         files: "reports/TEST-*.xml"
         format: "junit"
         branch: "^master|next$$"
@@ -377,9 +384,12 @@ steps:
     agents:
       queue: macos-10.15
     plugins:
-      artifacts#v1.5.0:
+      artifacts#v1.9.4:
         download: ["features/fixtures/macos/output/macOSTestApp_Release.zip"]
-        upload: ["macOSTestApp.log", "maze_output/failed/**/*"]
+        upload:
+          - "macOSTestApp.log"
+          - "maze_output/failed/**/*"
+          - "maze_output/maze_output.zip"
     commands:
       - bundle install
       - bundle exec maze-runner
@@ -394,11 +404,12 @@ steps:
     agents:
       queue: macos-10.14
     plugins:
-      artifacts#v1.5.0:
+      artifacts#v1.9.4:
         download: "features/fixtures/macos/output/macOSTestApp_Release.zip"
         upload:
           - "macOSTestApp.log"
           - "maze_output/failed/**/*"
+          - "maze_output/maze_output.zip"
     commands:
       - bundle install
       - bundle exec maze-runner
@@ -413,11 +424,12 @@ steps:
     agents:
       queue: macos-10.13
     plugins:
-      artifacts#v1.5.0:
+      artifacts#v1.9.4:
         download: "features/fixtures/macos/output/macOSTestApp_Release.zip"
         upload:
           - "macOSTestApp.log"
           - "maze_output/failed/**/*"
+          - "maze_output/maze_output.zip"
     commands:
       - bundle install
       - bundle exec maze-runner
@@ -440,10 +452,12 @@ steps:
     agents:
       queue: opensource
     plugins:
-      artifacts#v1.5.0:
+      artifacts#v1.9.4:
         download: "features/fixtures/ios/output/ipa_url_bs_release.txt"
-        upload: "maze_output/failed/**/*"
-      docker-compose#v3.7.0:
+        upload:
+          - "maze_output/failed/**/*"
+          - "maze_output/maze_output.zip"
+      docker-compose#v5.8.0:
         pull: cocoa-maze-runner
         run: cocoa-maze-runner
         service-ports: true
@@ -456,7 +470,7 @@ steps:
           - "--fail-fast"
           - "features/release"
           - "--exclude=features/release/[e-z].*.feature$"
-      test-collector#v1.10.2:
+      test-collector#v1.11.0:
         files: "reports/TEST-*.xml"
         format: "junit"
         branch: "^master|next$$"
@@ -475,10 +489,12 @@ steps:
     agents:
       queue: opensource
     plugins:
-      artifacts#v1.5.0:
+      artifacts#v1.9.4:
         download: "features/fixtures/ios/output/ipa_url_bs_release.txt"
-        upload: "maze_output/failed/**/*"
-      docker-compose#v3.7.0:
+        upload:
+          - "maze_output/failed/**/*"
+          - "maze_output/maze_output.zip"
+      docker-compose#v5.8.0:
         pull: cocoa-maze-runner
         run: cocoa-maze-runner
         service-ports: true
@@ -491,7 +507,7 @@ steps:
           - "--fail-fast"
           - "features/release"
           - "--exclude=features/release/[a-d].*.feature$"
-      test-collector#v1.10.2:
+      test-collector#v1.11.0:
         files: "reports/TEST-*.xml"
         format: "junit"
         branch: "^master|next$$"
@@ -511,10 +527,12 @@ steps:
     agents:
       queue: opensource
     plugins:
-      artifacts#v1.5.0:
+      artifacts#v1.9.4:
         download: "features/fixtures/ios/output/ipa_url_bs_release.txt"
-        upload: "maze_output/failed/**/*"
-      docker-compose#v3.7.0:
+        upload:
+          - "maze_output/failed/**/*"
+          - "maze_output/maze_output.zip"
+      docker-compose#v5.8.0:
         pull: cocoa-maze-runner
         run: cocoa-maze-runner
         command:
@@ -524,7 +542,7 @@ steps:
           - "--appium-version=1.21.0"
           - "--fail-fast"
           - "features/app_hangs.feature"
-      test-collector#v1.10.2:
+      test-collector#v1.11.0:
         files: "reports/TEST-*.xml"
         format: "junit"
         branch: "^master|next$$"
@@ -554,9 +572,11 @@ steps:
     agents:
       queue: opensource
     plugins:
-      artifacts#v1.9.3:
+      artifacts#v1.9.4:
         download: "features/fixtures/ios/output/ipa_url_bb_release.txt"
-        upload: "maze_output/failed/**/*"
+        upload:
+          - "maze_output/failed/**/*"
+          - "maze_output/maze_output.zip"
       docker-compose#v4.7.0:
         pull: cocoa-maze-runner-bitbar
         run: cocoa-maze-runner-bitbar
@@ -569,7 +589,7 @@ steps:
           - "--aws-public-ip"
           - "--fail-fast"
           - "features/release/barebone_tests.feature"
-      test-collector#v1.10.2:
+      test-collector#v1.11.0:
         files: "reports/TEST-*.xml"
         format: "junit"
         branch: "^master|next$$"
@@ -588,9 +608,11 @@ steps:
     agents:
       queue: opensource
     plugins:
-      artifacts#v1.9.3:
+      artifacts#v1.9.4:
         download: "features/fixtures/ios/output/ipa_url_bb_release.txt"
-        upload: "maze_output/failed/**/*"
+        upload:
+          - "maze_output/failed/**/*"
+          - "maze_output/maze_output.zip"
       docker-compose#v4.7.0:
         pull: cocoa-maze-runner-bitbar
         run: cocoa-maze-runner-bitbar
@@ -603,7 +625,7 @@ steps:
           - "--aws-public-ip"
           - "--fail-fast"
           - "features/release/barebone_tests.feature"
-      test-collector#v1.10.2:
+      test-collector#v1.11.0:
         files: "reports/TEST-*.xml"
         format: "junit"
         branch: "^master|next$$"
@@ -622,9 +644,11 @@ steps:
     agents:
       queue: opensource
     plugins:
-      artifacts#v1.9.3:
+      artifacts#v1.9.4:
         download: "features/fixtures/ios/output/ipa_url_bb_release.txt"
-        upload: "maze_output/failed/**/*"
+        upload:
+          - "maze_output/failed/**/*"
+          - "maze_output/maze_output.zip"
       docker-compose#v4.7.0:
         pull: cocoa-maze-runner-bitbar
         run: cocoa-maze-runner-bitbar
@@ -637,7 +661,7 @@ steps:
           - "--aws-public-ip"
           - "--fail-fast"
           - "features/release/barebone_tests.feature"
-      test-collector#v1.10.2:
+      test-collector#v1.11.0:
         files: "reports/TEST-*.xml"
         format: "junit"
         branch: "^master|next$$"
@@ -656,9 +680,11 @@ steps:
     agents:
       queue: opensource
     plugins:
-      artifacts#v1.9.3:
+      artifacts#v1.9.4:
         download: "features/fixtures/ios/output/ipa_url_bb_release.txt"
-        upload: "maze_output/failed/**/*"
+        upload:
+          - "maze_output/failed/**/*"
+          - "maze_output/maze_output.zip"
       docker-compose#v4.7.0:
         pull: cocoa-maze-runner-bitbar
         run: cocoa-maze-runner-bitbar
@@ -671,7 +697,7 @@ steps:
           - "--aws-public-ip"
           - "--fail-fast"
           - "features/release/barebone_tests.feature"
-      test-collector#v1.10.2:
+      test-collector#v1.11.0:
         files: "reports/TEST-*.xml"
         format: "junit"
         branch: "^master|next$$"
@@ -690,9 +716,11 @@ steps:
     agents:
       queue: opensource
     plugins:
-      artifacts#v1.9.3:
+      artifacts#v1.9.4:
         download: "features/fixtures/ios/output/ipa_url_bb_release.txt"
-        upload: "maze_output/failed/**/*"
+        upload:
+          - "maze_output/failed/**/*"
+          - "maze_output/maze_output.zip"
       docker-compose#v4.7.0:
         pull: cocoa-maze-runner-bitbar
         run: cocoa-maze-runner-bitbar
@@ -705,7 +733,7 @@ steps:
           - "--aws-public-ip"
           - "--fail-fast"
           - "features/release/barebone_tests.feature"
-      test-collector#v1.10.2:
+      test-collector#v1.11.0:
         files: "reports/TEST-*.xml"
         format: "junit"
         branch: "^master|next$$"
@@ -729,9 +757,11 @@ steps:
     agents:
       queue: opensource
     plugins:
-      artifacts#v1.9.3:
+      artifacts#v1.9.4:
         download: "features/fixtures/ios/output/ipa_url_bs_debug.txt"
-        upload: "maze_output/failed/**/*"
+        upload:
+          - "maze_output/failed/**/*"
+          - "maze_output/maze_output.zip"
       docker-compose#v4.7.0:
         pull: cocoa-maze-runner
         run: cocoa-maze-runner
@@ -741,7 +771,7 @@ steps:
           - "--device=IOS_18"
           - "--fail-fast"
           - "features/debug"
-      test-collector#v1.10.2:
+      test-collector#v1.11.0:
         files: "reports/TEST-*.xml"
         format: "junit"
         branch: "^master|next$$"
@@ -760,9 +790,11 @@ steps:
     agents:
       queue: opensource
     plugins:
-      artifacts#v1.9.3:
+      artifacts#v1.9.4:
         download: "features/fixtures/ios/output/ipa_url_bb_debug.txt"
-        upload: "maze_output/failed/**/*"
+        upload:
+          - "maze_output/failed/**/*"
+          - "maze_output/maze_output.zip"
       docker-compose#v4.7.0:
         pull: cocoa-maze-runner-bitbar
         run: cocoa-maze-runner-bitbar
@@ -775,7 +807,7 @@ steps:
           - "--aws-public-ip"
           - "--fail-fast"
           - "features/debug"
-      test-collector#v1.10.2:
+      test-collector#v1.11.0:
         files: "reports/TEST-*.xml"
         format: "junit"
         branch: "^master|next$$"
@@ -794,12 +826,13 @@ steps:
     agents:
       queue: macos-15-isolated
     plugins:
-      artifacts#v1.5.0:
+      artifacts#v1.9.4:
         download: "features/fixtures/macos/output/macOSTestApp_Debug.zip"
         upload:
           - "macOSTestApp.log"
           - "maze_output/failed/**/*"
-      test-collector#v1.10.2:
+          - "maze_output/maze_output.zip"
+      test-collector#v1.11.0:
         files: "reports/TEST-*.xml"
         format: "junit"
         branch: "^master|next$$"
@@ -817,11 +850,12 @@ steps:
     agents:
       queue: macos-10.13
     plugins:
-      artifacts#v1.5.0:
+      artifacts#v1.9.4:
         download: "features/fixtures/macos/output/macOSTestApp_Debug.zip"
         upload:
           - "macOSTestApp.log"
           - "maze_output/failed/**/*"
+          - "maze_output/maze_output.zip"
     commands:
       - bundle install
       - bundle exec maze-runner

--- a/.buildkite/pipeline.yml
+++ b/.buildkite/pipeline.yml
@@ -274,7 +274,7 @@ steps:
           - "macOSTestApp.log"
           - "maze_output/failed/**/*"
           - "maze_output/maze_output.zip"
-        test-collector#v1.11.0:
+      test-collector#v1.11.0:
         files: "reports/TEST-*.xml"
         format: "junit"
         branch: "^master|next$$"
@@ -298,7 +298,7 @@ steps:
           - "macOSTestApp.log"
           - "maze_output/failed/**/*"
           - "maze_output/maze_output.zip"
-        test-collector#v1.11.0:
+      test-collector#v1.11.0:
         files: "reports/TEST-*.xml"
         format: "junit"
         branch: "^master|next$$"
@@ -322,7 +322,7 @@ steps:
           - "macOSTestApp.log"
           - "maze_output/failed/**/*"
           - "maze_output/maze_output.zip"
-        test-collector#v1.11.0:
+      test-collector#v1.11.0:
         files: "reports/TEST-*.xml"
         format: "junit"
         branch: "^master|next$$"


### PR DESCRIPTION
## Goal

Upload maze_output.zip as build artifact, so that we can inspect payloads received for passing tests if we want to.

## Changeset

I've also bumped the plugin versions.

## Testing

Covered by a full CI run.