### PR TITLE
Do not clear error requests received in e2e tests

### DIFF
--- a/features/app_hangs.feature
+++ b/features/app_hangs.feature
@@ -114,7 +114,7 @@ Feature: App hangs
     And I set the HTTP status code to 500
     And I configure Bugsnag for "AppHangFatalOnlyScenario"
     And I wait to receive an error
-    And I clear the error queue
+    And I discard all errors
     # Wait for fixture to receive the response and save the payload
     And I wait for 2 seconds
     And I kill and relaunch the app

--- a/features/release/delivery.feature
+++ b/features/release/delivery.feature
@@ -10,7 +10,7 @@ Feature: Delivery of errors
     And I wait to receive an error
     And I wait for the fixture to process the response
     And I kill and relaunch the app
-    And I clear the error queue
+    And I discard all errors
     And I configure Bugsnag for "HandledExceptionScenario"
     And I wait to receive an error
     Then the error is valid for the error reporting API
@@ -20,7 +20,7 @@ Feature: Delivery of errors
     And I run "HandledExceptionScenario"
     And I wait to receive an error
     And I kill and relaunch the app
-    And I clear the error queue
+    And I discard all errors
     And I configure Bugsnag for "HandledExceptionScenario"
     Then I should receive no errors
 
@@ -31,7 +31,7 @@ Feature: Delivery of errors
     And I wait for the fixture to process the response
     # The error should not have been persited
     And I kill and relaunch the app
-    And I clear the error queue
+    And I discard all errors
     And I configure Bugsnag for "OversizedHandledErrorScenario"
     Then I should receive no errors
 
@@ -42,13 +42,13 @@ Feature: Delivery of errors
     And I wait for the fixture to process the response
     # The error should now have been persisted
     And I kill and relaunch the app
-    And I clear the error queue
+    And I discard all errors
     And I configure Bugsnag for "OldHandledErrorScenario"
     And I wait to receive an error
     And I wait for the fixture to process the response
     # The error should now have been deleted
     And I kill and relaunch the app
-    And I clear the error queue
+    And I discard all errors
     And I configure Bugsnag for "OldHandledErrorScenario"
     Then I should receive no errors
 
@@ -60,7 +60,7 @@ Feature: Delivery of errors
     And I wait for the fixture to process the response
     # The crash report should now have been deleted
     And I kill and relaunch the app
-    And I clear the error queue
+    And I discard all errors
     And I configure Bugsnag for "OversizedCrashReportScenario"
     Then I should receive no errors
 
@@ -72,7 +72,7 @@ Feature: Delivery of errors
     And I wait for the fixture to process the response
     # The crash report should now have been deleted
     And I kill and relaunch the app
-    And I clear the error queue
+    And I discard all errors
     And I configure Bugsnag for "OldCrashReportScenario"
     Then I should receive no errors
 

--- a/features/release/event_callbacks.feature
+++ b/features/release/event_callbacks.feature
@@ -130,7 +130,7 @@ Feature: Callbacks can access and modify event information
     Given I set the HTTP status code for the next request to 500
     And I run "OnSendErrorPersistenceScenario"
     And I wait to receive an error
-    And I clear the error queue
+    And I discard all errors
     # Wait for fixture to receive the response and save the payload
     And I wait for 2 seconds
     And I kill and relaunch the app

--- a/features/steps/app_steps.rb
+++ b/features/steps/app_steps.rb
@@ -86,10 +86,6 @@ end
 
 # No platform relevance
 
-When('I clear the error queue') do
-  Maze::Server.errors.clear
-end
-
 
 def execute_command(action, args)
   Maze::Server.commands.add({ action: action, args: args, launch_count: $launch_count })


### PR DESCRIPTION
## Goal

Ensure all errors received in e2e tests are written to file.

## Design

The approach that the step was taking causes all received errors to be removed completely, meaning that they were not written to `errors.log` at the end of the scenario.  This approach simply moves the "current" pointer on in Maze Runner's internal list, meaning that all received errors are written.

## Testing

Covered by a basic CI run - just inspect the contents of `maze_output.zip`