### PR TITLE
Restore OOM E2E tests

### DIFF
--- a/Bugsnag/BSGCrashSentry.m
+++ b/Bugsnag/BSGCrashSentry.m
@@ -43,13 +43,13 @@ void BSGCrashSentryInstall(BugsnagConfiguration *config, KSReportWriteCallback o
         onCrash(writer, requiresAsyncSafety);
     };
 
-    KSCrashMonitorType crashTypes = 0;
+    KSCrashMonitorType crashTypes = KSCrashMonitorTypeSystem;
     if (config.autoDetectErrors) {
         if (ksdebug_isBeingTraced()) {
             // TODO: To be fixed in PLAT-13869
-            crashTypes = (KSCrashMonitorTypeDebuggerSafe & ~KSCrashMonitorTypeMemoryTermination);
+            crashTypes = (crashTypes | (KSCrashMonitorTypeDebuggerSafe & (~KSCrashMonitorTypeMemoryTermination)));
         } else {
-            crashTypes = KSCrashTypeFromBugsnagErrorTypes(config.enabledErrorTypes);
+            crashTypes = (crashTypes | KSCrashTypeFromBugsnagErrorTypes(config.enabledErrorTypes));
         }
         if (config.attemptDeliveryOnCrash) {
             bsg_log_debug(@"Enabling on-crash delivery");

--- a/Bugsnag/Client/BugsnagClient.m
+++ b/Bugsnag/Client/BugsnagClient.m
@@ -261,6 +261,7 @@ BSG_OBJC_DIRECT_MEMBERS
     // Map our bridged API early on.
     [BugsnagCocoaPerformanceFromBugsnagCocoa sharedInstance];
 
+    // Install KSCrash
     BSGCrashSentryInstall(self.configuration, BSSerializeDataCrashHandler);
 
     self.systemState = [[BugsnagSystemState alloc] initWithConfiguration:self.configuration];

--- a/Tests/BugsnagTests/BSGOutOfMemoryTests.m
+++ b/Tests/BugsnagTests/BSGOutOfMemoryTests.m
@@ -14,140 +14,138 @@
 
 @implementation BSGOutOfMemoryTests
 
-// TODO Restore before PLAT-13748 is closed
+- (BugsnagClient *)newClient {
+    BugsnagConfiguration *config = [[BugsnagConfiguration alloc] initWithApiKey:DUMMY_APIKEY_32CHAR_1];
+//    config.autoDetectErrors = NO;
+    config.releaseStage = @"MagicalTestingTime";
 
-//- (BugsnagClient *)newClient {
-//    BugsnagConfiguration *config = [[BugsnagConfiguration alloc] initWithApiKey:DUMMY_APIKEY_32CHAR_1];
-////    config.autoDetectErrors = NO;
-//    config.releaseStage = @"MagicalTestingTime";
-//
-//    BugsnagClient *client = [[BugsnagClient alloc] initWithConfiguration:config];
-//    [client start];
-//    return client;
-//}
-//
-///**
-// * Test that the generated OOM report values exist and are correct (where that can be tested)
-// */
-//- (void)testOOMFieldsSetCorrectly {
-//    BugsnagClient *client = [self newClient];
-//    BugsnagSystemState *systemState = [client systemState];
-//
-//    client.codeBundleId = @"codeBundleIdHere";
-//    // The update happens on a bg thread, so let it run.
-//    [NSThread sleepForTimeInterval:0.01f];
-//
-//    NSDictionary *state = systemState.currentLaunchState;
-//    XCTAssertNotNil([state objectForKey:@"app"]);
-//    XCTAssertNotNil([state objectForKey:@"device"]);
-//    
-//    NSDictionary *app = [state objectForKey:@"app"];
-//    XCTAssertNotNil([app objectForKey:@"bundleVersion"]);
-//    XCTAssertNotNil([app objectForKey:@"id"]);
-//    XCTAssertNotNil([app objectForKey:@"version"]);
-//    XCTAssertNotNil([app objectForKey:@"name"]);
-//    XCTAssertEqualObjects([app valueForKey:@"codeBundleId"], @"codeBundleIdHere");
-//    XCTAssertEqualObjects([app valueForKey:@"releaseStage"], @"MagicalTestingTime");
-//    
-//    NSDictionary *device = [state objectForKey:@"device"];
-//    XCTAssertNotNil([device objectForKey:@"osName"]);
-//    XCTAssertNotNil([device objectForKey:@"osBuild"]);
-//    XCTAssertNotNil([device objectForKey:@"osVersion"]);
-//    XCTAssertNotNil([device objectForKey:@"id"]);
-//    XCTAssertNotNil([device objectForKey:@"model"]);
-//    XCTAssertNotNil([device objectForKey:@"simulator"]);
-//    XCTAssertNotNil([device objectForKey:@"wordSize"]);
-//    XCTAssertEqualObjects([device valueForKey:@"locale"], [[NSLocale currentLocale] localeIdentifier]);
-//}
-//
-//-(void)testBadJSONData {
-//    NSString *stateFilePath = [BSGFileLocations current].systemState;
-//    NSError* error;
-//    [@"{1=\"a\"" writeToFile:stateFilePath atomically:YES encoding:NSUTF8StringEncoding error:&error];
-//    XCTAssertNil(error);
-//
-//    // Should not crash
-//    [self newClient];
-//}
-//
-//- (void)testLastLaunchTerminatedUnexpectedly {
-//    if (!bsg_runContext) {
-//        BSGRunContextInit(BSGFileLocations.current.runContext);
-//    }
-//    const struct BSGRunContext *oldContext = bsg_lastRunContext;
-//    struct BSGRunContext lastRunContext = *bsg_runContext;
-//    bsg_lastRunContext = &lastRunContext;
-//
-//    // Debugger active
-//    
-//    lastRunContext.isDebuggerAttached = true;
-//    lastRunContext.isTerminating = true;
-//    lastRunContext.isForeground = true;
-//    lastRunContext.isActive = true;
-//    XCTAssertFalse(BSGRunContextWasKilled());
-//
-//    lastRunContext.isDebuggerAttached = true;
-//    lastRunContext.isTerminating = true;
-//    lastRunContext.isForeground = false;
-//    lastRunContext.isActive = false;
-//    XCTAssertFalse(BSGRunContextWasKilled());
-//
-//    lastRunContext.isDebuggerAttached = true;
-//    lastRunContext.isTerminating = false;
-//    lastRunContext.isForeground = true;
-//    lastRunContext.isActive = true;
-//    XCTAssertFalse(BSGRunContextWasKilled());
-//
-//    lastRunContext.isDebuggerAttached = true;
-//    lastRunContext.isTerminating = false;
-//    lastRunContext.isForeground = false;
-//    lastRunContext.isActive = false;
-//    XCTAssertFalse(BSGRunContextWasKilled());
-//
-//    // Debugger inactive
-//
-//    lastRunContext.isDebuggerAttached = false;
-//    lastRunContext.isTerminating = true;
-//    lastRunContext.isForeground = true;
-//    lastRunContext.isActive = true;
-//    XCTAssertFalse(BSGRunContextWasKilled());
-//
-//    lastRunContext.isDebuggerAttached = false;
-//    lastRunContext.isTerminating = true;
-//    lastRunContext.isForeground = false;
-//    lastRunContext.isActive = false;
-//    XCTAssertFalse(BSGRunContextWasKilled());
-//
-//    lastRunContext.isDebuggerAttached = false;
-//    lastRunContext.isTerminating = false;
-//    lastRunContext.isForeground = true;
-//    lastRunContext.isActive = false;
-//    XCTAssertFalse(BSGRunContextWasKilled());
-//
-//    lastRunContext.isDebuggerAttached = false;
-//    lastRunContext.isTerminating = false;
-//    lastRunContext.isForeground = true;
-//    lastRunContext.isActive = true;
-//    XCTAssertTrue(BSGRunContextWasKilled());
-//    
-//    uuid_generate(lastRunContext.machoUUID);
-//    XCTAssertFalse(BSGRunContextWasKilled());
-//    uuid_copy(lastRunContext.machoUUID, bsg_runContext->machoUUID);
-//    
-//    strncpy(lastRunContext.bundleVersion, "999.99", sizeof(lastRunContext.bundleVersion));
-//    XCTAssertFalse(BSGRunContextWasKilled());
-//
-//    lastRunContext.bootTime = 0;
-//    XCTAssertFalse(BSGRunContextWasKilled());
-//    lastRunContext.bootTime = bsg_runContext->bootTime;
-//
-//    lastRunContext.isDebuggerAttached = false;
-//    lastRunContext.isTerminating = false;
-//    lastRunContext.isForeground = false;
-//    lastRunContext.isActive = false;
-//    XCTAssertFalse(BSGRunContextWasKilled());
-//    
-//    bsg_lastRunContext = oldContext;
-//}
+    BugsnagClient *client = [[BugsnagClient alloc] initWithConfiguration:config];
+    [client start];
+    return client;
+}
+
+/**
+ * Test that the generated OOM report values exist and are correct (where that can be tested)
+ */
+- (void)testOOMFieldsSetCorrectly {
+    BugsnagClient *client = [self newClient];
+    BugsnagSystemState *systemState = [client systemState];
+
+    client.codeBundleId = @"codeBundleIdHere";
+    // The update happens on a bg thread, so let it run.
+    [NSThread sleepForTimeInterval:0.01f];
+
+    NSDictionary *state = systemState.currentLaunchState;
+    XCTAssertNotNil([state objectForKey:@"app"]);
+    XCTAssertNotNil([state objectForKey:@"device"]);
+
+    NSDictionary *app = [state objectForKey:@"app"];
+    XCTAssertNotNil([app objectForKey:@"bundleVersion"]);
+    XCTAssertNotNil([app objectForKey:@"id"]);
+    XCTAssertNotNil([app objectForKey:@"version"]);
+    XCTAssertNotNil([app objectForKey:@"name"]);
+    XCTAssertEqualObjects([app valueForKey:@"codeBundleId"], @"codeBundleIdHere");
+    XCTAssertEqualObjects([app valueForKey:@"releaseStage"], @"MagicalTestingTime");
+
+    NSDictionary *device = [state objectForKey:@"device"];
+    XCTAssertNotNil([device objectForKey:@"osName"]);
+    XCTAssertNotNil([device objectForKey:@"osBuild"]);
+    XCTAssertNotNil([device objectForKey:@"osVersion"]);
+    XCTAssertNotNil([device objectForKey:@"id"]);
+    XCTAssertNotNil([device objectForKey:@"model"]);
+    XCTAssertNotNil([device objectForKey:@"simulator"]);
+    XCTAssertNotNil([device objectForKey:@"wordSize"]);
+    XCTAssertEqualObjects([device valueForKey:@"locale"], [[NSLocale currentLocale] localeIdentifier]);
+}
+
+-(void)testBadJSONData {
+    NSString *stateFilePath = [BSGFileLocations current].systemState;
+    NSError* error;
+    [@"{1=\"a\"" writeToFile:stateFilePath atomically:YES encoding:NSUTF8StringEncoding error:&error];
+    XCTAssertNil(error);
+
+    // Should not crash
+    [self newClient];
+}
+
+- (void)testLastLaunchTerminatedUnexpectedly {
+    if (!bsg_runContext) {
+        BSGRunContextInit(BSGFileLocations.current.runContext);
+    }
+    const struct BSGRunContext *oldContext = bsg_lastRunContext;
+    struct BSGRunContext lastRunContext = *bsg_runContext;
+    bsg_lastRunContext = &lastRunContext;
+
+    // Debugger active
+
+    lastRunContext.isDebuggerAttached = true;
+    lastRunContext.isTerminating = true;
+    lastRunContext.isForeground = true;
+    lastRunContext.isActive = true;
+    XCTAssertFalse(BSGRunContextWasKilled());
+
+    lastRunContext.isDebuggerAttached = true;
+    lastRunContext.isTerminating = true;
+    lastRunContext.isForeground = false;
+    lastRunContext.isActive = false;
+    XCTAssertFalse(BSGRunContextWasKilled());
+
+    lastRunContext.isDebuggerAttached = true;
+    lastRunContext.isTerminating = false;
+    lastRunContext.isForeground = true;
+    lastRunContext.isActive = true;
+    XCTAssertFalse(BSGRunContextWasKilled());
+
+    lastRunContext.isDebuggerAttached = true;
+    lastRunContext.isTerminating = false;
+    lastRunContext.isForeground = false;
+    lastRunContext.isActive = false;
+    XCTAssertFalse(BSGRunContextWasKilled());
+
+    // Debugger inactive
+
+    lastRunContext.isDebuggerAttached = false;
+    lastRunContext.isTerminating = true;
+    lastRunContext.isForeground = true;
+    lastRunContext.isActive = true;
+    XCTAssertFalse(BSGRunContextWasKilled());
+
+    lastRunContext.isDebuggerAttached = false;
+    lastRunContext.isTerminating = true;
+    lastRunContext.isForeground = false;
+    lastRunContext.isActive = false;
+    XCTAssertFalse(BSGRunContextWasKilled());
+
+    lastRunContext.isDebuggerAttached = false;
+    lastRunContext.isTerminating = false;
+    lastRunContext.isForeground = true;
+    lastRunContext.isActive = false;
+    XCTAssertFalse(BSGRunContextWasKilled());
+
+    lastRunContext.isDebuggerAttached = false;
+    lastRunContext.isTerminating = false;
+    lastRunContext.isForeground = true;
+    lastRunContext.isActive = true;
+    XCTAssertTrue(BSGRunContextWasKilled());
+
+    uuid_generate(lastRunContext.machoUUID);
+    XCTAssertFalse(BSGRunContextWasKilled());
+    uuid_copy(lastRunContext.machoUUID, bsg_runContext->machoUUID);
+
+    strncpy(lastRunContext.bundleVersion, "999.99", sizeof(lastRunContext.bundleVersion));
+    XCTAssertFalse(BSGRunContextWasKilled());
+
+    lastRunContext.bootTime = 0;
+    XCTAssertFalse(BSGRunContextWasKilled());
+    lastRunContext.bootTime = bsg_runContext->bootTime;
+
+    lastRunContext.isDebuggerAttached = false;
+    lastRunContext.isTerminating = false;
+    lastRunContext.isForeground = false;
+    lastRunContext.isActive = false;
+    XCTAssertFalse(BSGRunContextWasKilled());
+
+    bsg_lastRunContext = oldContext;
+}
 
 @end

--- a/features/release/out_of_memory.feature
+++ b/features/release/out_of_memory.feature
@@ -1,5 +1,3 @@
-# TODO Restore before PLAT-13748 is closed
-@skip
 @skip_macos
 Feature: Out of memory errors
 


### PR DESCRIPTION
## Changeset
In case of enabled auto detection of errors the system monitor was not enabled and app info was not populated.

## Testing
Re-enabled mazerunner tests for OOM scenarios.