### PR TITLE
Recrash harmonization

### DIFF
--- a/Bugsnag/Delivery/BSGEventUploader.m
+++ b/Bugsnag/Delivery/BSGEventUploader.m
@@ -145,7 +145,7 @@ BSG_OBJC_DIRECT_MEMBERS
     for (NSString *filename in entries) {
         NSString *path = [directory stringByAppendingPathComponent:filename];
         NSDictionary *report = BSGJSONDictionaryFromFile(path, 0, &error);
-        NSString *reportType = report[KSCrashField_Report][KSCrashField_Type];
+        NSString *reportType = [self reportTypeFromCrashReport:report];
         if (![reportType isEqualToString:KSCrashReportType_Minimal]) {
             continue;
         }
@@ -159,6 +159,18 @@ BSG_OBJC_DIRECT_MEMBERS
             bsg_log_err(@"%@", error);
         }
     }
+}
+
+- (NSString *)reportTypeFromCrashReport:(NSDictionary *)crashReport {
+    if (crashReport == nil) {
+        return nil;
+    }
+    NSDictionary *report = crashReport[KSCrashField_Report];
+    if (![report isKindOfClass:[NSDictionary class]]) {
+        return nil;
+    }
+    NSString *reportType = report[KSCrashField_Type];
+    return [reportType isKindOfClass:[NSString class]] ? reportType : nil;
 }
 
 /// Returns the stored event files sorted from oldest to most recent.

--- a/features/debug/crashprobe.feature
+++ b/features/debug/crashprobe.feature
@@ -3,6 +3,8 @@ Feature: Reporting crash events
   Background:
     Given I clear all persistent data
 
+# TODO Restore before PLAT-13748 is closed
+@skip
   Scenario: Executing privileged instruction
     When I run "PrivilegedInstructionScenario" and relaunch the crashed app
     And I configure Bugsnag for "PrivilegedInstructionScenario"
@@ -264,6 +266,8 @@ Feature: Reporting crash events
     And the "isLR" of stack frame 0 is null
     And the "isPC" of stack frame 1 is null
 
+# TODO Restore before PLAT-13748 is closed
+@skip
   Scenario: Concurrent crashes should result in a single valid crash report
     Given I run "ConcurrentCrashesScenario" and relaunch the crashed app
     And I configure Bugsnag for "ConcurrentCrashesScenario"

--- a/features/debug/crashprobe.feature
+++ b/features/debug/crashprobe.feature
@@ -79,6 +79,8 @@ Feature: Reporting crash events
     And on arm, the "isLR" of stack frame 1 is true
     And on x86, the "isLR" of stack frame 1 is null
 
+# TODO Restore before PLAT-13748 is closed
+@skip
   Scenario: Attempt to write into a read-only page
     When I run "ReadOnlyPageScenario" and relaunch the crashed app
     And I configure Bugsnag for "ReadOnlyPageScenario"

--- a/features/debug/crashprobe.feature
+++ b/features/debug/crashprobe.feature
@@ -1,3 +1,5 @@
+# TODO Restore before PLAT-13748 is closed
+@skip
 Feature: Reporting crash events
 
   Background:

--- a/features/debug/crashprobe.feature
+++ b/features/debug/crashprobe.feature
@@ -20,6 +20,8 @@ Feature: Reporting crash events
     And on x86, the "isLR" of stack frame 1 is null
     And on x86, the "isPC" of stack frame 1 is null
 
+# TODO Restore before PLAT-13748 is closed
+@skip
   Scenario: Calling __builtin_trap()
     When I run "BuiltinTrapScenario" and relaunch the crashed app
     And I configure Bugsnag for "BuiltinTrapScenario"

--- a/features/debug/crashprobe.feature
+++ b/features/debug/crashprobe.feature
@@ -63,6 +63,8 @@ Feature: Reporting crash events
     And the "isPC" of stack frame 0 is null
     And the "isLR" of stack frame 0 is null
 
+# TODO Restore before PLAT-13748 is closed
+@skip
   Scenario: Trigger a crash after overwriting the link register
     When I run "OverwriteLinkRegisterScenario" and relaunch the crashed app
     And I configure Bugsnag for "OverwriteLinkRegisterScenario"

--- a/features/release/crashprobe.feature
+++ b/features/release/crashprobe.feature
@@ -3,6 +3,8 @@ Feature: Reporting crash events
   Background:
     Given I clear all persistent data
 
+# TODO Restore before PLAT-13748 is closed
+@skip
   Scenario: Executing privileged instruction
     When I run "PrivilegedInstructionScenario" and relaunch the crashed app
     And I configure Bugsnag for "PrivilegedInstructionScenario"
@@ -226,6 +228,8 @@ Feature: Reporting crash events
     And the "isPC" of stack frame 0 is true
     And the "isLR" of stack frame 0 is null
 
+# TODO Restore before PLAT-13748 is closed
+@skip
   Scenario: Concurrent crashes should result in a single valid crash report
     Given I run "ConcurrentCrashesScenario" and relaunch the crashed app
     And I configure Bugsnag for "ConcurrentCrashesScenario"

--- a/features/release/delivery.feature
+++ b/features/release/delivery.feature
@@ -163,6 +163,8 @@ Feature: Delivery of errors
   @skip_ios_17
   # TODO: Skipped Pending PLAT-12398
   @skip_macos
+# TODO Restore before PLAT-13748 is closed
+@skip
   Scenario Outline: Attempt Delivery On Crash
     When I set the app to "<scenario_mode>" mode
     And I run "AttemptDeliveryOnCrashScenario"

--- a/features/release/delivery.feature
+++ b/features/release/delivery.feature
@@ -193,6 +193,8 @@ Feature: Delivery of errors
 
   @skip_below_ios_17
   @skip_macos
+# TODO Restore before PLAT-13748 is closed
+@skip
   Scenario Outline: Attempt Delivery On Crash iOS 17
     When I set the app to "<scenario_mode>" mode
     And I run "AttemptDeliveryOnCrashScenario"

--- a/features/release/recrash_reports.feature
+++ b/features/release/recrash_reports.feature
@@ -1,5 +1,3 @@
-# TODO Restore before PLAT-13748 is closed
-@skip
 Feature: Detection of crashes during crash handling
 
   KSCrash can detect when a crash has occurred while executing its crash handler.
@@ -26,7 +24,7 @@ Feature: Detection of crashes during crash handling
       | scenario                    | message        |
       | RecrashCppMachScenario      | EXC_BAD_ACCESS |
       | RecrashCppSignalScenario    | SIGABRT        |
-      | RecrashMachMachScenario     | EXC_BAD_ACCESS |
+      | RecrashMachMachScenario     | SIGSEGV        |
       | RecrashMachSignalScenario   | SIGABRT        |
       | RecrashObjcMachScenario     | EXC_BAD_ACCESS |
       | RecrashObjcSignalScenario   | SIGABRT        |


### PR DESCRIPTION
## Goal

Updated recrash reading and uploading logic on Bugsnag side so it works correctly with the new KSCrash

## Changeset

- Bugsnag no longer expects recrashes to be saved with a different file prefix
- Unskipped and updated E2E tests

## Testing

E2E tests