### PR TITLE
Upload symbols to Insight Hub and bugsnag.com for e2e tests

### DIFF
--- a/.buildkite/pipeline.full.yml
+++ b/.buildkite/pipeline.full.yml
@@ -59,6 +59,8 @@ steps:
           - "--device=IOS_17"
           - "--no-tunnel"
           - "--aws-public-ip"
+          - "--repeater-api-key="
+          - "--hub-repeater-api-key="
           - "features/release/barebone_tests.feature"
       test-collector#v1.11.0:
         files: "reports/TEST-*.xml"
@@ -94,6 +96,8 @@ steps:
           - "--device=IOS_16"
           - "--no-tunnel"
           - "--aws-public-ip"
+          - "--repeater-api-key="
+          - "--hub-repeater-api-key="
           - "features/release/barebone_tests.feature"
       test-collector#v1.11.0:
         files: "reports/TEST-*.xml"
@@ -129,6 +133,8 @@ steps:
           - "--device=IOS_13"
           - "--no-tunnel"
           - "--aws-public-ip"
+          - "--repeater-api-key="
+          - "--hub-repeater-api-key="
           - "features/release/barebone_tests.feature"
       test-collector#v1.11.0:
         files: "reports/TEST-*.xml"
@@ -166,6 +172,8 @@ steps:
       - bundle exec maze-runner
         features/release/barebone_tests.feature
         --os=macos
+        --repeater-api-key=
+        --hub-repeater-api-key=
 
   - label: 'macOS 10.13 XcFramework barebone E2E tests'
     depends_on:
@@ -191,6 +199,8 @@ steps:
       - bundle exec maze-runner
         features/release/barebone_tests.feature
         --os=macos
+        --repeater-api-key=
+        --hub-repeater-api-key=
 
   #
   # BitBar

--- a/.buildkite/pipeline.yml
+++ b/.buildkite/pipeline.yml
@@ -169,6 +169,8 @@ steps:
     timeout_in_minutes: 10
     agents:
       queue: macos-15-isolated
+    env:
+      XCODE_VERSION: 16.3.0
     commands:
       - ./scripts/run-unit-tests.sh PLATFORM=iOS OS=15.5 DEVICE="iPhone 13"
     artifact_paths:
@@ -187,6 +189,8 @@ steps:
     timeout_in_minutes: 10
     agents:
       queue: macos-15-isolated
+    env:
+      XCODE_VERSION: 16.3.0
     commands:
       - ./scripts/run-unit-tests.sh PLATFORM=tvOS OS=18.4
     artifact_paths:
@@ -196,6 +200,8 @@ steps:
     timeout_in_minutes: 10
     agents:
       queue: macos-15-isolated
+    env:
+      XCODE_VERSION: 16.3.0
     commands:
       - ./scripts/run-unit-tests.sh PLATFORM=tvOS OS=15.4
     artifact_paths:

--- a/.buildkite/pipeline.yml
+++ b/.buildkite/pipeline.yml
@@ -43,7 +43,7 @@ steps:
       - features/fixtures/ios/output/ipa_url_bb_debug.txt
       - features/fixtures/ios/output/ipa_url_bs_debug.txt
     commands:
-      - ruby script/build-test-fixtures.rb
+      - ruby scripts/build-test-fixture.rb
 
   - label: Carthage
     timeout_in_minutes: 15
@@ -776,6 +776,8 @@ steps:
           - "--farm=bs"
           - "--device=IOS_18"
           - "--fail-fast"
+          - "--repeater-api-key="
+          - "--hub-repeater-api-key="
           - "features/debug"
       test-collector#v1.11.0:
         files: "reports/TEST-*.xml"
@@ -812,6 +814,8 @@ steps:
           - "--no-tunnel"
           - "--aws-public-ip"
           - "--fail-fast"
+          - "--repeater-api-key="
+          - "--hub-repeater-api-key="
           - "features/debug"
       test-collector#v1.11.0:
         files: "reports/TEST-*.xml"
@@ -846,6 +850,8 @@ steps:
       - bundle install
       - bundle exec maze-runner
         features/debug
+        --repeater-api-key=
+        --hub-repeater-api-key=
         --os=macos
         --fail-fast
 
@@ -866,6 +872,8 @@ steps:
       - bundle install
       - bundle exec maze-runner
         features/debug
+        --repeater-api-key=
+        --hub-repeater-api-key=
         --os=macos
         --fail-fast
 

--- a/.buildkite/pipeline.yml
+++ b/.buildkite/pipeline.yml
@@ -43,12 +43,7 @@ steps:
       - features/fixtures/ios/output/ipa_url_bb_debug.txt
       - features/fixtures/ios/output/ipa_url_bs_debug.txt
     commands:
-      - bundle install
-      - make test-fixtures
-      - bundle exec upload-app --farm=bb --app=./features/fixtures/ios/output/iOSTestApp_Release.ipa --app-id-file=./features/fixtures/ios/output/ipa_url_bb_release.txt
-      - bundle exec upload-app --farm=bs --app=./features/fixtures/ios/output/iOSTestApp_Release.ipa --app-id-file=./features/fixtures/ios/output/ipa_url_bs_release.txt
-      - bundle exec upload-app --farm=bb --app=./features/fixtures/ios/output/iOSTestApp_Debug.ipa --app-id-file=./features/fixtures/ios/output/ipa_url_bb_debug.txt
-      - bundle exec upload-app --farm=bs --app=./features/fixtures/ios/output/iOSTestApp_Debug.ipa --app-id-file=./features/fixtures/ios/output/ipa_url_bs_debug.txt
+      - ruby script/build-test-fixtures.rb
 
   - label: Carthage
     timeout_in_minutes: 15

--- a/features/fixtures/ios/iOSTestApp.xcodeproj/project.pbxproj
+++ b/features/fixtures/ios/iOSTestApp.xcodeproj/project.pbxproj
@@ -699,7 +699,6 @@
 				8AB8865C20404DD30003E444 /* Sources */,
 				8AB8865D20404DD30003E444 /* Frameworks */,
 				8AB8865E20404DD30003E444 /* Resources */,
-				3FACF0EFE4366E7546A22C90 /* [Bugsnag] Upload dSYMs */,
 			);
 			buildRules = (
 			);
@@ -757,29 +756,6 @@
 			runOnlyForDeploymentPostprocessing = 0;
 		};
 /* End PBXResourcesBuildPhase section */
-
-/* Begin PBXShellScriptBuildPhase section */
-		3FACF0EFE4366E7546A22C90 /* [Bugsnag] Upload dSYMs */ = {
-			isa = PBXShellScriptBuildPhase;
-			buildActionMask = 2147483647;
-			files = (
-			);
-			inputFileListPaths = (
-			);
-			inputPaths = (
-				"${DWARF_DSYM_FOLDER_PATH}/${DWARF_DSYM_FILE_NAME}/Contents/Resources/DWARF/${TARGET_NAME}",
-			);
-			name = "[Bugsnag] Upload dSYMs";
-			outputFileListPaths = (
-			);
-			outputPaths = (
-			);
-			runOnlyForDeploymentPostprocessing = 0;
-			shellPath = "/usr/bin/env ruby";
-			shellScript = "# First, attempt to get the API key from an environment variable\napi_key = ENV[\"BUGSNAG_API_KEY\"]\n\n# If not present, attempt to lookup the value from the Info.plist\nif !api_key\n  default_info_plist_location = Dir.glob(\"./{ios/,}*/Info.plist\").reject {|path| path =~ /build|test/i }\n  plist_buddy_response = `/usr/libexec/PlistBuddy -c \"print :BugsnagAPIKey\" \"#{default_info_plist_location.first}\"`\n  api_key = plist_buddy_response if $?.success?\nend\n\ndsyms = Dir[\"#{ENV[\"DWARF_DSYM_FOLDER_PATH\"]}/*/Contents/Resources/DWARF/*\"]\n\nfork do\n  Process.setsid\n  STDIN.reopen(\"/dev/null\")\n  STDOUT.reopen(\"/dev/null\", \"a\")\n  STDERR.reopen(\"/dev/null\", \"a\")\n\n  require 'shellwords'\n\n  dsyms.each do |dsym|\n    curl_command = \"curl -F dsym=@#{Shellwords.escape(dsym)} -F projectRoot=#{Shellwords.escape(ENV[\"PROJECT_DIR\"])} \"\n    curl_command += \"-F apiKey=#{Shellwords.escape(api_key)} \" if api_key\n    curl_command += \"https://upload.bugsnag.com/\"\n    system(curl_command)\n  end\nend\n";
-			showEnvVarsInLog = 0;
-		};
-/* End PBXShellScriptBuildPhase section */
 
 /* Begin PBXSourcesBuildPhase section */
 		8AB8865C20404DD30003E444 /* Sources */ = {

--- a/features/release/breadcrumbs.feature
+++ b/features/release/breadcrumbs.feature
@@ -40,6 +40,8 @@ Feature: Attaching a series of notable events leading up to errors
     And I wait to receive an error
     Then the event has a "manual" breadcrumb named "Cache locked"
 
+  # TODO: Flaky on iOS 18 - see PLAT-14585
+  @skip_ios_18
   @skip_below_ios_13
   @skip_macos
   Scenario: State breadcrumbs

--- a/features/scripts/export_ios_app.sh
+++ b/features/scripts/export_ios_app.sh
@@ -23,7 +23,7 @@ pushd features/fixtures/ios
     -workspace iOSTestApp.xcworkspace \
     -destination generic/platform=iOS \
     -configuration ${BUILD_CONFIGURATION} \
-    -archivePath archive/iosTestApp.xcarchive \
+    -archivePath archive/iosTestApp_$BUILD_CONFIGURATION.xcarchive \
     -allowProvisioningUpdates \
     -quiet \
     archive \
@@ -34,7 +34,7 @@ pushd features/fixtures/ios
 
   xcrun xcodebuild \
     -exportArchive \
-    -archivePath archive/iosTestApp.xcarchive \
+    -archivePath archive/iosTestApp_$BUILD_CONFIGURATION.xcarchive \
     -destination generic/platform=iOS \
     -exportPath output/ \
     -quiet \

--- a/features/scripts/export_mac_app.sh
+++ b/features/scripts/export_mac_app.sh
@@ -19,7 +19,7 @@ pushd features/fixtures/macos
     -scheme macOSTestApp
     -destination generic/platform=macOS
     -configuration ${BUILD_CONFIGURATION}
-    -archivePath archive/macOSTestApp.xcarchive
+    -archivePath archive/macOSTestApp_$BUILD_CONFIGURATION.xcarchive
     -quiet
     archive
     ONLY_ACTIVE_ARCH=NO
@@ -41,7 +41,7 @@ pushd features/fixtures/macos
     -exportArchive \
     -exportPath output/ \
     -exportOptionsPlist exportOptions.plist \
-    -archivePath archive/macOSTestApp.xcarchive \
+    -archivePath archive/macOSTestApp_$BUILD_CONFIGURATION.xcarchive \
     -destination generic/platform=macOS \
     -quiet
 

--- a/features/support/env.rb
+++ b/features/support/env.rb
@@ -82,6 +82,10 @@ Before('@skip_ios_17') do |_scenario|
   skip_between('ios', 17, 17.99)
 end
 
+Before('@skip_ios_18') do |_scenario|
+  skip_between('ios', 18, 18.99)
+end
+
 Before('@skip_below_ios_11') do |_scenario|
   skip_below('ios', 11)
 end

--- a/scripts/build-test-fixture.rb
+++ b/scripts/build-test-fixture.rb
@@ -1,0 +1,21 @@
+def upload_files(api_key, dest)
+  Dir.chdir('features/fixtures/mazerunner') do
+    upload = "bugsnag-cli upload"
+    options = "--api-key=#{api_key} --overwrite --version-code=1"
+    puts "Uploading symbol files to #{dest}"
+    puts `#{upload} android-ndk #{options}`
+    puts "Uploading mapping file to #{dest}"
+    puts `#{upload} android-proguard #{options} --application-id=com.bugsnag.android.mazerunner`
+  end
+end
+
+puts 'Building test fixture'
+puts `bundle install`
+puts `make fixture-r21`
+
+upload_files(ENV['MAZE_REPEATER_API_KEY'], 'bugsnag.com') if ENV['MAZE_REPEATER_API_KEY']
+upload_files(ENV['MAZE_HUB_REPEATER_API_KEY'], 'Insight Hub') if ENV['MAZE_HUB_REPEATER_API_KEY']
+
+puts 'Uploading to BrowserStack and BitBar'
+puts `bundle exec upload-app --farm=bb --app=./build/fixture-r21.apk --app-id-file=build/fixture-r21-url.txt`
+puts `bundle exec upload-app --farm=bs --app=./build/fixture-r21.apk --app-id-file=build/bs-fixture-r21-url.txt`

--- a/scripts/build-test-fixture.rb
+++ b/scripts/build-test-fixture.rb
@@ -17,7 +17,7 @@ end
 
 run_command 'bundle install'
 run_command 'make test-fixtures'
-run_command 'bugsnag-cli'
+
 puts 'Uploading IPAs to BrowserStack and BitBar'
 run_command 'bundle exec upload-app --farm=bb --app=./features/fixtures/ios/output/iOSTestApp_Release.ipa --app-id-file=./features/fixtures/ios/output/ipa_url_bb_release.txt'
 run_command 'bundle exec upload-app --farm=bs --app=./features/fixtures/ios/output/iOSTestApp_Release.ipa --app-id-file=./features/fixtures/ios/output/ipa_url_bs_release.txt'

--- a/scripts/build-test-fixture.rb
+++ b/scripts/build-test-fixture.rb
@@ -12,6 +12,7 @@ end
 def upload_dsyms(api_key, dest)
   puts "Uploading dsyms to #{dest}"
   run_command "bugsnag-cli upload dsym --api-key=#{api_key} --overwrite features/fixtures/ios/archive/iosTestApp_Release.xcarchive"
+  run_command "bugsnag-cli upload dsym --api-key=#{api_key} --overwrite features/fixtures/macos/archive/macOSTestApp_Release.xcarchive"
 end
 
 run_command 'bundle install'


### PR DESCRIPTION
## Goal

Upload symbols to Insight Hub and bugsnag.com for e2e tests, when the relevant Maze Runner repeater environment variables are set.

## Changeset

- Removes the Upload dSyms build phase, as it only uploads to bugsnag.com and is somewhat hidden away from view.
- Commands to build the test fixture are factored into their own script for brevity in the pipeline file and to allow conditional logic for cleanly.
- Symbols are only uploaded for the release macOS and iOS test fixtures, so the repeater API keys are explicitly set to empty values in other test runs - this disables the Maze Runner functionality that repeats the received events.
- The debug and release test fixtures are now archived to separate locations for both iOS and macOS, as writing to the same location was causing us surprises while investigation behaviour.

## Testing

Covered by running a full CI build and then inspecting the Bugsnag/Insight Hub dashboards.