### PR TITLE
Remove BSG_OBJC_DIRECT_MEMBERS macro

### DIFF
--- a/Bugsnag.xcodeproj/project.pbxproj
+++ b/Bugsnag.xcodeproj/project.pbxproj
@@ -4174,10 +4174,7 @@
 				DYLIB_COMPATIBILITY_VERSION = 1;
 				DYLIB_CURRENT_VERSION = 1;
 				DYLIB_INSTALL_NAME_BASE = "@rpath";
-				GCC_PREPROCESSOR_DEFINITIONS = (
-					"$(inherited)",
-					"BSG_OBJC_DIRECT_MEMBERS=''",
-				);
+				GCC_PREPROCESSOR_DEFINITIONS = "$(inherited)";
 				INSTALL_PATH = "$(LOCAL_LIBRARY_DIR)/Frameworks";
 				LD_RUNPATH_SEARCH_PATHS = (
 					"$(inherited)",
@@ -4220,10 +4217,7 @@
 			buildSettings = {
 				CODE_SIGN_STYLE = Automatic;
 				DEVELOPMENT_TEAM = 7W9PZ27Y5F;
-				GCC_PREPROCESSOR_DEFINITIONS = (
-					"$(inherited)",
-					"BSG_OBJC_DIRECT_MEMBERS=''",
-				);
+				GCC_PREPROCESSOR_DEFINITIONS = "$(inherited)";
 				INFOPLIST_FILE = Tests/BugsnagTests/Info.plist;
 				LD_RUNPATH_SEARCH_PATHS = (
 					"$(inherited)",
@@ -4272,10 +4266,7 @@
 				DYLIB_COMPATIBILITY_VERSION = 1;
 				DYLIB_CURRENT_VERSION = 1;
 				DYLIB_INSTALL_NAME_BASE = "@rpath";
-				GCC_PREPROCESSOR_DEFINITIONS = (
-					"$(inherited)",
-					"BSG_OBJC_DIRECT_MEMBERS=''",
-				);
+				GCC_PREPROCESSOR_DEFINITIONS = "$(inherited)";
 				INSTALL_PATH = "$(LOCAL_LIBRARY_DIR)/Frameworks";
 				LD_RUNPATH_SEARCH_PATHS = (
 					"$(inherited)",
@@ -4318,10 +4309,7 @@
 			buildSettings = {
 				CODE_SIGN_STYLE = Automatic;
 				COMBINE_HIDPI_IMAGES = YES;
-				GCC_PREPROCESSOR_DEFINITIONS = (
-					"$(inherited)",
-					"BSG_OBJC_DIRECT_MEMBERS=''",
-				);
+				GCC_PREPROCESSOR_DEFINITIONS = "$(inherited)";
 				INFOPLIST_FILE = Tests/BugsnagTests/Info.plist;
 				LD_RUNPATH_SEARCH_PATHS = (
 					"$(inherited)",
@@ -4366,10 +4354,7 @@
 				DYLIB_COMPATIBILITY_VERSION = 1;
 				DYLIB_CURRENT_VERSION = 1;
 				DYLIB_INSTALL_NAME_BASE = "@rpath";
-				GCC_PREPROCESSOR_DEFINITIONS = (
-					"$(inherited)",
-					"BSG_OBJC_DIRECT_MEMBERS=''",
-				);
+				GCC_PREPROCESSOR_DEFINITIONS = "$(inherited)";
 				INSTALL_PATH = "$(LOCAL_LIBRARY_DIR)/Frameworks";
 				LD_RUNPATH_SEARCH_PATHS = (
 					"$(inherited)",
@@ -4411,10 +4396,7 @@
 			isa = XCBuildConfiguration;
 			buildSettings = {
 				CODE_SIGN_STYLE = Automatic;
-				GCC_PREPROCESSOR_DEFINITIONS = (
-					"$(inherited)",
-					"BSG_OBJC_DIRECT_MEMBERS=''",
-				);
+				GCC_PREPROCESSOR_DEFINITIONS = "$(inherited)";
 				INFOPLIST_FILE = Tests/BugsnagTests/Info.plist;
 				LD_RUNPATH_SEARCH_PATHS = (
 					"$(inherited)",
@@ -4545,10 +4527,7 @@
 				DYLIB_COMPATIBILITY_VERSION = 1;
 				DYLIB_CURRENT_VERSION = 1;
 				DYLIB_INSTALL_NAME_BASE = "@rpath";
-				GCC_PREPROCESSOR_DEFINITIONS = (
-					"$(inherited)",
-					"BSG_OBJC_DIRECT_MEMBERS=''",
-				);
+				GCC_PREPROCESSOR_DEFINITIONS = "$(inherited)";
 				GCC_WARN_64_TO_32_BIT_CONVERSION = YES;
 				GCC_WARN_ABOUT_RETURN_TYPE = YES_ERROR;
 				GCC_WARN_UNDECLARED_SELECTOR = YES;
@@ -4660,10 +4639,7 @@
 				CODE_SIGN_STYLE = Automatic;
 				CURRENT_PROJECT_VERSION = 1;
 				DEVELOPMENT_TEAM = 7W9PZ27Y5F;
-				GCC_PREPROCESSOR_DEFINITIONS = (
-					"$(inherited)",
-					"BSG_OBJC_DIRECT_MEMBERS=''",
-				);
+				GCC_PREPROCESSOR_DEFINITIONS = "$(inherited)";
 				GCC_WARN_64_TO_32_BIT_CONVERSION = YES;
 				GCC_WARN_ABOUT_RETURN_TYPE = YES_ERROR;
 				GCC_WARN_UNDECLARED_SELECTOR = YES;

--- a/Bugsnag/Breadcrumbs/BSGNotificationBreadcrumbs.h
+++ b/Bugsnag/Breadcrumbs/BSGNotificationBreadcrumbs.h
@@ -16,7 +16,7 @@ NS_ASSUME_NONNULL_BEGIN
 
 static NSString * const BSGNotificationBreadcrumbsMessageAppWillTerminate = @"App Will Terminate";
 
-BSG_OBJC_DIRECT_MEMBERS
+
 @interface BSGNotificationBreadcrumbs : NSObject
 
 #pragma mark Initializers

--- a/Bugsnag/Breadcrumbs/BSGNotificationBreadcrumbs.m
+++ b/Bugsnag/Breadcrumbs/BSGNotificationBreadcrumbs.m
@@ -16,7 +16,7 @@
 #import "BugsnagBreadcrumbs.h"
 #import "BugsnagConfiguration+Private.h"
 
-BSG_OBJC_DIRECT_MEMBERS
+
 @interface BSGNotificationBreadcrumbs ()
 
 @property (nonatomic) NSDictionary<NSNotificationName, NSString *> *notificationNameMap;
@@ -42,7 +42,7 @@ BSG_OBJC_DIRECT_MEMBERS
 @end
 
 
-BSG_OBJC_DIRECT_MEMBERS
+
 @implementation BSGNotificationBreadcrumbs
 
 - (instancetype)initWithConfiguration:(BugsnagConfiguration *)configuration

--- a/Bugsnag/Breadcrumbs/BugsnagBreadcrumbs.h
+++ b/Bugsnag/Breadcrumbs/BugsnagBreadcrumbs.h
@@ -16,7 +16,7 @@ typedef struct BSG_KSCrashReportWriter BSG_KSCrashReportWriter;
 
 NS_ASSUME_NONNULL_BEGIN
 
-BSG_OBJC_DIRECT_MEMBERS
+
 @interface BugsnagBreadcrumbs : NSObject
 
 - (instancetype)initWithConfiguration:(BugsnagConfiguration *)config;

--- a/Bugsnag/Breadcrumbs/BugsnagBreadcrumbs.m
+++ b/Bugsnag/Breadcrumbs/BugsnagBreadcrumbs.m
@@ -47,7 +47,7 @@ static atomic_bool g_writing_crash_report;
 
 #pragma mark -
 
-BSG_OBJC_DIRECT_MEMBERS
+
 @implementation BugsnagBreadcrumbs
 
 - (instancetype)initWithConfiguration:(BugsnagConfiguration *)config {

--- a/Bugsnag/Bugsnag+Private.h
+++ b/Bugsnag/Bugsnag+Private.h
@@ -12,7 +12,7 @@
 
 NS_ASSUME_NONNULL_BEGIN
 
-BSG_OBJC_DIRECT_MEMBERS
+
 @interface Bugsnag ()
 
 #pragma mark Methods

--- a/Bugsnag/Bugsnag.m
+++ b/Bugsnag/Bugsnag.m
@@ -36,7 +36,7 @@
 
 static BugsnagClient *bsg_g_bugsnag_client = NULL;
 
-BSG_OBJC_DIRECT_MEMBERS
+
 @implementation Bugsnag
 
 + (BugsnagClient *_Nonnull)start {

--- a/Bugsnag/BugsnagSessionTracker.h
+++ b/Bugsnag/BugsnagSessionTracker.h
@@ -15,7 +15,7 @@
 
 NS_ASSUME_NONNULL_BEGIN
 
-BSG_OBJC_DIRECT_MEMBERS
+
 @interface BugsnagSessionTracker : NSObject
 
 /**

--- a/Bugsnag/BugsnagSessionTracker.m
+++ b/Bugsnag/BugsnagSessionTracker.m
@@ -27,7 +27,7 @@
  */
 static NSTimeInterval const BSGNewSessionBackgroundDuration = 30;
 
-BSG_OBJC_DIRECT_MEMBERS
+
 @interface BugsnagSessionTracker ()
 @property (strong, nonatomic) BugsnagConfiguration *config;
 @property (weak, nonatomic) BugsnagClient *client;
@@ -35,7 +35,7 @@ BSG_OBJC_DIRECT_MEMBERS
 @property (nonatomic) NSMutableDictionary *extraRuntimeInfo;
 @end
 
-BSG_OBJC_DIRECT_MEMBERS
+
 @implementation BugsnagSessionTracker
 
 - (instancetype)initWithConfig:(BugsnagConfiguration *)config client:(BugsnagClient *)client {

--- a/Bugsnag/BugsnagSystemState.h
+++ b/Bugsnag/BugsnagSystemState.h
@@ -20,7 +20,7 @@
 
 NS_ASSUME_NONNULL_BEGIN
 
-BSG_OBJC_DIRECT_MEMBERS
+
 @interface BugsnagSystemState : NSObject
 
 @property(readonly,nonatomic) NSDictionary *lastLaunchState;

--- a/Bugsnag/BugsnagSystemState.m
+++ b/Bugsnag/BugsnagSystemState.m
@@ -107,7 +107,7 @@ static NSDictionary *copyDictionary(NSDictionary *launchState) {
     return dictionary;
 }
 
-BSG_OBJC_DIRECT_MEMBERS
+
 @interface BugsnagSystemState ()
 
 @property(readwrite,atomic) NSDictionary *currentLaunchState;
@@ -116,7 +116,7 @@ BSG_OBJC_DIRECT_MEMBERS
 
 @end
 
-BSG_OBJC_DIRECT_MEMBERS
+
 @implementation BugsnagSystemState
 
 - (instancetype)initWithConfiguration:(BugsnagConfiguration *)config {

--- a/Bugsnag/Client/BugsnagClient+Private.h
+++ b/Bugsnag/Client/BugsnagClient+Private.h
@@ -23,7 +23,7 @@
 
 NS_ASSUME_NONNULL_BEGIN
 
-BSG_OBJC_DIRECT_MEMBERS
+
 @interface BugsnagClient ()
 
 #pragma mark Properties

--- a/Bugsnag/Client/BugsnagClient.m
+++ b/Bugsnag/Client/BugsnagClient.m
@@ -168,7 +168,7 @@ static void BSSerializeDataCrashHandler(const BSG_KSCrashReportWriter *writer, b
 
 // MARK: -
 
-BSG_OBJC_DIRECT_MEMBERS
+
 @interface BugsnagClient () <BSGBreadcrumbSink>
 
 @property (nonatomic) BSGNotificationBreadcrumbs *notificationBreadcrumbs;
@@ -202,7 +202,7 @@ BSG_OBJC_DIRECT_MEMBERS
 __attribute__((annotate("oclint:suppress[long class]")))
 __attribute__((annotate("oclint:suppress[too many methods]")))
 #endif
-BSG_OBJC_DIRECT_MEMBERS
+
 @implementation BugsnagClient
 
 - (instancetype)initWithConfiguration:(BugsnagConfiguration *)configuration {

--- a/Bugsnag/Configuration/BugsnagConfiguration+Private.h
+++ b/Bugsnag/Configuration/BugsnagConfiguration+Private.h
@@ -13,7 +13,7 @@
 
 NS_ASSUME_NONNULL_BEGIN
 
-BSG_OBJC_DIRECT_MEMBERS
+
 @interface BugsnagConfiguration ()
 
 #pragma mark Initializers

--- a/Bugsnag/Configuration/BugsnagConfiguration.m
+++ b/Bugsnag/Configuration/BugsnagConfiguration.m
@@ -57,7 +57,7 @@ static NSURLSession *getConfigDefaultURLSession(void) {
 // MARK: - BugsnagConfiguration
 // =============================================================================
 
-BSG_OBJC_DIRECT_MEMBERS
+
 @implementation BugsnagConfiguration
 
 + (instancetype _Nonnull)loadConfig {

--- a/Bugsnag/Delivery/BSGConnectivity.h
+++ b/Bugsnag/Delivery/BSGConnectivity.h
@@ -45,7 +45,7 @@ typedef void (^BSGConnectivityChangeBlock)(BOOL connected, NSString *typeDescrip
  * Monitors network connectivity using SCNetworkReachability callbacks,
  * providing a customizable callback block invoked when connectivity changes.
  */
-BSG_OBJC_DIRECT_MEMBERS
+
 @interface BSGConnectivity : NSObject
 
 /**

--- a/Bugsnag/Delivery/BSGEventUploadFileOperation.h
+++ b/Bugsnag/Delivery/BSGEventUploadFileOperation.h
@@ -15,7 +15,7 @@ NS_ASSUME_NONNULL_BEGIN
 /**
  * A concrete operation class for uploading an event that is stored on disk.
  */
-BSG_OBJC_DIRECT_MEMBERS
+
 @interface BSGEventUploadFileOperation : BSGEventUploadOperation
 
 - (instancetype)initWithFile:(NSString *)file delegate:(id<BSGEventUploadOperationDelegate>)delegate;

--- a/Bugsnag/Delivery/BSGEventUploadFileOperation.m
+++ b/Bugsnag/Delivery/BSGEventUploadFileOperation.m
@@ -16,7 +16,7 @@
 #import "BugsnagLogger.h"
 
 
-BSG_OBJC_DIRECT_MEMBERS
+
 @implementation BSGEventUploadFileOperation
 
 - (instancetype)initWithFile:(NSString *)file delegate:(id<BSGEventUploadOperationDelegate>)delegate {

--- a/Bugsnag/Delivery/BSGEventUploadKSCrashReportOperation.h
+++ b/Bugsnag/Delivery/BSGEventUploadKSCrashReportOperation.h
@@ -15,7 +15,7 @@ NS_ASSUME_NONNULL_BEGIN
 /**
  * A concrete operation class for reading a KSCrashReport from disk, converting it into a BugsnagEvent, and uploading.
  */
-BSG_OBJC_DIRECT_MEMBERS
+
 @interface BSGEventUploadKSCrashReportOperation : BSGEventUploadFileOperation
 
 @end

--- a/Bugsnag/Delivery/BSGEventUploadKSCrashReportOperation.m
+++ b/Bugsnag/Delivery/BSGEventUploadKSCrashReportOperation.m
@@ -51,7 +51,7 @@ static NSArray * CrashReportKeys(NSData *data, NSError *error) {
 }
 
 
-BSG_OBJC_DIRECT_MEMBERS
+
 @implementation BSGEventUploadKSCrashReportOperation
 
 - (BugsnagEvent *)loadEventAndReturnError:(NSError * __autoreleasing *)errorPtr {

--- a/Bugsnag/Delivery/BSGEventUploadObjectOperation.h
+++ b/Bugsnag/Delivery/BSGEventUploadObjectOperation.h
@@ -17,7 +17,7 @@ NS_ASSUME_NONNULL_BEGIN
  *
  * If the upload needs to be retried, the event will be persisted to disk.
  */
-BSG_OBJC_DIRECT_MEMBERS
+
 @interface BSGEventUploadObjectOperation : BSGEventUploadOperation
 
 - (instancetype)initWithEvent:(BugsnagEvent *)event delegate:(id<BSGEventUploadOperationDelegate>)delegate;

--- a/Bugsnag/Delivery/BSGEventUploadObjectOperation.m
+++ b/Bugsnag/Delivery/BSGEventUploadObjectOperation.m
@@ -12,7 +12,7 @@
 #import "BugsnagInternals.h"
 #import "BugsnagLogger.h"
 
-BSG_OBJC_DIRECT_MEMBERS
+
 @implementation BSGEventUploadObjectOperation
 
 - (instancetype)initWithEvent:(BugsnagEvent *)event delegate:(id<BSGEventUploadOperationDelegate>)delegate {

--- a/Bugsnag/Delivery/BSGEventUploader.h
+++ b/Bugsnag/Delivery/BSGEventUploader.h
@@ -17,7 +17,7 @@
 
 NS_ASSUME_NONNULL_BEGIN
 
-BSG_OBJC_DIRECT_MEMBERS
+
 @interface BSGEventUploader : NSObject
 
 - (instancetype)initWithConfiguration:(BugsnagConfiguration *)configuration notifier:(BugsnagNotifier *)notifier;

--- a/Bugsnag/Delivery/BSGEventUploader.m
+++ b/Bugsnag/Delivery/BSGEventUploader.m
@@ -39,7 +39,7 @@ static NSString * const RecrashReportPrefix = @"RecrashReport-";
 
 // MARK: -
 
-BSG_OBJC_DIRECT_MEMBERS
+
 @implementation BSGEventUploader
 
 @synthesize configuration = _configuration;

--- a/Bugsnag/Delivery/BSGSessionUploader.h
+++ b/Bugsnag/Delivery/BSGSessionUploader.h
@@ -15,7 +15,7 @@
 
 NS_ASSUME_NONNULL_BEGIN
 
-BSG_OBJC_DIRECT_MEMBERS
+
 @interface BSGSessionUploader : NSObject
 
 - (instancetype)initWithConfig:(BugsnagConfiguration *)configuration notifier:(BugsnagNotifier *)notifier;

--- a/Bugsnag/Delivery/BSGSessionUploader.m
+++ b/Bugsnag/Delivery/BSGSessionUploader.m
@@ -28,14 +28,14 @@ static const NSTimeInterval MaxPersistedAge = 60 * 24 * 60 * 60;
 static NSArray * SortedFiles(NSFileManager *fileManager, NSMutableDictionary<NSString *, NSDate *> **creationDates);
 
 
-BSG_OBJC_DIRECT_MEMBERS
+
 @interface BSGSessionUploader ()
 @property (nonatomic) NSMutableSet *activeIds;
 @property(nonatomic) BugsnagConfiguration *config;
 @end
 
 
-BSG_OBJC_DIRECT_MEMBERS
+
 @implementation BSGSessionUploader
 
 - (instancetype)initWithConfig:(BugsnagConfiguration *)config notifier:(BugsnagNotifier *)notifier {

--- a/Bugsnag/FeatureFlags/BSGAtomicFeatureFlagStore.h
+++ b/Bugsnag/FeatureFlags/BSGAtomicFeatureFlagStore.h
@@ -13,7 +13,7 @@
 NS_ASSUME_NONNULL_BEGIN
 
 
-BSG_OBJC_DIRECT_MEMBERS
+
 @interface BSGAtomicFeatureFlagStore ()
 
 + (instancetype)store;

--- a/Bugsnag/FeatureFlags/BSGCompositeFeatureFlagStore.h
+++ b/Bugsnag/FeatureFlags/BSGCompositeFeatureFlagStore.h
@@ -13,7 +13,7 @@
 NS_ASSUME_NONNULL_BEGIN
 
 
-BSG_OBJC_DIRECT_MEMBERS
+
 @interface BSGCompositeFeatureFlagStore ()
 
 @property(nonatomic,nonnull,readonly) NSArray<BugsnagFeatureFlag *> *persistedFlags;

--- a/Bugsnag/FeatureFlags/BSGMemoryFeatureFlagStore.h
+++ b/Bugsnag/FeatureFlags/BSGMemoryFeatureFlagStore.h
@@ -16,7 +16,7 @@ NSArray<NSDictionary *> * BSGFeatureFlagStoreToJSON(id<BSGFeatureFlagStore> stor
 BSGMemoryFeatureFlagStore * BSGFeatureFlagStoreFromJSON(id _Nullable json);
 BSGMemoryFeatureFlagStore * BSGFeatureFlagStoreWithFlags(NSArray<BugsnagFeatureFlag *> *);
 
-BSG_OBJC_DIRECT_MEMBERS
+
 @interface BSGMemoryFeatureFlagStore ()
 
 + (nonnull BSGMemoryFeatureFlagStore *) fromJSON:(nonnull id)json;

--- a/Bugsnag/FeatureFlags/BSGMemoryFeatureFlagStore.m
+++ b/Bugsnag/FeatureFlags/BSGMemoryFeatureFlagStore.m
@@ -42,7 +42,7 @@ BSGMemoryFeatureFlagStore * BSGFeatureFlagStoreWithFlags(NSArray<BugsnagFeatureF
  *
  * This gives the access speed of a dictionary while keeping ordering intact.
  */
-BSG_OBJC_DIRECT_MEMBERS
+
 @interface BSGMemoryFeatureFlagStore ()
 
 @property(nonatomic, readwrite) NSMutableArray *flags;
@@ -52,7 +52,7 @@ BSG_OBJC_DIRECT_MEMBERS
 
 static const int REBUILD_AT_HOLE_COUNT = 1000;
 
-BSG_OBJC_DIRECT_MEMBERS
+
 @implementation BSGMemoryFeatureFlagStore
 
 + (nonnull BSGMemoryFeatureFlagStore *)fromJSON:(nonnull id)json {

--- a/Bugsnag/FeatureFlags/BSGPersistentFeatureFlagStore.h
+++ b/Bugsnag/FeatureFlags/BSGPersistentFeatureFlagStore.h
@@ -13,7 +13,7 @@
 
 NS_ASSUME_NONNULL_BEGIN
 
-BSG_OBJC_DIRECT_MEMBERS
+
 @interface BSGPersistentFeatureFlagStore ()
 
 - (instancetype)initWithStorageDirectory:(NSString *)directory;

--- a/Bugsnag/FeatureFlags/BSGPersistentFeatureFlagStore.m
+++ b/Bugsnag/FeatureFlags/BSGPersistentFeatureFlagStore.m
@@ -12,7 +12,7 @@
 #import "BugsnagLogger.h"
 #import <Foundation/Foundation.h>
 
-BSG_OBJC_DIRECT_MEMBERS
+
 @interface BSGPersistentFeatureFlagStore ()
 
 @property(nonatomic, readwrite) uint64_t currentIndex;
@@ -20,7 +20,7 @@ BSG_OBJC_DIRECT_MEMBERS
 
 @end
 
-BSG_OBJC_DIRECT_MEMBERS
+
 @implementation BSGPersistentFeatureFlagStore
 
 - (nonnull instancetype)initWithStorageDirectory:(NSString *)directory {

--- a/Bugsnag/FeatureFlags/BSGStoredFeatureFlag.h
+++ b/Bugsnag/FeatureFlags/BSGStoredFeatureFlag.h
@@ -11,7 +11,7 @@
 
 NS_ASSUME_NONNULL_BEGIN
 
-BSG_OBJC_DIRECT_MEMBERS
+
 @interface BSGStoredFeatureFlag: NSObject
 
 @property (nonatomic, strong) NSString *name;

--- a/Bugsnag/Helpers/BSGAppHangDetector.h
+++ b/Bugsnag/Helpers/BSGAppHangDetector.h
@@ -21,7 +21,7 @@ NS_ASSUME_NONNULL_BEGIN
 @protocol BSGAppHangDetectorDelegate;
 
 
-BSG_OBJC_DIRECT_MEMBERS
+
 @interface BSGAppHangDetector : NSObject
 
 - (void)startWithDelegate:(id<BSGAppHangDetectorDelegate>)delegate;

--- a/Bugsnag/Helpers/BSGAppHangDetector.m
+++ b/Bugsnag/Helpers/BSGAppHangDetector.m
@@ -21,7 +21,7 @@
 #import "BugsnagThread+Private.h"
 
 
-BSG_OBJC_DIRECT_MEMBERS
+
 @interface BSGAppHangDetector ()
 
 @property (weak, nonatomic) id<BSGAppHangDetectorDelegate> delegate;
@@ -36,7 +36,7 @@ BSG_OBJC_DIRECT_MEMBERS
 
 static void * DetectAppHangs(void *object);
 
-BSG_OBJC_DIRECT_MEMBERS
+
 @implementation BSGAppHangDetector
 
 - (void)startWithDelegate:(id<BSGAppHangDetectorDelegate>)delegate {

--- a/Bugsnag/Helpers/BSGDefines.h
+++ b/Bugsnag/Helpers/BSGDefines.h
@@ -41,16 +41,6 @@
 #define BSG_KEYPATH(object, property) @ #property
 #endif
 
-// Causes methods to have no associated Objective-C metadata and use C function calling convention.
-// See https://reviews.llvm.org/D69991
-// Overridden when building for unit testing to make private interfaces accessible. 
-#ifndef BSG_OBJC_DIRECT_MEMBERS
-#if __has_attribute(objc_direct_members) && (__clang_major__ > 11)
-#define BSG_OBJC_DIRECT_MEMBERS __attribute__((objc_direct_members))
-#else
-#define BSG_OBJC_DIRECT_MEMBERS
-#endif
-#endif
 
 #endif /* __OBJC__ */
 

--- a/Bugsnag/Helpers/BSGInternalErrorReporter.h
+++ b/Bugsnag/Helpers/BSGInternalErrorReporter.h
@@ -19,7 +19,7 @@ NSString *_Nullable BSGErrorDescription(NSError *_Nullable error);
 
 // MARK: -
 
-BSG_OBJC_DIRECT_MEMBERS
+
 @interface BSGInternalErrorReporter : NSObject
 
 @property (class, nullable, nonatomic) BSGInternalErrorReporter *sharedInstance;

--- a/Bugsnag/Helpers/BSGInternalErrorReporter.m
+++ b/Bugsnag/Helpers/BSGInternalErrorReporter.m
@@ -50,7 +50,7 @@ static NSString * Sysctl(const char *name);
 
 // MARK: -
 
-BSG_OBJC_DIRECT_MEMBERS
+
 @interface BSGInternalErrorReporter ()
 
 @property (nonatomic) NSString *apiKey;
@@ -60,7 +60,7 @@ BSG_OBJC_DIRECT_MEMBERS
 @end
 
 
-BSG_OBJC_DIRECT_MEMBERS
+
 @implementation BSGInternalErrorReporter
 
 static BSGInternalErrorReporter *sharedInstance_;

--- a/Bugsnag/Helpers/BSG_RFC3339DateTool.h
+++ b/Bugsnag/Helpers/BSG_RFC3339DateTool.h
@@ -28,7 +28,7 @@
 /**
  * Tool for converting to/from RFC3339 compliant date strings.
  */
-BSG_OBJC_DIRECT_MEMBERS
+
 @interface BSG_RFC3339DateTool : NSObject
 
 /** Convert a date to an RFC3339 string representation.

--- a/Bugsnag/KSCrash/Source/KSCrash/Recording/BSG_KSCrash.h
+++ b/Bugsnag/KSCrash/Source/KSCrash/Recording/BSG_KSCrash.h
@@ -34,7 +34,7 @@
  *
  * The crash reports will be located in $APP_HOME/Library/Caches/KSCrashReports
  */
-BSG_OBJC_DIRECT_MEMBERS
+
 @interface BSG_KSCrash : NSObject
 
 /** Get the singleton instance of the crash reporter.

--- a/Bugsnag/KSCrash/Source/KSCrash/Recording/BSG_KSCrashDoctor.h
+++ b/Bugsnag/KSCrash/Source/KSCrash/Recording/BSG_KSCrashDoctor.h
@@ -10,7 +10,7 @@
 
 #import "BSGDefines.h"
 
-BSG_OBJC_DIRECT_MEMBERS
+
 @interface BSG_KSCrashDoctor : NSObject
 
 - (NSString *)diagnoseCrash:(NSDictionary *)crashReport;

--- a/Bugsnag/KSCrash/Source/KSCrash/Recording/BSG_KSCrashDoctor.m
+++ b/Bugsnag/KSCrash/Source/KSCrash/Recording/BSG_KSCrashDoctor.m
@@ -12,7 +12,7 @@
 #import "BSG_KSSystemInfo.h"
 #import "BugsnagLogger.h"
 
-BSG_OBJC_DIRECT_MEMBERS
+
 @implementation BSG_KSCrashDoctor
 
 - (NSDictionary *)crashReport:(NSDictionary *)report {

--- a/Bugsnag/KSCrash/Source/KSCrash/Recording/BSG_KSSystemInfo.h
+++ b/Bugsnag/KSCrash/Source/KSCrash/Recording/BSG_KSSystemInfo.h
@@ -55,7 +55,7 @@
 /**
  * Provides system information useful for a crash report.
  */
-BSG_OBJC_DIRECT_MEMBERS
+
 @interface BSG_KSSystemInfo : NSObject
 
 /** Get the system info.

--- a/Bugsnag/KSCrash/Source/KSCrash/Recording/BSG_KSSystemInfo.m
+++ b/Bugsnag/KSCrash/Source/KSCrash/Recording/BSG_KSSystemInfo.m
@@ -109,7 +109,7 @@ static NSDictionary * bsg_systemversion(void) {
 }
 #endif
 
-BSG_OBJC_DIRECT_MEMBERS
+
 @implementation BSG_KSSystemInfo
 
 // ============================================================================

--- a/Bugsnag/Metadata/BugsnagMetadata+Private.h
+++ b/Bugsnag/Metadata/BugsnagMetadata+Private.h
@@ -14,7 +14,7 @@ NS_ASSUME_NONNULL_BEGIN
 
 typedef void (^ BSGMetadataObserver)(BugsnagMetadata *);
 
-BSG_OBJC_DIRECT_MEMBERS
+
 @interface BugsnagMetadata () <NSCopying>
 
 #pragma mark Properties

--- a/Bugsnag/Metadata/BugsnagMetadata.m
+++ b/Bugsnag/Metadata/BugsnagMetadata.m
@@ -32,7 +32,7 @@
 #import "BugsnagLogger.h"
 
 
-BSG_OBJC_DIRECT_MEMBERS
+
 @interface BugsnagMetadata ()
 
 @property(atomic, readwrite, strong) NSMutableArray *stateEventBlocks;
@@ -46,7 +46,7 @@ BSG_OBJC_DIRECT_MEMBERS
 
 // MARK: -
 
-BSG_OBJC_DIRECT_MEMBERS
+
 @implementation BugsnagMetadata
 
 - (instancetype)init {

--- a/Bugsnag/Payload/BugsnagBreadcrumb+Private.h
+++ b/Bugsnag/Payload/BugsnagBreadcrumb+Private.h
@@ -11,7 +11,7 @@
 
 NS_ASSUME_NONNULL_BEGIN
 
-BSG_OBJC_DIRECT_MEMBERS
+
 @interface BugsnagBreadcrumb ()
 
 - (BOOL)isValid;

--- a/Bugsnag/Payload/BugsnagBreadcrumb.m
+++ b/Bugsnag/Payload/BugsnagBreadcrumb.m
@@ -81,7 +81,7 @@ BSGBreadcrumbType BSGBreadcrumbTypeFromString(NSString *value) {
 @end
 
 
-BSG_OBJC_DIRECT_MEMBERS
+
 @implementation BugsnagBreadcrumb
 
 - (instancetype)init {

--- a/Bugsnag/Payload/BugsnagError+Private.h
+++ b/Bugsnag/Payload/BugsnagError+Private.h
@@ -13,7 +13,7 @@ NS_ASSUME_NONNULL_BEGIN
 
 @class BugsnagThread;
 
-BSG_OBJC_DIRECT_MEMBERS
+
 @interface BugsnagError ()
 
 - (instancetype)initWithKSCrashReport:(NSDictionary *)event stacktrace:(NSArray<BugsnagStackframe *> *)stacktrace;

--- a/Bugsnag/Payload/BugsnagError.m
+++ b/Bugsnag/Payload/BugsnagError.m
@@ -84,7 +84,7 @@ NSString *BSGParseErrorMessage(NSDictionary *report, NSDictionary *error, NSStri
     return diagnosis ?: reason ?: @"";
 }
 
-BSG_OBJC_DIRECT_MEMBERS
+
 @implementation BugsnagError
 
 @dynamic type;

--- a/Bugsnag/Payload/BugsnagEvent+Private.h
+++ b/Bugsnag/Payload/BugsnagEvent+Private.h
@@ -13,7 +13,7 @@
 
 NS_ASSUME_NONNULL_BEGIN
 
-BSG_OBJC_DIRECT_MEMBERS
+
 @interface BugsnagEvent ()
 
 @property (copy, nonatomic) NSString *codeBundleId;

--- a/Bugsnag/Payload/BugsnagEvent.m
+++ b/Bugsnag/Payload/BugsnagEvent.m
@@ -142,7 +142,7 @@ NSDictionary *BSGParseCustomException(NSDictionary *report,
 
 // MARK: -
 
-BSG_OBJC_DIRECT_MEMBERS
+
 @implementation BugsnagEvent
 
 /**

--- a/Bugsnag/Payload/BugsnagHandledState.m
+++ b/Bugsnag/Payload/BugsnagHandledState.m
@@ -50,7 +50,7 @@ static NSString *const kHandledException = @"handledException";
 static NSString *const kUserSpecifiedSeverity = @"userSpecifiedSeverity";
 static NSString *const kUserCallbackSetSeverity = @"userCallbackSetSeverity";
 
-BSG_OBJC_DIRECT_MEMBERS
+
 @implementation BugsnagHandledState
 
 + (instancetype)handledStateFromJson:(NSDictionary *)json {

--- a/Bugsnag/Payload/BugsnagSession+Private.h
+++ b/Bugsnag/Payload/BugsnagSession+Private.h
@@ -14,7 +14,7 @@ NS_ASSUME_NONNULL_BEGIN
 
 @class BugsnagUser;
 
-BSG_OBJC_DIRECT_MEMBERS
+
 @interface BugsnagSession () <NSCopying>
 
 #pragma mark Initializers

--- a/Bugsnag/Payload/BugsnagSession.m
+++ b/Bugsnag/Payload/BugsnagSession.m
@@ -15,7 +15,7 @@
 #import "BugsnagDevice+Private.h"
 #import "BugsnagUser+Private.h"
 
-BSG_OBJC_DIRECT_MEMBERS
+
 @implementation BugsnagSession
 
 - (instancetype)initWithId:(NSString *)sessionId

--- a/Bugsnag/Payload/BugsnagStackframe+Private.h
+++ b/Bugsnag/Payload/BugsnagStackframe+Private.h
@@ -11,7 +11,7 @@
 
 NS_ASSUME_NONNULL_BEGIN
 
-BSG_OBJC_DIRECT_MEMBERS
+
 @interface BugsnagStackframe ()
 
 + (NSArray<BugsnagStackframe *> *)stackframesWithBacktrace:(uintptr_t *)backtrace length:(NSUInteger)length;

--- a/Bugsnag/Payload/BugsnagStackframe.m
+++ b/Bugsnag/Payload/BugsnagStackframe.m
@@ -26,7 +26,7 @@ static NSString * _Nullable FormatMemoryAddress(NSNumber * _Nullable address) {
 
 // MARK: -
 
-BSG_OBJC_DIRECT_MEMBERS
+
 @implementation BugsnagStackframe
 
 static NSDictionary * _Nullable FindImage(NSArray *images, uintptr_t addr) {

--- a/Bugsnag/Payload/BugsnagStacktrace.h
+++ b/Bugsnag/Payload/BugsnagStacktrace.h
@@ -15,7 +15,7 @@
 /**
  * Representation of a stacktrace in a bugsnag error report
  */
-BSG_OBJC_DIRECT_MEMBERS
+
 @interface BugsnagStacktrace : NSObject
 
 - (instancetype)initWithTrace:(NSArray<NSDictionary *> *)trace

--- a/Bugsnag/Payload/BugsnagStacktrace.m
+++ b/Bugsnag/Payload/BugsnagStacktrace.m
@@ -11,7 +11,7 @@
 #import "BSGKeys.h"
 #import "BugsnagStackframe+Private.h"
 
-BSG_OBJC_DIRECT_MEMBERS
+
 @implementation BugsnagStacktrace
 
 + (instancetype)stacktraceFromJson:(NSArray<NSDictionary *> *)json {

--- a/Bugsnag/Payload/BugsnagThread+Private.h
+++ b/Bugsnag/Payload/BugsnagThread+Private.h
@@ -11,7 +11,7 @@
 
 NS_ASSUME_NONNULL_BEGIN
 
-BSG_OBJC_DIRECT_MEMBERS
+
 @interface BugsnagThread ()
 
 - (instancetype)initWithId:(nullable NSString *)identifier

--- a/Bugsnag/Payload/BugsnagThread.m
+++ b/Bugsnag/Payload/BugsnagThread.m
@@ -68,7 +68,7 @@ NSString *BSGSerializeThreadType(BSGThreadType type) {
     return type == BSGThreadTypeCocoa ? @"cocoa" : @"reactnativejs";
 }
 
-BSG_OBJC_DIRECT_MEMBERS
+
 @implementation BugsnagThread
 
 + (instancetype)threadFromJson:(NSDictionary *)json {

--- a/Bugsnag/Payload/BugsnagUser+Private.h
+++ b/Bugsnag/Payload/BugsnagUser+Private.h
@@ -11,7 +11,7 @@
 
 NS_ASSUME_NONNULL_BEGIN
 
-BSG_OBJC_DIRECT_MEMBERS
+
 @interface BugsnagUser ()
 
 - (instancetype)initWithId:(nullable NSString *)id name:(nullable NSString *)name emailAddress:(nullable NSString *)emailAddress;

--- a/Bugsnag/Payload/BugsnagUser.m
+++ b/Bugsnag/Payload/BugsnagUser.m
@@ -11,7 +11,7 @@
 #import "BSG_KSSystemInfo.h"
 #import "BSGPersistentDeviceID.h"
 
-BSG_OBJC_DIRECT_MEMBERS
+
 @implementation BugsnagUser
 
 - (instancetype)initWithDictionary:(NSDictionary *)dict {

--- a/Bugsnag/Storage/BSGFileLocations.h
+++ b/Bugsnag/Storage/BSGFileLocations.h
@@ -12,7 +12,7 @@
 
 NS_ASSUME_NONNULL_BEGIN
 
-BSG_OBJC_DIRECT_MEMBERS
+
 @interface BSGFileLocations : NSObject
 
 @property (readonly, nonatomic) NSString *breadcrumbs;

--- a/Bugsnag/Storage/BSGFileLocations.m
+++ b/Bugsnag/Storage/BSGFileLocations.m
@@ -96,7 +96,7 @@ static NSString *getAndCreateSubdir(NSString *rootPath, NSString *relativePath) 
     return subdirPath;
 }
 
-BSG_OBJC_DIRECT_MEMBERS
+
 @implementation BSGFileLocations
 
 + (instancetype) current {

--- a/Bugsnag/Storage/BSGStorageMigratorV0V1.h
+++ b/Bugsnag/Storage/BSGStorageMigratorV0V1.h
@@ -12,7 +12,7 @@
 
 NS_ASSUME_NONNULL_BEGIN
 
-BSG_OBJC_DIRECT_MEMBERS
+
 @interface BSGStorageMigratorV0V1 : NSObject
 
 + (BOOL) migrate;

--- a/Bugsnag/Storage/BSGStorageMigratorV0V1.m
+++ b/Bugsnag/Storage/BSGStorageMigratorV0V1.m
@@ -11,7 +11,7 @@
 #import "BSGFileLocations.h"
 #import "BugsnagLogger.h"
 
-BSG_OBJC_DIRECT_MEMBERS
+
 @implementation BSGStorageMigratorV0V1
 
 static void RemoveItem(NSFileManager *fileManager, NSString *path) {


### PR DESCRIPTION
Remove the macro as it’s not needed anymore and it’s blocking progress on kotlin multiplatform project.