### PR TITLE
Correct IPHONEOS_DEPLOYMENT_TARGET for xcframework fixture

### DIFF
--- a/features/fixtures/ios/iOSTestAppXcFramework.xcodeproj/project.pbxproj
+++ b/features/fixtures/ios/iOSTestAppXcFramework.xcodeproj/project.pbxproj
@@ -1151,7 +1151,7 @@
 					../../../Bugsnag/Payload,
 				);
 				INFOPLIST_FILE = iOSTestApp/Info.plist;
-				IPHONEOS_DEPLOYMENT_TARGET = 9.0;
+				IPHONEOS_DEPLOYMENT_TARGET = 12.0;
 				LD_RUNPATH_SEARCH_PATHS = (
 					"$(inherited)",
 					"@executable_path/Frameworks",
@@ -1197,7 +1197,7 @@
 					../../../Bugsnag/Payload,
 				);
 				INFOPLIST_FILE = iOSTestApp/Info.plist;
-				IPHONEOS_DEPLOYMENT_TARGET = 9.0;
+				IPHONEOS_DEPLOYMENT_TARGET = 12.0;
 				LD_RUNPATH_SEARCH_PATHS = (
 					"$(inherited)",
 					"@executable_path/Frameworks",


### PR DESCRIPTION
## Goal

Corrects IPHONEOS_DEPLOYMENT_TARGET for xcframework fixture.

## Design

We didn't notice this before because the XcFramework test fixture is only built on a full CI run.

## Testing

Covered by a full CI run.