### PR TITLE
Send observer event on grouping discriminator update

### DIFF
--- a/Bugsnag/BugsnagInternals.h
+++ b/Bugsnag/BugsnagInternals.h
@@ -75,11 +75,12 @@ BUGSNAG_EXTERN BSGBreadcrumbType BSGBreadcrumbTypeFromString(NSString * _Nullabl
 #pragma mark -
 
 typedef NS_ENUM(NSInteger, BSGClientObserverEvent) {
-    BSGClientObserverAddFeatureFlag,    // value: BugsnagFeatureFlag
-    BSGClientObserverClearFeatureFlag,  // value: NSString
-    BSGClientObserverUpdateContext,     // value: NSString
-    BSGClientObserverUpdateMetadata,    // value: BugsnagMetadata
-    BSGClientObserverUpdateUser,        // value: BugsnagUser
+    BSGClientObserverAddFeatureFlag,              // value: BugsnagFeatureFlag
+    BSGClientObserverClearFeatureFlag,            // value: NSString
+    BSGClientObserverUpdateContext,               // value: NSString
+    BSGClientObserverUpdateMetadata,              // value: BugsnagMetadata
+    BSGClientObserverUpdateUser,                  // value: BugsnagUser
+    BSGClientObserverUpdateGroupingDiscriminator, // value: NSString
 };
 
 typedef void (^ BSGClientObserver)(BSGClientObserverEvent event, _Nullable id value);

--- a/Bugsnag/Client/BugsnagClient.m
+++ b/Bugsnag/Client/BugsnagClient.m
@@ -657,6 +657,9 @@ __attribute__((annotate("oclint:suppress[too many methods]")))
         NSString *previous = self.groupingDiscriminator_;
         self.groupingDiscriminator_ = groupingDiscriminator;
         [self.state addMetadata:groupingDiscriminator withKey:BSGKeyGroupingDiscriminator toSection:BSGKeyClient];
+        if (self.observer) {
+            self.observer(BSGClientObserverUpdateGroupingDiscriminator, groupingDiscriminator);
+        }
         return previous;
     }
 }
@@ -1030,7 +1033,8 @@ __attribute__((annotate("oclint:suppress[too many methods]")))
     if (observer) {
         observer(BSGClientObserverUpdateContext, self.context);
         observer(BSGClientObserverUpdateUser, self.user);
-        
+        observer(BSGClientObserverUpdateGroupingDiscriminator, self.groupingDiscriminator);
+
         observer(BSGClientObserverUpdateMetadata, self.metadata);
         self.metadata.observer = ^(BugsnagMetadata *metadata) {
             observer(BSGClientObserverUpdateMetadata, metadata);


### PR DESCRIPTION
## Goal
Needed to sync changes between cocoa notifier and RN notifier regarding grouping discriminator.

## Changeset
Started sending events on grouping discriminator update.

## Testing
Unit tests added.