### PR TITLE
Build pipeline improvements

### DIFF
--- a/.buildkite/pipeline.full.yml
+++ b/.buildkite/pipeline.full.yml
@@ -37,7 +37,10 @@ steps:
   # XcFramework E2E tests
   #
 
-  - label: ':bitbar: iOS 17 XcFramework barebone E2E tests'
+  - label: ':bitbar: {{matrix}} XcFramework barebone E2E tests'
+    matrix:
+      - "IOS_17"
+      - "IOS_13"
     depends_on:
       - xcframework_cocoa_fixture
     timeout_in_minutes: 20
@@ -56,85 +59,7 @@ steps:
         command:
           - "--app=@/app/build/xcframework_ipa_url_bb.txt"
           - "--farm=bb"
-          - "--device=IOS_17"
-          - "--no-tunnel"
-          - "--aws-public-ip"
-          - "--repeater-api-key="
-          - "--hub-repeater-api-key="
-          - "features/release/barebone_tests.feature"
-      test-collector#v1.11.0:
-        files: "reports/TEST-*.xml"
-        format: "junit"
-        branch: "^master|next$$"
-    concurrency: 25
-    concurrency_group: 'bitbar'
-    concurrency_method: eager
-    retry:
-      automatic:
-        - exit_status: -1  # Agent was lost
-          limit: 2
-        - exit_status: 103  # Appium session failed
-          limit: 2
-
-  - label: ':bitbar: iOS 16 XcFramework barebone E2E tests'
-    depends_on:
-      - xcframework_cocoa_fixture
-    timeout_in_minutes: 20
-    agents:
-      queue: opensource
-    plugins:
-      artifacts#v1.9.4:
-        download: "features/fixtures/ios/output/xcframework_ipa_url_bb.txt"
-        upload:
-          - "maze_output/failed/**/*"
-          - "maze_output/maze_output.zip"
-      docker-compose#v4.7.0:
-        pull: cocoa-maze-runner-bitbar
-        run: cocoa-maze-runner-bitbar
-        service-ports: true
-        command:
-          - "--app=@/app/build/xcframework_ipa_url_bb.txt"
-          - "--farm=bb"
-          - "--device=IOS_16"
-          - "--no-tunnel"
-          - "--aws-public-ip"
-          - "--repeater-api-key="
-          - "--hub-repeater-api-key="
-          - "features/release/barebone_tests.feature"
-      test-collector#v1.11.0:
-        files: "reports/TEST-*.xml"
-        format: "junit"
-        branch: "^master|next$$"
-    concurrency: 25
-    concurrency_group: 'bitbar'
-    concurrency_method: eager
-    retry:
-      automatic:
-        - exit_status: -1  # Agent was lost
-          limit: 2
-        - exit_status: 103  # Appium session failed
-          limit: 2
-
-  - label: ':bitbar: iOS 13 XcFramework barebone E2E tests'
-    depends_on:
-      - xcframework_cocoa_fixture
-    timeout_in_minutes: 20
-    agents:
-      queue: opensource
-    plugins:
-      artifacts#v1.9.4:
-        download: "features/fixtures/ios/output/xcframework_ipa_url_bb.txt"
-        upload:
-          - "maze_output/failed/**/*"
-          - "maze_output/maze_output.zip"
-      docker-compose#v4.7.0:
-        pull: cocoa-maze-runner-bitbar
-        run: cocoa-maze-runner-bitbar
-        service-ports: true
-        command:
-          - "--app=@/app/build/xcframework_ipa_url_bb.txt"
-          - "--farm=bb"
-          - "--device=IOS_13"
+          - "--device={{matrix}}"
           - "--no-tunnel"
           - "--aws-public-ip"
           - "--repeater-api-key="
@@ -211,7 +136,13 @@ steps:
   #
   # BitBar
   #
-  - label: ':bitbar: iOS 16 E2E tests batch 1'
+  - label: ':bitbar: {{matrix}} E2E tests batch 1'
+    matrix:
+      - "IOS_17"
+      - "IOS_16"
+      - "IOS_15"
+      - "IOS_14"
+      - "IOS_13"
     depends_on:
       - cocoa_fixture
     timeout_in_minutes: 60
@@ -230,11 +161,10 @@ steps:
         command:
           - "--app=@/app/build/ipa_url_bb_release.txt"
           - "--farm=bb"
-          - "--device=IOS_16"
+          - "--device={{matrix}}"
           - "--no-tunnel"
           - "--aws-public-ip"
           - "--fail-fast"
-          # PLAT-11155: App hang scenarios run on BrowserStack
           - "features/release"
           - "--exclude=features/release/[e-z].*.feature$"
       test-collector#v1.11.0:
@@ -251,7 +181,13 @@ steps:
         - exit_status: 103  # Appium session failed
           limit: 2
 
-  - label: ':bitbar: iOS 16 E2E tests batch 2'
+  - label: ':bitbar: {{matrix}} E2E tests batch 2'
+    matrix:
+      - "IOS_17"
+      - "IOS_16"
+      - "IOS_15"
+      - "IOS_14"
+      - "IOS_13"
     depends_on:
       - cocoa_fixture
     timeout_in_minutes: 60
@@ -270,238 +206,7 @@ steps:
         command:
           - "--app=@/app/build/ipa_url_bb_release.txt"
           - "--farm=bb"
-          - "--device=IOS_16"
-          - "--no-tunnel"
-          - "--aws-public-ip"
-          - "--fail-fast"
-          - "features/release"
-          - "--exclude=features/release/[a-d].*.feature$"
-      test-collector#v1.11.0:
-        files: "reports/TEST-*.xml"
-        format: "junit"
-        branch: "^master|next$$"
-    concurrency: 25
-    concurrency_group: 'bitbar'
-    concurrency_method: eager
-    retry:
-      automatic:
-        - exit_status: -1  # Agent was lost
-          limit: 2
-        - exit_status: 103  # Appium session failed
-          limit: 2
-
-  - label: ':bitbar: iOS 15 E2E tests batch 1'
-    depends_on: "cocoa_fixture"
-    timeout_in_minutes: 90
-    agents:
-      queue: opensource
-    plugins:
-      artifacts#v1.9.4:
-        download: "features/fixtures/ios/output/ipa_url_bb_release.txt"
-        upload:
-          - "maze_output/failed/**/*"
-          - "maze_output/maze_output.zip"
-      docker-compose#v4.7.0:
-        pull: cocoa-maze-runner-bitbar
-        run: cocoa-maze-runner-bitbar
-        service-ports: true
-        command:
-          # PLAT-11155: App hang scenarios run on BrowserStack
-          - "features/release"
-          - "--exclude=features/release/[e-z].*.feature$"
-          - "--app=@/app/build/ipa_url_bb_release.txt"
-          - "--farm=bb"
-          - "--device=IOS_15"
-          - "--no-tunnel"
-          - "--aws-public-ip"
-          - "--fail-fast"
-      test-collector#v1.11.0:
-        files: "reports/TEST-*.xml"
-        format: "junit"
-        branch: "^master|next$$"
-    concurrency: 25
-    concurrency_group: 'bitbar'
-    concurrency_method: eager
-    retry:
-      automatic:
-        - exit_status: 103  # Appium session failed
-          limit: 2
-
-  - label: ':bitbar: iOS 15 E2E tests batch 2'
-    depends_on: "cocoa_fixture"
-    timeout_in_minutes: 90
-    agents:
-      queue: opensource
-    plugins:
-      artifacts#v1.9.4:
-        download: "features/fixtures/ios/output/ipa_url_bb_release.txt"
-        upload:
-          - "maze_output/failed/**/*"
-          - "maze_output/maze_output.zip"
-      docker-compose#v4.7.0:
-        pull: cocoa-maze-runner-bitbar
-        run: cocoa-maze-runner-bitbar
-        service-ports: true
-        command:
-          - "features/release"
-          - "--exclude=features/release/[a-d].*.feature$"
-          - "--app=@/app/build/ipa_url_bb_release.txt"
-          - "--farm=bb"
-          - "--device=IOS_15"
-          - "--no-tunnel"
-          - "--aws-public-ip"
-          - "--fail-fast"
-      test-collector#v1.11.0:
-        files: "reports/TEST-*.xml"
-        format: "junit"
-        branch: "^master|next$$"
-    concurrency: 25
-    concurrency_group: 'bitbar'
-    concurrency_method: eager
-    retry:
-      automatic:
-        - exit_status: 103  # Appium session failed
-          limit: 2
-
-  - label: ':bitbar: iOS 14 E2E tests batch 1'
-    depends_on:
-      - cocoa_fixture
-    timeout_in_minutes: 60
-    agents:
-      queue: opensource
-    plugins:
-      artifacts#v1.9.4:
-        download: "features/fixtures/ios/output/ipa_url_bb_release.txt"
-        upload:
-          - "maze_output/failed/**/*"
-          - "maze_output/maze_output.zip"
-      docker-compose#v4.7.0:
-        pull: cocoa-maze-runner-bitbar
-        run: cocoa-maze-runner-bitbar
-        service-ports: true
-        command:
-          - "--app=@/app/build/ipa_url_bb_release.txt"
-          - "--farm=bb"
-          - "--device=IOS_14"
-          - "--no-tunnel"
-          - "--aws-public-ip"
-          - "--fail-fast"
-          # PLAT-11155: App hang scenarios run on BrowserStack
-          - "features/release"
-          - "--exclude=features/release/[e-z].*.feature$"
-      test-collector#v1.11.0:
-        files: "reports/TEST-*.xml"
-        format: "junit"
-        branch: "^master|next$$"
-    concurrency: 25
-    concurrency_group: 'bitbar'
-    concurrency_method: eager
-    retry:
-      automatic:
-        - exit_status: -1  # Agent was lost
-          limit: 2
-        - exit_status: 103  # Appium session failed
-          limit: 2
-
-  - label: ':bitbar: iOS 14 E2E tests batch 2'
-    depends_on:
-      - cocoa_fixture
-    timeout_in_minutes: 60
-    agents:
-      queue: opensource
-    plugins:
-      artifacts#v1.9.4:
-        download: "features/fixtures/ios/output/ipa_url_bb_release.txt"
-        upload:
-          - "maze_output/failed/**/*"
-          - "maze_output/maze_output.zip"
-      docker-compose#v4.7.0:
-        pull: cocoa-maze-runner-bitbar
-        run: cocoa-maze-runner-bitbar
-        service-ports: true
-        command:
-          - "--app=@/app/build/ipa_url_bb_release.txt"
-          - "--farm=bb"
-          - "--device=IOS_14"
-          - "--no-tunnel"
-          - "--aws-public-ip"
-          - "--fail-fast"
-          - "features/release"
-          - "--exclude=features/release/[a-d].*.feature$"
-      test-collector#v1.11.0:
-        files: "reports/TEST-*.xml"
-        format: "junit"
-        branch: "^master|next$$"
-    concurrency: 25
-    concurrency_group: 'bitbar'
-    concurrency_method: eager
-    retry:
-      automatic:
-        - exit_status: -1  # Agent was lost
-          limit: 2
-        - exit_status: 103  # Appium session failed
-          limit: 2
-
-  - label: ':bitbar: iOS 13 E2E tests batch 1'
-    depends_on:
-      - cocoa_fixture
-    timeout_in_minutes: 60
-    agents:
-      queue: opensource
-    plugins:
-      artifacts#v1.9.4:
-        download: "features/fixtures/ios/output/ipa_url_bb_release.txt"
-        upload:
-          - "maze_output/failed/**/*"
-          - "maze_output/maze_output.zip"
-      docker-compose#v4.7.0:
-        pull: cocoa-maze-runner-bitbar
-        run: cocoa-maze-runner-bitbar
-        service-ports: true
-        command:
-          - "--app=@/app/build/ipa_url_bb_release.txt"
-          - "--farm=bb"
-          - "--device=IOS_13"
-          - "--no-tunnel"
-          - "--aws-public-ip"
-          - "--fail-fast"
-          # PLAT-11155: App hang scenarios run on BrowserStack
-          - "features/release"
-          - "--exclude=features/release/[e-z].*.feature$"
-      test-collector#v1.11.0:
-        files: "reports/TEST-*.xml"
-        format: "junit"
-        branch: "^master|next$$"
-    concurrency: 25
-    concurrency_group: 'bitbar'
-    concurrency_method: eager
-    retry:
-      automatic:
-        - exit_status: -1  # Agent was lost
-          limit: 2
-        - exit_status: 103  # Appium session failed
-          limit: 2
-
-  - label: ':bitbar: iOS 13 E2E tests batch 2'
-    depends_on:
-      - cocoa_fixture
-    timeout_in_minutes: 60
-    agents:
-      queue: opensource
-    plugins:
-      artifacts#v1.9.4:
-        download: "features/fixtures/ios/output/ipa_url_bb_release.txt"
-        upload:
-          - "maze_output/failed/**/*"
-          - "maze_output/maze_output.zip"
-      docker-compose#v4.7.0:
-        pull: cocoa-maze-runner-bitbar
-        run: cocoa-maze-runner-bitbar
-        service-ports: true
-        command:
-          - "--app=@/app/build/ipa_url_bb_release.txt"
-          - "--farm=bb"
-          - "--device=IOS_13"
+          - "--device={{matrix}}"
           - "--no-tunnel"
           - "--aws-public-ip"
           - "--fail-fast"
@@ -524,86 +229,15 @@ steps:
   #
   # BrowserStack
   #
-  - label: ':bitbar: iOS 17 E2E tests batch 1'
-    depends_on:
-      - cocoa_fixture
-    timeout_in_minutes: 60
-    agents:
-      queue: opensource
-    plugins:
-      artifacts#v1.9.4:
-        download: "features/fixtures/ios/output/ipa_url_bb_release.txt"
-        upload:
-          - "maze_output/failed/**/*"
-          - "maze_output/maze_output.zip"
-      docker-compose#v4.7.0:
-        pull: cocoa-maze-runner-bitbar
-        run: cocoa-maze-runner-bitbar
-        service-ports: true
-        command:
-          - "--app=@/app/build/ipa_url_bb_release.txt"
-          - "--farm=bb"
-          - "--device=IOS_17"
-          - "--no-tunnel"
-          - "--aws-public-ip"
-          - "--fail-fast"
-          # PLAT-11155: App hang scenarios run on BrowserStack
-          - "features/release"
-          - "--exclude=features/release/[e-z].*.feature$"
-      test-collector#v1.11.0:
-        files: "reports/TEST-*.xml"
-        format: "junit"
-        branch: "^master|next$$"
-    concurrency: 25
-    concurrency_group: 'bitbar'
-    concurrency_method: eager
-    retry:
-      automatic:
-        - exit_status: -1  # Agent was lost
-          limit: 2
-        - exit_status: 103  # Appium session failed
-          limit: 2
-
-  - label: ':bitbar: iOS 17 E2E tests batch 2'
-    depends_on:
-      - cocoa_fixture
-    timeout_in_minutes: 60
-    agents:
-      queue: opensource
-    plugins:
-      artifacts#v1.9.4:
-        download: "features/fixtures/ios/output/ipa_url_bb_release.txt"
-        upload:
-          - "maze_output/failed/**/*"
-          - "maze_output/maze_output.zip"
-      docker-compose#v4.7.0:
-        pull: cocoa-maze-runner-bitbar
-        run: cocoa-maze-runner-bitbar
-        service-ports: true
-        command:
-          - "--app=@/app/build/ipa_url_bb_release.txt"
-          - "--farm=bb"
-          - "--device=IOS_17"
-          - "--no-tunnel"
-          - "--aws-public-ip"
-          - "--fail-fast"
-          - "features/release"
-          - "--exclude=features/release/[a-d].*.feature$"
-      test-collector#v1.11.0:
-        files: "reports/TEST-*.xml"
-        format: "junit"
-        branch: "^master|next$$"
-    concurrency: 25
-    concurrency_group: 'bitbar'
-    concurrency_method: eager
-    retry:
-      automatic:
-        - exit_status: -1  # Agent was lost
-          limit: 2
-        - exit_status: 103  # Appium session failed
-          limit: 2
-
-  - label: ':browserstack: iOS 17 app hang tests'
+  # PLAT-11155: App hang tests run on BrowserStack (Appium 1.x) for now
+  - label: ':browserstack: {{matrix}} app hang tests'
+    matrix:
+        - "IOS_17"
+        - "IOS_16"
+        - "IOS_15"
+        - "IOS_14"
+        # PLAT-12554: Currently being skipped due to issues with app-hang test on iOS 13
+        #- "IOS_13"
     depends_on:
       - cocoa_fixture
     timeout_in_minutes: 30
@@ -621,7 +255,7 @@ steps:
         command:
           - "--app=@build/ipa_url_bs_release.txt"
           - "--farm=bs"
-          - "--device=IOS_17"
+          - "--device={{matrix}}"
           - "--appium-version=1.21.0"
           - "--fail-fast"
           - "features/app_hangs.feature"
@@ -641,156 +275,10 @@ steps:
         - exit_status: 103  # Appium session failed
           limit: 2
 
-  # PLAT-11155: App hang tests run on BrowserStack (Appium 1.x) for now
-  - label: ':browserstack: iOS 16 app hang tests'
-    depends_on:
-      - cocoa_fixture
-    timeout_in_minutes: 30
-    agents:
-      queue: opensource
-    plugins:
-      artifacts#v1.9.4:
-        download: "features/fixtures/ios/output/ipa_url_bs_release.txt"
-        upload:
-          - "maze_output/failed/**/*"
-          - "maze_output/maze_output.zip"
-      docker-compose#v5.8.0:
-        pull: cocoa-maze-runner
-        run: cocoa-maze-runner
-        command:
-          - "--app=@build/ipa_url_bs_release.txt"
-          - "--farm=bs"
-          - "--device=IOS_16"
-          - "--appium-version=1.21.0"
-          - "--fail-fast"
-          - "features/app_hangs.feature"
-      test-collector#v1.11.0:
-        files: "reports/TEST-*.xml"
-        format: "junit"
-        branch: "^master|next$$"
-    concurrency: 5
-    concurrency_group: 'browserstack-app'
-    concurrency_method: eager
-    retry:
-      automatic:
-        - exit_status: -1  # Agent was lost
-          limit: 2
-        - exit_status: 104 # App hang related error
-          limit: 2
-        - exit_status: 103  # Appium session failed
-          limit: 2
-
-  # PLAT-11155: App hang tests run on BrowserStack (Appium 1.x) for now
-  - label: ':browserstack: iOS 15 app hang tests'
-    depends_on:
-      - cocoa_fixture
-    timeout_in_minutes: 30
-    agents:
-      queue: opensource
-    plugins:
-      artifacts#v1.9.4:
-        download: "features/fixtures/ios/output/ipa_url_bs_release.txt"
-        upload:
-          - "maze_output/failed/**/*"
-          - "maze_output/maze_output.zip"
-      docker-compose#v5.8.0:
-        pull: cocoa-maze-runner
-        run: cocoa-maze-runner
-        command:
-          - "--app=@build/ipa_url_bs_release.txt"
-          - "--farm=bs"
-          - "--device=IOS_15"
-          - "--appium-version=1.21.0"
-          - "--fail-fast"
-          - "features/app_hangs.feature"
-      test-collector#v1.11.0:
-        files: "reports/TEST-*.xml"
-        format: "junit"
-        branch: "^master|next$$"
-    concurrency: 5
-    concurrency_group: 'browserstack-app'
-    concurrency_method: eager
-    retry:
-      automatic:
-        - exit_status: -1  # Agent was lost
-          limit: 2
-        - exit_status: 103  # Appium session failed
-          limit: 2
-
-  # PLAT-11155: App hang tests run on BrowserStack (Appium 1.x) for now
-  - label: ':browserstack: iOS 14 app hang tests'
-    depends_on:
-      - cocoa_fixture
-    timeout_in_minutes: 30
-    agents:
-      queue: opensource
-    plugins:
-      artifacts#v1.9.4:
-        download: "features/fixtures/ios/output/ipa_url_bs_release.txt"
-        upload:
-          - "maze_output/failed/**/*"
-          - "maze_output/maze_output.zip"
-      docker-compose#v5.8.0:
-        pull: cocoa-maze-runner
-        run: cocoa-maze-runner
-        command:
-          - "--app=@build/ipa_url_bs_release.txt"
-          - "--farm=bs"
-          - "--device=IOS_14"
-          - "--appium-version=1.21.0"
-          - "--fail-fast"
-          - "features/app_hangs.feature"
-      test-collector#v1.11.0:
-        files: "reports/TEST-*.xml"
-        format: "junit"
-        branch: "^master|next$$"
-    concurrency: 5
-    concurrency_group: 'browserstack-app'
-    concurrency_method: eager
-    retry:
-      automatic:
-        - exit_status: -1  # Agent was lost
-          limit: 2
-        - exit_status: 103  # Appium session failed
-          limit: 2
-
-  # PLAT-11155: App hang tests run on BrowserStack (Appium 1.x) for now
   #
-  # PLAT-12554: Currently being skipped due to issues with app-hang test on iOS 13
+  # macOS e2e tests
   #
-  # - label: ':browserstack: iOS 13 app hang tests'
-  #   depends_on:
-  #     - cocoa_fixture
-  #   timeout_in_minutes: 30
-  #   agents:
-  #     queue: opensource
-  #   plugins:
-  #     artifacts#v1.9.4:
-  #       download: "features/fixtures/ios/output/ipa_url_bs_release.txt"
-  #       upload: "maze_output/failed/**/*"
-  #     docker-compose#v5.8.0:
-  #       pull: cocoa-maze-runner
-  #       run: cocoa-maze-runner
-  #       command:
-  #         - "--app=@build/ipa_url_bs_release.txt"
-  #         - "--farm=bs"
-  #         - "--device=IOS_13"
-  #         - "--appium-version=1.21.0"
-  #         - "--fail-fast"
-  #         - "features/app_hangs.feature"
-  #     test-collector#v1.11.0:
-  #       files: "reports/TEST-*.xml"
-  #       format: "junit"
-  #       branch: "^master|next$$"
-  #   concurrency: 5
-  #   concurrency_group: 'browserstack-app'
-  #   concurrency_method: eager
-  #   retry:
-  #     automatic:
-  #       - exit_status: -1  # Agent was lost
-  #         limit: 2
-
-  - label: 'ARM macOS 14 E2E tests'
+  - label: 'macOS 14 E2E tests'
     depends_on:
       - cocoa_fixture
     timeout_in_minutes: 60
@@ -814,7 +302,7 @@ steps:
         --os=macos
         --fail-fast
 
-  - label: 'ARM macOS 13 E2E tests'
+  - label: 'macOS 13 E2E tests'
     depends_on:
       - cocoa_fixture
     timeout_in_minutes: 60
@@ -838,7 +326,7 @@ steps:
         --os=macos
         --fail-fast
 
-  - label: 'ARM macOS 12 E2E tests'
+  - label: 'macOS 12 E2E tests'
     depends_on:
       - cocoa_fixture
     timeout_in_minutes: 60

--- a/.buildkite/pipeline.yml
+++ b/.buildkite/pipeline.yml
@@ -588,10 +588,16 @@ steps:
   # BitBar
   #
 
-  - label: ':bitbar: iOS 17 barebone tests'
+  - label: ':bitbar: {{matrix}} barebone tests'
+    matrix:
+      - "IOS_17"
+      - "IOS_16"
+      - "IOS_15"
+      - "IOS_14"
+      - "IOS_13"
     depends_on:
       - cocoa_fixture
-    timeout_in_minutes: 60
+    timeout_in_minutes: 30
     agents:
       queue: opensource
     plugins:
@@ -607,7 +613,7 @@ steps:
         command:
           - "--app=@/app/build/ipa_url_bb_release.txt"
           - "--farm=bb"
-          - "--device=IOS_17"
+          - "--device={{matrix}}"
           - "--no-tunnel"
           - "--aws-public-ip"
           - "--fail-fast"
@@ -626,157 +632,6 @@ steps:
         - exit_status: 103  # Appium session failed
           limit: 2
 
-  - label: ':bitbar: iOS 16 barebone tests'
-    depends_on:
-      - cocoa_fixture
-    timeout_in_minutes: 60
-    agents:
-      queue: opensource
-    plugins:
-      artifacts#v1.9.4:
-        download: "features/fixtures/ios/output/ipa_url_bb_release.txt"
-        upload:
-          - "maze_output/failed/**/*"
-          - "maze_output/maze_output.zip"
-      docker-compose#v4.7.0:
-        pull: cocoa-maze-runner-bitbar
-        run: cocoa-maze-runner-bitbar
-        service-ports: true
-        command:
-          - "--app=@/app/build/ipa_url_bb_release.txt"
-          - "--farm=bb"
-          - "--device=IOS_16"
-          - "--no-tunnel"
-          - "--aws-public-ip"
-          - "--fail-fast"
-          - "features/release/barebone_tests.feature"
-      test-collector#v1.11.0:
-        files: "reports/TEST-*.xml"
-        format: "junit"
-        branch: "^master|next$$"
-    concurrency: 25
-    concurrency_group: 'bitbar'
-    concurrency_method: eager
-    retry:
-      automatic:
-        - exit_status: -1  # Agent was lost
-          limit: 2
-        - exit_status: 103  # Appium session failed
-          limit: 2
-
-  - label: ':bitbar: iOS 15 barebone tests'
-    depends_on:
-      - cocoa_fixture
-    timeout_in_minutes: 60
-    agents:
-      queue: opensource
-    plugins:
-      artifacts#v1.9.4:
-        download: "features/fixtures/ios/output/ipa_url_bb_release.txt"
-        upload:
-          - "maze_output/failed/**/*"
-          - "maze_output/maze_output.zip"
-      docker-compose#v4.7.0:
-        pull: cocoa-maze-runner-bitbar
-        run: cocoa-maze-runner-bitbar
-        service-ports: true
-        command:
-          - "--app=@/app/build/ipa_url_bb_release.txt"
-          - "--farm=bb"
-          - "--device=IOS_15"
-          - "--no-tunnel"
-          - "--aws-public-ip"
-          - "--fail-fast"
-          - "features/release/barebone_tests.feature"
-      test-collector#v1.11.0:
-        files: "reports/TEST-*.xml"
-        format: "junit"
-        branch: "^master|next$$"
-    concurrency: 25
-    concurrency_group: 'bitbar'
-    concurrency_method: eager
-    retry:
-      automatic:
-        - exit_status: -1  # Agent was lost
-          limit: 2
-        - exit_status: 103  # Appium session failed
-          limit: 2
-
-  - label: ':bitbar: iOS 14 barebone tests'
-    depends_on:
-      - cocoa_fixture
-    timeout_in_minutes: 60
-    agents:
-      queue: opensource
-    plugins:
-      artifacts#v1.9.4:
-        download: "features/fixtures/ios/output/ipa_url_bb_release.txt"
-        upload:
-          - "maze_output/failed/**/*"
-          - "maze_output/maze_output.zip"
-      docker-compose#v4.7.0:
-        pull: cocoa-maze-runner-bitbar
-        run: cocoa-maze-runner-bitbar
-        service-ports: true
-        command:
-          - "--app=@/app/build/ipa_url_bb_release.txt"
-          - "--farm=bb"
-          - "--device=IOS_14"
-          - "--no-tunnel"
-          - "--aws-public-ip"
-          - "--fail-fast"
-          - "features/release/barebone_tests.feature"
-      test-collector#v1.11.0:
-        files: "reports/TEST-*.xml"
-        format: "junit"
-        branch: "^master|next$$"
-    concurrency: 25
-    concurrency_group: 'bitbar'
-    concurrency_method: eager
-    retry:
-      automatic:
-        - exit_status: -1  # Agent was lost
-          limit: 2
-        - exit_status: 103  # Appium session failed
-          limit: 2
-
-  - label: ':bitbar: iOS 13 barebone tests'
-    depends_on:
-      - cocoa_fixture
-    timeout_in_minutes: 60
-    agents:
-      queue: opensource
-    plugins:
-      artifacts#v1.9.4:
-        download: "features/fixtures/ios/output/ipa_url_bb_release.txt"
-        upload:
-          - "maze_output/failed/**/*"
-          - "maze_output/maze_output.zip"
-      docker-compose#v4.7.0:
-        pull: cocoa-maze-runner-bitbar
-        run: cocoa-maze-runner-bitbar
-        service-ports: true
-        command:
-          - "--app=@/app/build/ipa_url_bb_release.txt"
-          - "--farm=bb"
-          - "--device=IOS_13"
-          - "--no-tunnel"
-          - "--aws-public-ip"
-          - "--fail-fast"
-          - "features/release/barebone_tests.feature"
-      test-collector#v1.11.0:
-        files: "reports/TEST-*.xml"
-        format: "junit"
-        branch: "^master|next$$"
-    concurrency: 25
-    concurrency_group: 'bitbar'
-    concurrency_method: eager
-    retry:
-      automatic:
-        - exit_status: -1  # Agent was lost
-          limit: 2
-        - exit_status: 103  # Appium session failed
-          limit: 2
 
   ##############################################################################
   #


### PR DESCRIPTION
## Goal

Improve the maintainability of the Buildkite pipeline files.

## Design

Introduces the use of Build build matrices to remove a lot of duplication across jobs.  

## Changeset

The resulting set of build jobs should be the same as before this change, with the exception of removing the XcFramework-based fixture tests on iOS 16.  There appeared to be a hangover from when iOS 16 was "latest".  We are just testing that fixture with iOS 13 and 17 (to be bumped to 18/26 in due course).

## Testing

Covered by a full CI run.