### PR TITLE
Improved cxa_throw swapping

### DIFF
--- a/Bugsnag.xcodeproj/project.pbxproj
+++ b/Bugsnag.xcodeproj/project.pbxproj
@@ -844,6 +844,10 @@
 		962CE8142E65945200380522 /* PrivacyInfo.xcprivacy in Resources */ = {isa = PBXBuildFile; fileRef = ED0951B22B232A2E006FE348 /* PrivacyInfo.xcprivacy */; };
 		962CE8152E65945200380522 /* PrivacyInfo.xcprivacy in Resources */ = {isa = PBXBuildFile; fileRef = ED0951B22B232A2E006FE348 /* PrivacyInfo.xcprivacy */; };
 		962CE8162E65945200380522 /* PrivacyInfo.xcprivacy in Resources */ = {isa = PBXBuildFile; fileRef = ED0951B22B232A2E006FE348 /* PrivacyInfo.xcprivacy */; };
+		9630820E2E7C1FB7002F3E63 /* BSG_KSPlatformSpecificDefines.h in Headers */ = {isa = PBXBuildFile; fileRef = 9630820D2E7C1FB7002F3E63 /* BSG_KSPlatformSpecificDefines.h */; };
+		9630820F2E7C1FB7002F3E63 /* BSG_KSPlatformSpecificDefines.h in Headers */ = {isa = PBXBuildFile; fileRef = 9630820D2E7C1FB7002F3E63 /* BSG_KSPlatformSpecificDefines.h */; };
+		963082102E7C1FB7002F3E63 /* BSG_KSPlatformSpecificDefines.h in Headers */ = {isa = PBXBuildFile; fileRef = 9630820D2E7C1FB7002F3E63 /* BSG_KSPlatformSpecificDefines.h */; };
+		963082112E7C1FB7002F3E63 /* BSG_KSPlatformSpecificDefines.h in Headers */ = {isa = PBXBuildFile; fileRef = 9630820D2E7C1FB7002F3E63 /* BSG_KSPlatformSpecificDefines.h */; };
 		968BFBCB2D011BBB00DCC24B /* BSGPersistentFeatureFlagStore.h in Headers */ = {isa = PBXBuildFile; fileRef = 968BFBC92D011BBB00DCC24B /* BSGPersistentFeatureFlagStore.h */; };
 		968BFBCC2D011BBB00DCC24B /* BSGPersistentFeatureFlagStore.m in Sources */ = {isa = PBXBuildFile; fileRef = 968BFBCA2D011BBB00DCC24B /* BSGPersistentFeatureFlagStore.m */; };
 		968BFBCD2D011BC300DCC24B /* BSGPersistentFeatureFlagStore.h in Headers */ = {isa = PBXBuildFile; fileRef = 968BFBC92D011BBB00DCC24B /* BSGPersistentFeatureFlagStore.h */; };
@@ -862,6 +866,24 @@
 		968BFBDC2D0125CF00DCC24B /* BSGStoredFeatureFlag.m in Sources */ = {isa = PBXBuildFile; fileRef = 968BFBD42D0125C700DCC24B /* BSGStoredFeatureFlag.m */; };
 		968BFBDD2D0125D000DCC24B /* BSGStoredFeatureFlag.m in Sources */ = {isa = PBXBuildFile; fileRef = 968BFBD42D0125C700DCC24B /* BSGStoredFeatureFlag.m */; };
 		968BFBDE2D0125D000DCC24B /* BSGStoredFeatureFlag.m in Sources */ = {isa = PBXBuildFile; fileRef = 968BFBD42D0125C700DCC24B /* BSGStoredFeatureFlag.m */; };
+		969EE1072E7A9DC200600F63 /* BSG_KSCxaThrowSwapper.c in Sources */ = {isa = PBXBuildFile; fileRef = 969EE1062E7A9DC200600F63 /* BSG_KSCxaThrowSwapper.c */; };
+		969EE1082E7A9DC200600F63 /* BSG_KSCxaThrowSwapper.h in Headers */ = {isa = PBXBuildFile; fileRef = 969EE1052E7A9DC200600F63 /* BSG_KSCxaThrowSwapper.h */; };
+		969EE1092E7A9DC200600F63 /* BSG_KSCxaThrowSwapper.h in Headers */ = {isa = PBXBuildFile; fileRef = 969EE1052E7A9DC200600F63 /* BSG_KSCxaThrowSwapper.h */; };
+		969EE10A2E7A9DC200600F63 /* BSG_KSCxaThrowSwapper.c in Sources */ = {isa = PBXBuildFile; fileRef = 969EE1062E7A9DC200600F63 /* BSG_KSCxaThrowSwapper.c */; };
+		969EE10B2E7A9DC200600F63 /* BSG_KSCxaThrowSwapper.c in Sources */ = {isa = PBXBuildFile; fileRef = 969EE1062E7A9DC200600F63 /* BSG_KSCxaThrowSwapper.c */; };
+		969EE10C2E7A9DC200600F63 /* BSG_KSCxaThrowSwapper.c in Sources */ = {isa = PBXBuildFile; fileRef = 969EE1062E7A9DC200600F63 /* BSG_KSCxaThrowSwapper.c */; };
+		969EE10D2E7A9DC200600F63 /* BSG_KSCxaThrowSwapper.h in Headers */ = {isa = PBXBuildFile; fileRef = 969EE1052E7A9DC200600F63 /* BSG_KSCxaThrowSwapper.h */; };
+		969EE10E2E7A9DC200600F63 /* BSG_KSCxaThrowSwapper.c in Sources */ = {isa = PBXBuildFile; fileRef = 969EE1062E7A9DC200600F63 /* BSG_KSCxaThrowSwapper.c */; };
+		969EE10F2E7A9DC200600F63 /* BSG_KSCxaThrowSwapper.h in Headers */ = {isa = PBXBuildFile; fileRef = 969EE1052E7A9DC200600F63 /* BSG_KSCxaThrowSwapper.h */; };
+		969EE1122E7A9FA300600F63 /* BSG_KSMach-O.c in Sources */ = {isa = PBXBuildFile; fileRef = 969EE1112E7A9FA300600F63 /* BSG_KSMach-O.c */; };
+		969EE1132E7A9FA300600F63 /* BSG_KSMach-O.h in Headers */ = {isa = PBXBuildFile; fileRef = 969EE1102E7A9FA300600F63 /* BSG_KSMach-O.h */; };
+		969EE1142E7A9FA300600F63 /* BSG_KSMach-O.c in Sources */ = {isa = PBXBuildFile; fileRef = 969EE1112E7A9FA300600F63 /* BSG_KSMach-O.c */; };
+		969EE1152E7A9FA300600F63 /* BSG_KSMach-O.h in Headers */ = {isa = PBXBuildFile; fileRef = 969EE1102E7A9FA300600F63 /* BSG_KSMach-O.h */; };
+		969EE1162E7A9FA300600F63 /* BSG_KSMach-O.c in Sources */ = {isa = PBXBuildFile; fileRef = 969EE1112E7A9FA300600F63 /* BSG_KSMach-O.c */; };
+		969EE1172E7A9FA300600F63 /* BSG_KSMach-O.c in Sources */ = {isa = PBXBuildFile; fileRef = 969EE1112E7A9FA300600F63 /* BSG_KSMach-O.c */; };
+		969EE1182E7A9FA300600F63 /* BSG_KSMach-O.h in Headers */ = {isa = PBXBuildFile; fileRef = 969EE1102E7A9FA300600F63 /* BSG_KSMach-O.h */; };
+		969EE1192E7A9FA300600F63 /* BSG_KSMach-O.c in Sources */ = {isa = PBXBuildFile; fileRef = 969EE1112E7A9FA300600F63 /* BSG_KSMach-O.c */; };
+		969EE11A2E7A9FA300600F63 /* BSG_KSMach-O.h in Headers */ = {isa = PBXBuildFile; fileRef = 969EE1102E7A9FA300600F63 /* BSG_KSMach-O.h */; };
 		96E45BF32D1039F200BEF978 /* BSGAtomicFeatureFlagStore.h in Headers */ = {isa = PBXBuildFile; fileRef = 96E45BF22D1039F200BEF978 /* BSGAtomicFeatureFlagStore.h */; };
 		96E45BF42D1039F200BEF978 /* BSGAtomicFeatureFlagStore.h in Headers */ = {isa = PBXBuildFile; fileRef = 96E45BF22D1039F200BEF978 /* BSGAtomicFeatureFlagStore.h */; };
 		96E45BF52D1039F200BEF978 /* BSGAtomicFeatureFlagStore.h in Headers */ = {isa = PBXBuildFile; fileRef = 96E45BF22D1039F200BEF978 /* BSGAtomicFeatureFlagStore.h */; };
@@ -1655,10 +1677,15 @@
 		9627A1342D91CF9300696E3C /* BSGAtomicFeatureFlagStoreTests.m */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.objc; path = BSGAtomicFeatureFlagStoreTests.m; sourceTree = "<group>"; };
 		9627A1392D92200300696E3C /* WriterTestsSupport.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; path = WriterTestsSupport.h; sourceTree = "<group>"; };
 		9627A13A2D92201B00696E3C /* WriterTestsSupport.m */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.objc; path = WriterTestsSupport.m; sourceTree = "<group>"; };
+		9630820D2E7C1FB7002F3E63 /* BSG_KSPlatformSpecificDefines.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; path = BSG_KSPlatformSpecificDefines.h; sourceTree = "<group>"; };
 		968BFBC92D011BBB00DCC24B /* BSGPersistentFeatureFlagStore.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = BSGPersistentFeatureFlagStore.h; sourceTree = "<group>"; };
 		968BFBCA2D011BBB00DCC24B /* BSGPersistentFeatureFlagStore.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; path = BSGPersistentFeatureFlagStore.m; sourceTree = "<group>"; };
 		968BFBD42D0125C700DCC24B /* BSGStoredFeatureFlag.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; path = BSGStoredFeatureFlag.m; sourceTree = "<group>"; };
 		968BFBD52D0125C800DCC24B /* BSGStoredFeatureFlag.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = BSGStoredFeatureFlag.h; sourceTree = "<group>"; };
+		969EE1052E7A9DC200600F63 /* BSG_KSCxaThrowSwapper.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; path = BSG_KSCxaThrowSwapper.h; sourceTree = "<group>"; };
+		969EE1062E7A9DC200600F63 /* BSG_KSCxaThrowSwapper.c */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.c; path = BSG_KSCxaThrowSwapper.c; sourceTree = "<group>"; };
+		969EE1102E7A9FA300600F63 /* BSG_KSMach-O.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; path = "BSG_KSMach-O.h"; sourceTree = "<group>"; };
+		969EE1112E7A9FA300600F63 /* BSG_KSMach-O.c */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.c; path = "BSG_KSMach-O.c"; sourceTree = "<group>"; };
 		96E45BF22D1039F200BEF978 /* BSGAtomicFeatureFlagStore.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; path = BSGAtomicFeatureFlagStore.h; sourceTree = "<group>"; };
 		96E45BF72D103AA200BEF978 /* BSGAtomicFeatureFlagStore.m */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.objc; path = BSGAtomicFeatureFlagStore.m; sourceTree = "<group>"; };
 		96E45BFD2D103B1F00BEF978 /* BSGFeatureFlagStore.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; path = BSGFeatureFlagStore.h; sourceTree = "<group>"; };
@@ -1895,24 +1922,25 @@
 				CBD50F6025DA72EC00DF0314 /* BSG_Jailbreak.h */,
 				0089692D2486DAD000DC48C2 /* BSG_KSCrash.h */,
 				008969362486DAD000DC48C2 /* BSG_KSCrash.m */,
-				0089694B2486DAD000DC48C2 /* BSG_KSCrashC.c */,
 				0089692E2486DAD000DC48C2 /* BSG_KSCrashC.h */,
+				0089694B2486DAD000DC48C2 /* BSG_KSCrashC.c */,
 				0089692A2486DAD000DC48C2 /* BSG_KSCrashContext.h */,
 				008969332486DAD000DC48C2 /* BSG_KSCrashDoctor.h */,
 				008969002486DAD000DC48C2 /* BSG_KSCrashDoctor.m */,
 				0089694A2486DAD000DC48C2 /* BSG_KSCrashIdentifier.h */,
 				008969302486DAD000DC48C2 /* BSG_KSCrashIdentifier.m */,
-				CB33CCFD2703438400C76656 /* BSG_KSCrashNames.c */,
 				CB33CCFC2703438400C76656 /* BSG_KSCrashNames.h */,
-				008969492486DAD000DC48C2 /* BSG_KSCrashReport.c */,
+				CB33CCFD2703438400C76656 /* BSG_KSCrashNames.c */,
 				008969322486DAD000DC48C2 /* BSG_KSCrashReport.h */,
+				008969492486DAD000DC48C2 /* BSG_KSCrashReport.c */,
 				008969342486DAD000DC48C2 /* BSG_KSCrashReportFields.h */,
 				008969372486DAD000DC48C2 /* BSG_KSCrashReportVersion.h */,
 				008969352486DAD000DC48C2 /* BSG_KSCrashState.h */,
 				008969292486DAD000DC48C2 /* BSG_KSCrashState.m */,
 				008969482486DAD000DC48C2 /* BSG_KSCrashType.h */,
-				01CB95BE278F0C830077744A /* BSG_KSFile.c */,
 				01CB95BD278F0C830077744A /* BSG_KSFile.h */,
+				01CB95BE278F0C830077744A /* BSG_KSFile.c */,
+				9630820D2E7C1FB7002F3E63 /* BSG_KSPlatformSpecificDefines.h */,
 				0089692F2486DAD000DC48C2 /* BSG_KSSystemInfo.h */,
 				0089694C2486DAD000DC48C2 /* BSG_KSSystemInfo.m */,
 				008969312486DAD000DC48C2 /* BSG_KSSystemInfoC.h */,
@@ -1926,34 +1954,38 @@
 			isa = PBXGroup;
 			children = (
 				0089690E2486DAD000DC48C2 /* BSG_KSArchSpecific.h */,
-				008969162486DAD000DC48C2 /* BSG_KSBacktrace_Private.h */,
-				0089691B2486DAD000DC48C2 /* BSG_KSBacktrace.c */,
 				008969022486DAD000DC48C2 /* BSG_KSBacktrace.h */,
-				CB3744932845FA9500A3955E /* BSG_KSCrashStringConversion.c */,
+				0089691B2486DAD000DC48C2 /* BSG_KSBacktrace.c */,
+				008969162486DAD000DC48C2 /* BSG_KSBacktrace_Private.h */,
 				CB3744922845FA9500A3955E /* BSG_KSCrashStringConversion.h */,
-				008969182486DAD000DC48C2 /* BSG_KSFileUtils.c */,
+				CB3744932845FA9500A3955E /* BSG_KSCrashStringConversion.c */,
 				008969092486DAD000DC48C2 /* BSG_KSFileUtils.h */,
-				0089690B2486DAD000DC48C2 /* BSG_KSJSONCodec.c */,
+				008969182486DAD000DC48C2 /* BSG_KSFileUtils.c */,
 				008969222486DAD000DC48C2 /* BSG_KSJSONCodec.h */,
-				008969262486DAD000DC48C2 /* BSG_KSLogger.c */,
+				0089690B2486DAD000DC48C2 /* BSG_KSJSONCodec.c */,
 				008969152486DAD000DC48C2 /* BSG_KSLogger.h */,
+				008969262486DAD000DC48C2 /* BSG_KSLogger.c */,
+				008969282486DAD000DC48C2 /* BSG_KSMach.h */,
+				008969132486DAD000DC48C2 /* BSG_KSMach.c */,
 				008969072486DAD000DC48C2 /* BSG_KSMach_Arm.c */,
 				008969172486DAD000DC48C2 /* BSG_KSMach_Arm64.c */,
 				008969032486DAD000DC48C2 /* BSG_KSMach_x86_32.c */,
 				0089691F2486DAD000DC48C2 /* BSG_KSMach_x86_64.c */,
-				008969132486DAD000DC48C2 /* BSG_KSMach.c */,
-				008969282486DAD000DC48C2 /* BSG_KSMach.h */,
 				008969112486DAD000DC48C2 /* BSG_KSMachApple.h */,
-				008969102486DAD000DC48C2 /* BSG_KSMachHeaders.c */,
 				008969232486DAD000DC48C2 /* BSG_KSMachHeaders.h */,
-				008969212486DAD000DC48C2 /* BSG_KSSignalInfo.c */,
+				008969102486DAD000DC48C2 /* BSG_KSMachHeaders.c */,
 				0089690A2486DAD000DC48C2 /* BSG_KSSignalInfo.h */,
-				008969242486DAD000DC48C2 /* BSG_KSString.c */,
+				008969212486DAD000DC48C2 /* BSG_KSSignalInfo.c */,
 				008969122486DAD000DC48C2 /* BSG_KSString.h */,
-				0089691C2486DAD000DC48C2 /* BSG_KSSysCtl.c */,
+				008969242486DAD000DC48C2 /* BSG_KSString.c */,
 				008969042486DAD000DC48C2 /* BSG_KSSysCtl.h */,
-				01A2C540271EB9B300A27B23 /* BSG_Symbolicate.c */,
+				0089691C2486DAD000DC48C2 /* BSG_KSSysCtl.c */,
 				01A2C541271EB9B300A27B23 /* BSG_Symbolicate.h */,
+				01A2C540271EB9B300A27B23 /* BSG_Symbolicate.c */,
+				969EE1052E7A9DC200600F63 /* BSG_KSCxaThrowSwapper.h */,
+				969EE1062E7A9DC200600F63 /* BSG_KSCxaThrowSwapper.c */,
+				969EE1102E7A9FA300600F63 /* BSG_KSMach-O.h */,
+				969EE1112E7A9FA300600F63 /* BSG_KSMach-O.c */,
 			);
 			path = Tools;
 			sourceTree = "<group>";
@@ -2425,14 +2457,17 @@
 				3A700AA324A63ADC0068CD1B /* BugsnagDevice.h in Headers */,
 				3A700AA424A63ADC0068CD1B /* BugsnagApp.h in Headers */,
 				3A700AA524A63ADC0068CD1B /* BugsnagError.h in Headers */,
+				969EE10D2E7A9DC200600F63 /* BSG_KSCxaThrowSwapper.h in Headers */,
 				3A700AA624A63ADC0068CD1B /* BugsnagDeviceWithState.h in Headers */,
 				3A700AA724A63ADC0068CD1B /* BugsnagMetadata.h in Headers */,
 				008967F72486DA4500DC48C2 /* BugsnagApiClient.h in Headers */,
+				963082112E7C1FB7002F3E63 /* BSG_KSPlatformSpecificDefines.h in Headers */,
 				968BFBCB2D011BBB00DCC24B /* BSGPersistentFeatureFlagStore.h in Headers */,
 				008969CC2486DAD100DC48C2 /* BSG_KSMach.h in Headers */,
 				008968282486DA5600DC48C2 /* BSGKeys.h in Headers */,
 				CBCAF6FA25A457F90095771F /* BSGFileLocations.h in Headers */,
 				01A2C546271EB9B400A27B23 /* BSG_Symbolicate.h in Headers */,
+				969EE1152E7A9FA300600F63 /* BSG_KSMach-O.h in Headers */,
 				008969BD2486DAD100DC48C2 /* BSG_KSMachHeaders.h in Headers */,
 				0126F7BB25DD512B008483C2 /* BSGEventUploadKSCrashReportOperation.h in Headers */,
 				008969EA2486DAD100DC48C2 /* BSG_KSCrashReport.h in Headers */,
@@ -2519,6 +2554,7 @@
 				0126F7AC25DD5118008483C2 /* BSGEventUploadFileOperation.h in Headers */,
 				3A700AAE24A63CFD0068CD1B /* BSG_KSCrashReportWriter.h in Headers */,
 				3A700AAF24A63CFD0068CD1B /* BugsnagErrorTypes.h in Headers */,
+				969EE1092E7A9DC200600F63 /* BSG_KSCxaThrowSwapper.h in Headers */,
 				01847D972644140F00ADA4C7 /* BSGInternalErrorReporter.h in Headers */,
 				017DCF8D2874212F000ECB22 /* BSGTelemetry.h in Headers */,
 				01840B7025DC26E200F95648 /* BSGEventUploader.h in Headers */,
@@ -2558,6 +2594,7 @@
 				CB3744952845FA9500A3955E /* BSG_KSCrashStringConversion.h in Headers */,
 				0154E20328070AEA009044E4 /* BSGRunContext.h in Headers */,
 				008969BB2486DAD100DC48C2 /* BSG_KSJSONCodec.h in Headers */,
+				969EE11A2E7A9FA300600F63 /* BSG_KSMach-O.h in Headers */,
 				008969E82486DAD100DC48C2 /* BSG_KSSystemInfoC.h in Headers */,
 				00AD1F112486A17900A27979 /* BugsnagSessionTracker.h in Headers */,
 				0126F79C25DD510E008483C2 /* BSGEventUploadObjectOperation.h in Headers */,
@@ -2565,6 +2602,7 @@
 				00896A092486DAD100DC48C2 /* BSG_KSCrashSentry_Private.h in Headers */,
 				013D9CD226C5262F0077F0AD /* UISceneStub.h in Headers */,
 				CBCF77A425010648004AF22A /* BSGJSONSerialization.h in Headers */,
+				9630820E2E7C1FB7002F3E63 /* BSG_KSPlatformSpecificDefines.h in Headers */,
 				008969732486DAD000DC48C2 /* BSG_KSSignalInfo.h in Headers */,
 				CBEC892B2A4AC2920088A3CE /* BSGFilesystem.h in Headers */,
 				008967C32486DA1900DC48C2 /* BugsnagClient+Private.h in Headers */,
@@ -2630,6 +2668,7 @@
 				0126F7AD25DD5118008483C2 /* BSGEventUploadFileOperation.h in Headers */,
 				3A700AC224A63D110068CD1B /* BSG_KSCrashReportWriter.h in Headers */,
 				3A700AC324A63D110068CD1B /* BugsnagErrorTypes.h in Headers */,
+				969EE1082E7A9DC200600F63 /* BSG_KSCxaThrowSwapper.h in Headers */,
 				01847D982644140F00ADA4C7 /* BSGInternalErrorReporter.h in Headers */,
 				017DCF8E2874212F000ECB22 /* BSGTelemetry.h in Headers */,
 				01840B7125DC26E200F95648 /* BSGEventUploader.h in Headers */,
@@ -2669,6 +2708,7 @@
 				CB3744962845FA9500A3955E /* BSG_KSCrashStringConversion.h in Headers */,
 				0154E20428070AEA009044E4 /* BSGRunContext.h in Headers */,
 				008969BC2486DAD100DC48C2 /* BSG_KSJSONCodec.h in Headers */,
+				969EE1132E7A9FA300600F63 /* BSG_KSMach-O.h in Headers */,
 				008969E92486DAD100DC48C2 /* BSG_KSSystemInfoC.h in Headers */,
 				00AD1F122486A17900A27979 /* BugsnagSessionTracker.h in Headers */,
 				0126F79D25DD510E008483C2 /* BSGEventUploadObjectOperation.h in Headers */,
@@ -2676,6 +2716,7 @@
 				00896A0A2486DAD100DC48C2 /* BSG_KSCrashSentry_Private.h in Headers */,
 				013D9CD326C5262F0077F0AD /* UISceneStub.h in Headers */,
 				CBCF77A525010648004AF22A /* BSGJSONSerialization.h in Headers */,
+				963082102E7C1FB7002F3E63 /* BSG_KSPlatformSpecificDefines.h in Headers */,
 				008969742486DAD100DC48C2 /* BSG_KSSignalInfo.h in Headers */,
 				CBEC892C2A4AC2920088A3CE /* BSGFilesystem.h in Headers */,
 				008967C42486DA1900DC48C2 /* BugsnagClient+Private.h in Headers */,
@@ -2792,6 +2833,7 @@
 				CBBDE9972800699C0070DCD3 /* BSG_KSCrashSentry_CPPException.h in Headers */,
 				CBBDE941280068D40070DCD3 /* BSGMemoryFeatureFlagStore.h in Headers */,
 				CBBDE96B2800693F0070DCD3 /* BugsnagNotifier.h in Headers */,
+				9630820F2E7C1FB7002F3E63 /* BSG_KSPlatformSpecificDefines.h in Headers */,
 				CBBDE97F2800698F0070DCD3 /* BSG_KSFile.h in Headers */,
 				CBBDE961280068FD0070DCD3 /* BugsnagConfiguration.h in Headers */,
 				CBBDE951280068FD0070DCD3 /* BugsnagDeviceWithState.h in Headers */,
@@ -2804,8 +2846,10 @@
 				CBBDE960280068FD0070DCD3 /* BSG_KSCrashReportWriter.h in Headers */,
 				CBBDE91F280068880070DCD3 /* BugsnagClient+Private.h in Headers */,
 				CBBDE9852800698F0070DCD3 /* BSG_KSCrashC.h in Headers */,
+				969EE10F2E7A9DC200600F63 /* BSG_KSCxaThrowSwapper.h in Headers */,
 				CBBDE9202800688D0070DCD3 /* BSGConfigurationBuilder.h in Headers */,
 				CBBDE926280068AD0070DCD3 /* BSGEventUploadKSCrashReportOperation.h in Headers */,
+				969EE1182E7A9FA300600F63 /* BSG_KSMach-O.h in Headers */,
 				CBBDE953280068FD0070DCD3 /* BugsnagErrorTypes.h in Headers */,
 				CBBDE9962800699C0070DCD3 /* BSG_KSCrashSentry_NSException.h in Headers */,
 				CBBDE9932800698F0070DCD3 /* BSG_KSCrashIdentifier.h in Headers */,
@@ -3213,6 +3257,7 @@
 				0126F7BE25DD512B008483C2 /* BSGEventUploadKSCrashReportOperation.m in Sources */,
 				008969B12486DAD100DC48C2 /* BSG_KSMach_x86_64.c in Sources */,
 				008969B72486DAD100DC48C2 /* BSG_KSSignalInfo.c in Sources */,
+				969EE1142E7A9FA300600F63 /* BSG_KSMach-O.c in Sources */,
 				017DCF902874212F000ECB22 /* BSGTelemetry.m in Sources */,
 				008968992486DA9600DC48C2 /* BugsnagStackframe.m in Sources */,
 				96E45BF82D103AA200BEF978 /* BSGAtomicFeatureFlagStore.m in Sources */,
@@ -3225,6 +3270,7 @@
 				008968802486DA9600DC48C2 /* BugsnagAppWithState.m in Sources */,
 				008969572486DAD000DC48C2 /* BSG_KSCrashDoctor.m in Sources */,
 				008968B92486DA9600DC48C2 /* BugsnagStacktrace.m in Sources */,
+				969EE10C2E7A9DC200600F63 /* BSG_KSCxaThrowSwapper.c in Sources */,
 				09E312FE2BF34D6D0081F219 /* BugsnagCorrelation.m in Sources */,
 				00896A142486DAD100DC48C2 /* BSG_KSCrashSentry_Signal.c in Sources */,
 				01468F5525876DC1002B0519 /* BSGNotificationBreadcrumbs.m in Sources */,
@@ -3400,6 +3446,7 @@
 				00AD1F2F2486A17900A27979 /* BugsnagSessionTracker.m in Sources */,
 				010993A0273D13D800128BBE /* BSGMemoryFeatureFlagStore.m in Sources */,
 				008969B22486DAD100DC48C2 /* BSG_KSMach_x86_64.c in Sources */,
+				969EE1192E7A9FA300600F63 /* BSG_KSMach-O.c in Sources */,
 				0126F7BF25DD512B008483C2 /* BSGEventUploadKSCrashReportOperation.m in Sources */,
 				CB3744982845FA9500A3955E /* BSG_KSCrashStringConversion.c in Sources */,
 				96E45BF92D103AA200BEF978 /* BSGAtomicFeatureFlagStore.m in Sources */,
@@ -3412,6 +3459,7 @@
 				0089699D2486DAD100DC48C2 /* BSG_KSFileUtils.c in Sources */,
 				008969762486DAD100DC48C2 /* BSG_KSJSONCodec.c in Sources */,
 				00896A2D2486DAD100DC48C2 /* BSG_KSCrashReport.c in Sources */,
+				969EE10A2E7A9DC200600F63 /* BSG_KSCxaThrowSwapper.c in Sources */,
 				09E312FF2BF34D6D0081F219 /* BugsnagCorrelation.m in Sources */,
 				008968812486DA9600DC48C2 /* BugsnagAppWithState.m in Sources */,
 				008969582486DAD000DC48C2 /* BSG_KSCrashDoctor.m in Sources */,
@@ -3584,6 +3632,7 @@
 				008967B62486D9D800DC48C2 /* BugsnagBreadcrumbs.m in Sources */,
 				00AD1F302486A17900A27979 /* BugsnagSessionTracker.m in Sources */,
 				008969B32486DAD100DC48C2 /* BSG_KSMach_x86_64.c in Sources */,
+				969EE1122E7A9FA300600F63 /* BSG_KSMach-O.c in Sources */,
 				0126F7C025DD512B008483C2 /* BSGEventUploadKSCrashReportOperation.m in Sources */,
 				008969B92486DAD100DC48C2 /* BSG_KSSignalInfo.c in Sources */,
 				96E45BFA2D103AA200BEF978 /* BSGAtomicFeatureFlagStore.m in Sources */,
@@ -3596,6 +3645,7 @@
 				008969772486DAD100DC48C2 /* BSG_KSJSONCodec.c in Sources */,
 				00896A2E2486DAD100DC48C2 /* BSG_KSCrashReport.c in Sources */,
 				008968822486DA9600DC48C2 /* BugsnagAppWithState.m in Sources */,
+				969EE1072E7A9DC200600F63 /* BSG_KSCxaThrowSwapper.c in Sources */,
 				09E313002BF34D6D0081F219 /* BugsnagCorrelation.m in Sources */,
 				008969592486DAD000DC48C2 /* BSG_KSCrashDoctor.m in Sources */,
 				008968BB2486DA9600DC48C2 /* BugsnagStacktrace.m in Sources */,
@@ -3806,6 +3856,7 @@
 				008967DD2486DA2D00DC48C2 /* BugsnagConfiguration.m in Sources */,
 				01840B7525DC26E200F95648 /* BSGEventUploader.m in Sources */,
 				01CB95C5278F0C830077744A /* BSG_KSFile.c in Sources */,
+				969EE10B2E7A9DC200600F63 /* BSG_KSCxaThrowSwapper.c in Sources */,
 				008968BC2486DA9600DC48C2 /* BugsnagStacktrace.m in Sources */,
 				008967B72486D9D800DC48C2 /* BugsnagBreadcrumbs.m in Sources */,
 				008968872486DA9600DC48C2 /* BugsnagNotifier.m in Sources */,
@@ -3831,6 +3882,7 @@
 				008967E12486DA2D00DC48C2 /* BSGConfigurationBuilder.m in Sources */,
 				008967FD2486DA4500DC48C2 /* BugsnagApiClient.m in Sources */,
 				CB37449A2845FA9500A3955E /* BSG_KSCrashStringConversion.c in Sources */,
+				969EE1162E7A9FA300600F63 /* BSG_KSMach-O.c in Sources */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};
@@ -3873,6 +3925,7 @@
 				CBBDE93B280068D40070DCD3 /* BSGSerialization.m in Sources */,
 				CBBDE9AE280069B20070DCD3 /* BSG_KSJSONCodec.c in Sources */,
 				CBBDE9B1280069B20070DCD3 /* BSG_KSLogger.c in Sources */,
+				969EE1172E7A9FA300600F63 /* BSG_KSMach-O.c in Sources */,
 				CBBDE9672800691E0070DCD3 /* BugsnagDevice.m in Sources */,
 				CBBDE9812800698F0070DCD3 /* BSG_KSFile.c in Sources */,
 				96E45BFB2D103AA200BEF978 /* BSGAtomicFeatureFlagStore.m in Sources */,
@@ -3885,6 +3938,7 @@
 				CBBDE92C280068AD0070DCD3 /* BSGEventUploadObjectOperation.m in Sources */,
 				CBBDE910280068560070DCD3 /* BugsnagSessionTracker.m in Sources */,
 				CBBDE98C2800698F0070DCD3 /* BSG_KSCrashDoctor.m in Sources */,
+				969EE10E2E7A9DC200600F63 /* BSG_KSCxaThrowSwapper.c in Sources */,
 				09E313012BF34D6D0081F219 /* BugsnagCorrelation.m in Sources */,
 				CBBDE948280068E60070DCD3 /* MRCCanary.m in Sources */,
 				CBBDE93A280068D40070DCD3 /* BSGInternalErrorReporter.m in Sources */,

--- a/Bugsnag/KSCrash/Source/KSCrash/Recording/BSG_KSPlatformSpecificDefines.h
+++ b/Bugsnag/KSCrash/Source/KSCrash/Recording/BSG_KSPlatformSpecificDefines.h
@@ -1,0 +1,49 @@
+//
+//  KSPlatformSpecificDefines.h
+//
+//  Copyright (c) 2019 YANDEX LLC. All rights reserved.
+//
+// Permission is hereby granted, free of charge, to any person obtaining a copy
+// of this software and associated documentation files (the "Software"), to deal
+// in the Software without restriction, including without limitation the rights
+// to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+// copies of the Software, and to permit persons to whom the Software is
+// furnished to do so, subject to the following conditions:
+//
+// The above copyright notice and this permission notice shall remain in place
+// in this source code.
+//
+// THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+// IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+// FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+// AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+// LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+// OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+// THE SOFTWARE.
+//
+
+#ifndef KSPlatformSpecificDefines_h
+#define KSPlatformSpecificDefines_h
+
+#include <mach-o/loader.h>
+#include <mach-o/nlist.h>
+
+#ifdef __LP64__
+typedef struct mach_header_64 mach_header_t;
+typedef struct segment_command_64 segment_command_t;
+typedef struct section_64 section_t;
+typedef struct nlist_64 nlist_t;
+#define LC_SEGMENT_ARCH_DEPENDENT LC_SEGMENT_64
+#else /* __LP64__ */
+typedef struct mach_header mach_header_t;
+typedef struct segment_command segment_command_t;
+typedef struct section section_t;
+typedef struct nlist nlist_t;
+#define LC_SEGMENT_ARCH_DEPENDENT LC_SEGMENT
+#endif /* __LP64__ */
+
+#ifndef SEG_DATA_CONST
+#define SEG_DATA_CONST "__DATA_CONST"
+#endif /* SEG_DATA_CONST */
+
+#endif /* KSPlatformSpecificDefines_h */

--- a/Bugsnag/KSCrash/Source/KSCrash/Recording/Sentry/BSG_KSCrashSentry_CPPException.mm
+++ b/Bugsnag/KSCrash/Source/KSCrash/Recording/Sentry/BSG_KSCrashSentry_CPPException.mm
@@ -30,6 +30,7 @@
 #include "BSG_KSCrashSentry_Private.h"
 #include "BSG_KSCrashStringConversion.h"
 #include "BSG_KSMach.h"
+#include "../Tools/BSG_KSCxaThrowSwapper.h"
 
 //#define BSG_KSLogger_LocalLevel TRACE
 #include "BSG_KSLogger.h"
@@ -84,10 +85,10 @@ static BSG_KSCrash_SentryContext *bsg_g_context;
 typedef void (*cxa_throw_type)(void *, std::type_info *, void (*)(void *));
 
 extern "C" {
-void __cxa_throw(void *thrown_exception, std::type_info *tinfo,
+void BSG__cxa_throw_override(void *thrown_exception, std::type_info *tinfo,
                  void (*dest)(void *)) __attribute__((weak));
 
-void __cxa_throw(void *thrown_exception, std::type_info *tinfo,
+void BSG__cxa_throw_override(void *thrown_exception, std::type_info *tinfo,
                  void (*dest)(void *)) {
     if (bsg_g_captureNextStackTrace) {
         bsg_g_stackTraceCount =
@@ -262,6 +263,7 @@ extern "C" bool bsg_kscrashsentry_installCPPExceptionHandler(
 
     bsg_g_originalTerminateHandler = std::set_terminate(CPPExceptionTerminate);
     bsg_g_captureNextStackTrace = true;
+    bsg_ksct_swap(BSG__cxa_throw_override);
     return true;
 }
 

--- a/Bugsnag/KSCrash/Source/KSCrash/Recording/Tools/BSG_KSCxaThrowSwapper.c
+++ b/Bugsnag/KSCrash/Source/KSCrash/Recording/Tools/BSG_KSCxaThrowSwapper.c
@@ -1,0 +1,274 @@
+//
+//  KSCxaThrowSwapper.cpp
+//
+//  Copyright (c) 2019 YANDEX LLC. All rights reserved.
+//
+// Permission is hereby granted, free of charge, to any person obtaining a copy
+// of this software and associated documentation files (the "Software"), to deal
+// in the Software without restriction, including without limitation the rights
+// to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+// copies of the Software, and to permit persons to whom the Software is
+// furnished to do so, subject to the following conditions:
+//
+// The above copyright notice and this permission notice shall remain in place
+// in this source code.
+//
+// THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+// IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+// FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+// AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+// LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+// OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+// THE SOFTWARE.
+//
+//
+// Inspired by facebook/fishhook
+// https://github.com/facebook/fishhook
+//
+// Copyright (c) 2013, Facebook, Inc.
+// All rights reserved.
+// Redistribution and use in source and binary forms, with or without
+// modification, are permitted provided that the following conditions are met:
+//   * Redistributions of source code must retain the above copyright notice,
+//     this list of conditions and the following disclaimer.
+//   * Redistributions in binary form must reproduce the above copyright notice,
+//     this list of conditions and the following disclaimer in the documentation
+//     and/or other materials provided with the distribution.
+//   * Neither the name Facebook nor the names of its contributors may be used to
+//     endorse or promote products derived from this software without specific
+//     prior written permission.
+// THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
+// AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+// IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE
+// DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE LIABLE
+// FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL
+// DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR
+// SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER
+// CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY,
+// OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
+// OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+
+#include "BSG_KSCxaThrowSwapper.h"
+
+#include <dlfcn.h>
+#include <errno.h>
+#include <execinfo.h>
+#include <mach-o/dyld.h>
+#include <mach-o/nlist.h>
+#include <mach/mach.h>
+#include <stdio.h>
+#include <stdlib.h>
+#include <string.h>
+#include <sys/mman.h>
+#include <sys/types.h>
+
+#include "BSG_KSLogger.h"
+#include "BSG_KSMach-O.h"
+#include "BSG_KSPlatformSpecificDefines.h"
+
+typedef struct {
+    uintptr_t image;
+    uintptr_t function;
+} BSG_KSAddressPair;
+
+static cxa_throw_type g_cxa_throw_handler = NULL;
+static const char *const g_cxa_throw_name = "__cxa_throw";
+
+static BSG_KSAddressPair *g_cxa_originals = NULL;
+static size_t g_cxa_originals_capacity = 0;
+static size_t g_cxa_originals_count = 0;
+
+static void addPair(BSG_KSAddressPair pair)
+{
+    BSG_KSLOG_DEBUG("Adding address pair: image=%p, function=%p", (void *)pair.image, (void *)pair.function);
+
+    if (g_cxa_originals_count == g_cxa_originals_capacity) {
+        g_cxa_originals_capacity *= 2;
+        g_cxa_originals = (BSG_KSAddressPair *)realloc(g_cxa_originals, sizeof(BSG_KSAddressPair) * g_cxa_originals_capacity);
+        if (g_cxa_originals == NULL) {
+            BSG_KSLOG_ERROR("Failed to realloc memory for g_cxa_originals: %s", strerror(errno));
+            return;
+        }
+    }
+    memcpy(&g_cxa_originals[g_cxa_originals_count++], &pair, sizeof(BSG_KSAddressPair));
+}
+
+static uintptr_t findAddress(void *address)
+{
+    BSG_KSLOG_TRACE("Finding address for %p", address);
+
+    for (size_t i = 0; i < g_cxa_originals_count; i++) {
+        if (g_cxa_originals[i].image == (uintptr_t)address) {
+            return g_cxa_originals[i].function;
+        }
+    }
+    BSG_KSLOG_WARN("Address %p not found", address);
+    return (uintptr_t)NULL;
+}
+
+static void __cxa_throw_decorator(void *thrown_exception, void *tinfo, void (*dest)(void *))
+{
+#define REQUIRED_FRAMES 2
+
+    BSG_KSLOG_TRACE("Decorating __cxa_throw");
+
+    g_cxa_throw_handler(thrown_exception, tinfo, dest);
+
+    void *backtraceArr[REQUIRED_FRAMES];
+    int count = backtrace(backtraceArr, REQUIRED_FRAMES);
+
+    Dl_info info;
+    if (count >= REQUIRED_FRAMES) {
+        if (dladdr(backtraceArr[REQUIRED_FRAMES - 1], &info) != 0) {
+            uintptr_t function = findAddress(info.dli_fbase);
+            if (function != (uintptr_t)NULL) {
+                BSG_KSLOG_TRACE("Calling original __cxa_throw function at %p", (void *)function);
+                cxa_throw_type original = (cxa_throw_type)function;
+                original(thrown_exception, tinfo, dest);
+            }
+        }
+    }
+#undef REQUIRED_FRAMES
+}
+
+static void perform_rebinding_with_section(const section_t *dataSection, intptr_t slide, nlist_t *symtab, char *strtab,
+                                           uint32_t *indirect_symtab)
+{
+    BSG_KSLOG_TRACE("Performing rebinding with section %s,%s", dataSection->segname, dataSection->sectname);
+
+    const bool isDataConst = strcmp(dataSection->segname, SEG_DATA_CONST) == 0;
+    uint32_t *indirect_symbol_indices = indirect_symtab + dataSection->reserved1;
+    void **indirect_symbol_bindings = (void **)((uintptr_t)slide + dataSection->addr);
+    vm_prot_t oldProtection = VM_PROT_READ;
+    if (isDataConst) {
+        oldProtection = bsg_ksmacho_getSectionProtection(indirect_symbol_bindings);
+        if (mprotect(indirect_symbol_bindings, dataSection->size, PROT_READ | PROT_WRITE) != 0) {
+            BSG_KSLOG_DEBUG("mprotect failed to set PROT_READ | PROT_WRITE for section %s,%s: %s", dataSection->segname,
+                        dataSection->sectname, strerror(errno));
+            return;
+        }
+    }
+    for (uint i = 0; i < dataSection->size / sizeof(void *); i++) {
+        uint32_t symtab_index = indirect_symbol_indices[i];
+        if (symtab_index == INDIRECT_SYMBOL_ABS || symtab_index == INDIRECT_SYMBOL_LOCAL ||
+            symtab_index == (INDIRECT_SYMBOL_LOCAL | INDIRECT_SYMBOL_ABS)) {
+            continue;
+        }
+        uint32_t strtab_offset = symtab[symtab_index].n_un.n_strx;
+        char *symbol_name = strtab + strtab_offset;
+        bool symbol_name_longer_than_1 = symbol_name[0] && symbol_name[1];
+        if (symbol_name_longer_than_1 && strcmp(&symbol_name[1], g_cxa_throw_name) == 0) {
+            Dl_info info;
+            if (dladdr(dataSection, &info) != 0) {
+                BSG_KSAddressPair pair = { (uintptr_t)info.dli_fbase, (uintptr_t)indirect_symbol_bindings[i] };
+                addPair(pair);
+            }
+            indirect_symbol_bindings[i] = (void *)__cxa_throw_decorator;
+            continue;
+        }
+    }
+    if (isDataConst) {
+        int protection = 0;
+        if (oldProtection & VM_PROT_READ) {
+            protection |= PROT_READ;
+        }
+        if (oldProtection & VM_PROT_WRITE) {
+            protection |= PROT_WRITE;
+        }
+        if (oldProtection & VM_PROT_EXECUTE) {
+            protection |= PROT_EXEC;
+        }
+        if (mprotect(indirect_symbol_bindings, dataSection->size, protection) != 0) {
+            BSG_KSLOG_ERROR("mprotect failed to restore protection for section %s,%s: %s", dataSection->segname,
+                        dataSection->sectname, strerror(errno));
+        }
+    }
+}
+
+static void process_segment(const struct mach_header *header, intptr_t slide, const char *segname, nlist_t *symtab,
+                            char *strtab, uint32_t *indirect_symtab)
+{
+    BSG_KSLOG_DEBUG("Processing segment %s", segname);
+
+    const segment_command_t *segment = bsg_ksmacho_getSegmentByNameFromHeader((const mach_header_t *)header, segname);
+    if (segment != NULL) {
+        const section_t *lazy_sym_sect = bsg_ksmacho_getSectionByTypeFlagFromSegment(segment, S_LAZY_SYMBOL_POINTERS);
+        const section_t *non_lazy_sym_sect =
+            bsg_ksmacho_getSectionByTypeFlagFromSegment(segment, S_NON_LAZY_SYMBOL_POINTERS);
+
+        if (lazy_sym_sect != NULL) {
+            perform_rebinding_with_section(lazy_sym_sect, slide, symtab, strtab, indirect_symtab);
+        }
+        if (non_lazy_sym_sect != NULL) {
+            perform_rebinding_with_section(non_lazy_sym_sect, slide, symtab, strtab, indirect_symtab);
+        }
+    } else {
+        BSG_KSLOG_WARN("Segment %s not found", segname);
+    }
+}
+
+static void rebind_symbols_for_image(const struct mach_header *header, intptr_t slide)
+{
+    BSG_KSLOG_TRACE("Rebinding symbols for image with slide %p", (void *)slide);
+
+    Dl_info info;
+    if (dladdr(header, &info) == 0) {
+        BSG_KSLOG_WARN("dladdr failed");
+        return;
+    }
+    BSG_KSLOG_TRACE("Image name: %s", info.dli_fname);
+    if (slide == 0) {
+        BSG_KSLOG_TRACE("Zero slide, can't do anything with it");
+        return;
+    }
+
+    const struct symtab_command *symtab_cmd =
+        (const struct symtab_command *)bsg_ksmacho_getCommandByTypeFromHeader((const mach_header_t *)header, LC_SYMTAB);
+    const struct dysymtab_command *dysymtab_cmd =
+        (const struct dysymtab_command *)bsg_ksmacho_getCommandByTypeFromHeader((const mach_header_t *)header, LC_DYSYMTAB);
+    const segment_command_t *linkedit_segment =
+        bsg_ksmacho_getSegmentByNameFromHeader((const mach_header_t *)header, SEG_LINKEDIT);
+
+    if (symtab_cmd == NULL || dysymtab_cmd == NULL || linkedit_segment == NULL) {
+        BSG_KSLOG_WARN("Required commands or segments not found");
+        return;
+    }
+
+    // Find base symbol/string table addresses
+    uintptr_t linkedit_base = (uintptr_t)slide + linkedit_segment->vmaddr - linkedit_segment->fileoff;
+    nlist_t *symtab = (nlist_t *)(linkedit_base + symtab_cmd->symoff);
+    char *strtab = (char *)(linkedit_base + symtab_cmd->stroff);
+
+    // Get indirect symbol table (array of uint32_t indices into symbol table)
+    uint32_t *indirect_symtab = (uint32_t *)(linkedit_base + dysymtab_cmd->indirectsymoff);
+
+    process_segment(header, slide, SEG_DATA, symtab, strtab, indirect_symtab);
+    process_segment(header, slide, SEG_DATA_CONST, symtab, strtab, indirect_symtab);
+}
+
+int bsg_ksct_swap(const cxa_throw_type handler)
+{
+    BSG_KSLOG_DEBUG("Swapping __cxa_throw handler");
+
+    if (g_cxa_originals == NULL) {
+        g_cxa_originals_capacity = 25;
+        g_cxa_originals = (BSG_KSAddressPair *)malloc(sizeof(BSG_KSAddressPair) * g_cxa_originals_capacity);
+        if (g_cxa_originals == NULL) {
+            BSG_KSLOG_ERROR("Failed to allocate memory for g_cxa_originals: %s", strerror(errno));
+            return -1;
+        }
+    }
+    g_cxa_originals_count = 0;
+
+    if (g_cxa_throw_handler == NULL) {
+        g_cxa_throw_handler = handler;
+        _dyld_register_func_for_add_image(rebind_symbols_for_image);
+    } else {
+        g_cxa_throw_handler = handler;
+        uint32_t c = _dyld_image_count();
+        for (uint32_t i = 0; i < c; i++) {
+            rebind_symbols_for_image(_dyld_get_image_header(i), _dyld_get_image_vmaddr_slide(i));
+        }
+    }
+    return 0;
+}

--- a/Bugsnag/KSCrash/Source/KSCrash/Recording/Tools/BSG_KSCxaThrowSwapper.h
+++ b/Bugsnag/KSCrash/Source/KSCrash/Recording/Tools/BSG_KSCxaThrowSwapper.h
@@ -1,0 +1,45 @@
+//
+//  KSCxaThrowSwapper.h
+//
+//  Copyright (c) 2019 YANDEX LLC. All rights reserved.
+//
+// Permission is hereby granted, free of charge, to any person obtaining a copy
+// of this software and associated documentation files (the "Software"), to deal
+// in the Software without restriction, including without limitation the rights
+// to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+// copies of the Software, and to permit persons to whom the Software is
+// furnished to do so, subject to the following conditions:
+//
+// The above copyright notice and this permission notice shall remain in place
+// in this source code.
+//
+// THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+// IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+// FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+// AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+// LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+// OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+// THE SOFTWARE.
+//
+
+#ifndef KSCxaThrowSwapper_h
+#define KSCxaThrowSwapper_h
+
+#ifdef __cplusplus
+
+#include <typeinfo>
+
+extern "C" {
+
+typedef void (*cxa_throw_type)(void *, std::type_info *, void (*)(void *));
+#else
+typedef void (*cxa_throw_type)(void *, void *, void (*)(void *));
+#endif
+
+int bsg_ksct_swap(const cxa_throw_type handler);
+
+#ifdef __cplusplus
+}
+#endif
+
+#endif /* KSCxaThrowSwapper_h */

--- a/Bugsnag/KSCrash/Source/KSCrash/Recording/Tools/BSG_KSMach-O.c
+++ b/Bugsnag/KSCrash/Source/KSCrash/Recording/Tools/BSG_KSMach-O.c
@@ -1,0 +1,155 @@
+//
+//  KSMach-O.c
+//
+//  Copyright (c) 2019 YANDEX LLC. All rights reserved.
+//
+// Permission is hereby granted, free of charge, to any person obtaining a copy
+// of this software and associated documentation files (the "Software"), to deal
+// in the Software without restriction, including without limitation the rights
+// to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+// copies of the Software, and to permit persons to whom the Software is
+// furnished to do so, subject to the following conditions:
+//
+// The above copyright notice and this permission notice shall remain in place
+// in this source code.
+//
+// THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+// IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+// FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+// AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+// LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+// OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+// THE SOFTWARE.
+//
+// Contains code of getsegbyname.c
+// https://opensource.apple.com/source/cctools/cctools-921/libmacho/getsegbyname.c.auto.html
+// Copyright (c) 1999 Apple Computer, Inc. All rights reserved.
+//
+// @APPLE_LICENSE_HEADER_START@
+//
+// This file contains Original Code and/or Modifications of Original Code
+// as defined in and that are subject to the Apple Public Source License
+// Version 2.0 (the 'License'). You may not use this file except in
+// compliance with the License. Please obtain a copy of the License at
+// http://www.opensource.apple.com/apsl/ and read it before using this
+// file.
+//
+// The Original Code and all software distributed under the License are
+// distributed on an 'AS IS' basis, WITHOUT WARRANTY OF ANY KIND, EITHER
+// EXPRESS OR IMPLIED, AND APPLE HEREBY DISCLAIMS ALL SUCH WARRANTIES,
+// INCLUDING WITHOUT LIMITATION, ANY WARRANTIES OF MERCHANTABILITY,
+// FITNESS FOR A PARTICULAR PURPOSE, QUIET ENJOYMENT OR NON-INFRINGEMENT.
+// Please see the License for the specific language governing rights and
+// limitations under the License.
+//
+// @APPLE_LICENSE_HEADER_END@
+//
+
+#include "BSG_KSMach-O.h"
+
+#include <mach-o/loader.h>
+#include <mach/mach.h>
+#include <string.h>
+#include <sys/types.h>
+
+#include "BSG_KSLogger.h"
+
+const struct load_command *bsg_ksmacho_getCommandByTypeFromHeader(const mach_header_t *header, uint32_t commandType)
+{
+    BSG_KSLOG_TRACE("Getting command by type %u in Mach header at %p", commandType, header);
+
+    if (header == NULL) {
+        BSG_KSLOG_ERROR("Header is NULL");
+        return NULL;
+    }
+
+    uintptr_t current = (uintptr_t)header + sizeof(mach_header_t);
+    struct load_command *loadCommand = NULL;
+
+    for (uint commandIndex = 0; commandIndex < header->ncmds; commandIndex++) {
+        loadCommand = (struct load_command *)current;
+        if (loadCommand->cmd == commandType) {
+            return loadCommand;
+        }
+        current += loadCommand->cmdsize;
+    }
+    BSG_KSLOG_WARN("Command type %u not found", commandType);
+    return NULL;
+}
+
+const segment_command_t *bsg_ksmacho_getSegmentByNameFromHeader(const mach_header_t *header, const char *segmentName)
+{
+    BSG_KSLOG_TRACE("Searching for segment %s in Mach header at %p", segmentName, header);
+
+    if (header == NULL) {
+        BSG_KSLOG_ERROR("Header is NULL");
+        return NULL;
+    }
+
+    const segment_command_t *segmentCommand;
+    unsigned long commandIndex;
+
+    segmentCommand = (segment_command_t *)((uintptr_t)header + sizeof(mach_header_t));
+    for (commandIndex = 0; commandIndex < header->ncmds; commandIndex++) {
+        if (segmentCommand->cmd == LC_SEGMENT_ARCH_DEPENDENT &&
+            strncmp(segmentCommand->segname, segmentName, sizeof(segmentCommand->segname)) == 0) {
+            BSG_KSLOG_TRACE("Segment %s found at %p", segmentName, segmentCommand);
+            return segmentCommand;
+        }
+        segmentCommand = (segment_command_t *)((uintptr_t)segmentCommand + segmentCommand->cmdsize);
+    }
+
+    BSG_KSLOG_WARN("Segment %s not found in Mach header at %p", segmentName, header);
+    return NULL;
+}
+
+const section_t *bsg_ksmacho_getSectionByTypeFlagFromSegment(const segment_command_t *segmentCommand, uint32_t flag)
+{
+    BSG_KSLOG_TRACE("Getting section by flag %u in segment %s", flag, segmentCommand->segname);
+
+    if (segmentCommand == NULL) {
+        BSG_KSLOG_ERROR("Segment is NULL");
+        return NULL;
+    }
+
+    uintptr_t current = (uintptr_t)segmentCommand + sizeof(segment_command_t);
+    const section_t *section = NULL;
+
+    for (uint sectionIndex = 0; sectionIndex < segmentCommand->nsects; sectionIndex++) {
+        section = (const section_t *)(current + sectionIndex * sizeof(section_t));
+        if ((section->flags & SECTION_TYPE) == flag) {
+            return section;
+        }
+    }
+
+    BSG_KSLOG_TRACE("Section with flag %u not found in segment %s", flag, segmentCommand->segname);
+    return NULL;
+}
+
+vm_prot_t bsg_ksmacho_getSectionProtection(void *sectionStart)
+{
+    BSG_KSLOG_TRACE("Getting protection for section starting at %p", sectionStart);
+
+    mach_port_t task = mach_task_self();
+    vm_size_t size = 0;
+    vm_address_t address = (vm_address_t)sectionStart;
+    memory_object_name_t object;
+#if __LP64__
+    mach_msg_type_number_t count = VM_REGION_BASIC_INFO_COUNT_64;
+    vm_region_basic_info_data_64_t info;
+    kern_return_t info_ret =
+        vm_region_64(task, &address, &size, VM_REGION_BASIC_INFO_64, (vm_region_info_64_t)&info, &count, &object);
+#else
+    mach_msg_type_number_t count = VM_REGION_BASIC_INFO_COUNT;
+    vm_region_basic_info_data_t info;
+    kern_return_t info_ret =
+        vm_region(task, &address, &size, VM_REGION_BASIC_INFO, (vm_region_info_t)&info, &count, &object);
+#endif
+    if (info_ret == KERN_SUCCESS) {
+        BSG_KSLOG_TRACE("Protection obtained: %d", info.protection);
+        return info.protection;
+    } else {
+        BSG_KSLOG_ERROR("Failed to get protection for section: %s", mach_error_string(info_ret));
+        return VM_PROT_READ;
+    }
+}

--- a/Bugsnag/KSCrash/Source/KSCrash/Recording/Tools/BSG_KSMach-O.h
+++ b/Bugsnag/KSCrash/Source/KSCrash/Recording/Tools/BSG_KSMach-O.h
@@ -1,0 +1,80 @@
+//
+//  KSgetsect.h
+//
+//  Copyright (c) 2019 YANDEX LLC. All rights reserved.
+//
+// Permission is hereby granted, free of charge, to any person obtaining a copy
+// of this software and associated documentation files (the "Software"), to deal
+// in the Software without restriction, including without limitation the rights
+// to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+// copies of the Software, and to permit persons to whom the Software is
+// furnished to do so, subject to the following conditions:
+//
+// The above copyright notice and this permission notice shall remain in place
+// in this source code.
+//
+// THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+// IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+// FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+// AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+// LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+// OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+// THE SOFTWARE.
+//
+
+#ifndef KSMachO_h
+#define KSMachO_h
+
+#include <mach/vm_prot.h>
+
+#include "BSG_KSPlatformSpecificDefines.h"
+
+#ifdef __cplusplus
+extern "C" {
+#endif /* __cplusplus */
+
+/**
+ * This routine returns the `load_command` structure for the specified command type
+ * if it exists in the passed mach header. Otherwise, it returns `NULL`.
+ *
+ * @param header Pointer to the mach_header structure.
+ * @param command_type The type of the command to search for.
+ * @return Pointer to the `load_command` structure if found, otherwise `NULL`.
+ */
+const struct load_command *bsg_ksmacho_getCommandByTypeFromHeader(const mach_header_t *header, uint32_t command_type);
+
+/**
+ * This routine returns the `segment_command` structure for the named segment
+ * if it exists in the passed mach header. Otherwise, it returns `NULL`.
+ * It just looks through the load commands. Since these are mapped into the text
+ * segment, they are read-only and thus const.
+ *
+ * @param header Pointer to the mach_header structure.
+ * @param seg_name The name of the segment to search for.
+ * @return Pointer to the `segment_command` structure if found, otherwise `NULL`.
+ */
+const segment_command_t *bsg_ksmacho_getSegmentByNameFromHeader(const mach_header_t *header, const char *seg_name);
+
+/**
+ * This routine returns the section structure for the specified `SECTION_TYPE` flag
+ * from mach-o/loader.h if it exists in the passed segment command. Otherwise, it returns `NULL`.
+ *
+ * @param dataSegment Pointer to the segment_command structure.
+ * @param flag The `SECTION_TYPE` flag of the section to search for.
+ * @return Pointer to the section structure if found, otherwise `NULL`.
+ */
+const section_t *bsg_ksmacho_getSectionByTypeFlagFromSegment(const segment_command_t *dataSegment, uint32_t flag);
+
+/**
+ * This routine returns the protection attributes for a given memory section.
+ *
+ * @param sectionStart Pointer to the start of the memory section.
+ * @return Protection attributes of the section.
+ */
+vm_prot_t bsg_ksmacho_getSectionProtection(void *sectionStart);
+
+#ifdef __cplusplus
+}
+#endif /* __cplusplus */
+
+#endif /* KSMachO_h */

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,13 @@
 Changelog
 =========
 
+## TBD
+
+### Enhancements
+
+* Improved C++ exception stack trace capturing.
+  [1855](https://github.com/bugsnag/bugsnag-cocoa/pull/1855)
+
 ## 6.33.1 (2025-09-10)
 
 ### Enhancements


### PR DESCRIPTION
## Goal

Ensure our `cxa_throw` override is called so it capture C++ exception stack traces even if another binary also overrides it

## Changeset

- Changed to use the [KSCxaThrowSwapper implementation](https://github.com/kstenerud/KSCrash/blob/323dde2a3fbfb117cbfff1bd9dae36dedc1abb4b/Sources/KSCrashRecordingCore/KSCxaThrowSwapper.c) to make our interception of the `__cxa_throw` intrinsic more predictable.

## Testing

Existing tests