### PR TITLE
Fixed state breadcrumbs flakey test fix

### DIFF
--- a/features/fixtures/shared/scenarios/DelayedNotifyErrorScenario.swift
+++ b/features/fixtures/shared/scenarios/DelayedNotifyErrorScenario.swift
@@ -7,16 +7,44 @@
 //
 
 import Foundation
+import UIKit
 
 class DelayedNotifyErrorScenario: Scenario {
     
+    private var shouldNotifyOnForeground = false
+    
     override func configure() {
         super.configure()
-        self.config.autoTrackSessions = false;
+        self.config.autoTrackSessions = false
+        NotificationCenter.default.addObserver(self,
+                                               selector: #selector(willEnterForeground),
+                                               name: UIApplication.willEnterForegroundNotification,
+                                               object: nil)
     }
     
     @objc func notify_error() {
+        notify()
+    }
+    
+    @objc func notify_error_on_foreground() {
+        shouldNotifyOnForeground = true
+    }
+    
+    @objc func willEnterForeground() {
+        if (shouldNotifyOnForeground) {
+            DispatchQueue.main.asyncAfter(deadline: .now() + 0.5) {
+                self.notify()
+            }
+            shouldNotifyOnForeground = false
+        }
+    }
+    
+    func notify() {
         let error = NSError(domain: "DelayedNotifyErrorScenario", code: 100, userInfo: nil)
         Bugsnag.notifyError(error)
+    }
+    
+    deinit {
+        NotificationCenter.default.removeObserver(self)
     }
 }

--- a/features/release/breadcrumbs.feature
+++ b/features/release/breadcrumbs.feature
@@ -41,7 +41,6 @@ Feature: Attaching a series of notable events leading up to errors
     Then the event has a "manual" breadcrumb named "Cache locked"
 
   # TODO: Flaky on iOS 18 - see PLAT-14585
-  @skip_ios_18
   @skip_below_ios_13
   @skip_macos
   Scenario: State breadcrumbs
@@ -50,12 +49,12 @@ Feature: Attaching a series of notable events leading up to errors
     And I invoke "notify_error"
     And I wait to receive an error
     And I discard the oldest error
+    And I invoke "notify_error_on_foreground"
     # Now we know that the backgrounding will occur at an appropriate time
     And I switch to the web browser for 2 seconds
     # Give iOS sufficient time to raise the notification for foregrounding the app
     And I make the test fixture wait for 1 second
     # This next error should have the notification breadcrumbs
-    And I invoke "notify_error"
     And I wait to receive an error
     Then the event has a "state" breadcrumb named "Bugsnag loaded"
     # Bugsnag has been started too late to capture some early notifications

--- a/features/release/breadcrumbs.feature
+++ b/features/release/breadcrumbs.feature
@@ -40,7 +40,6 @@ Feature: Attaching a series of notable events leading up to errors
     And I wait to receive an error
     Then the event has a "manual" breadcrumb named "Cache locked"
 
-  # TODO: Flaky on iOS 18 - see PLAT-14585
   @skip_below_ios_13
   @skip_macos
   Scenario: State breadcrumbs
@@ -52,8 +51,6 @@ Feature: Attaching a series of notable events leading up to errors
     And I invoke "notify_error_on_foreground"
     # Now we know that the backgrounding will occur at an appropriate time
     And I switch to the web browser for 2 seconds
-    # Give iOS sufficient time to raise the notification for foregrounding the app
-    And I make the test fixture wait for 1 second
     # This next error should have the notification breadcrumbs
     And I wait to receive an error
     Then the event has a "state" breadcrumb named "Bugsnag loaded"


### PR DESCRIPTION
## Goal

There seems to be an issue with handling commands after the fixture returns from foreground on iOS 18.0+

## Changeset

The test schedules a notify call to be executed after the app returns to foreground