### PR TITLE
Fixed the issue causing flags with names that contain a slash to not appear in OOM crash reports

### DIFF
--- a/Bugsnag/FeatureFlags/BSGPersistentFeatureFlagStore.m
+++ b/Bugsnag/FeatureFlags/BSGPersistentFeatureFlagStore.m
@@ -121,7 +121,8 @@
 }
 
 - (NSString *)pathForFlagWithName:(NSString *)name {
-    return [self.directoryPath stringByAppendingPathComponent: [NSString stringWithFormat:@"%@.json", name]];
+    NSString *fileName = [name stringByAddingPercentEncodingWithAllowedCharacters:NSCharacterSet.alphanumericCharacterSet];
+    return [self.directoryPath stringByAppendingPathComponent: [NSString stringWithFormat:@"%@.json", fileName]];
 }
 
 - (void)deleteFile:(NSString *)path {

--- a/features/fixtures/shared/scenarios/OOMScenario.m
+++ b/features/fixtures/shared/scenarios/OOMScenario.m
@@ -57,6 +57,9 @@ void onCrashHandler(const BSG_KSCrashReportWriter *writer) {
 - (void)run {
     [Bugsnag setContext:@"OOM Scenario"];
     [Bugsnag setGroupingDiscriminator:@"OOMScenarioGroupingDiscriminator"];
+    [Bugsnag addFeatureFlagWithName:@"Feature-Flag/A"];
+    [Bugsnag addFeatureFlagWithName:@"Feature-Flag/B"];
+    [Bugsnag clearFeatureFlagWithName:@"Feature-Flag/B"];
     [NSNotificationCenter.defaultCenter addObserverForName:UIApplicationDidReceiveMemoryWarningNotification object:nil
                                                      queue:nil usingBlock:^(NSNotification *note) {
         logDebug(@"*** Received memory warning");

--- a/features/release/barebone_tests.feature
+++ b/features/release/barebone_tests.feature
@@ -329,8 +329,9 @@ Feature: Barebone tests
     And the event "user.id" equals "foobar"
     And the event "user.name" equals "Foo Bar"
     And the event contains the following feature flags:
-      | featureFlag | variant |
-      | Testing     |         |
+      | featureFlag        | variant |
+      | Testing            |         |
+      | Feature-Flag/A     |         |
     And the error payload field "events.0.app.dsymUUIDs" is a non-empty array
     And the error payload field "events.0.app.duration" is null
     And the error payload field "events.0.app.durationInForeground" is null


### PR DESCRIPTION
## Goal

Fix an issue causing flags with names that contain a slash to not appear in OOM crash reports 

## Changeset

- Save feature flags in JSON files named as percent encoded value of feature flag name

## Testing

E2E test