### PR TITLE
Add dynamically linked options to Swift Package Manager products

### DIFF
--- a/Package.swift
+++ b/Package.swift
@@ -11,7 +11,9 @@ let package = Package(
     ],
     products: [
         .library(name: "Bugsnag", targets: ["Bugsnag"]),
+        .library(name: "Bugsnag-Dynamic", type: .dynamic, targets: ["Bugsnag"]),
         .library(name: "BugsnagNetworkRequestPlugin", targets: ["BugsnagNetworkRequestPlugin"]),
+        .library(name: "BugsnagNetworkRequestPlugin-Dynamic", type: .dynamic, targets: ["BugsnagNetworkRequestPlugin"])
     ],
     dependencies: [],
     targets: [


### PR DESCRIPTION
For a project I'm working on, I need to link Bugsnag as a dynamic framework because I need to link against Bugsnag in both an app target and a framework target. Unfortunately there is a bug / behavior in Xcode where it always builds a static framework unless the dynamic option is explicitly specified in the Package.swift file. For more discussion, see this thread:

https://forums.swift.org/t/how-to-link-a-swift-package-as-dynamic/32062

Other projects, like SwiftMessages, have dealt with this by adding separate products that explicitly specify the dynamic option in Package.swift:

https://github.com/SwiftKickMobile/SwiftMessages/pull/495

This PR makes a similar change to Bugsnag.