### PR TITLE
plat-16493 root path removal in debug mode

### DIFF
--- a/scripts/build-xcframework.sh
+++ b/scripts/build-xcframework.sh
@@ -40,6 +40,19 @@ XCFW_DIR="${PROJECT_DIR}/build/xcframeworks"
 INTERMEDIATES_DIR="${XCFW_DIR}/intermediates"
 PRODUCTS_DIR="${XCFW_DIR}/products"
 
+#
+# This prevents released XCFramework debug metadata from exposing developer
+# machine paths such as:
+#   /Users/<developer>/.../bugsnag-cocoa/...
+#
+# It does not change SDK runtime behavior. It only affects debug/source-path
+# metadata used by Xcode/LLDB symbolication.
+DEBUG_PREFIX_MAP_FLAGS=(
+    "OTHER_CFLAGS=\$(inherited) -fdebug-prefix-map='${PROJECT_DIR}=bugsnag-cocoa' -fdebug-prefix-map='\$(DERIVED_FILE_DIR)=bugsnag-cocoa/DerivedSources' -fdebug-prefix-map='${HOME}/Library/Developer/Xcode/DerivedData=DerivedData'"
+    "OTHER_CPLUSPLUSFLAGS=\$(inherited) -fdebug-prefix-map='${PROJECT_DIR}=bugsnag-cocoa' -fdebug-prefix-map='\$(DERIVED_FILE_DIR)=bugsnag-cocoa/DerivedSources' -fdebug-prefix-map='${HOME}/Library/Developer/Xcode/DerivedData=DerivedData'"
+    "OTHER_SWIFT_FLAGS=\$(inherited) -debug-prefix-map '${PROJECT_DIR}=bugsnag-cocoa' -debug-prefix-map '\$(DERIVED_FILE_DIR)=bugsnag-cocoa/DerivedSources' -debug-prefix-map '${HOME}/Library/Developer/Xcode/DerivedData=DerivedData'"
+)
+
 ##
 # Build a framework.
 #
@@ -71,7 +84,8 @@ build_framework() {
                        SKIP_INSTALL=NO \
                        BUILD_LIBRARY_FOR_DISTRIBUTION=YES \
                        -destination "${destination}" \
-                       -archivePath "${archive_path}" 1>&2
+                       -archivePath "${archive_path}" \
+                       "${DEBUG_PREFIX_MAP_FLAGS[@]}" 1>&2
     echo "-archive ${archive_path}.xcarchive -framework ${framework_basename}.framework"
 
     if [ "${platform}" != "macOS" ]; then
@@ -84,7 +98,8 @@ build_framework() {
                            SKIP_INSTALL=NO \
                            BUILD_LIBRARY_FOR_DISTRIBUTION=YES \
                            -destination "${destination}" \
-                           -archivePath "${archive_path}" 1>&2
+                           -archivePath "${archive_path}" \
+                       "${DEBUG_PREFIX_MAP_FLAGS[@]}" 1>&2
         echo "-archive ${archive_path}.xcarchive -framework ${framework_basename}.framework"
     fi
 }


### PR DESCRIPTION
## Goal

Sanitize developer-local file paths from DWARF debug symbols in the bugsnag-cocoa XCFramework build output.


## Design

Added -fdebug-prefix-map (C/Obj-C/C++) and -debug-prefix-map (Swift) compiler flags to the build-xcframework script. These flags remap absolute local paths to generic relative paths during the archive build.


## Changeset

Modified build-xcframework to include the path-remapping compiler flags.

## Testing

Verified dSYM symbolication (auto & manual upload) works correctly with the fix applied.