### PR TITLE
Add capture-time callback for app hangs

### DIFF
--- a/Bugsnag/Client/BugsnagClient.m
+++ b/Bugsnag/Client/BugsnagClient.m
@@ -1232,6 +1232,15 @@ __attribute__((annotate("oclint:suppress[too many methods]")))
     @synchronized (self.featureFlagStore) {
         self.appHangEvent.featureFlagStore = [self.featureFlagStore copyMemoryStore];
     }
+
+    BugsnagAppHangCallback callback = self.configuration.appHangCallback;
+    if (callback) {
+        @try {
+            callback((BugsnagEvent * _Nonnull)self.appHangEvent);
+        } @catch (NSException *exception) {
+            bsg_log_err(@"Ignoring exception thrown by app hang callback: %@", exception);
+        }
+    }
     
     [self.appHangEvent symbolicateIfNeeded];
     

--- a/Bugsnag/Configuration/BugsnagConfiguration.m
+++ b/Bugsnag/Configuration/BugsnagConfiguration.m
@@ -97,6 +97,7 @@ static NSURLSession *getConfigDefaultURLSession(void) {
     BugsnagConfiguration *copy = [[BugsnagConfiguration alloc] initWithApiKey:[self.apiKey copy]];
     // Omit apiKey - it's set explicitly in the line above
 #if BSG_HAVE_APP_HANG_DETECTION
+    [copy setAppHangCallback:self.appHangCallback];
     [copy setAppHangThresholdMillis:self.appHangThresholdMillis];
     [copy setReportBackgroundAppHangs:self.reportBackgroundAppHangs];
 #endif

--- a/Bugsnag/include/Bugsnag/BugsnagConfiguration.h
+++ b/Bugsnag/include/Bugsnag/BugsnagConfiguration.h
@@ -90,6 +90,8 @@ typedef NS_OPTIONS(NSUInteger, BSGTelemetryOptions) {
  */
 BUGSNAG_EXTERN const NSUInteger BugsnagAppHangThresholdFatalOnly API_UNAVAILABLE(watchos);
 
+typedef void (^BugsnagAppHangCallback)(BugsnagEvent *_Nonnull event);
+
 /**
  *  A configuration block for modifying an error report
  *
@@ -264,6 +266,27 @@ BUGSNAG_EXTERN
  * By default this is false.
  */
 @property (nonatomic) BOOL reportBackgroundAppHangs API_UNAVAILABLE(watchos);
+
+/**
+ * An optional callback invoked when an app hang is detected, before the event is persisted.
+ *
+ * This can be used to attach time-sensitive in-memory diagnostics that may no longer be available
+ * when OnSendError callbacks run after the hang ends or on the next app launch.
+ *
+ * The callback is invoked synchronously on Bugsnag's app hang detector thread while the main
+ * thread is unresponsive. It must return quickly. Do not perform I/O, dispatch synchronously to
+ * the main thread, or wait for a lock or actor that may depend on the main thread. Delaying the
+ * callback also delays persistence of the app hang event. Mutate the event only during the
+ * callback, and do not retain it for asynchronous mutation.
+ *
+ * The callback may be invoked for a hang that later recovers. When appHangThresholdMillis is set to
+ * BugsnagAppHangThresholdFatalOnly, the provisional event is deleted on recovery, so modifications
+ * made by this callback are delivered only if the app is terminated while hung.
+ *
+ * If the app is terminated while hung, the modified event remains on disk. Bugsnag loads it on the
+ * next launch, marks it as unhandled, and delivers it without invoking this callback again.
+ */
+@property (copy, nullable, nonatomic) BugsnagAppHangCallback appHangCallback API_UNAVAILABLE(watchos);
 
 /**
  * Determines whether app sessions should be tracked automatically. By default this value is true.

--- a/Tests/BugsnagTests/BugsnagClientTests.m
+++ b/Tests/BugsnagTests/BugsnagClientTests.m
@@ -8,7 +8,10 @@
 
 #import "BSGTestCase.h"
 
+#import "BSGAppHangDetector.h"
+#import "BSGFileLocations.h"
 #import "BSGInternalErrorReporter.h"
+#import "BSGJSONSerialization.h"
 #import "BSGKeys.h"
 #import "BSGRunContext.h"
 #import "Bugsnag+Private.h"
@@ -325,5 +328,60 @@ NSString *BSGFormatSeverity(BSGSeverity severity);
     }
     return dict;
 }
+
+#if BSG_HAVE_APP_HANG_DETECTION
+- (void)testAppHangCallbackRunsSynchronouslyBeforePersistence {
+    BugsnagConfiguration *configuration = [[BugsnagConfiguration alloc] initWithApiKey:DUMMY_APIKEY_32CHAR_1];
+    __block NSThread *callbackThread;
+    configuration.appHangCallback = ^(BugsnagEvent *event) {
+        callbackThread = NSThread.currentThread;
+        [event addMetadata:@"rendering" withKey:@"phase" toSection:@"diagnostics"];
+    };
+    BugsnagClient *client = [[BugsnagClient alloc] initWithConfiguration:configuration];
+
+    id<BSGAppHangDetectorDelegate> delegate = client;
+    XCTAssertNil(BSGJSONDictionaryFromFile(BSGFileLocations.current.appHangEvent, 0, nil));
+
+    __block NSThread *invokingThread;
+    __block BOOL callbackCompletedBeforeReturn;
+    XCTestExpectation *expectation = [self expectationWithDescription:@"app hang callback"];
+    dispatch_async(dispatch_get_global_queue(QOS_CLASS_USER_INITIATED, 0), ^{
+        invokingThread = NSThread.currentThread;
+        [delegate appHangDetectedAtDate:[NSDate date]
+                            withThreads:@[]
+                             systemInfo:@{}];
+        callbackCompletedBeforeReturn = callbackThread == NSThread.currentThread;
+        [expectation fulfill];
+    });
+    [self waitForExpectations:@[expectation] timeout:10];
+
+    XCTAssertEqual(callbackThread, invokingThread);
+    XCTAssertFalse(callbackThread.isMainThread);
+    XCTAssertTrue(callbackCompletedBeforeReturn);
+    XCTAssertEqualObjects([client.appHangEvent getMetadataFromSection:@"diagnostics" withKey:@"phase"],
+                          @"rendering");
+    NSDictionary *persistedEvent = BSGJSONDictionaryFromFile(BSGFileLocations.current.appHangEvent, 0, nil);
+    XCTAssertEqualObjects([persistedEvent valueForKeyPath:@"metaData.diagnostics.phase"], @"rendering");
+    [delegate appHangEnded];
+    XCTAssertFalse([NSFileManager.defaultManager fileExistsAtPath:BSGFileLocations.current.appHangEvent]);
+}
+
+- (void)testAppHangCallbackExceptionDoesNotPreventPersistence {
+    BugsnagConfiguration *configuration = [[BugsnagConfiguration alloc] initWithApiKey:DUMMY_APIKEY_32CHAR_1];
+    configuration.appHangCallback = ^(__unused BugsnagEvent *event) {
+        @throw [NSException exceptionWithName:@"TestException" reason:nil userInfo:nil];
+    };
+    BugsnagClient *client = [[BugsnagClient alloc] initWithConfiguration:configuration];
+
+    id<BSGAppHangDetectorDelegate> delegate = client;
+    XCTAssertNil(BSGJSONDictionaryFromFile(BSGFileLocations.current.appHangEvent, 0, nil));
+    XCTAssertNoThrow([delegate appHangDetectedAtDate:[NSDate date]
+                                         withThreads:@[]
+                                          systemInfo:@{}]);
+
+    XCTAssertNotNil(BSGJSONDictionaryFromFile(BSGFileLocations.current.appHangEvent, 0, nil));
+    [delegate appHangEnded];
+}
+#endif
 
 @end

--- a/Tests/BugsnagTests/BugsnagConfigurationTests.m
+++ b/Tests/BugsnagTests/BugsnagConfigurationTests.m
@@ -962,6 +962,11 @@ static NSString *const HUB_APIKEY_32CHAR =
     BugsnagOnSendErrorBlock onSendBlock1 = ^BOOL(BugsnagEvent * _Nonnull event) { return true; };
     BugsnagOnSendErrorBlock onSendBlock2 = ^BOOL(BugsnagEvent * _Nonnull event) { return true; };
 
+#if BSG_HAVE_APP_HANG_DETECTION
+    BugsnagAppHangCallback appHangCallback = ^(BugsnagEvent * _Nonnull event) {};
+    config.appHangCallback = appHangCallback;
+#endif
+
     NSArray *sendBlocks = @[ onSendBlock1, onSendBlock2 ];
     [config setOnSendBlocks:[sendBlocks mutableCopy]]; // Mutable arg required
 
@@ -999,6 +1004,10 @@ static NSString *const HUB_APIKEY_32CHAR =
     XCTAssertEqual(config.onCrashHandler, clone.onCrashHandler);
     [clone setOnCrashHandler:(void *)^(const BSG_KSCrashReportWriter *_Nonnull writer){}];
     XCTAssertNotEqual(config.onCrashHandler, clone.onCrashHandler);
+
+#if BSG_HAVE_APP_HANG_DETECTION
+    XCTAssertEqual(config.appHangCallback, clone.appHangCallback);
+#endif
 
     // Array (of blocks)
     XCTAssertEqual(config.onSendBlocks, clone.onSendBlocks);

--- a/Tests/BugsnagTests/BugsnagSwiftPublicAPITests.swift
+++ b/Tests/BugsnagTests/BugsnagSwiftPublicAPITests.swift
@@ -43,6 +43,9 @@ class BugsnagSwiftPublicAPITests: BSGTestCase {
     let err = NSError(domain: "dom", code: 123, userInfo: nil)
     let sessionBlock: BugsnagOnSessionBlock = { (session) -> Bool in return false }
     let onSendErrorBlock: BugsnagOnSendErrorBlock = { (event) -> Bool in return false }
+#if !os(watchOS)
+    let appHangCallback: BugsnagAppHangCallback = { _ in }
+#endif
     let onBreadcrumbBlock: BugsnagOnBreadcrumbBlock = { (breadcrumb) -> Bool in return false }
     
     func testBugsnagClass() throws {
@@ -139,6 +142,9 @@ class BugsnagSwiftPublicAPITests: BSGTestCase {
         }
         config.removeOnSession(onSession)
         config.addOnSendError(block:onSendErrorBlock)
+#if !os(watchOS)
+        config.appHangCallback = appHangCallback
+#endif
         config.addOnSendError { (event: BugsnagEvent) -> Bool in
             return true
         }


### PR DESCRIPTION
## Goal

Allow applications to attach time-sensitive diagnostic context when an app hang is detected. Existing callbacks run after recovery or on the next launch, when useful in-memory state may be gone.

A motivating example is a SwiftUI hang whose stack contains only AttributeGraph internals. The stack identifies the framework subsystem but not the application view or recent body recomputations that contributed to the hang. The same problem applies to other hangs where application-owned context would improve attribution.

![image](https://github.com/user-attachments/assets/9824d57c-ee3c-4320-903a-280ecf075eea)

This callback would allow us to attach custom information at the time of a hang that may help us debug later.

## Design

Add an optional `appHangCallback` invoked synchronously on the detector thread before persistence. The callback must not block or wait for the unresponsive main thread.

## Changeset

- Add an optional callback for attaching diagnostic context before an app hang is persisted.
- Document its threading and lifecycle constraints, preserve it when copying configuration, and contain callback exceptions.

## Testing

- Added coverage to new API.


cc: @ladd