### PR TITLE
Added remoteConfig flag based on valid configuration

### DIFF
--- a/Bugsnag/Client/BugsnagClient.m
+++ b/Bugsnag/Client/BugsnagClient.m
@@ -976,7 +976,13 @@ __attribute__((annotate("oclint:suppress[too many methods]")))
     [self.sessionTracker incrementEventCountUnhandled:event.handledState.unhandled];
     event.session = self.sessionTracker.runningSession;
 
-    event.usage = BSGTelemetryCreateUsage(self.configuration);
+    NSMutableDictionary *usage = [BSGTelemetryCreateUsage(self.configuration) mutableCopy] ?: [NSMutableDictionary new];
+    
+    BOOL hasValidConfig = self.remoteConfigHandler && [self.remoteConfigHandler hasValidConfig];
+    
+    usage[@"remoteConfig"] = @(hasValidConfig); // true if config active, false otherwise
+    
+    event.usage = [NSDictionary dictionaryWithDictionary:usage];
 
     if (event.handledState.originalUnhandledValue) {
         // Unhandled Javscript exceptions from React Native result in the app being terminated shortly after the
@@ -1107,6 +1113,7 @@ __attribute__((annotate("oclint:suppress[too many methods]")))
     BSGEventDiscardRulesetSource *rulesetSource = [BSGEventDiscardRulesetSource sourceWithRemoteConfigHandler:self.remoteConfigHandler
                                                                                            discardRuleFactory:discardRuleFactory];
     self.discardProcessor.source = rulesetSource;
+    self.eventUploader.remoteConfigHandler = self.remoteConfigHandler;
     [self.remoteConfigHandler initialize];
 }
 

--- a/Bugsnag/Delivery/BSGEventUploadOperation.h
+++ b/Bugsnag/Delivery/BSGEventUploadOperation.h
@@ -60,6 +60,7 @@ static const NSUInteger MaxPersistedSize = 1000000;
 
 - (void)storeEventPayload:(NSDictionary *)eventPayload;
 - (BOOL)shouldDiscardEvent:(NSDictionary *)eventPayload;
+- (BOOL)hasValidRemoteConfig;
 
 @end
 

--- a/Bugsnag/Delivery/BSGEventUploadOperation.m
+++ b/Bugsnag/Delivery/BSGEventUploadOperation.m
@@ -62,6 +62,9 @@ typedef NS_ENUM(NSUInteger, BSGEventUploadOperationState) {
     
     BugsnagConfiguration *configuration = delegate.configuration;
     
+    BOOL hasValidConfig = [delegate hasValidRemoteConfig];
+    [event setRemoteConfigFlag:hasValidConfig];
+    
     if (!configuration.shouldSendReports || ![event shouldBeSent]) {
         bsg_log_info(@"Discarding event %@ because releaseStage not in enabledReleaseStages", self.name);
         [self deleteEvent];
@@ -158,14 +161,14 @@ typedef NS_ENUM(NSUInteger, BSGEventUploadOperationState) {
             return;
         }
     }
-    
+
     if ([delegate shouldDiscardEvent:eventPayload]) {
         bsg_log_info(@"Discarding event %@ because [delegate shouldDiscardEvent:] returned YES", self.name);
         [self deleteEvent];
         completionHandler();
         return;
     }
-    
+
     BSGPostJSONData(configuration.sessionOrDefault, data, requestHeaders, notifyURL, ^(BSGDeliveryStatus status, __unused NSError *deliveryError) {
         switch (status) {
             case BSGDeliveryStatusDelivered:

--- a/Bugsnag/Delivery/BSGEventUploader.h
+++ b/Bugsnag/Delivery/BSGEventUploader.h
@@ -15,11 +15,14 @@
 @class BugsnagEvent;
 @class BugsnagNotifier;
 @class BSGEventDiscardProcessor;
+@class BSGRemoteConfigHandler;
 
 NS_ASSUME_NONNULL_BEGIN
 
 
 @interface BSGEventUploader : NSObject
+
+@property (nonatomic, weak, nullable) BSGRemoteConfigHandler *remoteConfigHandler;
 
 - (instancetype)initWithConfiguration:(BugsnagConfiguration *)configuration
                              notifier:(BugsnagNotifier *)notifier

--- a/Bugsnag/Delivery/BSGEventUploader.m
+++ b/Bugsnag/Delivery/BSGEventUploader.m
@@ -19,6 +19,7 @@
 #import "BugsnagInternals.h"
 #import "BugsnagLogger.h"
 #import "../DiscardProcessor/Processor/BSGEventDiscardProcessor.h"
+#import "../RemoteConfig/Handler/BSGRemoteConfigHandler.h"
 
 
 static NSString * const CrashReportPrefix = @"CrashReport-";
@@ -279,6 +280,11 @@ static NSString * const RecrashReportPrefix = @"RecrashReport-";
 
 - (BOOL)shouldDiscardEvent:(NSDictionary *)eventPayload {
     return [self.discardProcessor shouldDiscardEvent:eventPayload];
+}
+
+- (BOOL)hasValidRemoteConfig {
+    BSGRemoteConfigHandler *handler = self.remoteConfigHandler;
+    return handler && [handler hasValidConfig];
 }
 
 @end

--- a/Bugsnag/Payload/BugsnagEvent+Private.h
+++ b/Bugsnag/Payload/BugsnagEvent+Private.h
@@ -61,6 +61,8 @@ NS_ASSUME_NONNULL_BEGIN
 
 - (void)truncateStrings:(NSUInteger)maxLength;
 
+- (void)setRemoteConfigFlag:(BOOL)hasValidConfig;
+
 - (void)notifyUnhandledOverridden;
 
 @end

--- a/Bugsnag/Payload/BugsnagEvent.m
+++ b/Bugsnag/Payload/BugsnagEvent.m
@@ -192,9 +192,7 @@ NSDictionary *BSGParseCustomException(NSDictionary *report,
         _featureFlagStore = [[BSGMemoryFeatureFlagStore alloc] init];
         _threads = threads;
         _session = [session copy];
-        _usage = @{
-            @"remoteConfig": @"true"
-        };
+        _usage = @{};
     }
     return self;
 }
@@ -238,9 +236,7 @@ NSDictionary *BSGParseCustomException(NSDictionary *report,
             return [BugsnagThread threadFromJson:dict];
         }) ?: @[];
 
-        _usage = BSGDictMerge(@{
-            @"remoteConfig": @"true"
-        }, BSGDeserializeDict(json[BSGKeyUsage]) ?: @{});
+        _usage = BSGDeserializeDict(json[BSGKeyUsage]) ?: @{};
 
         _user = BSGDeserializeObject(json[BSGKeyUser], ^id _Nullable(NSDictionary * _Nonnull dict) {
             return [[BugsnagUser alloc] initWithDictionary:dict];
@@ -814,6 +810,12 @@ NSDictionary *BSGParseCustomException(NSDictionary *report,
 
 - (void)setUnhandled:(BOOL)unhandled {
     self.handledState.unhandled = unhandled;
+}
+
+- (void)setRemoteConfigFlag:(BOOL)hasValidConfig {
+    NSMutableDictionary *usage = [self.usage mutableCopy] ?: [NSMutableDictionary new];
+    usage[@"remoteConfig"] = @(hasValidConfig);
+    self.usage = usage;
 }
 
 // MARK: - <BugsnagFeatureFlagStore>

--- a/features/fixtures/ios/iOSTestApp.xcodeproj/project.pbxproj
+++ b/features/fixtures/ios/iOSTestApp.xcodeproj/project.pbxproj
@@ -125,6 +125,9 @@
 		96A25F322D66AFAE00A18116 /* ObjCExceptionFeatureFlagsScenario.m in Sources */ = {isa = PBXBuildFile; fileRef = 96A25F312D66AFAE00A18116 /* ObjCExceptionFeatureFlagsScenario.m */; };
 		96C7357E2E870E7500F3CB3C /* RemoteConfigBasicScenario.m in Sources */ = {isa = PBXBuildFile; fileRef = 96C7357D2E870E7500F3CB3C /* RemoteConfigBasicScenario.m */; };
 		96C735902E89E58200F3CB3C /* RemoteConfigExpiryScenario.m in Sources */ = {isa = PBXBuildFile; fileRef = 96C7358F2E89E56A00F3CB3C /* RemoteConfigExpiryScenario.m */; };
+		96C735912E8A000000F3CB3C /* RemoteConfigHashScenario.m in Sources */ = {isa = PBXBuildFile; fileRef = 96C735932E8A000100F3CB3C /* RemoteConfigHashScenario.m */; };
+		96C735922E8A000200F3CB3C /* RemoteConfigOptOutScenario.m in Sources */ = {isa = PBXBuildFile; fileRef = 96C735942E8A000300F3CB3C /* RemoteConfigOptOutScenario.m */; };
+		96C7359D2E8A030000F3CB3C /* RemoteConfigCacheExpiryScenario.m in Sources */ = {isa = PBXBuildFile; fileRef = 96C7359F2E8A030100F3CB3C /* RemoteConfigCacheExpiryScenario.m */; };
 		A1117E552535A59100014FDA /* OOMLoadScenario.swift in Sources */ = {isa = PBXBuildFile; fileRef = A1117E542535A59100014FDA /* OOMLoadScenario.swift */; };
 		A1117E572535B22300014FDA /* OOMAutoDetectErrorsScenario.swift in Sources */ = {isa = PBXBuildFile; fileRef = A1117E562535B22300014FDA /* OOMAutoDetectErrorsScenario.swift */; };
 		A1117E592535B29800014FDA /* OOMEnabledErrorTypesScenario.swift in Sources */ = {isa = PBXBuildFile; fileRef = A1117E582535B29800014FDA /* OOMEnabledErrorTypesScenario.swift */; };
@@ -336,6 +339,9 @@
 		96A25F312D66AFAE00A18116 /* ObjCExceptionFeatureFlagsScenario.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; path = ObjCExceptionFeatureFlagsScenario.m; sourceTree = "<group>"; };
 		96C7357D2E870E7500F3CB3C /* RemoteConfigBasicScenario.m */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.objc; path = RemoteConfigBasicScenario.m; sourceTree = "<group>"; };
 		96C7358F2E89E56A00F3CB3C /* RemoteConfigExpiryScenario.m */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.objc; path = RemoteConfigExpiryScenario.m; sourceTree = "<group>"; };
+		96C735932E8A000100F3CB3C /* RemoteConfigHashScenario.m */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.objc; path = RemoteConfigHashScenario.m; sourceTree = "<group>"; };
+		96C735942E8A000300F3CB3C /* RemoteConfigOptOutScenario.m */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.objc; path = RemoteConfigOptOutScenario.m; sourceTree = "<group>"; };
+		96C7359F2E8A030100F3CB3C /* RemoteConfigCacheExpiryScenario.m */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.objc; path = RemoteConfigCacheExpiryScenario.m; sourceTree = "<group>"; };
 		A1117E542535A59100014FDA /* OOMLoadScenario.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = OOMLoadScenario.swift; sourceTree = "<group>"; };
 		A1117E562535B22300014FDA /* OOMAutoDetectErrorsScenario.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = OOMAutoDetectErrorsScenario.swift; sourceTree = "<group>"; };
 		A1117E582535B29800014FDA /* OOMEnabledErrorTypesScenario.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = OOMEnabledErrorTypesScenario.swift; sourceTree = "<group>"; };
@@ -642,7 +648,10 @@
 				0104B47D275A7B3C003EBDF0 /* RecrashScenarios.mm */,
 				F4295E71D7B2DFE77057F3DA /* ReleasedObjectScenario.m */,
 				96C7357D2E870E7500F3CB3C /* RemoteConfigBasicScenario.m */,
+				96C7359F2E8A030100F3CB3C /* RemoteConfigCacheExpiryScenario.m */,
 				96C7358F2E89E56A00F3CB3C /* RemoteConfigExpiryScenario.m */,
+				96C735932E8A000100F3CB3C /* RemoteConfigHashScenario.m */,
+				96C735942E8A000300F3CB3C /* RemoteConfigOptOutScenario.m */,
 				010BDFB82885562D007025F9 /* ReportBackgroundAppHangScenario.swift */,
 				E7767F12221C21E30006648C /* ResumedSessionScenario.swift */,
 				8AF6FD79225E3FA00056EF9E /* ResumeSessionOOMScenario.m */,
@@ -963,6 +972,9 @@
 				E700EE4A247D1164008CFFB6 /* UserSessionOverrideScenario.swift in Sources */,
 				8AF6FD77225E3F870056EF9E /* StopSessionOOMScenario.m in Sources */,
 				96C7357E2E870E7500F3CB3C /* RemoteConfigBasicScenario.m in Sources */,
+				96C7359D2E8A030000F3CB3C /* RemoteConfigCacheExpiryScenario.m in Sources */,
+				96C735912E8A000000F3CB3C /* RemoteConfigHashScenario.m in Sources */,
+				96C735922E8A000200F3CB3C /* RemoteConfigOptOutScenario.m in Sources */,
 				F4295109FCAB93708FDAFE12 /* DisabledSessionTrackingScenario.m in Sources */,
 				010BAB392833D21A0003FF36 /* UnhandledErrorChangeValidReleaseStageScenario.swift in Sources */,
 				010BAB3F2833D29A0003FF36 /* EnabledReleaseStageManualSessionScenario.swift in Sources */,

--- a/features/fixtures/ios/iOSTestAppXcFramework.xcodeproj/project.pbxproj
+++ b/features/fixtures/ios/iOSTestAppXcFramework.xcodeproj/project.pbxproj
@@ -124,6 +124,9 @@
 		96A25F342D66AFCC00A18116 /* ObjCExceptionFeatureFlagsScenario.m in Sources */ = {isa = PBXBuildFile; fileRef = 96A25F332D66AFCC00A18116 /* ObjCExceptionFeatureFlagsScenario.m */; };
 		96C7358A2E89E3F600F3CB3C /* RemoteConfigBasicScenario.m in Sources */ = {isa = PBXBuildFile; fileRef = 96C735892E89E3F600F3CB3C /* RemoteConfigBasicScenario.m */; };
 		96C735922E89E59A00F3CB3C /* RemoteConfigExpiryScenario.m in Sources */ = {isa = PBXBuildFile; fileRef = 96C735912E89E59A00F3CB3C /* RemoteConfigExpiryScenario.m */; };
+		96C735952E8A010000F3CB3C /* RemoteConfigHashScenario.m in Sources */ = {isa = PBXBuildFile; fileRef = 96C735972E8A010100F3CB3C /* RemoteConfigHashScenario.m */; };
+		96C735962E8A010200F3CB3C /* RemoteConfigOptOutScenario.m in Sources */ = {isa = PBXBuildFile; fileRef = 96C735982E8A010300F3CB3C /* RemoteConfigOptOutScenario.m */; };
+		96C735A02E8A040000F3CB3C /* RemoteConfigCacheExpiryScenario.m in Sources */ = {isa = PBXBuildFile; fileRef = 96C735A22E8A040100F3CB3C /* RemoteConfigCacheExpiryScenario.m */; };
 		A1117E552535A59100014FDA /* OOMLoadScenario.swift in Sources */ = {isa = PBXBuildFile; fileRef = A1117E542535A59100014FDA /* OOMLoadScenario.swift */; };
 		A1117E572535B22300014FDA /* OOMAutoDetectErrorsScenario.swift in Sources */ = {isa = PBXBuildFile; fileRef = A1117E562535B22300014FDA /* OOMAutoDetectErrorsScenario.swift */; };
 		A1117E592535B29800014FDA /* OOMEnabledErrorTypesScenario.swift in Sources */ = {isa = PBXBuildFile; fileRef = A1117E582535B29800014FDA /* OOMEnabledErrorTypesScenario.swift */; };
@@ -351,6 +354,9 @@
 		96A25F332D66AFCC00A18116 /* ObjCExceptionFeatureFlagsScenario.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; path = ObjCExceptionFeatureFlagsScenario.m; sourceTree = "<group>"; };
 		96C735892E89E3F600F3CB3C /* RemoteConfigBasicScenario.m */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.objc; path = RemoteConfigBasicScenario.m; sourceTree = "<group>"; };
 		96C735912E89E59A00F3CB3C /* RemoteConfigExpiryScenario.m */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.objc; path = RemoteConfigExpiryScenario.m; sourceTree = "<group>"; };
+		96C735972E8A010100F3CB3C /* RemoteConfigHashScenario.m */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.objc; path = RemoteConfigHashScenario.m; sourceTree = "<group>"; };
+		96C735982E8A010300F3CB3C /* RemoteConfigOptOutScenario.m */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.objc; path = RemoteConfigOptOutScenario.m; sourceTree = "<group>"; };
+		96C735A22E8A040100F3CB3C /* RemoteConfigCacheExpiryScenario.m */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.objc; path = RemoteConfigCacheExpiryScenario.m; sourceTree = "<group>"; };
 		A1117E542535A59100014FDA /* OOMLoadScenario.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = OOMLoadScenario.swift; sourceTree = "<group>"; };
 		A1117E562535B22300014FDA /* OOMAutoDetectErrorsScenario.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = OOMAutoDetectErrorsScenario.swift; sourceTree = "<group>"; };
 		A1117E582535B29800014FDA /* OOMEnabledErrorTypesScenario.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = OOMEnabledErrorTypesScenario.swift; sourceTree = "<group>"; };
@@ -659,7 +665,10 @@
 				0104B47D275A7B3C003EBDF0 /* RecrashScenarios.mm */,
 				F4295E71D7B2DFE77057F3DA /* ReleasedObjectScenario.m */,
 				96C735892E89E3F600F3CB3C /* RemoteConfigBasicScenario.m */,
+				96C735A22E8A040100F3CB3C /* RemoteConfigCacheExpiryScenario.m */,
 				96C735912E89E59A00F3CB3C /* RemoteConfigExpiryScenario.m */,
+				96C735972E8A010100F3CB3C /* RemoteConfigHashScenario.m */,
+				96C735982E8A010300F3CB3C /* RemoteConfigOptOutScenario.m */,
 				010BDFB82885562D007025F9 /* ReportBackgroundAppHangScenario.swift */,
 				E7767F12221C21E30006648C /* ResumedSessionScenario.swift */,
 				8AF6FD79225E3FA00056EF9E /* ResumeSessionOOMScenario.m */,
@@ -929,6 +938,9 @@
 				E700EE59247D321B008CFFB6 /* OriginalErrorNSErrorScenario.swift in Sources */,
 				010BAB032833CE570003FF36 /* UserPersistenceDontPersistUserScenario.m in Sources */,
 				96C7358A2E89E3F600F3CB3C /* RemoteConfigBasicScenario.m in Sources */,
+				96C735A02E8A040000F3CB3C /* RemoteConfigCacheExpiryScenario.m in Sources */,
+				96C735952E8A010000F3CB3C /* RemoteConfigHashScenario.m in Sources */,
+				96C735962E8A010200F3CB3C /* RemoteConfigOptOutScenario.m in Sources */,
 				010BAB0C2833CE570003FF36 /* DisableMachExceptionScenario.m in Sources */,
 				010BAB172833CF530003FF36 /* AppAndDeviceAttributesInfiniteLaunchDurationScenario.swift in Sources */,
 				F42953498545B853CC0B635E /* NullPointerScenario.m in Sources */,

--- a/features/fixtures/macos/macOSTestApp.xcodeproj/project.pbxproj
+++ b/features/fixtures/macos/macOSTestApp.xcodeproj/project.pbxproj
@@ -198,6 +198,9 @@
 		96A25F362D66B55E00A18116 /* ObjCExceptionFeatureFlagsScenario.m in Sources */ = {isa = PBXBuildFile; fileRef = 96A25F352D66B55E00A18116 /* ObjCExceptionFeatureFlagsScenario.m */; };
 		96C7358C2E89E42700F3CB3C /* RemoteConfigBasicScenario.m in Sources */ = {isa = PBXBuildFile; fileRef = 96C7358B2E89E42700F3CB3C /* RemoteConfigBasicScenario.m */; };
 		96C735942E89E5AE00F3CB3C /* RemoteConfigExpiryScenario.m in Sources */ = {isa = PBXBuildFile; fileRef = 96C735932E89E5AE00F3CB3C /* RemoteConfigExpiryScenario.m */; };
+		96C735992E8A020000F3CB3C /* RemoteConfigHashScenario.m in Sources */ = {isa = PBXBuildFile; fileRef = 96C7359B2E8A020100F3CB3C /* RemoteConfigHashScenario.m */; };
+		96C7359A2E8A020200F3CB3C /* RemoteConfigOptOutScenario.m in Sources */ = {isa = PBXBuildFile; fileRef = 96C7359C2E8A020300F3CB3C /* RemoteConfigOptOutScenario.m */; };
+		96C735A32E8A050000F3CB3C /* RemoteConfigCacheExpiryScenario.m in Sources */ = {isa = PBXBuildFile; fileRef = 96C735A52E8A050100F3CB3C /* RemoteConfigCacheExpiryScenario.m */; };
 		AA4C7F1829AEA31D009B09A9 /* BugsnagWrapper.swift in Sources */ = {isa = PBXBuildFile; fileRef = AA4C7F1729AEA31D009B09A9 /* BugsnagWrapper.swift */; };
 		AA6ACD1A2773E098006464C4 /* UserFromConfigScenario.swift in Sources */ = {isa = PBXBuildFile; fileRef = AA6ACD192773E098006464C4 /* UserFromConfigScenario.swift */; };
 		AA6ACD1E2773E39C006464C4 /* UserInfoScenario.swift in Sources */ = {isa = PBXBuildFile; fileRef = AA6ACD1D2773E39C006464C4 /* UserInfoScenario.swift */; };
@@ -423,6 +426,9 @@
 		96A25F352D66B55E00A18116 /* ObjCExceptionFeatureFlagsScenario.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; path = ObjCExceptionFeatureFlagsScenario.m; sourceTree = "<group>"; };
 		96C7358B2E89E42700F3CB3C /* RemoteConfigBasicScenario.m */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.objc; path = RemoteConfigBasicScenario.m; sourceTree = "<group>"; };
 		96C735932E89E5AE00F3CB3C /* RemoteConfigExpiryScenario.m */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.objc; path = RemoteConfigExpiryScenario.m; sourceTree = "<group>"; };
+		96C7359B2E8A020100F3CB3C /* RemoteConfigHashScenario.m */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.objc; path = RemoteConfigHashScenario.m; sourceTree = "<group>"; };
+		96C7359C2E8A020300F3CB3C /* RemoteConfigOptOutScenario.m */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.objc; path = RemoteConfigOptOutScenario.m; sourceTree = "<group>"; };
+		96C735A52E8A050100F3CB3C /* RemoteConfigCacheExpiryScenario.m */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.objc; path = RemoteConfigCacheExpiryScenario.m; sourceTree = "<group>"; };
 		AA4C7F1729AEA31D009B09A9 /* BugsnagWrapper.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = BugsnagWrapper.swift; sourceTree = "<group>"; };
 		AA6ACD192773E098006464C4 /* UserFromConfigScenario.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = UserFromConfigScenario.swift; sourceTree = "<group>"; };
 		AA6ACD1D2773E39C006464C4 /* UserInfoScenario.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = UserInfoScenario.swift; sourceTree = "<group>"; };
@@ -579,7 +585,10 @@
 				0123189B275921590007EFD7 /* RecrashScenarios.mm */,
 				01F47C53254B1B2D00B184AD /* ReleasedObjectScenario.m */,
 				96C7358B2E89E42700F3CB3C /* RemoteConfigBasicScenario.m */,
+				96C735A52E8A050100F3CB3C /* RemoteConfigCacheExpiryScenario.m */,
 				96C735932E89E5AE00F3CB3C /* RemoteConfigExpiryScenario.m */,
+				96C7359B2E8A020100F3CB3C /* RemoteConfigHashScenario.m */,
+				96C7359C2E8A020300F3CB3C /* RemoteConfigOptOutScenario.m */,
 				01F47C67254B1B2E00B184AD /* ResumedSessionScenario.swift */,
 				01F47CC1254B1B3000B184AD /* ResumeSessionOOMScenario.m */,
 				01F47C52254B1B2D00B184AD /* Scenario.h */,
@@ -917,6 +926,9 @@
 				017D9D032833C81100B0AA87 /* DisableNSExceptionScenario.m in Sources */,
 				01F47CDA254B1B3100B184AD /* NonExistentMethodScenario.m in Sources */,
 				96C7358C2E89E42700F3CB3C /* RemoteConfigBasicScenario.m in Sources */,
+				96C735A32E8A050000F3CB3C /* RemoteConfigCacheExpiryScenario.m in Sources */,
+				96C735992E8A020000F3CB3C /* RemoteConfigHashScenario.m in Sources */,
+				96C7359A2E8A020200F3CB3C /* RemoteConfigOptOutScenario.m in Sources */,
 				01F47CFE254B1B3100B184AD /* MetadataRedactionNestedScenario.swift in Sources */,
 				010BAB6C2833D34A0003FF36 /* AppHangDefaultConfigScenario.swift in Sources */,
 				010BAB682833D34A0003FF36 /* DisabledReleaseStageAutoSessionScenario.swift in Sources */,

--- a/features/fixtures/shared/scenarios/RemoteConfigBasicScenario.m
+++ b/features/fixtures/shared/scenarios/RemoteConfigBasicScenario.m
@@ -21,7 +21,8 @@
 
 - (void)configure {
     [super configure];
-    self.config.endpoints.configuration = self.fixtureConfig.configurationURL.absoluteString;
+    NSURL *configURL = [self.fixtureConfig.mazeRunnerURL URLByAppendingPathComponent:@"error-config"];
+    self.config.endpoints.configuration = configURL.absoluteString;
 }
 
 - (void)run {

--- a/features/fixtures/shared/scenarios/RemoteConfigCacheExpiryScenario.m
+++ b/features/fixtures/shared/scenarios/RemoteConfigCacheExpiryScenario.m
@@ -20,7 +20,8 @@
 
 - (void)configure {
     [super configure];
-    self.config.endpoints.configuration = self.fixtureConfig.configurationURL.absoluteString;
+    NSURL *configURL = [self.fixtureConfig.mazeRunnerURL URLByAppendingPathComponent:@"error-config"];
+    self.config.endpoints.configuration = configURL.absoluteString;
 }
 
 - (void)run {

--- a/features/fixtures/shared/scenarios/RemoteConfigCacheExpiryScenario.m
+++ b/features/fixtures/shared/scenarios/RemoteConfigCacheExpiryScenario.m
@@ -1,0 +1,36 @@
+//
+//  RemoteConfigCacheExpiryScenario.m
+//  iOSTestApp
+//
+//  Created on 09/07/2026.
+//  Copyright © 2026 Bugsnag. All rights reserved.
+//
+
+#import "Scenario.h"
+#import "Logging.h"
+
+// RemoteConfigExpiryError is defined in RemoteConfigExpiryScenario.m
+@interface RemoteConfigExpiryError : NSError
+@end
+
+@interface RemoteConfigCacheExpiryScenario : Scenario
+@end
+
+@implementation RemoteConfigCacheExpiryScenario
+
+- (void)configure {
+    [super configure];
+    self.config.endpoints.configuration = self.fixtureConfig.configurationURL.absoluteString;
+}
+
+- (void)run {
+    // Send a single error after waiting for config to expire and be refetched
+    dispatch_after(dispatch_time(DISPATCH_TIME_NOW, (int64_t)(5 * NSEC_PER_SEC)), dispatch_get_main_queue(), ^{
+        NSString *message = @"Err 0";
+        [Bugsnag notifyError:[RemoteConfigExpiryError errorWithDomain:@"com.example"
+                                                                 code:401
+                                                             userInfo:@{NSLocalizedDescriptionKey: message}]];
+    });
+}
+
+@end

--- a/features/fixtures/shared/scenarios/RemoteConfigExpiryScenario.m
+++ b/features/fixtures/shared/scenarios/RemoteConfigExpiryScenario.m
@@ -21,7 +21,8 @@
 
 - (void)configure {
     [super configure];
-    self.config.endpoints.configuration = self.fixtureConfig.configurationURL.absoluteString;
+    NSURL *configURL = [self.fixtureConfig.mazeRunnerURL URLByAppendingPathComponent:@"error-config"];
+    self.config.endpoints.configuration = configURL.absoluteString;
 }
 
 - (void)run {

--- a/features/fixtures/shared/scenarios/RemoteConfigHashScenario.m
+++ b/features/fixtures/shared/scenarios/RemoteConfigHashScenario.m
@@ -1,0 +1,54 @@
+//
+//  RemoteConfigHashScenario.m
+//  iOSTestApp
+//
+//  Created on 09/07/2026.
+//  Copyright © 2026 Bugsnag. All rights reserved.
+//
+
+#import "Scenario.h"
+#import "Logging.h"
+
+// RemoteConfigError is defined in RemoteConfigBasicScenario.m
+@interface RemoteConfigError : NSError
+@end
+
+@interface NonMatchingError : NSError
+@end
+@implementation NonMatchingError
+@end
+
+@interface RemoteConfigHashScenario : Scenario
+@end
+
+@implementation RemoteConfigHashScenario
+
+- (void)configure {
+    [super configure];
+    self.config.endpoints.configuration = self.fixtureConfig.configurationURL.absoluteString;
+}
+
+- (void)run {
+    dispatch_after(dispatch_time(DISPATCH_TIME_NOW, (int64_t)(3 * NSEC_PER_SEC)), dispatch_get_main_queue(), ^{
+        // This error should be discarded (matches hash)
+        NSString *message1 = @"Matches hash";
+        [Bugsnag notifyError:[RemoteConfigError errorWithDomain:@"com.example"
+                                                           code:401
+                                                       userInfo:@{NSLocalizedDescriptionKey: message1}]];
+        
+        dispatch_after(dispatch_time(DISPATCH_TIME_NOW, (int64_t)(2 * NSEC_PER_SEC)), dispatch_get_main_queue(), ^{
+            // This error should be delivered (does not match hash)
+            NSString *message2 = @"Does not match hash";
+            [Bugsnag notifyError:[NonMatchingError errorWithDomain:@"com.example"
+                                                              code:402
+                                                          userInfo:@{NSLocalizedDescriptionKey: message2}]];
+            
+            dispatch_after(dispatch_time(DISPATCH_TIME_NOW, (int64_t)(4 * NSEC_PER_SEC)), dispatch_get_main_queue(), ^{
+                @throw [NSException exceptionWithName:NSGenericException reason:@"Uncaught exception!"
+                                            userInfo:@{NSLocalizedDescriptionKey: @"I'm in your program, catching your exceptions!"}];
+            });
+        });
+    });
+}
+
+@end

--- a/features/fixtures/shared/scenarios/RemoteConfigHashScenario.m
+++ b/features/fixtures/shared/scenarios/RemoteConfigHashScenario.m
@@ -25,7 +25,8 @@
 
 - (void)configure {
     [super configure];
-    self.config.endpoints.configuration = self.fixtureConfig.configurationURL.absoluteString;
+    NSURL *configURL = [self.fixtureConfig.mazeRunnerURL URLByAppendingPathComponent:@"error-config"];
+    self.config.endpoints.configuration = configURL.absoluteString;
 }
 
 - (void)run {

--- a/features/fixtures/shared/scenarios/RemoteConfigOptOutScenario.m
+++ b/features/fixtures/shared/scenarios/RemoteConfigOptOutScenario.m
@@ -1,0 +1,33 @@
+//
+//  RemoteConfigOptOutScenario.m
+//  iOSTestApp
+//
+//  Created on 09/07/2026.
+//  Copyright © 2026 Bugsnag. All rights reserved.
+//
+
+#import "Scenario.h"
+#import "Logging.h"
+
+@interface RemoteConfigOptOutScenario : Scenario
+@end
+
+@implementation RemoteConfigOptOutScenario
+
+- (void)configure {
+    [super configure];
+    // Set configuration endpoint to nil to opt out of remote config
+    self.config.endpoints.configuration = nil;
+    // Ensure stored events are uploaded immediately
+    self.config.launchDurationMillis = 0;
+}
+
+- (void)run {
+    // Wait a moment to ensure stored events are processed and uploaded
+    dispatch_after(dispatch_time(DISPATCH_TIME_NOW, (int64_t)(2 * NSEC_PER_SEC)), dispatch_get_main_queue(), ^{
+        // Do nothing - just let the stored events from previous run be delivered
+        NSLog(@"RemoteConfigOptOutScenario: Waiting for stored events to upload");
+    });
+}
+
+@end

--- a/features/fixtures/shared/scenarios/Scenario.m
+++ b/features/fixtures/shared/scenarios/Scenario.m
@@ -78,6 +78,8 @@ static __weak Scenario *currentScenario;
     self.config = [[BugsnagConfiguration alloc] initWithApiKey:self.fixtureConfig.apiKey];
     self.config.endpoints.notify = self.fixtureConfig.notifyURL.absoluteString;
     self.config.endpoints.sessions = self.fixtureConfig.sessionsURL.absoluteString;
+    // Disable remote config by default - only RemoteConfig* scenarios should enable it
+    self.config.endpoints.configuration = nil;
 #if !TARGET_OS_WATCH
     self.config.enabledErrorTypes.ooms = NO;
 #endif

--- a/features/fixtures/shared/utils/FixtureConfig.m
+++ b/features/fixtures/shared/utils/FixtureConfig.m
@@ -21,7 +21,8 @@
         _notifyURL = [mazeRunnerBaseAddress URLByAppendingPathComponent:@"notify"];
         _sessionsURL = [mazeRunnerBaseAddress URLByAppendingPathComponent:@"sessions"];
         _reflectURL = [mazeRunnerBaseAddress URLByAppendingPathComponent:@"reflect"];
-        _configurationURL = [mazeRunnerBaseAddress URLByAppendingPathComponent:@"error-config"];
+        // configurationURL should be nil by default and only set explicitly in RemoteConfig scenarios
+        _configurationURL = nil;
     }
     return self;
 }

--- a/features/release/remote_config_discard.feature
+++ b/features/release/remote_config_discard.feature
@@ -167,3 +167,54 @@ Feature: Remote config discard rules are applied
     Then the error is valid for the error reporting API
     And the event "severity" equals "error"
     And the event "unhandled" is true
+
+  Scenario: Remote config with HASH rule to discard specific error
+    When I prepare an error config with:
+     | type     | name                  | value                 	                            |
+     | property | body                  | @features/support/config/rules_specific_error.json    |
+     | property | status                | 200                                                   |
+     | header   | Cache-Control         | max-age=604800                                        |
+     | header   | ETag                  | "42"                                                  |
+    And I run "RemoteConfigBasicScenario" 
+    And on macOS, I wait for 10 seconds
+    And I prepare an error config with:
+     | type     | name                  | value                 	                 |
+     | property | status                | 304                                        |
+     | header   | Cache-Control         | max-age=604800                             |
+     | header   | ETag                  | "42"                                       |
+    And I relaunch the app after a crash
+    And I configure Bugsnag for "RemoteConfigBasicScenario"
+    And I wait to receive an error
+    And the received errors match:
+        | exceptions.0.errorClass | exceptions.0.message |
+        | NSGenericException      | Uncaught exception!  |
+    Then the error is valid for the error reporting API
+    And the event "severity" equals "error"
+    And the event "unhandled" is true
+
+  Scenario: Remote config with HASH rule discards matching events and delivers non-matching
+    When I prepare an error config with:
+     | type     | name          | value                                          |
+     | property | body          | @features/support/config/rules_hash.json       |
+     | property | status        | 200                                            |
+     | header   | Cache-Control | max-age=604800                                 |
+     | header   | ETag          | "42"                                           |
+    And I run "RemoteConfigHashScenario"
+    And on macOS, I wait for 10 seconds
+    And I prepare an error config with:
+     | type     | name          | value          |
+     | property | status        | 304            |
+     | header   | Cache-Control | max-age=604800 |
+     | header   | ETag          | "42"           |
+    And I relaunch the app after a crash
+    And I configure Bugsnag for "RemoteConfigHashScenario"
+    And I wait to receive 2 errors
+    And the received errors match:
+        | exceptions.0.errorClass | exceptions.0.message |
+        | NonMatchingError        | Does not match hash  |
+        | NSGenericException      | Uncaught exception!  |
+    Then the error is valid for the error reporting API
+    And the event "unhandled" is false
+    And I discard the oldest error
+    Then the error is valid for the error reporting API
+    And the event "unhandled" is true

--- a/features/release/remote_config_expiry.feature
+++ b/features/release/remote_config_expiry.feature
@@ -139,3 +139,53 @@ Feature: Remote config discard rules are applied
     And the event "severity" equals "warning"
     And the event "unhandled" is false
     And I discard the oldest error
+
+  Scenario: Expired config is invalidated and replaced by new config
+    When I prepare an error config with:
+     | type     | name          | value                                     |
+     | property | body          | @features/support/config/rules_all.json   |
+     | property | status        | 200                                       |
+     | header   | Cache-Control | max-age=1                                 |
+     | header   | ETag          | "42"                                      |
+    And I run "RemoteConfigCacheExpiryScenario"
+    And I wait for 1 error config to be requested
+    And I wait for 3 seconds
+    And I prepare an error config with:
+     | type     | name          | value                                     |
+     | property | body          | @features/support/config/no_rules.json    |
+     | property | status        | 200                                       |
+     | header   | Cache-Control | max-age=604800                            |
+     | header   | ETag          | "43"                                      |
+    And I wait for 1 error config to be requested
+    And I wait to receive an error
+    And the received errors match:
+        | exceptions.0.errorClass | exceptions.0.message |
+        | RemoteConfigExpiryError | Err 0                |
+    Then the error is valid for the error reporting API
+    And the event "unhandled" is false
+
+  Scenario: Server error does not block delivery; nil endpoint disables config and deletes stored
+    When I prepare an error config with:
+     | type     | name          | value                                     |
+     | property | body          | @features/support/config/no_rules.json    |
+     | property | status        | 200                                       |
+     | header   | Cache-Control | max-age=604800                            |
+     | header   | ETag          | "42"                                      |
+    And I run "RemoteConfigBasicScenario"
+    And I wait for 1 error config to be requested
+    And on macOS, I wait for 10 seconds
+    And I prepare an error config with:
+     | type     | name   | value |
+     | property | status | 500   |
+    And I relaunch the app after a crash
+    And I configure Bugsnag for "RemoteConfigOptOutScenario"
+    And I wait to receive 2 errors
+    And the received errors match:
+        | exceptions.0.errorClass | exceptions.0.message |
+        | RemoteConfigError       | Err 0                |
+        | NSGenericException      | Uncaught exception!  |
+    Then the error is valid for the error reporting API
+    And the event "unhandled" is false
+    And I discard the oldest error
+    Then the error is valid for the error reporting API
+    And the event "unhandled" is true

--- a/features/release/telemetry.feature
+++ b/features/release/telemetry.feature
@@ -46,4 +46,7 @@ Feature: Telemetry
   Scenario: Usage telemetry is not send if disabled
     When I run "TelemetryUsageDisabledScenario"
     And I wait to receive an error
-    Then the event "usage" is null
+    Then the event "usage" is not null
+    Then the event "usage.remoteConfig" is not null
+    And the event "usage.config" is null
+    And the event "usage.callbacks" is null

--- a/features/support/config/rules_hash.json
+++ b/features/support/config/rules_hash.json
@@ -1,0 +1,16 @@
+{
+    "discardRules": [
+      {
+        "ruleType": "ERROR_CLASS_DISCARD",
+        "matchType": "HASH",
+        "hash": {
+          "paths": [
+            {"path": "exceptions.0.errorClass"}
+          ],
+          "matches": [
+            "b8709f0955704fd16ed695595646f3d3ed7214ad"
+          ]
+        }
+      }
+    ]
+}

--- a/features/support/config/rules_specific_error.json
+++ b/features/support/config/rules_specific_error.json
@@ -1,0 +1,17 @@
+{
+    "discardRules": [
+      {
+        "matchType": "HASH",
+        "hash": {
+          "paths": [
+            {
+              "path": "exceptions.-1.errorClass"
+            }
+          ],
+          "matches": [
+            "b8709f0955704fd16ed695595646f3d3ed7214ad"
+          ]
+        }
+      }
+    ]
+}


### PR DESCRIPTION
## Goal

Always include a remoteConfig boolean in event [usage] to indicate whether remote-config discard rules were active when the event was processed.
Make sure the flag appears for both fresh events (via notifyInternal:) and persisted/stored crash events uploaded later.

## Design

Keep event-data mutation inside the event model: add [-setRemoteConfigFlag:] to [BugsnagEvent] and let callers ask the delegate/uploader whether remote config is valid.
Uploader and upload operations determine the boolean value and instruct the event to set the flag; upload operation doesn't directly mutate event internals.
Use a strong local reference when reading the weak remoteConfigHandler to avoid race conditions and compiler warnings.

## Changeset

Added [- (void)setRemoteConfigFlag:(BOOL)hasValidConfig] to:
[BugsnagEvent+Private.h]
[BugsnagEvent.m] — implements merging remoteConfig into [self.usage].
[BSGEventUploadOperation.m] —  calls [[event setRemoteConfigFlag:hasValidConfig]] instead of inlining mutation.
Ensured notifyInternal: still sets [event.usage[@"remoteConfig"] = @(hasValidConfig)] when creating fresh events.

## Testing

Local testing has been done.
Added maze runner test case for remote config cache expiry and hash base event discard