### PR TITLE
BSGPreventInlining Thread Safe Implementation

### DIFF
--- a/Bugsnag/Bugsnag.m
+++ b/Bugsnag/Bugsnag.m
@@ -106,60 +106,68 @@ static BugsnagClient *bsg_g_bugsnag_client = NULL;
 // Note: Each BSGPreventInlining call site within a module MUST pass a different
 //       string to prevent outlining!
 
-+ (void)notify:(NSException *)exception {
++ (void)notify:(NSException *)exception BSG_KEEP_FUNCTION_IN_STACKTRACE {
     if ([self bugsnagReadyForInternalCalls]) {
         BSGPreventInlining(@"Prevent");
         [self.client notifyErrorOrException:exception stackStripDepth:2 options:nil block:nil];
     }
+    BSG_THWART_TAIL_CALL_OPTIMISATION
 }
 
-+ (void)notify:(NSException *)exception options:(BugsnagErrorOptions *)options{
++ (void)notify:(NSException *)exception options:(BugsnagErrorOptions *)options BSG_KEEP_FUNCTION_IN_STACKTRACE {
     if ([self bugsnagReadyForInternalCalls]) {
         BSGPreventInlining(@"Prevent");
         [self.client notifyErrorOrException:exception stackStripDepth:2 options:options block:nil];
     }
+    BSG_THWART_TAIL_CALL_OPTIMISATION
 }
 
-+ (void)notify:(NSException *)exception block:(BugsnagOnErrorBlock)block {
++ (void)notify:(NSException *)exception block:(BugsnagOnErrorBlock)block BSG_KEEP_FUNCTION_IN_STACKTRACE {
     if ([self bugsnagReadyForInternalCalls]) {
         BSGPreventInlining(@"inlining");
         [self.client notifyErrorOrException:exception stackStripDepth:2 options:nil block:block];
     }
+    BSG_THWART_TAIL_CALL_OPTIMISATION
 }
 
-+ (void)notify:(NSException *)exception options:(BugsnagErrorOptions *)options block:(BugsnagOnErrorBlock)block {
++ (void)notify:(NSException *)exception options:(BugsnagErrorOptions *)options block:(BugsnagOnErrorBlock)block BSG_KEEP_FUNCTION_IN_STACKTRACE {
     if ([self bugsnagReadyForInternalCalls]) {
         BSGPreventInlining(@"inlining");
         [self.client notifyErrorOrException:exception stackStripDepth:2 options:options block:block];
     }
+    BSG_THWART_TAIL_CALL_OPTIMISATION
 }
 
-+ (void)notifyError:(NSError *)error {
++ (void)notifyError:(NSError *)error BSG_KEEP_FUNCTION_IN_STACKTRACE {
     if ([self bugsnagReadyForInternalCalls]) {
         BSGPreventInlining(@"and");
         [self.client notifyErrorOrException:error stackStripDepth:2 options:nil block:nil];
     }
+    BSG_THWART_TAIL_CALL_OPTIMISATION
 }
 
-+ (void)notifyError:(NSError *)error options:(BugsnagErrorOptions *)options{
++ (void)notifyError:(NSError *)error options:(BugsnagErrorOptions *)options BSG_KEEP_FUNCTION_IN_STACKTRACE {
     if ([self bugsnagReadyForInternalCalls]) {
         BSGPreventInlining(@"and");
         [self.client notifyErrorOrException:error stackStripDepth:2 options:options block:nil];
     }
+    BSG_THWART_TAIL_CALL_OPTIMISATION
 }
 
-+ (void)notifyError:(NSError *)error block:(BugsnagOnErrorBlock)block {
++ (void)notifyError:(NSError *)error block:(BugsnagOnErrorBlock)block BSG_KEEP_FUNCTION_IN_STACKTRACE {
     if ([self bugsnagReadyForInternalCalls]) {
         BSGPreventInlining(@"outlining");
         [self.client notifyErrorOrException:error stackStripDepth:2 options:nil block:block];
     }
+    BSG_THWART_TAIL_CALL_OPTIMISATION
 }
 
-+ (void)notifyError:(NSError *)error options:(BugsnagErrorOptions *)options block:(BugsnagOnErrorBlock)block {
++ (void)notifyError:(NSError *)error options:(BugsnagErrorOptions *)options block:(BugsnagOnErrorBlock)block BSG_KEEP_FUNCTION_IN_STACKTRACE {
     if ([self bugsnagReadyForInternalCalls]) {
         BSGPreventInlining(@"outlining");
         [self.client notifyErrorOrException:error stackStripDepth:2 options:options block:block];
     }
+    BSG_THWART_TAIL_CALL_OPTIMISATION
 }
 
 + (BOOL)bugsnagReadyForInternalCalls {

--- a/Bugsnag/Client/BugsnagClient.m
+++ b/Bugsnag/Client/BugsnagClient.m
@@ -679,52 +679,60 @@ __attribute__((annotate("oclint:suppress[too many methods]")))
 // Note: Each BSGPreventInlining call site within a module MUST pass a different
 //       string to prevent outlining!
 
-- (void)notifyError:(NSError *)error {
+- (void)notifyError:(NSError *)error BSG_KEEP_FUNCTION_IN_STACKTRACE {
     bsg_log_debug(@"%s %@", __PRETTY_FUNCTION__, error);
     BSGPreventInlining(@"Prevent");
     [self notifyErrorOrException:error stackStripDepth:2 options:nil block:nil];
+    BSG_THWART_TAIL_CALL_OPTIMISATION
 }
 
-- (void)notifyError:(NSError *)error options:(BugsnagErrorOptions *_Nullable)options{
+- (void)notifyError:(NSError *)error options:(BugsnagErrorOptions *_Nullable)options BSG_KEEP_FUNCTION_IN_STACKTRACE {
     bsg_log_debug(@"%s %@", __PRETTY_FUNCTION__, error);
     BSGPreventInlining(@"Prevent");
     [self notifyErrorOrException:error stackStripDepth:2 options:options block:nil];
+    BSG_THWART_TAIL_CALL_OPTIMISATION
 }
 
-- (void)notifyError:(NSError *)error block:(BugsnagOnErrorBlock)block {
+- (void)notifyError:(NSError *)error block:(BugsnagOnErrorBlock)block BSG_KEEP_FUNCTION_IN_STACKTRACE {
     bsg_log_debug(@"%s %@", __PRETTY_FUNCTION__, error);
     BSGPreventInlining(@"inlining");
     [self notifyErrorOrException:error stackStripDepth:2 options:nil block:block];
+    BSG_THWART_TAIL_CALL_OPTIMISATION
 }
 
-- (void)notifyError:(NSError *)error options:(BugsnagErrorOptions *_Nullable)options block:(BugsnagOnErrorBlock)block {
+- (void)notifyError:(NSError *)error options:(BugsnagErrorOptions *_Nullable)options block:(BugsnagOnErrorBlock)block BSG_KEEP_FUNCTION_IN_STACKTRACE {
     bsg_log_debug(@"%s %@", __PRETTY_FUNCTION__, error);
     BSGPreventInlining(@"inlining");
     [self notifyErrorOrException:error stackStripDepth:2 options:options block:block];
+    BSG_THWART_TAIL_CALL_OPTIMISATION
 }
 
-- (void)notify:(NSException *)exception {
+- (void)notify:(NSException *)exception BSG_KEEP_FUNCTION_IN_STACKTRACE {
     bsg_log_debug(@"%s %@", __PRETTY_FUNCTION__, exception);
     BSGPreventInlining(@"and");
     [self notifyErrorOrException:exception stackStripDepth:2 options:nil block:nil];
+    BSG_THWART_TAIL_CALL_OPTIMISATION
 }
 
-- (void)notify:(NSException *)exception options:(BugsnagErrorOptions *_Nullable)options{
+- (void)notify:(NSException *)exception options:(BugsnagErrorOptions *_Nullable)options BSG_KEEP_FUNCTION_IN_STACKTRACE {
     bsg_log_debug(@"%s %@", __PRETTY_FUNCTION__, exception);
     BSGPreventInlining(@"and");
     [self notifyErrorOrException:exception stackStripDepth:2 options:options block:nil];
+    BSG_THWART_TAIL_CALL_OPTIMISATION
 }
 
-- (void)notify:(NSException *)exception block:(BugsnagOnErrorBlock)block {
+- (void)notify:(NSException *)exception block:(BugsnagOnErrorBlock)block BSG_KEEP_FUNCTION_IN_STACKTRACE {
     bsg_log_debug(@"%s %@", __PRETTY_FUNCTION__, exception);
     BSGPreventInlining(@"outlining");
     [self notifyErrorOrException:exception stackStripDepth:2 options:nil block:block];
+    BSG_THWART_TAIL_CALL_OPTIMISATION
 }
 
-- (void)notify:(NSException *)exception options:(BugsnagErrorOptions *_Nullable)options block:(BugsnagOnErrorBlock)block {
+- (void)notify:(NSException *)exception options:(BugsnagErrorOptions *_Nullable)options block:(BugsnagOnErrorBlock)block BSG_KEEP_FUNCTION_IN_STACKTRACE {
     bsg_log_debug(@"%s %@", __PRETTY_FUNCTION__, exception);
     BSGPreventInlining(@"outlining");
     [self notifyErrorOrException:exception stackStripDepth:2 options:options block:block];
+    BSG_THWART_TAIL_CALL_OPTIMISATION
 }
 
 // MARK: - Notify (Internal)

--- a/Bugsnag/Helpers/BSGUtils.h
+++ b/Bugsnag/Helpers/BSGUtils.h
@@ -45,7 +45,27 @@ static inline NSString * _Nullable BSGStringFromClass(Class _Nullable cls) {
  */
 void bsg_safe_strncpy(char *dst, const char *src, size_t length);
 
-NSString * _Nullable BSGPreventInlining(NSString * _Nullable someValue);
+/**
+ * Prevent compiler optimisations from combining public notify API methods.
+ * The implementation is intentionally free of shared mutable state because
+ * these APIs may be called concurrently.
+ */
+#if __has_attribute(not_tail_called)
+#define BSG_NOT_TAIL_CALLED __attribute__((not_tail_called))
+#else
+#define BSG_NOT_TAIL_CALLED
+#endif
+
+void BSGPreventInlining(NSString * _Nullable tag)
+    __attribute__((noinline)) BSG_NOT_TAIL_CALLED;
+
+#if __has_attribute(disable_tail_calls)
+#define BSG_KEEP_FUNCTION_IN_STACKTRACE __attribute__((disable_tail_calls))
+#else
+#define BSG_KEEP_FUNCTION_IN_STACKTRACE
+#endif
+
+#define BSG_THWART_TAIL_CALL_OPTIMISATION __asm__ __volatile__("");
 
 NS_ASSUME_NONNULL_END
 

--- a/Bugsnag/Helpers/BSGUtils.m
+++ b/Bugsnag/Helpers/BSGUtils.m
@@ -90,9 +90,6 @@ NSString *_Nullable BSGStringFromThermalState(NSProcessInfoThermalState thermalS
     return nil;
 }
 
-NSString * _Nullable BSGPreventInlining(NSString * _Nullable someValue) {
-    static NSString *lastValue = nil;
-    NSString *returnValue = lastValue;
-    lastValue = someValue;
-    return returnValue;
+void BSGPreventInlining(NSString * _Nullable tag) {
+    __asm__ __volatile__("" : : "r"(tag) : "memory");
 }

--- a/Tests/BugsnagTests/BSGUtilsTests.m
+++ b/Tests/BugsnagTests/BSGUtilsTests.m
@@ -16,12 +16,12 @@
 @implementation BSGUtilsTests
 
 - (void)testPreventInliningConcurrentAccess {
+    NSString *tag = @"BSGPreventInlining";
     dispatch_apply(10000,
                    dispatch_get_global_queue(QOS_CLASS_USER_INITIATED, 0),
                    ^(size_t index) {
-        @autoreleasepool {
-            BSGPreventInlining([NSString stringWithFormat:@"tag-%zu", index]);
-        }
+        (void)index;
+        BSGPreventInlining(tag);
     });
 }
 

--- a/Tests/BugsnagTests/BSGUtilsTests.m
+++ b/Tests/BugsnagTests/BSGUtilsTests.m
@@ -15,6 +15,47 @@
 
 @implementation BSGUtilsTests
 
+- (void)testPreventInliningConcurrentAccess {
+    dispatch_apply(10000,
+                   dispatch_get_global_queue(QOS_CLASS_USER_INITIATED, 0),
+                   ^(size_t index) {
+        @autoreleasepool {
+            BSGPreventInlining([NSString stringWithFormat:@"tag-%zu", index]);
+        }
+    });
+}
+
+- (void)testPreventInliningConcurrentAccessAnotherCheck {
+    const NSUInteger workerCount = 16;
+    const NSUInteger iterationsPerWorker = 100000;
+
+    dispatch_queue_t queue =
+        dispatch_get_global_queue(QOS_CLASS_USER_INITIATED, 0);
+    dispatch_group_t group = dispatch_group_create();
+
+    for (NSUInteger worker = 0; worker < workerCount; worker++) {
+        dispatch_group_async(group, queue, ^{
+            for (NSUInteger iteration = 0;
+                 iteration < iterationsPerWorker;
+                 iteration++) {
+                @autoreleasepool {
+                    NSString *value = [NSString stringWithFormat:
+                        @"worker-%lu-iteration-%lu",
+                        (unsigned long)worker,
+                        (unsigned long)iteration];
+
+                    BSGPreventInlining(value);
+                }
+            }
+        });
+    }
+
+    XCTAssertEqual(dispatch_group_wait(
+        group,
+        dispatch_time(DISPATCH_TIME_NOW, 30 * NSEC_PER_SEC)),
+        0);
+}
+
 #if TARGET_OS_IOS
 
 - (void)testBSGStringFromDeviceOrientation {


### PR DESCRIPTION
## Goal

BSGPreventInlining to a noinline asm barrier with no shared mutable state, replacing the previous static-variable implementation that could race under concurrent calls. 

## Design

Adds new compiler-attribute macros to discourage tail-call elimination, applies them to public `notify`/`notifyError` overloads in `Bugsnag` and `BugsnagClient`, and appends explicit tail-call-thwarting barriers so these API methods remain visible in stack traces. Includes stress tests to exercise `BSGPreventInlining` under heavy concurrent access.

## Testing

Unit Testing