### PR TITLE
[PLAT-17173] App-Hang-Callback-Imp

### DIFF
--- a/Bugsnag/Client/BugsnagClient.m
+++ b/Bugsnag/Client/BugsnagClient.m
@@ -1287,6 +1287,15 @@ __attribute__((annotate("oclint:suppress[too many methods]")))
     @synchronized (self.featureFlagStore) {
         self.appHangEvent.featureFlagStore = [self.featureFlagStore copyMemoryStore];
     }
+
+    BugsnagAppHangCallback callback = self.configuration.appHangCallback;
+    if (callback) {
+        @try {
+            callback((BugsnagEvent * _Nonnull)self.appHangEvent);
+        } @catch (NSException *exception) {
+            bsg_log_err(@"Ignoring exception thrown by app hang callback: %@", exception);
+        }
+    }
     
     [self.appHangEvent symbolicateIfNeeded];
     

--- a/Bugsnag/Configuration/BugsnagConfiguration.m
+++ b/Bugsnag/Configuration/BugsnagConfiguration.m
@@ -97,6 +97,7 @@ static NSURLSession *getConfigDefaultURLSession(void) {
     BugsnagConfiguration *copy = [[BugsnagConfiguration alloc] initWithApiKey:[self.apiKey copy]];
     // Omit apiKey - it's set explicitly in the line above
 #if BSG_HAVE_APP_HANG_DETECTION
+    [copy setAppHangCallback:self.appHangCallback];
     [copy setAppHangThresholdMillis:self.appHangThresholdMillis];
     [copy setReportBackgroundAppHangs:self.reportBackgroundAppHangs];
 #endif

--- a/Bugsnag/include/Bugsnag/BugsnagConfiguration.h
+++ b/Bugsnag/include/Bugsnag/BugsnagConfiguration.h
@@ -90,6 +90,8 @@ typedef NS_OPTIONS(NSUInteger, BSGTelemetryOptions) {
  */
 BUGSNAG_EXTERN const NSUInteger BugsnagAppHangThresholdFatalOnly API_UNAVAILABLE(watchos);
 
+typedef void (^BugsnagAppHangCallback)(BugsnagEvent *_Nonnull event);
+
 /**
  *  A configuration block for modifying an error report
  *
@@ -264,6 +266,27 @@ BUGSNAG_EXTERN
  * By default this is false.
  */
 @property (nonatomic) BOOL reportBackgroundAppHangs API_UNAVAILABLE(watchos);
+
+/**
+ * An optional callback invoked when an app hang is detected, before the event is persisted.
+ *
+ * This can be used to attach time-sensitive in-memory diagnostics that may no longer be available
+ * when OnSendError callbacks run after the hang ends or on the next app launch.
+ *
+ * The callback is invoked synchronously on Bugsnag's app hang detector thread while the main
+ * thread is unresponsive. It must return quickly. Do not perform I/O, dispatch synchronously to
+ * the main thread, or wait for a lock or actor that may depend on the main thread. Delaying the
+ * callback also delays persistence of the app hang event. Mutate the event only during the
+ * callback, and do not retain it for asynchronous mutation.
+ *
+ * The callback may be invoked for a hang that later recovers. When appHangThresholdMillis is set to
+ * BugsnagAppHangThresholdFatalOnly, the provisional event is deleted on recovery, so modifications
+ * made by this callback are delivered only if the app is terminated while hung.
+ *
+ * If the app is terminated while hung, the modified event remains on disk. Bugsnag loads it on the
+ * next launch, marks it as unhandled, and delivers it without invoking this callback again.
+ */
+@property (copy, nullable, nonatomic) BugsnagAppHangCallback appHangCallback API_UNAVAILABLE(watchos);
 
 /**
  * Determines whether app sessions should be tracked automatically. By default this value is true.

--- a/Tests/BugsnagTests/BugsnagClientTests.m
+++ b/Tests/BugsnagTests/BugsnagClientTests.m
@@ -8,7 +8,10 @@
 
 #import "BSGTestCase.h"
 
+#import "BSGAppHangDetector.h"
+#import "BSGFileLocations.h"
 #import "BSGInternalErrorReporter.h"
+#import "BSGJSONSerialization.h"
 #import "BSGKeys.h"
 #import "BSGRunContext.h"
 #import "Bugsnag+Private.h"
@@ -325,5 +328,60 @@ NSString *BSGFormatSeverity(BSGSeverity severity);
     }
     return dict;
 }
+
+#if BSG_HAVE_APP_HANG_DETECTION
+- (void)testAppHangCallbackRunsSynchronouslyBeforePersistence {
+    BugsnagConfiguration *configuration = [[BugsnagConfiguration alloc] initWithApiKey:DUMMY_APIKEY_32CHAR_1];
+    __block NSThread *callbackThread;
+    configuration.appHangCallback = ^(BugsnagEvent *event) {
+        callbackThread = NSThread.currentThread;
+        [event addMetadata:@"rendering" withKey:@"phase" toSection:@"diagnostics"];
+    };
+    BugsnagClient *client = [[BugsnagClient alloc] initWithConfiguration:configuration];
+
+    id<BSGAppHangDetectorDelegate> delegate = client;
+    XCTAssertNil(BSGJSONDictionaryFromFile(BSGFileLocations.current.appHangEvent, 0, nil));
+
+    __block NSThread *invokingThread;
+    __block BOOL callbackCompletedBeforeReturn;
+    XCTestExpectation *expectation = [self expectationWithDescription:@"app hang callback"];
+    dispatch_async(dispatch_get_global_queue(QOS_CLASS_USER_INITIATED, 0), ^{
+        invokingThread = NSThread.currentThread;
+        [delegate appHangDetectedAtDate:[NSDate date]
+                            withThreads:@[]
+                             systemInfo:@{}];
+        callbackCompletedBeforeReturn = callbackThread == NSThread.currentThread;
+        [expectation fulfill];
+    });
+    [self waitForExpectations:@[expectation] timeout:10];
+
+    XCTAssertEqual(callbackThread, invokingThread);
+    XCTAssertFalse(callbackThread.isMainThread);
+    XCTAssertTrue(callbackCompletedBeforeReturn);
+    XCTAssertEqualObjects([client.appHangEvent getMetadataFromSection:@"diagnostics" withKey:@"phase"],
+                          @"rendering");
+    NSDictionary *persistedEvent = BSGJSONDictionaryFromFile(BSGFileLocations.current.appHangEvent, 0, nil);
+    XCTAssertEqualObjects([persistedEvent valueForKeyPath:@"metaData.diagnostics.phase"], @"rendering");
+    [delegate appHangEnded];
+    XCTAssertFalse([NSFileManager.defaultManager fileExistsAtPath:BSGFileLocations.current.appHangEvent]);
+}
+
+- (void)testAppHangCallbackExceptionDoesNotPreventPersistence {
+    BugsnagConfiguration *configuration = [[BugsnagConfiguration alloc] initWithApiKey:DUMMY_APIKEY_32CHAR_1];
+    configuration.appHangCallback = ^(__unused BugsnagEvent *event) {
+        @throw [NSException exceptionWithName:@"TestException" reason:nil userInfo:nil];
+    };
+    BugsnagClient *client = [[BugsnagClient alloc] initWithConfiguration:configuration];
+
+    id<BSGAppHangDetectorDelegate> delegate = client;
+    XCTAssertNil(BSGJSONDictionaryFromFile(BSGFileLocations.current.appHangEvent, 0, nil));
+    XCTAssertNoThrow([delegate appHangDetectedAtDate:[NSDate date]
+                                         withThreads:@[]
+                                          systemInfo:@{}]);
+
+    XCTAssertNotNil(BSGJSONDictionaryFromFile(BSGFileLocations.current.appHangEvent, 0, nil));
+    [delegate appHangEnded];
+}
+#endif
 
 @end

--- a/Tests/BugsnagTests/BugsnagConfigurationTests.m
+++ b/Tests/BugsnagTests/BugsnagConfigurationTests.m
@@ -962,6 +962,11 @@ static NSString *const HUB_APIKEY_32CHAR =
     BugsnagOnSendErrorBlock onSendBlock1 = ^BOOL(BugsnagEvent * _Nonnull event) { return true; };
     BugsnagOnSendErrorBlock onSendBlock2 = ^BOOL(BugsnagEvent * _Nonnull event) { return true; };
 
+#if BSG_HAVE_APP_HANG_DETECTION
+    BugsnagAppHangCallback appHangCallback = ^(BugsnagEvent * _Nonnull event) {};
+    config.appHangCallback = appHangCallback;
+#endif
+
     NSArray *sendBlocks = @[ onSendBlock1, onSendBlock2 ];
     [config setOnSendBlocks:[sendBlocks mutableCopy]]; // Mutable arg required
 
@@ -999,6 +1004,10 @@ static NSString *const HUB_APIKEY_32CHAR =
     XCTAssertEqual(config.onCrashHandler, clone.onCrashHandler);
     [clone setOnCrashHandler:(void *)^(const BSG_KSCrashReportWriter *_Nonnull writer){}];
     XCTAssertNotEqual(config.onCrashHandler, clone.onCrashHandler);
+
+#if BSG_HAVE_APP_HANG_DETECTION
+    XCTAssertEqual(config.appHangCallback, clone.appHangCallback);
+#endif
 
     // Array (of blocks)
     XCTAssertEqual(config.onSendBlocks, clone.onSendBlocks);

--- a/Tests/BugsnagTests/BugsnagSwiftPublicAPITests.swift
+++ b/Tests/BugsnagTests/BugsnagSwiftPublicAPITests.swift
@@ -43,6 +43,9 @@ class BugsnagSwiftPublicAPITests: BSGTestCase {
     let err = NSError(domain: "dom", code: 123, userInfo: nil)
     let sessionBlock: BugsnagOnSessionBlock = { (session) -> Bool in return false }
     let onSendErrorBlock: BugsnagOnSendErrorBlock = { (event) -> Bool in return false }
+#if !os(watchOS)
+    let appHangCallback: BugsnagAppHangCallback = { _ in }
+#endif
     let onBreadcrumbBlock: BugsnagOnBreadcrumbBlock = { (breadcrumb) -> Bool in return false }
     
     func testBugsnagClass() throws {
@@ -139,6 +142,9 @@ class BugsnagSwiftPublicAPITests: BSGTestCase {
         }
         config.removeOnSession(onSession)
         config.addOnSendError(block:onSendErrorBlock)
+#if !os(watchOS)
+        config.appHangCallback = appHangCallback
+#endif
         config.addOnSendError { (event: BugsnagEvent) -> Bool in
             return true
         }

--- a/features/app_hangs.feature
+++ b/features/app_hangs.feature
@@ -193,3 +193,32 @@ Feature: App hangs
     And the event "app.inForeground" is false
     And the event "usage.config.appHangThresholdMillis" equals 1000
     And the event "usage.config.reportBackgroundAppHangs" is true
+    
+# --- App Hang Callback Scenarios ---
+Scenario: App hang callback metadata should be included in a recovered app hang
+    When I set the app to "2.1" mode
+    And I run "AppHangCallbackScenario"
+    And I wait to receive an error
+
+    Then the event "severityReason.type" equals "appHang"
+    And the event "unhandled" is false
+    And the event "metaData.appHangCallback.callbackState" equals "captured-at-detection"
+
+Scenario: App hang callback metadata should persist after fatal app hang relaunch
+    When I run "AppHangCallbackFatalOnlyScenario"
+    And I wait for 10 seconds
+    And I kill and relaunch the app
+    And I set the HTTP status code to 200
+    And I configure Bugsnag for "AppHangCallbackFatalOnlyScenario"
+    And I wait to receive an error
+
+    Then the event "severity" equals "error"
+    And the event "severityReason.type" equals "appHang"
+    And the event "unhandled" is true
+    And the exception "message" equals "The app was terminated while unresponsive"
+    And the event "metaData.appHangCallback.callbackState" equals "captured-at-detection"
+
+Scenario: Recovered fatal-only app hangs with callback metadata should not be delivered
+    When I run "AppHangCallbackFatalOnlyRecoveryScenario"
+    And I wait for 5 seconds
+    Then I should receive no errors

--- a/features/fixtures/ios/iOSTestApp.xcodeproj/project.pbxproj
+++ b/features/fixtures/ios/iOSTestApp.xcodeproj/project.pbxproj
@@ -149,6 +149,9 @@
 		CBB787912578FC0C0071BDE4 /* MarkUnhandledHandledScenario.m in Sources */ = {isa = PBXBuildFile; fileRef = CBB787902578FC0C0071BDE4 /* MarkUnhandledHandledScenario.m */; };
 		CBE1C9242574F532004B8B5B /* OnErrorOverwriteUnhandledFalseScenario.swift in Sources */ = {isa = PBXBuildFile; fileRef = CBE1C9222574F532004B8B5B /* OnErrorOverwriteUnhandledFalseScenario.swift */; };
 		CBE1C9252574F532004B8B5B /* OnErrorOverwriteUnhandledTrueScenario.swift in Sources */ = {isa = PBXBuildFile; fileRef = CBE1C9232574F532004B8B5B /* OnErrorOverwriteUnhandledTrueScenario.swift */; };
+		E17F94D53028EBD600E06CE8 /* AppHangCallbackFatalOnlyRecoveryScenario.swift in Sources */ = {isa = PBXBuildFile; fileRef = E17F94D23028EBD600E06CE8 /* AppHangCallbackFatalOnlyRecoveryScenario.swift */; };
+		E17F94D63028EBD600E06CE8 /* AppHangCallbackFatalOnlyScenario.swift in Sources */ = {isa = PBXBuildFile; fileRef = E17F94D33028EBD600E06CE8 /* AppHangCallbackFatalOnlyScenario.swift */; };
+		E17F94D73028EBD600E06CE8 /* AppHangCallbackScenario.swift in Sources */ = {isa = PBXBuildFile; fileRef = E17F94D43028EBD600E06CE8 /* AppHangCallbackScenario.swift */; };
 		E700EE48247D1158008CFFB6 /* UserEventOverrideScenario.swift in Sources */ = {isa = PBXBuildFile; fileRef = E700EE47247D1158008CFFB6 /* UserEventOverrideScenario.swift */; };
 		E700EE4A247D1164008CFFB6 /* UserSessionOverrideScenario.swift in Sources */ = {isa = PBXBuildFile; fileRef = E700EE49247D1164008CFFB6 /* UserSessionOverrideScenario.swift */; };
 		E700EE4E247D1317008CFFB6 /* UserFromClientScenario.swift in Sources */ = {isa = PBXBuildFile; fileRef = E700EE4D247D1317008CFFB6 /* UserFromClientScenario.swift */; };
@@ -372,6 +375,9 @@
 		CBB787902578FC0C0071BDE4 /* MarkUnhandledHandledScenario.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; path = MarkUnhandledHandledScenario.m; sourceTree = "<group>"; };
 		CBE1C9222574F532004B8B5B /* OnErrorOverwriteUnhandledFalseScenario.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = OnErrorOverwriteUnhandledFalseScenario.swift; sourceTree = "<group>"; };
 		CBE1C9232574F532004B8B5B /* OnErrorOverwriteUnhandledTrueScenario.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = OnErrorOverwriteUnhandledTrueScenario.swift; sourceTree = "<group>"; };
+		E17F94D23028EBD600E06CE8 /* AppHangCallbackFatalOnlyRecoveryScenario.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AppHangCallbackFatalOnlyRecoveryScenario.swift; sourceTree = "<group>"; };
+		E17F94D33028EBD600E06CE8 /* AppHangCallbackFatalOnlyScenario.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AppHangCallbackFatalOnlyScenario.swift; sourceTree = "<group>"; };
+		E17F94D43028EBD600E06CE8 /* AppHangCallbackScenario.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AppHangCallbackScenario.swift; sourceTree = "<group>"; };
 		E700EE47247D1158008CFFB6 /* UserEventOverrideScenario.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = UserEventOverrideScenario.swift; sourceTree = "<group>"; };
 		E700EE49247D1164008CFFB6 /* UserSessionOverrideScenario.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = UserSessionOverrideScenario.swift; sourceTree = "<group>"; };
 		E700EE4D247D1317008CFFB6 /* UserFromClientScenario.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = UserFromClientScenario.swift; sourceTree = "<group>"; };
@@ -524,14 +530,6 @@
 		F42953DE2BB41023C0B07F41 /* scenarios */ = {
 			isa = PBXGroup;
 			children = (
-				1C09E56B2F675E1400F468EF /* HttpErrorOnErrorCallbackScenario.swift */,
-				1C09E56C2F675E1400F468EF /* HttpErrorOnResponseCallbackScenario.swift */,
-				1C09E56D2F675E1400F468EF /* HttpErrorSendPostScenario.swift */,
-				1C09E56E2F675E1400F468EF /* HttpErrorSendScenario.swift */,
-				1C09E5592F5D01E200F468EF /* AutoInstrumentNetworkSharedSessionInvalidateScenario.swift */,
-				1C70DEA62EF09AF400F52112 /* CustomerControlledDeliveryScenario.swift */,
-				1C70DEA42EF07EEC00F52112 /* FatalErrorOptionScenario.swift */,
-				1C8CB8B42EBB9948007BF492 /* CaptureOptionsScenario.swift */,
 				010BAAF62833CE570003FF36 /* AbortOverrideScenario.m */,
 				F429534164257A2BE23ED72D /* AbortScenario.m */,
 				F4295A20DE438C2B28167714 /* AccessNonObjectScenario.m */,
@@ -543,6 +541,9 @@
 				010BAB1A2833CF810003FF36 /* AppAndDeviceAttributesUnhandledExceptionAfterLaunchScenario.swift */,
 				010BAB182833CF660003FF36 /* AppAndDeviceAttributesUnhandledExceptionDuringLaunchScenario.swift */,
 				01E0DB0A25E8EBD100A740ED /* AppDurationScenario.swift */,
+				E17F94D23028EBD600E06CE8 /* AppHangCallbackFatalOnlyRecoveryScenario.swift */,
+				E17F94D33028EBD600E06CE8 /* AppHangCallbackFatalOnlyScenario.swift */,
+				E17F94D43028EBD600E06CE8 /* AppHangCallbackScenario.swift */,
 				010BAB262833D0160003FF36 /* AppHangDefaultConfigScenario.swift */,
 				010BAB1C2833CFB00003FF36 /* AppHangDidBecomeActiveScenario.swift */,
 				010BAB1E2833CFD40003FF36 /* AppHangDidEnterBackgroundScenario.swift */,
@@ -560,6 +561,7 @@
 				E75040A32478052D005D33BD /* AutoDetectFalseAbortScenario.swift */,
 				E750409F2478019D005D33BD /* AutoDetectFalseHandledScenario.swift */,
 				E75040A1247801A8005D33BD /* AutoDetectFalseNSExceptionScenario.swift */,
+				1C09E5592F5D01E200F468EF /* AutoInstrumentNetworkSharedSessionInvalidateScenario.swift */,
 				8A98400220FD11BF0023ECD1 /* AutoSessionCustomVersionScenario.m */,
 				8AEFC79820F9132C00A78779 /* AutoSessionHandledEventsScenario.m */,
 				8AEEBBCF20FC9E1D00C60763 /* AutoSessionMixedEventsScenario.m */,
@@ -574,9 +576,11 @@
 				E7A324E9247E9DA5008B0052 /* BreadcrumbCallbackOverrideScenario.swift */,
 				E7A324EC247E9DB3008B0052 /* BreadcrumbCallbackRemovalScenario.m */,
 				F42956D34274D4ED16B4D491 /* BuiltinTrapScenario.m */,
+				1C8CB8B42EBB9948007BF492 /* CaptureOptionsScenario.swift */,
 				01DCB82A27985D2C0048640A /* ConcurrentCrashesScenario.mm */,
 				0184DBDF28C63F50006AF50B /* CouldNotCreateDirectoryScenario.swift */,
 				01DE903726CE99B800455213 /* CriticalThermalStateScenario.swift */,
+				1C70DEA62EF09AF400F52112 /* CustomerControlledDeliveryScenario.swift */,
 				8A72A0372396574F00328051 /* CustomPluginNotifierDescriptionScenario.m */,
 				8A096DFB27C7E77600DB6ECC /* CxxBareThrowScenario.mm */,
 				010BAAFA2833CE570003FF36 /* CxxExceptionOverrideScenario.mm */,
@@ -598,6 +602,7 @@
 				00432CC2240912A000826D05 /* EnabledErrorTypesCxxScenario.mm */,
 				E75040B324782597005D33BD /* EnabledReleaseStageAutoSessionScenario.swift */,
 				010BAB3E2833D29A0003FF36 /* EnabledReleaseStageManualSessionScenario.swift */,
+				1C70DEA42EF07EEC00F52112 /* FatalErrorOptionScenario.swift */,
 				010BAB342833D1F70003FF36 /* HandledErrorInvalidReleaseStageScenario.swift */,
 				F4295FA8EBBA645EECF7B483 /* HandledErrorOverrideScenario.swift */,
 				F4295A364B3851D3811BC648 /* HandledErrorScenario.swift */,
@@ -606,6 +611,10 @@
 				8AB1081823301FE600672818 /* HandledErrorValidReleaseStageScenario.swift */,
 				F429526319377A8848136413 /* HandledExceptionScenario.swift */,
 				8AF8FCAD22BD23BA00A967CA /* HandledInternalNotifyScenario.swift */,
+				1C09E56B2F675E1400F468EF /* HttpErrorOnErrorCallbackScenario.swift */,
+				1C09E56C2F675E1400F468EF /* HttpErrorOnResponseCallbackScenario.swift */,
+				1C09E56D2F675E1400F468EF /* HttpErrorSendPostScenario.swift */,
+				1C09E56E2F675E1400F468EF /* HttpErrorSendScenario.swift */,
 				967F6F1129B2236A0054EED8 /* InternalWorkingsScenario.swift */,
 				01847DD526453D4E00ADA4C7 /* InvalidCrashReportScenario.m */,
 				01B6BB7425D5748800FC4DE6 /* LastRunInfoScenario.swift */,
@@ -852,6 +861,9 @@
 				8AEEBBD020FC9E1D00C60763 /* AutoSessionMixedEventsScenario.m in Sources */,
 				010BAB052833CE570003FF36 /* DisableAllExceptManualExceptionsAndCrashScenario.m in Sources */,
 				E753F24624927409001FB671 /* NotifyCallbackCrashScenario.swift in Sources */,
+				E17F94D53028EBD600E06CE8 /* AppHangCallbackFatalOnlyRecoveryScenario.swift in Sources */,
+				E17F94D63028EBD600E06CE8 /* AppHangCallbackFatalOnlyScenario.swift in Sources */,
+				E17F94D73028EBD600E06CE8 /* AppHangCallbackScenario.swift in Sources */,
 				8A096DFC27C7E77600DB6ECC /* CxxBareThrowScenario.mm in Sources */,
 				AA6ACD1C2773E0B3006464C4 /* UserFromConfigScenario.swift in Sources */,
 				8AF8FCAC22BD1E5400A967CA /* UnhandledInternalNotifyScenario.swift in Sources */,

--- a/features/fixtures/ios/iOSTestAppXcFramework.xcodeproj/project.pbxproj
+++ b/features/fixtures/ios/iOSTestAppXcFramework.xcodeproj/project.pbxproj
@@ -143,6 +143,9 @@
 		CBB787912578FC0C0071BDE4 /* MarkUnhandledHandledScenario.m in Sources */ = {isa = PBXBuildFile; fileRef = CBB787902578FC0C0071BDE4 /* MarkUnhandledHandledScenario.m */; };
 		CBE1C9242574F532004B8B5B /* OnErrorOverwriteUnhandledFalseScenario.swift in Sources */ = {isa = PBXBuildFile; fileRef = CBE1C9222574F532004B8B5B /* OnErrorOverwriteUnhandledFalseScenario.swift */; };
 		CBE1C9252574F532004B8B5B /* OnErrorOverwriteUnhandledTrueScenario.swift in Sources */ = {isa = PBXBuildFile; fileRef = CBE1C9232574F532004B8B5B /* OnErrorOverwriteUnhandledTrueScenario.swift */; };
+		E1F394413041604D00D512BA /* AppHangCallbackScenario.swift in Sources */ = {isa = PBXBuildFile; fileRef = E1F394403041604900D512BA /* AppHangCallbackScenario.swift */; };
+		E1F394433041606B00D512BA /* AppHangCallbackFatalOnlyScenario.swift in Sources */ = {isa = PBXBuildFile; fileRef = E1F394423041606400D512BA /* AppHangCallbackFatalOnlyScenario.swift */; };
+		E1F394453041608D00D512BA /* AppHangCallbackFatalOnlyRecoveryScenario.swift in Sources */ = {isa = PBXBuildFile; fileRef = E1F394443041608A00D512BA /* AppHangCallbackFatalOnlyRecoveryScenario.swift */; };
 		E700EE48247D1158008CFFB6 /* UserEventOverrideScenario.swift in Sources */ = {isa = PBXBuildFile; fileRef = E700EE47247D1158008CFFB6 /* UserEventOverrideScenario.swift */; };
 		E700EE4A247D1164008CFFB6 /* UserSessionOverrideScenario.swift in Sources */ = {isa = PBXBuildFile; fileRef = E700EE49247D1164008CFFB6 /* UserSessionOverrideScenario.swift */; };
 		E700EE4E247D1317008CFFB6 /* UserFromClientScenario.swift in Sources */ = {isa = PBXBuildFile; fileRef = E700EE4D247D1317008CFFB6 /* UserFromClientScenario.swift */; };
@@ -374,6 +377,9 @@
 		CBB787902578FC0C0071BDE4 /* MarkUnhandledHandledScenario.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; path = MarkUnhandledHandledScenario.m; sourceTree = "<group>"; };
 		CBE1C9222574F532004B8B5B /* OnErrorOverwriteUnhandledFalseScenario.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = OnErrorOverwriteUnhandledFalseScenario.swift; sourceTree = "<group>"; };
 		CBE1C9232574F532004B8B5B /* OnErrorOverwriteUnhandledTrueScenario.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = OnErrorOverwriteUnhandledTrueScenario.swift; sourceTree = "<group>"; };
+		E1F394403041604900D512BA /* AppHangCallbackScenario.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AppHangCallbackScenario.swift; sourceTree = "<group>"; };
+		E1F394423041606400D512BA /* AppHangCallbackFatalOnlyScenario.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AppHangCallbackFatalOnlyScenario.swift; sourceTree = "<group>"; };
+		E1F394443041608A00D512BA /* AppHangCallbackFatalOnlyRecoveryScenario.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AppHangCallbackFatalOnlyRecoveryScenario.swift; sourceTree = "<group>"; };
 		E700EE47247D1158008CFFB6 /* UserEventOverrideScenario.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = UserEventOverrideScenario.swift; sourceTree = "<group>"; };
 		E700EE49247D1164008CFFB6 /* UserSessionOverrideScenario.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = UserSessionOverrideScenario.swift; sourceTree = "<group>"; };
 		E700EE4D247D1317008CFFB6 /* UserFromClientScenario.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = UserFromClientScenario.swift; sourceTree = "<group>"; };
@@ -527,6 +533,9 @@
 		F42953DE2BB41023C0B07F41 /* scenarios */ = {
 			isa = PBXGroup;
 			children = (
+				E1F394443041608A00D512BA /* AppHangCallbackFatalOnlyRecoveryScenario.swift */,
+				E1F394423041606400D512BA /* AppHangCallbackFatalOnlyScenario.swift */,
+				E1F394403041604900D512BA /* AppHangCallbackScenario.swift */,
 				1C8CB8B82EBE3CBE007BF492 /* CaptureOptionsScenario.swift */,
 				010BAAF62833CE570003FF36 /* AbortOverrideScenario.m */,
 				F429534164257A2BE23ED72D /* AbortScenario.m */,
@@ -968,6 +977,7 @@
 				E7A324E0247E70F9008B0052 /* SessionCallbackDiscardScenario.swift in Sources */,
 				09F025172BAD7B04007D9F73 /* DelayedNotifyErrorScenario.swift in Sources */,
 				01F6B75A2832756300B75C5D /* OldCrashReportScenario.swift in Sources */,
+				E1F394453041608D00D512BA /* AppHangCallbackFatalOnlyRecoveryScenario.swift in Sources */,
 				8A72A0382396574F00328051 /* CustomPluginNotifierDescriptionScenario.m in Sources */,
 				E700EE72247D79FF008CFFB6 /* SIGBUSScenario.m in Sources */,
 				E7767F11221C21D90006648C /* StoppedSessionScenario.swift in Sources */,
@@ -981,7 +991,9 @@
 				00432CC4240912A100826D05 /* EnabledErrorTypesCxxScenario.mm in Sources */,
 				E7A324DE247E70E6008B0052 /* SessionCallbackOrderScenario.swift in Sources */,
 				E7A324DA247E70C4008B0052 /* SessionCallbackCrashScenario.swift in Sources */,
+				E1F394433041606B00D512BA /* AppHangCallbackFatalOnlyScenario.swift in Sources */,
 				01F1474425F282E600C2DC65 /* AppHangScenario.swift in Sources */,
+				E1F394413041604D00D512BA /* AppHangCallbackScenario.swift in Sources */,
 				0104B47E275A7B3C003EBDF0 /* RecrashScenarios.mm in Sources */,
 				01EE7F57278C680C00A59DC6 /* OOMSessionlessScenario.m in Sources */,
 				E7A324E3247E7C17008B0052 /* SessionCallbackRemovalScenario.m in Sources */,

--- a/features/fixtures/shared/scenarios/AppHangCallbackFatalOnlyRecoveryScenario.swift
+++ b/features/fixtures/shared/scenarios/AppHangCallbackFatalOnlyRecoveryScenario.swift
@@ -1,0 +1,28 @@
+//
+//  AppHangCallbackFatalOnlyRecoveryScenario.swift
+//  iOSTestAppXcFramework
+//
+//  Created by Meiyalagan Ramadurai on 28/08/26.
+//  Copyright © 2026 Bugsnag. All rights reserved.
+//
+
+class AppHangCallbackFatalOnlyRecoveryScenario: Scenario {
+
+    override func configure() {
+        super.configure()
+        config.appHangThresholdMillis = BugsnagAppHangThresholdFatalOnly
+        config.sendLaunchCrashesSynchronously = false
+
+        config.appHangCallback = { event in
+            event.addMetadata("captured-at-detection",
+                              key: "callbackState",
+                              section: "appHangCallback")
+        }
+    }
+
+    override func run() {
+        // Exceeds the fatal-only threshold, then the app recovers.
+        Thread.sleep(forTimeInterval: 3)
+    }
+}
+

--- a/features/fixtures/shared/scenarios/AppHangCallbackFatalOnlyScenario.swift
+++ b/features/fixtures/shared/scenarios/AppHangCallbackFatalOnlyScenario.swift
@@ -1,0 +1,28 @@
+//
+//  AppHangCallbackFatalOnlyScenario.swift
+//  iOSTestAppXcFramework
+//
+//  Created by Meiyalagan Ramadurai on 28/08/26.
+//  Copyright © 2026 Bugsnag. All rights reserved.
+//
+
+class AppHangCallbackFatalOnlyScenario: Scenario {
+
+    override func configure() {
+        super.configure()
+        config.appHangThresholdMillis = BugsnagAppHangThresholdFatalOnly
+        config.sendLaunchCrashesSynchronously = false
+        config.addFeatureFlag(name: "Testing")
+
+        config.appHangCallback = { event in
+            event.addMetadata("captured-at-detection",
+                              key: "callbackState",
+                              section: "appHangCallback")
+        }
+    }
+
+    override func run() {
+        // Maze kills and relaunches the app after 10 seconds.
+        Thread.sleep(forTimeInterval: 500)
+    }
+}

--- a/features/fixtures/shared/scenarios/AppHangCallbackScenario.swift
+++ b/features/fixtures/shared/scenarios/AppHangCallbackScenario.swift
@@ -1,0 +1,48 @@
+//
+//  AppHangCallbackScenario.swift
+//  iOSTestAppXcFramework
+//
+//  Created by Meiyalagan Ramadurai on 28/08/26.
+//  Copyright © 2026 Bugsnag. All rights reserved.
+//
+
+class AppHangCallbackScenario: Scenario {
+
+    override func configure() {
+        super.configure()
+        config.appHangThresholdMillis = 2_000
+        config.enabledBreadcrumbTypes = [.user]
+        config.addFeatureFlag(name: "Testing")
+
+        config.appHangCallback = { event in
+            event.addMetadata("captured-at-detection",
+                              key: "callbackState",
+                              section: "appHangCallback")
+        }
+    }
+
+    override func run() {
+        Bugsnag.setContext("App Hang Callback Scenario")
+        Bugsnag.setGroupingDiscriminator(
+            "AppHangCallbackScenarioGroupingDiscriminator"
+        )
+
+        let timeInterval = TimeInterval(args[0])!
+        logDebug("Simulating an app hang of \(timeInterval) seconds...")
+
+        if timeInterval > 2 {
+            Thread.sleep(forTimeInterval: 1.5)
+            Bugsnag.leaveBreadcrumb(
+                withMessage: "This breadcrumb was left during the hang, before detection"
+            )
+            Thread.sleep(forTimeInterval: timeInterval - 1.5)
+        } else {
+            Thread.sleep(forTimeInterval: timeInterval)
+        }
+
+        Bugsnag.leaveBreadcrumb(
+            withMessage: "This breadcrumb was left after the hang"
+        )
+        logDebug("Finished sleeping")
+    }
+}


### PR DESCRIPTION
## Goal

Allow applications to attach time-sensitive diagnostic context when an app hang is detected. Existing callbacks run after recovery or on the next launch, when useful in-memory state may be gone.

A motivating example is a SwiftUI hang whose stack contains only AttributeGraph internals. The stack identifies the framework subsystem but not the application view or recent body recomputations that contributed to the hang. The same problem applies to other hangs where application-owned context would improve attribution.
## Design

Add an optional appHangCallback invoked synchronously on the detector thread before persistence. The callback must not block or wait for the unresponsive main thread.

## Changeset

- 1. Add an optional callback for attaching diagnostic context before an app hang is persisted.
- 2. Document its threading and lifecycle constraints, preserve it when copying configuration, and contain callback exceptions.

## Testing

Added coverage to new API + Maze runner test cases.