### PR TITLE
Avoid eager Mach image enumeration during startup

### DIFF
--- a/Bugsnag/Helpers/BSGRunContext.m
+++ b/Bugsnag/Helpers/BSGRunContext.m
@@ -67,9 +67,9 @@ static void InitRunContext(void) {
     // Make sure the images list is populated.
     bsg_mach_headers_initialize();
 
-    BSG_Mach_Header_Info *image = bsg_mach_headers_get_main_image();
-    if (image && image->uuid) {
-        uuid_copy(bsg_runContext->machoUUID, image->uuid);
+    BSG_Mach_Header_Info image;
+    if (bsg_mach_headers_get_main_image(&image) && image.uuid) {
+        uuid_copy(bsg_runContext->machoUUID, image.uuid);
     }
 
     NSString *bundleVersion = [[[NSBundle mainBundle] infoDictionary] objectForKey:@"CFBundleVersion"];

--- a/Bugsnag/Helpers/BSGTelemetry.m
+++ b/Bugsnag/Helpers/BSGTelemetry.m
@@ -22,7 +22,11 @@ static NSNumber *_Nullable IntegerValue(NSUInteger actual, NSUInteger defaultVal
 }
 
 static BOOL IsStaticallyLinked(void) {
-    return bsg_mach_headers_get_self_image() == bsg_mach_headers_get_main_image();
+    BSG_Mach_Header_Info selfImage;
+    BSG_Mach_Header_Info mainImage;
+    return bsg_mach_headers_get_self_image(&selfImage) &&
+           bsg_mach_headers_get_main_image(&mainImage) &&
+           selfImage.header == mainImage.header;
 }
 
 static NSDictionary * ConfigValue(BugsnagConfiguration *configuration) {

--- a/Bugsnag/KSCrash/Source/KSCrash/Recording/BSG_KSCrashReport.c
+++ b/Bugsnag/KSCrash/Source/KSCrash/Recording/BSG_KSCrashReport.c
@@ -47,6 +47,7 @@
 #include "BSGDefines.h"
 #include "BSGRunContext.h"
 
+#include <mach-o/dyld_images.h>
 #include <mach-o/loader.h>
 #include <sys/time.h>
 
@@ -78,6 +79,42 @@ typedef struct {
     char *data;
     size_t allocated_size;
 } BSG_ThreadDataBuffer;
+
+// Tracks images referenced by stack frames so compact crash reports can avoid
+// serializing unrelated images without mutating the shared image cache.
+#define BSG_MAX_REFERENCED_IMAGES 512
+typedef struct {
+    uintptr_t addresses[BSG_MAX_REFERENCED_IMAGES];
+    uint32_t count;
+    bool overflowed;
+} BSG_Referenced_Image_Set;
+
+static bool
+bsg_referenced_image_set_contains(const BSG_Referenced_Image_Set *set,
+                                  uintptr_t address) {
+    if (set == NULL) {
+        return false;
+    }
+    for (uint32_t i = 0; i < set->count; i++) {
+        if (set->addresses[i] == address) {
+            return true;
+        }
+    }
+    return false;
+}
+
+static void bsg_referenced_image_set_add(BSG_Referenced_Image_Set *set,
+                                         uintptr_t address) {
+    if (set == NULL || address == 0 || set->overflowed ||
+        bsg_referenced_image_set_contains(set, address)) {
+        return;
+    }
+    if (set->count < BSG_MAX_REFERENCED_IMAGES) {
+        set->addresses[set->count++] = address;
+    } else {
+        set->overflowed = true;
+    }
+}
 
 // ============================================================================
 #pragma mark - JSON Encoding -
@@ -485,17 +522,19 @@ void bsg_kscrashreport_writeKSCrashFields(BSG_KSCrash_Context *crashContext,
  */
 void bsg_kscrw_i_writeBacktraceEntry(
     const BSG_KSCrashReportWriter *const writer, const char *const key,
-    const uintptr_t address, struct bsg_symbolicate_result *info) {
+    const uintptr_t address, struct bsg_symbolicate_result *info,
+    BSG_Referenced_Image_Set *referencedImages) {
     writer->beginObject(writer, key);
     {
-        if (info->image && info->image->header) {
-            info->image->inCrashReport = true;
+        if (info->image_header) {
+            bsg_referenced_image_set_add(referencedImages,
+                                         (uintptr_t)info->image_header);
             writer->addUIntegerElement(writer, BSG_KSCrashField_ObjectAddr,
-                                       (uintptr_t)info->image->header);
+                                       (uintptr_t)info->image_header);
         }
-        if (info->image && info->image->name) {
+        if (info->image_name) {
             writer->addStringElement(writer, BSG_KSCrashField_ObjectName,
-                                     bsg_ksfulastPathEntry(info->image->name));
+                                     bsg_ksfulastPathEntry(info->image_name));
         }
         if (info->function_address) {
             writer->addUIntegerElement(writer, BSG_KSCrashField_SymbolAddr,
@@ -528,7 +567,8 @@ void bsg_kscrw_i_writeBacktrace(const BSG_KSCrashReportWriter *const writer,
                                 const char *const key,
                                 const uintptr_t *const backtrace,
                                 const int backtraceLength,
-                                const int skippedEntries) {
+                                const int skippedEntries,
+                                BSG_Referenced_Image_Set *referencedImages) {
     writer->beginObject(writer, key);
     {
         writer->beginArray(writer, BSG_KSCrashField_Contents);
@@ -540,7 +580,8 @@ void bsg_kscrw_i_writeBacktrace(const BSG_KSCrashReportWriter *const writer,
 
                 for (int i = 0; i < backtraceLength; i++) {
                     bsg_kscrw_i_writeBacktraceEntry(writer, NULL, backtrace[i],
-                                                    &symbolicated[i]);
+                                                    &symbolicated[i],
+                                                    referencedImages);
                 }
             }
         }
@@ -682,12 +723,12 @@ void bsg_kscrw_i_writeRegisters(
  */
 void bsg_kscrw_i_writeCrashInfoMessage(const BSG_KSCrashReportWriter *const writer,
                                        const char *key, uintptr_t address) {
-    BSG_Mach_Header_Info *image = bsg_mach_headers_image_at_address(address);
-    if (!image) {
+    BSG_Mach_Header_Info image;
+    if (!bsg_mach_headers_image_at_address(address, &image)) {
         BSG_KSLOG_ERROR("Could not locate mach header info");
         return;
     }
-    const char *message = bsg_mach_headers_get_crash_info_message(image);
+    const char *message = bsg_mach_headers_get_crash_info_message(&image);
     if (message) {
         writer->addStringElement(writer, key, message);
     }
@@ -704,9 +745,9 @@ void bsg_kscrw_i_writeCrashInfoMessage(const BSG_KSCrashReportWriter *const writ
 void bsg_kscrw_i_writeThread(const BSG_KSCrashReportWriter *const writer,
                              const char *const key,
                              const BSG_KSCrash_SentryContext *const crash,
-                             const thread_t thread,
-                             const int index,
-                             const integer_t threadRunState) {
+                             const thread_t thread, const int index,
+                             const integer_t threadRunState,
+                             BSG_Referenced_Image_Set *referencedImages) {
     bool isCrashedThread = thread == crash->offendingThread;
     bool isSelfThread = thread == bsg_ksmachthread_self();
     BSG_STRUCT_MCONTEXT_L machineContextBuffer;
@@ -728,7 +769,7 @@ void bsg_kscrw_i_writeThread(const BSG_KSCrashReportWriter *const writer,
         if (backtrace != NULL) {
             bsg_kscrw_i_writeBacktrace(writer, BSG_KSCrashField_Backtrace,
                                        backtrace, backtraceLength,
-                                       skippedEntries);
+                                       skippedEntries, referencedImages);
         }
         if (machineContext != NULL && isCrashedThread) {
             bsg_kscrw_i_writeRegisters(writer, BSG_KSCrashField_Registers,
@@ -773,7 +814,8 @@ void bsg_kscrw_i_writeThread(const BSG_KSCrashReportWriter *const writer,
  */
 void bsg_kscrw_i_writeAllThreads(const BSG_KSCrashReportWriter *const writer,
                                  const char *const key,
-                                 const BSG_KSCrash_SentryContext *const crash) {
+                                 const BSG_KSCrash_SentryContext *const crash,
+                                 BSG_Referenced_Image_Set *referencedImages) {
     // Fetch info for all threads.
     writer->beginArray(writer, key);
     {
@@ -781,7 +823,8 @@ void bsg_kscrw_i_writeAllThreads(const BSG_KSCrashReportWriter *const writer,
             thread_t thread = crash->allThreads[i];
             integer_t threadRunState = crash->allThreadRunStates[i];
             if (crash->threadTracingEnabled || thread == crash->offendingThread) {
-                bsg_kscrw_i_writeThread(writer, NULL, crash, thread, (int) i, threadRunState);
+                bsg_kscrw_i_writeThread(writer, NULL, crash, thread, (int)i,
+                                        threadRunState, referencedImages);
             }
         }
     }
@@ -847,15 +890,42 @@ void bsg_kscrw_i_writeBinaryImage(const BSG_KSCrashReportWriter *const writer,
  *
  * @param key The object key, if needed.
  */
-void bsg_kscrw_i_writeBinaryImages(const BSG_KSCrashReportWriter *const writer,
-                                   const char *const key)
-{
+void bsg_kscrw_i_writeBinaryImages(
+    const BSG_KSCrashReportWriter *const writer, const char *const key,
+    const BSG_Referenced_Image_Set *referencedImages) {
+    uint32_t count = 0;
+    const BSG_Dyld_Image_Info *images = bsg_mach_headers_get_images(&count);
+    BSG_Mach_Header_Info dyldImage;
+    bool hasDyldImage = bsg_mach_headers_get_dyld_image(&dyldImage);
+    bool wroteDyldImage = false;
     writer->beginArray(writer, key);
     {
-        for (BSG_Mach_Header_Info *img = bsg_mach_headers_get_images(); img != NULL; img = atomic_load(&img->next)) {
-            if (img->inCrashReport) {
-                bsg_kscrw_i_writeBinaryImage(writer, NULL, img);
+        for (uint32_t i = 0; i < count; i++) {
+            const struct mach_header *header = images[i].imageLoadAddress;
+            if (referencedImages != NULL && !referencedImages->overflowed &&
+                !bsg_referenced_image_set_contains(referencedImages,
+                                                   (uintptr_t)header)) {
+                continue;
             }
+            bool isDyldImage = hasDyldImage && header == dyldImage.header;
+            const char *name = images[i].imageFilePath;
+            if (isDyldImage && name == NULL) {
+                name = dyldImage.name;
+            }
+            BSG_Mach_Header_Info image;
+            if (bsg_mach_headers_image_for_header(header, name, &image)) {
+                bsg_kscrw_i_writeBinaryImage(writer, NULL, &image);
+                if (isDyldImage) {
+                    wroteDyldImage = true;
+                }
+            }
+        }
+
+        if (hasDyldImage && !wroteDyldImage &&
+            (referencedImages == NULL || referencedImages->overflowed ||
+             bsg_referenced_image_set_contains(referencedImages,
+                                               (uintptr_t)dyldImage.header))) {
+            bsg_kscrw_i_writeBinaryImage(writer, NULL, &dyldImage);
         }
     }
     writer->endContainer(writer);
@@ -1218,18 +1288,18 @@ void bsg_kscrashreport_writeMinimalReport(
         {
             bsg_kscrw_i_writeThread(
                 writer, BSG_KSCrashField_CrashedThread, &crashContext->crash,
-                crashContext->crash.offendingThread,
-                0,
-                bsg_kscrw_i_threadIndex(crashContext->crash.offendingThread));
+                crashContext->crash.offendingThread, 0,
+                bsg_kscrw_i_threadIndex(crashContext->crash.offendingThread),
+                NULL);
             bsg_kscrw_i_writeError(writer, BSG_KSCrashField_Error,
                                    &crashContext->crash);
         }
         writer->endContainer(writer);
 
-        BSG_Mach_Header_Info *image = bsg_mach_headers_get_self_image();
-        if (image) {
+        BSG_Mach_Header_Info image;
+        if (bsg_mach_headers_get_self_image(&image)) {
             writer->beginArray(writer, BSG_KSCrashField_BinaryImages);
-            bsg_kscrw_i_writeBinaryImage(writer, NULL, image);
+            bsg_kscrw_i_writeBinaryImage(writer, NULL, &image);
             writer->endContainer(writer);
         }
     }
@@ -1320,14 +1390,17 @@ void bsg_kscrashreport_writeKSCrashFields(BSG_KSCrash_Context *crashContext,
 void bsg_kscrw_i_writeTraceInfo(const BSG_KSCrash_Context *crashContext,
                                 const BSG_KSCrashReportWriter *writer) {
     const BSG_KSCrash_SentryContext *crash = &crashContext->crash;
+    BSG_Referenced_Image_Set referencedImages = {0};
 
     writer->beginObject(writer, BSG_KSCrashField_Crash);
     {
         bsg_kscrw_i_writeError(writer, BSG_KSCrashField_Error, crash);
-        bsg_kscrw_i_writeAllThreads(writer, BSG_KSCrashField_Threads, crash);
+        bsg_kscrw_i_writeAllThreads(writer, BSG_KSCrashField_Threads, crash,
+                                    &referencedImages);
     }
     writer->endContainer(writer);
 
     // Called *after* writeAllThreads() so that we know which images to include
-    bsg_kscrw_i_writeBinaryImages(writer, BSG_KSCrashField_BinaryImages);
+    bsg_kscrw_i_writeBinaryImages(writer, BSG_KSCrashField_BinaryImages,
+                                  &referencedImages);
 }

--- a/Bugsnag/KSCrash/Source/KSCrash/Recording/BSG_KSSystemInfo.m
+++ b/Bugsnag/KSCrash/Source/KSCrash/Recording/BSG_KSSystemInfo.m
@@ -55,7 +55,7 @@ static inline bool is_jailbroken(void) {
         get_jailbreak_status(&is_jb);
 
         // Also keep using the old detection method.
-        if(bsg_mach_headers_image_named("MobileSubstrate", false) != NULL) {
+        if (bsg_mach_headers_image_named("MobileSubstrate", false, NULL)) {
             is_jb = true;
         }
         initialized_jb = true;
@@ -148,9 +148,9 @@ static NSDictionary * bsg_systemversion(void) {
  * @return The UUID.
  */
 + (NSString *)appUUID {
-    BSG_Mach_Header_Info *image = bsg_mach_headers_get_main_image();
-    if (image && image->uuid) {
-        return [[[NSUUID alloc] initWithUUIDBytes:image->uuid] UUIDString];
+    BSG_Mach_Header_Info image;
+    if (bsg_mach_headers_get_main_image(&image) && image.uuid) {
+        return [[[NSUUID alloc] initWithUUIDBytes:image.uuid] UUIDString];
     }
     return nil;
 }

--- a/Bugsnag/KSCrash/Source/KSCrash/Recording/Tools/BSG_KSMachHeaders.c
+++ b/Bugsnag/KSCrash/Source/KSCrash/Recording/Tools/BSG_KSMachHeaders.c
@@ -3,6 +3,7 @@
 //  Bugsnag
 //
 //  Created by Robin Macharg on 04/05/2020.
+//  Current implementation created by Alex Cohen on 30/08/2026.
 //  Copyright © 2020 Bugsnag. All rights reserved.
 //
 
@@ -11,260 +12,82 @@
 #include "BSG_KSLogger.h"
 #include "BSG_KSMach.h"
 
-#include <dispatch/dispatch.h>
 #include <dlfcn.h>
 #include <mach-o/dyld.h>
 #include <mach-o/dyld_images.h>
-#include <os/trace.h>
-#include <stdlib.h>
+#include <mach-o/loader.h>
+#include <mach/task.h>
+#include <stdatomic.h>
+#include <string.h>
+
+extern struct mach_header __dso_handle;
 
 // Copied from https://github.com/apple/swift/blob/swift-5.0-RELEASE/include/swift/Runtime/Debug.h#L28-L40
 
 #define CRASHREPORTER_ANNOTATIONS_VERSION 7
 #define CRASHREPORTER_ANNOTATIONS_SECTION "__crash_info"
 
-// TODO: Update after PLAT-15173
+// Large enough for all images in normal applications while keeping lookup
+// storage bounded and allocation-free in crash handlers.
+#define BSG_MACH_HEADERS_MAX_CACHE_ENTRIES 2048
+#define BSG_MACH_HEADERS_MAX_SEGMENTS_PER_IMAGE 16
+
 struct crashreporter_annotations_t {
-    uint64_t version;          // unsigned long
-    uint64_t message;          // char *
-    uint64_t signature_string; // char *
-    uint64_t backtrace;        // char *
-    uint64_t message2;         // char *
-    uint64_t thread;           // uint64_t
-    uint64_t dialog_mode;      // unsigned int
-    uint64_t abort_cause;      // unsigned int
+    uint64_t version;
+    uint64_t message;
+    uint64_t signature_string;
+    uint64_t backtrace;
+    uint64_t message2;
+    uint64_t thread;
+    uint64_t dialog_mode;
+    uint64_t abort_cause;
 };
 
-static void add_image(const struct mach_header *header, intptr_t slide);
-static void remove_image(const struct mach_header *header, intptr_t slide);
-static void register_dyld_images(void);
-static void register_for_changes(void);
-static intptr_t compute_slide(const struct mach_header *header);
-static bool contains_address(BSG_Mach_Header_Info *image, vm_address_t address);
-static const char * get_path(const struct mach_header *header);
+typedef struct {
+    uintptr_t start;
+    uintptr_t end;
+} BSG_Mach_Segment_Range;
 
-static const struct dyld_all_image_infos *g_all_image_infos;
+typedef struct {
+    uintptr_t startAddress;
+    uintptr_t endAddress;
+    BSG_Mach_Header_Info image;
+    BSG_Mach_Segment_Range segments[BSG_MACH_HEADERS_MAX_SEGMENTS_PER_IMAGE];
+    uint8_t segmentCount;
+} BSG_Mach_Image_Range;
 
-// MARK: - Mach Header Linked List
+typedef struct {
+    BSG_Mach_Image_Range entries[BSG_MACH_HEADERS_MAX_CACHE_ENTRIES];
+    uint32_t count;
+} BSG_Mach_Image_Cache;
 
-// The list head is implemented as a dummy entry to simplify the algorithm.
-// We fetch g_head_dummy.next to get the real head of the list.
-static BSG_Mach_Header_Info g_head_dummy;
-static _Atomic(BSG_Mach_Header_Info *) g_images_tail = &g_head_dummy;
-static BSG_Mach_Header_Info *g_self_image;
+static BSG_Mach_Image_Cache g_cache_storage;
+// NULL means another caller currently has exclusive access to the cache.
+static _Atomic(BSG_Mach_Image_Cache *) g_cache;
 
-static _Atomic(bool) is_mach_headers_initialized;
+// dyld owns this append-only array. New entries become visible only after
+// their contents are initialized, so readers can safely iterate a snapshot in
+// crash handlers. See https://github.com/kstenerud/KSCrash/pull/655.
+static _Atomic(struct dyld_all_image_infos *) g_all_image_infos;
+static _Atomic(bool) g_initialized;
+static dyld_image_notifier g_original_notifier;
 
-void bsg_mach_headers_initialize(void) {
-    bool expected = false;
-    if (!atomic_compare_exchange_strong(&is_mach_headers_initialized, &expected, true)) {
-        // Already called
-        return;
-    }
+static bool populate_cache_entry(const struct mach_header *header,
+                                 const char *name, BSG_Mach_Image_Range *entry);
+static bool address_in_segments(const BSG_Mach_Image_Range *entry,
+                                uintptr_t address);
+static int32_t find_cached_header(const BSG_Mach_Image_Cache *cache,
+                                  const struct mach_header *header);
+static void insert_cache_entry(BSG_Mach_Image_Cache *cache,
+                               const BSG_Mach_Image_Range *entry);
+static bool linear_scan_for_address(uintptr_t address,
+                                    BSG_Mach_Image_Range *entry);
+static const char *dyld_path(void);
 
-    register_dyld_images();
-    register_for_changes();
-}
-
-BSG_Mach_Header_Info *bsg_mach_headers_get_images(void) {
-    return atomic_load(&g_head_dummy.next);
-}
-
-BSG_Mach_Header_Info *bsg_mach_headers_get_main_image(void) {
-    for (BSG_Mach_Header_Info *img = bsg_mach_headers_get_images(); img != NULL; img = atomic_load(&img->next)) {
-        if (img->header->filetype == MH_EXECUTE) {
-            return img;
-        }
-    }
-    return NULL;
-}
-
-BSG_Mach_Header_Info *bsg_mach_headers_get_self_image(void) {
-    return g_self_image;
-}
-
-static void register_dyld_images(void) {
-    // /usr/lib/dyld's mach header is is not exposed via the _dyld APIs, so to be able to include information
-    // about stack frames in dyld`start (for example) we need to acess "_dyld_all_image_infos"
-    task_dyld_info_data_t dyld_info = {0};
-    mach_msg_type_number_t count = TASK_DYLD_INFO_COUNT;
-    kern_return_t kr = task_info(mach_task_self(), TASK_DYLD_INFO, (task_info_t)&dyld_info, &count);
-    if (kr == KERN_SUCCESS && dyld_info.all_image_info_addr) {
-        g_all_image_infos = (const void *)dyld_info.all_image_info_addr;
-
-        intptr_t dyldImageSlide = compute_slide(g_all_image_infos->dyldImageLoadAddress);
-        add_image(g_all_image_infos->dyldImageLoadAddress, dyldImageSlide);
-
-#if TARGET_OS_SIMULATOR
-        // Get the mach header for `dyld_sim` which is not exposed via the _dyld APIs
-        // Note: dladdr() returns `/usr/lib/dyld` as the dli_fname for this image :-?
-        if (g_all_image_infos->infoArray &&
-            strstr(g_all_image_infos->infoArray->imageFilePath, "/usr/lib/dyld_sim")) {
-            const struct mach_header *header = g_all_image_infos->infoArray->imageLoadAddress;
-            add_image(header, compute_slide(header));
-        }
-#endif
-    } else {
-        BSG_KSLOG_ERROR("task_info TASK_DYLD_INFO failed: %s", mach_error_string(kr));
-    }
-}
-
-static void register_for_changes(void) {
-    // Register for binary images being loaded and unloaded. dyld calls the add function once
-    // for each library that has already been loaded and then keeps this cache up-to-date
-    // with future changes
-    _dyld_register_func_for_add_image(&add_image);
-    _dyld_register_func_for_remove_image(&remove_image);
-}
-
-/**
- * Populate a Mach binary image info structure
- *
- * @param header The Mach binary image header
- *
- * @param info Encapsulated Binary Image info
- *
- * @returns a boolean indicating success
- */
-bool bsg_mach_headers_populate_info(const struct mach_header *header, intptr_t slide, BSG_Mach_Header_Info *info) {
-    
-    // Early exit conditions; this is not a valid/useful binary image
-    // 1. We can't find a sensible Mach command
-    uintptr_t cmdPtr = bsg_mach_headers_first_cmd_after_header(header);
-    if (cmdPtr == 0) {
-        BSG_KSLOG_ERROR("Invalid mach header @ %p", header);
-        return false;
-    }
-
-    // 2. The image doesn't have a name.  Note: running with a debugger attached causes this condition to match.
-    const char *imageName = get_path(header);
-    if (!imageName) {
-        BSG_KSLOG_ERROR("Could not find name for mach header @ %p", header);
-        return false;
-    }
-    
-    // Look for the TEXT segment to get the image size.
-    // Also look for a UUID command.
-    uint64_t imageSize = 0;
-    uint64_t imageVmAddr = 0;
-    uint8_t *uuid = NULL;
-
-    for (uint32_t iCmd = 0; iCmd < header->ncmds; iCmd++) {
-        struct load_command *loadCmd = (struct load_command *)cmdPtr;
-        switch (loadCmd->cmd) {
-        case LC_SEGMENT: {
-            struct segment_command *segCmd = (struct segment_command *)cmdPtr;
-            if (strcmp(segCmd->segname, SEG_TEXT) == 0) {
-                imageSize = segCmd->vmsize;
-                imageVmAddr = segCmd->vmaddr;
-            }
-            break;
-        }
-        case LC_SEGMENT_64: {
-            struct segment_command_64 *segCmd =
-                (struct segment_command_64 *)cmdPtr;
-            if (strcmp(segCmd->segname, SEG_TEXT) == 0) {
-                imageSize = segCmd->vmsize;
-                imageVmAddr = segCmd->vmaddr;
-            }
-            break;
-        }
-        case LC_UUID: {
-            struct uuid_command *uuidCmd = (struct uuid_command *)cmdPtr;
-            uuid = uuidCmd->uuid;
-            break;
-        }
-        }
-        cmdPtr += loadCmd->cmdsize;
-    }
-    
-    // Sanity checks that should never fail
-    if (((uintptr_t)imageVmAddr + (uintptr_t)slide) != (uintptr_t)header) {
-        BSG_KSLOG_ERROR("Mach header != (vmaddr + slide) for %s; symbolication will be compromised.", imageName);
-    }
-    
-    info->header = header;
-    info->imageSize = imageSize;
-    info->imageVmAddr = imageVmAddr;
-    info->uuid = uuid;
-    info->name = imageName;
-    info->slide = slide;
-    info->unloaded = FALSE;
-    atomic_store(&info->next, NULL);
-    
-    return true;
-}
-
-static void add_image(const struct mach_header *header, intptr_t slide) {
-    BSG_Mach_Header_Info *newImage = calloc(1, sizeof(BSG_Mach_Header_Info));
-    if (newImage == NULL) {
-        return;
-    }
-
-    if (!bsg_mach_headers_populate_info(header, slide, newImage)) {
-        free(newImage);
-        return;
-    }
-
-    BSG_Mach_Header_Info *oldTail = atomic_exchange(&g_images_tail, newImage);
-    atomic_store(&oldTail->next, newImage);
-
-    if (header == &__dso_handle) {
-        g_self_image = newImage;
-    }
-}
-
-static void remove_image(const struct mach_header *header, intptr_t slide) {
-    BSG_Mach_Header_Info existingImage = { 0 };
-    if (!bsg_mach_headers_populate_info(header, slide, &existingImage)) {
-        return;
-    }
-
-    for (BSG_Mach_Header_Info *img = bsg_mach_headers_get_images(); img != NULL; img = atomic_load(&img->next)) {
-        if (img->imageVmAddr == existingImage.imageVmAddr) {
-            // To avoid a destructive operation that could lead thread safety problems,
-            // we maintain the image record, but mark it as unloaded
-            img->unloaded = true;
-        }
-    }
-}
-
-BSG_Mach_Header_Info *bsg_mach_headers_image_named(const char *const imageName, bool exactMatch) {
-        
-    if (imageName != NULL) {
-        
-        for (BSG_Mach_Header_Info *img = bsg_mach_headers_get_images(); img != NULL; img = atomic_load(&img->next)) {
-            if (img->name == NULL) {
-                continue; // name is null if the index is out of range per dyld(3)
-            } else if (img->unloaded == true) {
-                continue; // ignore unloaded libraries
-            } else if (exactMatch) {
-                if (strcmp(img->name, imageName) == 0) {
-                    return img;
-                }
-            } else {
-                if (strstr(img->name, imageName) != NULL) {
-                    return img;
-                }
-            }
-        }
-    }
-    
-    return NULL;
-}
-
-BSG_Mach_Header_Info *bsg_mach_headers_image_at_address(const uintptr_t address) {
-    for (BSG_Mach_Header_Info *img = bsg_mach_headers_get_images(); img; img = atomic_load(&img->next)) {
-        if (contains_address(img, address)) {
-            return img;
-        }
-    }
-    return NULL;
-}
-
-uintptr_t bsg_mach_headers_first_cmd_after_header(const struct mach_header *const header) {
+uintptr_t bsg_mach_headers_first_cmd_after_header(
+    const struct mach_header *const header) {
     if (header == NULL) {
-      return 0;
+        return 0;
     }
     switch (header->magic) {
     case MH_MAGIC:
@@ -274,18 +97,464 @@ uintptr_t bsg_mach_headers_first_cmd_after_header(const struct mach_header *cons
     case MH_CIGAM_64:
         return (uintptr_t)(((const struct mach_header_64 *)header) + 1);
     default:
-        // Header is corrupt
         return 0;
     }
 }
 
-static uintptr_t bsg_mach_header_info_get_section_addr_named(const BSG_Mach_Header_Info *header, const char *name) {
+static bool populate_cache_entry(const struct mach_header *header,
+                                 const char *name,
+                                 BSG_Mach_Image_Range *entry) {
+    *entry = (BSG_Mach_Image_Range){.image = {
+                                        .header = header,
+                                        .name = name,
+                                    }};
+
+    uintptr_t cmdPtr = bsg_mach_headers_first_cmd_after_header(header);
+    if (cmdPtr == 0) {
+        BSG_KSLOG_ERROR("Invalid mach header @ %p", header);
+        return false;
+    }
+
+    uint64_t minAddress = UINT64_MAX;
+    uint64_t maxAddress = 0;
+    uint8_t segmentCount = 0;
+    bool foundText = false;
+
+    for (uint32_t iCmd = 0; iCmd < header->ncmds; iCmd++) {
+        const struct load_command *loadCmd = (const void *)cmdPtr;
+        if (loadCmd->cmdsize < sizeof(*loadCmd)) {
+            BSG_KSLOG_ERROR("Invalid mach load command @ %p", loadCmd);
+            return false;
+        }
+
+        uint64_t vmaddr = 0;
+        uint64_t vmsize = 0;
+        uint64_t filesize = 0;
+        const char *segname = NULL;
+
+        switch (loadCmd->cmd) {
+        case LC_SEGMENT: {
+            const struct segment_command *segment = (const void *)loadCmd;
+            vmaddr = segment->vmaddr;
+            vmsize = segment->vmsize;
+            filesize = segment->filesize;
+            segname = segment->segname;
+            break;
+        }
+        case LC_SEGMENT_64: {
+            const struct segment_command_64 *segment = (const void *)loadCmd;
+            vmaddr = segment->vmaddr;
+            vmsize = segment->vmsize;
+            filesize = segment->filesize;
+            segname = segment->segname;
+            break;
+        }
+        case LC_UUID: {
+            const struct uuid_command *uuidCommand = (const void *)loadCmd;
+            entry->image.uuid = uuidCommand->uuid;
+            break;
+        }
+        default:
+            break;
+        }
+
+        if (segname != NULL) {
+            if (strncmp(segname, SEG_TEXT,
+                        sizeof(((struct segment_command *)0)->segname)) == 0) {
+                entry->image.imageVmAddr = vmaddr;
+                entry->image.imageSize = vmsize;
+                entry->image.slide = (intptr_t)header - (intptr_t)vmaddr;
+                foundText = true;
+            }
+
+            // Exclude __PAGEZERO and other segments with no file-backed
+            // content.
+            if (vmsize > 0 && filesize > 0) {
+                if (vmaddr < minAddress) {
+                    minAddress = vmaddr;
+                }
+                if (vmaddr + vmsize > maxAddress) {
+                    maxAddress = vmaddr + vmsize;
+                }
+                if (segmentCount < BSG_MACH_HEADERS_MAX_SEGMENTS_PER_IMAGE) {
+                    entry->segments[segmentCount++] = (BSG_Mach_Segment_Range){
+                        .start = (uintptr_t)vmaddr,
+                        .end = (uintptr_t)(vmaddr + vmsize),
+                    };
+                }
+            }
+        }
+        cmdPtr += loadCmd->cmdsize;
+    }
+
+    if (!foundText || segmentCount == 0) {
+        return false;
+    }
+
+    uintptr_t slide = (uintptr_t)entry->image.slide;
+    for (uint8_t i = 0; i < segmentCount; i++) {
+        entry->segments[i].start += slide;
+        entry->segments[i].end += slide;
+    }
+    entry->startAddress = (uintptr_t)minAddress + slide;
+    entry->endAddress = (uintptr_t)maxAddress + slide;
+    entry->segmentCount = segmentCount;
+    return true;
+}
+
+static bool address_in_segments(const BSG_Mach_Image_Range *entry,
+                                uintptr_t address) {
+    for (uint8_t i = 0; i < entry->segmentCount; i++) {
+        if (address >= entry->segments[i].start &&
+            address < entry->segments[i].end) {
+            return true;
+        }
+    }
+    return false;
+}
+
+static int32_t binary_search_cache(const BSG_Mach_Image_Cache *cache,
+                                   uintptr_t address) {
+    int32_t left = 0;
+    int32_t right = (int32_t)cache->count - 1;
+    int32_t result = -1;
+    while (left <= right) {
+        int32_t middle = left + (right - left) / 2;
+        if (cache->entries[middle].startAddress <= address) {
+            result = middle;
+            left = middle + 1;
+        } else {
+            right = middle - 1;
+        }
+    }
+    return result;
+}
+
+static int32_t find_cached_header(const BSG_Mach_Image_Cache *cache,
+                                  const struct mach_header *header) {
+    for (uint32_t i = 0; i < cache->count; i++) {
+        if (cache->entries[i].image.header == header) {
+            return (int32_t)i;
+        }
+    }
+    return -1;
+}
+
+static void insert_cache_entry(BSG_Mach_Image_Cache *cache,
+                               const BSG_Mach_Image_Range *entry) {
+    if (cache->count >= BSG_MACH_HEADERS_MAX_CACHE_ENTRIES ||
+        find_cached_header(cache, entry->image.header) >= 0) {
+        return;
+    }
+
+    uint32_t insertionIndex = 0;
+    while (insertionIndex < cache->count &&
+           cache->entries[insertionIndex].startAddress < entry->startAddress) {
+        insertionIndex++;
+    }
+    for (uint32_t i = cache->count; i > insertionIndex; i--) {
+        cache->entries[i] = cache->entries[i - 1];
+    }
+    cache->entries[insertionIndex] = *entry;
+    cache->count++;
+}
+
+const BSG_Dyld_Image_Info *bsg_mach_headers_get_images(uint32_t *count) {
+    if (count != NULL) {
+        *count = 0;
+    }
+    struct dyld_all_image_infos *allInfo =
+        atomic_load_explicit(&g_all_image_infos, memory_order_relaxed);
+    if (allInfo == NULL || allInfo->infoArray == NULL) {
+        return NULL;
+    }
+    const struct dyld_image_info *images = allInfo->infoArray;
+    if (count != NULL) {
+        *count = allInfo->infoArrayCount;
+    }
+    return images;
+}
+
+static const char *dyld_path(void) {
+    struct dyld_all_image_infos *allInfo =
+        atomic_load_explicit(&g_all_image_infos, memory_order_relaxed);
+    // dyldPath was added in version 15 (macOS 10.12 and iOS 10.0).
+    return allInfo != NULL && allInfo->version >= 15 &&
+                   allInfo->dyldPath != NULL
+               ? allInfo->dyldPath
+               : "/usr/lib/dyld";
+}
+
+bool bsg_mach_headers_image_for_header(const struct mach_header *header,
+                                       const char *name,
+                                       BSG_Mach_Header_Info *image) {
+    if (image == NULL) {
+        return false;
+    }
+    BSG_Mach_Image_Range entry;
+    if (!populate_cache_entry(header, name, &entry)) {
+        return false;
+    }
+    *image = entry.image;
+    return true;
+}
+
+static bool cached_image_for_header(const struct mach_header *header,
+                                    BSG_Mach_Header_Info *image) {
+    BSG_Mach_Image_Cache *cache = atomic_exchange(&g_cache, NULL);
+    if (cache == NULL) {
+        return false;
+    }
+    int32_t index = find_cached_header(cache, header);
+    if (index >= 0) {
+        *image = cache->entries[index].image;
+    }
+    atomic_store(&g_cache, cache);
+    return index >= 0;
+}
+
+bool bsg_mach_headers_get_main_image(BSG_Mach_Header_Info *image) {
+    if (image == NULL) {
+        return false;
+    }
+    const struct mach_header *mainHeader = _dyld_get_image_header(0);
+    if (mainHeader != NULL && mainHeader->filetype == MH_EXECUTE) {
+        if (cached_image_for_header(mainHeader, image)) {
+            return true;
+        }
+        if (bsg_mach_headers_image_for_header(mainHeader,
+                                              _dyld_get_image_name(0), image)) {
+            return true;
+        }
+    }
+
+    // Fall back to a filetype search for unusual dyld implementations.
+    uint32_t count = 0;
+    const BSG_Dyld_Image_Info *images = bsg_mach_headers_get_images(&count);
+    for (uint32_t i = 0; i < count; i++) {
+        const struct mach_header *header = images[i].imageLoadAddress;
+        if (header != NULL && header->filetype == MH_EXECUTE) {
+            if (cached_image_for_header(header, image)) {
+                return true;
+            }
+            return bsg_mach_headers_image_for_header(
+                header, images[i].imageFilePath, image);
+        }
+    }
+    return false;
+}
+
+bool bsg_mach_headers_get_self_image(BSG_Mach_Header_Info *image) {
+    if (image == NULL) {
+        return false;
+    }
+    const struct mach_header *header = &__dso_handle;
+    if (cached_image_for_header(header, image)) {
+        return true;
+    }
+
+    uint32_t count = 0;
+    const BSG_Dyld_Image_Info *images = bsg_mach_headers_get_images(&count);
+    for (uint32_t i = 0; i < count; i++) {
+        if (images[i].imageLoadAddress == header) {
+            return bsg_mach_headers_image_for_header(
+                header, images[i].imageFilePath, image);
+        }
+    }
+    return false;
+}
+
+bool bsg_mach_headers_get_dyld_image(BSG_Mach_Header_Info *image) {
+    if (image == NULL) {
+        return false;
+    }
+    struct dyld_all_image_infos *allInfo =
+        atomic_load_explicit(&g_all_image_infos, memory_order_relaxed);
+    if (allInfo == NULL || allInfo->dyldImageLoadAddress == NULL) {
+        return false;
+    }
+    if (cached_image_for_header(allInfo->dyldImageLoadAddress, image)) {
+        return true;
+    }
+    return bsg_mach_headers_image_for_header(allInfo->dyldImageLoadAddress,
+                                             dyld_path(), image);
+}
+
+bool bsg_mach_headers_image_named(const char *imageName, bool exactMatch,
+                                  BSG_Mach_Header_Info *image) {
+    if (imageName == NULL) {
+        return false;
+    }
+    uint32_t count = 0;
+    const BSG_Dyld_Image_Info *images = bsg_mach_headers_get_images(&count);
+    for (uint32_t i = 0; i < count; i++) {
+        const char *name = images[i].imageFilePath;
+        if (name != NULL &&
+            ((exactMatch && strcmp(name, imageName) == 0) ||
+             (!exactMatch && strstr(name, imageName) != NULL))) {
+            return image == NULL ||
+                   bsg_mach_headers_image_for_header(images[i].imageLoadAddress,
+                                                     name, image);
+        }
+    }
+    const char *name = dyld_path();
+    if ((exactMatch && strcmp(name, imageName) == 0) ||
+        (!exactMatch && strstr(name, imageName) != NULL)) {
+        return image == NULL || bsg_mach_headers_get_dyld_image(image);
+    }
+    return false;
+}
+
+static bool linear_scan_for_address(uintptr_t address,
+                                    BSG_Mach_Image_Range *entry) {
+    uint32_t count = 0;
+    const BSG_Dyld_Image_Info *images = bsg_mach_headers_get_images(&count);
+    for (uint32_t i = 0; i < count; i++) {
+        BSG_Mach_Image_Range candidate;
+        if (populate_cache_entry(images[i].imageLoadAddress,
+                                 images[i].imageFilePath, &candidate) &&
+            address_in_segments(&candidate, address)) {
+            *entry = candidate;
+            return true;
+        }
+    }
+
+    struct dyld_all_image_infos *allInfo =
+        atomic_load_explicit(&g_all_image_infos, memory_order_relaxed);
+    BSG_Mach_Image_Range candidate;
+    if (allInfo != NULL && allInfo->dyldImageLoadAddress != NULL &&
+        populate_cache_entry(allInfo->dyldImageLoadAddress, dyld_path(),
+                             &candidate) &&
+        address_in_segments(&candidate, address)) {
+        *entry = candidate;
+        return true;
+    }
+    return false;
+}
+
+bool bsg_mach_headers_image_at_address(uintptr_t address,
+                                       BSG_Mach_Header_Info *image) {
+    if (image == NULL) {
+        return false;
+    }
+    BSG_Mach_Image_Cache *cache = atomic_exchange(&g_cache, NULL);
+    if (cache != NULL) {
+        for (int32_t i = binary_search_cache(cache, address); i >= 0; i--) {
+            BSG_Mach_Image_Range *entry = &cache->entries[i];
+            if (address >= entry->startAddress && address < entry->endAddress &&
+                address_in_segments(entry, address)) {
+                *image = entry->image;
+                atomic_store(&g_cache, cache);
+                return true;
+            }
+        }
+
+        BSG_Mach_Image_Range entry;
+        bool found = linear_scan_for_address(address, &entry);
+        if (found) {
+            *image = entry.image;
+            insert_cache_entry(cache, &entry);
+        }
+        atomic_store(&g_cache, cache);
+        return found;
+    }
+
+    BSG_Mach_Image_Range entry;
+    if (linear_scan_for_address(address, &entry)) {
+        *image = entry.image;
+        return true;
+    }
+    return false;
+}
+
+static void image_notifier(enum dyld_image_mode mode, uint32_t infoCount,
+                           const struct dyld_image_info info[]) {
+    if (mode == dyld_image_adding) {
+        BSG_Mach_Image_Cache *cache = atomic_exchange(&g_cache, NULL);
+        if (cache != NULL) {
+            for (uint32_t i = 0;
+                 i < infoCount &&
+                 cache->count < BSG_MACH_HEADERS_MAX_CACHE_ENTRIES;
+                 i++) {
+                BSG_Mach_Image_Range entry;
+                if (populate_cache_entry(info[i].imageLoadAddress,
+                                         info[i].imageFilePath, &entry)) {
+                    insert_cache_entry(cache, &entry);
+                }
+            }
+            atomic_store(&g_cache, cache);
+        }
+    }
+
+    if (g_original_notifier != NULL) {
+        g_original_notifier(mode, infoCount, info);
+    }
+}
+
+void bsg_mach_headers_initialize(void) {
+    bool expected = false;
+    if (!atomic_compare_exchange_strong(&g_initialized, &expected, true)) {
+        return;
+    }
+
+    struct task_dyld_info dyldInfo = {0};
+    mach_msg_type_number_t count = TASK_DYLD_INFO_COUNT;
+    kern_return_t result = task_info(mach_task_self(), TASK_DYLD_INFO,
+                                     (task_info_t)&dyldInfo, &count);
+    if (result != KERN_SUCCESS || dyldInfo.all_image_info_addr == 0) {
+        BSG_KSLOG_ERROR("task_info TASK_DYLD_INFO failed: %s",
+                        mach_error_string(result));
+        return;
+    }
+
+    struct dyld_all_image_infos *allInfo = (void *)dyldInfo.all_image_info_addr;
+    atomic_store_explicit(&g_all_image_infos, allInfo, memory_order_relaxed);
+    g_cache_storage.count = 0;
+
+    const struct mach_header *mainHeader = _dyld_get_image_header(0);
+    if (mainHeader != NULL) {
+        BSG_Mach_Image_Range entry;
+        if (populate_cache_entry(mainHeader, _dyld_get_image_name(0), &entry)) {
+            insert_cache_entry(&g_cache_storage, &entry);
+        }
+    }
+
+    if (allInfo->dyldImageLoadAddress != NULL) {
+        BSG_Mach_Image_Range entry;
+        if (populate_cache_entry(allInfo->dyldImageLoadAddress, dyld_path(),
+                                 &entry)) {
+            insert_cache_entry(&g_cache_storage, &entry);
+        }
+    }
+
+    // Cache Bugsnag itself without replaying callbacks for all loaded images.
+    Dl_info selfInfo = {0};
+    const struct mach_header *selfHeader = &__dso_handle;
+    dladdr(selfHeader, &selfInfo);
+    BSG_Mach_Image_Range selfEntry;
+    if (populate_cache_entry(selfHeader, selfInfo.dli_fname, &selfEntry)) {
+        insert_cache_entry(&g_cache_storage, &selfEntry);
+    }
+
+    atomic_store(&g_cache, &g_cache_storage);
+
+    // Unlike _dyld_register_func_for_add_image, installing this notifier does
+    // not synchronously replay every image that is already loaded.
+    if (allInfo->notification != image_notifier) {
+        g_original_notifier = allInfo->notification;
+        allInfo->notification = image_notifier;
+    }
+}
+
+static uintptr_t
+bsg_mach_header_info_get_section_addr_named(const BSG_Mach_Header_Info *header,
+                                            const char *name) {
     uintptr_t cmdPtr = bsg_mach_headers_first_cmd_after_header(header->header);
     if (!cmdPtr) {
         return 0;
     }
     for (uint32_t i = 0; i < header->header->ncmds; i++) {
-        const struct load_command *loadCmd = (struct load_command *)cmdPtr;
+        const struct load_command *loadCmd = (void *)cmdPtr;
         if (loadCmd->cmd == LC_SEGMENT) {
             const struct segment_command *segment = (void *)cmdPtr;
             char *sectionPtr = (void *)(cmdPtr + sizeof(*segment));
@@ -312,112 +581,53 @@ static uintptr_t bsg_mach_header_info_get_section_addr_named(const BSG_Mach_Head
     return 0;
 }
 
-const char *bsg_mach_headers_get_crash_info_message(const BSG_Mach_Header_Info *header) {
+const char *
+bsg_mach_headers_get_crash_info_message(const BSG_Mach_Header_Info *header) {
     struct crashreporter_annotations_t info;
-    uintptr_t sectionAddress = bsg_mach_header_info_get_section_addr_named(header, CRASHREPORTER_ANNOTATIONS_SECTION);
+    uintptr_t sectionAddress = bsg_mach_header_info_get_section_addr_named(
+        header, CRASHREPORTER_ANNOTATIONS_SECTION);
     if (!sectionAddress) {
         return NULL;
     }
-    if (bsg_ksmachcopyMem((void *)sectionAddress, &info, sizeof(info)) != KERN_SUCCESS) {
+    if (bsg_ksmachcopyMem((void *)sectionAddress, &info, sizeof(info)) !=
+        KERN_SUCCESS) {
         return NULL;
     }
-    // Version 4 was in use until iOS 9 / Swift 2.0 when the version was bumped to 5.
-    if (info.version > CRASHREPORTER_ANNOTATIONS_VERSION) {
+    if (info.version > CRASHREPORTER_ANNOTATIONS_VERSION || !info.message) {
         return NULL;
     }
-    if (!info.message) {
-        return NULL;
-    }
-    // Probe the string to ensure it's safe to read.
     for (uintptr_t i = 0; i < 500; i++) {
         char c;
-        if (bsg_ksmachcopyMem((void *)(info.message + i), &c, sizeof(c)) != KERN_SUCCESS) {
-            // String is not readable.
+        if (bsg_ksmachcopyMem((void *)(info.message + i), &c, sizeof(c)) !=
+            KERN_SUCCESS) {
             return NULL;
         }
         if (c == '\0') {
-            // Found end of string.
             return (const char *)info.message;
         }
     }
     return NULL;
 }
 
-static intptr_t compute_slide(const struct mach_header *header) {
-    uintptr_t cmdPtr = bsg_mach_headers_first_cmd_after_header(header);
-    if (!cmdPtr) {
+void bsg_test_support_mach_headers_reset(void) {
+    struct dyld_all_image_infos *allInfo =
+        atomic_load_explicit(&g_all_image_infos, memory_order_relaxed);
+    if (allInfo != NULL && allInfo->notification == image_notifier) {
+        allInfo->notification = g_original_notifier;
+    }
+    g_original_notifier = NULL;
+    atomic_store_explicit(&g_all_image_infos, NULL, memory_order_relaxed);
+    atomic_store(&g_cache, NULL);
+    g_cache_storage.count = 0;
+    atomic_store(&g_initialized, false);
+}
+
+uint32_t bsg_test_support_mach_headers_cached_image_count(void) {
+    BSG_Mach_Image_Cache *cache = atomic_exchange(&g_cache, NULL);
+    if (cache == NULL) {
         return 0;
     }
-    for (uint32_t iCmd = 0; iCmd < header->ncmds; iCmd++) {
-        struct load_command *loadCmd = (void *)cmdPtr;
-        switch (loadCmd->cmd) {
-            case LC_SEGMENT: {
-                struct segment_command *segCmd = (void *)cmdPtr;
-                if (strcmp(segCmd->segname, SEG_TEXT) == 0) {
-                    return (intptr_t)header - (intptr_t)segCmd->vmaddr;
-                }
-            }
-            case LC_SEGMENT_64: {
-                struct segment_command_64 *segCmd = (void *)cmdPtr;
-                if (strcmp(segCmd->segname, SEG_TEXT) == 0) {
-                    return (intptr_t)header - (intptr_t)segCmd->vmaddr;
-                }
-            }
-        }
-        cmdPtr += loadCmd->cmdsize;
-    }
-    return 0;
-}
-
-static bool contains_address(BSG_Mach_Header_Info *img, vm_address_t address) {
-    if (img->unloaded) {
-        return false;
-    }
-    vm_address_t imageStart = (vm_address_t)img->header;
-    return address >= imageStart && address < (imageStart + img->imageSize);
-}
-
-static const char * get_path(const struct mach_header *header) {
-    Dl_info DlInfo = {0};
-    dladdr(header, &DlInfo);
-    if (DlInfo.dli_fname) {
-        return DlInfo.dli_fname;
-    }
-    if (g_all_image_infos &&
-        header == g_all_image_infos->dyldImageLoadAddress) {
-        return g_all_image_infos->dyldPath;
-    }
-#if TARGET_OS_SIMULATOR
-    if (g_all_image_infos &&
-        g_all_image_infos->infoArray &&
-        header == g_all_image_infos->infoArray[0].imageLoadAddress) {
-        return g_all_image_infos->infoArray[0].imageFilePath;
-    }
-#endif
-    return NULL;
-}
-
-void bsg_test_support_mach_headers_reset(void) {
-    // Erase all current images
-    BSG_Mach_Header_Info *next = NULL;
-    for (BSG_Mach_Header_Info *img = bsg_mach_headers_get_images(); img != NULL; img = next) {
-        next = atomic_load(&img->next);
-        free(img);
-    }
-
-    // Reset cached data
-    atomic_store(&g_head_dummy.next, NULL);
-    atomic_store(&g_images_tail, &g_head_dummy);
-    g_self_image = NULL;
-
-    // Force bsg_mach_headers_initialize to run again when requested.
-    atomic_store(&is_mach_headers_initialized, false);
-}
-
-void bsg_test_support_mach_headers_add_image(const struct mach_header *header, intptr_t slide) {
-    add_image(header, slide);
-}
-
-void bsg_test_support_mach_headers_remove_image(const struct mach_header *header, intptr_t slide) {
-    remove_image(header, slide);
+    uint32_t count = cache->count;
+    atomic_store(&g_cache, cache);
+    return count;
 }

--- a/Bugsnag/KSCrash/Source/KSCrash/Recording/Tools/BSG_KSMachHeaders.c
+++ b/Bugsnag/KSCrash/Source/KSCrash/Recording/Tools/BSG_KSMachHeaders.c
@@ -313,6 +313,29 @@ static bool cached_image_for_header(const struct mach_header *header,
     return index >= 0;
 }
 
+static bool cached_image_named(const char *imageName,
+                               BSG_Mach_Header_Info *image) {
+    BSG_Mach_Image_Cache *cache = atomic_exchange(&g_cache, NULL);
+    if (cache == NULL) {
+        return false;
+    }
+
+    bool found = false;
+    for (uint32_t i = 0; i < cache->count; i++) {
+        const char *cachedName = cache->entries[i].image.name;
+        if (cachedName != NULL && strcmp(cachedName, imageName) == 0) {
+            if (image != NULL) {
+                *image = cache->entries[i].image;
+            }
+            found = true;
+            break;
+        }
+    }
+
+    atomic_store(&g_cache, cache);
+    return found;
+}
+
 bool bsg_mach_headers_get_main_image(BSG_Mach_Header_Info *image) {
     if (image == NULL) {
         return false;
@@ -384,6 +407,12 @@ bool bsg_mach_headers_image_named(const char *imageName, bool exactMatch,
                                   BSG_Mach_Header_Info *image) {
     if (imageName == NULL) {
         return false;
+    }
+    // Getters may return a canonical name that differs from dyld's live path
+    // for the same image (for example /tmp versus /private/tmp). Honor names
+    // already returned by this module before consulting the live image list.
+    if (exactMatch && cached_image_named(imageName, image)) {
+        return true;
     }
     uint32_t count = 0;
     const BSG_Dyld_Image_Info *images = bsg_mach_headers_get_images(&count);

--- a/Bugsnag/KSCrash/Source/KSCrash/Recording/Tools/BSG_KSMachHeaders.c
+++ b/Bugsnag/KSCrash/Source/KSCrash/Recording/Tools/BSG_KSMachHeaders.c
@@ -3,7 +3,6 @@
 //  Bugsnag
 //
 //  Created by Robin Macharg on 04/05/2020.
-//  Current implementation created by Alex Cohen on 30/08/2026.
 //  Copyright © 2020 Bugsnag. All rights reserved.
 //
 

--- a/Bugsnag/KSCrash/Source/KSCrash/Recording/Tools/BSG_KSMachHeaders.h
+++ b/Bugsnag/KSCrash/Source/KSCrash/Recording/Tools/BSG_KSMachHeaders.h
@@ -3,6 +3,7 @@
 //  Bugsnag
 //
 //  Created by Robin Macharg on 04/05/2020.
+//  Current implementation created by Alex Cohen on 30/08/2026.
 //  Copyright © 2020 Bugsnag. All rights reserved.
 //
 
@@ -11,120 +12,88 @@
 
 #include <stdbool.h>
 #include <stdint.h>
-#include <stdatomic.h>
 
-/* Maintaining our own list of framework Mach headers means that we avoid potential
- * deadlock situations where we try and suspend lock-holding threads prior to
- * loading mach headers as part of our normal event handling behaviour.
- */
+struct dyld_image_info;
+struct mach_header;
 
-/**
- * An encapsulation of the Mach header data as a linked list - either 64 or 32 bit, along with some additiona
- * information required for detailing a crash report's binary images.
- */
+/** An image entry supplied by dyld. */
+typedef struct dyld_image_info BSG_Dyld_Image_Info;
+
+/** Information required to symbolicate an address and describe its binary
+ * image. */
 typedef struct bsg_mach_image {
-
-    /// The mach_header or mach_header_64
+    /// The mach_header or mach_header_64.
     ///
-    /// This is also the memory address where the __TEXT segment has been loaded by dyld, including slide.
+    /// This is also the address where the __TEXT segment was loaded by dyld,
+    /// including its slide.
     const struct mach_header *header;
 
-    /// The vmaddr specified for the __TEXT segment
-    ///
-    /// This is the load address specified at build time, and does not account for slide applied by dyld.
+    /// The vmaddr specified for the __TEXT segment.
     uint64_t imageVmAddr;
 
-    /// The vmsize of the __TEXT segment
+    /// The vmsize of the __TEXT segment.
     uint64_t imageSize;
 
-    /// A UUID that uniquely identifies this image, used to identify its associated dSYM
+    /// The image UUID used to identify its associated dSYM.
     const uint8_t *uuid;
 
-    /// The pathname of the shared object (Dl_info.dli_fname)
-    const char* name;
+    /// The pathname of the image.
+    const char *name;
 
-    /// The virtual memory address slide of the image
+    /// The virtual memory address slide of the image.
     intptr_t slide;
-
-    /// True if the image has been unloaded and should be ignored
-    bool unloaded;
-    
-    /// True if the image is referenced by the current crash report.
-    bool inCrashReport;
-
-    /// The next image in the linked list
-    _Atomic(struct bsg_mach_image *) next;
 } BSG_Mach_Header_Info;
 
 // MARK: - Operations
 
 /**
- * Initialize the headers management system.
+ * Initialize Mach image access and the bounded address lookup cache.
  * This MUST be called before calling anything else.
  */
 void bsg_mach_headers_initialize(void);
 
 /**
- * Returns the head of the link list of headers
+ * Return dyld's live array of loaded images and place its current count in
+ * `count`. dyld itself is not included in this array.
  */
-BSG_Mach_Header_Info *bsg_mach_headers_get_images(void);
+const BSG_Dyld_Image_Info *bsg_mach_headers_get_images(uint32_t *count);
+
+/** Copy information about the process's main image into `image`. */
+bool bsg_mach_headers_get_main_image(BSG_Mach_Header_Info *image);
+
+/** Copy information about the image that contains Bugsnag into `image`. */
+bool bsg_mach_headers_get_self_image(BSG_Mach_Header_Info *image);
+
+/** Copy information about dyld into `image`. */
+bool bsg_mach_headers_get_dyld_image(BSG_Mach_Header_Info *image);
 
 /**
- * Returns the process's main image
+ * Populate `image` for a known header and path. This does not add the image to
+ * the address lookup cache.
  */
-BSG_Mach_Header_Info *bsg_mach_headers_get_main_image(void);
+bool bsg_mach_headers_image_for_header(const struct mach_header *header,
+                                       const char *name,
+                                       BSG_Mach_Header_Info *image);
 
-/**
- * Returns the image that contains KSCrash.
+/** Find the loaded binary image containing `address` and copy it into `image`.
  */
-BSG_Mach_Header_Info *bsg_mach_headers_get_self_image(void);
+bool bsg_mach_headers_image_at_address(uintptr_t address,
+                                       BSG_Mach_Header_Info *image);
 
-/**
- * Find the loaded binary image that contains the specified instruction address.
-*/
-BSG_Mach_Header_Info *bsg_mach_headers_image_at_address(const uintptr_t address);
+/** Find a loaded image whose path matches `imageName`. */
+bool bsg_mach_headers_image_named(const char *imageName, bool exactMatch,
+                                  BSG_Mach_Header_Info *image);
 
-
-/** Find a loaded binary image with the specified name.
- *
- * @param imageName The image name to look for.
- *
- * @param exactMatch If true, look for an exact match instead of a partial one.
- *
- * @return the matched image, or NULL if not found.
- */
-BSG_Mach_Header_Info *bsg_mach_headers_image_named(const char *const imageName, bool exactMatch);
-
-/** Get the address of the first command following a header (which will be of
- * type struct load_command).
- *
- * @param header The header to get commands for.
- *
- * @return The address of the first command, or NULL if none was found (which
- *         should not happen unless the header or image is corrupt).
- */
+/** Get the address of the first load command following a Mach header. */
 uintptr_t bsg_mach_headers_first_cmd_after_header(const struct mach_header *header);
 
-/** Get the __crash_info message of the specified image.
- *
- * @param header The header to get commands for.
- * @return The __crash_info message, or NULL if no readable message could be found.
- */
+/** Get the __crash_info message of the specified image. */
 const char *bsg_mach_headers_get_crash_info_message(const BSG_Mach_Header_Info *header);
 
-/**
- * Resets mach header data (for unit tests).
- */
+/** Reset Mach header data for unit tests. */
 void bsg_test_support_mach_headers_reset(void);
 
-/**
- * Add a binary image (for unit tests).
- */
-void bsg_test_support_mach_headers_add_image(const struct mach_header *mh, intptr_t slide);
-
-/**
- * Remove a binary image (for unit tests).
- */
-void bsg_test_support_mach_headers_remove_image(const struct mach_header *mh, intptr_t slide);
+/** Return the number of address ranges currently cached, for unit tests. */
+uint32_t bsg_test_support_mach_headers_cached_image_count(void);
 
 #endif /* BSG_KSMachHeaders_h */

--- a/Bugsnag/KSCrash/Source/KSCrash/Recording/Tools/BSG_KSMachHeaders.h
+++ b/Bugsnag/KSCrash/Source/KSCrash/Recording/Tools/BSG_KSMachHeaders.h
@@ -3,7 +3,6 @@
 //  Bugsnag
 //
 //  Created by Robin Macharg on 04/05/2020.
-//  Current implementation created by Alex Cohen on 30/08/2026.
 //  Copyright © 2020 Bugsnag. All rights reserved.
 //
 

--- a/Bugsnag/KSCrash/Source/KSCrash/Recording/Tools/BSG_Symbolicate.c
+++ b/Bugsnag/KSCrash/Source/KSCrash/Recording/Tools/BSG_Symbolicate.c
@@ -49,26 +49,29 @@ __attribute__((annotate("oclint:suppress[deep nested block]")))
 #endif
 void bsg_symbolicate(const uintptr_t instruction_addr, struct bsg_symbolicate_result *result) {
     bzero(result, sizeof(*result));
-    
-    struct bsg_mach_image *image = bsg_mach_headers_image_at_address(instruction_addr);
-    if (!image || !image->header) {
+
+    BSG_Mach_Header_Info image;
+    if (!bsg_mach_headers_image_at_address(instruction_addr, &image) ||
+        !image.header) {
         return;
     }
-    
-    const struct load_command *load_cmd = (const void *)bsg_mach_headers_first_cmd_after_header(image->header);
+
+    const struct load_command *load_cmd =
+        (const void *)bsg_mach_headers_first_cmd_after_header(image.header);
     if (!load_cmd) {
         return;
     }
-    
-    result->image = image;
-    
-    const uintptr_t slide = (uintptr_t)image->slide;
-    
+
+    result->image_header = image.header;
+    result->image_name = image.name;
+
+    const uintptr_t slide = (uintptr_t)image.slide;
+
     const segment_command_t *linkedit = NULL;
     const struct linkedit_data_command *function_starts = NULL;
     const struct symtab_command *symtab = NULL;
-    
-    for (uint32_t lc_idx = 0; lc_idx < image->header->ncmds; ++lc_idx) {
+
+    for (uint32_t lc_idx = 0; lc_idx < image.header->ncmds; ++lc_idx) {
         switch (load_cmd->cmd) {
             case LC_SEGMENT_BSG: {
                 const segment_command_t *seg_cmd = (const void *)load_cmd;
@@ -90,8 +93,10 @@ void bsg_symbolicate(const uintptr_t instruction_addr, struct bsg_symbolicate_re
                             uintptr_t start = section->addr + slide;
                             uintptr_t end = start + section->size;
                             if (instruction_addr < start || instruction_addr >= end) {
-                                BSG_KSLOG_ERROR("Address %p is outside the " SECT_TEXT " section of image %s",
-                                                (void *)instruction_addr, image->name);
+                                BSG_KSLOG_ERROR(
+                                    "Address %p is outside the " SECT_TEXT
+                                    " section of image %s",
+                                    (void *)instruction_addr, image.name);
                                 return;
                             }
                             break;
@@ -117,9 +122,9 @@ void bsg_symbolicate(const uintptr_t instruction_addr, struct bsg_symbolicate_re
         }
         load_cmd = (const void *)(uintptr_t)load_cmd + load_cmd->cmdsize;
     }
-    
+
     if (!linkedit) {
-        BSG_KSLOG_INFO(SEG_LINKEDIT " not found for %s", image->name);
+        BSG_KSLOG_INFO(SEG_LINKEDIT " not found for %s", image.name);
         return;
     }
     
@@ -141,7 +146,7 @@ void bsg_symbolicate(const uintptr_t instruction_addr, struct bsg_symbolicate_re
     if (function_starts) {
         // Function starts are stored as a series of LEB128 encoded deltas
         // Starting with delta from start of __TEXT
-        uintptr_t addr = (uintptr_t)image->imageVmAddr + slide;
+        uintptr_t addr = (uintptr_t)image.imageVmAddr + slide;
         uintptr_t func_start = addr;
         struct leb128_uintptr_context context = {0};
         const uint8_t *data = get_linkedit_data(function_starts->dataoff, function_starts->datasize);
@@ -175,7 +180,9 @@ void bsg_symbolicate(const uintptr_t instruction_addr, struct bsg_symbolicate_re
         // may not have any symbols.
         //
         // The back-end will still be able to symbolicate if the dSYM was uploaded.
-        BSG_KSLOG_INFO("No LC_FUNCTION_STARTS, skipping in-process symbolication for %s", image->name);
+        BSG_KSLOG_INFO(
+            "No LC_FUNCTION_STARTS, skipping in-process symbolication for %s",
+            image.name);
         return;
     }
     

--- a/Bugsnag/KSCrash/Source/KSCrash/Recording/Tools/BSG_Symbolicate.h
+++ b/Bugsnag/KSCrash/Source/KSCrash/Recording/Tools/BSG_Symbolicate.h
@@ -10,12 +10,15 @@
 
 #include <stdint.h>
 
+struct mach_header;
+
 #ifdef __cplusplus
 extern "C" {
 #endif
 
 struct bsg_symbolicate_result {
-    struct bsg_mach_image *image;
+    const struct mach_header *image_header;
+    const char *image_name;
     uintptr_t function_address;
     const char *function_name;
 };

--- a/Bugsnag/Payload/BugsnagStackframe.m
+++ b/Bugsnag/Payload/BugsnagStackframe.m
@@ -184,12 +184,15 @@ static NSDictionary * _Nullable FindImage(NSArray *images, uintptr_t addr) {
     if ((self = [super init])) {
         _frameAddress = @(address);
         _needsSymbolication = YES;
-        BSG_Mach_Header_Info *header = bsg_mach_headers_image_at_address(address);
-        if (header) {
-            _machoFile = header->name ? @(header->name) : nil;
-            _machoLoadAddress = @((uintptr_t)header->header);
-            _machoVmAddress = @(header->imageVmAddr);
-            _machoUuid = header->uuid ? [[NSUUID alloc] initWithUUIDBytes:header->uuid].UUIDString : nil;
+        BSG_Mach_Header_Info header;
+        if (bsg_mach_headers_image_at_address(address, &header)) {
+            _machoFile = header.name ? @(header.name) : nil;
+            _machoLoadAddress = @((uintptr_t)header.header);
+            _machoVmAddress = @(header.imageVmAddr);
+            _machoUuid =
+                header.uuid
+                    ? [[NSUUID alloc] initWithUUIDBytes:header.uuid].UUIDString
+                    : nil;
         }
     }
     return self;

--- a/Tests/BugsnagTests/BugsnagStackframeTest.m
+++ b/Tests/BugsnagTests/BugsnagStackframeTest.m
@@ -234,7 +234,7 @@
 
 - (void)testRealCallStackSymbols {
     bsg_mach_headers_initialize();
-    bsg_mach_headers_get_images(); // Ensure call stack can be symbolicated
+    bsg_mach_headers_get_images(NULL); // Ensure call stack can be symbolicated
     
     NSArray<NSString *> *callStackSymbols = [NSThread callStackSymbols];
     NSArray<BugsnagStackframe *> *stackframes = [BugsnagStackframe stackframesWithCallStackSymbols:callStackSymbols];

--- a/Tests/BugsnagTests/BugsnagThreadTests.m
+++ b/Tests/BugsnagTests/BugsnagThreadTests.m
@@ -25,7 +25,7 @@
 + (void)setUp {
     [super setUp];
     bsg_mach_headers_initialize();
-    bsg_mach_headers_get_images(); // Ensure call stack can be symbolicated
+    bsg_mach_headers_get_images(NULL); // Ensure call stack can be symbolicated
 }
 
 - (void)setUp {

--- a/Tests/KSCrashTests/BSG_KSMachHeadersTests.m
+++ b/Tests/KSCrashTests/BSG_KSMachHeadersTests.m
@@ -3,49 +3,19 @@
 //  Tests
 //
 //  Created by Robin Macharg on 04/05/2020.
+//  Current tests created by Alex Cohen on 30/08/2026.
 //  Copyright © 2020 Bugsnag. All rights reserved.
 //
 
 #import "BSG_KSMachHeaders.h"
 #import <Bugsnag/Bugsnag.h>
 #import <XCTest/XCTest.h>
+#import <dispatch/dispatch.h>
 #import <dlfcn.h>
 #import <mach-o/dyld.h>
+#import <mach-o/dyld_images.h>
 #import <objc/runtime.h>
-
-const struct mach_header header1 = {
-    .magic = MH_MAGIC,
-    .cputype = 0,
-    .cpusubtype = 0,
-    .filetype = 0,
-    .ncmds = 1,
-    .sizeofcmds = 0,
-    .flags = 0
-};
-const struct segment_command command1 = {
-    .cmd = LC_SEGMENT,
-    .cmdsize = 0,
-    .segname = SEG_TEXT,
-    .vmaddr = 111,
-    .vmsize = 10,
-};
-
-const struct mach_header header2 = {
-    .magic = MH_MAGIC,
-    .cputype = 0,
-    .cpusubtype = 0,
-    .filetype = 0,
-    .ncmds = 1,
-    .sizeofcmds = 0,
-    .flags = 0
-};
-const struct segment_command command2 = {
-    .cmd = LC_SEGMENT,
-    .cmdsize = 0,
-    .segname = SEG_TEXT,
-    .vmaddr = 222,
-    .vmsize = 10,
-};
+#import <stdatomic.h>
 
 @interface BSG_KSMachHeadersTests : XCTestCase
 @end
@@ -54,94 +24,127 @@ const struct segment_command command2 = {
 
 - (void)setUp {
     [super setUp];
+    bsg_test_support_mach_headers_reset();
     bsg_mach_headers_initialize();
 }
 
-static BSG_Mach_Header_Info *get_tail(BSG_Mach_Header_Info *head) {
-    BSG_Mach_Header_Info *current = head;
-    for (; current->next != NULL; current = current->next) {
+- (void)tearDown {
+    bsg_test_support_mach_headers_reset();
+    [super tearDown];
+}
+
+- (void)testInitializationDoesNotEnumerateEveryImage {
+    uint32_t imageCount = 0;
+    XCTAssertNotEqual(bsg_mach_headers_get_images(&imageCount), NULL);
+    XCTAssertGreaterThan(imageCount, 0u);
+
+    // Initialization caches only the main executable, dyld, and Bugsnag.
+    uint32_t cachedImageCount =
+        bsg_test_support_mach_headers_cached_image_count();
+    XCTAssertLessThanOrEqual(cachedImageCount, 3u);
+    if (imageCount > 3) {
+        XCTAssertLessThan(cachedImageCount, imageCount);
     }
-    return current;
 }
 
-- (void)testAddRemove {
-    bsg_test_support_mach_headers_reset();
+- (void)testGetImagesReturnsDyldsLiveImageArray {
+    uint32_t imageCount = 0;
+    const BSG_Dyld_Image_Info *images =
+        bsg_mach_headers_get_images(&imageCount);
 
-    bsg_test_support_mach_headers_add_image(&header1, 0);
-    
-    BSG_Mach_Header_Info *listTail = get_tail(bsg_mach_headers_get_images());
-    XCTAssertEqual(listTail->imageVmAddr, command1.vmaddr);
-    XCTAssert(listTail->unloaded == FALSE);
-    
-    bsg_test_support_mach_headers_add_image(&header2, 0);
-    
-    XCTAssertEqual(listTail->imageVmAddr, command1.vmaddr);
-    XCTAssert(listTail->unloaded == FALSE);
-    XCTAssertEqual(listTail->next->imageVmAddr, command2.vmaddr);
-    XCTAssert(listTail->next->unloaded == FALSE);
-    
-    bsg_test_support_mach_headers_remove_image(&header1, 0);
-    
-    XCTAssertEqual(listTail->imageVmAddr, command1.vmaddr);
-    XCTAssert(listTail->unloaded == TRUE);
-    XCTAssertEqual(listTail->next->imageVmAddr, command2.vmaddr);
-    XCTAssert(listTail->next->unloaded == FALSE);
-    
-    bsg_test_support_mach_headers_remove_image(&header2, 0);
-    
-    XCTAssertEqual(listTail->imageVmAddr, command1.vmaddr);
-    XCTAssert(listTail->unloaded == TRUE);
-    XCTAssertEqual(listTail->next->imageVmAddr, command2.vmaddr);
-    XCTAssert(listTail->next->unloaded == TRUE);
+    XCTAssertNotEqual(images, NULL);
+    XCTAssertGreaterThan(imageCount, 0u);
+
+    const struct mach_header *mainHeader = _dyld_get_image_header(0);
+    BOOL foundMainImage = NO;
+    for (uint32_t i = 0; i < imageCount; i++) {
+        if (images[i].imageLoadAddress == mainHeader) {
+            foundMainImage = YES;
+            break;
+        }
+    }
+    XCTAssertTrue(foundMainImage);
 }
 
-- (void)testFindImageAtAddress {
-    bsg_test_support_mach_headers_reset();
-
-    bsg_test_support_mach_headers_add_image(&header1, 0);
-    bsg_test_support_mach_headers_add_image(&header2, 0);
-    
-    BSG_Mach_Header_Info *item;
-    item = bsg_mach_headers_image_at_address((uintptr_t)&header1);
-    XCTAssertEqual(item->imageVmAddr, command1.vmaddr);
-    
-    item = bsg_mach_headers_image_at_address((uintptr_t)&header2);
-    XCTAssertEqual(item->imageVmAddr, command2.vmaddr);
-}
-
-- (void) testGetImageNameNULL
-{
-    BSG_Mach_Header_Info *img = bsg_mach_headers_image_named(NULL, false);
-    XCTAssertTrue(img == NULL);
+- (void)testGetImageNameNULL {
+    XCTAssertFalse(bsg_mach_headers_image_named(NULL, false, NULL));
 }
 
 - (void)testGetSelfImage {
-    XCTAssertEqualObjects(@(bsg_mach_headers_get_self_image()->name),
+    BSG_Mach_Header_Info image;
+    XCTAssertTrue(bsg_mach_headers_get_self_image(&image));
+    XCTAssertEqualObjects(@(image.name),
                           @(class_getImageName([Bugsnag class])));
 }
 
 - (void)testMainImage {
-    XCTAssertEqualObjects(@(bsg_mach_headers_get_main_image()->name),
-                          NSBundle.mainBundle.executablePath);
+    BSG_Mach_Header_Info image;
+    XCTAssertTrue(bsg_mach_headers_get_main_image(&image));
+    XCTAssertEqualObjects(@(image.name), NSBundle.mainBundle.executablePath);
+    XCTAssertEqual(image.header->filetype, MH_EXECUTE);
+}
+
+- (void)testDyldImage {
+    BSG_Mach_Header_Info image;
+    XCTAssertTrue(bsg_mach_headers_get_dyld_image(&image));
+    XCTAssertNotEqual(image.header, NULL);
+    XCTAssertNotEqual(image.name, NULL);
+}
+
+- (void)testImageNamed {
+    BSG_Mach_Header_Info mainImage;
+    XCTAssertTrue(bsg_mach_headers_get_main_image(&mainImage));
+
+    BSG_Mach_Header_Info foundImage;
+    XCTAssertTrue(
+        bsg_mach_headers_image_named(mainImage.name, true, &foundImage));
+    XCTAssertEqual(foundImage.header, mainImage.header);
 }
 
 - (void)testImageAtAddress {
     for (NSNumber *number in NSThread.callStackReturnAddresses) {
         uintptr_t address = number.unsignedIntegerValue;
-        BSG_Mach_Header_Info *image = bsg_mach_headers_image_at_address(address);
+        BSG_Mach_Header_Info image;
         struct dl_info dlinfo = {0};
-        if (dladdr((const void*)address, &dlinfo) != 0) {
-            // If dladdr was able to locate the image, so should bsg_mach_headers_image_at_address
-            XCTAssertEqual(image->header, dlinfo.dli_fbase);
-            XCTAssertEqual(image->imageVmAddr + image->slide, (uint64_t)dlinfo.dli_fbase);
-            XCTAssertEqual(image->name, dlinfo.dli_fname);
-            XCTAssertFalse(image->unloaded);
+        if (dladdr((const void *)address, &dlinfo) != 0) {
+            XCTAssertTrue(bsg_mach_headers_image_at_address(address, &image));
+            XCTAssertEqual(image.header, dlinfo.dli_fbase);
+            XCTAssertEqual(image.imageVmAddr + image.slide,
+                           (uint64_t)dlinfo.dli_fbase);
+            XCTAssertEqualObjects(@(image.name), @(dlinfo.dli_fname));
         }
     }
-    
-    XCTAssertEqual(bsg_mach_headers_image_at_address(0x0000000000000000), NULL);
-    XCTAssertEqual(bsg_mach_headers_image_at_address(0x0000000000001000), NULL);
-    XCTAssertEqual(bsg_mach_headers_image_at_address(0x7FFFFFFFFFFFFFFF), NULL);
+}
+
+- (void)testImageLookupPopulatesCacheLazily {
+    uint32_t countBefore = bsg_test_support_mach_headers_cached_image_count();
+    uintptr_t address = (uintptr_t)class_getMethodImplementation(
+        [NSObject class], @selector(description));
+    BSG_Mach_Header_Info image;
+    XCTAssertTrue(bsg_mach_headers_image_at_address(address, &image));
+    XCTAssertGreaterThan(bsg_test_support_mach_headers_cached_image_count(),
+                         countBefore);
+}
+
+- (void)testConcurrentImageLookups {
+    uintptr_t address = (uintptr_t)class_getMethodImplementation(
+        [NSObject class], @selector(description));
+    __block atomic_bool allLookupsSucceeded = true;
+    dispatch_apply(64, dispatch_get_global_queue(QOS_CLASS_USER_INITIATED, 0),
+                   ^(__unused size_t index) {
+                     BSG_Mach_Header_Info image;
+                     if (!bsg_mach_headers_image_at_address(address, &image)) {
+                         atomic_store(&allLookupsSucceeded, false);
+                     }
+                   });
+    XCTAssertTrue(atomic_load(&allLookupsSucceeded));
+}
+
+- (void)testInvalidAddressesDoNotMatchAnImage {
+    BSG_Mach_Header_Info image;
+    XCTAssertFalse(bsg_mach_headers_image_at_address(0, &image));
+    XCTAssertFalse(bsg_mach_headers_image_at_address(0x1000, &image));
+    XCTAssertFalse(bsg_mach_headers_image_at_address(UINTPTR_MAX, &image));
 }
 
 @end

--- a/Tests/KSCrashTests/BSG_KSMachHeadersTests.m
+++ b/Tests/KSCrashTests/BSG_KSMachHeadersTests.m
@@ -3,7 +3,6 @@
 //  Tests
 //
 //  Created by Robin Macharg on 04/05/2020.
-//  Current tests created by Alex Cohen on 30/08/2026.
 //  Copyright © 2020 Bugsnag. All rights reserved.
 //
 


### PR DESCRIPTION
Fixes #1950.

Bugsnag currently walks every loaded Mach-O image when it starts, adding launch work that grows with the size of the app. This uses dyld's live image list instead and resolves image details lazily, following the approach used by current KSCrash.

The change is deliberately narrow and preserves compact crash reports and images loaded after startup. Since this is a specific, measurable launch regression, would you please consider it for a quick bug-fix release once the draft is ready?

Known limitation: The image list can theoretically change while we read it, and unloaded images remain cached. These cases are extremely rare in normal apps and match current KSCrash behavior, so we accept the small risk to avoid slowing startup.