### PR TITLE
Meiy/plat 16853 metadata capture issue fix

### DIFF
--- a/Bugsnag/Client/BugsnagClient.m
+++ b/Bugsnag/Client/BugsnagClient.m
@@ -777,7 +777,7 @@ __attribute__((annotate("oclint:suppress[too many methods]")))
                metadata:(BugsnagMetadata *)metadata {
     if (capture == nil || capture.metadata == nil) {
         // Copy all of the current metadata from self
-        for (NSString* sectionKey in self.metadata.dictionary) {
+        for (NSString* sectionKey in[self.metadata toDictionary]) {
             if (sectionKey == nil) {
                 continue;
             }

--- a/Tests/BugsnagTests/BugsnagCaptureOptionsTests.m
+++ b/Tests/BugsnagTests/BugsnagCaptureOptionsTests.m
@@ -304,11 +304,14 @@
 - (void)testMetadataCaptureIsThreadSafe {
     BugsnagConfiguration *config = [[BugsnagConfiguration alloc] initWithApiKey:DUMMY_APIKEY_32CHAR_1];
     BugsnagClient *client = [[BugsnagClient alloc] initWithConfiguration:config];
+    NSMutableArray<NSString *> *prefilledSections = [NSMutableArray arrayWithCapacity:300];
     
     for (NSUInteger index = 0; index < 300; index++) {
+        NSString *section = [NSString stringWithFormat:@"prefilled%lu", (unsigned long)index];
+        [prefilledSections addObject:section];
         [client addMetadata:@"value"
                    withKey:@"key"
-                 toSection:[NSString stringWithFormat:@"prefilled%lu", (unsigned long)index]];
+                 toSection:section];
     }
     
     const NSUInteger captureWorkerCount = 4;
@@ -318,6 +321,7 @@
     dispatch_group_t group = dispatch_group_create();
     dispatch_semaphore_t start = dispatch_semaphore_create(0);
     NSMutableArray<NSException *> *exceptions = [NSMutableArray array];
+    NSMutableArray<NSString *> *missingPrefilledSections = [NSMutableArray array];
     
     for (NSUInteger worker = 0; worker < captureWorkerCount; worker++) {
         dispatch_group_async(group, queue, ^{
@@ -325,7 +329,17 @@
             for (NSUInteger iteration = 0; iteration < 500; iteration++) {
                 @autoreleasepool {
                     @try {
-                        [client metadataCapture:nil metadata:[BugsnagMetadata new]];
+                        BugsnagMetadata*captured = [client metadataCapture:nil metadata:[BugsnagMetadata new]];
+                        NSDictionary*capturedDictionary = [captured toDictionary];
+                        for (NSString*sectionName in prefilledSections) {
+                            NSDictionary*section = capturedDictionary[sectionName];
+                            if (![section[@"key"] isEqual:@"value"]) {
+                                @synchronized(missingPrefilledSections) {
+                                    [missingPrefilledSections addObject:sectionName];
+                                }
+                                break;
+                            }
+                        }
                     } @catch (NSException *exception) {
                         @synchronized(exceptions) {
                             [exceptions addObject:exception];
@@ -356,6 +370,7 @@
     
     XCTAssertEqual(dispatch_group_wait(group, dispatch_time(DISPATCH_TIME_NOW, 30 * NSEC_PER_SEC)), 0);
     XCTAssertEqual(exceptions.count, 0);
+    XCTAssertEqual(missingPrefilledSections.count, 0);
 }
 
 - (void)testMetadataCombinationOfCaptureFlags {

--- a/Tests/BugsnagTests/BugsnagCaptureOptionsTests.m
+++ b/Tests/BugsnagTests/BugsnagCaptureOptionsTests.m
@@ -24,8 +24,16 @@
 #import "BugsnagClient+Private.h"
 #import "BugsnagConfiguration+Private.h"
 #import "BugsnagEvent+Private.h"
+#import "BugsnagMetadata+Private.h"
 #import "BugsnagTestConstants.h"
 #import "BugsnagNotifier.h"
+
+@interface BugsnagClient(BugsnagCaptureOptionsTests)
+
+- (BugsnagMetadata *)metadataCapture:(BugsnagCaptureOptions *)capture
+                            metadata:(BugsnagMetadata *)metadata;
+
+@end
 
 @interface BugsnagCaptureOptionsTests : BSGTestCase
 @end
@@ -293,6 +301,62 @@
     }];
 }
 
+- (void)testMetadataCaptureIsThreadSafe {
+    BugsnagConfiguration *config = [[BugsnagConfiguration alloc] initWithApiKey:DUMMY_APIKEY_32CHAR_1];
+    BugsnagClient *client = [[BugsnagClient alloc] initWithConfiguration:config];
+    
+    for (NSUInteger index = 0; index < 300; index++) {
+        [client addMetadata:@"value"
+                   withKey:@"key"
+                 toSection:[NSString stringWithFormat:@"prefilled%lu", (unsigned long)index]];
+    }
+    
+    const NSUInteger captureWorkerCount = 4;
+    const NSUInteger writingWorkerCount = 4;
+    const NSUInteger workerCount = captureWorkerCount + writingWorkerCount;
+    dispatch_queue_t queue = dispatch_get_global_queue(QOS_CLASS_USER_INITIATED, 0);
+    dispatch_group_t group = dispatch_group_create();
+    dispatch_semaphore_t start = dispatch_semaphore_create(0);
+    NSMutableArray<NSException *> *exceptions = [NSMutableArray array];
+    
+    for (NSUInteger worker = 0; worker < captureWorkerCount; worker++) {
+        dispatch_group_async(group, queue, ^{
+            dispatch_semaphore_wait(start, DISPATCH_TIME_FOREVER);
+            for (NSUInteger iteration = 0; iteration < 500; iteration++) {
+                @autoreleasepool {
+                    @try {
+                        [client metadataCapture:nil metadata:[BugsnagMetadata new]];
+                    } @catch (NSException *exception) {
+                        @synchronized(exceptions) {
+                            [exceptions addObject:exception];
+                        }
+                    }
+                }
+            }
+        });
+    }
+    
+    for (NSUInteger worker = 0; worker < writingWorkerCount; worker++) {
+        dispatch_group_async(group, queue, ^{
+            dispatch_semaphore_wait(start, DISPATCH_TIME_FOREVER);
+            for (NSUInteger iteration = 0; iteration < 2000; iteration++) {
+                @autoreleasepool {
+                    NSString *section = [NSString stringWithFormat:@"racing%lu-%lu",
+                        (unsigned long)worker, (unsigned long)iteration];
+                    [client addMetadata:@"value"withKey:@"key" toSection:section];
+                    [client clearMetadataFromSection:section];
+                }
+            }
+        });
+    }
+    
+    for (NSUInteger worker = 0; worker < workerCount; worker++) {
+        dispatch_semaphore_signal(start);
+    }
+    
+    XCTAssertEqual(dispatch_group_wait(group, dispatch_time(DISPATCH_TIME_NOW, 30 * NSEC_PER_SEC)), 0);
+    XCTAssertEqual(exceptions.count, 0);
+}
 
 - (void)testMetadataCombinationOfCaptureFlags {
     BugsnagClient *client = [self prepareClient];


### PR DESCRIPTION
## Goal

Prevent NSGenericException crashes when error capture and global metadata updates occur concurrently.

## Design

Enumerate a synchronized top-level metadata snapshot while retaining the existing synchronized per-section copying behavior.

## Changeset

Update BugsnagClient metadataCapture:metadata: and add a concurrency regression test covering simultaneous metadata capture, addition, and removal.

## Testing

Unit test and Maze runner test passed.